### PR TITLE
python310Packages.openpyxl: 3.1.1 -> 3.1.2

### DIFF
--- a/pkgs/development/python-modules/openpyxl/default.nix
+++ b/pkgs/development/python-modules/openpyxl/default.nix
@@ -1,11 +1,12 @@
 { lib
 , buildPythonPackage
-, fetchPypi
-, pythonOlder
-, pytest
-, jdcal
 , et_xmlfile
+, fetchFromGitLab
+, jdcal
 , lxml
+, pillow
+, pytestCheckHook
+, pythonOlder
 }:
 
 buildPythonPackage rec {
@@ -15,26 +16,31 @@ buildPythonPackage rec {
 
   disabled = pythonOlder "3.7";
 
-  src = fetchPypi {
-    inherit pname version;
-    hash = "sha256-pvWXdBjv87LVUA1U2dtQyCd6NoQ29OT43bG+NCKHAYQ=";
+  src = fetchFromGitLab {
+    domain = "foss.heptapod.net";
+    owner = "openpyxl";
+    repo = "openpyxl";
+    rev = version;
+    hash = "sha256-SWRbjA83AOLrfe6on2CSb64pH5EWXkfyYcTqWJNBEP0=";
   };
 
-  nativeCheckInputs = [ pytest ];
-  propagatedBuildInputs = [ jdcal et_xmlfile lxml ];
+  propagatedBuildInputs = [
+    jdcal
+    et_xmlfile
+    lxml
+  ];
 
-  postPatch = ''
-    # LICENSE.rst is missing, and setup.cfg currently doesn't contain anything useful anyway
-    # This should likely be removed in the next update
-    rm setup.cfg
-  '';
+  nativeCheckInputs = [
+    pillow
+    pytestCheckHook
+  ];
 
-  # Tests are not included in archive.
-  # https://bitbucket.org/openpyxl/openpyxl/issues/610
-  doCheck = false;
+  pythonImportsCheck = [
+    "openpyxl"
+  ];
 
   meta = with lib; {
-    description = "A Python library to read/write Excel 2007 xlsx/xlsm files";
+    description = "Python library to read/write Excel 2010 xlsx/xlsm files";
     homepage = "https://openpyxl.readthedocs.org";
     changelog = "https://foss.heptapod.net/openpyxl/openpyxl/-/blob/${version}/doc/changes.rst";
     license = licenses.mit;

--- a/pkgs/development/python-modules/openpyxl/default.nix
+++ b/pkgs/development/python-modules/openpyxl/default.nix
@@ -1,7 +1,7 @@
 { lib
 , buildPythonPackage
 , fetchPypi
-, isPy27
+, pythonOlder
 , pytest
 , jdcal
 , et_xmlfile
@@ -11,7 +11,9 @@
 buildPythonPackage rec {
   pname = "openpyxl";
   version = "3.1.2";
-  disabled = isPy27; # 2.6.4 was final python2 release
+  format = "setuptools";
+
+  disabled = pythonOlder "3.7";
 
   src = fetchPypi {
     inherit pname version;

--- a/pkgs/development/python-modules/openpyxl/default.nix
+++ b/pkgs/development/python-modules/openpyxl/default.nix
@@ -10,12 +10,12 @@
 
 buildPythonPackage rec {
   pname = "openpyxl";
-  version = "3.1.1";
+  version = "3.1.2";
   disabled = isPy27; # 2.6.4 was final python2 release
 
   src = fetchPypi {
     inherit pname version;
-    hash = "sha256-8G1E4slzeBBovOXs+GCgm82xx/XOH6zV6aqCySyTrnI=";
+    hash = "sha256-pvWXdBjv87LVUA1U2dtQyCd6NoQ29OT43bG+NCKHAYQ=";
   };
 
   nativeCheckInputs = [ pytest ];

--- a/pkgs/development/python-modules/openpyxl/default.nix
+++ b/pkgs/development/python-modules/openpyxl/default.nix
@@ -33,11 +33,11 @@ buildPythonPackage rec {
   # https://bitbucket.org/openpyxl/openpyxl/issues/610
   doCheck = false;
 
-  meta = {
+  meta = with lib; {
     description = "A Python library to read/write Excel 2007 xlsx/xlsm files";
     homepage = "https://openpyxl.readthedocs.org";
     changelog = "https://foss.heptapod.net/openpyxl/openpyxl/-/blob/${version}/doc/changes.rst";
-    license = lib.licenses.mit;
-    maintainers = with lib.maintainers; [ lihop ];
+    license = licenses.mit;
+    maintainers = with maintainers; [ lihop ];
   };
 }

--- a/pkgs/development/python-modules/openpyxl/default.nix
+++ b/pkgs/development/python-modules/openpyxl/default.nix
@@ -34,6 +34,7 @@ buildPythonPackage rec {
   meta = {
     description = "A Python library to read/write Excel 2007 xlsx/xlsm files";
     homepage = "https://openpyxl.readthedocs.org";
+    changelog = "https://foss.heptapod.net/openpyxl/openpyxl/-/blob/${version}/doc/changes.rst";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ lihop ];
   };


### PR DESCRIPTION
Changelog: https://foss.heptapod.net/openpyxl/openpyxl/-/blob/3.1.2/doc/changes.rst

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
