### PR TITLE
libowfat: 0.32 -> 0.33

### DIFF
--- a/pkgs/applications/networking/p2p/opentracker/default.nix
+++ b/pkgs/applications/networking/p2p/opentracker/default.nix
@@ -2,12 +2,12 @@
 
 stdenv.mkDerivation {
   pname = "opentracker";
-  version = "unstable-2018-05-26";
+  version = "unstable-2021-08-23";
 
   src = fetchgit {
     url = "https://erdgeist.org/gitweb/opentracker";
-    rev = "6411f1567f64248b0d145493c2e61004d2822623";
-    sha256 = "110nfb6n4clykwdzpk54iccsfjawq0krjfqhg114i1z0ri5dyl8j";
+    rev = "110868ec4ebe60521d5a4ced63feca6a1cf0aa2a";
+    sha256 = "sha256-SuElfmk7zONolTiyg0pyvbfvyJRn3r9OrXwpTzLw8LI=";
   };
 
   buildInputs = [ libowfat zlib ];

--- a/pkgs/development/libraries/libowfat/default.nix
+++ b/pkgs/development/libraries/libowfat/default.nix
@@ -2,20 +2,12 @@
 
 stdenv.mkDerivation rec {
   pname = "libowfat";
-  version = "0.32";
+  version = "0.33";
 
   src = fetchurl {
     url = "https://www.fefe.de/libowfat/${pname}-${version}.tar.xz";
-    sha256 = "1hcqg7pvy093bxx8wk7i4gvbmgnxz2grxpyy7b4mphidjbcv7fgl";
+    sha256 = "sha256-MR7Is/S3K7RC4yP7ATqY+Vb6dFVH8ryUVih7INAnzX0=";
   };
-
-  patches = [
-    (fetchurl {
-      name = "first_deferred.patch";
-      url = "https://gitweb.gentoo.org/repo/gentoo.git/plain/dev-libs/libowfat/files/libowfat-0.32-gcc10.patch?id=129f4ab9f8571c651937c46ba7bd4c82d6d052a2";
-      sha256 = "zxWb9qq5dkDucOsiPfGG1Gb4BZ6HmhBjgSe3tBnydP4=";
-    })
-  ];
 
   # Fix for glibc 2.34 from Gentoo
   # https://gitweb.gentoo.org/repo/gentoo.git/commit/?id=914a4aa87415dabfe77181a2365766417a5919a4
@@ -25,6 +17,9 @@ stdenv.mkDerivation rec {
     sed 's#__pure__$#__attrib__pure__#' -i  fmt.h scan.h byte.h stralloc.h str.h critbit.h || die
     # remove unneeded definition of __deprecated__
     sed '/^#define __deprecated__$/d' -i scan/scan_iso8601.c scan/scan_httpdate.c || die
+  '';
+  preBuild = ''
+    make headers
   '';
 
   makeFlags = [ "prefix=$(out)" ];


### PR DESCRIPTION
###### Description of changes

Security: fix buffer overread for len=0 in scan_longn (Martin Castillo)
Changelog: https://www.fefe.de/libowfat/changes-0.33.txt

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
