### PR TITLE
NixOS/opengl: Use the default Mesa package by default.

### DIFF
--- a/nixos/modules/hardware/opengl.nix
+++ b/nixos/modules/hardware/opengl.nix
@@ -90,8 +90,8 @@ in
 
       mesaPackage = mkOption {
         type = types.package;
-        default = pkgs.mesa_23;
-        defaultText = literalExpression "pkgs.mesa_23";
+        default = pkgs.mesa;
+        defaultText = literalExpression "pkgs.mesa";
         example = literalExpression "pkgs.mesa_22";
         description = lib.mdDoc ''
           The Mesa driver package used for rendering support on the system.
@@ -103,8 +103,8 @@ in
       };
       mesaPackage32 = mkOption {
         type = types.package;
-        default = pkgs.pkgsi686Linux.mesa_23;
-        defaultText = literalExpression "pkgs.pkgsi686Linux.mesa_23";
+        default = pkgs.pkgsi686Linux.mesa;
+        defaultText = literalExpression "pkgs.pkgsi686Linux.mesa";
         example = literalExpression "pkgs.pkgsi686Linux.mesa_22";
         description = lib.mdDoc ''
           Same as {option}`mesaPackage` but for the 32-bit Mesa on 64-bit


### PR DESCRIPTION
###### Description of changes

Currently, the NixOS opengl module default to mesa_23, while nixpkgs' mesa package still points to mesa_22. This causes several issues (see below).
I think it's more sane to default to nixpkgs' default package in this module.

Fixes #223458
Fixes #223331
Fixes  #223535

Ping @K900 @Atemu @vcunat 

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
