### PR TITLE
vscode-extensions: add 2 new extensions

### DIFF
--- a/pkgs/applications/editors/vscode/extensions/default.nix
+++ b/pkgs/applications/editors/vscode/extensions/default.nix
@@ -1256,6 +1256,22 @@ let
         };
       };
 
+      github.vscode-github-actions = buildVscodeMarketplaceExtension {
+        mktplcRef = {
+          name = "vscode-github-actions";
+          publisher = "github";
+          version = "0.25.3";
+          sha256 = "sha256-0Ag+xXVt+WBfN+7VmWILYU4RsVs+CBDBpMfUTczDCkI=";
+        };
+        meta = {
+          description = "A Visual Studio Code extension for GitHub Actions workflows and runs for github.com hosted repositories";
+          downloadPage = "https://marketplace.visualstudio.com/items?itemName=github.vscode-github-actions";
+          homepage = "https://github.com/github/vscode-github-actions";
+          license = lib.licenses.mit;
+          maintainers = [ lib.maintainers.drupol ];
+        };
+      };
+
       github.vscode-pull-request-github = buildVscodeMarketplaceExtension {
         mktplcRef = {
           name = "vscode-pull-request-github";

--- a/pkgs/applications/editors/vscode/extensions/default.nix
+++ b/pkgs/applications/editors/vscode/extensions/default.nix
@@ -2122,6 +2122,23 @@ let
         };
       };
 
+      nvarner.typst-lsp = buildVscodeMarketplaceExtension {
+        mktplcRef = {
+          name = "typst-lsp";
+          publisher = "nvarner";
+          version = "0.3.0";
+          sha256 = "sha256-ek5zXK4ecXwSPMJ4Ihy2l3PMxCdHwJN7dbwZfQVjNG8=";
+        };
+        meta = {
+          changelog = "https://marketplace.visualstudio.com/items/nvarner.typst-lsp/changelog";
+          description = "A VSCode extension for providing a language server for Typst";
+          downloadPage = "https://marketplace.visualstudio.com/items?itemName=nvarner.typst-lsp";
+          homepage = "https://github.com/nvarner/typst-lsp";
+          license = lib.licenses.mit;
+          maintainers = [ lib.maintainers.drupol ];
+        };
+      };
+
       ocamllabs.ocaml-platform = buildVscodeMarketplaceExtension {
         meta = {
           changelog = "https://marketplace.visualstudio.com/items/ocamllabs.ocaml-platform/changelog";


### PR DESCRIPTION
This PR provides 2 new VSCode extensions:

1. Since `typst` and [`typst-lsp`](https://github.com/NixOS/nixpkgs/pull/223720)is now in Nix, let's use the VSCode extension. This extension ship the `typst-lsp` binary, however it is not yet possible to customize a custom binary, there is an issue for that: https://github.com/nvarner/typst-lsp/issues/55
2. New github extension: https://github.blog/changelog/2023-03-28-github-actions-visual-studio-code-extension-is-now-in-public-beta/

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
