### PR TITLE
Revert "symlinkjoin: print warning when keeping existing file"

### DIFF
--- a/pkgs/build-support/trivial-builders.nix
+++ b/pkgs/build-support/trivial-builders.nix
@@ -511,8 +511,8 @@ rec {
       ''
         mkdir -p $out
         for i in $(cat $pathsPath); do
-          ${lndir}/bin/lndir $i $out
-        done 2>&1 | sed 's/^/symlinkJoin: warning: keeping existing file: /'
+          ${lndir}/bin/lndir -silent $i $out
+        done
         ${postBuild}
       '';
 


### PR DESCRIPTION
Reverts NixOS/nixpkgs#214710 for the reasons explained [there](https://github.com/NixOS/nixpkgs/pull/214710#issuecomment-1488518677).