### PR TITLE
coqPackages.HoTT: 8.16 -> 8.17

### DIFF
--- a/pkgs/development/coq-modules/HoTT/default.nix
+++ b/pkgs/development/coq-modules/HoTT/default.nix
@@ -1,4 +1,4 @@
-{ lib, mkCoqDerivation, autoconf, automake, coq, version ? null }:
+{ lib, mkCoqDerivation, coq, version ? null }:
 
 mkCoqDerivation {
   pname = "HoTT";
@@ -6,20 +6,41 @@ mkCoqDerivation {
   owner = "HoTT";
   inherit version;
   defaultVersion = with lib.versions; lib.switch coq.coq-version [
-    { case = range "8.14" "8.16"; out = coq.coq-version; }
+    { case = range "8.14" "8.17"; out = coq.coq-version; }
   ] null;
   releaseRev = v: "V${v}";
-  release."8.16".sha256 = "sha256-xcEbz4ZQ+U7mb0SEJopaczfoRc2GSgF2BGzUSWI0/HY=";
-  release."8.15".sha256 = "sha256-JfeiRZVnrjn3SQ87y6dj9DWNwCzrkK3HBogeZARUn9g=";
   release."8.14".sha256 = "sha256-7kXk2pmYsTNodHA+Qts3BoMsewvzmCbYvxw9Sgwyvq0=";
+  release."8.15".sha256 = "sha256-JfeiRZVnrjn3SQ87y6dj9DWNwCzrkK3HBogeZARUn9g=";
+  release."8.16".sha256 = "sha256-xcEbz4ZQ+U7mb0SEJopaczfoRc2GSgF2BGzUSWI0/HY=";
+  release."8.17".sha256 = "sha256-GjTUpzL9UzJm4C2ilCaYEufLG3hcj7rJPc5Op+OMal8=";
 
+  # versions of HoTT for Coq 8.17 and onwards will use dune
+  # opam-name = if lib.versions.isLe "8.17" coq.coq-version then "coq-hott" else null;
+  opam-name = "coq-hott";
+  useDune = lib.versions.isGe "8.17" coq.coq-version;
+  
   patchPhase = ''
     patchShebangs etc
   '';
 
   meta = {
     homepage = "https://homotopytypetheory.org/";
-    description = "Homotopy type theory";
-    maintainers = with lib.maintainers; [ siddharthist ];
+    description = "The Homotopy Type Theory library";
+    longDescription = ''
+      Homotopy Type Theory is an interpretation of Martin-Löf’s intensional
+      type theory into abstract homotopy theory. Propositional equality is
+      interpreted as homotopy and type isomorphism as homotopy equivalence.
+      Logical constructions in type theory then correspond to
+      homotopy-invariant constructions on spaces, while theorems and even
+      proofs in the logical system inherit a homotopical meaning. As the
+      natural logic of homotopy, type theory is also related to higher
+      category theory as it is used e.g. in the notion of a higher topos.
+
+      The HoTT library is a development of homotopy-theoretic ideas in the Coq
+      proof assistant. It draws many ideas from Vladimir Voevodsky's
+      Foundations library (which has since been incorporated into the Unimath
+      library) and also cross-pollinates with the HoTT-Agda library.
+    '';
+    maintainers = with lib.maintainers; [ alizter siddharthist ];
   };
 }


### PR DESCRIPTION
We bump the HoTT library to 8.17 and switch to using Dune for the build.

I attempted to include the 8.10 - 8.13 builds but I couldn't get autoconf to work the way I wanted so I gave up in the end.

ping @NixOS/coq 

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
