### PR TITLE
intel-mpi: init at 2021.8.0

### DIFF
--- a/doc/using/overlays.chapter.md
+++ b/doc/using/overlays.chapter.md
@@ -147,7 +147,7 @@ stdenv.mkDerivation {
 
 ### Switching the MPI implementation {#sec-overlays-alternatives-mpi}
 
-All programs that are built with [MPI](https://en.wikipedia.org/wiki/Message_Passing_Interface) support use the generic attribute `mpi` as an input. At the moment Nixpkgs natively provides two different MPI implementations:
+All programs that are built with [MPI](https://en.wikipedia.org/wiki/Message_Passing_Interface) support use the generic attribute `mpi` as an input. Nixpkgs natively provides different MPI implementations:
 
 -   [Open MPI](https://www.open-mpi.org/) (default), attribute name
     `openmpi`
@@ -155,6 +155,8 @@ All programs that are built with [MPI](https://en.wikipedia.org/wiki/Message_Pas
 -   [MPICH](https://www.mpich.org/), attribute name `mpich`
 
 -   [MVAPICH](https://mvapich.cse.ohio-state.edu/), attribute name `mvapich`
+
+-   [Intel MPI](https://www.intel.com/content/www/us/en/developer/tools/oneapi/mpi-library.html), attribute name `intel-mpi`
 
 To provide MPI enabled applications that use `MPICH`, instead of the default `Open MPI`, simply use the following overlay:
 

--- a/pkgs/development/libraries/intel-mpi/default.nix
+++ b/pkgs/development/libraries/intel-mpi/default.nix
@@ -1,0 +1,81 @@
+{ lib
+, stdenvNoCC
+, callPackage
+, fetchurl
+, rpmextract
+}:
+let
+  version = "2021.8.0";
+  rel = "25329";
+  oneapi-mpi = fetchurl {
+    url = "https://yum.repos.intel.com/oneapi/intel-oneapi-mpi-${version}-${version}-${rel}.x86_64.rpm";
+    sha256 = "sha256-6RPaGXKPa3InyFar4dypV0lhkpzL/2NDXyXeGFkNQvE=";
+  };
+  oneapi-mpi-devel = fetchurl {
+    url = "https://yum.repos.intel.com/oneapi/intel-oneapi-mpi-devel-${version}-${version}-${rel}.x86_64.rpm";
+    sha256 = "sha256-e4Kx1EUzZ5B9tac/TWzJf0qUA++TpdntM+H/4UAL4VQ=";
+  };
+in
+stdenvNoCC.mkDerivation {
+  pname = "intel-mpi";
+  inherit version;
+  dontUnpack = true;  # unpack using rpmextract
+  # do not modify the binary per license agreement
+  dontStrip = true;
+  dontPatchELF = true;
+
+  nativeBuildInputs = [ rpmextract ];
+
+  buildPhase = ''
+    rpmextract ${oneapi-mpi}
+    rpmextract ${oneapi-mpi-devel}
+  '';
+
+  installPhase = ''
+    # hardcode MPI root paths for any scripts (non-binary-files found via grep)
+    for f in $(find opt/intel/oneapi/mpi/${version}/bin -type f -exec grep -Il . "{}" \; ) ; do
+      substituteInPlace $f \
+        --replace $\{I_MPI_ROOT} "$out" \
+        --replace '$I_MPI_ROOT' "$out"
+    done
+
+    # License
+    install -Dm0655 -t $out/share/doc/mpi opt/intel/oneapi/mpi/${version}/licensing/*.txt
+
+    # Binaries
+    # mkdir -p $out/bin
+    cp -r opt/intel/oneapi/mpi/${version}/bin $out
+    rm $out/bin/impi_info
+
+    # Libraries (dynamic + static)
+    # mkdir -p $out/lib
+    cp -a opt/intel/oneapi/mpi/${version}/lib $out/
+
+    # Headers
+    cp -r opt/intel/oneapi/mpi/${version}/include $out/
+
+    # CMake Config: none found?
+
+    # TODO: include man files?
+    # echo "TODO: finish implementation" && exit 1
+  '';
+
+  passthru.tests = {
+    pkg-config = callPackage ./test.nix {intel-mpi-devel-src = oneapi-mpi-devel;};
+  };
+
+  meta = with lib; {
+    description = "Intel OneAPI Message Passing Interface (MPI) Library";
+    longDescription = ''
+      Intel® MPI Library is a multifabric message-passing library that implements
+      the open source MPICH specification. Use the library to create, maintain,
+      and test advanced, complex applications that perform better on HPC clusters
+      based on Intel® and compatible processors.
+    '';
+    homepage = "https://www.intel.com/content/www/us/en/developer/tools/oneapi/mpi-library.html";
+    sourceProvenance = with sourceTypes; [ binaryNativeCode ];
+    license = licenses.issl;
+    platforms = [ "x86_64-linux" ];
+    maintainers = with maintainers; [ drewrisinger ];
+  };
+}

--- a/pkgs/development/libraries/intel-mpi/test.nix
+++ b/pkgs/development/libraries/intel-mpi/test.nix
@@ -1,0 +1,45 @@
+{ stdenv
+, intel-mpi
+, pkg-config
+, intel-mpi-devel-src
+, rpmextract
+}:
+stdenv.mkDerivation rec {
+  pname = "intel-mpi-test";
+  version = intel-mpi.version;
+
+  nativeBuildInputs = [ rpmextract pkg-config ];
+  buildInputs = [ intel-mpi ];
+  dontUnpack = true;
+
+  env.test_exts = toString ["c" "cpp"];
+
+  buildPhase = ''
+    rpmextract ${intel-mpi-devel-src}
+    cd opt/intel/oneapi/mpi/${version}/test
+
+    # note that -lstdc++ is required for some reason, not sure why it's not auto-populated?
+
+    # regular Nix build
+    for ext in ''${test_exts[@]}; do
+      gcc test.''${ext} -o test_''${ext}.exe $(pkg-config --cflags --libs impi) -lstdc++
+    done
+
+    # Clear Nix flags to only use pkg-config options
+    for ext in ''${test_exts[@]}; do
+      NIX_CFLAGS_COMPILE="" NIX_LDFLAGS="" gcc test.''${ext} -o test_''${ext}.exe $(pkg-config --cflags --libs impi) -lstdc++
+    done
+  '';
+
+  # requires some output to be a successful derivation
+  installPhase = ''
+    echo "Success" > $out
+  '';
+
+  # TODO: tests require mpiexec.hydra to be running?
+  # checkPhase = ''
+  #   for ext in ''${test_exts[@]}; do
+  #     mpiexec -n 1 -ppn 1 ./test_''${ext}.exe
+  #   done
+  # '';
+}

--- a/pkgs/development/libraries/science/math/mkl/default.nix
+++ b/pkgs/development/libraries/science/math/mkl/default.nix
@@ -142,10 +142,15 @@ in stdenvNoCC.mkDerivation ({
 
     # CMake config
     cp -r opt/intel/oneapi/mkl/${mklVersion}/lib/cmake $out/lib
+
+    # pkgconfig
+    # sdl: library for choosing mkl threading library at runtime
+    install -Dm0644 -t $out/lib/pkgconfig opt/intel/oneapi/mkl/${mklVersion}/lib/pkgconfig/mkl-sdl.pc
+    install -Dm0644 -t $out/lib/pkgconfig opt/intel/oneapi/compiler/${openmpVersion}/lib/pkgconfig/openmp.pc
   '' +
     (if enableStatic then ''
       install -Dm0644 -t $out/lib opt/intel/oneapi/mkl/${mklVersion}/lib/intel64/*.a
-      install -Dm0644 -t $out/lib/pkgconfig opt/intel/oneapi/mkl/${mklVersion}/tools/pkgconfig/*.pc
+      install -Dm0644 -t $out/lib/pkgconfig opt/intel/oneapi/mkl/${mklVersion}/lib/pkgconfig/*static*.pc
     '' else ''
       cp opt/intel/oneapi/mkl/${mklVersion}/lib/intel64/*.so* $out/lib
       install -Dm0644 -t $out/lib/pkgconfig opt/intel/oneapi/mkl/${mklVersion}/lib/pkgconfig/*dynamic*.pc

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -20795,6 +20795,8 @@ with pkgs;
 
   intel-media-driver = callPackage ../development/libraries/intel-media-driver { };
 
+  intel-mpi = callPackage ../development/libraries/intel-mpi { };
+
   intltool = callPackage ../development/tools/misc/intltool { };
 
   ios-cross-compile = callPackage ../development/compilers/ios-cross-compile/9.2.nix { };


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
* Init intel-mpi library at version 2021.8.0
* Add documentation references to intel-mpi as an MPI provider.
* Fix ``mkl`` build using ``enableStatic`` flag.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
