### PR TITLE
gutenprint: add perl to nativeBuildInputs

### DIFF
--- a/pkgs/misc/drivers/gutenprint/default.nix
+++ b/pkgs/misc/drivers/gutenprint/default.nix
@@ -16,7 +16,7 @@ stdenv.mkDerivation rec {
 
   strictDeps = true;
   nativeBuildInputs = [ makeWrapper pkg-config ]
-    ++ lib.optional cupsSupport cups; # for cups-config
+    ++ lib.optionals cupsSupport [ cups perl ]; # for cups-config
   buildInputs =
     [ ijs zlib ]
     ++ lib.optionals gimp2Support [ gimp.gtk gimp ]


### PR DESCRIPTION
###### Description of changes

It seems like #219309 caused an issue with Gutenprint that causes CUPS to fail to start
```
Mar 30 16:38:13 tomservo systemd[1]: Starting CUPS Scheduler...
Mar 30 16:38:13 tomservo cups-pre-start[236964]: /nix/store/szcjgs0larwglkb121m9y6ms11ayf0qi-unit-script-cups-pre-start/bin/cups-pre-start: line 37: /nix/store/94nfgny9q8zkg3afi7ji87dpd7zzq3ic-gutenprint-5.3.4/bin/cups-genppdupdate: cannot execute: required file not found
Mar 30 16:38:13 tomservo systemd[1]: cups.service: Control process exited, code=exited, status=127/n/a
Mar 30 16:38:13 tomservo systemd[1]: cups.service: Failed with result 'exit-code'.
Mar 30 16:38:13 tomservo systemd[1]: Failed to start CUPS Scheduler.
```

which seems to be caused by `perl` not being available to run the `cups-genppdupdate` script, as evidenced by this bit actually missing an interpreter
```
       │ File: /nix/store/94nfgny9q8zkg3afi7ji87dpd7zzq3ic-gutenprint-5.3.4/bin/cups-genppdupdate
   1   │ #!  -w
   2   │ # Update CUPS PPDs for Gutenprint queues.
   3   │ # Copyright (C) 2002-2003 Roger Leigh (rleigh@debian.org)
```
which I assume to be related to setting `strictDeps = true;` in #219309.

Adding `perl` to `nativeBuildInputs` seems to resolve the issue.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
