### PR TITLE
karabiner-elements: Add updateScript

### DIFF
--- a/pkgs/os-specific/darwin/karabiner-elements/default.nix
+++ b/pkgs/os-specific/darwin/karabiner-elements/default.nix
@@ -40,6 +40,8 @@ stdenv.mkDerivation rec {
     cp "$out/Library/Application Support/org.pqrs/Karabiner-Elements/package-version" "$out/Library/Application Support/org.pqrs/Karabiner-Elements/version"
   '';
 
+  passthru.updateScript = ./updater.sh;
+
   meta = with lib; {
     description = "Karabiner-Elements is a powerful utility for keyboard customization on macOS Sierra (10.12) or later.";
     homepage = "https://karabiner-elements.pqrs.org/";

--- a/pkgs/os-specific/darwin/karabiner-elements/updater.sh
+++ b/pkgs/os-specific/darwin/karabiner-elements/updater.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env nix-shell
+#!nix-shell -I nixpkgs=./. -i bash -p curl jq common-updater-scripts
+set -eo pipefail
+
+new_version="$(curl -s  "https://api.github.com/repos/pqrs-org/Karabiner-Elements/releases/latest" | jq -r '.tag_name | ltrimstr("v")')"
+old_version="$(sed -nE 's/\s*version = "(.*)".*/\1/p' ./default.nix)"
+
+if [[ "$new_version" == "$old_version" ]]; then
+  echo "Already up to date!"
+  exit 0
+fi
+
+update-source-version karabiner-elements "${new_version}"


### PR DESCRIPTION
###### Description of changes

Added an update script to automate updates to this package.
Created https://github.com/NixOS/nixpkgs/pull/223557 using this script.

I'm unsure if this should be a separate PR, or part of the version bump.
Happy to change/merge/close as necessary.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
