### PR TITLE
Revert "tzdata: 2023a -> 2023b"

### DIFF
--- a/pkgs/data/misc/tzdata/default.nix
+++ b/pkgs/data/misc/tzdata/default.nix
@@ -2,16 +2,16 @@
 
 stdenv.mkDerivation rec {
   pname = "tzdata";
-  version = "2023b";
+  version = "2023a";
 
   srcs = [
     (fetchurl {
       url = "https://data.iana.org/time-zones/releases/tzdata${version}.tar.gz";
-      hash = "sha256-m3j9Jk+VYR/ph6lXIUVs1arJ9V5pFb5KnKKZe8fODmw=";
+      hash = "sha256-oqJ+23r1o4TPzv2une+tan7SPz8s/a89U5TB6CmXELw=";
     })
     (fetchurl {
       url = "https://data.iana.org/time-zones/releases/tzcode${version}.tar.gz";
-      hash = "sha256-EVSC47pm3LZRyI8s2nnFcQNqz5tjhzF41qBELNO+E9I=";
+      hash = "sha256-bczNJqE6S3HFPlc6C/MrmN5GeqMxa4Lf0l//22yfxGo=";
     })
   ];
 


### PR DESCRIPTION
Reverts NixOS/nixpkgs#222895

Lebanon apparently decided not to do the hasty change after all (on March 30). See
https://mm.icann.org/pipermail/tz/2023-March/date.html