### PR TITLE
doc/stdenv/Dependencies: fix inference rule var name

### DIFF
--- a/doc/stdenv/stdenv.chapter.md
+++ b/doc/stdenv/stdenv.chapter.md
@@ -253,7 +253,7 @@ propagated-dep(mapOffset(h0, t0, h1),
 ```
 let mapOffset(h, t, i) = i + (if i <= 0 then h else t - 1)
 
-dep(h0, _, A, B)
+dep(h0, t0, A, B)
 propagated-dep(h1, t1, B, C)
 h0 + h1 in {-1, 0, 1}
 h0 + t1 in {-1, 0, -1}


### PR DESCRIPTION
t0 is mentioned in the conclusion so we cannot use placeholder in the premise.

Noticed in https://discourse.nixos.org/t/help-me-understand-propagation-rules/26848