### PR TITLE
youki: 0.0.4 -> 0.0.5

### DIFF
--- a/pkgs/applications/virtualization/youki/default.nix
+++ b/pkgs/applications/virtualization/youki/default.nix
@@ -10,13 +10,13 @@
 
 rustPlatform.buildRustPackage rec {
   pname = "youki";
-  version = "0.0.4";
+  version = "0.0.5";
 
   src = fetchFromGitHub {
     owner = "containers";
     repo = pname;
     rev = "v${version}";
-    sha256 = "sha256-XwapCfu6Me0xSe+qFz9BFRYpQvG+ztb6QyhGejYRPb4=";
+    sha256 = "sha256-00eSXRPy0lQKEabl569gY770viPyB2sEnq1uaT3peE0=";
   };
 
   nativeBuildInputs = [ pkg-config installShellFiles ];
@@ -33,9 +33,7 @@ rustPlatform.buildRustPackage rec {
   cargoBuildFlags = [ "-p" "youki" ];
   cargoTestFlags = [ "-p" "youki" ];
 
-  cargoSha256 = "sha256-PT1kVo4gQFH9sIprEoAioNvDL/soMHcA2utEiQJPS/0=";
-
-  doCheck = false; # test failed
+  cargoSha256 = "sha256-9EgexnsxHxLTXGRbUJZtJEoCeD425zRLfCiIqrXQJkU=";
 
   meta = with lib; {
     description = "A container runtime written in Rust";


### PR DESCRIPTION
###### Description of changes

- Release with changelog: https://github.com/containers/youki/releases/tag/v0.0.5
- Diff: https://github.com/containers/youki/compare/v0.0.4...v0.0.5 (566 commits long)
- Tests reactivated

###### Things done

The tests run successfully at build time:

```console
test result: ok. 10 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 1.00s
```

The resulting binary seems to work:

```console
╰─λ ./result/bin/youki info
Version           0.0.5
Commit            unknown
Kernel-Release    6.2.7-lqx1
Kernel-Version    #1-NixOS ZEN SMP PREEMPT_DYNAMIC Tue Jan  1 00:00:00 UTC 1980
Architecture      x86_64
Operating System  NixOS 23.05 (Stoat)
Cores             24
Total Memory      64209
Cgroup setup      unified
Cgroup mounts
Capabilities
CAP_BPF           available
CAP_PERFMON       available
CAP_CHECKPOINT_RESTORE available
```

I didn't test beyond this.

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
