### PR TITLE
qucs-s: 0.0.22 -> 1.0.2

### DIFF
--- a/pkgs/applications/science/electronics/qucs-s/default.nix
+++ b/pkgs/applications/science/electronics/qucs-s/default.nix
@@ -18,26 +18,22 @@
 
 stdenv.mkDerivation rec {
   pname = "qucs-s";
-  version = "1.0.1";
+  version = "1.0.2";
 
   src = fetchFromGitHub {
     owner = "ra3xdh";
     repo = "qucs_s";
     rev = version;
-    sha256 = "sha256-IdIq/ZY8y/OJ2E51DwhJvcgT+cMAMLozgSuxn8As6ZY=";
+    sha256 = "sha256-2YyVeeUnLBS1Si9gwEsQLZVG98715dz/v+WCYjB3QlI=";
   };
 
-  nativeBuildInputs = [ wrapQtAppsHook cmake ];
-  buildInputs = [ flex bison qtbase qttools qtsvg qtwayland libX11 gperf adms ] ++ kernels;
+  nativeBuildInputs = [ flex bison wrapQtAppsHook cmake ];
+  buildInputs = [ qtbase qttools qtsvg qtwayland libX11 gperf adms ] ++ kernels;
 
   # Make custom kernels avaible from qucs-s
   qtWrapperArgs = [ "--prefix" "PATH" ":" (lib.makeBinPath kernels) ];
 
   QTDIR = qtbase.dev;
-
-  # Use Qt6 rather then 5. This can be removed starting from 1.0.2,
-  # see https://github.com/ra3xdh/qucs_s/commit/888feebcebfc373398b40c9b35ebabf27a87edd7
-  cmakeFlags = [ "-DWITH_QT6=ON" ];
 
   doInstallCheck = true;
   installCheck = ''

--- a/pkgs/applications/science/electronics/qucs-s/default.nix
+++ b/pkgs/applications/science/electronics/qucs-s/default.nix
@@ -1,27 +1,37 @@
-{ stdenv, lib, fetchFromGitHub, flex, bison, qt4, libX11, cmake, gperf, adms,
-ngspice, wrapGAppsHook,
-kernels ? [ ngspice ] }:
+{ stdenv
+, lib
+, fetchFromGitHub
+, flex
+, bison
+, qtbase
+, qttools
+, wrapQtAppsHook
+, libX11
+, cmake
+, gperf
+, adms
+, ngspice
+, kernels ? [ ngspice ]
+}:
 
 stdenv.mkDerivation rec {
   pname = "qucs-s";
-  version = "0.0.22";
+  version = "1.0.1";
 
   src = fetchFromGitHub {
     owner = "ra3xdh";
     repo = "qucs_s";
     rev = version;
-    sha256 = "0rrq2ddridc09m6fixdmbngn42xmv8cmdf6r8zzn2s98fqib5qd6";
+    sha256 = "sha256-IdIq/ZY8y/OJ2E51DwhJvcgT+cMAMLozgSuxn8As6ZY=";
   };
 
-  nativeBuildInputs = [ wrapGAppsHook cmake ];
-  buildInputs = [ flex bison qt4 libX11 gperf adms ] ++ kernels;
+  nativeBuildInputs = [ wrapQtAppsHook cmake ];
+  buildInputs = [ flex bison qtbase qttools libX11 gperf adms ] ++ kernels;
 
-  preConfigure = ''
-    # Make custom kernels avaible from qucs-s
-    gappsWrapperArgs+=(--prefix PATH ":" ${lib.escapeShellArg (lib.makeBinPath kernels)})
-  '';
+  # Make custom kernels avaible from qucs-s
+  qtWrapperArgs = [ "--prefix" "PATH" ":" (lib.makeBinPath kernels) ];
 
-  QTDIR=qt4;
+  QTDIR = qtbase.dev;
 
   doInstallCheck = true;
   installCheck = ''

--- a/pkgs/applications/science/electronics/qucs-s/default.nix
+++ b/pkgs/applications/science/electronics/qucs-s/default.nix
@@ -5,6 +5,7 @@
 , bison
 , qtbase
 , qttools
+, qtsvg
 , wrapQtAppsHook
 , libX11
 , cmake
@@ -26,12 +27,16 @@ stdenv.mkDerivation rec {
   };
 
   nativeBuildInputs = [ wrapQtAppsHook cmake ];
-  buildInputs = [ flex bison qtbase qttools libX11 gperf adms ] ++ kernels;
+  buildInputs = [ flex bison qtbase qttools qtsvg libX11 gperf adms ] ++ kernels;
 
   # Make custom kernels avaible from qucs-s
   qtWrapperArgs = [ "--prefix" "PATH" ":" (lib.makeBinPath kernels) ];
 
   QTDIR = qtbase.dev;
+
+  # Use Qt6 rather then 5. This can be removed starting from 1.0.2,
+  # see https://github.com/ra3xdh/qucs_s/commit/888feebcebfc373398b40c9b35ebabf27a87edd7
+  cmakeFlags = [ "-DWITH_QT6=ON" ];
 
   doInstallCheck = true;
   installCheck = ''

--- a/pkgs/applications/science/electronics/qucs-s/default.nix
+++ b/pkgs/applications/science/electronics/qucs-s/default.nix
@@ -6,6 +6,7 @@
 , qtbase
 , qttools
 , qtsvg
+, qtwayland
 , wrapQtAppsHook
 , libX11
 , cmake
@@ -27,7 +28,7 @@ stdenv.mkDerivation rec {
   };
 
   nativeBuildInputs = [ wrapQtAppsHook cmake ];
-  buildInputs = [ flex bison qtbase qttools qtsvg libX11 gperf adms ] ++ kernels;
+  buildInputs = [ flex bison qtbase qttools qtsvg qtwayland libX11 gperf adms ] ++ kernels;
 
   # Make custom kernels avaible from qucs-s
   qtWrapperArgs = [ "--prefix" "PATH" ":" (lib.makeBinPath kernels) ];

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -37557,7 +37557,7 @@ with pkgs;
 
   qucs = callPackage ../applications/science/electronics/qucs { };
 
-  qucs-s = callPackage ../applications/science/electronics/qucs-s { };
+  qucs-s = libsForQt5.callPackage ../applications/science/electronics/qucs-s { };
 
   xcircuit = callPackage ../applications/science/electronics/xcircuit { };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -37557,7 +37557,7 @@ with pkgs;
 
   qucs = callPackage ../applications/science/electronics/qucs { };
 
-  qucs-s = libsForQt5.callPackage ../applications/science/electronics/qucs-s { };
+  qucs-s = qt6Packages.callPackage ../applications/science/electronics/qucs-s { };
 
   xcircuit = callPackage ../applications/science/electronics/xcircuit { };
 


### PR DESCRIPTION
###### Description of changes

For changelog see [Releases](https://github.com/ra3xdh/qucs_s/releases) for 0.0.23 .. 1.0.1.
Qt has been bumped from 4 to 6 as 5 is approaching EOL.

Checked the program opens, a simple circuit can be drown and ngspice integration works.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

