### PR TITLE
twitter-color-emoji: 14.0.2 -> 14.1.2

### DIFF
--- a/pkgs/data/fonts/twitter-color-emoji/default.nix
+++ b/pkgs/data/fonts/twitter-color-emoji/default.nix
@@ -14,14 +14,14 @@
 }:
 
 let
-  version = "14.0.0";
+  version = "14.1.2";
 
   twemojiSrc = fetchFromGitHub {
     name = "twemoji";
-    owner = "twitter";
+    owner = "jdecked";
     repo = "twemoji";
     rev = "v${version}";
-    sha256 = "sha256-ar6rBYudMIMngMVe/IowDV3X8wA77JBA6g0x/M7YLMg=";
+    sha256 = "sha256-UQ4PwO4D1kw7JOMf6xSaRBfT822KwrvWBPDmaQjkRVQ=";
   };
 
   pythonEnv =
@@ -100,7 +100,7 @@ stdenv.mkDerivation rec {
 
       This font uses Google’s CBDT format making it work on Android and Linux graphical stack.
     '';
-    homepage = "https://twemoji.twitter.com/";
+    homepage = "https://github.com/jdecked/twemoji";
     # In noto-emoji-fonts source
     ## noto-emoji code is in ASL 2.0 license
     ## Emoji fonts are under OFL license


### PR DESCRIPTION
###### Description of changes

This update switches to @jdecked's fork, which is now used by Discord.

Elon Musk fired the employees who maintained Twemoji; @jdecked is one
of the two former employees who maintained it, so it seems likely this
could become the new upstream of its development.

https://github.com/jdecked/twemoji/issues/10#issuecomment-1487768059

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
