### PR TITLE
matrix-hookshot: 3.0.1 -> 3.2.0

### DIFF
--- a/pkgs/servers/matrix-synapse/matrix-hookshot/package.json
+++ b/pkgs/servers/matrix-synapse/matrix-hookshot/package.json
@@ -1,6 +1,6 @@
 {
   "name": "matrix-hookshot",
-  "version": "3.0.1",
+  "version": "3.2.0",
   "description": "A bridge between Matrix and multiple project management services, such as GitHub, GitLab and JIRA.",
   "main": "lib/app.js",
   "repository": "https://github.com/matrix-org/matrix-hookshot",

--- a/pkgs/servers/matrix-synapse/matrix-hookshot/pin.json
+++ b/pkgs/servers/matrix-synapse/matrix-hookshot/pin.json
@@ -1,6 +1,6 @@
 {
-  "version": "3.0.1",
-  "srcHash": "GQfQWOyiI/rxRsj9GYoc2wPaG8phl+2d9Hulxrar5Jc=",
+  "version": "3.2.0",
+  "srcHash": "7u3JT7BFoJB95vlpKagMgWzoJg0vPYX4CEoqANW0FL4=",
   "yarnHash": "0ivizv90wrbz583xjvbakv6vg782h7pjm5zbm8wb9qkpnj735avz",
-  "cargoHash": "/yEupeMwzTh/Ujbh2mPXXQbUCajFK/yl1QM3XmFS/Cc="
+  "cargoHash": "CVJoDaQzyMJUaCx7MQg/bQHVicbkmwNpwncLSbWQwbA="
 }


### PR DESCRIPTION
###### Description of changes

https://github.com/matrix-org/matrix-hookshot/releases/tag/3.1.0  
https://github.com/matrix-org/matrix-hookshot/releases/tag/3.1.1  
https://github.com/matrix-org/matrix-hookshot/releases/tag/3.2.0  

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
