### PR TITLE
releaseTools.binaryTarball: fix evaluation and usage

### DIFF
--- a/pkgs/build-support/release/binary-tarball.nix
+++ b/pkgs/build-support/release/binary-tarball.nix
@@ -27,7 +27,7 @@ stdenv.mkDerivation (
     postPhases = "finalPhase";
   }
 
-  // args //
+  // (builtins.removeAttrs args ["lib" "stdenv"]) //
 
   {
     name = name + (lib.optionalString (src ? version) "-${src.version}");
@@ -67,7 +67,9 @@ stdenv.mkDerivation (
 
       # Propagate the release name of the source tarball.  This is
       # to get nice package names in channels.
-      test -n "$releaseName" && (echo "$releaseName" >> $out/nix-support/hydra-release-name)
+      if [[ -n "$releaseName" ]]; then
+        echo "$releaseName" >> $out/nix-support/hydra-release-name
+      fi
     '';
 
     meta = (if args ? meta then args.meta else {}) // {


### PR DESCRIPTION
###### Description of changes

- Fixes evaluation of `releaseTools.binaryTarball`. It was failing by trying to pass `lib` to `stdenv.mkDerivation`.
- Fixes build when `$src/nix-support/hydra-release-name` isn't present.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
