### PR TITLE
powertop-unstable: init at 2023-04-03

### DIFF
--- a/pkgs/os-specific/linux/powertop-unstable/default.nix
+++ b/pkgs/os-specific/linux/powertop-unstable/default.nix
@@ -1,0 +1,60 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, gettext
+, libnl
+, libtraceevent
+, libtracefs
+, ncurses
+, pciutils
+, pkg-config
+, zlib
+, autoreconfHook
+, autoconf-archive
+, nix-update-script
+, testers
+, powertop
+}:
+
+stdenv.mkDerivation rec {
+  pname = "powertop-unstable";
+  baseVersion = "2.15";
+  version = "2023-04-03";
+
+  src = fetchFromGitHub {
+    owner = "fenrus75";
+    repo = pname;
+    rev = "b6d1569203f32ec1c2aaa065d05961c552a76a6f";
+    hash = "sha256-JUqzyYyv2zi3UpuSnvjiJwecp9yYomlif6kla1wv7ZM=";
+  };
+
+  outputs = [ "out" "man" ];
+
+  nativeBuildInputs = [ pkg-config autoreconfHook autoconf-archive ];
+  buildInputs = [ gettext libnl libtraceevent libtracefs ncurses pciutils zlib ];
+
+  postPatch = ''
+    substituteInPlace configure.ac --replace "[powertop], [${baseVersion}]" "[powertop], [${version}]"
+    substituteInPlace src/main.cpp --replace "/sbin/modprobe" "modprobe"
+    substituteInPlace src/calibrate/calibrate.cpp --replace "/usr/bin/xset" "xset"
+    substituteInPlace src/tuning/bluetooth.cpp --replace "/usr/bin/hcitool" "hcitool"
+  '';
+
+  passthru = {
+    updateScript = nix-update-script { };
+    tests.version = testers.testVersion {
+      package = powertop;
+      command = "powertop --version";
+      inherit version;
+    };
+  };
+
+  meta = with lib; {
+    inherit (src.meta) homepage;
+    changelog = "https://github.com/fenrus75/powertop/releases/tag/v${baseVersion}";
+    description = "Analyze power consumption on Intel-based laptops";
+    license = licenses.gpl2Only;
+    maintainers = with maintainers; [ fpletz anthonyroussel hughobrien ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -26973,6 +26973,8 @@ with pkgs;
 
   powertop = callPackage ../os-specific/linux/powertop { };
 
+  powertop-unstable = callPackage ../os-specific/linux/powertop-unstable { };
+
   pps-tools = callPackage ../os-specific/linux/pps-tools { };
 
   prayer = callPackage ../servers/prayer { };


### PR DESCRIPTION
###### Description of changes

Use unreleased but master committed powertop.

It's been six months since a powertop release, since then two PRs of interest have been merged:

1. [libtracefs](https://github.com/fenrus75/powertop/pull/122)
2. [--auto-tune-dump](https://github.com/fenrus75/powertop/commit/fa916f11b7cd5dadeb838068e2a0aaec03e062ff)

This PR switches the package to the master branch version and adds the required dependencies.

`--auto-tune-dump` is particularly useful in situations where one wants 'most' of the auto-tune behaviour but not all, e.g. if USB devices are being disconnected regularly one can remove just that component.

```
❯ diff pkgs/os-specific/linux/powertop{,-unstable}/default.nix
5a6,7
> , libtraceevent
> , libtracefs
18,19c20,22
<   pname = "powertop";
<   version = "2.15";
---
>   pname = "powertop-unstable";
>   baseVersion = "2.15";
>   version = "unstable-20230403";
24,25c27,28
<     rev = "v${version}";
<     hash = "sha256-53jfqt0dtMqMj3W3m6ravUTzApLQcljDHfdXejeZa4M=";
---
>     rev = "b6d1569";
>     hash = "sha256-JUqzyYyv2zi3UpuSnvjiJwecp9yYomlif6kla1wv7ZM=";
31c34
<   buildInputs = [ gettext libnl ncurses pciutils zlib ];
---
>   buildInputs = [ gettext libnl libtraceevent libtracefs ncurses pciutils zlib ];
33a37
>     substituteInPlace configure.ac --replace "[powertop], [${baseVersion}]" "[powertop], [${version}]"
50c54
<     changelog = "https://github.com/fenrus75/powertop/releases/tag/v${version}";
---
>     changelog = "https://github.com/fenrus75/powertop/releases/tag/v${baseVersion}";
53c57
<     maintainers = with maintainers; [ fpletz anthonyroussel ];
---
>     maintainers = with maintainers; [ fpletz anthonyroussel hughobrien ];
```


<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
