### PR TITLE
grafana-loki,promtail: 2.7.4 -> 2.8.0, remove buildGoModule pin, add myself as maintainer

### DIFF
--- a/pkgs/servers/monitoring/loki/default.nix
+++ b/pkgs/servers/monitoring/loki/default.nix
@@ -54,7 +54,7 @@ buildGoModule rec {
     description = "Like Prometheus, but for logs";
     license = with licenses; [ agpl3Only asl20 ];
     homepage = "https://grafana.com/oss/loki/";
-    maintainers = with maintainers; [ willibutz globin mmahut ];
+    maintainers = with maintainers; [ willibutz globin mmahut indeednotjames ];
     platforms = platforms.unix;
   };
 }

--- a/pkgs/servers/monitoring/loki/default.nix
+++ b/pkgs/servers/monitoring/loki/default.nix
@@ -8,17 +8,17 @@
 }:
 
 buildGoModule rec {
-  version = "2.7.4";
+  version = "2.8.0";
   pname = "grafana-loki";
 
   src = fetchFromGitHub {
     rev = "v${version}";
     owner = "grafana";
     repo = "loki";
-    sha256 = "sha256-afa4uInoNyEgNDJ7nB1yr+YYoOsU+S7XWhKvkeApgRQ=";
+    hash = "sha256-RPa3G1zrWzunyQOdNUQ/dZGJ/7sh2OGvoEqeYaT7Qv0=";
   };
 
-  vendorSha256 = null;
+  vendorHash = null;
 
   subPackages = [
     # TODO split every executable into its own package

--- a/pkgs/servers/monitoring/loki/default.nix
+++ b/pkgs/servers/monitoring/loki/default.nix
@@ -12,9 +12,9 @@ buildGoModule rec {
   pname = "grafana-loki";
 
   src = fetchFromGitHub {
-    rev = "v${version}";
     owner = "grafana";
     repo = "loki";
+    rev = "v${version}";
     hash = "sha256-RPa3G1zrWzunyQOdNUQ/dZGJ/7sh2OGvoEqeYaT7Qv0=";
   };
 
@@ -48,13 +48,10 @@ buildGoModule rec {
     "-X ${t}.Revision=unknown"
   ];
 
-  doCheck = true;
-
   meta = with lib; {
     description = "Like Prometheus, but for logs";
     license = with licenses; [ agpl3Only asl20 ];
     homepage = "https://grafana.com/oss/loki/";
     maintainers = with maintainers; [ willibutz globin mmahut indeednotjames ];
-    platforms = platforms.unix;
   };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -24831,9 +24831,7 @@ with pkgs;
     buildGoModule = buildGo119Module; # nixosTests.grafana-agent go 1.20 failure
   };
 
-  grafana-loki = callPackage ../servers/monitoring/loki {
-    buildGoModule = buildGo119Module; # nixosTests.loki go 1.20 failure
-  };
+  grafana-loki = callPackage ../servers/monitoring/loki { };
   promtail = callPackage ../servers/monitoring/loki/promtail.nix { };
 
   mimir = callPackage ../servers/monitoring/mimir { };


### PR DESCRIPTION
###### Description of changes

https://github.com/grafana/loki/releases/tag/v2.8.0
https://github.com/grafana/loki/releases/tag/v2.7.5
https://github.com/grafana/loki/blob/4ff61d4a1b70c1f64fa7fd367295eaee336cf070/CHANGELOG.md#280-2023-04-04
diff: https://github.com/grafana/loki/compare/v2.7.4...v2.8.0

Also removed the `buildGo119Module` pin which was needed in < v2.7.4 (#218904, #219885)
From https://github.com/grafana/loki/releases/tag/v2.7.4
> Go version upgraded to `1.20.1` 

And added myself as maintainer :)

Somewhat related: #223754

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).


---

Result of `nixpkgs-review` run on x86_64-linux [1](https://github.com/Mic92/nixpkgs-review)
<details>
  <summary>2 packages built:</summary>
  <ul>
    <li>grafana-loki</li>
    <li>promtail</li>
  </ul>
</details>