### PR TITLE
Simpler pure nixpkgs

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -53,7 +53,7 @@
       # attribute it displays `omitted` instead of evaluating all packages,
       # which keeps `nix flake show` on Nixpkgs reasonably fast, though less
       # information rich.
-      legacyPackages = forAllSystems (system: import ./. { inherit system; });
+      legacyPackages = forAllSystems (system: import ./pkgs/top-level { inherit system; });
 
       nixosModules = {
         notDetected = ./nixos/modules/installer/scan/not-detected.nix;

--- a/pkgs/top-level/default.nix
+++ b/pkgs/top-level/default.nix
@@ -52,7 +52,7 @@
 } @ args:
 
 # Check that either system or localSystem was passed
-assert localSystem.system != null;
+assert ((localSystem.system or null) != null || !localSystem ? device);
 
 let
   # Rename the function arguments

--- a/pkgs/top-level/default.nix
+++ b/pkgs/top-level/default.nix
@@ -16,10 +16,19 @@
    evaluation is taking place, and the configuration from environment variables
    or dot-files. */
 
-{ # The system packages will be built on. See the manual for the
+{ # Represents the system on which to build nixpkgs as a string. Eg:
+  # "x86_64-linux". For more sophisticated scenarios, use localSystem and
+  # crossSystem.
+  system ? null
+
+, # The system packages will be built on. See the manual for the
   # subtle division of labor between these two `*System`s and the three
   # `*Platform`s.
-  localSystem
+  #
+  # We put legacy `system` into `localSystem`, if `localSystem` was not passed.
+  # If neither is passed, assume we are building packages on the current
+  # (build, in GNU Autotools parlance) platform.
+  localSystem ? { inherit system; }
 
 , # The system packages will ultimately be run on.
   crossSystem ? localSystem
@@ -42,8 +51,12 @@
   ...
 } @ args:
 
-let # Rename the function arguments
-  config0 = config;
+# Check that either system or localSystem was passed
+assert localSystem.system != null;
+
+let
+  # Rename the function arguments
+  localSystem0 = localSystem;
   crossSystem0 = crossSystem;
 
 in let

--- a/pkgs/top-level/default.nix
+++ b/pkgs/top-level/default.nix
@@ -58,7 +58,7 @@ let
   # Rename the function arguments
   localSystem0 = localSystem;
   crossSystem0 = crossSystem;
-
+  config0 = config;
 in let
   lib = import ../../lib;
 
@@ -71,11 +71,11 @@ in let
     lib.foldr (x: throwIfNot (lib.isFunction x) "All crossOverlays passed to nixpkgs must be functions.") (r: r) crossOverlays
     ;
 
-  localSystem = lib.systems.elaborate args.localSystem;
+  localSystem = lib.systems.elaborate localSystem0;
 
   # Condition preserves sharing which in turn affects equality.
   crossSystem =
-    if crossSystem0 == null || crossSystem0 == args.localSystem
+    if crossSystem0 == null || crossSystem0 == localSystem0
     then localSystem
     else lib.systems.elaborate crossSystem0;
 

--- a/pkgs/top-level/impure.nix
+++ b/pkgs/top-level/impure.nix
@@ -11,15 +11,10 @@ let
 
 in
 
-{ # We put legacy `system` into `localSystem`, if `localSystem` was not passed.
-  # If neither is passed, assume we are building packages on the current
-  # (build, in GNU Autotools parlance) platform.
-  localSystem ? { system = args.system or builtins.currentSystem; }
-
-# These are needed only because nix's `--arg` command-line logic doesn't work
-# with unnamed parameters allowed by ...
-, system ? localSystem.system
-, crossSystem ? localSystem
+{ # Represents the system on which to build nixpkgs as a string. Eg:
+  # "x86_64-linux". For more sophisticated scenarios, take a look at
+  # localSystem and crossSystem in ./pkgs/top-level/default.nix
+  system ? builtins.currentSystem
 
 , # Fallback: The contents of the configuration file found at $NIXPKGS_CONFIG or
   # $HOME/.config/nixpkgs/config.nix.
@@ -74,16 +69,9 @@ in
         else overlays homeOverlaysDir
       else []
 
-, crossOverlays ? []
-
 , ...
 } @ args:
 
-# If `localSystem` was explicitly passed, legacy `system` should
-# not be passed, and vice-versa.
-assert args ? localSystem -> !(args ? system);
-assert args ? system -> !(args ? localSystem);
-
-import ./. (builtins.removeAttrs args [ "system" ] // {
-  inherit config overlays localSystem;
+import ./. (args // {
+  inherit config overlays system;
 })


### PR DESCRIPTION
###### Description of changes

Make it easier to use the pure version of nixpkgs by allowing the `system` argument. I'm happy that localSystem and crossSystem exist, but the common case for me is to pass the relevant system.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
