### PR TITLE
draft: ligo: 0.60.0 -> 0.63.2

### DIFF
--- a/pkgs/development/compilers/ligo/default.nix
+++ b/pkgs/development/compilers/ligo/default.nix
@@ -10,12 +10,12 @@
 
 ocamlPackages.buildDunePackage rec {
   pname = "ligo";
-  version = "0.60.0";
+  version = "0.63.2";
   src = fetchFromGitLab {
     owner = "ligolang";
     repo = "ligo";
     rev = version;
-    sha256 = "sha256-gyMSpy+F3pF2Kv1ygUs20mrspJ6GtJ6ySyZD7zfZj2w=";
+    sha256 = "sha256-VR8ceCRiSaOteVkd6WfTzzYnpeBbCfDltSknx8mwuS4=";
     fetchSubmodules = true;
   };
 

--- a/pkgs/development/compilers/ligo/default.nix
+++ b/pkgs/development/compilers/ligo/default.nix
@@ -6,6 +6,9 @@
 , ocamlPackages
 , cacert
 , ocaml-crunch
+, jq
+, mustache-go
+, yaml2json
 }:
 
 ocamlPackages.buildDunePackage rec {
@@ -21,6 +24,7 @@ ocamlPackages.buildDunePackage rec {
 
   # The build picks this up for ligo --version
   LIGO_VERSION = version;
+  CHANGELOG_PATH = "./changelog.txt";
 
   duneVersion = "3";
 
@@ -33,6 +37,10 @@ ocamlPackages.buildDunePackage rec {
     ocamlPackages.crunch
     ocamlPackages.menhir
     ocamlPackages.ocaml-recovery-parser
+    # deps for changelog
+    jq
+    mustache-go
+    yaml2json
   ];
 
   buildInputs = with ocamlPackages; [
@@ -101,6 +109,13 @@ ocamlPackages.buildDunePackage rec {
     cacert
     ocamlPackages.ca-certs
   ];
+
+  preBuild = ''
+    # The scripts use `nix-shell` in the shebang which seems to fail
+    sed -i -e '1,5d' ./scripts/changelog-generation.sh
+    sed -i -e '1,5d' ./scripts/changelog-json.sh
+    ./scripts/changelog-generation.sh
+  '';
 
   doCheck = false; # Tests fail, but could not determine the reason
 

--- a/pkgs/development/compilers/ligo/default.nix
+++ b/pkgs/development/compilers/ligo/default.nix
@@ -68,6 +68,8 @@ ocamlPackages.buildDunePackage rec {
     lambda-term
     tar-unix
     parse-argv
+    linol
+    linol-lwt
 
     # Test helpers deps
     qcheck

--- a/pkgs/development/ocaml-modules/linol/default.nix
+++ b/pkgs/development/ocaml-modules/linol/default.nix
@@ -1,0 +1,27 @@
+{ lib, fetchFromGitHub, buildDunePackage, yojson, logs, lsp, ppx_yojson_conv_lib }:
+
+buildDunePackage
+rec {
+  pname = "linol";
+  version = "2023-04-25";
+
+  minimalOCamlVersion = "4.08";
+  duneVersion = "3";
+
+  src = fetchFromGitHub {
+    owner = "c-cube";
+    repo = "linol";
+    # Brings support for newer LSP
+    rev = "439534e0c5b7a3fbf93ba05fae7d171426153763";
+    sha256 = "sha256-EW35T7KUc/L1Zy4+oaJOC6mlVpbvhTfnU3NNFGoZAJg=";
+  };
+
+  propagatedBuildInputs = [ yojson logs lsp ppx_yojson_conv_lib ];
+
+  meta = with lib; {
+    description = "LSP server library";
+    license = licenses.mit;
+    maintainers = [ maintainers.ulrikstrid ];
+    homepage = "https://github.com/c-cube/linol";
+  };
+}

--- a/pkgs/development/ocaml-modules/linol/lwt.nix
+++ b/pkgs/development/ocaml-modules/linol/lwt.nix
@@ -1,0 +1,19 @@
+{ lib, buildDunePackage, linol, jsonrpc, lwt, yojson }:
+
+buildDunePackage {
+  pname = "linol-lwt";
+  inherit (linol) version src;
+
+  duneVersion = "3";
+
+  propagatedBuildInputs = [
+    linol
+    jsonrpc
+    lwt
+    yojson
+  ];
+
+  meta = linol.meta // {
+    description = "LSP server library (with Lwt for concurrency)";
+  };
+}

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -845,6 +845,10 @@ let
 
     linksem = callPackage ../development/ocaml-modules/linksem { };
 
+    linol = callPackage ../development/ocaml-modules/linol { };
+
+    linol-lwt = callPackage ../development/ocaml-modules/linol/lwt.nix { };
+
     llvm = callPackage ../development/ocaml-modules/llvm {
       libllvm = pkgs.llvmPackages_10.libllvm;
     };


### PR DESCRIPTION
###### Description of changes 

Update ligo version to latest one 

###### Things done 

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
