### PR TITLE
correct key name in output of ssh-keygen command

### DIFF
--- a/nixos/doc/manual/configuration/sshfs-file-systems.section.md
+++ b/nixos/doc/manual/configuration/sshfs-file-systems.section.md
@@ -26,8 +26,8 @@ To create a new key without a passphrase you can do:
 ```ShellSession
 $ ssh-keygen -t ed25519 -P '' -f example-key
 Generating public/private ed25519 key pair.
-Your identification has been saved in test-key
-Your public key has been saved in test-key.pub
+Your identification has been saved in example-key
+Your public key has been saved in example-key.pub
 The key fingerprint is:
 SHA256:yjxl3UbTn31fLWeyLYTAKYJPRmzknjQZoyG8gSNEoIE my-user@workstation
 ```


### PR DESCRIPTION
the ssh-keygen example specifies `example-key` as the name for the key in the command line, then uses `test-key` in the example output. That's not the output that would be generated from executing the command and it's probably a remnant of a previous version of this example. Later in the example for the filesystem configuration, example-key is used as expected.

###### Description of changes

I've corrected the two occurrences of `test-key` in the example to be `example-key` to bring them in line with the command and later on the same page the SSHFS configuration example.