### PR TITLE
nixos/users-groups: move home dir creation to systemd tmpfiles

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2305.section.md
+++ b/nixos/doc/manual/release-notes/rl-2305.section.md
@@ -362,6 +362,8 @@ In addition to numerous new and upgraded packages, this release has the followin
 
 - `boot.initrd.luks.device.<name>` has a new `tryEmptyPassphrase` option, this is useful for OEM's who need to install an encrypted disk with a future settable passphrase
 
+- `users.users.<name>.home` directories are created with systemd tmpfiles rules instead of activation scripts. This fixes a bug where home directories were not created when home directories were on a separate mount. (See issue [#6481](https://github.com/NixOS/nixpkgs/issues/6481))
+
 ## Detailed migration information {#sec-release-23.05-migration}
 
 ### Pipewire configuration overrides {#sec-release-23.05-migration-pipewire}

--- a/nixos/modules/config/update-users-groups.pl
+++ b/nixos/modules/config/update-users-groups.pl
@@ -224,13 +224,6 @@ foreach my $u (@{$spec->{users}}) {
         }
     }
 
-    # Ensure home directory incl. ownership and permissions.
-    if ($u->{createHome} and !$is_dry) {
-        make_path($u->{home}, { mode => oct($u->{homeMode}) }) if ! -e $u->{home};
-        chown $u->{uid}, $u->{gid}, $u->{home};
-        chmod oct($u->{homeMode}), $u->{home};
-    }
-
     if (defined $u->{passwordFile}) {
         if (-e $u->{passwordFile}) {
             $u->{hashedPassword} = read_file($u->{passwordFile});

--- a/nixos/modules/config/users-groups.nix
+++ b/nixos/modules/config/users-groups.nix
@@ -749,6 +749,12 @@ in {
         else null
       ));
 
+    systemd.tmpfiles.rules = lib.concatLists (lib.mapAttrsToList
+      (_: user:
+        lib.optionals user.createHome [
+          "d ${lib.escapeShellArg user.home} ${user.homeMode} ${user.name} ${user.group}"
+        ])
+      config.users.users);
   };
 
 }

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -736,6 +736,7 @@ in {
   usbguard = handleTest ./usbguard.nix {};
   user-activation-scripts = handleTest ./user-activation-scripts.nix {};
   user-home-mode = handleTest ./user-home-mode.nix {};
+  user-home-mounts = handleTest ./user-home-mounts.nix {};
   uwsgi = handleTest ./uwsgi.nix {};
   v2ray = handleTest ./v2ray.nix {};
   varnish60 = handleTest ./varnish.nix { package = pkgs.varnish60; };

--- a/nixos/tests/mutable-users.nix
+++ b/nixos/tests/mutable-users.nix
@@ -69,5 +69,9 @@ import ./make-test-python.nix ({ pkgs, ...} : {
         for file in files_to_check:
             assert machine.succeed(f"sha256sum {file}") == expected_hashes[file]
             assert machine.succeed(f"stat {file}") == expected_stats[file]
+
+    with subtest("activate does change things"):
+        machine.succeed("/run/current-system/bin/switch-to-configuration test")
+        machine.succeed('test -e /home/dry-test') # home WAS recreated
   '';
 })

--- a/nixos/tests/user-home-mounts.nix
+++ b/nixos/tests/user-home-mounts.nix
@@ -1,0 +1,87 @@
+# This tests for race conditions creating home directories mounted
+# in a few different ways
+
+let
+  alice = {
+    isNormalUser = true;
+    name = "alice";
+    group = "users";
+    home = "/home/alice";
+    homeMode = "755";
+  };
+
+  bob = {
+    isNormalUser = true;
+    name = "bob";
+    group = "users";
+    home = "${mounts.auto}/bob";
+    homeMode = "700";
+  };
+
+  cara = {
+    isNormalUser = true;
+    name = "cara";
+    group = "users";
+    home = "${mounts.nfs}/cara";
+    homeMode = "755";
+  };
+
+  mounts = { nfs = "/mnt/nfs"; auto = "/mnt/auto"; };
+in
+import ./make-test-python.nix ({ lib, ... }: {
+  name = "user-home-mounts";
+
+  meta.maintainers = [ lib.maintainers.jsoo1 ];
+
+  nodes = {
+    machine = {
+      users.users = { inherit alice bob cara; };
+
+      systemd.automounts = [{ where = mounts.auto; }];
+
+      virtualisation.fileSystems."${mounts.nfs}" = {
+        device = "nfs:/export";
+        fsType = "nfs";
+      };
+    };
+
+    nfs = {
+      networking.firewall.allowedTCPPorts = [ 2049 ];
+
+      virtualisation.fileSystems."/export" = {
+        device = "/home";
+        options = [ "bind" ];
+      };
+
+      services.nfs.server = {
+        enable = true;
+        exports = ''
+          /export machine(rw,no_root_squash,sync)
+        '';
+      };
+    };
+  };
+
+  testScript = ''
+    nfs.wait_for_unit("nfs-mountd.service")
+    machine.wait_for_unit("remote-fs.target")
+    machine.wait_for_unit("multi-user.target")
+
+    with subtest("local"):
+        alice_out = machine.succeed("stat -c '%U %G %a' ${alice.home}")
+        assert alice_out.strip() == "${alice.name} ${alice.group} ${alice.homeMode}", f"alice's home failed, got: {alice_out}"
+
+    with subtest("automount"):
+        machine.succeed("ls ${mounts.auto}")
+        bob_out = machine.succeed("stat -c '%U %G %a' ${bob.home}")
+        assert bob_out.strip() == "${bob.name} ${bob.group} ${bob.homeMode}", f"bob's home failed, got: {bob_out}"
+
+    with subtest("nfs is not supported"):
+        # just make sure nfs is working
+        machine.succeed("mkdir ${mounts.nfs}/foo")
+        nfs.succeed("stat /export/foo")
+
+        # nfs mounts are expected to overwrite tmpfiles.d homes
+        machine.fail("stat -c '%U %G %a' ${cara.home}")
+  '';
+})


### PR DESCRIPTION
Fixes https://github.com/NixOS/nixpkgs/issues/6481

When the home directory is on a separate mount the user home directories were not created.

Using systemd tmpfiles solves the race condition.

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [x] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
