### PR TITLE
pigz: 2.6 -> 2.7

### DIFF
--- a/pkgs/tools/compression/pigz/default.nix
+++ b/pkgs/tools/compression/pigz/default.nix
@@ -1,15 +1,23 @@
-{ lib, stdenv, fetchFromGitHub, zlib, util-linux }:
+{ lib, stdenv, fetchFromGitHub, fetchpatch, zlib, util-linux }:
 
 stdenv.mkDerivation rec {
   pname = "pigz";
-  version = "2.6";
+  version = "2.7";
 
   src = fetchFromGitHub {
       owner = "madler";
       repo = "${pname}";
       rev = "refs/tags/v${version}";
-      sha256 = "146qkmzi199xwmmf6bllanqfyl702fm1rnad8cd5r5yyrp5ks115";
+      sha256 = "sha256-RYp3vRwlI6S/lcib+3t7qLYFWv11GUnj1Cmxm9eaVro=";
   };
+
+  patches = [
+    # needed to build the pigzn test binary
+    (fetchpatch {
+      url = "https://github.com/madler/pigz/commit/67fd6e436f4f479aead529a719e24d6864cf1dfa.patch";
+      sha256 = "sha256-FkzLYob/WIVIB7eh03cdzpLy6SzoHLqEMsWyHdMTjbU=";
+    })
+  ];
 
   enableParallelBuilding = true;
 

--- a/pkgs/tools/compression/pigz/default.nix
+++ b/pkgs/tools/compression/pigz/default.nix
@@ -6,7 +6,7 @@ stdenv.mkDerivation rec {
 
   src = fetchFromGitHub {
       owner = "madler";
-      repo = "${pname}";
+      repo = pname;
       rev = "refs/tags/v${version}";
       sha256 = "sha256-RYp3vRwlI6S/lcib+3t7qLYFWv11GUnj1Cmxm9eaVro=";
   };


### PR DESCRIPTION
###### Description of changes

Update pigz to the latest version: 2.7

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

