### PR TITLE
writeTextFile: chmod before checkPhase

### DIFF
--- a/pkgs/build-support/trivial-builders.nix
+++ b/pkgs/build-support/trivial-builders.nix
@@ -150,9 +150,11 @@ rec {
           echo -n "$text" > "$target"
         fi
 
-        eval "$checkPhase"
+        if [ -n "$executable" ]; then
+          chmod +x "$target"
+        fi
 
-        (test -n "$executable" && chmod +x "$target") || true
+        eval "$checkPhase"
       '';
 
   /*
@@ -411,7 +413,10 @@ rec {
         mkdir -p "$(dirname "$file")"
         cat $files > "$file"
 
-        (test -n "$executable" && chmod +x "$file") || true
+        if [ -n "$executable" ]; then
+          chmod +x "$file"
+        fi
+
         eval "$checkPhase"
       '';
 

--- a/pkgs/build-support/trivial-builders/test/write-shell-script.nix
+++ b/pkgs/build-support/trivial-builders/test/write-shell-script.nix
@@ -1,0 +1,14 @@
+{ lib, writeShellScript }: let
+  output = "hello";
+in (writeShellScript "test-script" ''
+  echo ${lib.escapeShellArg output}
+'').overrideAttrs (old: {
+  checkPhase = old.checkPhase or "" + ''
+    expected=${lib.escapeShellArg output}
+    got=$("$target")
+    if [[ "$got" != "$expected" ]]; then
+      echo "wrong output: expected $expected, got $got"
+      exit 1
+    fi
+  '';
+})

--- a/pkgs/test/default.nix
+++ b/pkgs/test/default.nix
@@ -70,6 +70,7 @@ with pkgs;
   trivial-builders = recurseIntoAttrs {
     writeStringReferencesToFile = callPackage ../build-support/trivial-builders/test/writeStringReferencesToFile.nix {};
     writeTextFile = callPackage ../build-support/trivial-builders/test/write-text-file.nix {};
+    writeShellScript = callPackage ../build-support/trivial-builders/test/write-shell-script.nix {};
     references = callPackage ../build-support/trivial-builders/test/references.nix {};
     overriding = callPackage ../build-support/trivial-builders/test-overriding.nix {};
     concat = callPackage ../build-support/trivial-builders/test/concat-test.nix {};


### PR DESCRIPTION
Set the executable bit before running the check phase, so that the check phase can run the script to test its behaviour.

This aligns with what `concatTextFile` is doing.

Also use explicit `if` statements so that we don't silently ignore `chmod` failures.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
