### PR TITLE
fix nuspell provider for enchant

### DIFF
--- a/pkgs/development/libraries/enchant/2.x.nix
+++ b/pkgs/development/libraries/enchant/2.x.nix
@@ -46,6 +46,10 @@ stdenv.mkDerivation rec {
 
   configureFlags = [
     "--enable-relocatable" # needed for tests
+    "--with-aspell"
+    "--with-hspell"
+    "--with-hunspell"
+    "--with-nuspell"
   ];
 
   meta = with lib; {

--- a/pkgs/development/libraries/nuspell/default.nix
+++ b/pkgs/development/libraries/nuspell/default.nix
@@ -12,7 +12,7 @@ stdenv.mkDerivation rec {
   };
 
   nativeBuildInputs = [ cmake pkg-config ];
-  buildInputs = [ icu ];
+  propagatedBuildInputs = [ icu ];
 
   outputs = [ "out" "lib" "dev" ];
 


### PR DESCRIPTION
###### Description of changes

nuspell support was originally added in #133205

Before this change, it wasn't working as proven by it being missing from the output of enchant-lsmod:

```console
$ enchant-lsmod-2
aspell (Aspell Provider)
hspell (Hspell Provider)
hunspell (Hunspell Provider)
```

Nuspell requires icu for its shared library to be linkable in other software:

```pc
# nuspell.pc
prefix=/nix/store/7ga52l093n2zdvhg5za1jvgw1qlfq947-nuspell-5.1.2
exec_prefix=${prefix}
libdir=/nix/store/z4bn034dd4vfwzi7gwpn6wki4w9zlzpp-nuspell-5.1.2-lib/lib
includedir=/nix/store/v357g1r4h1ga6qm5rgnww080hv1j2pw9-nuspell-5.1.2-dev/include

Name: nuspell
Description: Nuspell spellchecking library
URL: https://nuspell.github.io/
Version: 5.1.2
Libs: -L${libdir} -lnuspell 
Requires: icu-uc
Cflags: -I${includedir}
```
I've added `icu` to `nuspell`'s `propagatedInputs` and also explicitly enabled the providers we want to use in `enchant`, so it will fail to compile in the future in case of unmet dependencies.

After these changes:

```console
$ enchant-lsmod-2
aspell (Aspell Provider)
hspell (Hspell Provider)
hunspell (Hunspell Provider)
nuspell (Nuspell Provider)
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
