### PR TITLE
fcitx5-skk: init at 5.0.15

### DIFF
--- a/pkgs/tools/inputmethods/fcitx5/fcitx5-skk.nix
+++ b/pkgs/tools/inputmethods/fcitx5/fcitx5-skk.nix
@@ -1,0 +1,55 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, pkg-config
+, cmake
+, extra-cmake-modules
+, gettext
+, fcitx5
+, fcitx5-qt
+, libskk
+, qtbase
+, skk-dicts
+, wrapQtAppsHook
+, enableQt ? false
+}:
+
+stdenv.mkDerivation rec {
+  pname = "fcitx5-skk";
+  version = "5.0.15";
+
+  src = fetchFromGitHub {
+    owner = "fcitx";
+    repo = pname;
+    rev = version;
+    sha256 = "sha256-y5GciWJMEFQM8SsqYANXe/SdVq6GEqsfF1yrKKhw0KA=";
+  };
+
+  nativeBuildInputs = [
+    cmake
+    extra-cmake-modules
+    gettext
+    pkg-config
+  ] ++ lib.optional enableQt wrapQtAppsHook;
+
+  buildInputs = [
+    fcitx5
+    libskk
+  ] ++ lib.optionals enableQt [
+    fcitx5-qt
+    qtbase
+  ];
+
+  cmakeFlags = [
+    "-DENABLE_QT=${toString enableQt}"
+    "-DSKK_DEFAULT_PATH=${skk-dicts}/share/SKK-JISYO.L"
+  ];
+
+  meta = with lib; {
+    description = "Input method engine for Fcitx5, which uses libskk as its backend";
+    homepage = "https://github.com/fcitx/fcitx5-skk";
+    license = licenses.gpl3Plus;
+    maintainers = with maintainers; [ milran ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/tools/inputmethods/fcitx5/update.py
+++ b/pkgs/tools/inputmethods/fcitx5/update.py
@@ -21,6 +21,7 @@ REPOS = [
         "fcitx5-m17n",
         "fcitx5-qt",
         "fcitx5-rime",
+        "fcitx5-skk",
         "fcitx5-table-extra",
         "fcitx5-table-other",
         "fcitx5-unikey"

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7316,6 +7316,12 @@ with pkgs;
     };
   };
 
+  fcitx5-skk = libsForQt5.callPackage ../tools/inputmethods/fcitx5/fcitx5-skk.nix { };
+
+  fcitx5-skk-qt = fcitx5-skk.override {
+    enableQt = true;
+  };
+
   fcitx5-unikey = libsForQt5.callPackage ../tools/inputmethods/fcitx5/fcitx5-unikey.nix { };
 
   fcitx5-configtool = libsForQt5.callPackage ../tools/inputmethods/fcitx5/fcitx5-configtool.nix { };


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

fcitx5-skk is an input method engine for Fcitx5, which uses libskk as its backend.

https://github.com/fcitx/fcitx5-skk

Fixes https://github.com/NixOS/nixpkgs/issues/167872.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
