### PR TITLE
ocamlPackages.posix: 2.0.0 → 2.0.2

### DIFF
--- a/pkgs/development/ocaml-modules/posix/base.nix
+++ b/pkgs/development/ocaml-modules/posix/base.nix
@@ -4,16 +4,17 @@
 
 buildDunePackage rec {
   pname = "posix-base";
-  version = "2.0.0";
+  version = "2.0.2";
 
   src = fetchFromGitHub {
     owner = "savonet";
     repo = "ocaml-posix";
     rev = "v${version}";
-    sha256 = "18px8hfqcfy2lk8105ki3hrxxigs44gs046ba0fqda6wzd0hr82b";
+    hash = "sha256-xxNaPJZdcW+KnT7rYUuC7ZgmHtXTppZG2BOmpKweC/U=";
   };
 
-  useDune2 = true;
+  duneVersion = "3";
+  minimalOCamlVersion = "4.08";
 
   propagatedBuildInputs = [ ctypes integers ];
 

--- a/pkgs/development/ocaml-modules/posix/socket.nix
+++ b/pkgs/development/ocaml-modules/posix/socket.nix
@@ -3,7 +3,9 @@
 buildDunePackage {
   pname = "posix-socket";
 
-  inherit (posix-base) version src useDune2;
+  inherit (posix-base) version src;
+
+  duneVersion = "3";
 
   propagatedBuildInputs = [ posix-base ];
 

--- a/pkgs/development/ocaml-modules/posix/time2.nix
+++ b/pkgs/development/ocaml-modules/posix/time2.nix
@@ -5,6 +5,8 @@ buildDunePackage {
 
   inherit (posix-base) version src;
 
+  duneVersion = "3";
+
   propagatedBuildInputs = [ posix-base posix-types unix-errno ];
 
   doCheck = true;

--- a/pkgs/development/ocaml-modules/posix/types.nix
+++ b/pkgs/development/ocaml-modules/posix/types.nix
@@ -3,9 +3,10 @@
 buildDunePackage {
   pname = "posix-types";
 
-  inherit (posix-base) version src useDune2;
+  inherit (posix-base) version src;
 
-  minimumOCamlVersion = "4.03";
+  minimalOCamlVersion = "4.03";
+  duneVersion = "3";
 
   propagatedBuildInputs = [ posix-base ];
 


### PR DESCRIPTION
###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
