### PR TITLE
dapr-cli: Use correct licence (mit -> asl20)

### DIFF
--- a/pkgs/development/tools/dapr/cli/default.nix
+++ b/pkgs/development/tools/dapr/cli/default.nix
@@ -37,7 +37,7 @@ buildGoModule rec {
   meta = with lib; {
     description = "A CLI for managing Dapr, the distributed application runtime";
     homepage = "https://dapr.io";
-    license = licenses.mit;
+    license = licenses.asl20;
     maintainers = with maintainers; [ joshvanl lucperkins ];
     mainProgram = "dapr";
   };


### PR DESCRIPTION
Wrong license was set https://github.com/dapr/cli

/cc @lucperkins
