### PR TITLE
tmpreaper: init at 1.6.17

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -9305,6 +9305,11 @@
     github = "marius851000";
     githubId = 22586596;
   };
+  mar-jac = {
+    email = "mar.jacq0296@gmail.com";
+    github = "mar-jac";
+    githubId = 55053226";
+  };
   markbeep = {
     email = "mrkswrn@gmail.com";
     github = "markbeep";

--- a/pkgs/data/themes/adw-gtk3/default.nix
+++ b/pkgs/data/themes/adw-gtk3/default.nix
@@ -37,7 +37,7 @@ stdenvNoCC.mkDerivation rec {
     description = "The theme from libadwaita ported to GTK-3";
     homepage = "https://github.com/lassekongo83/adw-gtk3";
     license = licenses.lgpl21Only;
-    platforms = platforms.linux;
+    platforms = platforms.unix;
     maintainers = with maintainers; [ ciferkey ];
   };
 }

--- a/pkgs/tools/misc/tmpreaper/default.nix
+++ b/pkgs/tools/misc/tmpreaper/default.nix
@@ -1,0 +1,19 @@
+{ stdenv, fetchurl, autoconf, automake }:
+
+stdenv.mkDerivation rec {
+  pname = "tmpreaper";
+  version = "1.6.17";
+  src = fetchurl {
+    url = "https://deb.debian.org/debian/pool/main/t/tmpreaper/tmpreaper_${version}.tar.gz";
+    sha256 = "1ca94d156eb68160ec9b6ed8b97d70fbee996de21437f0cf7d0c3b46709fecbc";
+  };
+
+  meta = {
+    platforms = [ "x86_64-darwin" "aarch64-darwin" ];
+    homepage = "https://packages.debian.org/sid/tmpreaper";
+    description = "Clean up files in directories based on their age";
+    license = "GPL-2.0-only";
+  };
+
+  buildInputs = [ autoconf automake ];
+}

--- a/pkgs/tools/misc/tmpreaper/default.nix
+++ b/pkgs/tools/misc/tmpreaper/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, autoconf, automake }:
+{ stdenv, fetchurl, e2fsprogs }:
 
 stdenv.mkDerivation rec {
   pname = "tmpreaper";
@@ -8,12 +8,12 @@ stdenv.mkDerivation rec {
     sha256 = "1ca94d156eb68160ec9b6ed8b97d70fbee996de21437f0cf7d0c3b46709fecbc";
   };
 
+  buildInputs = [ e2fsprogs.dev ];
+
   meta = {
-    platforms = [ "x86_64-darwin" "aarch64-darwin" ];
+    platforms = [ "x86_64-darwin" "aarch64-darwin" "x86_64-linux" "aarch64-darwin"];
     homepage = "https://packages.debian.org/sid/tmpreaper";
     description = "Clean up files in directories based on their age";
-    license = "GPL-2.0-only";
+    license = "lib.licenses.gpl2Only";
   };
-
-  buildInputs = [ autoconf automake ];
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -12791,6 +12791,8 @@ with pkgs;
 
   tmate-ssh-server = callPackage ../servers/tmate-ssh-server { };
 
+  tmpreaper = callPackage ../tools/misc/tmpreaper { };
+
   tmpwatch = callPackage ../tools/misc/tmpwatch  { };
 
   tmpmail = callPackage ../applications/networking/tmpmail { };


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [x] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
