### PR TITLE
raycast: init at 1.48.9

### DIFF
--- a/pkgs/os-specific/darwin/raycast/default.nix
+++ b/pkgs/os-specific/darwin/raycast/default.nix
@@ -6,7 +6,7 @@
 
 stdenvNoCC.mkDerivation rec {
   pname = "raycast";
-  version = "1.48.9";
+  version = "1.49.0";
 
   src = fetchurl {
     # https://github.com/NixOS/nixpkgs/pull/223495
@@ -17,7 +17,7 @@ stdenvNoCC.mkDerivation rec {
     # to host GitHub Actions to periodically check for updates
     # and re-release the `.dmg` file to Internet Archive (https://archive.org/details/raycast)
     url = "https://archive.org/download/raycast/raycast-${version}.dmg";
-    sha256 = "sha256-PSK/PLIOLUrqHAvEfOVMuGojLjwrCR4Vm9okE9d/5dE=";
+    sha256 = "sha256-6j5PyzJ7g3p+5gE2CQHlZrLj5b3rLdpodl+By7xxcjo=";
   };
 
   dontPatch = true;

--- a/pkgs/os-specific/darwin/raycast/default.nix
+++ b/pkgs/os-specific/darwin/raycast/default.nix
@@ -1,0 +1,49 @@
+{ lib
+, stdenvNoCC
+, fetchurl
+, undmg
+}:
+
+stdenvNoCC.mkDerivation rec {
+  pname = "raycast";
+  version = "1.48.9";
+
+  src = fetchurl {
+    # https://github.com/NixOS/nixpkgs/pull/223495
+    # official download API: https://api.raycast.app/v2/download
+    # this returns an AWS CloudFront signed URL with expiration timestamp and signature
+    # the returned URL will always be the latest Raycast which might result in an impure derivation
+    # the package maintainer created a repo (https://github.com/stepbrobd/raycast-overlay)
+    # to host GitHub Actions to periodically check for updates
+    # and re-release the `.dmg` file to Internet Archive (https://archive.org/details/raycast)
+    url = "https://archive.org/download/raycast/raycast-${version}.dmg";
+    sha256 = "sha256-PSK/PLIOLUrqHAvEfOVMuGojLjwrCR4Vm9okE9d/5dE=";
+  };
+
+  dontPatch = true;
+  dontConfigure = true;
+  dontBuild = true;
+  dontFixup = true;
+
+  nativeBuildInputs = [ undmg ];
+
+  sourceRoot = "Raycast.app";
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/Applications/Raycast.app
+    cp -R . $out/Applications/Raycast.app
+
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    description = "Control your tools with a few keystrokes";
+    homepage = "https://raycast.app/";
+    license = licenses.unfree;
+    sourceProvenance = with sourceTypes; [ binaryNativeCode ];
+    maintainers = with maintainers; [ lovesegfault stepbrobd ];
+    platforms = platforms.darwin;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -36080,6 +36080,8 @@ with pkgs;
 
   raylib-games = callPackage ../games/raylib-games { };
 
+  raycast = callPackage ../os-specific/darwin/raycast { };
+
   redeclipse = callPackage ../games/redeclipse { };
 
   rftg = callPackage ../games/rftg { };


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Added [Raycast](https://www.raycast.com/) to nixpkgs.

I tried using the official download link (https://api.raycast.app/v2/download), but it returns a AWS CloudFront signed URL with a expiration timestamp and signature [^url].

[^url]:  https://d3jdrrl94b667u.cloudfront.net/Raycast_v1.48.9_9175190e05d819bce9b0a750813cb92014dba689_universal.dmg?response-content-disposition=attachment%3B%20filename%3DRaycast.dmg&Expires=1679977644&Signature=PMNYoqtn8RLcFVhGapgZiHTFT5Hn6tyipJwp5yXFqklbler~wdlKKnf4QIq3RBztwvPsjUI88g3HNaDXfd6vm1oyPXlVMoLq8DjDSC-4qXFpZ52y5nKqrkkZg6b5pJSQ1-WKmBq8108WT46LjIbWUjU3SeM-xCIE41elQKhySTaqE7RNslIH3RTWW2Hx9XznnPvifXvJUR9A~vJG-aYvtm3q3Ri3Mi4axUEJCm4lrDkS1Cu3jrPGdMA3aQKW2uXsJrSR~lwGp90j7xebYz9mddOoU8XJPPvJxEqm0ZnY3uay7PR3A~Vf8W3NTj68BQOBZmu0IlwEsXXAa8foIqm4Zw__&Key-Pair-Id=K69CUC23G592W)

I double checked with support community and Raycast staff member confirmed there is currently no way getting a permalink for a specific version of Raycast. To fix this, I created a [repo](https://github.com/StepBroBD/Raycast-Overlay) with GitHub Action to periodically check and grab the `.dmg` file from it's download API and release the `.dmg` file with GitHub Releases. As seen in the package source:
```nix
src = fetchurl {
    url = "https://github.com/stepbrobd/raycast-overlay/releases/download/${version}/Raycast.dmg";
    sha256 = "sha256-PSK/PLIOLUrqHAvEfOVMuGojLjwrCR4Vm9okE9d/5dE=";
};
```

I'll change the link to official permalink if Raycast decided to release one.

Please refer to [readme](https://github.com/StepBroBD/Raycast-Overlay) for more details.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
