### PR TITLE
firefox-{beta,devedition}{-bin}-unwrapped: 112.0b{3,6,7} -> 112.0b8

### DIFF
--- a/pkgs/applications/networking/browsers/firefox-bin/beta_sources.nix
+++ b/pkgs/applications/networking/browsers/firefox-bin/beta_sources.nix
@@ -1,1005 +1,1005 @@
 {
-  version = "112.0b3";
+  version = "112.0b8";
   sources = [
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b3/linux-x86_64/ach/firefox-112.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b8/linux-x86_64/ach/firefox-112.0b8.tar.bz2";
       locale = "ach";
       arch = "linux-x86_64";
-      sha256 = "7e45e3f7a8b985f05fe32c038d8dcf707d4c7f7d544443554923e54222c10f69";
+      sha256 = "2243ac96b3207ff374f00da9bbcd4ad5285e476e0ea53f646f87d4ccad5dc640";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b3/linux-x86_64/af/firefox-112.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b8/linux-x86_64/af/firefox-112.0b8.tar.bz2";
       locale = "af";
       arch = "linux-x86_64";
-      sha256 = "3ef52da36f6944f458af7730f3a0052f94dafe7daf81996364930dab63208cb5";
+      sha256 = "5ae81c6eecc9cdec47fff2e5ca0483d097fb5b574d36aadacac073decaf855a0";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b3/linux-x86_64/an/firefox-112.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b8/linux-x86_64/an/firefox-112.0b8.tar.bz2";
       locale = "an";
       arch = "linux-x86_64";
-      sha256 = "c9d4d16d7b6035babc3ca12149dcce628ceea7c6caa05663ca9d7e4a61570cd5";
+      sha256 = "71c159677d1234d041b5b8a9d471f1c01c352104e8a2a4d249ccb9a4cffde9f0";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b3/linux-x86_64/ar/firefox-112.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b8/linux-x86_64/ar/firefox-112.0b8.tar.bz2";
       locale = "ar";
       arch = "linux-x86_64";
-      sha256 = "d5dcaa8b76a9699eb9af6cc30c6de560c9b8e7ceaa96d0d208f2e30b29471dd6";
+      sha256 = "608f93efe2c76b875d6a1b0799aec2d1a71ee609d3cd75b1c6c8fe0ddefce504";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b3/linux-x86_64/ast/firefox-112.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b8/linux-x86_64/ast/firefox-112.0b8.tar.bz2";
       locale = "ast";
       arch = "linux-x86_64";
-      sha256 = "d61ba0ee0079683a47163644fd5abbd0dda0c6387c6f30d0de90abfba4f5261f";
+      sha256 = "425259d3b90127a51bf08b6f354eab7364d2ff58c5d6b8845afde1513c64feb8";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b3/linux-x86_64/az/firefox-112.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b8/linux-x86_64/az/firefox-112.0b8.tar.bz2";
       locale = "az";
       arch = "linux-x86_64";
-      sha256 = "3cf3a5bf77bce607b26b8cf34aa3d148d9e09b0de9010b7ee6032553e165e6c1";
+      sha256 = "0e4b1e1b78dc599547fbda1db6762761301874f571df9b5ced8bcfa73edb4cba";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b3/linux-x86_64/be/firefox-112.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b8/linux-x86_64/be/firefox-112.0b8.tar.bz2";
       locale = "be";
       arch = "linux-x86_64";
-      sha256 = "bbbdd7092f34e116d9974303dc224fdbc6cf510413ff45f15d8036e27f2a8bf2";
+      sha256 = "5a3de39ce38855472cc345a88ac6460da4ea61f0b97bdc079930e31855b7e682";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b3/linux-x86_64/bg/firefox-112.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b8/linux-x86_64/bg/firefox-112.0b8.tar.bz2";
       locale = "bg";
       arch = "linux-x86_64";
-      sha256 = "47bf112189e74f5d4e87864a695915e0ecbfd454890b0f709f229869bf15bd7f";
+      sha256 = "8fd4506a0ce7427758404e04132d4b32a7543f076eb1c473ef368089e51e6795";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b3/linux-x86_64/bn/firefox-112.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b8/linux-x86_64/bn/firefox-112.0b8.tar.bz2";
       locale = "bn";
       arch = "linux-x86_64";
-      sha256 = "8d4a77d3eed954c442c91e1f43f83c1abedcd394fa26b3b55594f6879cbfb564";
+      sha256 = "0b41e7c3c068ceb02612fc3d4277059e2640fd1708163c6b9695aca849164c76";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b3/linux-x86_64/br/firefox-112.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b8/linux-x86_64/br/firefox-112.0b8.tar.bz2";
       locale = "br";
       arch = "linux-x86_64";
-      sha256 = "99464a0825965bf95fc20f3f02c5263e6adb9ffe95c5457724d708d7cf35345b";
+      sha256 = "e5a8c2a3b4168b3eeb99ebaf42909c99e23d5f774a71af2a9fd13782a4914753";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b3/linux-x86_64/bs/firefox-112.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b8/linux-x86_64/bs/firefox-112.0b8.tar.bz2";
       locale = "bs";
       arch = "linux-x86_64";
-      sha256 = "d508c6cd95261589e597c3d38555d8182f1d6bb7df3fee6bf51d69ff62bb4ba6";
+      sha256 = "a510f6c220c55ded84d6f0da98c872aa1aab3dbd7d09567d76b4217a0235b14c";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b3/linux-x86_64/ca-valencia/firefox-112.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b8/linux-x86_64/ca-valencia/firefox-112.0b8.tar.bz2";
       locale = "ca-valencia";
       arch = "linux-x86_64";
-      sha256 = "66c160faefc80ea3a4d7bdb8bd4ec415d6e6880decc0ae8b785ba41245fe7788";
+      sha256 = "a224c3afa85b8e2e664b7cb0180bc8c5368403d9f14308f7a605401afe3af793";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b3/linux-x86_64/ca/firefox-112.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b8/linux-x86_64/ca/firefox-112.0b8.tar.bz2";
       locale = "ca";
       arch = "linux-x86_64";
-      sha256 = "81aa78e972989fcfcd36f46698863806853d92514afaac7adf567aa55bd6a60e";
+      sha256 = "a4aa1296fd1590612b63a1063409b0779ff9b6e3f4e871c4480a51940c6dcc45";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b3/linux-x86_64/cak/firefox-112.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b8/linux-x86_64/cak/firefox-112.0b8.tar.bz2";
       locale = "cak";
       arch = "linux-x86_64";
-      sha256 = "d9631a4c750b65377210266c8461c529e2ab5fa625b78e971d11a0116ab9d1a3";
+      sha256 = "f0e65232445effbf458ac05546824591346d2ce264452159bc1854a154831648";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b3/linux-x86_64/cs/firefox-112.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b8/linux-x86_64/cs/firefox-112.0b8.tar.bz2";
       locale = "cs";
       arch = "linux-x86_64";
-      sha256 = "7f90dc968b6d4c25ffef4708adf2031b29fe4b0b11a694a4d3c4c35c071a73da";
+      sha256 = "f92da7c25745e8262c4ac16f2bd7ad0e45689d89ec4b8e8a354f9163e130c075";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b3/linux-x86_64/cy/firefox-112.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b8/linux-x86_64/cy/firefox-112.0b8.tar.bz2";
       locale = "cy";
       arch = "linux-x86_64";
-      sha256 = "1a9e15ad5733a86000a31f93a403cbb43578de54c05a97b0e6e40a8f3fd244ac";
+      sha256 = "4cfea6a733a9120d866f28bc74f932cc2beec57d316a4be0f3e22adac92cc9c8";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b3/linux-x86_64/da/firefox-112.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b8/linux-x86_64/da/firefox-112.0b8.tar.bz2";
       locale = "da";
       arch = "linux-x86_64";
-      sha256 = "ebf834bcae918981e89795434ae40768b826b13371acc7ec9ba08dc72aaa73b1";
+      sha256 = "a296ed20aa46f5a53df7860390eaa8d69f0ba4e651a18d6ac004cfd9edaf6e68";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b3/linux-x86_64/de/firefox-112.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b8/linux-x86_64/de/firefox-112.0b8.tar.bz2";
       locale = "de";
       arch = "linux-x86_64";
-      sha256 = "666dbf7af58657fe9b0b7f99bfbc8d46ae02305d1289e8a91be8f4aea9b46006";
+      sha256 = "c530ff97db3fd4760994ee6ce3536a4ba3a1853bd46588dfbb1b92fcf4f43411";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b3/linux-x86_64/dsb/firefox-112.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b8/linux-x86_64/dsb/firefox-112.0b8.tar.bz2";
       locale = "dsb";
       arch = "linux-x86_64";
-      sha256 = "236a9920e1f6800d5625ce580cbc631a42fd30e5bf25dafe154708a0fbdc677f";
+      sha256 = "e9bf3073a0503e00a3b5100d4040491a8028fd526b8b1468d3f3cfe3b7be1117";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b3/linux-x86_64/el/firefox-112.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b8/linux-x86_64/el/firefox-112.0b8.tar.bz2";
       locale = "el";
       arch = "linux-x86_64";
-      sha256 = "0c93516a4c1902ff9be2f1e3a0e782246f6105142ce0fa2bb77401ce271efb76";
+      sha256 = "acdd96bf7d68eb8a0bf62f5c3250fc4258d0dda674358d5443219ae51472b9d6";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b3/linux-x86_64/en-CA/firefox-112.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b8/linux-x86_64/en-CA/firefox-112.0b8.tar.bz2";
       locale = "en-CA";
       arch = "linux-x86_64";
-      sha256 = "18e1068a3b3cbac8db7ea9525f2baca3cac3daeb817143069a92ae8684868ae8";
+      sha256 = "de462bc27449e62dca1689c190adfcf72551d44385523672d6326c31727ba32e";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b3/linux-x86_64/en-GB/firefox-112.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b8/linux-x86_64/en-GB/firefox-112.0b8.tar.bz2";
       locale = "en-GB";
       arch = "linux-x86_64";
-      sha256 = "ff19e3ac8ddfcf24c32f497576a5df245846b09242ced4a9da4354597b6d19c2";
+      sha256 = "c9afc752f399b57d0624bcced35621a2936c4e6e92cf1ce18ec6e0e281941a0b";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b3/linux-x86_64/en-US/firefox-112.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b8/linux-x86_64/en-US/firefox-112.0b8.tar.bz2";
       locale = "en-US";
       arch = "linux-x86_64";
-      sha256 = "96c66b52507aff413b5acaf9bc146908cd6725397189cb535a2e6b411ec5cf25";
+      sha256 = "69808b4f2b9af48e157c80c8e8580c2043afb0e631ca34cf23a1d45c1673ae11";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b3/linux-x86_64/eo/firefox-112.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b8/linux-x86_64/eo/firefox-112.0b8.tar.bz2";
       locale = "eo";
       arch = "linux-x86_64";
-      sha256 = "150b2447d458eb34ca6139aa0046c843971749de0359503c8cbef7106b6a7838";
+      sha256 = "b32f9d5ce30d36bccdd2ba28639de181b01fca64c2ce41057f84e323fa2ba6a0";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b3/linux-x86_64/es-AR/firefox-112.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b8/linux-x86_64/es-AR/firefox-112.0b8.tar.bz2";
       locale = "es-AR";
       arch = "linux-x86_64";
-      sha256 = "33870347b2573594f7118b53d535c4100e3aa5dfd79ead8e3e98594e35f02c44";
+      sha256 = "ed67849de6484b356b5d659acc7ca915f69f08bc12960535f4b5607ba5224860";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b3/linux-x86_64/es-CL/firefox-112.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b8/linux-x86_64/es-CL/firefox-112.0b8.tar.bz2";
       locale = "es-CL";
       arch = "linux-x86_64";
-      sha256 = "f6a885941ea044b02823c7ee3e7e59eb7edf9fbd916c207c03a3adb1ac5e9532";
+      sha256 = "10e1f2e3b8a5cd124445981b5f0fd18fd8063d6b8d8021356890702e0e094087";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b3/linux-x86_64/es-ES/firefox-112.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b8/linux-x86_64/es-ES/firefox-112.0b8.tar.bz2";
       locale = "es-ES";
       arch = "linux-x86_64";
-      sha256 = "388d1759395e920f60fc1cdb6b93a936ac59e80cbea18ecab1bd48274ec64241";
+      sha256 = "711e9b95f45385df0797228f7f07cb72e0a611fb2875be2a421be4e51e8a8946";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b3/linux-x86_64/es-MX/firefox-112.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b8/linux-x86_64/es-MX/firefox-112.0b8.tar.bz2";
       locale = "es-MX";
       arch = "linux-x86_64";
-      sha256 = "fc35234ccd7428a0d16a9ed8403912d2f20a145efc89a74c743ba6e187b1a1b5";
+      sha256 = "05c03963bbc7082a233e44f3e85de66b626ad97e27b073e5c95283d95af403db";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b3/linux-x86_64/et/firefox-112.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b8/linux-x86_64/et/firefox-112.0b8.tar.bz2";
       locale = "et";
       arch = "linux-x86_64";
-      sha256 = "12116fb38aba397c30b61ba0d13f1eb334a2240e0cc16e303dfdb4274678ce00";
+      sha256 = "f5aec804e97baac99e0c7263d9914f2d74dd38054e8998ba6729d7a5e0aeb286";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b3/linux-x86_64/eu/firefox-112.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b8/linux-x86_64/eu/firefox-112.0b8.tar.bz2";
       locale = "eu";
       arch = "linux-x86_64";
-      sha256 = "c0c3e164e67e31ce5686479f0494749b5eb1badc157ec3b7148afe490a4296a3";
+      sha256 = "4b4ebf32dbe6a6e987066f4ba246b04fe60d7bbbb6dc981b735628a4a46c4ff7";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b3/linux-x86_64/fa/firefox-112.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b8/linux-x86_64/fa/firefox-112.0b8.tar.bz2";
       locale = "fa";
       arch = "linux-x86_64";
-      sha256 = "b0bd2b70aca166e66d102ab263fa9532dbff40c563ae463aeb2302d7b958e1ff";
+      sha256 = "3a52687d057445e3edbffb654f0fdf40c8e50473788f5d20e7a09a8acf368a9f";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b3/linux-x86_64/ff/firefox-112.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b8/linux-x86_64/ff/firefox-112.0b8.tar.bz2";
       locale = "ff";
       arch = "linux-x86_64";
-      sha256 = "c456cad156aad5c99f49a697266fa67d273b5bccae9704db6a0106e3f3e363bb";
+      sha256 = "004d494217951542c6f713695b1a52ed959a405392b12a1555b0d4ca487b3ba7";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b3/linux-x86_64/fi/firefox-112.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b8/linux-x86_64/fi/firefox-112.0b8.tar.bz2";
       locale = "fi";
       arch = "linux-x86_64";
-      sha256 = "c63837738b96928de3367fc0a23ba69b339d5ab81f21280681546be5bcc9a03b";
+      sha256 = "1343323a3a87b2d94069b53964db05b97f943f567ead44b820de90ed9db23b4c";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b3/linux-x86_64/fr/firefox-112.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b8/linux-x86_64/fr/firefox-112.0b8.tar.bz2";
       locale = "fr";
       arch = "linux-x86_64";
-      sha256 = "d066890f90b57b5f6fc53cb3b4e70630d2f2fc4db6283b4e4c4198a68bdfc556";
+      sha256 = "a4c6d695ed474fa40b8879ce79b21e619de538def5620850fad14fbbc11f7558";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b3/linux-x86_64/fur/firefox-112.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b8/linux-x86_64/fur/firefox-112.0b8.tar.bz2";
       locale = "fur";
       arch = "linux-x86_64";
-      sha256 = "e081e4e51f0359e41a6ddc27c9d57263c558ea2a7e80f61ce6dac29d9bee6a19";
+      sha256 = "79231731bfbdbd248c05c6c13cce105f8e07e7a6dcd65e0852d2855ced4e6d5b";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b3/linux-x86_64/fy-NL/firefox-112.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b8/linux-x86_64/fy-NL/firefox-112.0b8.tar.bz2";
       locale = "fy-NL";
       arch = "linux-x86_64";
-      sha256 = "e021fcc87736c1ced1a81de06ceb30100e30a39f6db04789ac48f2d1c95a781d";
+      sha256 = "64d0e7e0795e164be84154e147314c6726175d477ba58932cf48c42881668243";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b3/linux-x86_64/ga-IE/firefox-112.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b8/linux-x86_64/ga-IE/firefox-112.0b8.tar.bz2";
       locale = "ga-IE";
       arch = "linux-x86_64";
-      sha256 = "ee95f7e8eae3c1a7c9884bb62c96a886bfcffd41dfb7b46515ed9298720d805e";
+      sha256 = "5039462f24622eb2f3bd8e34e5de9f9b5bcbc885260efef85e7fb70b4fdaad0b";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b3/linux-x86_64/gd/firefox-112.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b8/linux-x86_64/gd/firefox-112.0b8.tar.bz2";
       locale = "gd";
       arch = "linux-x86_64";
-      sha256 = "c111e1f78a1050e8b31b86bcdd8814a691c9b9c8a71f0659027f6c5a33fdb4b0";
+      sha256 = "67d842a511ada3390e2c0a386cab00180fc610827200acab09fa122f5c4c11f3";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b3/linux-x86_64/gl/firefox-112.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b8/linux-x86_64/gl/firefox-112.0b8.tar.bz2";
       locale = "gl";
       arch = "linux-x86_64";
-      sha256 = "6eb9e74b87d47ddd1d03792067f27252d9980664e78afd661fc60910687b67a5";
+      sha256 = "61bbd21e91700c496812cbd7c6481c1f208d937b4df9aff0da840593eace8661";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b3/linux-x86_64/gn/firefox-112.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b8/linux-x86_64/gn/firefox-112.0b8.tar.bz2";
       locale = "gn";
       arch = "linux-x86_64";
-      sha256 = "3edb762012527ed2c7c404f3fb3eaac4283bb6a8d199861bec1f2cb24fafa416";
+      sha256 = "2ecec3ff0e49f1ff5736842401fa1f896237712894c0d15fea874bfe4e0ca3f2";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b3/linux-x86_64/gu-IN/firefox-112.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b8/linux-x86_64/gu-IN/firefox-112.0b8.tar.bz2";
       locale = "gu-IN";
       arch = "linux-x86_64";
-      sha256 = "db7a2992c6843c7b02686133ebb49cadfdbcb6bbd955a298b3f7b66a73bfc22e";
+      sha256 = "7c5314e1a3eaf53dd7a5447187283e4653f7927ac76327880c33dde45f329700";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b3/linux-x86_64/he/firefox-112.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b8/linux-x86_64/he/firefox-112.0b8.tar.bz2";
       locale = "he";
       arch = "linux-x86_64";
-      sha256 = "e09c49922bce9515d8c7be8c4b3b732856b6aeddcdc10c0e7190c3cf98495cfd";
+      sha256 = "c7216746058657ede3cde2032947d52a1453ae3ffbf025a09152245750c202ac";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b3/linux-x86_64/hi-IN/firefox-112.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b8/linux-x86_64/hi-IN/firefox-112.0b8.tar.bz2";
       locale = "hi-IN";
       arch = "linux-x86_64";
-      sha256 = "6448f743d9a3522dc45c1b6be1e4c984318e37ff40b04b67c491e5131c27285e";
+      sha256 = "a5296762e12971d7864110adbe64fce4739a26b4f992996e34f950408fe1638c";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b3/linux-x86_64/hr/firefox-112.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b8/linux-x86_64/hr/firefox-112.0b8.tar.bz2";
       locale = "hr";
       arch = "linux-x86_64";
-      sha256 = "7cb65061d1bcf2e569ec641c636c5088b9fe345ba06fc228d2080f30591407e1";
+      sha256 = "bb157441fea15eca97105cddc18599c815186dd82a9a8d44ba206d5ebc0f8df4";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b3/linux-x86_64/hsb/firefox-112.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b8/linux-x86_64/hsb/firefox-112.0b8.tar.bz2";
       locale = "hsb";
       arch = "linux-x86_64";
-      sha256 = "78a03d24c65f074baba3dd4dee539f29a78fd0d5b269f169e7a23959acbe1b1a";
+      sha256 = "4a550ca4b0bed05ad91185ec0b4180f6f897005e5ab8f68f9108feb1c3f95bbd";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b3/linux-x86_64/hu/firefox-112.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b8/linux-x86_64/hu/firefox-112.0b8.tar.bz2";
       locale = "hu";
       arch = "linux-x86_64";
-      sha256 = "010d3d910887002cdfe0f027192acdbb8ecc020d79ef6533989729ae46233532";
+      sha256 = "d7e05859fc491669c30f973732769a5e4866efc2985bbe9421de8728a5d34a79";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b3/linux-x86_64/hy-AM/firefox-112.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b8/linux-x86_64/hy-AM/firefox-112.0b8.tar.bz2";
       locale = "hy-AM";
       arch = "linux-x86_64";
-      sha256 = "1bb2a3784e45dcc2dc3569d527137b8aaea2ccca3139801a8060acb37a50558e";
+      sha256 = "af91bc85a24fa02eaa55f906195d34f61f3694e47be7376996de0b5bd03d0a3c";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b3/linux-x86_64/ia/firefox-112.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b8/linux-x86_64/ia/firefox-112.0b8.tar.bz2";
       locale = "ia";
       arch = "linux-x86_64";
-      sha256 = "b067c8cf7007fc3f8afab8b254e88c985b116e09bde24b56ca9f67a645d63b85";
+      sha256 = "ede077d82196780be9daf0ed69c51332035e5dabbb0ebfbcbba523fc616f8b28";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b3/linux-x86_64/id/firefox-112.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b8/linux-x86_64/id/firefox-112.0b8.tar.bz2";
       locale = "id";
       arch = "linux-x86_64";
-      sha256 = "caa1a74846f17d80dd0694b6b5e45f0e67ac19c9dca2d700ec17df12fb517972";
+      sha256 = "484126b2310bf64f72044e0aa6a41c03bc3ce6d473571e7cdbe61f8e7093f340";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b3/linux-x86_64/is/firefox-112.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b8/linux-x86_64/is/firefox-112.0b8.tar.bz2";
       locale = "is";
       arch = "linux-x86_64";
-      sha256 = "a09d2f36353fe3cb39b69f0420ba5cd63629023c534ce95c7ef438d659161eaa";
+      sha256 = "0d15c2e0ec0b74cc4b5c8d0f0ec746b15a57d0ef256952be2dab2514f950f53f";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b3/linux-x86_64/it/firefox-112.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b8/linux-x86_64/it/firefox-112.0b8.tar.bz2";
       locale = "it";
       arch = "linux-x86_64";
-      sha256 = "6eec2dc4eda3777a040320e85d46b67269f5f3ed455e14cbdeaec7b3183a8c94";
+      sha256 = "ca4c479fd98978261c117d8e23e28f78fcba9f78bc279583835a758907da4b20";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b3/linux-x86_64/ja/firefox-112.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b8/linux-x86_64/ja/firefox-112.0b8.tar.bz2";
       locale = "ja";
       arch = "linux-x86_64";
-      sha256 = "ac6eea4ed4080f64b6e2a4f1e55fec434a8cfd2177e069c38a4700d9ddcaf2fc";
+      sha256 = "ac09759334e293939f8e93517512da2499ebdad9d71ffa2bedef9a9d32fd2557";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b3/linux-x86_64/ka/firefox-112.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b8/linux-x86_64/ka/firefox-112.0b8.tar.bz2";
       locale = "ka";
       arch = "linux-x86_64";
-      sha256 = "764b2cd0b531d06845390c84a68707ba3c590325984ad0eb493050e045554538";
+      sha256 = "75ac469fc48c945a7ba7f88597028e96392d40edb5a5ef9f808b6307e6728672";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b3/linux-x86_64/kab/firefox-112.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b8/linux-x86_64/kab/firefox-112.0b8.tar.bz2";
       locale = "kab";
       arch = "linux-x86_64";
-      sha256 = "d3e2481e32f3ce0816f73ee194d16267692cb90dfa44bf0af6257d06b2cb1845";
+      sha256 = "99f0d057e04a74e77133144d0fa5299c6d9e71328e06999123689932f832b316";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b3/linux-x86_64/kk/firefox-112.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b8/linux-x86_64/kk/firefox-112.0b8.tar.bz2";
       locale = "kk";
       arch = "linux-x86_64";
-      sha256 = "ce9b2e0f7badb1e707ca80aeb65bbf918ed9d8affa2052d93acf150610e669a1";
+      sha256 = "3c0f35e128d3e3217b5deb31a3b4f4d166f87fc6664a292ae5d600bf69334282";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b3/linux-x86_64/km/firefox-112.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b8/linux-x86_64/km/firefox-112.0b8.tar.bz2";
       locale = "km";
       arch = "linux-x86_64";
-      sha256 = "8f9ff69366b06a06baa60ba36f04423b01f846342318646edb1c05efb20e4da8";
+      sha256 = "3620322ecf94efc45b3d3986166d040a81f9a4c44584006d6b068956e9ff71db";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b3/linux-x86_64/kn/firefox-112.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b8/linux-x86_64/kn/firefox-112.0b8.tar.bz2";
       locale = "kn";
       arch = "linux-x86_64";
-      sha256 = "c05f319cc0d2f63632968dd0491c9452168e56196c83dd6a19f2e4e1b025888e";
+      sha256 = "d46f7f01aa3782eceed107e58622df6ade5db67381564405c295928eaca399d1";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b3/linux-x86_64/ko/firefox-112.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b8/linux-x86_64/ko/firefox-112.0b8.tar.bz2";
       locale = "ko";
       arch = "linux-x86_64";
-      sha256 = "ae3dc7e532dd3defc4ece73f04fa593d4108951e28118e47d22ea4469f90981d";
+      sha256 = "4c15d74d7bdb2043b9eff801d9d981e220f5f71dd27dbabdda19e79b83bac406";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b3/linux-x86_64/lij/firefox-112.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b8/linux-x86_64/lij/firefox-112.0b8.tar.bz2";
       locale = "lij";
       arch = "linux-x86_64";
-      sha256 = "2892bb5071818ea646ffb1baef35c1e2afd8a1336ccc61f1ca5c2b16dff898a4";
+      sha256 = "8f75913e681841c06c148d1601516ca5c876a4dbe05f05a50d73cbd4da1832da";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b3/linux-x86_64/lt/firefox-112.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b8/linux-x86_64/lt/firefox-112.0b8.tar.bz2";
       locale = "lt";
       arch = "linux-x86_64";
-      sha256 = "c1f2f2ac21ac4aa2baf884e2c33e627a122e5be2cfe28abe7b5955b9ccfa0356";
+      sha256 = "e81886bd26573d77d6ca1c1751c4eaafd8a8058dd3a27a9a715fe4f8a935a9c6";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b3/linux-x86_64/lv/firefox-112.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b8/linux-x86_64/lv/firefox-112.0b8.tar.bz2";
       locale = "lv";
       arch = "linux-x86_64";
-      sha256 = "9e8eefe5d71ec1a8f2584c295e9dbcab46bb5c91647ca54a2e0d8e33e609c598";
+      sha256 = "ab9008d20842006c3451a4b2b4f6e92db8a74990a8780979ff0584be9e87fdb7";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b3/linux-x86_64/mk/firefox-112.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b8/linux-x86_64/mk/firefox-112.0b8.tar.bz2";
       locale = "mk";
       arch = "linux-x86_64";
-      sha256 = "5a63aa725162b1915b16b94a237f4adec1f15c982ee4640ac3f1af9207ccd2fc";
+      sha256 = "e3a3a1bfdd12d8df260969071dd439156610bb95f2598843dd1cc2a44ff86319";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b3/linux-x86_64/mr/firefox-112.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b8/linux-x86_64/mr/firefox-112.0b8.tar.bz2";
       locale = "mr";
       arch = "linux-x86_64";
-      sha256 = "b2ada28e6bc7e5805e802aea02ceff5cc84e05716363c1a57cd38ec10fe6a132";
+      sha256 = "a054158ce648410c327c448401bf060b5e946505211ac441e3f576c0841668c6";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b3/linux-x86_64/ms/firefox-112.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b8/linux-x86_64/ms/firefox-112.0b8.tar.bz2";
       locale = "ms";
       arch = "linux-x86_64";
-      sha256 = "0205f2ab90af921cd5ba92a1679ef3e2b955f806ab4da4c4817222e25ecbeda3";
+      sha256 = "1c53b658ea9ea9922c5f60cf6565e6d79401dc0d0a3a0ec0738bb13b52421bb5";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b3/linux-x86_64/my/firefox-112.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b8/linux-x86_64/my/firefox-112.0b8.tar.bz2";
       locale = "my";
       arch = "linux-x86_64";
-      sha256 = "6c8620a171bb486d5fb110568f2bcdadd31a012a22d886762286724eb4d299f7";
+      sha256 = "685e611b048d6c112adfe250f52139208599b0d77f684606c441104e28551743";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b3/linux-x86_64/nb-NO/firefox-112.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b8/linux-x86_64/nb-NO/firefox-112.0b8.tar.bz2";
       locale = "nb-NO";
       arch = "linux-x86_64";
-      sha256 = "d2ff3b33732ecc1693f4c93f63a8b750cb25c02e5f2df91a6266ff1f54c40692";
+      sha256 = "b66eca6d42f89a011acfd237f0576bb03efd86c01f9ade8c1fbc446f9b82db44";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b3/linux-x86_64/ne-NP/firefox-112.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b8/linux-x86_64/ne-NP/firefox-112.0b8.tar.bz2";
       locale = "ne-NP";
       arch = "linux-x86_64";
-      sha256 = "c3b25f66028043244a8da57d7d9e091c6a8d8cd0c153a157839b4aeaf66e743b";
+      sha256 = "1e718aea978c9119b15e2ec398ae21bb1fe538d78e657032a58ee3d64e3322e1";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b3/linux-x86_64/nl/firefox-112.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b8/linux-x86_64/nl/firefox-112.0b8.tar.bz2";
       locale = "nl";
       arch = "linux-x86_64";
-      sha256 = "66af5afead6aa2b596342d117e6d9aee3df99b5e87a4ff765cd62e98a74c28ee";
+      sha256 = "f51e5a6a44d80948345561ee43ecb01b0567cdb5e1813ef68c4229f1df20caab";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b3/linux-x86_64/nn-NO/firefox-112.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b8/linux-x86_64/nn-NO/firefox-112.0b8.tar.bz2";
       locale = "nn-NO";
       arch = "linux-x86_64";
-      sha256 = "fe48675b369b36eebfd6c25907bc12b29540698f8fbd13bc111a85fb80cd710f";
+      sha256 = "29b081f1c879a4ad6a97f0e282eecb9f33f7358d925c2e4bbb3722196ea94ebd";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b3/linux-x86_64/oc/firefox-112.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b8/linux-x86_64/oc/firefox-112.0b8.tar.bz2";
       locale = "oc";
       arch = "linux-x86_64";
-      sha256 = "0a1ef700dd183a4d63fa74fd69e633e808b7049dd6594acd39e99d8a10e4eebe";
+      sha256 = "77dab4224d6c0de52e5f106f25c0d3ad01bae7245cf416e16c05e11221963be3";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b3/linux-x86_64/pa-IN/firefox-112.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b8/linux-x86_64/pa-IN/firefox-112.0b8.tar.bz2";
       locale = "pa-IN";
       arch = "linux-x86_64";
-      sha256 = "d80243b94c87c6746fb905ea87f17309d646207798e5b9641f19da7a63c2d287";
+      sha256 = "0efe5e08bad66bd3423ef9ed1b9c68aa9bbb12621831328c259e17100bac5040";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b3/linux-x86_64/pl/firefox-112.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b8/linux-x86_64/pl/firefox-112.0b8.tar.bz2";
       locale = "pl";
       arch = "linux-x86_64";
-      sha256 = "7960a3ca66d1298f5c8d42211e59cbf7445f30f61537bb52e3d62819b8e1ba46";
+      sha256 = "a76253acf5163d9072b98b3af680d703ee607843b5a45edbeccb489b11c57e89";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b3/linux-x86_64/pt-BR/firefox-112.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b8/linux-x86_64/pt-BR/firefox-112.0b8.tar.bz2";
       locale = "pt-BR";
       arch = "linux-x86_64";
-      sha256 = "239bb21c476967ac08019c463f216a6c0af2ee25a6180f8fea7ddbf98e9e141f";
+      sha256 = "8a684ad41338ac94b41a707d222eed00c273bb7dcf7b837ad10d0479984756e7";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b3/linux-x86_64/pt-PT/firefox-112.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b8/linux-x86_64/pt-PT/firefox-112.0b8.tar.bz2";
       locale = "pt-PT";
       arch = "linux-x86_64";
-      sha256 = "ace072d1c550e9589ff8fc24d12babb625eb72b87fc8a8dbb772675fffa04a28";
+      sha256 = "f4171e6a1bba95d07fbca8ec9a484a2762cb57dc34c4ff7cc2682f8ba10293c7";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b3/linux-x86_64/rm/firefox-112.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b8/linux-x86_64/rm/firefox-112.0b8.tar.bz2";
       locale = "rm";
       arch = "linux-x86_64";
-      sha256 = "933fcbb0cf009af7f6ab8859e935345475a7dbcd64b550ede2ad2ec08b6d349a";
+      sha256 = "fb0ae58eb8a6f70cae895aa71ce267fe419ee51df690d53a7860b641be58ca57";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b3/linux-x86_64/ro/firefox-112.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b8/linux-x86_64/ro/firefox-112.0b8.tar.bz2";
       locale = "ro";
       arch = "linux-x86_64";
-      sha256 = "aafd262fdfd1565babf682ca8f14d536323a56c580cadfc241b85ddbcdcff9e3";
+      sha256 = "cd9c0d9b15f879dbc3551cc6907f2bd2dd7ed92d5d27b469cbeb96823a7635fa";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b3/linux-x86_64/ru/firefox-112.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b8/linux-x86_64/ru/firefox-112.0b8.tar.bz2";
       locale = "ru";
       arch = "linux-x86_64";
-      sha256 = "4b0105bf3f127b672caaf6276d7a10484a3d96b1f59d2af08532dd7a7215f002";
+      sha256 = "695805e82ece79cfbe226ce3bdfd91fbaa554fb0ba7f3795ea60a61b9e77d610";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b3/linux-x86_64/sc/firefox-112.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b8/linux-x86_64/sc/firefox-112.0b8.tar.bz2";
       locale = "sc";
       arch = "linux-x86_64";
-      sha256 = "df94931cc329f8b8ee3013dc95f6636450cc9338a4328d0972fe770b7968aff5";
+      sha256 = "8046d5cf96540f50c8b6639bee471996e46073e872dc2fb177240ee98e6464ae";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b3/linux-x86_64/sco/firefox-112.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b8/linux-x86_64/sco/firefox-112.0b8.tar.bz2";
       locale = "sco";
       arch = "linux-x86_64";
-      sha256 = "d456cc9c89b5746a56c5b446a97c6495a55aac8e18a909a55d3403cd6bb1b2e2";
+      sha256 = "1b952061abb4a2741e3f279a8013aa01b335689215e4f948ad6303597690937b";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b3/linux-x86_64/si/firefox-112.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b8/linux-x86_64/si/firefox-112.0b8.tar.bz2";
       locale = "si";
       arch = "linux-x86_64";
-      sha256 = "99f9511a925b16777df8e1950c56ce68e111bb0ac1eb332e0f7cb6f4de534a3e";
+      sha256 = "6eb0d5032391f80ae44f68ab3d2f9cdba3b2c94c4a6d996b32092bc609e478e5";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b3/linux-x86_64/sk/firefox-112.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b8/linux-x86_64/sk/firefox-112.0b8.tar.bz2";
       locale = "sk";
       arch = "linux-x86_64";
-      sha256 = "8aadec2e42537328b890bbcaff86d14a194abb2bd850986cac9dcf21ba7f4ff7";
+      sha256 = "2070881290efbb99546ddd0255af47856df1829e9cc797de92f9b5828dacbe0c";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b3/linux-x86_64/sl/firefox-112.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b8/linux-x86_64/sl/firefox-112.0b8.tar.bz2";
       locale = "sl";
       arch = "linux-x86_64";
-      sha256 = "4af6d8fa4ec9021bddb98b0b97f940f5e8cf3676e1a32549ed52f8dda3101c7c";
+      sha256 = "12418dc9321753a3708701f26e57c7ff95b373d77c6ab36746958faab860b1a7";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b3/linux-x86_64/son/firefox-112.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b8/linux-x86_64/son/firefox-112.0b8.tar.bz2";
       locale = "son";
       arch = "linux-x86_64";
-      sha256 = "77016e2537c61ebbcd17fd72d4ff2164ab6bfa7dd0824245ed088af842381192";
+      sha256 = "b7c594000b6f0e226e0fc67847cdee189f12dbcc32eba7b481e2014056e96bd4";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b3/linux-x86_64/sq/firefox-112.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b8/linux-x86_64/sq/firefox-112.0b8.tar.bz2";
       locale = "sq";
       arch = "linux-x86_64";
-      sha256 = "96f56bee14f7f04bd2996795eb2b805ac45858e7021878aeef9fa4359cfc0435";
+      sha256 = "1e1035861d7e43ebd5b92c3066b5709954215b8af64273de52f6cf1b8041f060";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b3/linux-x86_64/sr/firefox-112.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b8/linux-x86_64/sr/firefox-112.0b8.tar.bz2";
       locale = "sr";
       arch = "linux-x86_64";
-      sha256 = "732891efa9a44ef318631031ec04e8b7697cb4cb446acbc95ebaa181f3b8f352";
+      sha256 = "0d8d9a7ff92ccbc9e45d8d261530d36b7cb80208ba8c47b2e8d6967778dda817";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b3/linux-x86_64/sv-SE/firefox-112.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b8/linux-x86_64/sv-SE/firefox-112.0b8.tar.bz2";
       locale = "sv-SE";
       arch = "linux-x86_64";
-      sha256 = "d36b1964911bf0d9ab1263eaf74aebe6d9c8cf441957758b53e7a89beb95d583";
+      sha256 = "ad3c54de9d2c1f242e12cd0d722a766ac028db38657ea01d499ca16ac8b4fa87";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b3/linux-x86_64/szl/firefox-112.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b8/linux-x86_64/szl/firefox-112.0b8.tar.bz2";
       locale = "szl";
       arch = "linux-x86_64";
-      sha256 = "4bff66e23e172c3aa559ac30556a4037ad6ed5c677dbdd9600204eea3fc25425";
+      sha256 = "cccb19f295dc5b07b52bea083ee783f1a99cc89993e410995d7dc82a3dbc1825";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b3/linux-x86_64/ta/firefox-112.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b8/linux-x86_64/ta/firefox-112.0b8.tar.bz2";
       locale = "ta";
       arch = "linux-x86_64";
-      sha256 = "4903f9b69bb1ca205ea80846cf613bc647895b40af291ed5646678a55e2e18be";
+      sha256 = "6a6d808a7738ded579be2e81600cb69fc0a3c2c7450b03f4ee2d278be8417f58";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b3/linux-x86_64/te/firefox-112.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b8/linux-x86_64/te/firefox-112.0b8.tar.bz2";
       locale = "te";
       arch = "linux-x86_64";
-      sha256 = "a4abc8854330301bc802a3af9cd18417a112f0593dab7d1aecb405dc36ed7af4";
+      sha256 = "4b2d3d3836967619f8f2041274070a982357459c101d4131b73f66d50435e2e8";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b3/linux-x86_64/th/firefox-112.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b8/linux-x86_64/th/firefox-112.0b8.tar.bz2";
       locale = "th";
       arch = "linux-x86_64";
-      sha256 = "4763629e8af04123a4e7b8c78d0278865e8d6f89c3f6a3cbe9f651ee4d88e7fc";
+      sha256 = "631b7de435649777412b07f11ba1dce788d7bd832684f192bd248d73da17c1d1";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b3/linux-x86_64/tl/firefox-112.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b8/linux-x86_64/tl/firefox-112.0b8.tar.bz2";
       locale = "tl";
       arch = "linux-x86_64";
-      sha256 = "497b8b0734acf68dcbcd178b2497cc8ac6035b6149aa6d65d9bb8bbfba9c60c1";
+      sha256 = "aa4d57aaa4ff587aa204f73239d68f212ceb12381535b9d5c92d1ed4be649f79";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b3/linux-x86_64/tr/firefox-112.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b8/linux-x86_64/tr/firefox-112.0b8.tar.bz2";
       locale = "tr";
       arch = "linux-x86_64";
-      sha256 = "794523fcee761f9bcb6280b0f128593efdcb09ff9b20d88440a2186119605d8f";
+      sha256 = "db6ce989962d930a387b20a15c5a089893550572e502758d2a2a7aa91f1ceed6";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b3/linux-x86_64/trs/firefox-112.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b8/linux-x86_64/trs/firefox-112.0b8.tar.bz2";
       locale = "trs";
       arch = "linux-x86_64";
-      sha256 = "363221e20eca037f4e5634f6d8d4fe5486be98b7f0459357914c55fc6818499f";
+      sha256 = "4a0492652933a351943ceb5dc96e4b7f25efedc039d176d61668106257a14468";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b3/linux-x86_64/uk/firefox-112.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b8/linux-x86_64/uk/firefox-112.0b8.tar.bz2";
       locale = "uk";
       arch = "linux-x86_64";
-      sha256 = "a32b0eeb5b3129cdae61bcbbb504dcf38642c0e1207a99f548ca6aaf4da4c0e3";
+      sha256 = "c18a3f766e06be35fec21617f86e1f1a40e3e05a5d7dfb4a75adb254c4d3fb15";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b3/linux-x86_64/ur/firefox-112.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b8/linux-x86_64/ur/firefox-112.0b8.tar.bz2";
       locale = "ur";
       arch = "linux-x86_64";
-      sha256 = "fde4b30f65dcf087ea90cdb07fae9a7b25a828de522fd464fa30a6a6e173660c";
+      sha256 = "012cff977e3620099a3837bfdc525fb093277c35f91830e886a2cfda7169390f";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b3/linux-x86_64/uz/firefox-112.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b8/linux-x86_64/uz/firefox-112.0b8.tar.bz2";
       locale = "uz";
       arch = "linux-x86_64";
-      sha256 = "8b25e6ee128ca64beeec953984891b771effd17432b5848eccee200cfadfc2be";
+      sha256 = "efbc53a94c1e34ae4b36f100d298493431dee41df26901168e2a233229e8c746";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b3/linux-x86_64/vi/firefox-112.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b8/linux-x86_64/vi/firefox-112.0b8.tar.bz2";
       locale = "vi";
       arch = "linux-x86_64";
-      sha256 = "b9c97a1deea781928d37118859211b9294af08e13c816017d0782f454fdb2261";
+      sha256 = "43dbef1939a816be4fbead7f7923532485eb70df6a9e8bc4745657b9ebb7889b";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b3/linux-x86_64/xh/firefox-112.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b8/linux-x86_64/xh/firefox-112.0b8.tar.bz2";
       locale = "xh";
       arch = "linux-x86_64";
-      sha256 = "a26e56faa92b9cd893d43db669fb7d48b4451df3e0c7011ba1f37aa509cf3d6b";
+      sha256 = "9a1c44a0aaa70a2ab7b7669b8f81712fcdc53673f8d5f262e1c62d2a45217e10";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b3/linux-x86_64/zh-CN/firefox-112.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b8/linux-x86_64/zh-CN/firefox-112.0b8.tar.bz2";
       locale = "zh-CN";
       arch = "linux-x86_64";
-      sha256 = "48ad92a48bc034f00b5b100abc8cb548a74afa5330d44e8582d4dc50eaa6c673";
+      sha256 = "4df89a6b4c452d9ca32538952ac91758b829eb280db43a5dbecec34b349adc15";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b3/linux-x86_64/zh-TW/firefox-112.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b8/linux-x86_64/zh-TW/firefox-112.0b8.tar.bz2";
       locale = "zh-TW";
       arch = "linux-x86_64";
-      sha256 = "fc02b6787480605a7e6c388a6e912379918dda5c833a27640ba2b81cd674db06";
+      sha256 = "b5b5434fefad06254eb56dc8fc9d953dc9d5c0af92233887119855f7cde0c058";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b3/linux-i686/ach/firefox-112.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b8/linux-i686/ach/firefox-112.0b8.tar.bz2";
       locale = "ach";
       arch = "linux-i686";
-      sha256 = "fd6efbb6835cd3b1940d2767c554b288b947d1621da4ec0f521866ce117d3d1d";
+      sha256 = "b970983d12db8f02d710ca3811bfd2509b0b22b493ab5494990534d12fee5150";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b3/linux-i686/af/firefox-112.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b8/linux-i686/af/firefox-112.0b8.tar.bz2";
       locale = "af";
       arch = "linux-i686";
-      sha256 = "2c8ed270f390281869c1024f2859ed31f8f6eb1cdb25111bcc69a5613c824329";
+      sha256 = "c532e7bc844d825163cd41149c52976c6ca81f85d2835e6b2333d8a15fd59ac9";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b3/linux-i686/an/firefox-112.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b8/linux-i686/an/firefox-112.0b8.tar.bz2";
       locale = "an";
       arch = "linux-i686";
-      sha256 = "4701be757ce5e6a0cfaa105228cf058393c0dd9b6be17336aa6878fbb51a5bf8";
+      sha256 = "3bb4b2e2f9fdd3b5aae43b89d230e245b7dc0cd4e7f47945e90cbe1c87ff22d3";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b3/linux-i686/ar/firefox-112.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b8/linux-i686/ar/firefox-112.0b8.tar.bz2";
       locale = "ar";
       arch = "linux-i686";
-      sha256 = "c4a1fb484d3567a12875c60647526201c181f6caf487d92f344deb7b8175e421";
+      sha256 = "bc79bbab6e123f6be02781902a0365ce7089b70858a7b9a914bab1c8f7a3a729";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b3/linux-i686/ast/firefox-112.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b8/linux-i686/ast/firefox-112.0b8.tar.bz2";
       locale = "ast";
       arch = "linux-i686";
-      sha256 = "225deefcab138bc85de7692244a3e4a640f1202e28f9471fddc7d3f1dafd9900";
+      sha256 = "fb7554cf478257ec1d10a4bf5c10b69dc69a4dd3398dc1f8d0cd40a6886cbfae";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b3/linux-i686/az/firefox-112.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b8/linux-i686/az/firefox-112.0b8.tar.bz2";
       locale = "az";
       arch = "linux-i686";
-      sha256 = "cb5974e3710ed6a24a79169daa53bdddbe35942c5bc000d9b3a0ad2fb7664f4b";
+      sha256 = "d2c1c8b6ffdf1f7d9f0bebd35b1b7e0b16b4f1351d68340a5dd8e2c9d8c780aa";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b3/linux-i686/be/firefox-112.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b8/linux-i686/be/firefox-112.0b8.tar.bz2";
       locale = "be";
       arch = "linux-i686";
-      sha256 = "202fb330e07ae5fabe19f4e30fb6e617598b8d79b1485f2355f09c5d4e5e1c4c";
+      sha256 = "f50ed8f32389b238593935186a5ffd93505492a156de344f037e19e7c3cc40f9";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b3/linux-i686/bg/firefox-112.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b8/linux-i686/bg/firefox-112.0b8.tar.bz2";
       locale = "bg";
       arch = "linux-i686";
-      sha256 = "5a8996968a3bebcfa5dcf9c05f5b819ab0a4463e9e2849a38d301f367f079a25";
+      sha256 = "7458787afc0a5364a290708eb443494bc9d2ab32ed098afa22e2eab8966554c2";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b3/linux-i686/bn/firefox-112.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b8/linux-i686/bn/firefox-112.0b8.tar.bz2";
       locale = "bn";
       arch = "linux-i686";
-      sha256 = "1ba44bc65faba2ac0bd66dee11d446caff87ffc45ecaf1a417bcca87ebc6ab66";
+      sha256 = "396c8a01c690d6cab7181259092e053e7932216f81debeccdce754b1121300f3";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b3/linux-i686/br/firefox-112.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b8/linux-i686/br/firefox-112.0b8.tar.bz2";
       locale = "br";
       arch = "linux-i686";
-      sha256 = "36013e74a785dd5f106adcc36721765f6f91ea7553947c63b970f11390d8b5ed";
+      sha256 = "659f881e7a56cf971f9b2a4417e8e99f6814b46c4c1ca07e9baf9aa62a7eadb8";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b3/linux-i686/bs/firefox-112.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b8/linux-i686/bs/firefox-112.0b8.tar.bz2";
       locale = "bs";
       arch = "linux-i686";
-      sha256 = "ca7d6a7ff5694583b20cb10e2e9b5695254245243fe916493bacbc157a8ec027";
+      sha256 = "c1ee220a098d587aff9ba5c527459053bcd1029fc2aeef54952bfa84bc3a69f9";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b3/linux-i686/ca-valencia/firefox-112.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b8/linux-i686/ca-valencia/firefox-112.0b8.tar.bz2";
       locale = "ca-valencia";
       arch = "linux-i686";
-      sha256 = "3b74ecb0d7a297a11f9f0baa177ef9cdb1bb3c16c0a2f53833c7b247cb52285e";
+      sha256 = "9503f081ef3bd96da09565a62ac115e56cb257f77205d780a733ec3f6d114bff";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b3/linux-i686/ca/firefox-112.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b8/linux-i686/ca/firefox-112.0b8.tar.bz2";
       locale = "ca";
       arch = "linux-i686";
-      sha256 = "c7f258bf9286e5efd49e85dad6483b6bb64f6743d869d5c89ccde1840cb9e737";
+      sha256 = "4d5c56c99beba23e0160d8ee55cfdbbc84933007ee454d8af62a211ad2e14a9c";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b3/linux-i686/cak/firefox-112.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b8/linux-i686/cak/firefox-112.0b8.tar.bz2";
       locale = "cak";
       arch = "linux-i686";
-      sha256 = "75ba9cdf0d382afcb9172c4103ceb14468c0e25f91c1409e233cd471053dd35f";
+      sha256 = "5b930a5cc6fabc42cdf959819d62ae3f12cb8cad9ce66a5e97573f427f5465b8";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b3/linux-i686/cs/firefox-112.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b8/linux-i686/cs/firefox-112.0b8.tar.bz2";
       locale = "cs";
       arch = "linux-i686";
-      sha256 = "d9268af6747ae4dd093167d3ae221a5fe91a2c3f78614fed313794727bd0245b";
+      sha256 = "fe0cd2d3e820abc55629afca52d4109c940d6bba69d29bf7aaa604dc15ed7c71";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b3/linux-i686/cy/firefox-112.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b8/linux-i686/cy/firefox-112.0b8.tar.bz2";
       locale = "cy";
       arch = "linux-i686";
-      sha256 = "7e51ee320ad6f1f46f9a026cbb38a87d49044b69022faa39a32912c889646175";
+      sha256 = "3f5e93445d24765221a94feb938064aa8b64514208a9690dc10ebdef017a31e5";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b3/linux-i686/da/firefox-112.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b8/linux-i686/da/firefox-112.0b8.tar.bz2";
       locale = "da";
       arch = "linux-i686";
-      sha256 = "574441bb9df851311e86779f0643975266ebf1a8698191c5ae66d06daca6f35a";
+      sha256 = "235197b2c87360657afd2f358ed3f0c0f07ce444bc9c85d34585703c301ce8f7";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b3/linux-i686/de/firefox-112.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b8/linux-i686/de/firefox-112.0b8.tar.bz2";
       locale = "de";
       arch = "linux-i686";
-      sha256 = "402e3a3f52b529e1e16fa5c594235dc80433fc7372024a8e73df57e0597a78bf";
+      sha256 = "145a105a27a855f49985bcda9d826cc880aa180b3583d6e1f3f76f0945a6b52c";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b3/linux-i686/dsb/firefox-112.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b8/linux-i686/dsb/firefox-112.0b8.tar.bz2";
       locale = "dsb";
       arch = "linux-i686";
-      sha256 = "b7f23e90d48a112fb003829a6f5e7ba26495ba911f80401b7dbfa56da979050c";
+      sha256 = "2b9f2b9d16c57dece9c4e9a94603bc4da83fbd76d40de8959f7a7b038f6996c0";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b3/linux-i686/el/firefox-112.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b8/linux-i686/el/firefox-112.0b8.tar.bz2";
       locale = "el";
       arch = "linux-i686";
-      sha256 = "ae6c8b95e69c6ac2055e3055d66e8311f6dfb8712ec9b2103fdb955d351c8a2b";
+      sha256 = "50a17dcadef00432c0b28ba15aab55df5c3131e4103b97ee671b4f3c283a236a";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b3/linux-i686/en-CA/firefox-112.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b8/linux-i686/en-CA/firefox-112.0b8.tar.bz2";
       locale = "en-CA";
       arch = "linux-i686";
-      sha256 = "e79630b19fddcfafd6be36d9213820feaf6c4f317543495a749699e6c03587f8";
+      sha256 = "ff750dc2d42b29d9eef17f29ee9b3d6d0f12cea47d5d644a499efd871f6838a0";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b3/linux-i686/en-GB/firefox-112.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b8/linux-i686/en-GB/firefox-112.0b8.tar.bz2";
       locale = "en-GB";
       arch = "linux-i686";
-      sha256 = "56191b9c44c2d8bc6239c01ca9c8de489604bff6b6a38a5d2294f3e71ed9835d";
+      sha256 = "6eaaebd3531d3174777bd40abf9b6f920906b7431a662ed7f867f32c5ecbecbf";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b3/linux-i686/en-US/firefox-112.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b8/linux-i686/en-US/firefox-112.0b8.tar.bz2";
       locale = "en-US";
       arch = "linux-i686";
-      sha256 = "b1d9e8244ddfdfae0d649f874afe2f91e56146ef141287e80d84967e950ae49b";
+      sha256 = "4f7e5731799f03e845ba24e9cf459b1580d8013a3ada55e9632feae69ed10485";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b3/linux-i686/eo/firefox-112.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b8/linux-i686/eo/firefox-112.0b8.tar.bz2";
       locale = "eo";
       arch = "linux-i686";
-      sha256 = "e5eb0fbabbcdfa8b833644d5f155faed0345d5aecca49a04c74e6eda618d873f";
+      sha256 = "ca610f2eba98a2ff6b6698497d3d1992faf717d517be29321080a1219d860c7a";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b3/linux-i686/es-AR/firefox-112.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b8/linux-i686/es-AR/firefox-112.0b8.tar.bz2";
       locale = "es-AR";
       arch = "linux-i686";
-      sha256 = "6aca750cd572e1634f76328cb136c40ed6c1b0d95d40af4661c42484b603f15e";
+      sha256 = "d0fdbf3021f7acf7d36109799504aed2823b3647cf230c8febf200bccd2c92d8";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b3/linux-i686/es-CL/firefox-112.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b8/linux-i686/es-CL/firefox-112.0b8.tar.bz2";
       locale = "es-CL";
       arch = "linux-i686";
-      sha256 = "0f05f255ea1f7219ba59b81cb4f955ee85c01aed90b03d2ce6a2594c3fa0b65b";
+      sha256 = "8f0f1ea2ff448067d91d279e506580557a5e23b4987887c81d8799dc8535cc5a";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b3/linux-i686/es-ES/firefox-112.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b8/linux-i686/es-ES/firefox-112.0b8.tar.bz2";
       locale = "es-ES";
       arch = "linux-i686";
-      sha256 = "b26beacd1f722e1ecec27350a5e426e743c0ac095935704e2a930d2a13ee3f9e";
+      sha256 = "433cb4ef6e5c1e367e8b486362af49b470cb45949dc3664f6af319f665b935be";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b3/linux-i686/es-MX/firefox-112.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b8/linux-i686/es-MX/firefox-112.0b8.tar.bz2";
       locale = "es-MX";
       arch = "linux-i686";
-      sha256 = "8d9239e6ae5f40bf13bb7b097deb0db6d5ba4b85bee304116209e34358ccd3da";
+      sha256 = "fbbc4db1fbe96ba2e07c824f5c46a245cfed111ac9e61d823381fa236723e0e1";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b3/linux-i686/et/firefox-112.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b8/linux-i686/et/firefox-112.0b8.tar.bz2";
       locale = "et";
       arch = "linux-i686";
-      sha256 = "8cb6366cd787e45884a381acbf9c0feec34da769c91a13b131ff48552e75d45f";
+      sha256 = "3bbcfe864ae19a3f5057ef3f87f2462b40bb71e4f1f5bfe828c36089ab7bbed8";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b3/linux-i686/eu/firefox-112.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b8/linux-i686/eu/firefox-112.0b8.tar.bz2";
       locale = "eu";
       arch = "linux-i686";
-      sha256 = "06c7856729f040335bfbb88faa933e716d6ebd50e584bc9e036aec05cf62af8f";
+      sha256 = "f9f26a6b9a991854694f494057eb4508a4bbc667bcfbf028e6c7a04900f020cc";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b3/linux-i686/fa/firefox-112.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b8/linux-i686/fa/firefox-112.0b8.tar.bz2";
       locale = "fa";
       arch = "linux-i686";
-      sha256 = "ce29544712a38833c9df54c6de81c3e305de8e12612ce348fba379779c3b3736";
+      sha256 = "55057add60209a5539ef7ecf0001e4ba93e2c999dcfa0d8a14d91201f1f753d7";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b3/linux-i686/ff/firefox-112.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b8/linux-i686/ff/firefox-112.0b8.tar.bz2";
       locale = "ff";
       arch = "linux-i686";
-      sha256 = "7b822538f42ac95aefb9ea46e19cd6f5f59b79ad9ee09a6b9d2ddbbdb7ce9a8b";
+      sha256 = "98ea5cb9f5dc110efe26c8e8729ab7d63e5bd4ad1d589002e64c5f946fb6e75a";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b3/linux-i686/fi/firefox-112.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b8/linux-i686/fi/firefox-112.0b8.tar.bz2";
       locale = "fi";
       arch = "linux-i686";
-      sha256 = "64e39b57ab5564d5c28cb0332592aedd6d2c793b95e82ece546792d7dfb2687c";
+      sha256 = "ff7b43de25f995ba29fafd55aed283f36051037a6390a27f0efdfae392761c09";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b3/linux-i686/fr/firefox-112.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b8/linux-i686/fr/firefox-112.0b8.tar.bz2";
       locale = "fr";
       arch = "linux-i686";
-      sha256 = "78491283531d63b15b00d980e12d2708be521c2b5a55bd0cabd0d9c293ea8bdd";
+      sha256 = "6ec5c36b56cd1f262ed9a23a55d841bff5ecf7688df3cc3ea870b8d8a1acfa42";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b3/linux-i686/fur/firefox-112.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b8/linux-i686/fur/firefox-112.0b8.tar.bz2";
       locale = "fur";
       arch = "linux-i686";
-      sha256 = "e6bf78af33ef8364a50a4de4693eed99ed44da076e5c13ae10d0ba60de313a8a";
+      sha256 = "d65d9601dedbf8aa3fe022eaaa824c411b77da9d49cc62422f9487548f7edf29";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b3/linux-i686/fy-NL/firefox-112.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b8/linux-i686/fy-NL/firefox-112.0b8.tar.bz2";
       locale = "fy-NL";
       arch = "linux-i686";
-      sha256 = "76a511d238f1b1b4bbdaa00442af01d01b561b146c6dffbdbce4ded4052bea0d";
+      sha256 = "1e7751bba4321324c5f88b628c43d8690cfcf38083d2d21ed4f26d80de4d26cc";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b3/linux-i686/ga-IE/firefox-112.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b8/linux-i686/ga-IE/firefox-112.0b8.tar.bz2";
       locale = "ga-IE";
       arch = "linux-i686";
-      sha256 = "39cb4c00166b9b7f460983dde113e59b8a58186400624d563cc0e8eb1e9666a5";
+      sha256 = "9f6c1502f939e64c82e244b6d180424cdd1b9c315c7d8a2794d34adcc9aa5487";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b3/linux-i686/gd/firefox-112.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b8/linux-i686/gd/firefox-112.0b8.tar.bz2";
       locale = "gd";
       arch = "linux-i686";
-      sha256 = "65c7bda40ac1d50b9b07153af2110c50fbbe1fb601426d0ffb4ad176ececfae7";
+      sha256 = "e02cacc43e781cc00292aa040d1551c7977c74984508c80f236ff5409ea2dbe3";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b3/linux-i686/gl/firefox-112.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b8/linux-i686/gl/firefox-112.0b8.tar.bz2";
       locale = "gl";
       arch = "linux-i686";
-      sha256 = "c8f62afc3c51e4563a06f111019750a0f953abeeb01e2685c93138da6fca1b77";
+      sha256 = "7c1d60e0b51d3e8b336e2e1163406ef9a568716216e471ca933309656a4b2420";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b3/linux-i686/gn/firefox-112.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b8/linux-i686/gn/firefox-112.0b8.tar.bz2";
       locale = "gn";
       arch = "linux-i686";
-      sha256 = "e8c897978b7a943673ce7f45475b5743de57359b4483edfc0e1fc5a39c98c247";
+      sha256 = "5d2cf139d73565dd5541f1e0bcccff89f7893b946a3f86241148c932e4c72c86";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b3/linux-i686/gu-IN/firefox-112.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b8/linux-i686/gu-IN/firefox-112.0b8.tar.bz2";
       locale = "gu-IN";
       arch = "linux-i686";
-      sha256 = "8bb1463039a243fa72412da9ccd9fb8637c980e48bac95db701380056405ccf5";
+      sha256 = "3182a52e21687511dc44c1ed4800a4d374e0a7fd7c10d688c0ebb9fc0ea10af6";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b3/linux-i686/he/firefox-112.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b8/linux-i686/he/firefox-112.0b8.tar.bz2";
       locale = "he";
       arch = "linux-i686";
-      sha256 = "453a1e79be7733c1b3e757f63966b66a8e253fe6933d4cdb03078992ad005bb1";
+      sha256 = "ff9c300679209cd3441a6b93f1b296a1358a420b233db05335c645eb520f272a";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b3/linux-i686/hi-IN/firefox-112.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b8/linux-i686/hi-IN/firefox-112.0b8.tar.bz2";
       locale = "hi-IN";
       arch = "linux-i686";
-      sha256 = "6e38248bb9c1406c97ac98df120ad13d80d47e84b2038300448bbd248801a114";
+      sha256 = "9d252e4264741704f9bd229f0a27e4b645710aa552b3a381f29db4ebe49b8c63";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b3/linux-i686/hr/firefox-112.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b8/linux-i686/hr/firefox-112.0b8.tar.bz2";
       locale = "hr";
       arch = "linux-i686";
-      sha256 = "86cf98d857b948f5a154eb0c11eb3c8568cd52b34a1cbc2ebb5317bb4fb1f5a0";
+      sha256 = "965a065780922808c4e38c34450419cacaa7e53acd34ff69cfa3b567a2bbbb31";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b3/linux-i686/hsb/firefox-112.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b8/linux-i686/hsb/firefox-112.0b8.tar.bz2";
       locale = "hsb";
       arch = "linux-i686";
-      sha256 = "284dfd8803d3b50ca4c872b5823b24719d7a96cd537fa9638404e0568385465a";
+      sha256 = "8479363daadcd846f967059c0f141532d958e18c3edaec62b52776eb5ee5b12b";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b3/linux-i686/hu/firefox-112.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b8/linux-i686/hu/firefox-112.0b8.tar.bz2";
       locale = "hu";
       arch = "linux-i686";
-      sha256 = "f9c2dcfb3ed57e7edc09b9c3381828b1987b6f7f5fc311ed7bc4d3231ba5dc2d";
+      sha256 = "3434a97ef1bcd3f382c88b7ea1e2bb74a94e486f0ce3e27c1a7900d8ed8078c8";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b3/linux-i686/hy-AM/firefox-112.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b8/linux-i686/hy-AM/firefox-112.0b8.tar.bz2";
       locale = "hy-AM";
       arch = "linux-i686";
-      sha256 = "fa5474508ade068cf51dd20f3d0ce8fc9e15c5e9df225f4825e93b4ea745d0a5";
+      sha256 = "2f572581874b1b160ec399bf575fa972ccca071db75cc8df9bf7e18a432e245a";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b3/linux-i686/ia/firefox-112.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b8/linux-i686/ia/firefox-112.0b8.tar.bz2";
       locale = "ia";
       arch = "linux-i686";
-      sha256 = "771273640090beeb82641e79d732ddf37adf84d724b931ad443736c58ff9dd3f";
+      sha256 = "1cd6e2e3e3d6ab5b02ed3373d72489ed3258a177170f62e328266b59398341bf";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b3/linux-i686/id/firefox-112.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b8/linux-i686/id/firefox-112.0b8.tar.bz2";
       locale = "id";
       arch = "linux-i686";
-      sha256 = "cf6a81709b810b40aca35f34e81fc9f7a356b83098697980ca9e47fb209797d7";
+      sha256 = "a33619620e076879412d6ae8377e2f4d2a4e3ba0d814d4383e7a8226d25dfbf5";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b3/linux-i686/is/firefox-112.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b8/linux-i686/is/firefox-112.0b8.tar.bz2";
       locale = "is";
       arch = "linux-i686";
-      sha256 = "45b72d161d44e8c84c4938eccfbaeff2fd0bca26132dbafc67bd344bdc0f408a";
+      sha256 = "6714432ccb19601d05f81eebca31a990edb785bc7b0e1622ef44d5215d6c6e33";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b3/linux-i686/it/firefox-112.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b8/linux-i686/it/firefox-112.0b8.tar.bz2";
       locale = "it";
       arch = "linux-i686";
-      sha256 = "f7bcc97abc9fc855c0e63eb36994bcfb0ec7867ec365e4b00c197523f4ea38a5";
+      sha256 = "59c4675b245ee7dc31c55d86d203004c0c563340510a3fff42519cbf033c2f68";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b3/linux-i686/ja/firefox-112.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b8/linux-i686/ja/firefox-112.0b8.tar.bz2";
       locale = "ja";
       arch = "linux-i686";
-      sha256 = "6e0b15e2e06dbf7efce749c78ea4c8e2847b140fb1af0e4fd47cbe24d791c568";
+      sha256 = "a0135cb2bdd5e4f5f6ccbdcf789480f1cf8657ebf086438383b199a1d4d05ec1";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b3/linux-i686/ka/firefox-112.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b8/linux-i686/ka/firefox-112.0b8.tar.bz2";
       locale = "ka";
       arch = "linux-i686";
-      sha256 = "95d80e66bf4ccc98389eadaa9b4c27a658ee5f3557cba61f222a351f9dd5eb25";
+      sha256 = "aa020194e0a2637f77b47a998d2fde77000d13bec4fa734132d2650261e8b137";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b3/linux-i686/kab/firefox-112.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b8/linux-i686/kab/firefox-112.0b8.tar.bz2";
       locale = "kab";
       arch = "linux-i686";
-      sha256 = "5fb3bd857d3ca6f01b70a8b57a01eb0d662e2fa48bfd0384fe83ab504fc63eaf";
+      sha256 = "f43944308e1263203e29029f267d15d2818cfc56cd64ff2b7e2967362ff6bcb8";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b3/linux-i686/kk/firefox-112.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b8/linux-i686/kk/firefox-112.0b8.tar.bz2";
       locale = "kk";
       arch = "linux-i686";
-      sha256 = "5291f1066c14bdd2ae0fd4d7ed27587bf3700aaef9d3e492cfd2fa70cc38f4b4";
+      sha256 = "0f6f2607eb2d17306a442011ef757ddba8becfb58b52538f459dec4c01b6aee3";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b3/linux-i686/km/firefox-112.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b8/linux-i686/km/firefox-112.0b8.tar.bz2";
       locale = "km";
       arch = "linux-i686";
-      sha256 = "4f0ea7cc4d8f8cbcb531bf833aefd0cff184f8186edec7f8a9f79863e67ade65";
+      sha256 = "0c689a0960f701bc803971cfdb14b678c85f37d3a0309bd7835802c52862536f";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b3/linux-i686/kn/firefox-112.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b8/linux-i686/kn/firefox-112.0b8.tar.bz2";
       locale = "kn";
       arch = "linux-i686";
-      sha256 = "ceef5951674c987373934fda3d9d658f66a4c302eef2cf8048a59ceb6a1ab23a";
+      sha256 = "2de4c309f32532312dd634f494cfe2ebaa8581a17b0d3de866821688c72a68ed";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b3/linux-i686/ko/firefox-112.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b8/linux-i686/ko/firefox-112.0b8.tar.bz2";
       locale = "ko";
       arch = "linux-i686";
-      sha256 = "a76f87be07432079ddc9518ac7b6c6ecce4d80ed7d7f9b11b81d4e191a3da33e";
+      sha256 = "1ee7d6f40472b17fdbacbf03a4ef4b1b17c0b7f766a18a359edfff38723f9305";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b3/linux-i686/lij/firefox-112.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b8/linux-i686/lij/firefox-112.0b8.tar.bz2";
       locale = "lij";
       arch = "linux-i686";
-      sha256 = "9d128dc913a66b2d4c9723ef96616306c52e2a89fda1c6cf8a84b3e8db5a8c66";
+      sha256 = "33ac452d6fcb3dd36e8a950bc8b751ac72e5af4639e48c1e29aca200f1c13531";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b3/linux-i686/lt/firefox-112.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b8/linux-i686/lt/firefox-112.0b8.tar.bz2";
       locale = "lt";
       arch = "linux-i686";
-      sha256 = "8a01dd960b2589f08bb984993b31ab46b424521b00ce05d427759a3dd2623558";
+      sha256 = "fba0602a530a9b46a06e527733db7234d50e59bd2e2d523a77d6392020c26c7a";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b3/linux-i686/lv/firefox-112.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b8/linux-i686/lv/firefox-112.0b8.tar.bz2";
       locale = "lv";
       arch = "linux-i686";
-      sha256 = "f8a87f1e0f476764610aa7ffa1f77569f35d6fc191f51da8c0a2d512f881121e";
+      sha256 = "c54ef95649e6b7c01a38ade647b04557141857bc6132c48a50523c91c07a77b8";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b3/linux-i686/mk/firefox-112.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b8/linux-i686/mk/firefox-112.0b8.tar.bz2";
       locale = "mk";
       arch = "linux-i686";
-      sha256 = "566c249066c839d2927bc8c851fa26e1abbd56b8594220ab0b1b8e2870dba11e";
+      sha256 = "b6820814fff826a1fb46cac30c0c9f0943e25ac79e7eeec969122d0104bf7c54";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b3/linux-i686/mr/firefox-112.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b8/linux-i686/mr/firefox-112.0b8.tar.bz2";
       locale = "mr";
       arch = "linux-i686";
-      sha256 = "8c13cc845f43a58f417944deadacd95ae097a41b81ae28f80bddeac8464ad7c1";
+      sha256 = "1ba298db6f162ba98288655b7755725b1a579192d7f63d96ce35cd0fc9be160b";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b3/linux-i686/ms/firefox-112.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b8/linux-i686/ms/firefox-112.0b8.tar.bz2";
       locale = "ms";
       arch = "linux-i686";
-      sha256 = "ae4acae5d58a92d6811aa6d3cefc41441a91973d218f719dc1602c6324602923";
+      sha256 = "485afb072fb830adf0d0a0b199a4d9a47b0c49e121a1ade0a82e7f2ed9b71ff6";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b3/linux-i686/my/firefox-112.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b8/linux-i686/my/firefox-112.0b8.tar.bz2";
       locale = "my";
       arch = "linux-i686";
-      sha256 = "500ba72bcf205b037638bfad91e852a799b0870ffa79ad7c0dea70a820a41fd1";
+      sha256 = "fa6ab9c5b8ad1f785d900d87178550393ac8d82dc9edb591503f35251921387a";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b3/linux-i686/nb-NO/firefox-112.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b8/linux-i686/nb-NO/firefox-112.0b8.tar.bz2";
       locale = "nb-NO";
       arch = "linux-i686";
-      sha256 = "3b46885d4191b2eecd7cd02f014bdc34cc2142913e0dc80af8f967eb6b5a8cda";
+      sha256 = "82c0f4324fe3b63253444dd9aa5429bee8ab0fd64da30f6d5b539c672a2896d3";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b3/linux-i686/ne-NP/firefox-112.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b8/linux-i686/ne-NP/firefox-112.0b8.tar.bz2";
       locale = "ne-NP";
       arch = "linux-i686";
-      sha256 = "c161443c4af482335ba1e92186fe6241d4652be9382f3b6d04dc7e1b5998c800";
+      sha256 = "fed05049cb270f84dfdd8701e634ec1a34cae6556032fbe5647d7a03f5ed7d10";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b3/linux-i686/nl/firefox-112.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b8/linux-i686/nl/firefox-112.0b8.tar.bz2";
       locale = "nl";
       arch = "linux-i686";
-      sha256 = "4c2dff3098bb943b761e00f5f2677b79f4179eb194d1fd09e22c5097e27a0702";
+      sha256 = "49a24868626222d8f5c206df8107d2ff84c84dfa3bc5e7785138f35d35c2ade6";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b3/linux-i686/nn-NO/firefox-112.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b8/linux-i686/nn-NO/firefox-112.0b8.tar.bz2";
       locale = "nn-NO";
       arch = "linux-i686";
-      sha256 = "51de7ca0c7142615f72a60adc7eda0c776c81a4be7298e08ae3577f0d7180d78";
+      sha256 = "936eae264ff5786c654fa3f28c44da83f5cf5f10520c1dacc2adf83ecec16feb";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b3/linux-i686/oc/firefox-112.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b8/linux-i686/oc/firefox-112.0b8.tar.bz2";
       locale = "oc";
       arch = "linux-i686";
-      sha256 = "7bd6b02d7b24f32e5726076b4e1fc4e5872cb12b23d9e3042e26beff07c76f30";
+      sha256 = "ea41cc78ed6134ad3d498832cf2a0b839ccfdd51a5550184314ea9e131ddc2da";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b3/linux-i686/pa-IN/firefox-112.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b8/linux-i686/pa-IN/firefox-112.0b8.tar.bz2";
       locale = "pa-IN";
       arch = "linux-i686";
-      sha256 = "0a7a19e006413bdc77c5230d6c64b523615cc06dd4eb82175beee902c4ad036b";
+      sha256 = "e1c3e57b8248c8ef3483fe41502ffe82741eb16aef47bdf0c7a3175aaf95b6c1";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b3/linux-i686/pl/firefox-112.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b8/linux-i686/pl/firefox-112.0b8.tar.bz2";
       locale = "pl";
       arch = "linux-i686";
-      sha256 = "4df4b9e7adb488784f5100d126a4c6ad71bc0d8b4ce0d3ea6e48d7f75d54ef4d";
+      sha256 = "49c0f88d7cf6a7e203b7938175af0017f0559d18913a2b074abf987c072f1d4f";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b3/linux-i686/pt-BR/firefox-112.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b8/linux-i686/pt-BR/firefox-112.0b8.tar.bz2";
       locale = "pt-BR";
       arch = "linux-i686";
-      sha256 = "e5546555d191d194a7032547c4fe0bd80b105589306d075afe7a0b22fdbe6d15";
+      sha256 = "d337719378272a0a1acd2f304e3ff160d9b57192640f1d0e353f74982aad714d";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b3/linux-i686/pt-PT/firefox-112.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b8/linux-i686/pt-PT/firefox-112.0b8.tar.bz2";
       locale = "pt-PT";
       arch = "linux-i686";
-      sha256 = "23f09232a8b863eb738af2dabbd1f94567641fc17cba85e3664a2e3182eecc48";
+      sha256 = "a8bc6e781c7b182aaf544315f84e2bbf8531eddf0a03c6885e289bd9109d58dd";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b3/linux-i686/rm/firefox-112.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b8/linux-i686/rm/firefox-112.0b8.tar.bz2";
       locale = "rm";
       arch = "linux-i686";
-      sha256 = "d01d41c06a2e1772607e6e97396404d19e17d19d3f6cf1ee3c001078ddbabb72";
+      sha256 = "4e01c6d3cf70be243440e604a330fd50a77f2cc08838a941c57ff818c847d863";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b3/linux-i686/ro/firefox-112.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b8/linux-i686/ro/firefox-112.0b8.tar.bz2";
       locale = "ro";
       arch = "linux-i686";
-      sha256 = "2a3e6306f376242af8cc412ae23abb0cc80b1dd31093680ba89be10496fa4c70";
+      sha256 = "07c4d2befa67265e4caa0b8164a5072a8a92b794cc02b86eded81567aa8eada8";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b3/linux-i686/ru/firefox-112.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b8/linux-i686/ru/firefox-112.0b8.tar.bz2";
       locale = "ru";
       arch = "linux-i686";
-      sha256 = "e541d7b0c8e7c2d808171483ad2b6c074cdea110cb2108161859097657c8c3b8";
+      sha256 = "ac2d4ef1052af42ee4ca5a7f3509b373d3c6cf31f74021fe7196d17819f9c12e";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b3/linux-i686/sc/firefox-112.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b8/linux-i686/sc/firefox-112.0b8.tar.bz2";
       locale = "sc";
       arch = "linux-i686";
-      sha256 = "eb72cfb24e9f52ded6ad44a3e070f9a6c351a6c1902336b0fa714e3eac7bda2e";
+      sha256 = "a05a8caf5782b0d3426159a686a38f7b09e3c7b4d07e6e4a976723a21512441c";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b3/linux-i686/sco/firefox-112.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b8/linux-i686/sco/firefox-112.0b8.tar.bz2";
       locale = "sco";
       arch = "linux-i686";
-      sha256 = "07c3eb72214d2b4cac0d47edee71aa46f0b821eb2b6d5bdd0e80c5e12031d160";
+      sha256 = "3449a3cbce587d58d34ff82d8a1f57b73de9eacc4bc4b7bbad865bccc5936ac4";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b3/linux-i686/si/firefox-112.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b8/linux-i686/si/firefox-112.0b8.tar.bz2";
       locale = "si";
       arch = "linux-i686";
-      sha256 = "07bc2a11048cb769351d1bb9d5a34b8ecb6b9d3c38f9ef678324eb18d223aebc";
+      sha256 = "7351bca897aa61dcb258a45d8dc05a3087f6ae648e3db882643aee8768d4aebc";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b3/linux-i686/sk/firefox-112.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b8/linux-i686/sk/firefox-112.0b8.tar.bz2";
       locale = "sk";
       arch = "linux-i686";
-      sha256 = "4ea7716fcc9320d6fd8b760f198bb6ad52129df43395d2b5ccd81a23611d54c2";
+      sha256 = "68d384af94ef396c0261030bb5958c51be8578cb4ac1c254b3f46282e939b47a";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b3/linux-i686/sl/firefox-112.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b8/linux-i686/sl/firefox-112.0b8.tar.bz2";
       locale = "sl";
       arch = "linux-i686";
-      sha256 = "4b5aa23325f13265d45527d2f38c14060943a046e3fb0d394dfe2af3903772a9";
+      sha256 = "ac34b1450c443a1e0534714a69467392f1ccbbceb3eac3830e66f22f113fa57a";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b3/linux-i686/son/firefox-112.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b8/linux-i686/son/firefox-112.0b8.tar.bz2";
       locale = "son";
       arch = "linux-i686";
-      sha256 = "fbbe7a8d06487eb34b2459de48bc0e9f5751e42bbbf3f8e9dd8fd1d99ac45b43";
+      sha256 = "c900556a6c84af8accdef8b1a20f811bd26be97665ed89a5a84bdd281d4b3edc";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b3/linux-i686/sq/firefox-112.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b8/linux-i686/sq/firefox-112.0b8.tar.bz2";
       locale = "sq";
       arch = "linux-i686";
-      sha256 = "7daba093868e7636120d0340b0283fcddb7cd88db11c3525771456decb0ae415";
+      sha256 = "61d3a8da4dcb987562a1c78b818c4599cf965a1080af0828887b0dc9485b3e53";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b3/linux-i686/sr/firefox-112.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b8/linux-i686/sr/firefox-112.0b8.tar.bz2";
       locale = "sr";
       arch = "linux-i686";
-      sha256 = "15b6c1412c86309a7d86107a771d8c74df497e0a7edc7a6e5bc23b753b47a5d0";
+      sha256 = "c03250fc930891c78c87ccf9ce21a16d3d26ee43631f9e01a0d53cad89ae2450";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b3/linux-i686/sv-SE/firefox-112.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b8/linux-i686/sv-SE/firefox-112.0b8.tar.bz2";
       locale = "sv-SE";
       arch = "linux-i686";
-      sha256 = "21ffcc5c44079186ffd49ac61c00832118ce39adea2014a6ce79205d16d5a111";
+      sha256 = "9ff3baf28c1907f8e41d26721eedaa2a9ab791f53ed6f86c694234e77cc53108";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b3/linux-i686/szl/firefox-112.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b8/linux-i686/szl/firefox-112.0b8.tar.bz2";
       locale = "szl";
       arch = "linux-i686";
-      sha256 = "2d38fe586e4101ac6167080b811f82d8f4cc06c5e5e3e58d5aff2818730c6614";
+      sha256 = "d1519b895d5448c2a51cb8319922d4a6c948169c25bc243ec0321d6649e44bf5";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b3/linux-i686/ta/firefox-112.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b8/linux-i686/ta/firefox-112.0b8.tar.bz2";
       locale = "ta";
       arch = "linux-i686";
-      sha256 = "44137e81b556948cf22ff52b4482185d50ad572410848078854fab6dd1f1ba8a";
+      sha256 = "b289fd6cf03eeeb998063a55f0ae1ab1d4bb3b2218311008a72ff7eced4292b5";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b3/linux-i686/te/firefox-112.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b8/linux-i686/te/firefox-112.0b8.tar.bz2";
       locale = "te";
       arch = "linux-i686";
-      sha256 = "b382ab85234da946f364711911efc6152bf7057e8d3a498b1346db815344391f";
+      sha256 = "936eb5004e1062a88c7b2293f4de56034a6c53fd456c4af476a2173809e2be10";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b3/linux-i686/th/firefox-112.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b8/linux-i686/th/firefox-112.0b8.tar.bz2";
       locale = "th";
       arch = "linux-i686";
-      sha256 = "dfa0d72ccddbb62c4ecdb5aaebf2bfe2019293fbb82c4861d496976cbda4328e";
+      sha256 = "ee51b633e603e4b712954eb285f597b0a22043aa664f6af92728dd3e3e4f1411";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b3/linux-i686/tl/firefox-112.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b8/linux-i686/tl/firefox-112.0b8.tar.bz2";
       locale = "tl";
       arch = "linux-i686";
-      sha256 = "84ddccb78c589a725e8c2d607cd7eba65f5dff3fd2acf29d66d0464ff135ed93";
+      sha256 = "cffb8d701893ed0c593802bb5cc6d9c32840f6bf3c0463ac84831a348c12ab90";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b3/linux-i686/tr/firefox-112.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b8/linux-i686/tr/firefox-112.0b8.tar.bz2";
       locale = "tr";
       arch = "linux-i686";
-      sha256 = "041eed5a64b2a2c1638c37fc1a497c976c1c56065f4ce308f46edac9d45f164f";
+      sha256 = "e0b9b1dd1fff7f8d271404725e69e620a0638df5f7d8c793b7faf340b4e98c3f";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b3/linux-i686/trs/firefox-112.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b8/linux-i686/trs/firefox-112.0b8.tar.bz2";
       locale = "trs";
       arch = "linux-i686";
-      sha256 = "deff021046e8ea1cbde7d9e8ae2aff834ebcc206f5abf143eb77a3789c191ddf";
+      sha256 = "54b97a6cb7abcbd019642e5932deb587836bc70e89f8df9d7be075bf32f2bed1";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b3/linux-i686/uk/firefox-112.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b8/linux-i686/uk/firefox-112.0b8.tar.bz2";
       locale = "uk";
       arch = "linux-i686";
-      sha256 = "c1e55a63ed9cbbf52ab0604d13c4a7e2161c9f1b59a8688a02785cb340e550f0";
+      sha256 = "e573cd9026590d288473894b4179472ac8f62bb771fea7ac0a5938741bde603d";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b3/linux-i686/ur/firefox-112.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b8/linux-i686/ur/firefox-112.0b8.tar.bz2";
       locale = "ur";
       arch = "linux-i686";
-      sha256 = "4ea19582fd6b96a2f4617bf499b8c3c07b42ad4cd1b3858cae3698c36efcdecf";
+      sha256 = "1f6e02d28e38567be0830075e251390f80d54d083ec84be5f4c7cee94d15d9f9";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b3/linux-i686/uz/firefox-112.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b8/linux-i686/uz/firefox-112.0b8.tar.bz2";
       locale = "uz";
       arch = "linux-i686";
-      sha256 = "e25aee3dd0d0e219dfc45496022ae52aede9ef757557a532becffaa67f529ac9";
+      sha256 = "a636bb65335a32783bf1bd9e0f0814efff83155cc3c04ba32037a51484383987";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b3/linux-i686/vi/firefox-112.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b8/linux-i686/vi/firefox-112.0b8.tar.bz2";
       locale = "vi";
       arch = "linux-i686";
-      sha256 = "0b292f41a14c89e769aee963d411ed5ca0e29716d2c3793f0525b7f77b1590e1";
+      sha256 = "163b7047b8aef031068456ad2fd0f054ca687a475d792b8fda4a63b97d2287a2";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b3/linux-i686/xh/firefox-112.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b8/linux-i686/xh/firefox-112.0b8.tar.bz2";
       locale = "xh";
       arch = "linux-i686";
-      sha256 = "7ff0aa0707c0c4bd448786466cff1d51c38cc00afd88b6582126b4038f109345";
+      sha256 = "98996a66340d54d325556a9783b6447d47cb4ad9dafe7bf68e8b952c29cc0318";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b3/linux-i686/zh-CN/firefox-112.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b8/linux-i686/zh-CN/firefox-112.0b8.tar.bz2";
       locale = "zh-CN";
       arch = "linux-i686";
-      sha256 = "53f0b6d73fd03fb86283ecb55d144dbb261a1b0d17e1a4a8d3a322bd870d0248";
+      sha256 = "06d68807fbd396ae46144c06bf85bb568457a646bca370310745cf3eadfa7e0a";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b3/linux-i686/zh-TW/firefox-112.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b8/linux-i686/zh-TW/firefox-112.0b8.tar.bz2";
       locale = "zh-TW";
       arch = "linux-i686";
-      sha256 = "2f2aa9ba12db48ccfc3fce025e676eee84d23728dd28f2d94ed76ee427410a65";
+      sha256 = "8dc10847c3520a2421a088ea1bd5c9c6788985225754f98a92349d1cd3b465fb";
     }
     ];
 }

--- a/pkgs/applications/networking/browsers/firefox-bin/devedition_sources.nix
+++ b/pkgs/applications/networking/browsers/firefox-bin/devedition_sources.nix
@@ -1,1005 +1,1005 @@
 {
-  version = "112.0b6";
+  version = "112.0b8";
   sources = [
-    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b6/linux-x86_64/ach/firefox-112.0b6.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b8/linux-x86_64/ach/firefox-112.0b8.tar.bz2";
       locale = "ach";
       arch = "linux-x86_64";
-      sha256 = "3c07e964f23adfb557c30aabd83afda74cd1431e6f56c636a27a31d5732f2895";
+      sha256 = "17af489a91fb1e7aee5cf04b42c1b2991286bfade1e11e7aef59c60bb04b0937";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b6/linux-x86_64/af/firefox-112.0b6.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b8/linux-x86_64/af/firefox-112.0b8.tar.bz2";
       locale = "af";
       arch = "linux-x86_64";
-      sha256 = "2c944716a6c695f6a7e02b2592f63b879f1d9ecc1d98148920941e03cc24d3d8";
+      sha256 = "a6978b3206b0df3be81b4b65f4d5982e3b75b56124f570e6660615576b0228f2";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b6/linux-x86_64/an/firefox-112.0b6.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b8/linux-x86_64/an/firefox-112.0b8.tar.bz2";
       locale = "an";
       arch = "linux-x86_64";
-      sha256 = "ce14c24ee1477912b5671364472ab07016e14277258487bfe7766d50bd757f8f";
+      sha256 = "58b5c298ade02e18b072e95624e275c4080d4a3b45b6cf7065f9db69595edfe2";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b6/linux-x86_64/ar/firefox-112.0b6.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b8/linux-x86_64/ar/firefox-112.0b8.tar.bz2";
       locale = "ar";
       arch = "linux-x86_64";
-      sha256 = "dd265c505f5263a2cc9a7fcab83d29587ba986d1d0e9e17b1b3d25c617af8e61";
+      sha256 = "43de9691a3471913f898f0b2fc10918c98338710ebe85b0d79920b91a5cee40a";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b6/linux-x86_64/ast/firefox-112.0b6.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b8/linux-x86_64/ast/firefox-112.0b8.tar.bz2";
       locale = "ast";
       arch = "linux-x86_64";
-      sha256 = "9128fc4c7b505c30b23a953cfab428fec361b7bca94b13718ec806b802bfaef0";
+      sha256 = "7e8b92289b007232ee3b11dffe1de397044e8701cd9ee8abf27a86a2c7887305";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b6/linux-x86_64/az/firefox-112.0b6.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b8/linux-x86_64/az/firefox-112.0b8.tar.bz2";
       locale = "az";
       arch = "linux-x86_64";
-      sha256 = "6ad10ede0403064a94d98c802e8082a1988b2914565473034f068874588b0c7a";
+      sha256 = "d11d34c740671807b365533905d226430478aab07e782dd3d4565c33794113e8";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b6/linux-x86_64/be/firefox-112.0b6.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b8/linux-x86_64/be/firefox-112.0b8.tar.bz2";
       locale = "be";
       arch = "linux-x86_64";
-      sha256 = "b2b03e037a5d68c0f8e6bca169b513fd25167c710c84011d0162e435ca3dbcf1";
+      sha256 = "f923e8f985e7cd0f4f1fe099ab616256442e1ea67e31e428fb10971f07c73cf1";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b6/linux-x86_64/bg/firefox-112.0b6.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b8/linux-x86_64/bg/firefox-112.0b8.tar.bz2";
       locale = "bg";
       arch = "linux-x86_64";
-      sha256 = "b3d8c55193980e6b705bfb728eeb0da53a9df676288433df312002e2feff60cd";
+      sha256 = "5f1a36e5e62ae21a98be5f22ee9824476c2eff9eda3d4bc7585323ef818e4eec";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b6/linux-x86_64/bn/firefox-112.0b6.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b8/linux-x86_64/bn/firefox-112.0b8.tar.bz2";
       locale = "bn";
       arch = "linux-x86_64";
-      sha256 = "513bbf8cb0fc17ceae546dccf6c8f5cd43d78d2fccf212fb5762a210cdd2bd3d";
+      sha256 = "21a4855e95ab0d57485dd6d2e8fdf37b6792bfc3b51d0ce87139213c1cca46f1";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b6/linux-x86_64/br/firefox-112.0b6.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b8/linux-x86_64/br/firefox-112.0b8.tar.bz2";
       locale = "br";
       arch = "linux-x86_64";
-      sha256 = "4ee6a09aa510535dd483a5cc570a202ac7ba5d9699070969740f38f98f143e7e";
+      sha256 = "15c98d831cb8b6edeb43c4a61c309445f6b1f2c2b0aba43ca4c39f33fd7e012b";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b6/linux-x86_64/bs/firefox-112.0b6.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b8/linux-x86_64/bs/firefox-112.0b8.tar.bz2";
       locale = "bs";
       arch = "linux-x86_64";
-      sha256 = "144558775c3e28b27cebaa136aec69d38abc29bd51af2cd625bcd15b1d5291c9";
+      sha256 = "1574e74d681c4084f59152c6dbe8965de435906787ad47d1cf263538b485514a";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b6/linux-x86_64/ca-valencia/firefox-112.0b6.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b8/linux-x86_64/ca-valencia/firefox-112.0b8.tar.bz2";
       locale = "ca-valencia";
       arch = "linux-x86_64";
-      sha256 = "7c6654dda1029eb23f41e73104187ea157298994127976e24ec0c82326de35bd";
+      sha256 = "bb378dd094ec170b93f977772b9f58bd8929811d8e5d2cde79424da8a3ed4398";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b6/linux-x86_64/ca/firefox-112.0b6.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b8/linux-x86_64/ca/firefox-112.0b8.tar.bz2";
       locale = "ca";
       arch = "linux-x86_64";
-      sha256 = "389b901dd0a4069ef9860379e71a12239dd4a33d4df05dfd7d16d35ec50d7748";
+      sha256 = "4549e130f2e6fe2a836fd04c021554ad94fe9337743944a8f88266965be021ee";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b6/linux-x86_64/cak/firefox-112.0b6.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b8/linux-x86_64/cak/firefox-112.0b8.tar.bz2";
       locale = "cak";
       arch = "linux-x86_64";
-      sha256 = "e91ea1785dd87c2bb92f0f2126f82d4f6127301250886de313751118d4d86d02";
+      sha256 = "f85d94fe30f1d2a38be3d1649bb74fd6af39ab9c692b12c5d218c41e952cd42f";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b6/linux-x86_64/cs/firefox-112.0b6.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b8/linux-x86_64/cs/firefox-112.0b8.tar.bz2";
       locale = "cs";
       arch = "linux-x86_64";
-      sha256 = "6ffd6aae1b31bf22095c1acff6d6fe53c747a875ef3868d0624873267a6ca7c2";
+      sha256 = "1da4a1fb77a8497edabc0a61c837380dacf2805e24a4f8c31d2ed06947d4b011";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b6/linux-x86_64/cy/firefox-112.0b6.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b8/linux-x86_64/cy/firefox-112.0b8.tar.bz2";
       locale = "cy";
       arch = "linux-x86_64";
-      sha256 = "ae0cfbbe890991bd30762f181a4ae7bde2701d5e0f924f6142b71e1cf9474f86";
+      sha256 = "dd858ff9f42d7ec24a7b4798d7ba0a0d16e37cc22cc98b42dda906898fbf1e02";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b6/linux-x86_64/da/firefox-112.0b6.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b8/linux-x86_64/da/firefox-112.0b8.tar.bz2";
       locale = "da";
       arch = "linux-x86_64";
-      sha256 = "b7a6aecd661653c93e2237a27fed8ac169bfc4f2dcd2b377b820b685cffe7d1a";
+      sha256 = "d6c638422af811a2a9a01a44b24a1dcaf8f4dc918be38d7a0b95d439d594180d";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b6/linux-x86_64/de/firefox-112.0b6.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b8/linux-x86_64/de/firefox-112.0b8.tar.bz2";
       locale = "de";
       arch = "linux-x86_64";
-      sha256 = "936d530879ba9715446ac97b8a433987d25bd8d41e01b70c10e99994b56433a9";
+      sha256 = "62d60bf0957e43b1a2977a47e010ae78b69b86710a8650badad0ed2d5d4d6357";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b6/linux-x86_64/dsb/firefox-112.0b6.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b8/linux-x86_64/dsb/firefox-112.0b8.tar.bz2";
       locale = "dsb";
       arch = "linux-x86_64";
-      sha256 = "96566692bd75645538f336b2322ad6821889bc1de73b63646b880d6b1263c90a";
+      sha256 = "3ea22409e268745a90cf471ba6f2b40182004d7ae6d87a30d653d76b1ddef12c";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b6/linux-x86_64/el/firefox-112.0b6.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b8/linux-x86_64/el/firefox-112.0b8.tar.bz2";
       locale = "el";
       arch = "linux-x86_64";
-      sha256 = "d52d4040df2b1398eedea68f8253ed58b897c6da68ee11b13c81b5768c1d221f";
+      sha256 = "dbd5d7828c41a303680ad2cb7abd47f1fe6b147c8c531601867bf8027e75f518";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b6/linux-x86_64/en-CA/firefox-112.0b6.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b8/linux-x86_64/en-CA/firefox-112.0b8.tar.bz2";
       locale = "en-CA";
       arch = "linux-x86_64";
-      sha256 = "ac8763f0b3dadce233ac88e93f24695b9acb5299e1884feac7bfbd0a04cff0f1";
+      sha256 = "9254ebdae4e37277a2764c7c36b5aaa0e2ac0b7c99317abf10c80e37192fe6b5";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b6/linux-x86_64/en-GB/firefox-112.0b6.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b8/linux-x86_64/en-GB/firefox-112.0b8.tar.bz2";
       locale = "en-GB";
       arch = "linux-x86_64";
-      sha256 = "6e5567e859557151c093727f7c7bab1961de6d1c8b8b8e11717d1f55c93f628b";
+      sha256 = "aea47e6b0ffb720f334f4cc7b9421e630a0f67b81e8b1a91551c4f4737375de5";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b6/linux-x86_64/en-US/firefox-112.0b6.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b8/linux-x86_64/en-US/firefox-112.0b8.tar.bz2";
       locale = "en-US";
       arch = "linux-x86_64";
-      sha256 = "235972a20d398a3641ffe7e427375f01744b0cf0487b450e23bf2d217f7390d2";
+      sha256 = "f57683aeeb746a9d56babf341a43e90c15aae1942e1781361309d81d539df8f9";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b6/linux-x86_64/eo/firefox-112.0b6.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b8/linux-x86_64/eo/firefox-112.0b8.tar.bz2";
       locale = "eo";
       arch = "linux-x86_64";
-      sha256 = "3a4eda3ada0681c3033adde3b5de46cda7901de136cb18e64221e47e97f7bba5";
+      sha256 = "70f2375b018e3975c00810e363d364ed774f97d140a8e6750959d7e36d747cbd";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b6/linux-x86_64/es-AR/firefox-112.0b6.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b8/linux-x86_64/es-AR/firefox-112.0b8.tar.bz2";
       locale = "es-AR";
       arch = "linux-x86_64";
-      sha256 = "70448e290002f4dd8ed8a3ae48f53eeaa568f68302bb36e0175c7b417ad8d3a5";
+      sha256 = "6dc42442a6997dbbaff17f5abca534245aced2646e90f577f10bdd0d73e99f33";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b6/linux-x86_64/es-CL/firefox-112.0b6.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b8/linux-x86_64/es-CL/firefox-112.0b8.tar.bz2";
       locale = "es-CL";
       arch = "linux-x86_64";
-      sha256 = "13e5eddfa538961a0cd587c7d498a88daae23d578750e23ae48dd6f2398a3216";
+      sha256 = "ab32d35ff766119d456f0ceef9d63ae88c3ec018d785eb21c7a36e16d08d52a3";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b6/linux-x86_64/es-ES/firefox-112.0b6.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b8/linux-x86_64/es-ES/firefox-112.0b8.tar.bz2";
       locale = "es-ES";
       arch = "linux-x86_64";
-      sha256 = "0429f562d61626e701c23292eb13f6787b29f8b8cb2aaa33adf35ba791e9166c";
+      sha256 = "ffe13c43b3779bb49f544017a6cb9a0b20eb04740259c4b6f6ed6039d9c73814";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b6/linux-x86_64/es-MX/firefox-112.0b6.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b8/linux-x86_64/es-MX/firefox-112.0b8.tar.bz2";
       locale = "es-MX";
       arch = "linux-x86_64";
-      sha256 = "df33f30d6f1852b4ae2f5fc2be567009d62c76d519c8741d83645bfbe5847701";
+      sha256 = "afd8b36f4cc0bee81941bff960559c6f35bfb3e9a754107f92ea2a3e2d0bd489";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b6/linux-x86_64/et/firefox-112.0b6.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b8/linux-x86_64/et/firefox-112.0b8.tar.bz2";
       locale = "et";
       arch = "linux-x86_64";
-      sha256 = "d89fafb4fdfa59e61478ee0668b1a51723bf7d974c8acfa568d73004ee022237";
+      sha256 = "41033e642e38b08ee338ca2d4f2a7d713bd8f030ad911e8697537750ae267ee5";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b6/linux-x86_64/eu/firefox-112.0b6.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b8/linux-x86_64/eu/firefox-112.0b8.tar.bz2";
       locale = "eu";
       arch = "linux-x86_64";
-      sha256 = "0d46ea00d2babd59fd78a754ea6e6a872912e5e9a956366a3b0bd402e3f31a0c";
+      sha256 = "be2e35990796a7fd15d0bc3afecb26394498969b27a07de7241916d05a451689";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b6/linux-x86_64/fa/firefox-112.0b6.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b8/linux-x86_64/fa/firefox-112.0b8.tar.bz2";
       locale = "fa";
       arch = "linux-x86_64";
-      sha256 = "c829052709ed804781b2f3f04eccc2fc5d6ef88f4cd049a0ab0ac98189fc8578";
+      sha256 = "61d52a82a3c7bdc29ffa3e867dd6020167b52929374cf7f9feda965c8d146569";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b6/linux-x86_64/ff/firefox-112.0b6.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b8/linux-x86_64/ff/firefox-112.0b8.tar.bz2";
       locale = "ff";
       arch = "linux-x86_64";
-      sha256 = "bf7c2c400dea1fa5df076d7478cce9de30af37ddc192c889b4738a166d9cfa5b";
+      sha256 = "d21745467426453ca3e101251459b042a809d34fdbb4b3a2807f31358cae1e83";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b6/linux-x86_64/fi/firefox-112.0b6.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b8/linux-x86_64/fi/firefox-112.0b8.tar.bz2";
       locale = "fi";
       arch = "linux-x86_64";
-      sha256 = "5edfebdfebe51909c1ec7177e497bd4d0728dcbfbb3e81aafa3878b7a6406418";
+      sha256 = "9e118fbbc6a5f5b52c15152fa47604cea85dbc73babeca7fd7886b40458be373";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b6/linux-x86_64/fr/firefox-112.0b6.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b8/linux-x86_64/fr/firefox-112.0b8.tar.bz2";
       locale = "fr";
       arch = "linux-x86_64";
-      sha256 = "2958284604ce96177fe3973460b2eb96e12902c363e40517cdfa0e90bb3c0858";
+      sha256 = "5685910a6c54908cd523073bf50287f9d1ac928c80b2580f04c48c21c6b1ac64";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b6/linux-x86_64/fur/firefox-112.0b6.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b8/linux-x86_64/fur/firefox-112.0b8.tar.bz2";
       locale = "fur";
       arch = "linux-x86_64";
-      sha256 = "e82ee24e0bf4fffe3c185bec25563016906b7d0c093b4dcd1e67f72432c74399";
+      sha256 = "1259447806fac7cab853299ccc974fd9804d1a36dabc493855fc93962d51ef58";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b6/linux-x86_64/fy-NL/firefox-112.0b6.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b8/linux-x86_64/fy-NL/firefox-112.0b8.tar.bz2";
       locale = "fy-NL";
       arch = "linux-x86_64";
-      sha256 = "90c3862b789a5507026696c4794964cfc9d1f0c1ec3e41be2c7d6c008b56e1f8";
+      sha256 = "254f91ba6dc56cbc72f154ff098abb4a9030699e567270e1045c48873dbc9288";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b6/linux-x86_64/ga-IE/firefox-112.0b6.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b8/linux-x86_64/ga-IE/firefox-112.0b8.tar.bz2";
       locale = "ga-IE";
       arch = "linux-x86_64";
-      sha256 = "8dc83431305b71d33c85533304c054c9975ed835e610af800dcbc7e3b83eba5f";
+      sha256 = "0e8879e4b3a6168317a512c4e1ad514cf90f03a36c6cdc8145f722c39845538f";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b6/linux-x86_64/gd/firefox-112.0b6.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b8/linux-x86_64/gd/firefox-112.0b8.tar.bz2";
       locale = "gd";
       arch = "linux-x86_64";
-      sha256 = "3f656718bf9dabe3cf4fc3b8b089aec67acc4c8c61f4c3d2eb1a49cb13f7ceaf";
+      sha256 = "f4828b8c60b05927fa7b057b9ee2b06ed89013642e8fb7d0baff865ccec03d1d";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b6/linux-x86_64/gl/firefox-112.0b6.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b8/linux-x86_64/gl/firefox-112.0b8.tar.bz2";
       locale = "gl";
       arch = "linux-x86_64";
-      sha256 = "6d7db43edcaf6c797bcd2a6fa8684c3e56ae8fdcb344b7a8f2c86fab0e03c1fc";
+      sha256 = "687d5d3b2527f039a67cecfa1bb1f9e82e6a6c60edbc68d50b6ad86aaf497efd";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b6/linux-x86_64/gn/firefox-112.0b6.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b8/linux-x86_64/gn/firefox-112.0b8.tar.bz2";
       locale = "gn";
       arch = "linux-x86_64";
-      sha256 = "812518dab7d7d964ba8babca078df50cc38453b103ca803e09eb2e48173f1c1f";
+      sha256 = "a5a26eb2740a2cfdcb09c783a4f0d339af0c7999d65254e07688932877aa51f8";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b6/linux-x86_64/gu-IN/firefox-112.0b6.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b8/linux-x86_64/gu-IN/firefox-112.0b8.tar.bz2";
       locale = "gu-IN";
       arch = "linux-x86_64";
-      sha256 = "ccc8b86769c127c3f041c89ebe48fb88ff50df0ff95021f944801ab530f9c304";
+      sha256 = "7287bc6c3c65a22326d1fa7a52a125b570e4deeb19fafe678b764dc997f0b0cd";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b6/linux-x86_64/he/firefox-112.0b6.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b8/linux-x86_64/he/firefox-112.0b8.tar.bz2";
       locale = "he";
       arch = "linux-x86_64";
-      sha256 = "b275c9ef40ce81cb6a85e210d7e3b547913af7ca3715dd54074e5024b428ba1b";
+      sha256 = "5fc656fe148b159f96b7677828299625399a8499a94217f4db3c9a9868c552c0";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b6/linux-x86_64/hi-IN/firefox-112.0b6.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b8/linux-x86_64/hi-IN/firefox-112.0b8.tar.bz2";
       locale = "hi-IN";
       arch = "linux-x86_64";
-      sha256 = "4f3b3743ca324935aa3fec117a6d6cc1ee8321fd64e281529a8ed070ae2a013b";
+      sha256 = "b3ff74e987dcf5884abf7dd59da541864743f3990a5d4f0af743b2cad5379087";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b6/linux-x86_64/hr/firefox-112.0b6.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b8/linux-x86_64/hr/firefox-112.0b8.tar.bz2";
       locale = "hr";
       arch = "linux-x86_64";
-      sha256 = "059ff55d680a0d8f1bdfebe5deca396de923f6f4fecfca82b123061f5c47d3a8";
+      sha256 = "4d65ceddd98c1bb5706067ec2b70ea9e9cfae11386f98caa847c9f3762ccedc8";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b6/linux-x86_64/hsb/firefox-112.0b6.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b8/linux-x86_64/hsb/firefox-112.0b8.tar.bz2";
       locale = "hsb";
       arch = "linux-x86_64";
-      sha256 = "f62efb1274177339936547265b10de4e507e5ee71220aac10c9f00091f67abe5";
+      sha256 = "c8fecf26861f75e1887319d07ee2b3bc91cb45f6da4870c70890763a10edfdf9";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b6/linux-x86_64/hu/firefox-112.0b6.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b8/linux-x86_64/hu/firefox-112.0b8.tar.bz2";
       locale = "hu";
       arch = "linux-x86_64";
-      sha256 = "4e66d7fed06b0b247e5b253b27a7bd647db142f1deda1edb4c0f3498843ae439";
+      sha256 = "3df8987d32611199d3d8b5de9ed134217b8224ec4eaf9b4655eaca4333038929";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b6/linux-x86_64/hy-AM/firefox-112.0b6.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b8/linux-x86_64/hy-AM/firefox-112.0b8.tar.bz2";
       locale = "hy-AM";
       arch = "linux-x86_64";
-      sha256 = "ef9dd23be04d7ee7b06ca830ad516765e95172dbbaae14b8a33e77c38edf7c84";
+      sha256 = "162ae6d4296df89b7b70a466b593ae1b3d469c4325f7575284d4d32fb128ceef";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b6/linux-x86_64/ia/firefox-112.0b6.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b8/linux-x86_64/ia/firefox-112.0b8.tar.bz2";
       locale = "ia";
       arch = "linux-x86_64";
-      sha256 = "163f9577825303ad0705df664d2359190d4555893d4deb60d8999b5f98f4578a";
+      sha256 = "118e51b4d05a62dc0021a90487cece1c528b765477072c6e522da37687bf5982";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b6/linux-x86_64/id/firefox-112.0b6.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b8/linux-x86_64/id/firefox-112.0b8.tar.bz2";
       locale = "id";
       arch = "linux-x86_64";
-      sha256 = "558c1d87e938084462a118e1991d1d7e1e21cc4f046a9ff41a87bf1d5f883bd1";
+      sha256 = "c639987defa98588366bbd6d54ca3893acd03b28558e3eb5672e7e6f1009db8c";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b6/linux-x86_64/is/firefox-112.0b6.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b8/linux-x86_64/is/firefox-112.0b8.tar.bz2";
       locale = "is";
       arch = "linux-x86_64";
-      sha256 = "0cfa8d0c8f797266c6fcc8bf31d559d1c107c0e9a9c2e255ad41169496f25f44";
+      sha256 = "cfab8f71b3dfc5354d5e57f66b9e656c9eb6377ea1cea2e7533559b6784ee664";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b6/linux-x86_64/it/firefox-112.0b6.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b8/linux-x86_64/it/firefox-112.0b8.tar.bz2";
       locale = "it";
       arch = "linux-x86_64";
-      sha256 = "8e9b0088965dc9a12aa7147ce057b1ad5950d4e935764edf8075e7a954870c86";
+      sha256 = "74d206cb21ce302d93ec485f76193e4e8b41e0261300b9646215e9ab7acc45c8";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b6/linux-x86_64/ja/firefox-112.0b6.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b8/linux-x86_64/ja/firefox-112.0b8.tar.bz2";
       locale = "ja";
       arch = "linux-x86_64";
-      sha256 = "37055a2e0dbcb2ae5daf068b1665a18a69623e0f16e3ae3e92bc1cbd763c4eac";
+      sha256 = "c5da22f2ccf61363b2aec0dda134682b7e871c1d0ff0b5609a9467b11b8924a5";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b6/linux-x86_64/ka/firefox-112.0b6.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b8/linux-x86_64/ka/firefox-112.0b8.tar.bz2";
       locale = "ka";
       arch = "linux-x86_64";
-      sha256 = "32ce3679cfd4496c2b15726e526589f88cf32be1c67015d2e7b64cf25d482c90";
+      sha256 = "fb137656c93d6e349978ebe822949fc0f31302337e4293680d358683682f9887";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b6/linux-x86_64/kab/firefox-112.0b6.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b8/linux-x86_64/kab/firefox-112.0b8.tar.bz2";
       locale = "kab";
       arch = "linux-x86_64";
-      sha256 = "3c2f0bc4289872cc4af3fedec73f378f5bed1494725b5166ff0241ea7a1cfacc";
+      sha256 = "d5d7e1066241ad0dbe20cf2bd295956b0b3562a3e2c12208ac72130b99a9f34d";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b6/linux-x86_64/kk/firefox-112.0b6.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b8/linux-x86_64/kk/firefox-112.0b8.tar.bz2";
       locale = "kk";
       arch = "linux-x86_64";
-      sha256 = "81b32893eac3bf5da780136b68f5bd8b7ff07d228f0745b2183275bd1d4c4cc8";
+      sha256 = "8a2d79dd07373a828e3f756c499ec8db956cb14af4573911f439e007d63f3d11";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b6/linux-x86_64/km/firefox-112.0b6.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b8/linux-x86_64/km/firefox-112.0b8.tar.bz2";
       locale = "km";
       arch = "linux-x86_64";
-      sha256 = "d14299677c06c038c5065d2beb492ddc7589817e8da5f4ec18060ea2badcdf01";
+      sha256 = "4a2b351fdc09aef91396c3b0bbf1d04bc7c1a0a120a2a0239b17dc985ae64b92";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b6/linux-x86_64/kn/firefox-112.0b6.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b8/linux-x86_64/kn/firefox-112.0b8.tar.bz2";
       locale = "kn";
       arch = "linux-x86_64";
-      sha256 = "50ae16bbb02bd429052822d86a1a380782f4662ae3e422e609ab9dd0c49c7fd9";
+      sha256 = "852ecf7e732f544c21535890f6caefc454d3823c22776be9087c971b6dd48821";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b6/linux-x86_64/ko/firefox-112.0b6.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b8/linux-x86_64/ko/firefox-112.0b8.tar.bz2";
       locale = "ko";
       arch = "linux-x86_64";
-      sha256 = "6eece940c50c4140480c81ef8f0ce5c69e58056b522c6a0e6afbe365a670ac52";
+      sha256 = "2083809d4b78d278e07dab56e344027af1d50f7875632c915d162ec2a6c7e711";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b6/linux-x86_64/lij/firefox-112.0b6.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b8/linux-x86_64/lij/firefox-112.0b8.tar.bz2";
       locale = "lij";
       arch = "linux-x86_64";
-      sha256 = "b530e6c0ba7c339d2c9acdd09093d91c446078fcf3e206067d0ed3307d58e730";
+      sha256 = "b04bf009c11b574d568233d0b8091bddbacd1c63d17540045e271b87f3c99c33";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b6/linux-x86_64/lt/firefox-112.0b6.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b8/linux-x86_64/lt/firefox-112.0b8.tar.bz2";
       locale = "lt";
       arch = "linux-x86_64";
-      sha256 = "4c80c748503e6dd3610a16a1c5aa659ccd7c87e36995dc4dc8d6866f94bb0c63";
+      sha256 = "4b9321893129dc1df05b34eb7b0696f0df37d9fc3c43d2adf6489eba8ea05757";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b6/linux-x86_64/lv/firefox-112.0b6.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b8/linux-x86_64/lv/firefox-112.0b8.tar.bz2";
       locale = "lv";
       arch = "linux-x86_64";
-      sha256 = "f6c9a2c64dcb1fbf5ed1926ec97c2f2d027f2293373570b144b8e848315b9932";
+      sha256 = "7c155340fcf94d626075c243b1c0c905a187f2d729e9e524a28aec88eb82373e";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b6/linux-x86_64/mk/firefox-112.0b6.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b8/linux-x86_64/mk/firefox-112.0b8.tar.bz2";
       locale = "mk";
       arch = "linux-x86_64";
-      sha256 = "27e1ea632973fe0f033a867af5f640c9062c4a094374f06f7ed24920bbd90dac";
+      sha256 = "4d413977ca0e194e47becb7f5e3f24bf98f4c95b08980399fc36837fb19c91fd";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b6/linux-x86_64/mr/firefox-112.0b6.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b8/linux-x86_64/mr/firefox-112.0b8.tar.bz2";
       locale = "mr";
       arch = "linux-x86_64";
-      sha256 = "b800670eb9767d3fdc7c1f4eee3dcb114a643aeac04a7c46c6dcd1fd26d767b5";
+      sha256 = "967cb11cce490f399d32cc195bc6f986fdade60bc4e537aea0cdcf72a8339485";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b6/linux-x86_64/ms/firefox-112.0b6.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b8/linux-x86_64/ms/firefox-112.0b8.tar.bz2";
       locale = "ms";
       arch = "linux-x86_64";
-      sha256 = "bf48affb46b6f6b1ef28eda29b4ba4050c4d0386c07261181c5f1e46fa3ec682";
+      sha256 = "f03287384daa99fd6e665845baecbdedd004e86373a1b810da4f388b9a86e972";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b6/linux-x86_64/my/firefox-112.0b6.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b8/linux-x86_64/my/firefox-112.0b8.tar.bz2";
       locale = "my";
       arch = "linux-x86_64";
-      sha256 = "eba976f190093299f0eda2b486a690400a52e81be037e8cd12afce94f8df97cb";
+      sha256 = "506bbafa9e25d92cb91a4952b3362abd3a6a6ea1da97a78bf71a356e57d5a3c7";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b6/linux-x86_64/nb-NO/firefox-112.0b6.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b8/linux-x86_64/nb-NO/firefox-112.0b8.tar.bz2";
       locale = "nb-NO";
       arch = "linux-x86_64";
-      sha256 = "28a5a231ef583e9e2a9a1275c386491f5a32de673d7d6f91ddc6f47dc183ce16";
+      sha256 = "480a74d9d2eaed2cb948b670d6ce79f04b1fe79d0bbfd0c35371085b3562418a";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b6/linux-x86_64/ne-NP/firefox-112.0b6.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b8/linux-x86_64/ne-NP/firefox-112.0b8.tar.bz2";
       locale = "ne-NP";
       arch = "linux-x86_64";
-      sha256 = "7b504900c0b68be9b63bc08d8a148fb237eb65900b152a687639ccd32fe43c2d";
+      sha256 = "68217679f5f888b26cb48f0dc5bc703ea5b55c510b11291159ba0d009255f287";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b6/linux-x86_64/nl/firefox-112.0b6.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b8/linux-x86_64/nl/firefox-112.0b8.tar.bz2";
       locale = "nl";
       arch = "linux-x86_64";
-      sha256 = "30ecc6272f59d3db4018b131efbcb98ac9724c4c8f6d48309c488113d658b206";
+      sha256 = "5b6052a5848ab13f067e5e0fbd5ec60a4dfcf583d427c0009f5804ddba7a45b1";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b6/linux-x86_64/nn-NO/firefox-112.0b6.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b8/linux-x86_64/nn-NO/firefox-112.0b8.tar.bz2";
       locale = "nn-NO";
       arch = "linux-x86_64";
-      sha256 = "e483a0f44f631a4f01c62ec4e31fcbf10e9b5de86aad0470ed46792c263078d5";
+      sha256 = "5787c7b434a4948b14437a2e0582b0434e4a528fb1135f4e0085f4b38cd74872";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b6/linux-x86_64/oc/firefox-112.0b6.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b8/linux-x86_64/oc/firefox-112.0b8.tar.bz2";
       locale = "oc";
       arch = "linux-x86_64";
-      sha256 = "6df8c4f8cd34074e2e86de468a785ac00bc2d8fceb2bc9d62ff1b083ceee04f6";
+      sha256 = "b76fc6198316c21a6f57cf0935075cb10375192a096fbec0d71ee9663af02f70";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b6/linux-x86_64/pa-IN/firefox-112.0b6.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b8/linux-x86_64/pa-IN/firefox-112.0b8.tar.bz2";
       locale = "pa-IN";
       arch = "linux-x86_64";
-      sha256 = "6fc85246861bc852f413d1c4ee42784f7969df13504ce54a3c570c47e1741844";
+      sha256 = "1c0bfec608cd1a5235558c65b8a0c3d76030426bd22823e4545a10a46948c376";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b6/linux-x86_64/pl/firefox-112.0b6.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b8/linux-x86_64/pl/firefox-112.0b8.tar.bz2";
       locale = "pl";
       arch = "linux-x86_64";
-      sha256 = "814a0bfef6e077f86c8d142b0fef2e1017836dbba4bd9247cd13325a6f88ca89";
+      sha256 = "21599e49147867d566d1cecee76fd94255f889906340817e4b752e9b8076540d";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b6/linux-x86_64/pt-BR/firefox-112.0b6.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b8/linux-x86_64/pt-BR/firefox-112.0b8.tar.bz2";
       locale = "pt-BR";
       arch = "linux-x86_64";
-      sha256 = "02442f1b2de00105fc6dcaa46a040b48446b671e5b8129f51ee600ee0f122e76";
+      sha256 = "5734325bbc9ac6c3cb046aaee27ef0fe1b2df96c77e949a3db26cdf46d6204f7";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b6/linux-x86_64/pt-PT/firefox-112.0b6.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b8/linux-x86_64/pt-PT/firefox-112.0b8.tar.bz2";
       locale = "pt-PT";
       arch = "linux-x86_64";
-      sha256 = "f48a79caa82e3b307e3a3de7bb4a883a662db6f2ac9f44172e0d9e3ad4d71ba4";
+      sha256 = "bcbac61f303a3539a6bf00b6b4effcda03651c1f5cd8ff11fc9e6f5839631b96";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b6/linux-x86_64/rm/firefox-112.0b6.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b8/linux-x86_64/rm/firefox-112.0b8.tar.bz2";
       locale = "rm";
       arch = "linux-x86_64";
-      sha256 = "99fc942cd487d122433ffa64645d9187fbf42c10f4415fa8c0616d52f6d065f2";
+      sha256 = "ca8b8a7141bcfe7b6816258abbb16ecdb4640035fa0c32b0c114716ecdad4ddd";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b6/linux-x86_64/ro/firefox-112.0b6.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b8/linux-x86_64/ro/firefox-112.0b8.tar.bz2";
       locale = "ro";
       arch = "linux-x86_64";
-      sha256 = "5168fc51d066e5a576c1ad3392259b45ab4f8eb14c66461dc2a9e7721ce1f000";
+      sha256 = "3d9db81c9d884214c8ec862a4cd26d0db1728d8b7fd1029c265bcbb673cfd14f";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b6/linux-x86_64/ru/firefox-112.0b6.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b8/linux-x86_64/ru/firefox-112.0b8.tar.bz2";
       locale = "ru";
       arch = "linux-x86_64";
-      sha256 = "2de9e8d22b3e60c5cc700c481fc7228097680076eb636a188c507086c81b236f";
+      sha256 = "0898593e4a839fbb1aa93caaccdecfeff86ac1a040734ef60a9e699871771d07";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b6/linux-x86_64/sc/firefox-112.0b6.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b8/linux-x86_64/sc/firefox-112.0b8.tar.bz2";
       locale = "sc";
       arch = "linux-x86_64";
-      sha256 = "563ebfaea00c3e25b753e77e10fb3ba1132396996a2ec5744093b72398973722";
+      sha256 = "e4ac8238c8e14dad49e930b5cb3cc567e5a00f59e23431d9b2ab6ff35dca3507";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b6/linux-x86_64/sco/firefox-112.0b6.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b8/linux-x86_64/sco/firefox-112.0b8.tar.bz2";
       locale = "sco";
       arch = "linux-x86_64";
-      sha256 = "c643b62d62ed158a41e6aeacb533795e1c3774d207afbe8a95488bca91742eb5";
+      sha256 = "0ef022238a27e40cc32ea18bf71b22af7c40179260c1ea46fb6c84f8077fd392";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b6/linux-x86_64/si/firefox-112.0b6.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b8/linux-x86_64/si/firefox-112.0b8.tar.bz2";
       locale = "si";
       arch = "linux-x86_64";
-      sha256 = "6a82759501c7a6da27df5dd3e998e514a459d35139cb17648249599f3c521722";
+      sha256 = "df054c52cb7525b34b4bd66953814a67a705af695938da812bfe1c8e9d4193f1";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b6/linux-x86_64/sk/firefox-112.0b6.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b8/linux-x86_64/sk/firefox-112.0b8.tar.bz2";
       locale = "sk";
       arch = "linux-x86_64";
-      sha256 = "2dd5c7c2743dd8018f46594c4ab7ade8b76e94b88f13ada5874722a88c48f72a";
+      sha256 = "0550a7c651431b0a76c85730363325490926e6c4bde72961b957a888763e0737";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b6/linux-x86_64/sl/firefox-112.0b6.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b8/linux-x86_64/sl/firefox-112.0b8.tar.bz2";
       locale = "sl";
       arch = "linux-x86_64";
-      sha256 = "7f5ea08a2978b7fdb148c515c213183217deb9f23c2bcd9fcff07ef0d58c5228";
+      sha256 = "5671c6b2d69ff75c86b312316eea458ed69e8a8f775996498694680f194af633";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b6/linux-x86_64/son/firefox-112.0b6.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b8/linux-x86_64/son/firefox-112.0b8.tar.bz2";
       locale = "son";
       arch = "linux-x86_64";
-      sha256 = "ce987ec89797e07c51d0b96346243826d08a52365511e8671b3a2d1f8b0a57e1";
+      sha256 = "753bdba1b8820ac13602a333534768c591ec761a2716949b7937094a6403a4ac";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b6/linux-x86_64/sq/firefox-112.0b6.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b8/linux-x86_64/sq/firefox-112.0b8.tar.bz2";
       locale = "sq";
       arch = "linux-x86_64";
-      sha256 = "c5062fc67d51dd29df304b5ee381ddaad4fa62fa92a7b1ae5278671e95c2314a";
+      sha256 = "1007aa39e8332948b1180d1a4b69ae3fb43608a78eaf9552958f6fb9a31ac2b6";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b6/linux-x86_64/sr/firefox-112.0b6.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b8/linux-x86_64/sr/firefox-112.0b8.tar.bz2";
       locale = "sr";
       arch = "linux-x86_64";
-      sha256 = "6fc309a7a2412e7822d7017ba2fee5f1cc5dec9d8021f0ae4cf9101a2c4dadd9";
+      sha256 = "52f01f8437fd6ac07ad09a56d22d361dcb00f02af387f951f95463f0802115d6";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b6/linux-x86_64/sv-SE/firefox-112.0b6.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b8/linux-x86_64/sv-SE/firefox-112.0b8.tar.bz2";
       locale = "sv-SE";
       arch = "linux-x86_64";
-      sha256 = "c0794112545d72c57a98398d984ec88ce465559e7648cd835fb8df2944eec376";
+      sha256 = "9c324d61840eaafe56c72bdab2d46441ba49509a17bf065cd9392da5aabf2f39";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b6/linux-x86_64/szl/firefox-112.0b6.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b8/linux-x86_64/szl/firefox-112.0b8.tar.bz2";
       locale = "szl";
       arch = "linux-x86_64";
-      sha256 = "e1e134dd0e9bfbdf06b2348bab4020e904fc50c3792738cee479562ed1093fc6";
+      sha256 = "983f6e7c5712ac00e578235c2ff176d601d5008cd8b48ca0d796df41645f2c5b";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b6/linux-x86_64/ta/firefox-112.0b6.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b8/linux-x86_64/ta/firefox-112.0b8.tar.bz2";
       locale = "ta";
       arch = "linux-x86_64";
-      sha256 = "2cb9caa865ed321016cefb2d69c304b57a5346bc19f491163e6f7750719f3788";
+      sha256 = "85331992596010d1e1d7b99858fea5dfee22a253e8e6c6114445b75964c699ce";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b6/linux-x86_64/te/firefox-112.0b6.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b8/linux-x86_64/te/firefox-112.0b8.tar.bz2";
       locale = "te";
       arch = "linux-x86_64";
-      sha256 = "8bd811c257f9dea90ecb67a681ebe38c8e822c99a3a131008009570db5812b81";
+      sha256 = "a7370e48ed30489403da41a2c7ee58894964a5c24070cf52094bf5625a60db40";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b6/linux-x86_64/th/firefox-112.0b6.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b8/linux-x86_64/th/firefox-112.0b8.tar.bz2";
       locale = "th";
       arch = "linux-x86_64";
-      sha256 = "968c068773476365ef0649b39354f46b4391d5adcc75ec7dedcdaf24bc9c3fac";
+      sha256 = "e5aee3fbd315b78a0ca8f132efe8bed0fdab288c6c5f07886bcc61c4bc0042e4";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b6/linux-x86_64/tl/firefox-112.0b6.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b8/linux-x86_64/tl/firefox-112.0b8.tar.bz2";
       locale = "tl";
       arch = "linux-x86_64";
-      sha256 = "f62b4e88589a4bd66a29881e0f296bda9458616c922c9f727e37486703ee4103";
+      sha256 = "52bf56e9e93fe0779bdb0840ae5de30d668d6827533b51bbee087e9c7e67a47d";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b6/linux-x86_64/tr/firefox-112.0b6.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b8/linux-x86_64/tr/firefox-112.0b8.tar.bz2";
       locale = "tr";
       arch = "linux-x86_64";
-      sha256 = "bbc7c06f87d6c7a2de53182f8584ccf74298af1ad64013e6c6915df90e26cb47";
+      sha256 = "2a866984991be3caa0e325698191bb61d6622584346a49a7346f6c2fd0795451";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b6/linux-x86_64/trs/firefox-112.0b6.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b8/linux-x86_64/trs/firefox-112.0b8.tar.bz2";
       locale = "trs";
       arch = "linux-x86_64";
-      sha256 = "18370b2ffb2b584c664c687ef716af4a0eeddb6851790ad2fb67dff393c85f88";
+      sha256 = "25231c71ad2ba64a01003bd43f2fa5126b4016a87d0ae59a29aaaa7b2199d704";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b6/linux-x86_64/uk/firefox-112.0b6.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b8/linux-x86_64/uk/firefox-112.0b8.tar.bz2";
       locale = "uk";
       arch = "linux-x86_64";
-      sha256 = "196fc861eea70145835f93e7111e4453a42d16b1f243bb4ffcf1234f305d0c8c";
+      sha256 = "0f1ddd4a25d77298d159287cbb0cd064774d1c6959853556daa2142e9fba6cc0";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b6/linux-x86_64/ur/firefox-112.0b6.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b8/linux-x86_64/ur/firefox-112.0b8.tar.bz2";
       locale = "ur";
       arch = "linux-x86_64";
-      sha256 = "0725751ea0f6f7fbe0f4e104ae7a9ad5957b9185c29d3955a9d0d30f3c09e06a";
+      sha256 = "d709c925f899674c749ce9ce26264063602c927546cd5b72d88b67381d0412b1";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b6/linux-x86_64/uz/firefox-112.0b6.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b8/linux-x86_64/uz/firefox-112.0b8.tar.bz2";
       locale = "uz";
       arch = "linux-x86_64";
-      sha256 = "c9a139b876bbd13eef0e51316c07264aa7b2e1405b7e9b2bc5992cb954cd5975";
+      sha256 = "c0e33667785887eac0f7e72845e4330abe17ef545a1e4cd3c8109e58dc45de32";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b6/linux-x86_64/vi/firefox-112.0b6.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b8/linux-x86_64/vi/firefox-112.0b8.tar.bz2";
       locale = "vi";
       arch = "linux-x86_64";
-      sha256 = "73d827171ce290803434b0763efb9d93ce44089823f6dead23cd11cfb48b7dda";
+      sha256 = "44602876fcce27cc593f87c348221e86f7e0e1670925ed9b947096cfabd0d6ef";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b6/linux-x86_64/xh/firefox-112.0b6.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b8/linux-x86_64/xh/firefox-112.0b8.tar.bz2";
       locale = "xh";
       arch = "linux-x86_64";
-      sha256 = "3ff3c8f0f0d2cb18da7b8f110499491a8d5d285eb2cf52d38898706a03104dad";
+      sha256 = "baab1cc439d13ea4380d1e4261fa69e014f2982c76df699899bd5451ae551a0d";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b6/linux-x86_64/zh-CN/firefox-112.0b6.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b8/linux-x86_64/zh-CN/firefox-112.0b8.tar.bz2";
       locale = "zh-CN";
       arch = "linux-x86_64";
-      sha256 = "74c30b59b36560a275f89ae666c9f4d8ab41fb6dfe9c3176a993b85f6eb03f2a";
+      sha256 = "d1b72cfa16acfd0d5a7f7e6b4fbab4b9892846cf3d30acf6cc693cf858dfd41c";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b6/linux-x86_64/zh-TW/firefox-112.0b6.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b8/linux-x86_64/zh-TW/firefox-112.0b8.tar.bz2";
       locale = "zh-TW";
       arch = "linux-x86_64";
-      sha256 = "97d25ac61d9a85a00c2cd8ed4d5d47f2e3f4c5c1a46ca036cc79a0cd2eb955da";
+      sha256 = "31052fa53e6d6cff9364150ba703780a08608c41e3583b70f83576a0cabb52a4";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b6/linux-i686/ach/firefox-112.0b6.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b8/linux-i686/ach/firefox-112.0b8.tar.bz2";
       locale = "ach";
       arch = "linux-i686";
-      sha256 = "19776a30548215f780e8013709cddbf77a92810e66847ef38a8e29e81221e50f";
+      sha256 = "19ba40eac531c96527c501e5dc689bba37626ccd0780ffc722d72effba7a68cc";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b6/linux-i686/af/firefox-112.0b6.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b8/linux-i686/af/firefox-112.0b8.tar.bz2";
       locale = "af";
       arch = "linux-i686";
-      sha256 = "2a575a6f8348e0e0084373f80197cbf78fddba5716b51926e9d2b707a7c64149";
+      sha256 = "cde55e4c9977bb30d849b8ee793b9ebbd2d3e7eb79ddfe38b893b5d74554614e";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b6/linux-i686/an/firefox-112.0b6.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b8/linux-i686/an/firefox-112.0b8.tar.bz2";
       locale = "an";
       arch = "linux-i686";
-      sha256 = "580a30e4e45bcacada0c42e7f4461df118bedcb3bef3dc32d78030025b4a1e6f";
+      sha256 = "6702e8e6425664a2effccb37f511c69430e6a0c8763a3ca64c2c01c8f80e0971";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b6/linux-i686/ar/firefox-112.0b6.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b8/linux-i686/ar/firefox-112.0b8.tar.bz2";
       locale = "ar";
       arch = "linux-i686";
-      sha256 = "705dff2e9135a5db4260f16f1d4b94a01d2aba642049d5dc38c0b60c4bff0fc4";
+      sha256 = "494a53d6f71d6307f9fe315725a2ab1d5a43bea4ced7d294849917a43854ef3e";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b6/linux-i686/ast/firefox-112.0b6.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b8/linux-i686/ast/firefox-112.0b8.tar.bz2";
       locale = "ast";
       arch = "linux-i686";
-      sha256 = "30ef9890c33ec4f4c4b5a8c41ebcca3db93a20f24a61523b8446d4d89746a507";
+      sha256 = "32228b2fe7b0d5a0466ef3da9ce7fde672e857fbc96cf52d431eaf09b5aa4796";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b6/linux-i686/az/firefox-112.0b6.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b8/linux-i686/az/firefox-112.0b8.tar.bz2";
       locale = "az";
       arch = "linux-i686";
-      sha256 = "7f679b6e47afeec3e5bf85ae2c3235e4962e36b751cf1a6fd67c0c822e20065b";
+      sha256 = "9d5b9f9e94b0d3b29c1e03a1d9f1d6adf7633c13ae890a69c835379df7ff3e82";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b6/linux-i686/be/firefox-112.0b6.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b8/linux-i686/be/firefox-112.0b8.tar.bz2";
       locale = "be";
       arch = "linux-i686";
-      sha256 = "ee9f99eee4460cb0862f6dc647cc494ffe28f11ed2999f005097510487eb165c";
+      sha256 = "79d2ada9e2c5060322a90fe0bb1bf43542515b7a697350bc7707c6cc9ef53006";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b6/linux-i686/bg/firefox-112.0b6.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b8/linux-i686/bg/firefox-112.0b8.tar.bz2";
       locale = "bg";
       arch = "linux-i686";
-      sha256 = "f73d2142887d3a4ebc1c98b8482901039f5073bb6f07ee190753b7b892adf47d";
+      sha256 = "2eb52eddb7f52c59ebcfd15cb938b82801094f55155f22e7c93d616819072c4b";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b6/linux-i686/bn/firefox-112.0b6.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b8/linux-i686/bn/firefox-112.0b8.tar.bz2";
       locale = "bn";
       arch = "linux-i686";
-      sha256 = "e6a255f95e9bed6295c03383eb5b32930a7600529abd885c912638fc2c33ea33";
+      sha256 = "d9ea4347366648b25deb9b6a8a83a40a025cba34a16037fcc84e4f21001b1290";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b6/linux-i686/br/firefox-112.0b6.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b8/linux-i686/br/firefox-112.0b8.tar.bz2";
       locale = "br";
       arch = "linux-i686";
-      sha256 = "a14a44af3576aae7ada0fe14856219803d7d2a025702430418e9ed46e62acd85";
+      sha256 = "cb2aec673514478bf12ce2a34d908cd1618423d3a6ffdbb7db78ff0d0cdf9ebb";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b6/linux-i686/bs/firefox-112.0b6.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b8/linux-i686/bs/firefox-112.0b8.tar.bz2";
       locale = "bs";
       arch = "linux-i686";
-      sha256 = "62a797df2f195d1fc3a402a55acef10c0e3aaeaa7c8dabdecf6ca41d3094a442";
+      sha256 = "a1bde0daa1a5f73a3402b4c7857fe8f95655ca02ccc148dbd3cba847dd2cff1c";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b6/linux-i686/ca-valencia/firefox-112.0b6.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b8/linux-i686/ca-valencia/firefox-112.0b8.tar.bz2";
       locale = "ca-valencia";
       arch = "linux-i686";
-      sha256 = "91d512c997715a15d4b02f59668587e8fce15dac958719c556abd452d82a3327";
+      sha256 = "28be3ec47f35b5a831438b730805b72d15f4ab6e57efd7d5641d731f53cb2f63";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b6/linux-i686/ca/firefox-112.0b6.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b8/linux-i686/ca/firefox-112.0b8.tar.bz2";
       locale = "ca";
       arch = "linux-i686";
-      sha256 = "f302ccd5ad1ef1f4611fe4a8fcd9f9af14e5cb803c515419c464dbe41fe61b7c";
+      sha256 = "9cdefd1ce6ae32cd081fe9598e4e68889af6815bd3551a4997136c66057332bf";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b6/linux-i686/cak/firefox-112.0b6.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b8/linux-i686/cak/firefox-112.0b8.tar.bz2";
       locale = "cak";
       arch = "linux-i686";
-      sha256 = "05ea38ce95db95c44cb29cc72865f578d71353756a344d7e168bbed0796253f4";
+      sha256 = "12d0ab99974502cd1fccd778af3967e653b6c131afa1304571f850b25cbae6eb";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b6/linux-i686/cs/firefox-112.0b6.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b8/linux-i686/cs/firefox-112.0b8.tar.bz2";
       locale = "cs";
       arch = "linux-i686";
-      sha256 = "dd74c98db61d4adaaa89262438430841501815adcf285fddb8b86456ead1284f";
+      sha256 = "6db7534e66227a0c51ebaa8e63c8b6c2e26b03d16a89d970d6621982b8cb0d6c";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b6/linux-i686/cy/firefox-112.0b6.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b8/linux-i686/cy/firefox-112.0b8.tar.bz2";
       locale = "cy";
       arch = "linux-i686";
-      sha256 = "56337dacca8929d3c65b188c56c333d0cf874cba2df89cf7b530853ffa6f1e19";
+      sha256 = "1754d144402db4bd231d9cd2a3001945280f107315646b56933484e5dfd14f35";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b6/linux-i686/da/firefox-112.0b6.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b8/linux-i686/da/firefox-112.0b8.tar.bz2";
       locale = "da";
       arch = "linux-i686";
-      sha256 = "c7a86a7c2bd94cbced67eb151a102c9e59b86c623a5df86a6ea8e936ceca4074";
+      sha256 = "d899f778690a047717c363f4447fffe1c68c425c7ae64a3174ae246a2167afe6";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b6/linux-i686/de/firefox-112.0b6.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b8/linux-i686/de/firefox-112.0b8.tar.bz2";
       locale = "de";
       arch = "linux-i686";
-      sha256 = "2a9417463238e4cade10ba64dc8677410dcb8ac1d0917e715f059060e52d6fb3";
+      sha256 = "016888cf4ced56b38c99114f9091c0c36fabdb8db4350bafc06cbe284c68b20b";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b6/linux-i686/dsb/firefox-112.0b6.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b8/linux-i686/dsb/firefox-112.0b8.tar.bz2";
       locale = "dsb";
       arch = "linux-i686";
-      sha256 = "70b660be2e0bed4a05cc0ee8adc2becd6583b835a9486228febd8905cca63ff9";
+      sha256 = "9f25312ed0687fe6b76052e3b7cadcf00882e066c81ab8fa679f64633cfbc5d9";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b6/linux-i686/el/firefox-112.0b6.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b8/linux-i686/el/firefox-112.0b8.tar.bz2";
       locale = "el";
       arch = "linux-i686";
-      sha256 = "604183c159eab56032cd1a9ed45f9f63e9054eb860429e4d5e49159d8b422e18";
+      sha256 = "e9f030b1f1e7225bc175ae0f63a8cd7f3f016db0d48b08a19fc220059115318f";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b6/linux-i686/en-CA/firefox-112.0b6.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b8/linux-i686/en-CA/firefox-112.0b8.tar.bz2";
       locale = "en-CA";
       arch = "linux-i686";
-      sha256 = "979e3e37d25202601c2123f2175bf65c96111154e338c59780b8ba3afb018390";
+      sha256 = "fe423e6e1ef9bd01d6cac302ff03e8d8593afd0943b1c32884c6e578c6c8a86c";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b6/linux-i686/en-GB/firefox-112.0b6.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b8/linux-i686/en-GB/firefox-112.0b8.tar.bz2";
       locale = "en-GB";
       arch = "linux-i686";
-      sha256 = "5b3a8d845970563c991053327e4951f0b44d4e0ac2e96ef060dca757ba7dadf6";
+      sha256 = "e5c03cccbf940f00df60d5ba6261ae36248a7ea6a6c1151238c26d3c3cf38372";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b6/linux-i686/en-US/firefox-112.0b6.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b8/linux-i686/en-US/firefox-112.0b8.tar.bz2";
       locale = "en-US";
       arch = "linux-i686";
-      sha256 = "9349b8674173490d9886e2c3c31a72041da819021d1bd3f7eb85cd62f66468c9";
+      sha256 = "790a0ca46dc990cd4d10be661ae593ecf3a862effee72b1249ce36d6f4355b07";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b6/linux-i686/eo/firefox-112.0b6.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b8/linux-i686/eo/firefox-112.0b8.tar.bz2";
       locale = "eo";
       arch = "linux-i686";
-      sha256 = "5a7d10519cb3744f558605a4090fb2b3994cd5694f3210f5b0fcb1c82ba206b8";
+      sha256 = "c1ae4807a44e1d70a0db1b4a108ce1c7dd07a3b62efcedd4d95617bceee75ddb";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b6/linux-i686/es-AR/firefox-112.0b6.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b8/linux-i686/es-AR/firefox-112.0b8.tar.bz2";
       locale = "es-AR";
       arch = "linux-i686";
-      sha256 = "e4bf9dc36cc77e6581c2eeded1915138e944cf113f7b733bf3f3323c6d954d50";
+      sha256 = "0afab6c53c43c37060a887cf8f9b6069038663a6639807379fe27d05c6c4245f";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b6/linux-i686/es-CL/firefox-112.0b6.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b8/linux-i686/es-CL/firefox-112.0b8.tar.bz2";
       locale = "es-CL";
       arch = "linux-i686";
-      sha256 = "93b4d67bfc8d8d6fbaa49b2973f4ab3f46d7f7dcecf4b4f4e44265c528145e76";
+      sha256 = "e44760754abe65ba0dd1d8373108cb2ea7090b2a2320214f55794da48a6e602b";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b6/linux-i686/es-ES/firefox-112.0b6.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b8/linux-i686/es-ES/firefox-112.0b8.tar.bz2";
       locale = "es-ES";
       arch = "linux-i686";
-      sha256 = "3ee2c2475362ec2a4da4e5870676bece65a43f3b55a0d61dddb3c9875ab6ee31";
+      sha256 = "a7cb095b06c7e8a471106655fdfa1dafdba772f490bd8e723c98041fe5f1c205";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b6/linux-i686/es-MX/firefox-112.0b6.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b8/linux-i686/es-MX/firefox-112.0b8.tar.bz2";
       locale = "es-MX";
       arch = "linux-i686";
-      sha256 = "62e6ae0e8636ae43d0151fa549cf62c87cbc472ed9cd6f5783b8d4b76fb76996";
+      sha256 = "b0f1b00d4607887e3c7e2ac2f79d80e5fccaf6fb490c02de0b8ae76cd5eb9f2b";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b6/linux-i686/et/firefox-112.0b6.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b8/linux-i686/et/firefox-112.0b8.tar.bz2";
       locale = "et";
       arch = "linux-i686";
-      sha256 = "0a9bd46034f708195466c4002efec47e0a6316f31c3131a50f1cb6a31727b061";
+      sha256 = "6ffe6e79b41b33dc547d827ac1b04efcfc339e8014ffbc6c9da8cfe1719a173a";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b6/linux-i686/eu/firefox-112.0b6.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b8/linux-i686/eu/firefox-112.0b8.tar.bz2";
       locale = "eu";
       arch = "linux-i686";
-      sha256 = "334dc2222832a40d8bdfb831544300662be6c8ad650782a417e40d211bb7156c";
+      sha256 = "f4c4ba0b68e6be4502ed6dea77640153f2294415c4e9242a36f49d355d80cc3d";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b6/linux-i686/fa/firefox-112.0b6.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b8/linux-i686/fa/firefox-112.0b8.tar.bz2";
       locale = "fa";
       arch = "linux-i686";
-      sha256 = "a1cb40d0e0cc30e6430a2b24c33fa8721a82a0724d52098048d659d8f4b4aa27";
+      sha256 = "4e957fcb8a50043838cbcab6b2428dc63ecbb00bb7cad6248b5394359bc0a395";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b6/linux-i686/ff/firefox-112.0b6.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b8/linux-i686/ff/firefox-112.0b8.tar.bz2";
       locale = "ff";
       arch = "linux-i686";
-      sha256 = "a687a279ae9b75d48b030458cf6ee82601f5da63fa3f1a856dfd03c9c185a371";
+      sha256 = "4f7cc3ffa7526d2d22f9bbfe78674a1246501afdb9aada099ef2ce3ac2e0e39d";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b6/linux-i686/fi/firefox-112.0b6.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b8/linux-i686/fi/firefox-112.0b8.tar.bz2";
       locale = "fi";
       arch = "linux-i686";
-      sha256 = "26c51b6966c6a1042baaeed143e242f47692bab7caab22037240d6f52d3e48a5";
+      sha256 = "6bc089de770a23b3dad1daeb700955a886475df8fd1095f093075bd008df00e6";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b6/linux-i686/fr/firefox-112.0b6.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b8/linux-i686/fr/firefox-112.0b8.tar.bz2";
       locale = "fr";
       arch = "linux-i686";
-      sha256 = "6d75a816c793be15a3747cc550317abf443f9a348ca049769ca84ce9e09e46d9";
+      sha256 = "8b811e21c72d0cc554abf95827aa907df88d6cc4002672d7282ca2b5af11de8d";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b6/linux-i686/fur/firefox-112.0b6.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b8/linux-i686/fur/firefox-112.0b8.tar.bz2";
       locale = "fur";
       arch = "linux-i686";
-      sha256 = "1b6093306c6d8b5c4158c9b93fa95eeba5bc5a683ca25a126c95bde31ca97e16";
+      sha256 = "1680f9d84d1737711768ce9ada322fa3ec6bbec79ea1a8c6edf2c4ec85ad9938";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b6/linux-i686/fy-NL/firefox-112.0b6.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b8/linux-i686/fy-NL/firefox-112.0b8.tar.bz2";
       locale = "fy-NL";
       arch = "linux-i686";
-      sha256 = "e5edfba6e09a677a8ac5d7e482a26210c9c34c35ddf18d558aa26428b6a1f29f";
+      sha256 = "be23299565a467e3e862e6f71844b3aa8f40e264b00443d2e2b840316626dd4c";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b6/linux-i686/ga-IE/firefox-112.0b6.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b8/linux-i686/ga-IE/firefox-112.0b8.tar.bz2";
       locale = "ga-IE";
       arch = "linux-i686";
-      sha256 = "4e8e0584ed9246be2d41eda90852a202f259ee041a239f6005f37eb2127e0d6e";
+      sha256 = "b5c18bca50a1eacee1f9ebdb7a576b40a6093d8c10b0a5710e513600de4a38c2";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b6/linux-i686/gd/firefox-112.0b6.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b8/linux-i686/gd/firefox-112.0b8.tar.bz2";
       locale = "gd";
       arch = "linux-i686";
-      sha256 = "9dca713182c1a40859a648da50ab2b9d69fb3c213b34e7ef7ce328c0f2b04556";
+      sha256 = "2e71cd3e17307c3560ae9555036c9f7b679b11f63d762864bc8445415e761700";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b6/linux-i686/gl/firefox-112.0b6.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b8/linux-i686/gl/firefox-112.0b8.tar.bz2";
       locale = "gl";
       arch = "linux-i686";
-      sha256 = "4a551695702b3cdff799390e783b0924432af243e5a546e183772de555874e47";
+      sha256 = "9334887af196701f92dc9847107d551fc71a67a73db3832dded090f5996d50d5";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b6/linux-i686/gn/firefox-112.0b6.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b8/linux-i686/gn/firefox-112.0b8.tar.bz2";
       locale = "gn";
       arch = "linux-i686";
-      sha256 = "9e0130b8d9b093afb1896c3a70ee26d94bb8f486b449edb4774cdfaba0783201";
+      sha256 = "4c3bfa47d5109a41f0a03623c00ea0278d5d102f5d6a038ca19d77b66b0857a8";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b6/linux-i686/gu-IN/firefox-112.0b6.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b8/linux-i686/gu-IN/firefox-112.0b8.tar.bz2";
       locale = "gu-IN";
       arch = "linux-i686";
-      sha256 = "dab88118d1ab466c7726a1789381614fa21dc829aa6ce65ab57f8caf8079c065";
+      sha256 = "70a645e53a8ae5d6d75a1dea9f39fbe98d2b3d9900f7a950dd58dd517d6ad8dc";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b6/linux-i686/he/firefox-112.0b6.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b8/linux-i686/he/firefox-112.0b8.tar.bz2";
       locale = "he";
       arch = "linux-i686";
-      sha256 = "4b7debe735b5b8aef668cf586be61a39e964d7990047deece2ba90f058917746";
+      sha256 = "8c07417e24fa214a42826ed3a7691ddcac8c68a89002708ad583f7f88caa6626";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b6/linux-i686/hi-IN/firefox-112.0b6.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b8/linux-i686/hi-IN/firefox-112.0b8.tar.bz2";
       locale = "hi-IN";
       arch = "linux-i686";
-      sha256 = "2e166358b50df0ebbf3c37a4fcfdb12c11d37c6ccdf215a1fa75b6abf6022a92";
+      sha256 = "8b7bbb05a2ad5062fe30ebd9060d60fd0991b7c5bf6860d2f3e26c47b94c580e";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b6/linux-i686/hr/firefox-112.0b6.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b8/linux-i686/hr/firefox-112.0b8.tar.bz2";
       locale = "hr";
       arch = "linux-i686";
-      sha256 = "550c33b0c45f69b8bcc90ab2f79b40ed63e65e9c93a16c6457838c3a1437c852";
+      sha256 = "7a43bb2dc5f6559f96674fc6b62518b69b0e18bd06f790b7a885197215c521a3";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b6/linux-i686/hsb/firefox-112.0b6.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b8/linux-i686/hsb/firefox-112.0b8.tar.bz2";
       locale = "hsb";
       arch = "linux-i686";
-      sha256 = "cbf4ab6aa4789bcd2e2eefb49285ef557148af04b9b80a7e705f8477c475b1c1";
+      sha256 = "c846bceea79f6fc2d5f473be853716e2043f99e86c2eb6933b82df9616d7db62";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b6/linux-i686/hu/firefox-112.0b6.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b8/linux-i686/hu/firefox-112.0b8.tar.bz2";
       locale = "hu";
       arch = "linux-i686";
-      sha256 = "b62c4ad1bb3e4ced77ee7f37685206974302598d9bd3e4fe5bb8d6631404896c";
+      sha256 = "52f0cfd6e53b8db6a30755bcdaf8ed9cd3dd6c37f1793c7fd8b762ca24f790d9";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b6/linux-i686/hy-AM/firefox-112.0b6.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b8/linux-i686/hy-AM/firefox-112.0b8.tar.bz2";
       locale = "hy-AM";
       arch = "linux-i686";
-      sha256 = "3348e171f9457adc872272f420e3c657532220a8b562f4baf55731944a36e9db";
+      sha256 = "e8f66e48f27585e6d95b6b2dded296ee9f44a81ab3c8cfd5cec5e2c1198f855b";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b6/linux-i686/ia/firefox-112.0b6.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b8/linux-i686/ia/firefox-112.0b8.tar.bz2";
       locale = "ia";
       arch = "linux-i686";
-      sha256 = "6ce221f1bdf3d0af0d149ff6ad630ae79e165a3e56d1157d12bd0530a669a635";
+      sha256 = "7a3c27576c0a2a50ee16e1dfcc17c8aad8716a7a58439b214dadb79fce141882";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b6/linux-i686/id/firefox-112.0b6.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b8/linux-i686/id/firefox-112.0b8.tar.bz2";
       locale = "id";
       arch = "linux-i686";
-      sha256 = "f35d99e6410bc31c9bcb87f96aceb0c303223b57f5640e2bd950ae2dacc8432d";
+      sha256 = "5ff427d85fae28533e10fba5ce365565bc723a5201324b6d25fd22312e66ce28";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b6/linux-i686/is/firefox-112.0b6.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b8/linux-i686/is/firefox-112.0b8.tar.bz2";
       locale = "is";
       arch = "linux-i686";
-      sha256 = "456cde1dccb24c86e9ea049f1fd0d2b939307aa519f70761b90f9edb3cc3c103";
+      sha256 = "eb6d40a42a7a7a0200a4eff0983f7dbdafd249e3297361ee24da0404e3e547d8";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b6/linux-i686/it/firefox-112.0b6.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b8/linux-i686/it/firefox-112.0b8.tar.bz2";
       locale = "it";
       arch = "linux-i686";
-      sha256 = "0cb75b4dfcd9d75673eeffe0d779cc4ea8762d97e9feea2e49d3908f63726b60";
+      sha256 = "b35e50f348d955adc6d481e3793c18e70deecddc377cc2700b599eed3c4a0028";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b6/linux-i686/ja/firefox-112.0b6.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b8/linux-i686/ja/firefox-112.0b8.tar.bz2";
       locale = "ja";
       arch = "linux-i686";
-      sha256 = "278dd545a883088cad75b13225ecf639c6799ab198c0c3791e8bca5c92d2d177";
+      sha256 = "7c420e49f4fab80048a27566c031011bc04f6bc4e953c3aeccadbbe8406ea063";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b6/linux-i686/ka/firefox-112.0b6.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b8/linux-i686/ka/firefox-112.0b8.tar.bz2";
       locale = "ka";
       arch = "linux-i686";
-      sha256 = "ac969431f2807db57035faa6722cd124838a128e3f21011e98e95f6dcb57ad22";
+      sha256 = "7297a55e1510524ae75f3068f91fd4f4f47e5bac7e5d6f788df56a4d506b64e5";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b6/linux-i686/kab/firefox-112.0b6.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b8/linux-i686/kab/firefox-112.0b8.tar.bz2";
       locale = "kab";
       arch = "linux-i686";
-      sha256 = "ff59f7d076f1410274bb627778b3ea672c47c576585f24aaf259eaf9329dea92";
+      sha256 = "588c879af41b7156f3d392ac52d20462f37a08ed0db813be4654893cfd796a24";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b6/linux-i686/kk/firefox-112.0b6.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b8/linux-i686/kk/firefox-112.0b8.tar.bz2";
       locale = "kk";
       arch = "linux-i686";
-      sha256 = "3a4b1a95db17b68cd39da5c1cff17c4af616b45f754403a8ca7e26745cca447f";
+      sha256 = "d14b902978d837b67a2e6b03c4b58c1decb7955ff99724251d3a8cdc069621a7";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b6/linux-i686/km/firefox-112.0b6.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b8/linux-i686/km/firefox-112.0b8.tar.bz2";
       locale = "km";
       arch = "linux-i686";
-      sha256 = "5626087484f861a701387858f77852e7c89e86d65fb0826f256f59a94f45d791";
+      sha256 = "0fefed1e3f6769846a41fc9a3ea7e72af4363836ff5ceab5b3a675a61ef49c6a";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b6/linux-i686/kn/firefox-112.0b6.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b8/linux-i686/kn/firefox-112.0b8.tar.bz2";
       locale = "kn";
       arch = "linux-i686";
-      sha256 = "56d4e7875ad5a4aa3b4eaf48aa6dd9df6311b78fdc5c7d3bd6cd3a425c203974";
+      sha256 = "ba09f158d3ae03955090eefff59324f78ccad9627453710da4f6fd079a8f5840";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b6/linux-i686/ko/firefox-112.0b6.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b8/linux-i686/ko/firefox-112.0b8.tar.bz2";
       locale = "ko";
       arch = "linux-i686";
-      sha256 = "f9c93dcf09240788b0ca138c77ea3aa1f6c0aec58920be3fd4040e127e69ddaf";
+      sha256 = "b92972ca074f3680cd342319383aa32fcf149e543d91e995c31b362ceb1cd83e";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b6/linux-i686/lij/firefox-112.0b6.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b8/linux-i686/lij/firefox-112.0b8.tar.bz2";
       locale = "lij";
       arch = "linux-i686";
-      sha256 = "e038a14c85ea3937ec770364449cc595257264f05f1cc6b8cdb143f66a891aee";
+      sha256 = "a7e2cdb06f27821ec1ae4f890406ce375efd8aa2f80dc3c79a48bc9342190b0a";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b6/linux-i686/lt/firefox-112.0b6.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b8/linux-i686/lt/firefox-112.0b8.tar.bz2";
       locale = "lt";
       arch = "linux-i686";
-      sha256 = "5a47ee907197e21f2a7c8e13c22e6e01aa336c1adb608ba99a85e10f83058b94";
+      sha256 = "3908be16ccee0924d5a93c2a8f45d1b99f2113c50b8a72b278f50ffbfc2addff";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b6/linux-i686/lv/firefox-112.0b6.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b8/linux-i686/lv/firefox-112.0b8.tar.bz2";
       locale = "lv";
       arch = "linux-i686";
-      sha256 = "dd97002a88bdeb2de908dace8f67b9240589e22f29d8a39ba3062aa07c925980";
+      sha256 = "b9de936bc8ce2487522ba25101c8ef3a259bfafa43e623c9be880442710d2351";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b6/linux-i686/mk/firefox-112.0b6.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b8/linux-i686/mk/firefox-112.0b8.tar.bz2";
       locale = "mk";
       arch = "linux-i686";
-      sha256 = "685647a2951a1684c71fe9179f49442cf8e14b26a137d8cce4eea7beec7e3839";
+      sha256 = "15baabc1d559ab11bc886e78798662c763c61f30c141053d9867139d1e9e58ce";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b6/linux-i686/mr/firefox-112.0b6.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b8/linux-i686/mr/firefox-112.0b8.tar.bz2";
       locale = "mr";
       arch = "linux-i686";
-      sha256 = "1033c1f9dbd85640256c130331706867ed9f8bdffa5545212040712fac5e8d62";
+      sha256 = "d92bcae2140ca878fc8b8dabd65ce3f757cb80c0db65518e9d3100436e833d81";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b6/linux-i686/ms/firefox-112.0b6.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b8/linux-i686/ms/firefox-112.0b8.tar.bz2";
       locale = "ms";
       arch = "linux-i686";
-      sha256 = "d71844cbe97105e5bdf7c7a0b01c33dceb190c331526113f0efe114a163a2af9";
+      sha256 = "305fe064288cceea5d076979cee54070d312ddd66e268b77c89afd006af0831f";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b6/linux-i686/my/firefox-112.0b6.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b8/linux-i686/my/firefox-112.0b8.tar.bz2";
       locale = "my";
       arch = "linux-i686";
-      sha256 = "4767bce810321d63d14a4b74a1e5387bca6f2181967fd2f06b03e0da849ef20c";
+      sha256 = "7fe5769ebba170c7a1300f8edbe2630da52024d5dc5d70d2d50f762827d7d919";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b6/linux-i686/nb-NO/firefox-112.0b6.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b8/linux-i686/nb-NO/firefox-112.0b8.tar.bz2";
       locale = "nb-NO";
       arch = "linux-i686";
-      sha256 = "45048e94308db389ac5c42745024320d6dfe054e11b7ddbcb826382883b040c2";
+      sha256 = "d4c35b1041aec3c0c17ad1b160b979a1f4e525ca3276cf0cee28fdccffbd3b09";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b6/linux-i686/ne-NP/firefox-112.0b6.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b8/linux-i686/ne-NP/firefox-112.0b8.tar.bz2";
       locale = "ne-NP";
       arch = "linux-i686";
-      sha256 = "5dd376e2a9c23088cc729c1c729830f9d1c2cda3ae9ea79e13c0ff722638d070";
+      sha256 = "20e954fd4db01ac3964619b515516951f8451a75d38fad4d25bcaa18d1be6514";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b6/linux-i686/nl/firefox-112.0b6.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b8/linux-i686/nl/firefox-112.0b8.tar.bz2";
       locale = "nl";
       arch = "linux-i686";
-      sha256 = "9a6dd57d5ab5ca98d229d7d4a851fe6f8fcd2a996914b8a23dafae8b8fc8fc17";
+      sha256 = "cfe937d1d66d12be29319ced0843e8f9a7f1056f811940ef402b2cf147b2ec94";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b6/linux-i686/nn-NO/firefox-112.0b6.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b8/linux-i686/nn-NO/firefox-112.0b8.tar.bz2";
       locale = "nn-NO";
       arch = "linux-i686";
-      sha256 = "f991770a8a2685acf994d3dd12ae82f3eec687bfc90e2708cb53ca73b392cecf";
+      sha256 = "fa5a38fa4d4f4ef13ecf8a9f38c92b47284447a59a3ae0950499e0df9e31b802";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b6/linux-i686/oc/firefox-112.0b6.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b8/linux-i686/oc/firefox-112.0b8.tar.bz2";
       locale = "oc";
       arch = "linux-i686";
-      sha256 = "48981d0797793095954146806120e894472dcfd98396f8bba4328036ca43ea7f";
+      sha256 = "3118e44232acbd4c683e1a82fa3176dbca95be86969b97e8af13c9abe79e8690";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b6/linux-i686/pa-IN/firefox-112.0b6.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b8/linux-i686/pa-IN/firefox-112.0b8.tar.bz2";
       locale = "pa-IN";
       arch = "linux-i686";
-      sha256 = "21b3fab3b57b512ce4699c18dbc3abcec7dc0b4cdba30ebcea0ec7c662ed2159";
+      sha256 = "243b0eb9504cc0302c782fbb49bebd8589ded1e7cf3e45ba7e60e2c11e49a7bc";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b6/linux-i686/pl/firefox-112.0b6.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b8/linux-i686/pl/firefox-112.0b8.tar.bz2";
       locale = "pl";
       arch = "linux-i686";
-      sha256 = "730232af1251d6b41b82b35fb21465a9d6af22d97654df0092a5070dd23d2f37";
+      sha256 = "92084c1b3433540bfacacdd3f935362040624d1d3caaf9a7c229642ab8816658";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b6/linux-i686/pt-BR/firefox-112.0b6.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b8/linux-i686/pt-BR/firefox-112.0b8.tar.bz2";
       locale = "pt-BR";
       arch = "linux-i686";
-      sha256 = "ad03de89aa51b401845a663887dc707880ad2abb63ff763103f6d17b4e8eeefa";
+      sha256 = "f0f9e02b2bd6f855927590de281d6295c52eae977291db3aa0b26a1a52610fca";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b6/linux-i686/pt-PT/firefox-112.0b6.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b8/linux-i686/pt-PT/firefox-112.0b8.tar.bz2";
       locale = "pt-PT";
       arch = "linux-i686";
-      sha256 = "b12b8c60458e366c975f88dfa3749ea43c2bd68486883b2bfe922541e4982f20";
+      sha256 = "7b3ca497bc431e95f7294af77aaf44c0ffb15d64bd300a0d7922c63e28c00db5";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b6/linux-i686/rm/firefox-112.0b6.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b8/linux-i686/rm/firefox-112.0b8.tar.bz2";
       locale = "rm";
       arch = "linux-i686";
-      sha256 = "899de725c2b8fa7652c79f1b4e816acb93a2f32602c6530988f83f06bac7d975";
+      sha256 = "e8586d48a3cc34ff65101f2efbd9cd11f7882a1f5b398988897bd3993b760f62";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b6/linux-i686/ro/firefox-112.0b6.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b8/linux-i686/ro/firefox-112.0b8.tar.bz2";
       locale = "ro";
       arch = "linux-i686";
-      sha256 = "025a050940b6388d791b9c3a08f6c5840615417ced4481cd11d7ef5c7e64f8ec";
+      sha256 = "3d1e601101adc5bc0a133016aa4a81f031978baf801b954f5111df42f404ca5b";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b6/linux-i686/ru/firefox-112.0b6.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b8/linux-i686/ru/firefox-112.0b8.tar.bz2";
       locale = "ru";
       arch = "linux-i686";
-      sha256 = "a35164120fa259bcc2c325aace7bee3b9a7d12c27ea7efd357c5ca35b3be1248";
+      sha256 = "92cbfea52dbfede42e3f608d76fbb92926f2f434ebb7169918756ad192c7f6dd";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b6/linux-i686/sc/firefox-112.0b6.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b8/linux-i686/sc/firefox-112.0b8.tar.bz2";
       locale = "sc";
       arch = "linux-i686";
-      sha256 = "383638b4d42846f7560f7ec9c7ad922048bd4a26d9c3ad970135f6c3c974cbbf";
+      sha256 = "5cf569eef6215430f0183336793981ad848b5fc3f7d818f977f80a621710c656";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b6/linux-i686/sco/firefox-112.0b6.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b8/linux-i686/sco/firefox-112.0b8.tar.bz2";
       locale = "sco";
       arch = "linux-i686";
-      sha256 = "e8db341fad63d07e25a6df1833e7cec51be6dba50df1d9b56ca7723f275228f9";
+      sha256 = "958aa0ced431a5439fb00e814a21ded3b4946d000c2b2d6bee01b653b53b4f07";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b6/linux-i686/si/firefox-112.0b6.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b8/linux-i686/si/firefox-112.0b8.tar.bz2";
       locale = "si";
       arch = "linux-i686";
-      sha256 = "5bbdcb123d8d7679838589353cccda6472cc656af103ca3fdcaad73b9e13d5a7";
+      sha256 = "e084915795794b370df66642ab14dc92ec2d58678f97c1028ca9ebfe415b3867";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b6/linux-i686/sk/firefox-112.0b6.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b8/linux-i686/sk/firefox-112.0b8.tar.bz2";
       locale = "sk";
       arch = "linux-i686";
-      sha256 = "f2eea2a25a651232fd2a6f7292ff4aecf198260e354b6835827f7c917fac740c";
+      sha256 = "5fab3f2d0f74c4cea615f85ed5ae5d117574df580737aa04c7427973719cf387";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b6/linux-i686/sl/firefox-112.0b6.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b8/linux-i686/sl/firefox-112.0b8.tar.bz2";
       locale = "sl";
       arch = "linux-i686";
-      sha256 = "07fa7dbdfe3aec9222d77ed0bf5622262970c899559514ac1a802fdda5aeeb96";
+      sha256 = "388d1668ba5c8dde895fd123843db413eecbbe752f2d8fa0abeef6ad5d1d5ce5";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b6/linux-i686/son/firefox-112.0b6.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b8/linux-i686/son/firefox-112.0b8.tar.bz2";
       locale = "son";
       arch = "linux-i686";
-      sha256 = "a1b8ea0657a86a5bf6177b7367604f3090799c75a81e126ded4b172c2141f522";
+      sha256 = "e072e2f4422d6465b6715e9f1c97d391f74b9ddec44aa442b623e71d3ecbfbf1";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b6/linux-i686/sq/firefox-112.0b6.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b8/linux-i686/sq/firefox-112.0b8.tar.bz2";
       locale = "sq";
       arch = "linux-i686";
-      sha256 = "e06ae973fd38b96bac35ab0bc9cf4b126309f91accc74d7a516212dfae9a60cc";
+      sha256 = "494afebb067452da4645fa70fee084d8dcae0a093aa877d72afa9e877e8c3785";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b6/linux-i686/sr/firefox-112.0b6.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b8/linux-i686/sr/firefox-112.0b8.tar.bz2";
       locale = "sr";
       arch = "linux-i686";
-      sha256 = "7dd65f794705aa6a397327b9468b349bb91773022124b1aff0d3077bc1aa7855";
+      sha256 = "29a3a46ce32271fa6bf561618638f34edc563656dc0a89c389c6e488662f4f24";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b6/linux-i686/sv-SE/firefox-112.0b6.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b8/linux-i686/sv-SE/firefox-112.0b8.tar.bz2";
       locale = "sv-SE";
       arch = "linux-i686";
-      sha256 = "0a21d28820d5412136805f036aa36264852b1633f950d7292f10231335545d0a";
+      sha256 = "57a8803cc353be8533b6b7fbd002c10f7c8beba0f3adee65c16175a6f3a1cfed";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b6/linux-i686/szl/firefox-112.0b6.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b8/linux-i686/szl/firefox-112.0b8.tar.bz2";
       locale = "szl";
       arch = "linux-i686";
-      sha256 = "4865191a0fed0a435ce6970e5a61683ce0482737cbf0619b58faae263f3b84b6";
+      sha256 = "21e13a69edd7035b8c8de29e6f8f8573ec113e149421dd3cc83d31155c43ce9f";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b6/linux-i686/ta/firefox-112.0b6.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b8/linux-i686/ta/firefox-112.0b8.tar.bz2";
       locale = "ta";
       arch = "linux-i686";
-      sha256 = "6f77a1fe557eb3c31b588ad3da1656fb887f644a2732df958d04c7be072ec630";
+      sha256 = "db90e7e3c78d4a6ef821f122a43d312d7a62597f5d4b5fe4b0bc5c14cb463576";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b6/linux-i686/te/firefox-112.0b6.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b8/linux-i686/te/firefox-112.0b8.tar.bz2";
       locale = "te";
       arch = "linux-i686";
-      sha256 = "5c00deefee9ba062189416083cf1c69d16df8afdce5d3bf24c164977c60018b5";
+      sha256 = "f238bf9e63817873afdad8e740020d9d9d024237f3ef9796fafbf7b57b65441f";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b6/linux-i686/th/firefox-112.0b6.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b8/linux-i686/th/firefox-112.0b8.tar.bz2";
       locale = "th";
       arch = "linux-i686";
-      sha256 = "b07e63db0a6c4c93da04304305bc2ea5d98c1802102e644de11d9fa59210545c";
+      sha256 = "f1946a59a6ad7fe3d1cf62a47f8893c1f1b51262115e95857c7c675f17bbf6bf";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b6/linux-i686/tl/firefox-112.0b6.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b8/linux-i686/tl/firefox-112.0b8.tar.bz2";
       locale = "tl";
       arch = "linux-i686";
-      sha256 = "8a251397d02cf17bc4fa32c8c7c271a69de9ee896d60195c8dbf37171d42774a";
+      sha256 = "5570570c0bb53643fb04658b57607c8584a738ea732994c52f859ba00461c17c";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b6/linux-i686/tr/firefox-112.0b6.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b8/linux-i686/tr/firefox-112.0b8.tar.bz2";
       locale = "tr";
       arch = "linux-i686";
-      sha256 = "e5462ff92013f55e0e62e482c1ab75bde96ba227cc997fe6b7368e52c700fde2";
+      sha256 = "6eb0276bbe9b12e6c76b6f938cf56487ead0e094351b8ad2678973509ceba39b";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b6/linux-i686/trs/firefox-112.0b6.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b8/linux-i686/trs/firefox-112.0b8.tar.bz2";
       locale = "trs";
       arch = "linux-i686";
-      sha256 = "97d33e734780c3c8f47f87b2db8c04e709c64ba6080e86352df9cdf0f74d8eb6";
+      sha256 = "da3567165a93b03dbad8333bfa5b3108dac118576a1d3ee7ee994ebb65534207";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b6/linux-i686/uk/firefox-112.0b6.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b8/linux-i686/uk/firefox-112.0b8.tar.bz2";
       locale = "uk";
       arch = "linux-i686";
-      sha256 = "1d48cf9b0da2b9131e80fbca068c69a6e93d5fad1c0e6501ca9952f88bc5c3ce";
+      sha256 = "c1f689e8dcf525055ee96ab7eab28a917fd608493307cebed8f9d42c368e919f";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b6/linux-i686/ur/firefox-112.0b6.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b8/linux-i686/ur/firefox-112.0b8.tar.bz2";
       locale = "ur";
       arch = "linux-i686";
-      sha256 = "3524739074f3355682aae83165b0617f27f967ff52f736e91f4a2502c9a0475d";
+      sha256 = "28b79ab763cad9d6f8625c6f79ac1858f40e339ac2f4278c605070e93a7fba85";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b6/linux-i686/uz/firefox-112.0b6.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b8/linux-i686/uz/firefox-112.0b8.tar.bz2";
       locale = "uz";
       arch = "linux-i686";
-      sha256 = "a5a8709a01c2c80371e2e996d15b987f637f80f450fec83d30b3912fb9780e5d";
+      sha256 = "2ef98d582aa77f0175f1e2e18428ce66b16518e839095f9ae9d3d7a80758db4f";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b6/linux-i686/vi/firefox-112.0b6.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b8/linux-i686/vi/firefox-112.0b8.tar.bz2";
       locale = "vi";
       arch = "linux-i686";
-      sha256 = "a70fe7c7724459eef0af6aa473b39f1e67b1e97df0d5d668f605c3462929d3a9";
+      sha256 = "40b16fcd14d3f31c4996be68b23986665d410a51989b474fec47d434787fc856";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b6/linux-i686/xh/firefox-112.0b6.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b8/linux-i686/xh/firefox-112.0b8.tar.bz2";
       locale = "xh";
       arch = "linux-i686";
-      sha256 = "96345654ac1c667f7d44a12c83a59492ccc9ba86e02be6ef25479a60a7196743";
+      sha256 = "5ad3e7a48251b4d905b99cd2110db5a2533c27d53c3dfe757680b4e1cda1f37d";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b6/linux-i686/zh-CN/firefox-112.0b6.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b8/linux-i686/zh-CN/firefox-112.0b8.tar.bz2";
       locale = "zh-CN";
       arch = "linux-i686";
-      sha256 = "4d1ba4d9703ceb99680d4e64f508eb727547593d153cc0639b372c4e09a7b6bb";
+      sha256 = "4f01df45be46c709c78765d851c69acb970ded5648d334ad7588ee4e3e2e6668";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b6/linux-i686/zh-TW/firefox-112.0b6.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b8/linux-i686/zh-TW/firefox-112.0b8.tar.bz2";
       locale = "zh-TW";
       arch = "linux-i686";
-      sha256 = "ec18e28bc82af7610f78e6c396bef2071300e692080de794acc42e6303a44ad2";
+      sha256 = "a18112b679d66367cb1acbcceb3ada2740ec468e3bcf1931ddbd48f0d3567405";
     }
     ];
 }

--- a/pkgs/applications/networking/browsers/firefox/packages.nix
+++ b/pkgs/applications/networking/browsers/firefox/packages.nix
@@ -29,11 +29,11 @@ rec {
 
   firefox-beta = buildMozillaMach rec {
     pname = "firefox-beta";
-    version = "112.0b7";
+    version = "112.0b8";
     applicationName = "Mozilla Firefox Beta";
     src = fetchurl {
       url = "mirror://mozilla/firefox/releases/${version}/source/firefox-${version}.source.tar.xz";
-      sha512 = "sha512-81g/K0tLZ6lDnMnomMlX1++WMfK45PLBw7AzppuJGNhl9cnryc4BXilSMF9ibIuyTuSMpLHoCggFtH0k7IRyAA==";
+      sha512 = "6f63380e9b6ccf5d1c17bf4d9ee6997744354c1bc818fad7555cc1761ca798a0493cee5f451c477d32a9acdc04134d8f7bdbc40e83e001d671188e74af1db8d0";
     };
 
     meta = {

--- a/pkgs/applications/networking/browsers/firefox/packages.nix
+++ b/pkgs/applications/networking/browsers/firefox/packages.nix
@@ -56,12 +56,12 @@ rec {
 
   firefox-devedition = buildMozillaMach rec {
     pname = "firefox-devedition";
-    version = "112.0b7";
+    version = "112.0b8";
     applicationName = "Mozilla Firefox Developer Edition";
     branding = "browser/branding/aurora";
     src = fetchurl {
       url = "mirror://mozilla/devedition/releases/${version}/source/firefox-${version}.source.tar.xz";
-      sha512 = "sha512-2g+2/0s2lp36P+W2Z+9zd8AaMKvDFXjV+JgRoqtFr57HPIC+HwW1f9Swg4dFUVN7oz1CQ7cZiPBuH+FmMT7Q6Q==";
+      sha512 = "a77504bd80022bd0c908d2c6b59781f0d71d65e92be001bce993935b6a55775369bf36829c2979912f4d920e29e63c043b93c5e932669674ff47140e13a9519f";
     };
 
     meta = {


### PR DESCRIPTION
###### Description of changes
Updates all versions of firefox beta and devedition to 112.0b8

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
