### PR TITLE
svu: init at 1.10.2

### DIFF
--- a/pkgs/tools/misc/svu/default.nix
+++ b/pkgs/tools/misc/svu/default.nix
@@ -1,0 +1,27 @@
+{ lib, buildGoModule, fetchFromGitHub, testers, svu }:
+
+buildGoModule rec {
+  pname = "svu";
+  version = "1.10.2";
+
+  src = fetchFromGitHub {
+    owner = "caarlos0";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "37AT+ygN7u3KfFqr26M9c7aTt15z8m4PBrSd+G5mJcE=";
+  };
+
+  vendorHash = "sha256-+e1oL08KvBSNaRepGR2SBBrEDJaGxl5V9rOBysGEfQs=";
+
+  ldflags =
+    [ "-s" "-w" "-X main.version=${version}" "-X main.builtBy=nixpkgs" ];
+
+  passthru.tests.version = testers.testVersion { package = svu; };
+
+  meta = with lib; {
+    description = "Semantic Version Util";
+    homepage = "https://github.com/caarlos0/svu";
+    maintainers = with maintainers; [ caarlos0 ];
+    license = licenses.mit;
+  };
+}

--- a/pkgs/tools/misc/svu/default.nix
+++ b/pkgs/tools/misc/svu/default.nix
@@ -13,8 +13,12 @@ buildGoModule rec {
 
   vendorHash = "sha256-+e1oL08KvBSNaRepGR2SBBrEDJaGxl5V9rOBysGEfQs=";
 
-  ldflags =
-    [ "-s" "-w" "-X main.version=${version}" "-X main.builtBy=nixpkgs" ];
+  ldflags = [ "-s" "-w" "-X=main.version=${version}" "-X=main.builtBy=nixpkgs" ];
+
+  # test assumes source directory to be a git repository
+  postPatch = ''
+    rm internal/git/git_test.go
+  '';
 
   passthru.tests.version = testers.testVersion { package = svu; };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -12422,6 +12422,8 @@ with pkgs;
 
   svgcleaner = callPackage ../tools/graphics/svgcleaner { };
 
+  svu = callPackage ../tools/misc/svu { };
+
   ssb = callPackage ../tools/security/ssb { };
 
   ssb-patchwork = callPackage ../applications/networking/ssb-patchwork { };


### PR DESCRIPTION
###### Description of changes

Add a new package, [svu](https://github.com/caarlos0/svu)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
