### PR TITLE
ocamlPackages.cstruct: 6.1.1 → 6.2.0

### DIFF
--- a/pkgs/development/ocaml-modules/asn1-combinators/default.nix
+++ b/pkgs/development/ocaml-modules/asn1-combinators/default.nix
@@ -4,6 +4,7 @@
 
 buildDunePackage rec {
   minimalOCamlVersion = "4.08";
+  duneVersion = "3";
 
   pname = "asn1-combinators";
   version = "0.2.6";

--- a/pkgs/development/ocaml-modules/callipyge/default.nix
+++ b/pkgs/development/ocaml-modules/callipyge/default.nix
@@ -1,8 +1,6 @@
 { lib
 , buildDunePackage
 , fetchurl
-, ocaml
-
 , alcotest
 , eqaf
 , fmt
@@ -14,17 +12,16 @@ buildDunePackage rec {
 
   src = fetchurl {
     url = "https://github.com/oklm-wsh/Callipyge/releases/download/v${version}/${pname}-${version}.tbz";
-    sha256 = "sha256-T/94a88xvK51TggjXecdKc9kyTE9aIyueIt5T24sZB0=";
+    hash = "sha256-T/94a88xvK51TggjXecdKc9kyTE9aIyueIt5T24sZB0=";
   };
 
-  useDune2 = true;
+  duneVersion = "3";
 
-  minimumOCamlVersion = "4.03";
+  minimalOCamlVersion = "4.08";
 
   propagatedBuildInputs = [ fmt eqaf ];
 
-  # alcotest isn't available for OCaml < 4.08 due to fmt
-  doCheck = lib.versionAtLeast ocaml.version "4.08";
+  doCheck = true;
   checkInputs = [ alcotest ];
 
   meta = {

--- a/pkgs/development/ocaml-modules/cstruct/async.nix
+++ b/pkgs/development/ocaml-modules/cstruct/async.nix
@@ -4,6 +4,8 @@ buildDunePackage rec {
   pname = "cstruct-async";
   inherit (cstruct) src version meta;
 
+  duneVersion = "3";
+
   propagatedBuildInputs = [
     async_unix
     async

--- a/pkgs/development/ocaml-modules/cstruct/default.nix
+++ b/pkgs/development/ocaml-modules/cstruct/default.nix
@@ -2,13 +2,14 @@
 
 buildDunePackage rec {
   pname = "cstruct";
-  version = "6.1.1";
+  version = "6.2.0";
 
   minimalOCamlVersion = "4.08";
+  duneVersion = "3";
 
   src = fetchurl {
     url = "https://github.com/mirage/ocaml-cstruct/releases/download/v${version}/cstruct-${version}.tbz";
-    sha256 = "sha256-G3T5hw9qfuYAiSRZBxbdUzpyijyhC7GNqf6ovkZ/UY0=";
+    hash = "sha256-mngHM5JYDoNJFI+jq0sbLpidydMNB0AbBMlrfGDwPmI=";
   };
 
   buildInputs = [ fmt ];

--- a/pkgs/development/ocaml-modules/cstruct/lwt.nix
+++ b/pkgs/development/ocaml-modules/cstruct/lwt.nix
@@ -9,6 +9,7 @@ else
     inherit (cstruct) version src meta;
 
     minimalOCamlVersion = "4.08";
+    duneVersion = "3";
 
     propagatedBuildInputs = [ cstruct lwt ];
   }

--- a/pkgs/development/ocaml-modules/cstruct/ppx.nix
+++ b/pkgs/development/ocaml-modules/cstruct/ppx.nix
@@ -11,6 +11,7 @@ else
     inherit (cstruct) version src meta;
 
     minimalOCamlVersion = "4.08";
+    duneVersion = "3";
 
     propagatedBuildInputs = [ cstruct ppxlib sexplib stdlib-shims ];
 

--- a/pkgs/development/ocaml-modules/cstruct/sexp.nix
+++ b/pkgs/development/ocaml-modules/cstruct/sexp.nix
@@ -9,6 +9,7 @@ buildDunePackage rec {
   inherit (cstruct) version src meta;
 
   minimalOCamlVersion = "4.08";
+  duneVersion = "3";
 
   doCheck = true;
   checkInputs = [ alcotest ];

--- a/pkgs/development/ocaml-modules/cstruct/unix.nix
+++ b/pkgs/development/ocaml-modules/cstruct/unix.nix
@@ -9,6 +9,7 @@ else
     inherit (cstruct) version src meta;
 
     minimalOCamlVersion = "4.08";
+    duneVersion = "3";
 
     propagatedBuildInputs = [ cstruct ];
   }

--- a/pkgs/development/ocaml-modules/dbf/default.nix
+++ b/pkgs/development/ocaml-modules/dbf/default.nix
@@ -7,13 +7,13 @@ buildDunePackage rec {
 
   minimalOCamlVersion = "4.08";
 
-  useDune2 = true;
+  duneVersion = "3";
 
   src = fetchFromGitHub {
     owner = "pveber";
     repo = "dbf";
-    rev = "${version}";
-    sha256 = "sha256-h1K5YDLbXGEJi/quKXvSR0gZ+WkBzut7AsVFv+Bm8/g=";
+    rev = version;
+    hash = "sha256-h1K5YDLbXGEJi/quKXvSR0gZ+WkBzut7AsVFv+Bm8/g=";
   };
 
   buildInputs = [ ppx_cstruct ];

--- a/pkgs/development/ocaml-modules/eqaf/default.nix
+++ b/pkgs/development/ocaml-modules/eqaf/default.nix
@@ -2,12 +2,13 @@
 
 buildDunePackage rec {
   minimalOCamlVersion = "4.07";
+  duneVersion = "3";
   pname = "eqaf";
   version = "0.9";
 
   src = fetchurl {
     url = "https://github.com/mirage/eqaf/releases/download/v${version}/eqaf-${version}.tbz";
-    sha256 = "sha256-7A4oqUasaBf5XVhU8FqZYa46hAi7YQ55z60BubJV3+A=";
+    hash = "sha256-7A4oqUasaBf5XVhU8FqZYa46hAi7YQ55z60BubJV3+A=";
   };
 
   propagatedBuildInputs = [ cstruct ];

--- a/pkgs/development/ocaml-modules/io-page/default.nix
+++ b/pkgs/development/ocaml-modules/io-page/default.nix
@@ -5,10 +5,11 @@ buildDunePackage rec {
   version = "3.0.0";
 
   minimalOCamlVersion = "4.08";
+  duneVersion = "3";
 
   src = fetchurl {
     url = "https://github.com/mirage/${pname}/releases/download/v${version}/${pname}-${version}.tbz";
-    sha256 = "sha256-DjbKdNkFa6YQgJDLmLsuvyrweb4/TNvqAiggcj/3hu4=";
+    hash = "sha256-DjbKdNkFa6YQgJDLmLsuvyrweb4/TNvqAiggcj/3hu4=";
   };
 
   nativeBuildInputs = [ pkg-config ];

--- a/pkgs/development/ocaml-modules/mirage-channel/default.nix
+++ b/pkgs/development/ocaml-modules/mirage-channel/default.nix
@@ -8,10 +8,11 @@ buildDunePackage rec {
   version = "4.1.0";
 
   minimalOCamlVersion = "4.07";
+  duneVersion = "3";
 
   src = fetchurl {
     url = "https://github.com/mirage/mirage-channel/releases/download/v${version}/mirage-channel-${version}.tbz";
-    sha256 = "sha256-sBdoUdTd9ZeNcHK0IBGBeOYDDqULM7EYX+Pz2f2nIQA=";
+    hash = "sha256-sBdoUdTd9ZeNcHK0IBGBeOYDDqULM7EYX+Pz2f2nIQA=";
   };
 
   propagatedBuildInputs = [ cstruct logs lwt mirage-flow ];

--- a/pkgs/development/ocaml-modules/mirage-console/default.nix
+++ b/pkgs/development/ocaml-modules/mirage-console/default.nix
@@ -7,10 +7,11 @@ buildDunePackage rec {
   version = "5.1.0";
 
   minimalOCamlVersion = "4.08";
+  duneVersion = "3";
 
   src = fetchurl {
     url = "https://github.com/mirage/mirage-console/releases/download/v${version}/mirage-console-${version}.tbz";
-    sha256 = "sha256-mjYRisbNOJbYoSuWaGoPueXakmqAwmWh0ATvLLsvpNM=";
+    hash = "sha256-mjYRisbNOJbYoSuWaGoPueXakmqAwmWh0ATvLLsvpNM=";
   };
 
   propagatedBuildInputs = [ lwt mirage-flow ];

--- a/pkgs/development/ocaml-modules/mirage-console/unix.nix
+++ b/pkgs/development/ocaml-modules/mirage-console/unix.nix
@@ -5,6 +5,8 @@ buildDunePackage {
 
   inherit (mirage-console) version src;
 
+  duneVersion = "3";
+
   propagatedBuildInputs = [
     mirage-console
     cstruct

--- a/pkgs/development/ocaml-modules/mirage-flow/combinators.nix
+++ b/pkgs/development/ocaml-modules/mirage-flow/combinators.nix
@@ -1,11 +1,13 @@
-{ buildDunePackage, mirage-flow, fmt, ocaml_lwt, logs, cstruct, mirage-clock }:
+{ buildDunePackage, mirage-flow, fmt, lwt, logs, cstruct, mirage-clock }:
 
 buildDunePackage {
   pname = "mirage-flow-combinators";
 
-  inherit (mirage-flow) version useDune2 src;
+  inherit (mirage-flow) version src;
 
-  propagatedBuildInputs = [ ocaml_lwt logs cstruct mirage-clock mirage-flow ];
+  duneVersion = "3";
+
+  propagatedBuildInputs = [ lwt logs cstruct mirage-clock mirage-flow ];
 
   meta = mirage-flow.meta // {
     description = "Flow implementations and combinators for MirageOS specialized to lwt";

--- a/pkgs/development/ocaml-modules/mirage-flow/default.nix
+++ b/pkgs/development/ocaml-modules/mirage-flow/default.nix
@@ -1,18 +1,18 @@
-{ lib, buildDunePackage, fetchurl, cstruct, fmt, ocaml_lwt }:
+{ lib, buildDunePackage, fetchurl, cstruct, fmt, lwt }:
 
 buildDunePackage rec {
   pname = "mirage-flow";
   version = "3.0.0";
 
-  useDune2 = true;
-  minimumOCamlVersion = "4.05";
+  duneVersion = "3";
+  minimalOCamlVersion = "4.05";
 
   src = fetchurl {
     url = "https://github.com/mirage/mirage-flow/releases/download/v${version}/mirage-flow-v${version}.tbz";
-    sha256 = "sha256-1wvabIXsJ0e+2IvE2V8mnSgQUDuSkT8IB75SkWlhOPw=";
+    hash = "sha256-1wvabIXsJ0e+2IvE2V8mnSgQUDuSkT8IB75SkWlhOPw=";
   };
 
-  propagatedBuildInputs = [ cstruct fmt ocaml_lwt ];
+  propagatedBuildInputs = [ cstruct fmt lwt ];
 
   meta = {
     description = "Flow implementations and combinators for MirageOS";

--- a/pkgs/development/ocaml-modules/mirage-flow/unix.nix
+++ b/pkgs/development/ocaml-modules/mirage-flow/unix.nix
@@ -5,7 +5,9 @@
 buildDunePackage {
   pname = "mirage-flow-unix";
 
-  inherit (mirage-flow) version useDune2 src;
+  inherit (mirage-flow) version src;
+
+  duneVersion = "3";
 
   # Make tests compatible with alcotest 1.4.0
   postPatch = ''

--- a/pkgs/development/ocaml-modules/mirage-random-test/default.nix
+++ b/pkgs/development/ocaml-modules/mirage-random-test/default.nix
@@ -6,10 +6,9 @@ buildDunePackage rec {
   pname = "mirage-random-test";
   version = "0.1.0";
 
-  minimumOCamlVersion = "4.06";
+  minimalOCamlVersion = "4.06";
 
-  # due to cstruct
-  useDune2 = true;
+  duneVersion = "3";
 
   src = fetchurl {
     url = "https://github.com/mirage/${pname}/releases/download/v${version}/${pname}-v${version}.tbz";

--- a/pkgs/development/ocaml-modules/mirage-random/default.nix
+++ b/pkgs/development/ocaml-modules/mirage-random/default.nix
@@ -4,6 +4,8 @@ buildDunePackage rec {
   pname = "mirage-random";
   version = "3.0.0";
 
+  duneVersion = "3";
+
   src = fetchurl {
     url = "https://github.com/mirage/mirage-random/releases/download/v${version}/mirage-random-v${version}.tbz";
     sha256 = "sha256-Sf4/KB1kMMwXI+yr5H/JuOmynYPNXwlk9dAA+gFAZs8=";

--- a/pkgs/development/ocaml-modules/randomconv/default.nix
+++ b/pkgs/development/ocaml-modules/randomconv/default.nix
@@ -4,7 +4,7 @@ buildDunePackage rec {
   pname = "randomconv";
   version = "0.1.3";
 
-  useDune2 = true;
+  duneVersion = "3";
 
   src = fetchurl {
     url = "https://github.com/hannesm/randomconv/releases/download/v${version}/randomconv-v${version}.tbz";

--- a/pkgs/development/ocaml-modules/vchan/default.nix
+++ b/pkgs/development/ocaml-modules/vchan/default.nix
@@ -9,10 +9,11 @@ buildDunePackage rec {
   version = "6.0.1";
 
   minimalOCamlVersion = "4.08";
+  duneVersion = "3";
 
   src = fetchurl {
     url = "https://github.com/mirage/ocaml-vchan/releases/download/v${version}/vchan-${version}.tbz";
-    sha256 = "sha256-5E7dITMVirYoxUkp8ZamRAolyhA6avXGJNAioxeBuV0=";
+    hash = "sha256-5E7dITMVirYoxUkp8ZamRAolyhA6avXGJNAioxeBuV0=";
   };
 
   propagatedBuildInputs = [

--- a/pkgs/development/ocaml-modules/wayland/default.nix
+++ b/pkgs/development/ocaml-modules/wayland/default.nix
@@ -15,6 +15,7 @@ buildDunePackage rec {
   version = "1.1";
 
   minimalOCamlVersion = "4.08";
+  duneVersion = "3";
 
   src = fetchurl {
     url = "https://github.com/talex5/ocaml-wayland/releases/download/v${version}/wayland-${version}.tbz";

--- a/pkgs/development/ocaml-modules/xenstore-tool/default.nix
+++ b/pkgs/development/ocaml-modules/xenstore-tool/default.nix
@@ -5,6 +5,8 @@ buildDunePackage {
 
   inherit (xenstore_transport) src version;
 
+  duneVersion = "3";
+
   buildInputs = [ xenstore_transport xenstore lwt ];
 
   meta = xenstore_transport.meta // {

--- a/pkgs/development/ocaml-modules/xenstore/default.nix
+++ b/pkgs/development/ocaml-modules/xenstore/default.nix
@@ -7,6 +7,7 @@ buildDunePackage rec {
   version = "2.2.0";
 
   minimalOCamlVersion = "4.08";
+  duneVersion = "3";
 
   src = fetchurl {
     url = "https://github.com/mirage/ocaml-xenstore/releases/download/v${version}/xenstore-${version}.tbz";

--- a/pkgs/development/ocaml-modules/xenstore_transport/default.nix
+++ b/pkgs/development/ocaml-modules/xenstore_transport/default.nix
@@ -5,6 +5,7 @@ buildDunePackage rec {
   version = "1.3.0";
 
   minimalOCamlVersion = "4.08";
+  duneVersion = "3";
 
   src = fetchFromGitHub {
     owner = "xapi-project";

--- a/pkgs/tools/wayland/wayland-proxy-virtwl/default.nix
+++ b/pkgs/tools/wayland/wayland-proxy-virtwl/default.nix
@@ -22,8 +22,8 @@ ocamlPackages.buildDunePackage rec {
   '';
 
   minimalOCamlVersion = "4.12";
+  duneVersion = "3";
 
-  strictDeps = true;
   nativeBuildInputs = [
     pkg-config
   ];


### PR DESCRIPTION
###### Description of changes

https://github.com/mirage/ocaml-cstruct/releases/tag/v6.2.0

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
