### PR TITLE
Fix cfs-zen-tweaks

### DIFF
--- a/nixos/modules/programs/cfs-zen-tweaks.nix
+++ b/nixos/modules/programs/cfs-zen-tweaks.nix
@@ -23,6 +23,12 @@ in
   config = mkIf cfg.enable {
     systemd.packages = [ pkgs.cfs-zen-tweaks ];
 
-    systemd.services.set-cfs-tweak.wantedBy = [ "multi-user.target" "suspend.target" "hibernate.target" "hybrid-sleep.target" "suspend-then-hibernate.target" ];
+    systemd.services.set-cfs-tweaks.wantedBy = [
+      "multi-user.target"
+      "suspend.target"
+      "hibernate.target"
+      "hybrid-sleep.target"
+      "suspend-then-hibernate.target"
+    ];
   };
 }

--- a/pkgs/os-specific/linux/cfs-zen-tweaks/default.nix
+++ b/pkgs/os-specific/linux/cfs-zen-tweaks/default.nix
@@ -17,21 +17,16 @@ stdenv.mkDerivation rec {
     sha256 = "HRR2tdjNmWyrpbcMlihSdb/7g/tHma3YyXogQpRCVyo=";
   };
 
-  postPatch = ''
-    patchShebangs set-cfs-zen-tweaks.bash
-    chmod +x set-cfs-zen-tweaks.bash
+  preConfigure = ''
     substituteInPlace set-cfs-zen-tweaks.bash \
       --replace '$(gawk' '$(${gawk}/bin/gawk'
   '';
 
-  buildInputs = [
-    gawk
-  ];
+  preFixup = ''
+    chmod +x $out/lib/cfs-zen-tweaks/set-cfs-zen-tweaks.bash
+  '';
 
-  nativeBuildInputs = [
-    cmake
-    makeWrapper
-  ];
+  nativeBuildInputs = [ cmake ];
 
   meta = with lib; {
     description = "Tweak Linux CPU scheduler for desktop responsiveness";


### PR DESCRIPTION
###### Description of changes

Fixes cfs-zen-tweaks package (exec bit missing on script) and module (typo in systemd service name).

NB: the upstream project's owner [doesn't want to maintain it anymore](https://github.com/igo95862/cfs-zen-tweaks/pull/9#issuecomment-1289549208), so we might want to deprecate the package/module here at some point?

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).