### PR TITLE
playwright-driver: init at 1.30.1

### DIFF
--- a/pkgs/development/python-modules/playwright/default.nix
+++ b/pkgs/development/python-modules/playwright/default.nix
@@ -1,131 +1,21 @@
 { lib
-, stdenv
 , buildPythonPackage
-, chromium
-, ffmpeg
 , git
 , greenlet
-, jq
-, nodejs
 , fetchFromGitHub
-, fetchurl
-, makeFontsConf
-, makeWrapper
 , pyee
 , python
 , pythonOlder
-, runCommand
 , setuptools-scm
-, unzip
+, playwright-driver
 }:
 
 let
-  inherit (stdenv.hostPlatform) system;
-  throwSystem = throw "Unsupported system: ${system}";
-
-  driverVersion = "1.31.1";
-
-  driver = let
-    suffix = {
-      x86_64-linux = "linux";
-      aarch64-linux = "linux-arm64";
-      x86_64-darwin = "mac";
-      aarch64-darwin = "mac-arm64";
-    }.${system} or throwSystem;
-    filename = "playwright-${driverVersion}-${suffix}.zip";
-  in stdenv.mkDerivation {
-    pname = "playwright-driver";
-    version = driverVersion;
-
-    src = fetchurl {
-      url = "https://playwright.azureedge.net/builds/driver/${filename}";
-      sha256 = {
-        x86_64-linux = "1wg49kfs8fflmx8g01bkckbjkghhwy7c44akckjf7dp4lbh1z8fd";
-        aarch64-linux = "0f09a0cxqxihy8lmbjzii80jkpf3n5xlvhjpgdkwmrr3wh0nnixj";
-        x86_64-darwin = "1zd0dz8jazymcpa1im5yzxb7rwl6wn4xz19lpz83bnpd1njq01b3";
-        aarch64-darwin = "0hcn80zm9aki8hzsf1cljzcmi4iaw7fascs8ajj0qcwqkkm4jnw0";
-      }.${system} or throwSystem;
-    };
-
-    sourceRoot = ".";
-
-    nativeBuildInputs = [ unzip ];
-
-    postPatch = ''
-      # Use Nix's NodeJS instead of the bundled one.
-      substituteInPlace playwright.sh --replace '"$SCRIPT_PATH/node"' '"${nodejs}/bin/node"'
-      rm node
-
-      # Hard-code the script path to $out directory to avoid a dependency on coreutils
-      substituteInPlace playwright.sh \
-        --replace 'SCRIPT_PATH="$(cd "$(dirname "$0")" ; pwd -P)"' "SCRIPT_PATH=$out"
-
-      patchShebangs playwright.sh package/bin/*.sh
-    '';
-
-    installPhase = ''
-      runHook preInstall
-
-      mkdir -p $out/bin
-      mv playwright.sh $out/bin/playwright
-      mv package $out/
-
-      runHook postInstall
-    '';
-
-    passthru = {
-      inherit filename;
-    };
-  };
-
-  browsers-mac = stdenv.mkDerivation {
-    pname = "playwright-browsers";
-    version = driverVersion;
-
-    dontUnpack = true;
-
-    installPhase = ''
-      runHook preInstall
-
-      export PLAYWRIGHT_BROWSERS_PATH=$out
-      ${driver}/bin/playwright install
-      rm -r $out/.links
-
-      runHook postInstall
-    '';
-
-    meta.platforms = lib.platforms.darwin;
-  };
-
-  browsers-linux = {}: let
-    fontconfig = makeFontsConf {
-      fontDirectories = [];
-    };
-  in runCommand "playwright-browsers"
-  {
-    nativeBuildInputs = [
-      makeWrapper
-      jq
-    ];
-  } (''
-    BROWSERS_JSON=${driver}/package/browsers.json
-    CHROMIUM_REVISION=$(jq -r '.browsers[] | select(.name == "chromium").revision' $BROWSERS_JSON)
-    mkdir -p $out/chromium-$CHROMIUM_REVISION/chrome-linux
-
-    # See here for the Chrome options:
-    # https://github.com/NixOS/nixpkgs/issues/136207#issuecomment-908637738
-    makeWrapper ${chromium}/bin/chromium $out/chromium-$CHROMIUM_REVISION/chrome-linux/chrome \
-      --set SSL_CERT_FILE /etc/ssl/certs/ca-bundle.crt \
-      --set FONTCONFIG_FILE ${fontconfig}
-
-    FFMPEG_REVISION=$(jq -r '.browsers[] | select(.name == "ffmpeg").revision' $BROWSERS_JSON)
-    mkdir -p $out/ffmpeg-$FFMPEG_REVISION
-    ln -s ${ffmpeg}/bin/ffmpeg $out/ffmpeg-$FFMPEG_REVISION/ffmpeg-linux
-  '');
+  driver = playwright-driver;
 in
 buildPythonPackage rec {
   pname = "playwright";
-  version = "1.31.1";
+  version =  "1.31.1";
   format = "setuptools";
   disabled = pythonOlder "3.7";
 
@@ -191,18 +81,11 @@ buildPythonPackage rec {
     "playwright"
   ];
 
-  passthru = rec {
+  passthru = {
     inherit driver;
-    browsers = {
-      x86_64-linux = browsers-linux { };
-      aarch64-linux = browsers-linux { };
-      x86_64-darwin = browsers-mac;
-      aarch64-darwin = browsers-mac;
-    }.${system} or throwSystem;
-    browsers-chromium = browsers-linux { };
-
     tests = {
-      inherit driver browsers;
+      driver = playwright-driver;
+      browsers = playwright-driver.browsers;
     };
   };
 

--- a/pkgs/development/python-modules/pytest-playwright/default.nix
+++ b/pkgs/development/python-modules/pytest-playwright/default.nix
@@ -2,6 +2,7 @@
 , fetchFromGitHub
 , buildPythonPackage
 , playwright
+, playwright-driver
 , pytest
 , pytest-base-url
 , pytestCheckHook
@@ -46,7 +47,7 @@ buildPythonPackage rec {
   doCheck = false;
 
   preCheck = ''
-    export PLAYWRIGHT_BROWSERS_PATH=${playwright.browsers}
+    export PLAYWRIGHT_BROWSERS_PATH=${playwright-driver.browsers}
   '';
 
   pythonImportsCheck = [

--- a/pkgs/development/web/playwright/driver.nix
+++ b/pkgs/development/web/playwright/driver.nix
@@ -1,0 +1,130 @@
+{ lib
+, stdenv
+, chromium
+, ffmpeg
+, git
+, jq
+, nodejs
+, fetchFromGitHub
+, fetchurl
+, makeFontsConf
+, makeWrapper
+, runCommand
+, unzip
+}:
+let
+  inherit (stdenv.hostPlatform) system;
+
+  throwSystem = throw "Unsupported system: ${system}";
+
+  driver = stdenv.mkDerivation (finalAttrs:
+    let
+      suffix = {
+        x86_64-linux = "linux";
+        aarch64-linux = "linux-arm64";
+        x86_64-darwin = "mac";
+        aarch64-darwin = "mac-arm64";
+      }.${system} or throwSystem;
+      filename = "playwright-${finalAttrs.version}-${suffix}.zip";
+    in
+    {
+    pname = "playwright-driver";
+    version =  "1.31.1";
+
+    src = fetchurl {
+      url = "https://playwright.azureedge.net/builds/driver/${filename}";
+      sha256 = {
+        x86_64-linux = "1wg49kfs8fflmx8g01bkckbjkghhwy7c44akckjf7dp4lbh1z8fd";
+        aarch64-linux = "0f09a0cxqxihy8lmbjzii80jkpf3n5xlvhjpgdkwmrr3wh0nnixj";
+        x86_64-darwin = "1zd0dz8jazymcpa1im5yzxb7rwl6wn4xz19lpz83bnpd1njq01b3";
+        aarch64-darwin = "0hcn80zm9aki8hzsf1cljzcmi4iaw7fascs8ajj0qcwqkkm4jnw0";
+      }.${system} or throwSystem;
+    };
+
+    sourceRoot = ".";
+
+    nativeBuildInputs = [ unzip ];
+
+    postPatch = ''
+      # Use Nix's NodeJS instead of the bundled one.
+      substituteInPlace playwright.sh --replace '"$SCRIPT_PATH/node"' '"${nodejs}/bin/node"'
+      rm node
+
+      # Hard-code the script path to $out directory to avoid a dependency on coreutils
+      substituteInPlace playwright.sh \
+        --replace 'SCRIPT_PATH="$(cd "$(dirname "$0")" ; pwd -P)"' "SCRIPT_PATH=$out"
+
+      patchShebangs playwright.sh package/bin/*.sh
+    '';
+
+    installPhase = ''
+      runHook preInstall
+
+      mkdir -p $out/bin
+      mv playwright.sh $out/bin/playwright
+      mv package $out/
+
+      runHook postInstall
+    '';
+
+    passthru = {
+      inherit filename;
+      browsers = {
+        x86_64-linux = browsers-linux { };
+        aarch64-linux = browsers-linux { };
+        x86_64-darwin = browsers-mac;
+        aarch64-darwin = browsers-mac;
+      }.${system} or throwSystem;
+      browsers-chromium = browsers-linux {};
+    };
+  });
+
+  browsers-mac = stdenv.mkDerivation {
+    pname = "playwright-browsers";
+    inherit (driver) version;
+
+    dontUnpack = true;
+
+    installPhase = ''
+      runHook preInstall
+
+      export PLAYWRIGHT_BROWSERS_PATH=$out
+      ${driver}/bin/playwright install
+      rm -r $out/.links
+
+      runHook postInstall
+    '';
+
+    meta.platforms = lib.platforms.darwin;
+  };
+
+  browsers-linux = { withChromium ? true }: let
+    fontconfig = makeFontsConf {
+      fontDirectories = [];
+    };
+  in
+    runCommand ("playwright-browsers"
+    + lib.optionalString withChromium "-chromium")
+  {
+    nativeBuildInputs = [
+      makeWrapper
+      jq
+    ];
+  } (''
+    BROWSERS_JSON=${driver}/package/browsers.json
+  '' + lib.optionalString withChromium ''
+    CHROMIUM_REVISION=$(jq -r '.browsers[] | select(.name == "chromium").revision' $BROWSERS_JSON)
+    mkdir -p $out/chromium-$CHROMIUM_REVISION/chrome-linux
+
+    # See here for the Chrome options:
+    # https://github.com/NixOS/nixpkgs/issues/136207#issuecomment-908637738
+    makeWrapper ${chromium}/bin/chromium $out/chromium-$CHROMIUM_REVISION/chrome-linux/chrome \
+      --set SSL_CERT_FILE /etc/ssl/certs/ca-bundle.crt \
+      --set FONTCONFIG_FILE ${fontconfig}
+  '' + ''
+    FFMPEG_REVISION=$(jq -r '.browsers[] | select(.name == "ffmpeg").revision' $BROWSERS_JSON)
+    mkdir -p $out/ffmpeg-$FFMPEG_REVISION
+    ln -s ${ffmpeg}/bin/ffmpeg $out/ffmpeg-$FFMPEG_REVISION/ffmpeg-linux
+  '');
+in
+  driver

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -11134,6 +11134,8 @@ with pkgs;
 
   playwright = with python3Packages; toPythonApplication playwright;
 
+  playwright-driver = callPackage ../development/web/playwright/driver.nix { };
+
   please = callPackage ../tools/security/please { };
 
   plecost = callPackage ../tools/security/plecost { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -7400,9 +7400,7 @@ self: super: with self; {
 
   pkuseg = callPackage ../development/python-modules/pkuseg { };
 
-  playwright = callPackage ../development/python-modules/playwright {
-    inherit (pkgs) jq;
-  };
+  playwright = callPackage ../development/python-modules/playwright { };
 
   pmsensor = callPackage ../development/python-modules/pmsensor { };
 


### PR DESCRIPTION
it was actually moved from
pkgs/development/python-modules/playwright/default.nix to its own pkgs/development/web/playwright/driver.nix .

I am trying to package the typescript version of playwright and the browsers are needed there, it's more convenient to split them away from the python module.

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
