### PR TITLE
nixos/k3s: start after network-online.target

### DIFF
--- a/nixos/modules/services/cluster/k3s/default.nix
+++ b/nixos/modules/services/cluster/k3s/default.nix
@@ -147,8 +147,8 @@ in
 
     systemd.services.k3s = {
       description = "k3s service";
-      after = [ "network.service" "firewall.service" ];
-      wants = [ "network.service" "firewall.service" ];
+      after = [ "firewall.service" "network-online.target" ];
+      wants = [ "firewall.service" "network-online.target" ];
       wantedBy = [ "multi-user.target" ];
       path = optional config.boot.zfs.enabled config.boot.zfs.package;
       serviceConfig = {


### PR DESCRIPTION
nixos/k3s: start after network-online.target

Fixes #103158

Wants `network.service` does not exist:

![image](https://user-images.githubusercontent.com/5861043/228700434-c2c06f61-46d9-440e-8512-034bfd132617.png)

Thought of `network.target`. But Arch Wiki says it is not necessary:

![image](https://user-images.githubusercontent.com/5861043/228702017-f74a5a1b-8e71-4353-b6b7-88b7792b92ef.png)

* https://wiki.archlinux.org/title/Systemd#Targets

Will remove `wants = [ "network.target" ]` then.