### PR TITLE
Remove self from maintainer-list.nix

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -13792,12 +13792,6 @@
     github = "ShamrockLee";
     githubId = 44064051;
   };
-  shanemikel = {
-    email = "shanepearlman@pm.me";
-    github = "shanemikel";
-    githubId = 6720672;
-    name = "Shane Pearlman";
-  };
   shanesveller = {
     email = "shane@sveller.dev";
     github = "shanesveller";

--- a/pkgs/tools/typesetting/htmldoc/default.nix
+++ b/pkgs/tools/typesetting/htmldoc/default.nix
@@ -30,7 +30,7 @@ stdenv.mkDerivation rec {
     homepage    = "https://michaelrsweet.github.io/htmldoc";
     changelog   = "https://github.com/michaelrsweet/htmldoc/releases/tag/v${version}";
     license     = licenses.gpl2Only;
-    maintainers = with maintainers; [ shanemikel ];
+    maintainers = with maintainers; [ ];
     platforms   = platforms.unix;
 
     longDescription = ''


### PR DESCRIPTION
It has been a while!  I'm sorry to say I do not expect to contribute in the immediate future, as I have not used Nix for several years.

I don't believe I have my name on any packages any longer.  I had contributed updates to one package: htmldoc, which has been adopted by `michaelrsweet`.  I was also the original author of the script in `maintainers/scripts/nix-diff.sh`, but it doesn't have an official owner.

Is there anything else I can fix other than removing my name from the list?