### PR TITLE
mongodb: Fix aarch64 target; 4.4.13 -> 4.4.19

### DIFF
--- a/pkgs/servers/nosql/mongodb/4.4.nix
+++ b/pkgs/servers/nosql/mongodb/4.4.nix
@@ -1,4 +1,4 @@
-{ stdenv, callPackage, lib, sasl, boost, Security, CoreFoundation, cctools }:
+{ stdenv, callPackage, lib, fetchpatch, sasl, boost, Security, CoreFoundation, cctools }:
 
 let
   buildMongoDB = callPackage ./mongodb.nix {
@@ -6,10 +6,15 @@ let
   };
 in
 buildMongoDB {
-  version = "4.4.13";
-  sha256 = "sha256-ebg3R6P+tjRvizDzsl7mZzhTfqIaRJPfHBu0IfRvtS8=";
+  version = "4.4.19";
+  sha256 = "sha256-DqkEOsTGB9gDYPxdEi9Kv3xJDz6XBe3fI59pnI1Upnk=";
   patches = [
     ./forget-build-dependencies-4-4.patch
     ./fix-build-with-boost-1.79-4_4.patch
+    (fetchpatch {
+      name = "mongodb-4.4.15-adjust-the-cache-alignment-assumptions.patch";
+      url = "https://aur.archlinux.org/cgit/aur.git/plain/mongodb-4.4.15-adjust-cache-alignment-assumptions.patch.arm64?h=mongodb44";
+      sha256 = "Ah4zdSFgXUJ/HSN8VRLJqDpNy3CjMCBnRqlpALXzx+g=";
+    })
   ] ++ lib.optionals stdenv.isDarwin [ ./asio-no-experimental-string-view-4-4.patch ];
 }

--- a/pkgs/servers/nosql/mongodb/fix-build-with-boost-1.79-4_4.patch
+++ b/pkgs/servers/nosql/mongodb/fix-build-with-boost-1.79-4_4.patch
@@ -1,4 +1,4 @@
-From 9a4c7b33e49cdf121ff9dee858539568d009fc27 Mon Sep 17 00:00:00 2001
+From f0c7e9190e9d61515ab3f95c6665754d3b972cd1 Mon Sep 17 00:00:00 2001
 From: Et7f3 <cadeaudeelie@gmail.com>
 Date: Tue, 19 Jul 2022 22:11:11 +0200
 Subject: [PATCH] build: Upgrade boost to 1.79.0
@@ -17,6 +17,8 @@ would catch this error.
 
 In upstream they fixed in a simmilar way
 https://github.com/mongodb/mongo/commit/13389dc222fc372442be8c147e09685bb9a26a3a
+
+Co-Authored-By: Adrian Pistol <vifino@tty.sh>
 ---
  src/mongo/db/storage/storage_repair_observer.cpp    | 1 +
  src/mongo/db/storage/wiredtiger/wiredtiger_util.cpp | 1 +
@@ -38,7 +40,7 @@ index 22b76a6a39c..453f48229cd 100644
  #include "mongo/db/dbhelpers.h"
  #include "mongo/db/operation_context.h"
 diff --git a/src/mongo/db/storage/wiredtiger/wiredtiger_util.cpp b/src/mongo/db/storage/wiredtiger/wiredtiger_util.cpp
-index 85121941458..7464022fb28 100644
+index ee87aca4723..bde2c1b2b83 100644
 --- a/src/mongo/db/storage/wiredtiger/wiredtiger_util.cpp
 +++ b/src/mongo/db/storage/wiredtiger/wiredtiger_util.cpp
 @@ -37,6 +37,7 @@
@@ -46,9 +48,9 @@ index 85121941458..7464022fb28 100644
  #include <boost/filesystem.hpp>
  #include <boost/filesystem/path.hpp>
 +#include <boost/filesystem/fstream.hpp>
+ #include <pcrecpp.h>
  
  #include "mongo/base/simple_string_data_comparator.h"
- #include "mongo/bson/bsonobjbuilder.h"
 diff --git a/src/mongo/shell/shell_utils_extended.cpp b/src/mongo/shell/shell_utils_extended.cpp
 index 8cd7f035f1d..cd672eb513f 100644
 --- a/src/mongo/shell/shell_utils_extended.cpp
@@ -62,7 +64,7 @@ index 8cd7f035f1d..cd672eb513f 100644
  
  #include "mongo/bson/bson_validate.h"
 diff --git a/src/mongo/util/processinfo_linux.cpp b/src/mongo/util/processinfo_linux.cpp
-index de4b84bca5a..7fa9d5d128e 100644
+index 9063f140988..d74949d45fc 100644
 --- a/src/mongo/util/processinfo_linux.cpp
 +++ b/src/mongo/util/processinfo_linux.cpp
 @@ -33,7 +33,7 @@
@@ -87,5 +89,5 @@ index 4667a261ab7..73a36015bd6 100644
  #include <cstdint>
  #include <cstdlib>
 -- 
-2.32.1 (Apple Git-133)
+2.39.2
 

--- a/pkgs/servers/nosql/mongodb/mongodb.nix
+++ b/pkgs/servers/nosql/mongodb/mongodb.nix
@@ -116,6 +116,9 @@ in stdenv.mkDerivation rec {
     #include <string>'
     substituteInPlace src/mongo/db/exec/plan_stats.h --replace '#include <string>' '#include <optional>
     #include <string>'
+  '' + lib.optionalString (versionOlder version "5.0") ''
+    # remove -march overriding, we know better.
+    sed -i 's/env.Append.*-march=.*$/pass/' SConstruct
   '' + lib.optionalString (stdenv.isDarwin && versionOlder version "6.0") ''
     substituteInPlace src/third_party/mozjs-${variants.mozjsVersion}/extract/js/src/jsmath.cpp --replace '${variants.mozjsReplace}' 0
   '' + lib.optionalString (stdenv.isDarwin && versionOlder version "3.6") ''


### PR DESCRIPTION
###### Description of changes

As of https://github.com/mongodb/mongo/commit/e500fa8527f3fb17cb4c5cb38e7cdcbd8021d207 all aarch64 builds are forced to `armv8.2-a` instead of `armv8-a`, which results in mongodb not working for earlier processors, like the one in the Raspberry Pi 4. So I patched it out.

This PR also bumps the 4.4 build to 4.4.19, which contains the problematic change.
The 4.2 build also has this change as of the latest release - so it also needs this fix or running `mongod` will get SIGILL.

Thanks to @Stary2001 for helping diagnose this issue!

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
