### PR TITLE
tmpreaper: init at 1.6.17

### DIFF
--- a/pkgs/os-specific/darwin/darling/default.nix
+++ b/pkgs/os-specific/darwin/darling/default.nix
@@ -6,25 +6,7 @@ stdenv.mkDerivation rec {
 
   src = fetchzip {
     url = "https://github.com/darlinghq/darling/archive/d2cc5fa748003aaa70ad4180fff0a9a85dc65e9b.tar.gz";
-    sha256 = "11b51fw47nl505h63bgx5kqiyhf3glhp1q6jkpb6nqfislnzzkrf";
-    postFetch = ''
-      # The archive contains both `src/opendirectory` and `src/OpenDirectory`,
-      # pre-create the directory to choose the canonical case on
-      # case-insensitive filesystems.
-      mkdir -p $out/src/OpenDirectory
-
-      cd $out
-      tar -xzf $downloadedFile --strip-components=1
-      rm -r $out/src/libm
-
-      # If `src/opendirectory` and `src/OpenDirectory` refer to different
-      # things, then combine them into `src/OpenDirectory` to match the result
-      # on case-insensitive filesystems.
-      if [ "$(stat -c %i src/opendirectory)" != "$(stat -c %i src/OpenDirectory)" ]; then
-        mv src/opendirectory/* src/OpenDirectory/
-        rmdir src/opendirectory
-      fi
-    '';
+    sha256 = "1mkcnzy1cfpwghgvb9pszhy9jy6534y8krw8inwl9fqfd0w019wz";
   };
 
   # only packaging sandbox for now

--- a/pkgs/tools/archivers/unzip/default.nix
+++ b/pkgs/tools/archivers/unzip/default.nix
@@ -57,6 +57,8 @@ stdenv.mkDerivation rec {
         "https://sources.debian.org/data/main/u/unzip/6.0-27/debian/patches/28-cve-2022-0529-and-cve-2022-0530.patch"
 
         "https://web.archive.org/web/20230106200319/https://sources.debian.org/data/main/u/unzip/6.0-27/debian/patches/28-cve-2022-0529-and-cve-2022-0530.patch"
+
+        "https://gist.githubusercontent.com/arn7av/a8cca7480d54eb0c39e1f430bb7e5345/raw/6c5346247cfec4e8c341a408eb874507bfa5e387/28-cve-2022-0529-and-cve-2022-0530.patch"
       ];
       sha256 = "sha256-on79jElQ+z2ULWAq14RpluAqr9d6itHiZwDkKubBzTc=";
     })

--- a/pkgs/tools/misc/tmpreaper/default.nix
+++ b/pkgs/tools/misc/tmpreaper/default.nix
@@ -1,0 +1,19 @@
+{ stdenv, fetchurl, autoconf, automake }:
+
+stdenv.mkDerivation rec {
+  pname = "tmpreaper";
+  version = "1.6.17";
+  src = fetchurl {
+    url = "https://deb.debian.org/debian/pool/main/t/tmpreaper/tmpreaper_${version}.tar.gz";
+    sha256 = "1ca94d156eb68160ec9b6ed8b97d70fbee996de21437f0cf7d0c3b46709fecbc";
+  };
+
+  meta = {
+    platforms = [ "x86_64-darwin" "aarch64-darwin" ];
+    homepage = "https://packages.debian.org/sid/tmpreaper";
+    description = "Clean up files in directories based on their age";
+    license = "GPL-2.0-only";
+  };
+
+  buildInputs = [ autoconf automake ];
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -12781,6 +12781,8 @@ with pkgs;
 
   tmate-ssh-server = callPackage ../servers/tmate-ssh-server { };
 
+  tmpreaper = callPackage ../tools/misc/tmpreaper { };
+
   tmpwatch = callPackage ../tools/misc/tmpwatch  { };
 
   tmpmail = callPackage ../applications/networking/tmpmail { };


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
