### PR TITLE
openasar: unstable-2023-01-13 -> unstable-2023-04-01

### DIFF
--- a/pkgs/applications/networking/instant-messengers/discord/openasar.nix
+++ b/pkgs/applications/networking/instant-messengers/discord/openasar.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation rec {
   pname = "openasar";
-  version = "unstable-2023-01-13";
+  version = "unstable-2023-04-01";
 
   src = fetchFromGitHub {
     owner = "GooseMod";
     repo = "OpenAsar";
-    rev = "40b27dd1b8dd48277207db1b165c220c3441484c";
-    hash = "sha256-tDJxcnbX0REu8DX+bQ7i4JzvLl6lRyB7+/dnAJI18Ss=";
+    rev = "ac0ad4d48a1a198c0a8a784da973b96684b336a7";
+    hash = "sha256-Ul2fXH4yjGe2oub1uVYY0mPJ4ou79TdokxvxvCAPXqs=";
   };
 
   postPatch = ''


### PR DESCRIPTION
###### Description of changes

Changelog: https://github.com/GooseMod/OpenAsar/compare/40b27dd1b8dd48277207db1b165c220c3441484c...ac0ad4d48a1a198c0a8a784da973b96684b336a7

###### Things done

```console
╰─λ ./result/bin/discord
[Nix] Disabling updates already done
[OpenAsar > Init] OpenAsar unstable-2023-04-01
[OpenAsar > Settings] /home/pedrohlc/.config/discord/settings.json {
  openasar: { setup: true, noTrack: true, quickstart: true },
  IS_MAXIMIZED: true,
  IS_MINIMIZED: false,
  SKIP_HOST_UPDATE: true,
  trayBalloonShown: true,
  enableHardwareAcceleration: false
}
[OpenAsar > BuildInfo] { releaseChannel: 'stable', version: '0.0.25' }
[OpenAsar > Modules] Checking
Optional module ./ElectronTestRpc was not included.
[OpenAsar > Modules] Checking
[OpenAsar > AsarUpdate] Removed
```

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
