### PR TITLE
newcomputermodern: init at 4.4

### DIFF
--- a/pkgs/data/fonts/newcomputermodern/default.nix
+++ b/pkgs/data/fonts/newcomputermodern/default.nix
@@ -1,0 +1,28 @@
+{ lib, stdenvNoCC, fetchzip, texlive }:
+
+stdenvNoCC.mkDerivation rec {
+  pname = "newcomputermodern";
+  inherit (src) version;
+
+  src = lib.head (builtins.filter (p: p.tlType == "run") texlive.newcomputermodern.pkgs);
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/share/fonts/otf
+    mv fonts/opentype/public/newcomputermodern/*.otf $out/share/fonts/otf/
+
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "Computer Modern fonts including matching non-latin alphabets";
+    homepage = "https://ctan.org/pkg/newcomputermodern";
+    # "The GUST Font License (GFL), which is a free license, legally
+    # equivalent to the LaTeX Project Public # License (LPPL), version 1.3c or
+    # later." - GUST website
+    license = lib.licenses.lppl13c;
+    maintainers = [ lib.maintainers.drupol ];
+    platforms = lib.platforms.all;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -27958,6 +27958,8 @@ with pkgs;
     inherit (darwin.apple_sdk.frameworks) Foundation SystemConfiguration;
   };
 
+  newcomputermodern = callPackage ../data/fonts/newcomputermodern { };
+
   nordic = callPackage ../data/themes/nordic { };
 
   nordzy-cursor-theme = callPackage ../data/icons/nordzy-cursor-theme { };


### PR DESCRIPTION
`newcomputermodern` font from https://ctan.org/pkg/newcomputermodern?lang=en

Related to https://github.com/typst/typst/pull/340

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
