### PR TITLE
functiontrace-server: init at 0.5.2

### DIFF
--- a/pkgs/development/tools/functiontrace-server/default.nix
+++ b/pkgs/development/tools/functiontrace-server/default.nix
@@ -1,0 +1,23 @@
+{ lib, rustPlatform, fetchCrate, stdenv, darwin }:
+
+rustPlatform.buildRustPackage rec {
+  pname = "functiontrace-server";
+  version = "0.5.2";
+
+  src = fetchCrate {
+    inherit pname version;
+    hash = "sha256-p6ypMfg99ohQCyPB2O0wXbGmPvD2K9V3EnFDd5dC6js=";
+  };
+
+  cargoHash = "sha256-3tLjW7yiS1dNsV81KUZbfN2pvYT9kqiC62nWFid2NH8=";
+
+  buildInputs = lib.optionals stdenv.isDarwin
+    [ darwin.apple_sdk.frameworks.CoreFoundation ];
+
+  meta = with lib; {
+    description = "Server for FunctionTrace, a graphical Python profiler";
+    homepage = "https://functiontrace.com";
+    license = with licenses; [ prosperity30 ];
+    maintainers = with maintainers; [ tehmatt ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -542,6 +542,8 @@ with pkgs;
 
   frugal = callPackage ../development/tools/frugal { };
 
+  functiontrace-server = callPackage ../development/tools/functiontrace-server { };
+
   glade = callPackage ../development/tools/glade { };
 
   goda = callPackage ../development/tools/goda { };


### PR DESCRIPTION
###### Description of changes

Added initial version of the server-piece of https://functiontrace.com. 
This is most useful with a functiontrace client, which depends on this and will therefore be added as a new package afterwards.

###### Things done


- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
