### PR TITLE
[22.11] rustPlatform.importCargoLock: add support for git dependencies that use workspace inheritance

### DIFF
--- a/pkgs/build-support/rust/import-cargo-lock.nix
+++ b/pkgs/build-support/rust/import-cargo-lock.nix
@@ -1,4 +1,4 @@
-{ fetchgit, fetchurl, lib, runCommand, cargo, jq }:
+{ fetchgit, fetchurl, lib, writers, python3Packages, runCommand, cargo, jq }:
 
 {
   # Cargo lock file
@@ -89,6 +89,11 @@ let
       sha256 = pkg.checksum;
     };
 
+  # Replaces values inherited by workspace members.
+  replaceWorkspaceValues = writers.writePython3 "replace-workspace-values"
+    { libraries = with python3Packages; [ tomli tomli-w ]; flakeIgnore = [ "E501" ]; }
+    (builtins.readFile ./replace-workspace-values.py);
+
   # Fetch and unpack a crate.
   mkCrate = pkg:
     let
@@ -157,6 +162,11 @@ let
 
         cp -prvd "$tree/" $out
         chmod u+w $out
+
+        if grep -q workspace "$out/Cargo.toml"; then
+          chmod u+w "$out/Cargo.toml"
+          ${replaceWorkspaceValues} "$out/Cargo.toml" "${tree}/Cargo.toml"
+        fi
 
         # Cargo is happy with empty metadata.
         printf '{"files":{},"package":null}' > "$out/.cargo-checksum.json"

--- a/pkgs/build-support/rust/replace-workspace-values.py
+++ b/pkgs/build-support/rust/replace-workspace-values.py
@@ -1,0 +1,95 @@
+# This script implements the workspace inheritance mechanism described
+# here: https://doc.rust-lang.org/cargo/reference/workspaces.html#the-package-table
+#
+# Please run `mypy --strict`, `black`, and `isort --profile black` on this after editing, thanks!
+
+import sys
+from typing import Any
+
+import tomli
+import tomli_w
+
+
+def load_file(path: str) -> dict[str, Any]:
+    with open(path, "rb") as f:
+        return tomli.load(f)
+
+
+def replace_key(
+    workspace_manifest: dict[str, Any], table: dict[str, Any], section: str, key: str
+) -> bool:
+    if "workspace" in table[key] and table[key]["workspace"] is True:
+        print("replacing " + key)
+
+        replaced = table[key]
+        del replaced["workspace"]
+
+        workspace_copy = workspace_manifest[section][key]
+
+        if section == "dependencies":
+            crate_features = replaced.get("features")
+
+            if type(workspace_copy) is str:
+                replaced["version"] = workspace_copy
+            else:
+                replaced.update(workspace_copy)
+
+                merged_features = (crate_features or []) + (
+                    workspace_copy.get("features") or []
+                )
+
+                if len(merged_features) > 0:
+                    # Dictionaries are guaranteed to be ordered (https://stackoverflow.com/a/7961425)
+                    replaced["features"] = list(dict.fromkeys(merged_features))
+        elif section == "package":
+            table[key] = replaced = workspace_copy
+
+        return True
+
+    return False
+
+
+def replace_dependencies(
+    workspace_manifest: dict[str, Any], root: dict[str, Any]
+) -> bool:
+    changed = False
+
+    for key in ["dependencies", "dev-dependencies", "build-dependencies"]:
+        if key in root:
+            for k in root[key].keys():
+                changed |= replace_key(workspace_manifest, root[key], "dependencies", k)
+
+    return changed
+
+
+def main() -> None:
+    crate_manifest = load_file(sys.argv[1])
+    workspace_manifest = load_file(sys.argv[2])["workspace"]
+
+    if "workspace" in crate_manifest:
+        return
+
+    changed = False
+
+    for key in crate_manifest["package"].keys():
+        changed |= replace_key(
+            workspace_manifest, crate_manifest["package"], "package", key
+        )
+
+    changed |= replace_dependencies(workspace_manifest, crate_manifest)
+
+    if "target" in crate_manifest:
+        for key in crate_manifest["target"].keys():
+            changed |= replace_dependencies(
+                workspace_manifest, crate_manifest["target"][key]
+            )
+
+    if not changed:
+        return
+
+    with open(sys.argv[1], "wb") as f:
+        tomli_w.dump(crate_manifest, f)
+
+
+if __name__ == "__main__":
+    main()

--- a/pkgs/build-support/rust/test/import-cargo-lock/default.nix
+++ b/pkgs/build-support/rust/test/import-cargo-lock/default.nix
@@ -1,4 +1,4 @@
-{ callPackage }:
+{ callPackage, writers, python3Packages }:
 
 # Build like this from nixpkgs root:
 # $ nix-build -A tests.importCargoLock
@@ -11,4 +11,9 @@
   gitDependencyTag = callPackage ./git-dependency-tag { };
   gitDependencyBranch = callPackage ./git-dependency-branch { };
   maturin = callPackage ./maturin { };
+  gitDependencyWorkspaceInheritance = callPackage ./git-dependency-workspace-inheritance {
+    replaceWorkspaceValues = writers.writePython3 "replace-workspace-values"
+      { libraries = with python3Packages; [ tomli tomli-w ]; flakeIgnore = [ "E501" ]; }
+      (builtins.readFile ../../replace-workspace-values.py);
+  };
 }

--- a/pkgs/build-support/rust/test/import-cargo-lock/git-dependency-workspace-inheritance/crate.toml
+++ b/pkgs/build-support/rust/test/import-cargo-lock/git-dependency-workspace-inheritance/crate.toml
@@ -1,0 +1,6 @@
+[package]
+version = { workspace = true }
+
+[dependencies]
+foo = { workspace = true, features = ["cat"] }
+bar = "1.0.0"

--- a/pkgs/build-support/rust/test/import-cargo-lock/git-dependency-workspace-inheritance/default.nix
+++ b/pkgs/build-support/rust/test/import-cargo-lock/git-dependency-workspace-inheritance/default.nix
@@ -1,0 +1,7 @@
+{ replaceWorkspaceValues, runCommand }:
+
+runCommand "git-dependency-workspace-inheritance-test" { } ''
+  cp --no-preserve=mode ${./crate.toml} "$out"
+  ${replaceWorkspaceValues} "$out" ${./workspace.toml}
+  diff -u "$out" ${./want.toml}
+''

--- a/pkgs/build-support/rust/test/import-cargo-lock/git-dependency-workspace-inheritance/want.toml
+++ b/pkgs/build-support/rust/test/import-cargo-lock/git-dependency-workspace-inheritance/want.toml
@@ -1,0 +1,12 @@
+[package]
+version = "1.0.0"
+
+[dependencies]
+bar = "1.0.0"
+
+[dependencies.foo]
+features = [
+    "cat",
+    "meow",
+]
+version = "1.0.0"

--- a/pkgs/build-support/rust/test/import-cargo-lock/git-dependency-workspace-inheritance/workspace.toml
+++ b/pkgs/build-support/rust/test/import-cargo-lock/git-dependency-workspace-inheritance/workspace.toml
@@ -1,0 +1,5 @@
+[workspace.package]
+version = "1.0.0"
+
+[workspace.dependencies]
+foo = { version = "1.0.0", features = ["meow"] }


### PR DESCRIPTION
###### Description of changes

partial backport of #217232 to 22.11

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
