### PR TITLE
twitter-color-emoji: update description to mention "Twemoji"

### DIFF
--- a/pkgs/data/fonts/twitter-color-emoji/default.nix
+++ b/pkgs/data/fonts/twitter-color-emoji/default.nix
@@ -94,9 +94,8 @@ stdenv.mkDerivation rec {
   meta = with lib; {
     description = "Color emoji font with a flat visual style, designed and used by Twitter";
     longDescription = ''
-      A bitmap color emoji font built from the Twitter Emoji for
-      Everyone artwork with support for ZWJ, skin tone diversity and country
-      flags.
+      A bitmap color emoji font built from Twitter's Twemoji emoji set
+      with support for ZWJ, skin tone diversity and country flags.
 
       This font uses Google’s CBDT format making it work on Android and Linux graphical stack.
     '';


### PR DESCRIPTION
###### Description of changes

I've updated the description of twitter-color-emoji to mention "Twemoji." When looking for this emoji font, most people, including myself, will try to find it using the NixOS package search with the search term "twemoji," which [currently only comes up with twemoji-color-font](https://search.nixos.org/packages?channel=unstable&from=0&size=50&sort=relevance&type=packages&query=twemoji), a color emoji SVGinOT font version of Twemoji. Because of this, I tried to package Twemoji again in #211477 not realizing that twitter-color-emoji existed. (Thank you @somasis for pointing it out.) Updating the description to include "Twemoji" will make it easier for people to find this package instead of twemoji-color-font, which has many compatibility issues.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
