### PR TITLE
gfortran: fix build for mingwW64

### DIFF
--- a/pkgs/development/compilers/gcc/11/default.nix
+++ b/pkgs/development/compilers/gcc/11/default.nix
@@ -87,7 +87,9 @@ let majorVersion = "11";
       ++ optional (!crossStageStatic && targetPlatform.isMinGW && threadsCross.model == "mcf") ./Added-mcf-thread-model-support-from-mcfgthread.patch
 
       # openjdk build fails without this on -march=opteron; is upstream in gcc12
-      ++ [ ./gcc-issue-103910.patch ];
+      ++ [ ./gcc-issue-103910.patch ]
+
+      ++ optional (langFortran && crossMingw) ../mingw-gfortran-no-pthread_t-alias.patch;
 
     /* Cross-gcc settings (build == host != target) */
     crossMingw = targetPlatform != hostPlatform && targetPlatform.libc == "msvcrt";

--- a/pkgs/development/compilers/gcc/12/default.nix
+++ b/pkgs/development/compilers/gcc/12/default.nix
@@ -121,7 +121,9 @@ let majorVersion = "12";
       ++ optional (stdenv.isDarwin && langAda) ../gnat-darwin-dylib-install-name.patch
 
       # Obtain latest patch with ../update-mcfgthread-patches.sh
-      ++ optional (!crossStageStatic && targetPlatform.isMinGW && threadsCross.model == "mcf") ./Added-mcf-thread-model-support-from-mcfgthread.patch;
+      ++ optional (!crossStageStatic && targetPlatform.isMinGW && threadsCross.model == "mcf") ./Added-mcf-thread-model-support-from-mcfgthread.patch
+
+      ++ optional (langFortran && crossMingw) ../mingw-gfortran-no-pthread_t-alias.patch;
 
     /* Cross-gcc settings (build == host != target) */
     crossMingw = targetPlatform != hostPlatform && targetPlatform.libc == "msvcrt";

--- a/pkgs/development/compilers/gcc/mingw-gfortran-no-pthread_t-alias.patch
+++ b/pkgs/development/compilers/gcc/mingw-gfortran-no-pthread_t-alias.patch
@@ -1,0 +1,13 @@
+diff --git a/libgfortran/io/async.h b/libgfortran/io/async.h
+index efd542a..d57722a 100644
+--- a/libgfortran/io/async.h
++++ b/libgfortran/io/async.h
+@@ -351,7 +351,7 @@ typedef struct async_unit
+   struct adv_cond work;
+   struct adv_cond emptysignal;
+   struct st_parameter_dt *pdt;
+-  pthread_t thread;
++  __gthread_t thread;
+   struct transfer_queue *head;
+   struct transfer_queue *tail;
+ 


### PR DESCRIPTION
###### Description of changes

This fixes the following compilation error, e.g. observable when building `pkgsCross.mingwW64.lapack-reference`:
```
../../../gcc-12.2.0/libgfortran/io/async.h:354:3: error: unknown type name 'pthread_t'
  354 |   pthread_t thread;
      |   ^~~~~~~~~
```

The fix is to replace `pthread_t` with `__gthread_t` (which is what `pthread_t` is defined as in other places), though I am not sure why this is necessary for mingwW64 cross compilation.

I included the test for GCC 11 and 12; I guess that it works for older versions too, but I haven't tested it.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
