### PR TITLE
cargo-all-features: 1.7.0 -> 1.9.0

### DIFF
--- a/pkgs/development/tools/rust/cargo-all-features/default.nix
+++ b/pkgs/development/tools/rust/cargo-all-features/default.nix
@@ -1,17 +1,18 @@
-{ lib, rustPlatform, fetchFromGitHub }:
+{ lib
+, rustPlatform
+, fetchCrate
+}:
 
 rustPlatform.buildRustPackage rec {
   pname = "cargo-all-features";
-  version = "1.7.0";
+  version = "1.9.0";
 
-  src = fetchFromGitHub {
-    owner = "frewsxcv";
-    repo = pname;
-    rev = version;
-    sha256 = "sha256-p9UQaqytqpD2u9X9zaTPIgVEloU2UbD/AxVERNs1Lt8=";
+  src = fetchCrate {
+    inherit pname version;
+    hash = "sha256-OLnz1SmMLs/yats/lZugqNUlBQHSNR1bOuEmnHGdoN8=";
   };
 
-  cargoSha256 = "sha256-krtuLFQlInqdv7j8v13/X3lL0JdaMsApb9Ga5muThgw=";
+  cargoHash = "sha256-Gg5tF8IvbtIoqR0AKRS7IbcCNOCJO8oxwX0KkUr+l/M=";
 
   meta = with lib; {
     description = "A Cargo subcommand to build and test all feature flag combinations";


### PR DESCRIPTION
###### Description of changes

The github source has outdated Cargo.lock so I switched to fetchCrate

https://github.com/frewsxcv/cargo-all-features/compare/1.7.0...1.9.0

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
