### PR TITLE
pleroma: remove crypt

### DIFF
--- a/pkgs/servers/pleroma/default.nix
+++ b/pkgs/servers/pleroma/default.nix
@@ -1,5 +1,5 @@
 { lib, beamPackages
-, fetchFromGitHub, fetchFromGitLab, fetchHex
+, fetchFromGitHub, fetchFromGitLab, fetchHex, fetchpatch
 , file, cmake
 , libxcrypt
 , nixosTests, writeText
@@ -17,6 +17,15 @@ beamPackages.mixRelease rec {
     rev = "v${version}";
     sha256 = "sha256-3iG2s7jVEnhq1kLLgtaHnFmLYBO2Xr5M5jjZfSNA9z4=";
   };
+
+  # TODO: Remove this patch for > 2.5.1
+  patches = [
+    (fetchpatch {
+      url = "https://git.pleroma.social/pleroma/pleroma/-/commit/5716654d127921d86b3aa8c9307ab9ac2ca6ab1b.patch";
+      sha256 = "sha256-dHU8Y9P6ppZ+w5zKV1zUOUysfAkjdFCqvHFApSYXSWY=";
+    })
+  ];
+
   stripDebug = false;
 
   mixNixDeps = import ./mix.nix {
@@ -160,13 +169,6 @@ beamPackages.mixRelease rec {
           mkdir config
           cp ${cfgFile} config/config.exs
         '';
-      };
-
-      crypt = let
-        version = prev.crypt.version;
-      in prev.crypt.override {
-        buildInputs = [ libxcrypt ];
-        postInstall = "mv $out/lib/erlang/lib/crypt-${version}/priv/{hex-source-crypt-${version},crypt}.so";
       };
     });
   };

--- a/pkgs/servers/pleroma/mix.nix
+++ b/pkgs/servers/pleroma/mix.nix
@@ -281,19 +281,6 @@ let
       beamDeps = [ ecto ];
     };
 
-    crypt = buildRebar3 rec {
-      name = "crypt";
-      version = "1.0.1";
-
-      src = fetchHex {
-        pkg = "${name}";
-        version = "${version}";
-        sha256 = "10ir7nsa0dkn5jr0w9x2m38jc73aym7llz2pnkwxk9f747izz3cn";
-      };
-
-      beamDeps = [];
-    };
-
     custom_base = buildMix rec {
       name = "custom_base";
       version = "0.2.1";
@@ -1673,4 +1660,3 @@ let
     };
   };
 in self
-


### PR DESCRIPTION
Let's wait for upstream to come back to us there https://git.pleroma.social/pleroma/pleroma/-/issues/3030#note_99394 before un-drafting this  PR

---------------------------------------------------------

4e300e071b97e1e3a6ba4d856cc65e5386366f6f disabled the libxcrypt "weak cyphers". This somehow breaks the crypt hex library.

Luckily for us, upstream decided to get rid of crypt for unrelated reasons. See https://git.pleroma.social/pleroma/pleroma/-/merge_requests/3847

This removal will be part of the next pleroma release. Until then, let's cherry pick this specific commit to unblock the situation on our side.

Fixes #223518

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
