### PR TITLE
[Backport release-22.11] qtile: add more options to NixOS module and expose unwrapped package

### DIFF
--- a/nixos/modules/services/x11/window-managers/qtile.nix
+++ b/nixos/modules/services/x11/window-managers/qtile.nix
@@ -1,23 +1,63 @@
-{ config, lib, pkgs, ... }:
+{ config, pkgs, lib, ... }:
 
 with lib;
 
 let
   cfg = config.services.xserver.windowManager.qtile;
+  pyEnv = pkgs.python3.withPackages (p: [ (cfg.package.unwrapped or cfg.package) ] ++ (cfg.extraPackages p));
 in
 
 {
   options.services.xserver.windowManager.qtile = {
     enable = mkEnableOption (lib.mdDoc "qtile");
 
-    package = mkPackageOptionMD pkgs "qtile" { };
+    package = mkPackageOptionMD pkgs "qtile-unwrapped" { };
+
+    configFile = mkOption {
+      type = with types; nullOr path;
+      default = null;
+      example = literalExpression "./your_config.py";
+      description = lib.mdDoc ''
+          Path to the qtile configuration file.
+          If null, $XDG_CONFIG_HOME/qtile/config.py will be used.
+      '';
+    };
+
+    backend = mkOption {
+      type = types.enum [ "x11" "wayland" ];
+      default = "x11";
+      description = lib.mdDoc ''
+          Backend to use in qtile:
+          <option>x11</option> or <option>wayland</option>.
+      '';
+    };
+
+    extraPackages = mkOption {
+        type = types.functionTo (types.listOf types.package);
+        default = _: [];
+        defaultText = literalExpression ''
+          python3Packages: with python3Packages; [];
+        '';
+        description = lib.mdDoc ''
+          Extra Python packages available to Qtile.
+          An example would be to include `python3Packages.qtile-extras`
+          for additional unoffical widgets.
+        '';
+        example = literalExpression ''
+          python3Packages: with python3Packages; [
+            qtile-extras
+          ];
+        '';
+      };
   };
 
   config = mkIf cfg.enable {
     services.xserver.windowManager.session = [{
       name = "qtile";
       start = ''
-        ${cfg.package}/bin/qtile start &
+        ${pyEnv}/bin/qtile start -b ${cfg.backend} \
+        ${optionalString (cfg.configFile != null)
+        "--config \"${cfg.configFile}\""} &
         waitPID=$!
       '';
     }];

--- a/pkgs/applications/window-managers/qtile/default.nix
+++ b/pkgs/applications/window-managers/qtile/default.nix
@@ -11,6 +11,7 @@
 , wayland
 , wlroots
 , xcbutilcursor
+, pulseaudio
 }:
 
 let
@@ -60,6 +61,7 @@ let
       pywayland
       pywlroots
       xkbcommon
+      pulseaudio
     ];
 
     buildInputs = [

--- a/pkgs/applications/window-managers/qtile/default.nix
+++ b/pkgs/applications/window-managers/qtile/default.nix
@@ -14,85 +14,74 @@
 , pulseaudio
 }:
 
-let
-  unwrapped = python3Packages.buildPythonPackage rec {
-    pname = "qtile";
-    version = "0.22.1";
+python3Packages.buildPythonPackage rec {
+  pname = "qtile";
+  version = "0.22.1";
 
-    src = fetchFromGitHub {
-      owner = "qtile";
-      repo = "qtile";
-      rev = "v${version}";
-      hash = "sha256-HOyExVKOqZ4OeNM1/AiXQeiUV+EbSJLEjWEibm07ff8=";
-    };
-
-    patches = [
-      ./fix-restart.patch # https://github.com/NixOS/nixpkgs/issues/139568
-    ];
-
-    postPatch = ''
-      substituteInPlace libqtile/pangocffi.py \
-        --replace libgobject-2.0.so.0 ${glib.out}/lib/libgobject-2.0.so.0 \
-        --replace libpangocairo-1.0.so.0 ${pango.out}/lib/libpangocairo-1.0.so.0 \
-        --replace libpango-1.0.so.0 ${pango.out}/lib/libpango-1.0.so.0
-      substituteInPlace libqtile/backend/x11/xcursors.py \
-        --replace libxcb-cursor.so.0 ${xcbutilcursor.out}/lib/libxcb-cursor.so.0
-    '';
-
-    SETUPTOOLS_SCM_PRETEND_VERSION = version;
-
-    nativeBuildInputs = [
-      pkg-config
-    ] ++ (with python3Packages; [
-      setuptools-scm
-    ]);
-
-    propagatedBuildInputs = with python3Packages; [
-      xcffib
-      (cairocffi.override { withXcffib = true; })
-      setuptools
-      python-dateutil
-      dbus-python
-      dbus-next
-      mpd2
-      psutil
-      pyxdg
-      pygobject3
-      pywayland
-      pywlroots
-      xkbcommon
-      pulseaudio
-    ];
-
-    buildInputs = [
-      libinput
-      wayland
-      wlroots
-      libxkbcommon
-    ];
-
-    # for `qtile check`, needs `stubtest` and `mypy` commands
-    makeWrapperArgs = [
-      "--suffix PATH : ${lib.makeBinPath [ mypy ]}"
-    ];
-
-    doCheck = false; # Requires X server #TODO this can be worked out with the existing NixOS testing infrastructure.
-
-    meta = with lib; {
-      homepage = "http://www.qtile.org/";
-      license = licenses.mit;
-      description = "A small, flexible, scriptable tiling window manager written in Python";
-      platforms = platforms.linux;
-      maintainers = with maintainers; [ kamilchm arjan-s ];
-    };
+  src = fetchFromGitHub {
+    owner = "qtile";
+    repo = "qtile";
+    rev = "v${version}";
+    hash = "sha256-HOyExVKOqZ4OeNM1/AiXQeiUV+EbSJLEjWEibm07ff8=";
   };
-in
-(python3.withPackages (_: [ unwrapped ])).overrideAttrs (_: {
-  # otherwise will be exported as "env", this restores `nix search` behavior
-  name = "${unwrapped.pname}-${unwrapped.version}";
-  # export underlying qtile package
-  passthru = { inherit unwrapped; };
 
-  # restore original qtile attrs
-  inherit (unwrapped) pname version meta;
-})
+  patches = [
+    ./fix-restart.patch # https://github.com/NixOS/nixpkgs/issues/139568
+  ];
+
+  postPatch = ''
+    substituteInPlace libqtile/pangocffi.py \
+      --replace libgobject-2.0.so.0 ${glib.out}/lib/libgobject-2.0.so.0 \
+      --replace libpangocairo-1.0.so.0 ${pango.out}/lib/libpangocairo-1.0.so.0 \
+      --replace libpango-1.0.so.0 ${pango.out}/lib/libpango-1.0.so.0
+    substituteInPlace libqtile/backend/x11/xcursors.py \
+      --replace libxcb-cursor.so.0 ${xcbutilcursor.out}/lib/libxcb-cursor.so.0
+  '';
+
+  SETUPTOOLS_SCM_PRETEND_VERSION = version;
+
+  nativeBuildInputs = [
+    pkg-config
+  ] ++ (with python3Packages; [
+    setuptools-scm
+  ]);
+
+  propagatedBuildInputs = with python3Packages; [
+    xcffib
+    (cairocffi.override { withXcffib = true; })
+    setuptools
+    python-dateutil
+    dbus-python
+    dbus-next
+    mpd2
+    psutil
+    pyxdg
+    pygobject3
+    pywayland
+    pywlroots
+    xkbcommon
+    pulseaudio
+  ];
+
+  buildInputs = [
+    libinput
+    wayland
+    wlroots
+    libxkbcommon
+  ];
+
+  # for `qtile check`, needs `stubtest` and `mypy` commands
+  makeWrapperArgs = [
+    "--suffix PATH : ${lib.makeBinPath [ mypy ]}"
+  ];
+
+  doCheck = false; # Requires X server #TODO this can be worked out with the existing NixOS testing infrastructure.
+
+  meta = with lib; {
+    homepage = "http://www.qtile.org/";
+    license = licenses.mit;
+    description = "A small, flexible, scriptable tiling window manager written in Python";
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ kamilchm arjan-s ];
+  };
+}

--- a/pkgs/applications/window-managers/qtile/default.nix
+++ b/pkgs/applications/window-managers/qtile/default.nix
@@ -83,7 +83,7 @@ let
       license = licenses.mit;
       description = "A small, flexible, scriptable tiling window manager written in Python";
       platforms = platforms.linux;
-      maintainers = with maintainers; [ kamilchm ];
+      maintainers = with maintainers; [ kamilchm arjan-s ];
     };
   };
 in

--- a/pkgs/applications/window-managers/qtile/wrapper.nix
+++ b/pkgs/applications/window-managers/qtile/wrapper.nix
@@ -1,0 +1,9 @@
+{ python3, qtile-unwrapped }:
+(python3.withPackages (_: [ qtile-unwrapped ])).overrideAttrs (_: {
+  # otherwise will be exported as "env", this restores `nix search` behavior
+  name = "${qtile-unwrapped.pname}-${qtile-unwrapped.version}";
+  # export underlying qtile package
+  passthru = { unwrapped = qtile-unwrapped; };
+  # restore original qtile attrs
+  inherit (qtile-unwrapped) pname version meta;
+})

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -32765,7 +32765,8 @@ with pkgs;
 
   qpdfview = libsForQt5.callPackage ../applications/misc/qpdfview {};
 
-  qtile = callPackage ../applications/window-managers/qtile { };
+  qtile-unwrapped = callPackage ../applications/window-managers/qtile { };
+  qtile = callPackage ../applications/window-managers/qtile/wrapper.nix { };
 
   vimgolf = callPackage ../games/vimgolf { };
 


### PR DESCRIPTION
###### Description of changes

Manual backport of #220450 to `release-22.11`, as requested in https://github.com/NixOS/nixpkgs/pull/220450#issuecomment-1485005891

Qtile version was not bumped and the change should be backwards compatible for any existing uses of `pkgs.qtile`, `pkgs.qtile.unwrapped`, and the `services.xserver.windowManager.qtile` NixOS options

cc: @arjan-s 

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).