### PR TITLE
vscode-extensions: clean up

### DIFF
--- a/pkgs/applications/editors/vscode/extensions/default.nix
+++ b/pkgs/applications/editors/vscode/extensions/default.nix
@@ -1257,59 +1257,57 @@ let
         };
       };
 
-      github = {
-        codespaces = buildVscodeMarketplaceExtension {
-          mktplcRef = {
-            publisher = "github";
-            name = "codespaces";
-            version = "1.14.1";
-            sha256 = "sha256-oiAn/tW4jfccsY8zH6L7UzldeM7sV9tllSvgZD8c9aY=";
-          };
-          meta = { license = lib.licenses.unfree; };
+      github.codespaces = buildVscodeMarketplaceExtension {
+        mktplcRef = {
+          publisher = "github";
+          name = "codespaces";
+          version = "1.14.1";
+          sha256 = "sha256-oiAn/tW4jfccsY8zH6L7UzldeM7sV9tllSvgZD8c9aY=";
         };
+        meta = { license = lib.licenses.unfree; };
+      };
 
-        copilot = buildVscodeMarketplaceExtension {
-          mktplcRef = {
-            publisher = "github";
-            name = "copilot";
-            version = "1.78.9758";
-            sha256 = "sha256-qIaaM72SenMv+vtkTMBodD2JsroZLpw8qEttr5aIDQk=";
-          };
-          meta = {
-            description = "GitHub Copilot uses OpenAI Codex to suggest code and entire functions in real-time right from your editor.";
-            downloadPage = "https://marketplace.visualstudio.com/items?itemName=GitHub.copilot";
-            homepage = "https://github.com/features/copilot";
-            license = lib.licenses.unfree;
-            maintainers = [ lib.maintainers.Zimmi48 ];
-          };
+      github.copilot = buildVscodeMarketplaceExtension {
+        mktplcRef = {
+          publisher = "github";
+          name = "copilot";
+          version = "1.78.9758";
+          sha256 = "sha256-qIaaM72SenMv+vtkTMBodD2JsroZLpw8qEttr5aIDQk=";
         };
+        meta = {
+          description = "GitHub Copilot uses OpenAI Codex to suggest code and entire functions in real-time right from your editor.";
+          downloadPage = "https://marketplace.visualstudio.com/items?itemName=GitHub.copilot";
+          homepage = "https://github.com/features/copilot";
+          license = lib.licenses.unfree;
+          maintainers = [ lib.maintainers.Zimmi48 ];
+        };
+      };
 
-        github-vscode-theme = buildVscodeMarketplaceExtension {
-          mktplcRef = {
-            name = "github-vscode-theme";
-            publisher = "github";
-            version = "6.3.3";
-            sha256 = "sha256-fN9ljeZlbbSNW9qggLEz5HOLZlPhHmTHNi1VsZo7Uxk=";
-          };
-          meta = {
-            description = "GitHub theme for VS Code";
-            downloadPage =
-              "https://marketplace.visualstudio.com/items?itemName=GitHub.github-vscode-theme";
-            homepage = "https://github.com/primer/github-vscode-theme";
-            license = lib.licenses.mit;
-            maintainers = [ lib.maintainers.hugolgst ];
-          };
+      github.github-vscode-theme = buildVscodeMarketplaceExtension {
+        mktplcRef = {
+          name = "github-vscode-theme";
+          publisher = "github";
+          version = "6.3.3";
+          sha256 = "sha256-fN9ljeZlbbSNW9qggLEz5HOLZlPhHmTHNi1VsZo7Uxk=";
         };
+        meta = {
+          description = "GitHub theme for VS Code";
+          downloadPage =
+            "https://marketplace.visualstudio.com/items?itemName=GitHub.github-vscode-theme";
+          homepage = "https://github.com/primer/github-vscode-theme";
+          license = lib.licenses.mit;
+          maintainers = [ lib.maintainers.hugolgst ];
+        };
+      };
 
-        vscode-pull-request-github = buildVscodeMarketplaceExtension {
-          mktplcRef = {
-            name = "vscode-pull-request-github";
-            publisher = "github";
-            version = "0.61.2023032418";
-            sha256 = "sha256-pCFq0lAMH3fno4/BtHJHhS4hX1KqxsPf4wEmAm66Y8E=";
-          };
-          meta = { license = lib.licenses.mit; };
+      github.vscode-pull-request-github = buildVscodeMarketplaceExtension {
+        mktplcRef = {
+          name = "vscode-pull-request-github";
+          publisher = "github";
+          version = "0.61.2023032418";
+          sha256 = "sha256-pCFq0lAMH3fno4/BtHJHhS4hX1KqxsPf4wEmAm66Y8E=";
         };
+        meta = { license = lib.licenses.mit; };
       };
 
       gitlab.gitlab-workflow = buildVscodeMarketplaceExtension {

--- a/pkgs/applications/editors/vscode/extensions/default.nix
+++ b/pkgs/applications/editors/vscode/extensions/default.nix
@@ -2076,18 +2076,6 @@ let
 
       ms-vsliveshare.vsliveshare = callPackage ./ms-vsliveshare.vsliveshare { };
 
-      msjsdiag.debugger-for-chrome = buildVscodeMarketplaceExtension {
-        mktplcRef = {
-          name = "debugger-for-chrome";
-          publisher = "msjsdiag";
-          version = "4.12.11";
-          sha256 = "sha256-9i3TgCFThnFF5ccwzS4ATj5c2Xoe/4tDFGv75jJxeQ4=";
-        };
-        meta = {
-          license = lib.licenses.mit;
-        };
-      };
-
       mskelton.one-dark-theme = buildVscodeMarketplaceExtension {
         mktplcRef = {
           name = "one-dark-theme";

--- a/pkgs/applications/editors/vscode/extensions/default.nix
+++ b/pkgs/applications/editors/vscode/extensions/default.nix
@@ -25,11 +25,13 @@ let
   inherit (vscode-utils) buildVscodeMarketplaceExtension;
 
   #
-  # Unless there is a good reason not to, we attempt to use the same name as the
-  # extension's unique identifier (the name the extension gets when installed
-  # from vscode under `~/.vscode`) and found on the marketplace extension page.
-  # So an extension's attribute name should be of the form:
-  # "${mktplcRef.publisher}.${mktplcRef.name}".
+  # Unless there is a good reason not to, we attempt to use the lowercase
+  # version of the extension's unique identifier. The unique identifier can be
+  # found on the marketplace extension page, and is the name under which the
+  # extension is installed by VSCode under `~/.vscode`.
+  #
+  # This means an extension should be located at
+  # ${lib.strings.toLower mktplcRef.publisher}.${lib.string.toLower mktplcRef.name}
   #
   baseExtensions = self: lib.mapAttrs (_n: lib.recurseIntoAttrs)
     {
@@ -253,7 +255,7 @@ let
         };
       };
 
-      Arjun.swagger-viewer = buildVscodeMarketplaceExtension {
+      arjun.swagger-viewer = buildVscodeMarketplaceExtension {
         mktplcRef = {
           publisher = "Arjun";
           name = "swagger-viewer";
@@ -2026,7 +2028,7 @@ let
         };
       };
 
-      ms-vscode.PowerShell = buildVscodeMarketplaceExtension {
+      ms-vscode.powershell = buildVscodeMarketplaceExtension {
         mktplcRef = {
           name = "PowerShell";
           publisher = "ms-vscode";
@@ -2297,7 +2299,7 @@ let
         };
       };
 
-      rioj7.commandOnAllFiles = buildVscodeMarketplaceExtension {
+      rioj7.commandonallfiles = buildVscodeMarketplaceExtension {
         mktplcRef = {
           name = "commandOnAllFiles";
           publisher = "rioj7";
@@ -3028,7 +3030,7 @@ let
         };
       };
 
-      WakaTime.vscode-wakatime = callPackage ./WakaTime.vscode-wakatime { };
+      wakatime.vscode-wakatime = callPackage ./WakaTime.vscode-wakatime { };
 
       wholroyd.jinja = buildVscodeMarketplaceExtension {
         mktplcRef = {
@@ -3161,11 +3163,18 @@ let
     };
 
   aliases = self: super: {
-    # aliases
+    Arjun.swagger-viewer = super.arjun.swagger-viewer;
     jakebecker.elixir-ls = super.elixir-lsp.vscode-elixir-ls;
     jpoissonnier.vscode-styled-components = super.styled-components.vscode-styled-components;
     matklad.rust-analyzer = super.rust-lang.rust-analyzer; # Previous publisher
-    ms-vscode = lib.recursiveUpdate super.ms-vscode { inherit (super.golang) go; };
+    ms-vscode = lib.recursiveUpdate super.ms-vscode {
+      go = super.golang.go;
+      PowerShell = super.ms-vscode.powershell;
+    };
+    rioj7 = lib.recursiveUpdate super.rioj7 {
+      commandOnAllFiles = super.rioj7.commandonallfiles;
+    };
+    WakaTime.vscode-wakatime = super.wakatime.vscode-wakatime;
     _1Password = throw ''_1Password has been replaced with "1Password"'';
     _2gua = throw ''_2gua has been replaced with "2gua"'';
     _4ops = throw ''_4ops has been replaced with "4ops"'';

--- a/pkgs/applications/editors/vscode/extensions/default.nix
+++ b/pkgs/applications/editors/vscode/extensions/default.nix
@@ -1550,18 +1550,6 @@ let
         };
       };
 
-      jpoissonnier.vscode-styled-components = buildVscodeMarketplaceExtension {
-        mktplcRef = {
-          name = "vscode-styled-components";
-          publisher = "jpoissonnier";
-          version = "1.4.1";
-          sha256 = "sha256-ojbeuYBCS+DjF5R0aLuBImzoSOb8mXw1s0Uh0CzggzE=";
-        };
-        meta = {
-          license = lib.licenses.mit;
-        };
-      };
-
       justusadam.language-haskell = buildVscodeMarketplaceExtension {
         mktplcRef = {
           name = "language-haskell";
@@ -2616,6 +2604,22 @@ let
         };
       };
 
+      styled-components.vscode-styled-components = buildVscodeMarketplaceExtension {
+        mktplcRef = {
+          name = "vscode-styled-components";
+          publisher = "styled-components";
+          version = "1.7.6";
+          sha256 = "sha256-ZXXXFUriu//2Wmj1N+plj7xzJauGBfj+79SyrkUZAO4=";
+        };
+        meta = {
+          changelog = "https://marketplace.visualstudio.com/items/styled-components.vscode-styled-components/changelog";
+          description = "Syntax highlighting and IntelliSense for styled-components";
+          downloadPage = "https://marketplace.visualstudio.com/items?itemName=styled-components.vscode-styled-components";
+          homepage = "https://github.com/styled-components/vscode-styled-components";
+          license = lib.licenses.mit;
+        };
+      };
+
       sumneko.lua = callPackage ./sumneko.lua { };
 
       svelte.svelte-vscode = buildVscodeMarketplaceExtension {
@@ -3161,6 +3165,7 @@ let
   aliases = self: super: {
     # aliases
     jakebecker.elixir-ls = super.elixir-lsp.vscode-elixir-ls;
+    jpoissonnier.vscode-styled-components = super.styled-components.vscode-styled-components;
     ms-vscode = lib.recursiveUpdate super.ms-vscode { inherit (super.golang) go; };
     _1Password = throw ''_1Password has been replaced with "1Password"'';
     _2gua = throw ''_2gua has been replaced with "2gua"'';

--- a/pkgs/applications/editors/vscode/extensions/default.nix
+++ b/pkgs/applications/editors/vscode/extensions/default.nix
@@ -634,18 +634,6 @@ let
         };
       };
 
-      coenraads.bracket-pair-colorizer-2 = buildVscodeMarketplaceExtension {
-        mktplcRef = {
-          name = "bracket-pair-colorizer-2";
-          publisher = "CoenraadS";
-          version = "0.2.2";
-          sha256 = "0zcbs7h801agfs2cggk1cz8m8j0i2ypmgznkgw17lcx3zisll9ad";
-        };
-        meta = {
-          license = lib.licenses.mit;
-        };
-      };
-
       colejcummins.llvm-syntax-highlighting = buildVscodeMarketplaceExtension {
         mktplcRef = {
           name = "llvm-syntax-highlighting";

--- a/pkgs/applications/editors/vscode/extensions/default.nix
+++ b/pkgs/applications/editors/vscode/extensions/default.nix
@@ -1051,23 +1051,6 @@ let
         };
       };
 
-      faustinoaq.lex-flex-yacc-bison = buildVscodeMarketplaceExtension {
-        mktplcRef = {
-          name = "lex-flex-yacc-bison";
-          publisher = "faustinoaq";
-          version = "0.0.3";
-          sha256 = "6254f52157dc796eae7bf135ac88c1c9cc19d884625331a1e634f9768722cc3d";
-        };
-        meta = {
-          changelog = "https://marketplace.visualstudio.com/items/faustinoaq.lex-flex-yacc-bison/changelog";
-          description = "Language support for Lex, Flex, Yacc and Bison.";
-          downloadPage = "https://marketplace.visualstudio.com/items?itemName=faustinoaq.lex-flex-yacc-bison";
-          homepage = "https://github.com/faustinoaq/vscode-lex-flex-yacc-bison";
-          license = lib.licenses.mit;
-          maintainers = [ lib.maintainers.emilytrau ];
-        };
-      };
-
       file-icons.file-icons = buildVscodeMarketplaceExtension {
         meta = {
           changelog = "https://marketplace.visualstudio.com/items/file-icons.file-icons/changelog";

--- a/pkgs/applications/editors/vscode/extensions/default.nix
+++ b/pkgs/applications/editors/vscode/extensions/default.nix
@@ -3162,18 +3162,14 @@ let
       };
     };
 
-  aliases = self: super: {
+  aliases = super: {
     Arjun.swagger-viewer = super.arjun.swagger-viewer;
     jakebecker.elixir-ls = super.elixir-lsp.vscode-elixir-ls;
     jpoissonnier.vscode-styled-components = super.styled-components.vscode-styled-components;
     matklad.rust-analyzer = super.rust-lang.rust-analyzer; # Previous publisher
-    ms-vscode = lib.recursiveUpdate super.ms-vscode {
-      go = super.golang.go;
-      PowerShell = super.ms-vscode.powershell;
-    };
-    rioj7 = lib.recursiveUpdate super.rioj7 {
-      commandOnAllFiles = super.rioj7.commandonallfiles;
-    };
+    ms-vscode.go = super.golang.go;
+    ms-vscode.PowerShell = super.ms-vscode.powershell;
+    rioj7.commandOnAllFiles = super.rioj7.commandonallfiles;
     WakaTime.vscode-wakatime = super.wakatime.vscode-wakatime;
     _1Password = throw ''_1Password has been replaced with "1Password"'';
     _2gua = throw ''_2gua has been replaced with "2gua"'';
@@ -3184,7 +3180,9 @@ let
   # then apply extension specific modifcations to packages.
 
   # overlays will be applied left to right, overrides should come after aliases.
-  overlays = lib.optionals config.allowAliases [ aliases ];
+  overlays = lib.optionals config.allowAliases [
+    (self: super: lib.recursiveUpdate super (aliases super))
+  ];
 
   toFix = lib.foldl' (lib.flip lib.extends) baseExtensions overlays;
 in

--- a/pkgs/applications/editors/vscode/extensions/default.nix
+++ b/pkgs/applications/editors/vscode/extensions/default.nix
@@ -2486,18 +2486,6 @@ let
         };
       };
 
-      silvenon.mdx = buildVscodeMarketplaceExtension {
-        mktplcRef = {
-          name = "mdx";
-          publisher = "silvenon";
-          version = "0.1.0";
-          sha256 = "1mzsqgv0zdlj886kh1yx1zr966yc8hqwmiqrb1532xbmgyy6adz3";
-        };
-        meta = {
-          license = lib.licenses.mit;
-        };
-      };
-
       skellock.just = buildVscodeMarketplaceExtension {
         mktplcRef = {
           name = "just";

--- a/pkgs/applications/editors/vscode/extensions/default.nix
+++ b/pkgs/applications/editors/vscode/extensions/default.nix
@@ -1749,8 +1749,6 @@ let
         meta.license = lib.licenses.mit;
       };
 
-      matklad.rust-analyzer = self.rust-lang.rust-analyzer; # Previous publisher
-
       matthewpi.caddyfile-support = buildVscodeMarketplaceExtension {
         mktplcRef = {
           name = "caddyfile-support";
@@ -3166,6 +3164,7 @@ let
     # aliases
     jakebecker.elixir-ls = super.elixir-lsp.vscode-elixir-ls;
     jpoissonnier.vscode-styled-components = super.styled-components.vscode-styled-components;
+    matklad.rust-analyzer = super.rust-lang.rust-analyzer; # Previous publisher
     ms-vscode = lib.recursiveUpdate super.ms-vscode { inherit (super.golang) go; };
     _1Password = throw ''_1Password has been replaced with "1Password"'';
     _2gua = throw ''_2gua has been replaced with "2gua"'';

--- a/pkgs/applications/editors/vscode/extensions/default.nix
+++ b/pkgs/applications/editors/vscode/extensions/default.nix
@@ -451,18 +451,6 @@ let
         };
       };
 
-      bodil.file-browser = buildVscodeMarketplaceExtension {
-        mktplcRef = {
-          name = "file-browser";
-          publisher = "bodil";
-          version = "0.2.11";
-          sha256 = "sha256-yPVhhsAUZxnlhj58fXkk+yhxop2q7YJ6X4W9dXGKJfo=";
-        };
-        meta = {
-          license = lib.licenses.mit;
-        };
-      };
-
       bierner.emojisense = buildVscodeMarketplaceExtension {
         mktplcRef = {
           name = "emojisense";
@@ -536,6 +524,18 @@ let
         };
       };
 
+      bodil.file-browser = buildVscodeMarketplaceExtension {
+        mktplcRef = {
+          name = "file-browser";
+          publisher = "bodil";
+          version = "0.2.11";
+          sha256 = "sha256-yPVhhsAUZxnlhj58fXkk+yhxop2q7YJ6X4W9dXGKJfo=";
+        };
+        meta = {
+          license = lib.licenses.mit;
+        };
+      };
+
       bradlc.vscode-tailwindcss = buildVscodeMarketplaceExtension {
         mktplcRef = {
           name = "vscode-tailwindcss";
@@ -593,6 +593,23 @@ let
       };
 
       chenglou92.rescript-vscode = callPackage ./chenglou92.rescript-vscode { };
+
+      chris-hayes.chatgpt-reborn = buildVscodeMarketplaceExtension {
+        meta = {
+          changelog = "https://marketplace.visualstudio.com/items/chris-hayes.chatgpt-reborn/changelog";
+          description = "A Visual Studio Code extension to support ChatGPT, GPT-3 and Codex conversations";
+          downloadPage = "https://marketplace.visualstudio.com/items?itemName=chris-hayes.chatgpt-reborn";
+          homepage = "https://github.com/christopher-hayes/vscode-chatgpt-reborn";
+          license = lib.licenses.isc;
+          maintainers = [ lib.maintainers.drupol ];
+        };
+        mktplcRef = {
+          name = "chatgpt-reborn";
+          publisher = "chris-hayes";
+          version = "3.11.2";
+          sha256 = "sha256-YidcekYTgPYlzfmDHHAxywF+bJE8Da3pg/TCumK4Epo=";
+        };
+      };
 
       christian-kohler.path-intellisense = buildVscodeMarketplaceExtension {
         mktplcRef = {
@@ -660,23 +677,6 @@ let
         meta = {
           license = lib.licenses.mit;
           maintainers = [ lib.maintainers.kamadorueda ];
-        };
-      };
-
-      chris-hayes.chatgpt-reborn = buildVscodeMarketplaceExtension {
-        meta = {
-          changelog = "https://marketplace.visualstudio.com/items/chris-hayes.chatgpt-reborn/changelog";
-          description = "A Visual Studio Code extension to support ChatGPT, GPT-3 and Codex conversations";
-          downloadPage = "https://marketplace.visualstudio.com/items?itemName=chris-hayes.chatgpt-reborn";
-          homepage = "https://github.com/christopher-hayes/vscode-chatgpt-reborn";
-          license = lib.licenses.isc;
-          maintainers = [ lib.maintainers.drupol ];
-        };
-        mktplcRef = {
-          name = "chatgpt-reborn";
-          publisher = "chris-hayes";
-          version = "3.11.2";
-          sha256 = "sha256-YidcekYTgPYlzfmDHHAxywF+bJE8Da3pg/TCumK4Epo=";
         };
       };
 
@@ -1928,6 +1928,56 @@ let
         };
       };
 
+      ms-toolsai.jupyter = callPackage ./ms-toolsai.jupyter { };
+
+      ms-toolsai.jupyter-keymap = buildVscodeMarketplaceExtension {
+        mktplcRef = {
+          name = "jupyter-keymap";
+          publisher = "ms-toolsai";
+          version = "1.1.0";
+          sha256 = "sha256-krDtR+ZJiJf1Kxcu5mdXOaSAiJb2bXC1H0XWWviWeMQ=";
+        };
+        meta = {
+          license = lib.licenses.mit;
+        };
+      };
+
+      ms-toolsai.jupyter-renderers = buildVscodeMarketplaceExtension {
+        mktplcRef = {
+          name = "jupyter-renderers";
+          publisher = "ms-toolsai";
+          version = "1.0.15";
+          sha256 = "sha256-JR6PunvRRTsSqjSGGAn/1t1B+Ia6X0MgqahehcuSNYA=";
+        };
+        meta = {
+          license = lib.licenses.mit;
+        };
+      };
+
+      ms-toolsai.vscode-jupyter-cell-tags = buildVscodeMarketplaceExtension {
+        mktplcRef = {
+          name = "vscode-jupyter-cell-tags";
+          publisher = "ms-toolsai";
+          version = "0.1.8";
+          sha256 = "sha256-0oPyptnUWL1h/H13SdR+FdgGzVwEpTaK9SCE7BvI/5M=";
+        };
+        meta = {
+          license = lib.licenses.mit;
+        };
+      };
+
+      ms-toolsai.vscode-jupyter-slideshow = buildVscodeMarketplaceExtension {
+        mktplcRef = {
+          name = "vscode-jupyter-slideshow";
+          publisher = "ms-toolsai";
+          version = "0.1.5";
+          sha256 = "1p6r5vkzvwvxif3wxqi9599vplabzig27fzzz0bx9z0awfglzyi7";
+        };
+        meta = {
+          license = lib.licenses.mit;
+        };
+      };
+
       ms-vscode.anycode = buildVscodeMarketplaceExtension {
         mktplcRef = {
           name = "anycode";
@@ -1992,8 +2042,6 @@ let
         };
       };
 
-      ms-vscode-remote.remote-ssh = callPackage ./ms-vscode-remote.remote-ssh { };
-
       ms-vscode.theme-tomorrowkit = buildVscodeMarketplaceExtension {
         mktplcRef = {
           name = "Theme-TomorrowKit";
@@ -2010,55 +2058,7 @@ let
         };
       };
 
-      ms-toolsai.jupyter = callPackage ./ms-toolsai.jupyter { };
-
-      ms-toolsai.jupyter-keymap = buildVscodeMarketplaceExtension {
-        mktplcRef = {
-          name = "jupyter-keymap";
-          publisher = "ms-toolsai";
-          version = "1.1.0";
-          sha256 = "sha256-krDtR+ZJiJf1Kxcu5mdXOaSAiJb2bXC1H0XWWviWeMQ=";
-        };
-        meta = {
-          license = lib.licenses.mit;
-        };
-      };
-
-      ms-toolsai.jupyter-renderers = buildVscodeMarketplaceExtension {
-        mktplcRef = {
-          name = "jupyter-renderers";
-          publisher = "ms-toolsai";
-          version = "1.0.15";
-          sha256 = "sha256-JR6PunvRRTsSqjSGGAn/1t1B+Ia6X0MgqahehcuSNYA=";
-        };
-        meta = {
-          license = lib.licenses.mit;
-        };
-      };
-
-      ms-toolsai.vscode-jupyter-cell-tags = buildVscodeMarketplaceExtension {
-        mktplcRef = {
-          name = "vscode-jupyter-cell-tags";
-          publisher = "ms-toolsai";
-          version = "0.1.8";
-          sha256 = "sha256-0oPyptnUWL1h/H13SdR+FdgGzVwEpTaK9SCE7BvI/5M=";
-        };
-        meta = {
-          license = lib.licenses.mit;
-        };
-      };
-
-      ms-toolsai.vscode-jupyter-slideshow = buildVscodeMarketplaceExtension {
-        mktplcRef = {
-          name = "vscode-jupyter-slideshow";
-          publisher = "ms-toolsai";
-          version = "0.1.5";
-          sha256 = "1p6r5vkzvwvxif3wxqi9599vplabzig27fzzz0bx9z0awfglzyi7";
-        };
-        meta = {
-          license = lib.licenses.mit;
-        };
-      };
+      ms-vscode-remote.remote-ssh = callPackage ./ms-vscode-remote.remote-ssh { };
 
       ms-vsliveshare.vsliveshare = callPackage ./ms-vsliveshare.vsliveshare { };
 
@@ -2137,6 +2137,18 @@ let
         };
       };
 
+      octref.vetur = buildVscodeMarketplaceExtension {
+        mktplcRef = {
+          name = "vetur";
+          publisher = "octref";
+          version = "0.37.3";
+          sha256 = "sha256-3hi1LOZto5AYaomB9ihkAt4j/mhkCDJ8Jqa16piwHIQ=";
+        };
+        meta = {
+          license = lib.licenses.mit;
+        };
+      };
+
       oderwat.indent-rainbow = buildVscodeMarketplaceExtension {
         mktplcRef = {
           name = "indent-rainbow";
@@ -2150,18 +2162,6 @@ let
           homepage = "https://github.com/oderwat/vscode-indent-rainbow";
           license = lib.licenses.mit;
           maintainers = [ lib.maintainers.imgabe ];
-        };
-      };
-
-      octref.vetur = buildVscodeMarketplaceExtension {
-        mktplcRef = {
-          name = "vetur";
-          publisher = "octref";
-          version = "0.37.3";
-          sha256 = "sha256-3hi1LOZto5AYaomB9ihkAt4j/mhkCDJ8Jqa16piwHIQ=";
-        };
-        meta = {
-          license = lib.licenses.mit;
         };
       };
 
@@ -2263,6 +2263,16 @@ let
         };
       };
 
+      redhat.vscode-xml = buildVscodeMarketplaceExtension {
+        mktplcRef = {
+          name = "vscode-xml";
+          publisher = "redhat";
+          version = "0.25.2023032304";
+          sha256 = "sha256-3hU/MZU9dP91p2PVycFL6yg/nf4/x8tt76vmlkiHnE8=";
+        };
+        meta.license = lib.licenses.epl20;
+      };
+
       redhat.vscode-yaml = buildVscodeMarketplaceExtension {
         mktplcRef = {
           name = "vscode-yaml";
@@ -2273,16 +2283,6 @@ let
         meta = {
           license = lib.licenses.mit;
         };
-      };
-
-      redhat.vscode-xml = buildVscodeMarketplaceExtension {
-        mktplcRef = {
-          name = "vscode-xml";
-          publisher = "redhat";
-          version = "0.25.2023032304";
-          sha256 = "sha256-3hU/MZU9dP91p2PVycFL6yg/nf4/x8tt76vmlkiHnE8=";
-        };
-        meta.license = lib.licenses.epl20;
       };
 
       richie5um2.snake-trail = buildVscodeMarketplaceExtension {
@@ -2333,24 +2333,24 @@ let
         };
       };
 
-      rubymaniac.vscode-paste-and-indent = buildVscodeMarketplaceExtension {
-        mktplcRef = {
-          name = "vscode-paste-and-indent";
-          publisher = "Rubymaniac";
-          version = "0.0.8";
-          sha256 = "0fqwcvwq37ndms6vky8jjv0zliy6fpfkh8d9raq8hkinfxq6klgl";
-        };
-        meta = {
-          license = lib.licenses.mit;
-        };
-      };
-
       rubbersheep.gi = buildVscodeMarketplaceExtension {
         mktplcRef = {
           name = "gi";
           publisher = "rubbersheep";
           version = "0.2.11";
           sha256 = "0j9k6wm959sziky7fh55awspzidxrrxsdbpz1d79s5lr5r19rs6j";
+        };
+        meta = {
+          license = lib.licenses.mit;
+        };
+      };
+
+      rubymaniac.vscode-paste-and-indent = buildVscodeMarketplaceExtension {
+        mktplcRef = {
+          name = "vscode-paste-and-indent";
+          publisher = "Rubymaniac";
+          version = "0.0.8";
+          sha256 = "0fqwcvwq37ndms6vky8jjv0zliy6fpfkh8d9raq8hkinfxq6klgl";
         };
         meta = {
           license = lib.licenses.mit;

--- a/pkgs/applications/editors/vscode/extensions/default.nix
+++ b/pkgs/applications/editors/vscode/extensions/default.nix
@@ -634,23 +634,6 @@ let
         };
       };
 
-      coenraads.bracket-pair-colorizer = buildVscodeMarketplaceExtension {
-        meta = {
-          changelog = "https://marketplace.visualstudio.com/items/CoenraadS.bracket-pair-colorizer/changelog";
-          description = "A customizable extension for colorizing matching brackets";
-          downloadPage = "https://marketplace.visualstudio.com/items?itemName=CoenraadS.bracket-pair-colorizer";
-          homepage = "https://github.com/CoenraadS/BracketPair";
-          license = lib.licenses.mit;
-          maintainers = [ ];
-        };
-        mktplcRef = {
-          name = "bracket-pair-colorizer";
-          publisher = "CoenraadS";
-          version = "1.0.61";
-          sha256 = "0r3bfp8kvhf9zpbiil7acx7zain26grk133f0r0syxqgml12i652";
-        };
-      };
-
       coenraads.bracket-pair-colorizer-2 = buildVscodeMarketplaceExtension {
         mktplcRef = {
           name = "bracket-pair-colorizer-2";


### PR DESCRIPTION
###### Description of changes

A continuation of #223308

- Removes extensions that have vanished from the marketplace or been deprecated
- Renames an extension that moved
- Some more cleanup for consistency

During the creation of this PR, I noticed a few inconsistently capitalized extensions. I could attempt to fix them in this PR, a new PR, or just leave them be:
- `Arjun.swagger-viewer` (-> `arjun.swagger-viewer`)
- `ms-vscode.PowerShell` (-> `ms-vscode.powershell`)
- `rioj7.commandOnAllFiles` (-> `rioj7.commandonallfiles`)
- `WakaTime.vscode-wakatime` (-> `wakatime.vscode-wakatime`)

I also noticed that some aliases throw while others just point to the correct name. Not sure why.

I also noticed that `elixir-lsp.vscode-elixir-ls` is actually `jakebecker.elixir-ls` (which is currently an alias), not the other way around. I assume there is a good reason for this, as per the comment at the top of the file.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [X] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
