### PR TITLE
omnisharp-roslyn: use dotnet from PATH

### DIFF
--- a/pkgs/development/tools/omnisharp-roslyn/default.nix
+++ b/pkgs/development/tools/omnisharp-roslyn/default.nix
@@ -1,9 +1,7 @@
 { buildDotnetModule
 , dotnetCorePackages
 , fetchFromGitHub
-, icu
 , lib
-, patchelf
 , stdenv
 , runCommand
 , expect
@@ -25,9 +23,7 @@ let finalPackage = buildDotnetModule rec {
   projectFile = "src/OmniSharp.Stdio.Driver/OmniSharp.Stdio.Driver.csproj";
   nugetDeps = ./deps.nix;
 
-  nativeBuildInputs = [
-    patchelf
-  ];
+  useAppHost = false;
 
   dotnetInstallFlags = [ "--framework net6.0" ];
   dotnetBuildFlags = [ "--framework net6.0" "--no-self-contained" ];
@@ -53,25 +49,27 @@ let finalPackage = buildDotnetModule rec {
   '';
 
   dontDotnetFixup = true; # we'll fix it ourselves
-  postFixup = lib.optionalString stdenv.isLinux ''
-    # Emulate what .NET 7 does to its binaries while a fix doesn't land in buildDotnetModule
-    patchelf --set-interpreter $(patchelf --print-interpreter ${sdk_6_0}/dotnet) \
-      --set-rpath $(patchelf --print-rpath ${sdk_6_0}/dotnet) \
-      $out/lib/omnisharp-roslyn/OmniSharp
+  preFixup = ''
+    # We create a wrapper that will run the OmniSharp dll using the `dotnet`
+    # executable from PATH. Doing it this way allows it to run using newer SDK
+    # versions than it was build with, which allows it to properly find those SDK
+    # versions - OmniSharp only finds SDKs with the same version or newer as
+    # itself. We still provide a fallback, in case no `dotnet` is provided in
+    # PATH
+    mkdir -p "$out/bin"
 
-  '' + ''
-    # Now create a wrapper without DOTNET_ROOT
-    # we explicitly don't set DOTNET_ROOT as it should get the one from PATH
-    # as you can use any .NET SDK higher than 6 to run OmniSharp and you most
-    # likely will NOT want the .NET 6 runtime running it (as it'll use that to
-    # detect the SDKs for its own use, so it's better to let it find it in PATH).
-    makeWrapper $out/lib/omnisharp-roslyn/OmniSharp $out/bin/OmniSharp \
-      --prefix LD_LIBRARY_PATH : ${sdk_6_0.icu}/lib \
-      --set-default DOTNET_ROOT ${sdk_6_0}
+    cat << EOF > "$out/bin/OmniSharp"
+    #!${stdenv.shell}
+    export PATH="\''${PATH}:${sdk_6_0}/bin"
+    dotnet "$out/lib/omnisharp-roslyn/OmniSharp.dll" "\$@"
+    EOF
+
+    chmod +x "$out/bin/OmniSharp"
   '';
 
-  passthru.tests = {
-    no-sdk = runCommand "no-sdk" { nativeBuildInputs = [ finalPackage expect ]; meta.timeout = 60; } ''
+  passthru.tests = let
+    with-sdk = sdk: runCommand "with-${if sdk ? version then sdk.version else "no"}-sdk"
+      { nativeBuildInputs = [ finalPackage sdk expect ]; meta.timeout = 60; } ''
       HOME=$TMPDIR
       expect <<"EOF"
         spawn OmniSharp
@@ -79,24 +77,7 @@ let finalPackage = buildDotnetModule rec {
           send_error "timeout!\n"
           exit 1
         }
-        expect "\"ERROR\",\"Name\":\"OmniSharp.MSBuild.Discovery.Providers.SdkInstanceProvider\""
-        expect eof
-        catch wait result
-        if { [lindex $result 3] == 0 } {
-          exit 1
-        }
-      EOF
-      touch $out
-    '';
-
-    with-sdk = runCommand "with-sdk" { nativeBuildInputs = [ finalPackage sdk_6_0 expect ]; meta.timeout = 60; } ''
-      HOME=$TMPDIR
-      expect <<"EOF"
-        spawn OmniSharp
-        expect_before timeout {
-          send_error "timeout!\n"
-          exit 1
-        }
+        expect ".NET Core SDK ${if sdk ? version then sdk.version else sdk_6_0.version}"
         expect "{\"Event\":\"started\","
         send \x03
         expect eof
@@ -105,6 +86,11 @@ let finalPackage = buildDotnetModule rec {
       EOF
       touch $out
     '';
+  in {
+    # Make sure we can run OmniSharp with any supported SDK version, as well as without
+    with-net6-sdk = with-sdk sdk_6_0;
+    with-net7-sdk = with-sdk dotnetCorePackages.sdk_7_0;
+    no-sdk = with-sdk null;
   };
 
   meta = with lib; {


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Changes the omnisharp-roslyn wrapper script to execute OmniSharp.dll using the dotnet from PATH. This allows omnisharp-roslyn to work properly in situations where we only have a newer .NET SDK version available. Looking at https://github.com/microsoft/MSBuildLocator/blob/f1cf5647d1a13f55ff0beff455617fe75280456f/src/MSBuildLocator/DotNetSdkLocationHelper.cs#L57, we can see that OmniSharp will only find and use sdks with the same or lower version.

Currently, OmniSharp only uses at max .NET 6 and errors out if ie. only .NET 7 is available, since it's setup to run only using .NET 6 (with `patchelf`)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
