### PR TITLE
snac2: 2.15 -> 2.25

### DIFF
--- a/pkgs/servers/snac2/default.nix
+++ b/pkgs/servers/snac2/default.nix
@@ -3,31 +3,42 @@
 , fetchFromGitea
 , curl
 , openssl
+, nix-update-script
+, testers
+, snac2
 }:
 
 stdenv.mkDerivation rec {
   pname = "snac2";
-  version = "2.15";
+  version = "2.25";
 
   src = fetchFromGitea {
     domain = "codeberg.org";
     owner = "grunfink";
     repo = pname;
     rev = version;
-    hash = "sha256-aK98nolgf/pju6jPZell1qLZMxArDna4FMqf3THGV1I=";
+    hash = "sha256-xWRsJ1b2Ddf4H9KLIyc4GpRc6xUNFRQpIdgfrdPg/0c=";
   };
 
   buildInputs = [ curl openssl ];
 
   makeFlags = [ "PREFIX=$(out)" ];
 
-  preInstall = "mkdir -p $out/bin";
+  passthru = {
+    tests.version = testers.testVersion {
+      package = snac2;
+      command = "${meta.mainProgram} || true";
+    };
+    updateScript = nix-update-script { };
+  };
 
   meta = with lib; {
     homepage = "https://codeberg.org/grunfink/snac2";
     description = "A simple, minimalistic ActivityPub instance (2.x, C)";
+    changelog = "https://codeberg.org/grunfink/snac2/src/tag/${version}/RELEASE_NOTES.md";
     license = licenses.mit;
     maintainers = with maintainers; [ misuzu ];
     platforms = platforms.linux;
+    mainProgram = "snac";
   };
 }


### PR DESCRIPTION
###### Description of changes
https://codeberg.org/grunfink/snac2/src/tag/2.25/RELEASE_NOTES.md
https://codeberg.org/grunfink/snac2/compare/2.15...2.25
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [X] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
