### PR TITLE
zabbix: Add support for zabbix v6, update v5 and v4 to latest versions

### DIFF
--- a/pkgs/servers/monitoring/zabbix/agent.nix
+++ b/pkgs/servers/monitoring/zabbix/agent.nix
@@ -1,6 +1,6 @@
 { lib, stdenv, fetchurl, pkg-config, libiconv, openssl, pcre }:
 
-import ./versions.nix ({ version, sha256 }:
+import ./versions.nix ({ version, sha256, ... }:
   stdenv.mkDerivation {
     pname = "zabbix-agent";
     inherit version;

--- a/pkgs/servers/monitoring/zabbix/agent2.nix
+++ b/pkgs/servers/monitoring/zabbix/agent2.nix
@@ -12,7 +12,10 @@ import ./versions.nix ({ version, sha256 }:
 
     modRoot = "src/go";
 
-    vendorSha256 = "1417qi061xc4m55z0vz420fr7qpi24kw5yj9wq7iic92smakgkjn";
+    vendorSha256 =
+        if "${lib.versions.majorMinor version}" == "5.0" then "1417qi061xc4m55z0vz420fr7qpi24kw5yj9wq7iic92smakgkjn"
+        else if "${lib.versions.majorMinor version}" == "6.0" then "sha256-W95Z9pIhd5MQJAGn94kiVbQVFkmvjGPWfMx4JyJ2/EU="
+        else throw "unsupported version ${version} for zabbix-agent2";
 
     nativeBuildInputs = [ autoreconfHook pkg-config ];
     buildInputs = [ libiconv openssl pcre zlib ];

--- a/pkgs/servers/monitoring/zabbix/agent2.nix
+++ b/pkgs/servers/monitoring/zabbix/agent2.nix
@@ -1,6 +1,6 @@
 { lib, buildGoModule, fetchurl, autoreconfHook, pkg-config, libiconv, openssl, pcre, zlib }:
 
-import ./versions.nix ({ version, sha256 }:
+import ./versions.nix ({ version, sha256, vendorSha256 ? throw "unsupported version ${version} for zabbix-agent2", ... }:
   buildGoModule {
     pname = "zabbix-agent2";
     inherit version;
@@ -12,10 +12,7 @@ import ./versions.nix ({ version, sha256 }:
 
     modRoot = "src/go";
 
-    vendorSha256 =
-        if "${lib.versions.majorMinor version}" == "5.0" then "1417qi061xc4m55z0vz420fr7qpi24kw5yj9wq7iic92smakgkjn"
-        else if "${lib.versions.majorMinor version}" == "6.0" then "sha256-W95Z9pIhd5MQJAGn94kiVbQVFkmvjGPWfMx4JyJ2/EU="
-        else throw "unsupported version ${version} for zabbix-agent2";
+    inherit vendorSha256;
 
     nativeBuildInputs = [ autoreconfHook pkg-config ];
     buildInputs = [ libiconv openssl pcre zlib ];

--- a/pkgs/servers/monitoring/zabbix/proxy.nix
+++ b/pkgs/servers/monitoring/zabbix/proxy.nix
@@ -15,7 +15,7 @@ assert sqliteSupport -> !mysqlSupport && !postgresqlSupport;
 let
   inherit (lib) optional optionalString;
 in
-  import ./versions.nix ({ version, sha256 }:
+  import ./versions.nix ({ version, sha256, ... }:
     stdenv.mkDerivation {
       pname = "zabbix-proxy";
       inherit version;

--- a/pkgs/servers/monitoring/zabbix/server.nix
+++ b/pkgs/servers/monitoring/zabbix/server.nix
@@ -16,7 +16,7 @@ assert postgresqlSupport -> !mysqlSupport;
 let
   inherit (lib) optional optionalString;
 in
-  import ./versions.nix ({ version, sha256 }:
+  import ./versions.nix ({ version, sha256, ... }:
     stdenv.mkDerivation {
       pname = "zabbix-server";
       inherit version;

--- a/pkgs/servers/monitoring/zabbix/versions.nix
+++ b/pkgs/servers/monitoring/zabbix/versions.nix
@@ -6,9 +6,9 @@ generic: {
   };
 
   v50 = generic {
-    version = "5.0.19";
-    sha256 = "sha256-esa7DczdaWiG8Ru9py8HlOhvhkjV8IQjMwuiJ6F5c6E=";
-    vendorSha256 = "1417qi061xc4m55z0vz420fr7qpi24kw5yj9wq7iic92smakgkjn";
+    version = "5.0.33";
+    sha256 = "sha256-VimTMcnYaFXeBW3zkDRGMxmtOFgPBU2ANKXLjgtr0GE=";
+    vendorSha256 = "sha256-RG6tSQk3dGaoTG/LHsZkayYCHbguSNOOuAFCmpSwElQ=";
   };
 
   v40 = generic {

--- a/pkgs/servers/monitoring/zabbix/versions.nix
+++ b/pkgs/servers/monitoring/zabbix/versions.nix
@@ -1,8 +1,8 @@
 generic: {
   v60 = generic {
-    version = "6.0.9";
-    sha256 = "0rzdlmfvyqys166zi94q1c6pbf57b0g1dygb23ixsx083gq1hh01";
-    vendorSha256 = "sha256-W95Z9pIhd5MQJAGn94kiVbQVFkmvjGPWfMx4JyJ2/EU=";
+    version = "6.0.14";
+    sha256 = "sha256-YxrVl12OBxkB/cEvlGR+mV7bTBe6nRi71wLCtZPCzlg=";
+    vendorSha256 = null;
   };
 
   v50 = generic {

--- a/pkgs/servers/monitoring/zabbix/versions.nix
+++ b/pkgs/servers/monitoring/zabbix/versions.nix
@@ -12,7 +12,7 @@ generic: {
   };
 
   v40 = generic {
-    version = "4.0.37";
-    sha256 = "sha256-Wuexl8I2zA63jyTRDe8bMSP++imwSOxc4LEdUnH8jps=";
+    version = "4.0.44";
+    sha256 = "sha256-qB3hSHnPffenBC6gv/QQXJuVpj4/oN4/jt/O6QmiX+c=";
   };
 }

--- a/pkgs/servers/monitoring/zabbix/versions.nix
+++ b/pkgs/servers/monitoring/zabbix/versions.nix
@@ -1,7 +1,14 @@
 generic: {
+  v60 = generic {
+    version = "6.0.9";
+    sha256 = "0rzdlmfvyqys166zi94q1c6pbf57b0g1dygb23ixsx083gq1hh01";
+    vendorSha256 = "sha256-W95Z9pIhd5MQJAGn94kiVbQVFkmvjGPWfMx4JyJ2/EU=";
+  };
+
   v50 = generic {
     version = "5.0.19";
     sha256 = "sha256-esa7DczdaWiG8Ru9py8HlOhvhkjV8IQjMwuiJ6F5c6E=";
+    vendorSha256 = "1417qi061xc4m55z0vz420fr7qpi24kw5yj9wq7iic92smakgkjn";
   };
 
   v40 = generic {

--- a/pkgs/servers/monitoring/zabbix/web.nix
+++ b/pkgs/servers/monitoring/zabbix/web.nix
@@ -1,6 +1,6 @@
 { lib, stdenv, fetchurl, writeText }:
 
-import ./versions.nix ({ version, sha256 }:
+import ./versions.nix ({ version, sha256, ... }:
   stdenv.mkDerivation rec {
     pname = "zabbix-web";
     inherit version;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -24632,7 +24632,7 @@ with pkgs;
   zabbix50 = recurseIntoAttrs (zabbixFor "v50");
   zabbix40 = dontRecurseIntoAttrs (zabbixFor "v40");
 
-  zabbix = zabbix50;
+  zabbix = zabbix60;
 
   zipkin = callPackage ../servers/monitoring/zipkin { };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -24615,7 +24615,6 @@ with pkgs;
 
   zabbixFor = version: rec {
     agent = (callPackages ../servers/monitoring/zabbix/agent.nix {}).${version};
-    agent2 = (callPackages ../servers/monitoring/zabbix/agent2.nix {}).${version};
     proxy-mysql = (callPackages ../servers/monitoring/zabbix/proxy.nix { mysqlSupport = true; }).${version};
     proxy-pgsql = (callPackages ../servers/monitoring/zabbix/proxy.nix { postgresqlSupport = true; }).${version};
     proxy-sqlite = (callPackages ../servers/monitoring/zabbix/proxy.nix { sqliteSupport = true; }).${version};
@@ -24625,6 +24624,8 @@ with pkgs;
 
     # backwards compatibility
     server = server-pgsql;
+  } // lib.optionalAttrs ( version != "v40" ) {  # agent2 is not supported in v4
+    agent2 = (callPackages ../servers/monitoring/zabbix/agent2.nix {}).${version};
   };
 
   zabbix60 = recurseIntoAttrs (zabbixFor "v60");

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -24627,6 +24627,7 @@ with pkgs;
     server = server-pgsql;
   };
 
+  zabbix60 = recurseIntoAttrs (zabbixFor "v60");
   zabbix50 = recurseIntoAttrs (zabbixFor "v50");
   zabbix40 = dontRecurseIntoAttrs (zabbixFor "v40");
 

--- a/pkgs/top-level/packages-config.nix
+++ b/pkgs/top-level/packages-config.nix
@@ -27,6 +27,7 @@
       ut2004Packages
       zabbix40
       zabbix50
+      zabbix60
       zeroadPackages
     ;
 


### PR DESCRIPTION
###### Description of changes
This is followup to #196451. I have removed the update script which had multiple issues (https://github.com/NixOS/nixpkgs/pull/196451#issuecomment-1312604065).

The code is rebased to current master, all zabbix versions are updated to latest LTS versions.

CC: @andreaswolf

@aanderse Could you please help me with the review?

Closes: #196451 #145502

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
