### PR TITLE
Fix wrong URL of fetchPypi

### DIFF
--- a/pkgs/build-support/fetchpypi/default.nix
+++ b/pkgs/build-support/fetchpypi/default.nix
@@ -8,7 +8,7 @@ let
     computeWheelUrl = {pname, version, dist ? "py2.py3", python ? "py2.py3", abi ? "none", platform ? "any"}:
     # Fetch a wheel. By default we fetch an universal wheel.
     # See https://www.python.org/dev/peps/pep-0427/#file-name-convention for details regarding the optional arguments.
-      "https://files.pythonhosted.org/packages/${dist}/${builtins.substring 0 1 pname}/${pname}/${pname}-${version}-${python}-${abi}-${platform}.whl";
+      "https://files.pythonhosted.org/packages/${dist}/${builtins.substring 0 1 pname}/${pname}/${builtins.replaceStrings ["-"] ["_"] pname}-${version}-${python}-${abi}-${platform}.whl";
 
     computeSourceUrl = {pname, version, extension ? "tar.gz"}:
     # Fetch a source tarball.


### PR DESCRIPTION
For example:

```sh
$ wget https://files.pythonhosted.org/packages/py3/t/translate-shell/translate-shell-0.0.19-py3-none-any.whl
2023-03-30 00:53:20 ERROR 404: Not Found.
$ wget https://files.pythonhosted.org/packages/py3/t/translate-shell/translate_shell-0.0.19-py3-none-any.whl
translate_shell-0.0.19-py3-none-any.whl  100%[==================================================================================>]  63.98K   193KB/s    in 0.3s
```

when pname contains `-`, it must be replaced to `_`.