### PR TITLE
cudaPackages: use the same libstdc++ as the rest of nixpkgs

### DIFF
--- a/pkgs/development/compilers/cudatoolkit/common.nix
+++ b/pkgs/development/compilers/cudatoolkit/common.nix
@@ -205,6 +205,7 @@ backendStdenv.mkDerivation rec {
 
       mv pkg/builds/nsight_systems/target-linux-x64 $out/target-linux-x64
       mv pkg/builds/nsight_systems/host-linux-x64 $out/host-linux-x64
+      rm $out/host-linux-x64/libstdc++.so*
     ''}
 
     rm -f $out/tools/CUDA_Occupancy_Calculator.xls # FIXME: why?

--- a/pkgs/development/compilers/cudatoolkit/common.nix
+++ b/pkgs/development/compilers/cudatoolkit/common.nix
@@ -29,6 +29,7 @@ args@
 , python3 # FIXME: CUDAToolkit 10 may still need python27
 , pulseaudio
 , requireFile
+, stdenv
 , backendStdenv # E.g. gcc11Stdenv, set in extension.nix
 , unixODBC
 , wayland
@@ -121,8 +122,8 @@ backendStdenv.mkDerivation rec {
     (placeholder "lib")
     (placeholder "out")
     "${placeholder "out"}/nvvm"
-    # Is it not handled by autoPatchelf automatically?
-    "${lib.getLib backendStdenv.cc.cc}/lib64"
+    # NOTE: use the same libstdc++ as the rest of nixpkgs, not from backendStdenv
+    "${lib.getLib stdenv.cc.cc}/lib64"
     "${placeholder "out"}/jre/lib/amd64/jli"
     "${placeholder "out"}/lib64"
     "${placeholder "out"}/nvvm/lib64"

--- a/pkgs/development/compilers/cudatoolkit/redist/build-cuda-redist-package.nix
+++ b/pkgs/development/compilers/cudatoolkit/redist/build-cuda-redist-package.nix
@@ -1,4 +1,5 @@
 { lib
+, stdenv
 , backendStdenv
 , fetchurl
 , autoPatchelfHook
@@ -30,11 +31,11 @@ backendStdenv.mkDerivation {
   ];
 
   buildInputs = [
-    # autoPatchelfHook will search for a libstdc++ and we're giving it a
-    # "compatible" libstdc++ from the same toolchain that NVCC uses.
-    #
+    # autoPatchelfHook will search for a libstdc++ and we're giving it
+    # one that is compatible with the rest of nixpkgs, even when
+    # nvcc forces us to use an older gcc
     # NB: We don't actually know if this is the right thing to do
-    backendStdenv.cc.cc.lib
+    stdenv.cc.cc.lib
   ];
 
   dontBuild = true;

--- a/pkgs/development/compilers/cudatoolkit/stdenv.nix
+++ b/pkgs/development/compilers/cudatoolkit/stdenv.nix
@@ -1,0 +1,17 @@
+{ nixpkgsStdenv
+, nvccCompatibleStdenv
+, overrideCC
+, wrapCCWith
+}:
+
+overrideCC nixpkgsStdenv (wrapCCWith {
+  cc = nvccCompatibleStdenv.cc.cc;
+
+  # This option is for clang's libcxx, but we (ab)use it for gcc's libstdc++.
+  # Note that libstdc++ maintains forward-compatibility: if we load a newer
+  # libstdc++ into the process, we can still use libraries built against an
+  # older libstdc++. This, in practice, means that we should use libstdc++ from
+  # the same stdenv that the rest of nixpkgs uses.
+  # We currently do not try to support anything other than gcc and linux.
+  libcxx = nixpkgsStdenv.cc.cc.lib;
+})

--- a/pkgs/development/libraries/science/math/cudnn/generic.nix
+++ b/pkgs/development/libraries/science/math/cudnn/generic.nix
@@ -1,4 +1,4 @@
-{
+{ stdenv,
   backendStdenv,
   lib,
   zlib,
@@ -26,7 +26,6 @@
   maxCudaVersion,
 }:
 assert useCudatoolkitRunfile || (libcublas != null); let
-  inherit (backendStdenv) cc;
   inherit (lib) lists strings trivial versions;
 
   # majorMinorPatch :: String -> String
@@ -63,7 +62,10 @@ in
 
     # Used by autoPatchelfHook
     buildInputs = [
-      cc.cc.lib # libstdc++
+      # Note this libstdc++ isn't from the (possibly older) nvcc-compatible
+      # stdenv, but from the (newer) stdenv that the rest of nixpkgs uses
+      stdenv.cc.cc.lib
+
       zlib
       cudatoolkit_root
     ];

--- a/pkgs/development/libraries/science/math/faiss/default.nix
+++ b/pkgs/development/libraries/science/math/faiss/default.nix
@@ -25,7 +25,7 @@
   builtins.head optLevels
 , faiss # To run demos in the tests
 , runCommand
-}:
+}@inputs:
 
 assert cudaSupport -> nvidia-thrust.cudaSupport;
 
@@ -33,8 +33,10 @@ let
   pname = "faiss";
   version = "1.7.2";
 
-  inherit (cudaPackages) cudaFlags;
+  inherit (cudaPackages) cudaFlags backendStdenv;
   inherit (cudaFlags) cudaCapabilities dropDot;
+
+  stdenv = if cudaSupport then backendStdenv else inputs.stdenv;
 
   cudaJoined = symlinkJoin {
     name = "cuda-packages-unsplit";


### PR DESCRIPTION
###### Description of changes

A potential solution to https://github.com/NixOS/nixpkgs/issues/220341, work in progress.
TLDR: we're dealing with libstdc++ mismatches when using cuda-enabled c++ packages (built using gcc11, because nvcc requires so) with any other c++ packages built via gcc12.

@pennae suggested we could try and rely on libstdc++ backward compatibility, specifically we could build with gcc11 and patchelf the resulting artifacts to consume libstdc++ from gcc12

In a similar spirit, this PR explores the possibility of directly passing the new libstdc++ to the old gcc11, avoiding the need to patchelf (and maintain the patchelfing logic)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Fixes at least some derivations: e.g. cuda-enabled `easyocr` fails without this patch, but succeeds with it
- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->


CC @NixOS/cuda-maintainers 