### PR TITLE
aeolus: use aeolus-stops; aeolus-stops: init at 0.4.0

### DIFF
--- a/pkgs/applications/audio/aeolus/stops.nix
+++ b/pkgs/applications/audio/aeolus/stops.nix
@@ -1,0 +1,33 @@
+{ lib, stdenvNoCC, fetchurl }:
+
+stdenvNoCC.mkDerivation rec {
+  pname = "stops";
+  version = "0.4.0";
+
+  src = fetchurl {
+    url = "https://kokkinizita.linuxaudio.org/linuxaudio/downloads/${pname}-${version}.tar.bz2";
+    hash = "sha256-DnmguOAGyw9nv88ekJfbC04Qwbsw5tXEAaKeiCQR/LA=";
+  };
+
+  outputHashMode = "recursive";
+  outputHash = "sha256-gGHowq7g7MZmnhrpqG+3wNLwQCtpiBB88euIKeQIpJ0=";
+
+  subdir = "share/Aeolus/stops";
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/${subdir}
+    cp -r * $out/${subdir}
+
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    description = "aeolus synthesizer instrument definitions";
+    homepage = "http://kokkinizita.linuxaudio.org/linuxaudio/aeolus/index.html";
+    license = licenses.lgpl3;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ nico202 orivej ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -28565,6 +28565,7 @@ with pkgs;
   };
 
   aeolus = callPackage ../applications/audio/aeolus { };
+  aeolus-stops = callPackage ../applications/audio/aeolus/stops.nix { };
 
   aewan = callPackage ../applications/editors/aewan { };
 


### PR DESCRIPTION
###### Description of changes

This makes aeolus useful out of the box. Without stops it has no instruments. From its readme:

---

"3. Binary packages

This release permits packagers to install a working Aeolus without touching a users's home directory, as follows.

*  Install the aeolus binary in /usr/bin and the two plugins in /usr/lib.
*  Install the stops directory in /usr/share/Aeolus.
*  Install this README into /usr/share/doc/packages/Aeolus.
*  Create the file /etc/aeolus.conf containing:

```
# Aeolus default options
-u -A -S /usr/share/Aeolus/stops-0.3.0
```

This will use the default instrument 'Aeolus', and save the presets in .aeolus-presets in the users's home directory."

---

`-A` forces ALSA, and thus is not enabled in our package.

Aeolus starts up faster when stops are installed in a user-writable directory (and the user presses Save in aeolus), but this writes about 50 MB of wave files; so using a system-wide installation to save space is a trade off:

---

"The waves directory will be empty initially. When Aeolus starts up, it will compute wavetables, one for each pipe. This is indicated by the flashing stop buttons. The same will happen whenever the tuning or temperament is changed. These wavetables can be saved (so Aeolus will be ready for use much faster next time), but only if the stops directory is writeable for the user. This will not be the case for a binary installation as the stops dir will be system-wide (e.g. /usr/share/Aeolus/stops-0.3.0).

"In order to be able to save wavetables or edited stops the stops directory must be copied to a location where it can be modified by the user, (e.g. ~/stops-0.4.0)."

---

This is based on #223089 and is made into a separate PR because the changes I wanted to propose were too many. /cc @Rampoina for review

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
