### PR TITLE
[22.11] python3Packages.cairosvg: apply patch for CVE-2023-27586

### DIFF
--- a/pkgs/development/python-modules/cairosvg/default.nix
+++ b/pkgs/development/python-modules/cairosvg/default.nix
@@ -1,6 +1,7 @@
 { lib
 , buildPythonPackage
 , fetchPypi
+, fetchpatch
 , isPy3k
 , cairocffi
 , cssselect2
@@ -19,6 +20,14 @@ buildPythonPackage rec {
     inherit pname version;
     sha256 = "sha256-sLmSnPXboAUXjXRqgDb88AJVUPSYylTbYYczIjhHg7w=";
   };
+
+  patches = [
+    (fetchpatch {
+      name = "CVE-2023-27586.patch";
+      url = "https://github.com/Kozea/CairoSVG/commit/12d31c653c0254fa9d9853f66b04ea46e7397255.patch";
+      hash = "sha256-6ElTepPjEmhbv59jkzTnw+qhY7JlqS/lToIzZtfkh08=";
+    })
+  ];
 
   propagatedBuildInputs = [ cairocffi cssselect2 defusedxml pillow tinycss2 ];
 


### PR DESCRIPTION
###### Description of changes

https://github.com/Kozea/CairoSVG/security/advisories/GHSA-rwmf-w63j-p7gv

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

Result of `nixpkgs-review pr 223623` run on x86_64-linux [1](https://github.com/Mic92/nixpkgs-review)
<details>
  <summary>21 packages built:</summary>
  <ul>
    <li>mirage-im</li>
    <li>python310Packages.Nikola</li>
    <li>python310Packages.Nikola.dist</li>
    <li>python310Packages.cairosvg</li>
    <li>python310Packages.cairosvg.dist</li>
    <li>python310Packages.pygal</li>
    <li>python310Packages.pygal.dist</li>
    <li>python310Packages.wavedrom</li>
    <li>python310Packages.wavedrom.dist</li>
    <li>python39Packages.Nikola</li>
    <li>python39Packages.Nikola.dist</li>
    <li>python39Packages.cairosvg</li>
    <li>python39Packages.cairosvg.dist</li>
    <li>python39Packages.pygal</li>
    <li>python39Packages.pygal.dist</li>
    <li>python39Packages.wavedrom</li>
    <li>python39Packages.wavedrom.dist</li>
    <li>skytemple</li>
    <li>skytemple.dist</li>
    <li>streamdeck-ui</li>
    <li>streamdeck-ui.dist</li>
  </ul>
</details>