### PR TITLE
nixos/modules/config/resolvconf.nix: Don't add systemPackages if the module is disabled

### DIFF
--- a/nixos/modules/config/resolvconf.nix
+++ b/nixos/modules/config/resolvconf.nix
@@ -132,12 +132,12 @@ in
             exit 1
           ''
         else configText;
-
-      environment.systemPackages = [ cfg.package ];
     }
 
     (mkIf cfg.enable {
       networking.resolvconf.package = pkgs.openresolv;
+
+      environment.systemPackages = [ cfg.package ];
 
       systemd.services.resolvconf = {
         description = "resolvconf update";


### PR DESCRIPTION
###### Description of changes
Fixes #221641. Essentially making sure that the `nixos/modules/config/resolvconf.nix` module respects the `networking.resolvconf.enable` option, instead of unconditionally adding the `networking.resolvconf.package` to the `environment.systemPackages` list.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Testing
Tested by building a system profile with my changes, see the log [here](https://github.com/filakhtov/test-proof-artifacts/blob/8f7ba9c36cfb0d93d4e1dd7c46d5498769b2b423/gh/nixos/nixpkgs/221785/nixos-rebuild.log). Here are the steps taken:

1. Identified the commit which is currently running on my system, which ended up being `7067edc68c0`
2. Checked out that specific commit
3. Cherry-picked my change from this branch
4. Ran `nixos-rebuild switch -p resolvconf-test -I nixpkgs=.` to build a new system profile using the modified nixpkgs tree
5. Identified the store path for the new profile
6. Queried the store path to ensure that `openresolv` package is no longer in the package list, unlike before

Note: for testing above I have both `networking.resolvconf.enable` and `services.resolved.enable` set to `false`.

Then I changed the `networking.resolvconf.enable` to `true` and ran another `nixos-rebuild` and verified that `openresolv` is now installed as expected. See [this log](https://github.com/filakhtov/test-proof-artifacts/blob/b3e3a4dcb571757aa7c384ab880e1983a420a858/gh/nixos/nixpkgs/221785/nixos-rebuild.log) for details.