### PR TITLE
python310Packages.peft: init at 0.2.0

### DIFF
--- a/pkgs/development/python-modules/accelerate/default.nix
+++ b/pkgs/development/python-modules/accelerate/default.nix
@@ -1,0 +1,74 @@
+{ stdenv
+, lib
+, buildPythonPackage
+, fetchFromGitHub
+, pythonOlder
+, pytestCheckHook
+, setuptools
+, numpy
+, packaging
+, psutil
+, pyyaml
+, torch
+, evaluate
+, parameterized
+, transformers
+}:
+
+buildPythonPackage rec {
+  pname = "accelerate";
+  version = "0.18.0";
+  format = "pyproject";
+  disabled = pythonOlder "3.7";
+
+  src = fetchFromGitHub {
+    owner = "huggingface";
+    repo = pname;
+    rev = "refs/tags/v${version}";
+    hash = "sha256-fCIvVbMaWAWzRfPc5/1CZq3gZ8kruuk9wBt8mzLHmyw=";
+  };
+
+  nativeBuildInputs = [ setuptools ];
+
+  propagatedBuildInputs = [
+    numpy
+    packaging
+    psutil
+    pyyaml
+    torch
+  ];
+
+  nativeCheckInputs = [
+    evaluate
+    parameterized
+    pytestCheckHook
+    transformers
+  ];
+  preCheck = ''
+    export HOME=$(mktemp -d)
+    export PATH=$out/bin:$PATH
+  '';
+  pytestFlagsArray = [ "tests" ];
+  disabledTests = [
+    # try to download data:
+    "FeatureExamplesTests"
+    "test_infer_auto_device_map_on_t0pp"
+  ] ++ lib.optionals (stdenv.isLinux && stdenv.isAarch64) [
+    # usual aarch64-linux RuntimeError: DataLoader worker (pid(s) <...>) exited unexpectedly
+    "CheckpointTest"
+  ];
+  # numerous instances of torch.multiprocessing.spawn.ProcessRaisedException:
+  doCheck = !stdenv.isDarwin;
+  pythonImportsCheck = [
+    "accelerate"
+  ];
+
+  meta = with lib; {
+    homepage = "https://huggingface.co/docs/accelerate";
+    description = "A simple way to train and use PyTorch models with multi-GPU, TPU, mixed-precision";
+    changelog = "https://github.com/huggingface/accelerate/releases/tag/v${version}";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ bcdarwin ];
+    mainProgram = "accelerate";
+  };
+}

--- a/pkgs/development/python-modules/peft/default.nix
+++ b/pkgs/development/python-modules/peft/default.nix
@@ -1,0 +1,54 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, pythonOlder
+, pytestCheckHook
+, setuptools
+, numpy
+, packaging
+, psutil
+, pyyaml
+, torch
+, transformers
+, accelerate
+}:
+
+buildPythonPackage rec {
+  pname = "peft";
+  version = "0.2.0";
+  format = "pyproject";
+
+  disabled = pythonOlder "3.7";
+
+  src = fetchFromGitHub {
+    owner = "huggingface";
+    repo = pname;
+    rev = "refs/tags/v${version}";
+    hash = "sha256-NPpY29HMQe5KT0JdlLAXY9MVycDslbP2i38NSTirB3I=";
+  };
+
+  nativeBuildInputs = [ setuptools ];
+
+  propagatedBuildInputs = [
+    numpy
+    packaging
+    psutil
+    pyyaml
+    torch
+    transformers
+    accelerate
+  ];
+
+  doCheck = false;  # tried to download pretrained model
+  pythonImportsCheck = [
+    "peft"
+  ];
+
+  meta = with lib; {
+    homepage = "https://github.com/huggingface/peft";
+    description = "State-of-the art parameter-efficient fine tuning";
+    changelog = "https://github.com/huggingface/peft/releases/tag/v${version}";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ bcdarwin ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -22,6 +22,8 @@ self: super: with self; {
 
   accessible-pygments = callPackage ../development/python-modules/accessible-pygments { };
 
+  accelerate = callPackage ../development/python-modules/accelerate { };
+
   accuweather = callPackage ../development/python-modules/accuweather { };
 
   accupy = callPackage ../development/python-modules/accupy { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -7119,6 +7119,8 @@ self: super: with self; {
 
   pefile = callPackage ../development/python-modules/pefile { };
 
+  peft = callPackage ../development/python-modules/peft { };
+
   pelican = callPackage ../development/python-modules/pelican {
     inherit (pkgs) glibcLocales git;
   };


### PR DESCRIPTION
###### Description of changes

Add a package and its dependency.

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [NA] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).