### PR TITLE
deepin.util-dfm: init at 1.2.7

### DIFF
--- a/pkgs/desktops/deepin/default.nix
+++ b/pkgs/desktops/deepin/default.nix
@@ -28,6 +28,7 @@ let
     gio-qt = callPackage ./library/gio-qt { };
     image-editor = callPackage ./library/image-editor { };
     udisks2-qt5 = callPackage ./library/udisks2-qt5 { };
+    util-dfm = callPackage ./library/util-dfm { };
 
     #### CORE
     dde-calendar = callPackage ./core/dde-calendar { };

--- a/pkgs/desktops/deepin/library/util-dfm/default.nix
+++ b/pkgs/desktops/deepin/library/util-dfm/default.nix
@@ -1,0 +1,62 @@
+{ stdenv
+, lib
+, fetchFromGitHub
+, fetchpatch
+, cmake
+, pkg-config
+, qtbase
+, libmediainfo
+, libsecret
+, libisoburn
+, libuuid
+, udisks
+}:
+
+stdenv.mkDerivation rec {
+  pname = "util-dfm";
+  version = "1.2.7";
+
+  src = fetchFromGitHub {
+    owner = "linuxdeepin";
+    repo = pname;
+    rev = version;
+    sha256 = "sha256-+qqirRkvVyKvt+Pu/ghQjMe+O6a7/7IoJL8AWL4QlvE=";
+  };
+
+  patches = [
+    (fetchpatch {
+      name = "fix: use pkgconfig to check mount";
+      url = "https://github.com/linuxdeepin/util-dfm/commit/fb8425a8c13f16e86db38ff84f43347fdc8ea468.diff";
+      sha256 = "sha256-PGSRfnQ1MGmq0V3NBCoMk4p/T2x19VA04u9C+WcBKow=";
+    })
+  ];
+
+  nativeBuildInputs = [
+    cmake
+    pkg-config
+  ];
+
+  dontWrapQtApps = true;
+
+  buildInputs = [
+    qtbase
+    libmediainfo
+    libsecret
+    libuuid
+    libisoburn
+    udisks
+  ];
+
+  cmakeFlags = [
+    "-DCMAKE_INSTALL_LIBDIR=lib"
+    "-DPROJECT_VERSION=${version}"
+  ];
+
+  meta = with lib; {
+    description = "A Toolkits of libdfm-io,libdfm-mount and libdfm-burn";
+    homepage = "https://github.com/linuxdeepin/util-dfm";
+    license = licenses.gpl3Plus;
+    platforms = platforms.linux;
+    maintainers = teams.deepin.members;
+  };
+}


### PR DESCRIPTION
###### Description of changes
build dependencies for new [linuxdeepin/dde-file-manager](https://github.com/linuxdeepin/dde-file-manager)
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
