### PR TITLE
davinci-resolve: adding aprutil and linking libcypto

### DIFF
--- a/pkgs/applications/video/davinci-resolve/default.nix
+++ b/pkgs/applications/video/davinci-resolve/default.nix
@@ -17,6 +17,7 @@
 , libarchive
 , libxcrypt
 , python2
+, aprutil
 }:
 
 let
@@ -127,6 +128,7 @@ let
             addOpenGLRunpath "$program"
           fi
         done
+        ln -s $out/libs/libcrypto.so.1.1 $out/libs/libcrypt.so.1
       '';
     }
   );
@@ -159,6 +161,7 @@ buildFHSUserEnv {
     python2
     # currently they want python 3.6 which is EOL
     #python3
+    aprutil
   ];
 
   runScript = "${bash}/bin/bash ${


### PR DESCRIPTION
Davinci complained that libcrypt.so.1 was missing so linked libcrypto.so.1.0 libcryt had a dependency on aprutil

###### Description of changes

Symlinked `libcrypto.so.1.0` lib to `libcrypt.so.1` because that's how davinci-resolve expects it.
Added dependency `aprutil`, without it you will get the following error:

```
/nix/store/idwxv2fb51zm5z0ch44ahypbpvvkagha-davinci-resolve-17.4.3/bin/resolve: /nix/store/idwxv2fb51zm5z0ch44ahypbpvvkagha-davinci-resolve-17.4.3/libs/libcrypt.so.1: version `GLIBC_2.2.5' not found (required by /nix/store/idwxv2fb51zm5z0ch44ahypbpvvkagha-davinci-resolve-17.4.3/libs/libaprutil-1.so.0)
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
