### PR TITLE
ocamlPackages.git: 3.12.0 -> 3.13.0

### DIFF
--- a/pkgs/development/ocaml-modules/awa/default.nix
+++ b/pkgs/development/ocaml-modules/awa/default.nix
@@ -8,14 +8,14 @@
 
 buildDunePackage rec {
   pname = "awa";
-  version = "0.1.2";
+  version = "0.2.0";
 
   minimalOCamlVersion = "4.08";
   duneVersion = "3";
 
   src = fetchurl {
     url = "https://github.com/mirage/awa-ssh/releases/download/v${version}/awa-${version}.tbz";
-    hash = "sha256-HfIqvmvmdizPSfSHthj2syszVZXVhju7tI8yNEetc38=";
+    hash = "sha256-hsmTuoubBdsEyGe8zmfG7JihY0LFM4lErpPKUVobIX8=";
   };
 
   propagatedBuildInputs = [

--- a/pkgs/development/ocaml-modules/git/default.nix
+++ b/pkgs/development/ocaml-modules/git/default.nix
@@ -8,14 +8,14 @@
 
 buildDunePackage rec {
   pname = "git";
-  version = "3.12.0";
+  version = "3.13.0";
 
   minimalOCamlVersion = "4.08";
   duneVersion = "3";
 
   src = fetchurl {
     url = "https://github.com/mirage/ocaml-git/releases/download/${version}/git-${version}.tbz";
-    hash = "sha256-qgd5fny23J6pcOdgwB3Yt1UxJii2XE25OjcSVFdLMKA=";
+    hash = "sha256-98w2Amze/B+YN/ENfSb0V8I2yyFUf8rSEOcUg1YbVdM=";
   };
 
   # remove changelog for the carton package

--- a/pkgs/development/ocaml-modules/git/unix.nix
+++ b/pkgs/development/ocaml-modules/git/unix.nix
@@ -14,13 +14,6 @@ buildDunePackage {
   pname = "git-unix";
   inherit (git) version src;
 
-  patches = [
-    (fetchpatch {
-      url = "https://github.com/mirage/ocaml-git/commit/b708db8319cc456a5640618210d740a1e00468e9.patch";
-      hash = "sha256-Fe+eDhU/beZT/8br8XmOhHYJowaVEha16eGqyuu2Zr4=";
-    })
-  ];
-
   minimalOCamlVersion = "4.08";
   duneVersion = "3";
 


### PR DESCRIPTION
###### Description of changes

https://github.com/ocaml/opam-repository/pull/23571

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
