### PR TITLE
setbfree: build GUI

### DIFF
--- a/pkgs/applications/audio/setbfree/default.nix
+++ b/pkgs/applications/audio/setbfree/default.nix
@@ -14,9 +14,9 @@ stdenv.mkDerivation  rec {
   };
 
   postPatch = ''
-    sed 's#/usr/local#$(out)#g' -i common.mak
-    sed 's#/usr/share/fonts/truetype/ttf-bitstream-vera#${ttf_bitstream_vera}/share/fonts/truetype#g' \
-      -i b_synth/Makefile
+    substituteInPlace common.mak \
+      --replace /usr/local "$out" \
+      --replace /usr/share/fonts/truetype/ttf-bitstream-vera "${ttf_bitstream_vera}/share/fonts/truetype"
   '';
 
   nativeBuildInputs = [ pkg-config ];
@@ -24,6 +24,15 @@ stdenv.mkDerivation  rec {
     alsa-lib freetype ftgl libjack2 libX11 lv2 libGLU libGL
     ttf_bitstream_vera
   ];
+
+  doInstallCheck = true;
+
+  installCheckPhase = ''(
+    set -x
+    test -e $out/bin/setBfreeUI
+  )'';
+
+  enableParallelBuilding = true;
 
   meta = with lib; {
     description = "A DSP tonewheel organ emulator";


### PR DESCRIPTION
###### Description of changes

`setBfreeUI` (and plugin GUI) are only built when ttf-bitstream-vera is found.

Based on #223070

/cc @Rampoina

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
