### PR TITLE
google-cloud-sdk: add libxcrypt-legacy

### DIFF
--- a/pkgs/tools/admin/google-cloud-sdk/components.nix
+++ b/pkgs/tools/admin/google-cloud-sdk/components.nix
@@ -5,6 +5,7 @@
 , snapshotPath
 , autoPatchelfHook
 , python3
+, libxcrypt-legacy
 , ...
 }:
 
@@ -166,6 +167,9 @@ let
         stdenv.cc.cc
       ] ++ lib.optionals stdenv.isLinux [
         autoPatchelfHook
+      ];
+      buildInputs = [
+        libxcrypt-legacy
       ];
       passthru = {
         dependencies = filterForSystem dependencies;


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

Fixes the below build error:
```
error: builder for '/nix/store/59kj94x8mw61h22797q5iyjbd9vw3cms-bundled-python3-unix-linux-x86_64-3.9.12.drv' failed with exit code 1;
       last 10 log lines:
       > auto-patchelf: 4 dependencies could not be satisfied
       > error: auto-patchelf could not satisfy dependency libcrypt.so.1 wanted by /nix/store/bq6a2rvpqw2jh40ryjvghi64rzl0mjr5-bundled-python3-unix-linux-x86_64-3.9.12/google-cloud-sdk/platform/bundledpythonunix/lib/libpython3.9.so
       > error: auto-patchelf could not satisfy dependency libcrypt.so.1 wanted by /nix/store/bq6a2rvpqw2jh40ryjvghi64rzl0mjr5-bundled-python3-unix-linux-x86_64-3.9.12/google-cloud-sdk/platform/bundledpythonunix/lib/libpython3.9.so.1.0
       > error: auto-patchelf could not satisfy dependency libcrypt.so.1 wanted by /nix/store/bq6a2rvpqw2jh40ryjvghi64rzl0mjr5-bundled-python3-unix-linux-x86_64-3.9.12/google-cloud-sdk/platform/bundledpythonunix/bin/python3
       > error: auto-patchelf could not satisfy dependency libcrypt.so.1 wanted by /nix/store/bq6a2rvpqw2jh40ryjvghi64rzl0mjr5-bundled-python3-unix-linux-x86_64-3.9.12/google-cloud-sdk/platform/bundledpythonunix/bin/python3.9
       > auto-patchelf failed to find all the required dependencies.
       > Add the missing dependencies to --libs or use `--ignore-missing="foo.so.1 bar.so etc.so"`.
       > /nix/store/sw36plhp82916wwg6i6097rkzza7d950-stdenv-linux/setup: line 79: pop_var_context: head of shell_variables not a function context
       > /nix/store/sw36plhp82916wwg6i6097rkzza7d950-stdenv-linux/setup: line 1457: pop_var_context: head of shell_variables not a function context
       > /nix/store/sw36plhp82916wwg6i6097rkzza7d950-stdenv-linux/setup: line 1594: pop_var_context: head of shell_variables not a function context
       For full logs, run 'nix log /nix/store/59kj94x8mw61h22797q5iyjbd9vw3cms-bundled-python3-unix-linux-x86_64-3.9.12.drv'.
error: 1 dependencies of derivation '/nix/store/w90v449mcbj95slc0qs7bl7kg7hclfzc-google-cloud-sdk-408.0.1.drv' failed to build
```