### PR TITLE
crystal: make Crystal default target match Nix target platform

### DIFF
--- a/pkgs/development/compilers/crystal/default.nix
+++ b/pkgs/development/compilers/crystal/default.nix
@@ -174,6 +174,7 @@ let
 
       makeFlags = [
         "CRYSTAL_CONFIG_VERSION=${version}"
+        "CRYSTAL_CONFIG_TARGET=${stdenv.targetPlatform.config}"
         "progress=1"
       ];
 


### PR DESCRIPTION
###### Description of changes

When building the Crystal compiler, it picks a default LLVM target triple by either looking at the env var CRYSTAL_CONFIG_TARGET if set, or by calling LLVMGetDefaultTargetTriple on the linked LLVM. https://github.com/crystal-lang/crystal/blob/master/src/compiler/crystal/config.cr#L47

On nix linux builds of Crystal using the LLVM function seems to be fine. However on MacOS, it can cause a mismatch with nix's MacOS stdenv.

stdenv.targetPlatform.darwinMinVersion defaults to "11.0" and this makes it's way into all the clang and ld wrapper scripts. However, the default LLVM target can be something such as "aarch64-apple-darwin22.3.0" which would translate to kernel version 13. Then Crystal would build .o files targeting 13, and the wrapped clang/ld would try and link them to be compatible with 11 and generate hundreds of warning messages such as "<file> was built for newer macOS version (13.0) than being linked (11.0)".

By setting the CRYSTAL_CONFIG_TARGET to match the nix targetPlatform, the default target for the compiler becomes just "aarch64-apple-darwin", and everything works as expected.

On linux setting this env var has no effect, since the LLVM detected triple matches that of the nix targetPlatform.


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

fixes: https://github.com/NixOS/nixpkgs/issues/219512
ref: https://github.com/NixOS/nixpkgs/issues/164648#issuecomment-1320673682
