### PR TITLE
logseq: 0.8.18 -> 0.9.0

### DIFF
--- a/pkgs/applications/misc/logseq/default.nix
+++ b/pkgs/applications/misc/logseq/default.nix
@@ -5,15 +5,16 @@
 , makeWrapper
 , electron
 , git
+, nix-update-script
 }:
 
 stdenv.mkDerivation rec {
   pname = "logseq";
-  version = "0.8.18";
+  version = "0.9.0";
 
   src = fetchurl {
     url = "https://github.com/logseq/logseq/releases/download/${version}/logseq-linux-x64-${version}.AppImage";
-    hash = "sha256-tD7uNSgcGMPyiA/HfOOZs3NRbWTrds0AdEXTaHYfUjk=";
+    hash = "sha256-5oX1LhqWvNiMF9ZI7BvpHe4bhB3vQp6dsjLYMQ9Jy+o=";
     name = "${pname}-${version}.AppImage";
   };
 
@@ -54,7 +55,7 @@ stdenv.mkDerivation rec {
       --add-flags $out/share/${pname}/resources/app
   '';
 
-  passthru.updateScript = ./update.sh;
+  passthru.updateScript = nix-update-script { };
 
   meta = with lib; {
     description = "A local-first, non-linear, outliner notebook for organizing and sharing your personal knowledge base";

--- a/pkgs/applications/misc/logseq/update.sh
+++ b/pkgs/applications/misc/logseq/update.sh
@@ -1,5 +1,0 @@
-#!/usr/bin/env nix-shell
-#!nix-shell -i bash -p curl jq common-updater-scripts
-
-version="$(curl -sL "https://api.github.com/repos/logseq/logseq/releases" | jq 'map(select(.prerelease == false)) | .[0].tag_name' --raw-output)"
-update-source-version logseq "$version"


### PR DESCRIPTION
###### Description of changes
https://github.com/logseq/logseq/releases/tag/0.9.0

Utilize nix-update-script in lieu of a custom update script, as it provides equivalent functionality.

###### Things done
- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).