### PR TITLE
ocamlPackages.bigarray-overlap: 0.2.0 → 0.2.1

### DIFF
--- a/pkgs/development/ocaml-modules/bigarray-overlap/default.nix
+++ b/pkgs/development/ocaml-modules/bigarray-overlap/default.nix
@@ -1,24 +1,22 @@
-{ lib, buildDunePackage, ocaml, fetchurl
-, bigarray-compat, alcotest, astring, fpath, bos, findlib, pkg-config
+{ lib, buildDunePackage, fetchurl
+, alcotest, pkg-config
 }:
 
 buildDunePackage rec {
   pname = "bigarray-overlap";
-  version = "0.2.0";
+  version = "0.2.1";
 
   src = fetchurl {
-    url = "https://github.com/dinosaure/overlap/releases/download/v${version}/bigarray-overlap-v${version}.tbz";
-    sha256 = "1v86avafsbyxjccy0y9gny31s2jzb0kd42v3mhcalklx5f044lcy";
+    url = "https://github.com/dinosaure/overlap/releases/download/v${version}/bigarray-overlap-${version}.tbz";
+    hash = "sha256-L1IKxHAFTjNYg+upJUvyi2Z23bV3U8+1iyLPhK4aZuA=";
   };
 
-  minimumOCamlVersion = "4.07";
-  useDune2 = true;
+  minimalOCamlVersion = "4.08";
+  duneVersion = "3";
 
-  propagatedBuildInputs = [ bigarray-compat ];
-
-  nativeBuildInputs = [ findlib pkg-config ];
-  checkInputs = [ alcotest astring fpath bos ];
-  doCheck = lib.versionAtLeast ocaml.version "4.08";
+  nativeBuildInputs = [ pkg-config ];
+  checkInputs = [ alcotest ];
+  doCheck = true;
 
   meta = with lib; {
     homepage = "https://github.com/dinosaure/overlap";


### PR DESCRIPTION
###### Description of changes

https://github.com/dinosaure/overlap/blob/v0.2.1/CHANGES.md

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
