### PR TITLE
Respect global config.cudaSupport

### DIFF
--- a/doc/languages-frameworks/cuda.section.md
+++ b/doc/languages-frameworks/cuda.section.md
@@ -12,8 +12,11 @@ compatible are available as well. For example, there can be a
 
 To use one or more CUDA packages in an expression, give the expression a `cudaPackages` parameter, and in case CUDA is optional
 ```nix
-cudaSupport ? false
-cudaPackages ? {}
+{ config
+, cudaSupport ? config.cudaSupport or false
+, cudaPackages ? { }
+, ...
+}:
 ```
 
 When using `callPackage`, you can choose to pass in a different variant, e.g.

--- a/doc/languages-frameworks/cuda.section.md
+++ b/doc/languages-frameworks/cuda.section.md
@@ -13,7 +13,7 @@ compatible are available as well. For example, there can be a
 To use one or more CUDA packages in an expression, give the expression a `cudaPackages` parameter, and in case CUDA is optional
 ```nix
 { config
-, cudaSupport ? config.cudaSupport or false
+, cudaSupport ? config.cudaSupport
 , cudaPackages ? { }
 , ...
 }:

--- a/pkgs/applications/graphics/digikam/default.nix
+++ b/pkgs/applications/graphics/digikam/default.nix
@@ -54,7 +54,7 @@
 , breeze-icons
 , oxygen
 
-, cudaSupport ? config.cudaSupport or false
+, cudaSupport ? config.cudaSupport
 , cudaPackages ? {}
 }:
 

--- a/pkgs/applications/misc/blender/default.nix
+++ b/pkgs/applications/misc/blender/default.nix
@@ -5,7 +5,7 @@
 , openvdb, libXxf86vm, tbb, alembic
 , zlib, zstd, fftw, opensubdiv, freetype, jemalloc, ocl-icd, addOpenGLRunpath
 , jackaudioSupport ? false, libjack2
-, cudaSupport ? config.cudaSupport or false, cudaPackages ? {}
+, cudaSupport ? config.cudaSupport, cudaPackages ? { }
 , hipSupport ? false, hip # comes with a significantly larger closure size
 , colladaSupport ? true, opencollada
 , spaceNavSupport ? stdenv.isLinux, libspnav

--- a/pkgs/applications/science/math/caffe/default.nix
+++ b/pkgs/applications/science/math/caffe/default.nix
@@ -13,7 +13,7 @@
 , Accelerate, CoreGraphics, CoreVideo
 , lmdbSupport ? true, lmdb
 , leveldbSupport ? true, leveldb, snappy
-, cudaSupport ? config.cudaSupport or false, cudaPackages ? {}
+, cudaSupport ? config.cudaSupport, cudaPackages ? { }
 , cudnnSupport ? cudaSupport
 , ncclSupport ? false
 , pythonSupport ? false, python ? null, numpy ? null

--- a/pkgs/applications/science/math/cntk/default.nix
+++ b/pkgs/applications/science/math/cntk/default.nix
@@ -2,7 +2,8 @@
 , fetchpatch
 , openblas, blas, lapack, opencv3, libzip, boost, protobuf, mpi
 , onebitSGDSupport ? false
-, cudaSupport ? false, cudaPackages ? {}, addOpenGLRunpath, cudatoolkit, nvidia_x11
+, config
+, cudaSupport ? config.cudaSupport or false, cudaPackages ? {}, addOpenGLRunpath, cudatoolkit, nvidia_x11
 , cudnnSupport ? cudaSupport
 }:
 

--- a/pkgs/applications/science/math/cntk/default.nix
+++ b/pkgs/applications/science/math/cntk/default.nix
@@ -3,7 +3,7 @@
 , openblas, blas, lapack, opencv3, libzip, boost, protobuf, mpi
 , onebitSGDSupport ? false
 , config
-, cudaSupport ? config.cudaSupport or false, cudaPackages ? {}, addOpenGLRunpath, cudatoolkit, nvidia_x11
+, cudaSupport ? config.cudaSupport, cudaPackages ? { }, addOpenGLRunpath, cudatoolkit, nvidia_x11
 , cudnnSupport ? cudaSupport
 }:
 

--- a/pkgs/applications/science/math/mathematica/default.nix
+++ b/pkgs/applications/science/math/mathematica/default.nix
@@ -2,7 +2,7 @@
 , config
 , lib
 , cudaPackages
-, cudaSupport ? config.cudaSupport or false
+, cudaSupport ? config.cudaSupport
 , lang ? "en"
 , webdoc ? false
 , version ? null

--- a/pkgs/applications/science/math/mxnet/default.nix
+++ b/pkgs/applications/science/math/mxnet/default.nix
@@ -1,6 +1,6 @@
 { config, stdenv, lib, fetchurl, fetchpatch, bash, cmake
 , opencv3, gtest, blas, gomp, llvmPackages, perl
-, cudaSupport ? config.cudaSupport or false, cudaPackages ? {}, nvidia_x11
+, cudaSupport ? config.cudaSupport, cudaPackages ? { }, nvidia_x11
 , cudnnSupport ? cudaSupport
 }:
 

--- a/pkgs/applications/science/misc/colmap/default.nix
+++ b/pkgs/applications/science/misc/colmap/default.nix
@@ -1,6 +1,7 @@
 { mkDerivation, lib, fetchFromGitHub, cmake, boost179, ceres-solver, eigen,
   freeimage, glog, libGLU, glew, qtbase,
-  cudaSupport ? false, cudaPackages }:
+  config,
+  cudaSupport ? config.cudaSupport or false, cudaPackages }:
 
 assert cudaSupport -> cudaPackages != { };
 

--- a/pkgs/applications/science/misc/colmap/default.nix
+++ b/pkgs/applications/science/misc/colmap/default.nix
@@ -1,7 +1,7 @@
 { mkDerivation, lib, fetchFromGitHub, cmake, boost179, ceres-solver, eigen,
   freeimage, glog, libGLU, glew, qtbase,
   config,
-  cudaSupport ? config.cudaSupport or false, cudaPackages }:
+  cudaSupport ? config.cudaSupport, cudaPackages }:
 
 assert cudaSupport -> cudaPackages != { };
 

--- a/pkgs/applications/science/molecular-dynamics/gromacs/default.nix
+++ b/pkgs/applications/science/molecular-dynamics/gromacs/default.nix
@@ -1,7 +1,8 @@
 { lib, stdenv, fetchurl, cmake, hwloc, fftw, perl, blas, lapack, mpi, cudatoolkit
 , singlePrec ? true
+, config
 , enableMpi ? false
-, enableCuda ? false
+, enableCuda ? config.cudaSupport or false
 , cpuAcceleration ? null
 }:
 

--- a/pkgs/applications/science/molecular-dynamics/gromacs/default.nix
+++ b/pkgs/applications/science/molecular-dynamics/gromacs/default.nix
@@ -2,7 +2,7 @@
 , singlePrec ? true
 , config
 , enableMpi ? false
-, enableCuda ? config.cudaSupport or false
+, enableCuda ? config.cudaSupport
 , cpuAcceleration ? null
 }:
 

--- a/pkgs/development/compilers/cudatoolkit/common.nix
+++ b/pkgs/development/compilers/cudatoolkit/common.nix
@@ -129,7 +129,7 @@ backendStdenv.mkDerivation rec {
     (lib.getLib libtiff)
     qt6Packages.qtwayland
     rdma-core
-    ucx
+    (ucx.override { enableCuda = false; }) # Avoid infinite recursion
     xorg.libxshmfence
     xorg.libxkbfile
   ] ++ (lib.optionals (lib.versionAtLeast version "12.1") (map lib.getLib ([

--- a/pkgs/development/libraries/arrayfire/default.nix
+++ b/pkgs/development/libraries/arrayfire/default.nix
@@ -19,7 +19,8 @@
 , clblas
 , doxygen
 , buildDocs ? false
-, cudaSupport ? false
+, config
+, cudaSupport ? config.cudaSupport or false
 , cudatoolkit
 , darwin
 }:

--- a/pkgs/development/libraries/arrayfire/default.nix
+++ b/pkgs/development/libraries/arrayfire/default.nix
@@ -20,7 +20,7 @@
 , doxygen
 , buildDocs ? false
 , config
-, cudaSupport ? config.cudaSupport or false
+, cudaSupport ? config.cudaSupport
 , cudatoolkit
 , darwin
 }:

--- a/pkgs/development/libraries/elpa/default.nix
+++ b/pkgs/development/libraries/elpa/default.nix
@@ -4,10 +4,11 @@
 , avxSupport ? stdenv.hostPlatform.avxSupport
 , avx2Support ? stdenv.hostPlatform.avx2Support
 , avx512Support ? stdenv.hostPlatform.avx512Support
+, config
 # Enable NIVIA GPU support
 # Note, that this needs to be built on a system with a GPU
 # present for the tests to succeed.
-, enableCuda ? false
+, enableCuda ? config.cudaSupport or false
 # type of GPU architecture
 , nvidiaArch ? "sm_60"
 , cudatoolkit

--- a/pkgs/development/libraries/elpa/default.nix
+++ b/pkgs/development/libraries/elpa/default.nix
@@ -8,7 +8,7 @@
 # Enable NIVIA GPU support
 # Note, that this needs to be built on a system with a GPU
 # present for the tests to succeed.
-, enableCuda ? config.cudaSupport or false
+, enableCuda ? config.cudaSupport
 # type of GPU architecture
 , nvidiaArch ? "sm_60"
 , cudatoolkit

--- a/pkgs/development/libraries/frei0r/default.nix
+++ b/pkgs/development/libraries/frei0r/default.nix
@@ -7,7 +7,7 @@
 , opencv
 , pcre
 , pkg-config
-, cudaSupport ? config.cudaSupport or false
+, cudaSupport ? config.cudaSupport
 , cudaPackages
 }:
 

--- a/pkgs/development/libraries/hwloc/default.nix
+++ b/pkgs/development/libraries/hwloc/default.nix
@@ -2,7 +2,8 @@
 , x11Support ? false
 , libX11
 , cairo
-, enableCuda ? false
+, config
+, enableCuda ? config.cudaSupport or false
 , cudaPackages
 }:
 

--- a/pkgs/development/libraries/hwloc/default.nix
+++ b/pkgs/development/libraries/hwloc/default.nix
@@ -3,7 +3,7 @@
 , libX11
 , cairo
 , config
-, enableCuda ? config.cudaSupport or false
+, enableCuda ? config.cudaSupport
 , cudaPackages
 }:
 

--- a/pkgs/development/libraries/librealsense/default.nix
+++ b/pkgs/development/libraries/librealsense/default.nix
@@ -13,7 +13,7 @@
 , glfw
 , libGLU
 , curl
-, cudaSupport ? config.cudaSupport or false, cudaPackages ? {}
+, cudaSupport ? config.cudaSupport, cudaPackages ? { }
 , enablePython ? false, pythonPackages ? null
 , enableGUI ? false,
 }:

--- a/pkgs/development/libraries/lightgbm/default.nix
+++ b/pkgs/development/libraries/lightgbm/default.nix
@@ -1,5 +1,5 @@
 { config, stdenv, lib, fetchFromGitHub, cmake, gtest, doCheck ? true
-, cudaSupport ? config.cudaSupport or false, openclSupport ? false, mpiSupport ? false, javaWrapper ? false, hdfsSupport ? false
+, cudaSupport ? config.cudaSupport, openclSupport ? false, mpiSupport ? false, javaWrapper ? false, hdfsSupport ? false
 , rLibrary ? false, cudaPackages, opencl-headers, ocl-icd, boost, llvmPackages, openmpi, openjdk, swig, hadoop, R, rPackages }:
 
 assert doCheck -> mpiSupport != true;

--- a/pkgs/development/libraries/mlt/default.nix
+++ b/pkgs/development/libraries/mlt/default.nix
@@ -21,7 +21,7 @@
 , sox
 , vid-stab
 , darwin
-, cudaSupport ? config.cudaSupport or false
+, cudaSupport ? config.cudaSupport
 , cudaPackages ? { }
 , enableJackrack ? stdenv.isLinux
 , ladspa-sdk

--- a/pkgs/development/libraries/nvidia-thrust/default.nix
+++ b/pkgs/development/libraries/nvidia-thrust/default.nix
@@ -8,7 +8,7 @@
 , symlinkJoin
 , tbb
 , hostSystem ? "CPP"
-, deviceSystem ? if config.cudaSupport or false then "CUDA" else "OMP"
+, deviceSystem ? if config.cudaSupport then "CUDA" else "OMP"
 }:
 
 # Policy for device_vector<T>

--- a/pkgs/development/libraries/opencv/3.x.nix
+++ b/pkgs/development/libraries/opencv/3.x.nix
@@ -14,7 +14,7 @@
 , enableOpenblas  ? true, openblas, blas, lapack
 , enableContrib   ? true
 
-, enableCuda      ? (config.cudaSupport or false) &&
+, enableCuda      ? config.cudaSupport &&
                     stdenv.hostPlatform.isx86_64
 , cudaPackages ? { }
 , enableUnfree    ? false

--- a/pkgs/development/libraries/opencv/4.x.nix
+++ b/pkgs/development/libraries/opencv/4.x.nix
@@ -37,7 +37,7 @@
 , blas
 , enableContrib ? true
 
-, enableCuda ? (config.cudaSupport or false) && stdenv.hostPlatform.isx86_64
+, enableCuda ? config.cudaSupport && stdenv.hostPlatform.isx86_64
 , enableCublas ? enableCuda
 , enableCudnn ? false # NOTE: CUDNN has a large impact on closure size so we disable it by default
 , enableCufft ? enableCuda

--- a/pkgs/development/libraries/openmpi/default.nix
+++ b/pkgs/development/libraries/openmpi/default.nix
@@ -1,9 +1,9 @@
 { lib, stdenv, fetchurl, gfortran, perl, libnl
 , rdma-core, zlib, numactl, libevent, hwloc, targetPackages, symlinkJoin
 , libpsm2, libfabric, pmix, ucx
-
+, config
 # Enable CUDA support
-, cudaSupport ? false, cudatoolkit
+, cudaSupport ? config.cudaSupport or false, cudatoolkit
 
 # Enable the Sun Grid Engine bindings
 , enableSGE ? false

--- a/pkgs/development/libraries/openmpi/default.nix
+++ b/pkgs/development/libraries/openmpi/default.nix
@@ -3,7 +3,7 @@
 , libpsm2, libfabric, pmix, ucx
 , config
 # Enable CUDA support
-, cudaSupport ? config.cudaSupport or false, cudatoolkit
+, cudaSupport ? config.cudaSupport, cudatoolkit
 
 # Enable the Sun Grid Engine bindings
 , enableSGE ? false

--- a/pkgs/development/libraries/opensubdiv/default.nix
+++ b/pkgs/development/libraries/opensubdiv/default.nix
@@ -1,6 +1,6 @@
 { config, lib, stdenv, fetchFromGitHub, cmake, pkg-config, xorg, libGLU
 , libGL, glew, ocl-icd, python3
-, cudaSupport ? config.cudaSupport or false, cudatoolkit
+, cudaSupport ? config.cudaSupport, cudatoolkit
   # For visibility mostly. The whole approach to cuda architectures and capabilities
   # will be reworked soon.
 , cudaArch ? "compute_37"

--- a/pkgs/development/libraries/science/chemistry/openmm/default.nix
+++ b/pkgs/development/libraries/science/chemistry/openmm/default.nix
@@ -11,7 +11,8 @@
 , enableOpencl ? true
 , opencl-headers
 , ocl-icd
-, enableCuda ? false
+, config
+, enableCuda ? config.cudaSupport or false
 , cudaPackages
 , addOpenGLRunpath
 }:

--- a/pkgs/development/libraries/science/chemistry/openmm/default.nix
+++ b/pkgs/development/libraries/science/chemistry/openmm/default.nix
@@ -12,7 +12,7 @@
 , opencl-headers
 , ocl-icd
 , config
-, enableCuda ? config.cudaSupport or false
+, enableCuda ? config.cudaSupport
 , cudaPackages
 , addOpenGLRunpath
 }:

--- a/pkgs/development/libraries/science/math/faiss/default.nix
+++ b/pkgs/development/libraries/science/math/faiss/default.nix
@@ -5,7 +5,7 @@
 , stdenv
 , cmake
 , cudaPackages ? { }
-, cudaSupport ? config.cudaSupport or false
+, cudaSupport ? config.cudaSupport
 , nvidia-thrust
 , useThrustSourceBuild ? true
 , pythonSupport ? true

--- a/pkgs/development/libraries/science/math/suitesparse/4.4.nix
+++ b/pkgs/development/libraries/science/math/suitesparse/4.4.nix
@@ -1,5 +1,6 @@
 { lib, stdenv, fetchurl, gfortran, blas, lapack
-, enableCuda ? false, cudatoolkit
+, config
+, enableCuda ? config.cudaSupport or false, cudatoolkit
 }:
 
 let

--- a/pkgs/development/libraries/science/math/suitesparse/4.4.nix
+++ b/pkgs/development/libraries/science/math/suitesparse/4.4.nix
@@ -1,6 +1,6 @@
 { lib, stdenv, fetchurl, gfortran, blas, lapack
 , config
-, enableCuda ? config.cudaSupport or false, cudatoolkit
+, enableCuda ? config.cudaSupport, cudatoolkit
 }:
 
 let

--- a/pkgs/development/libraries/science/math/suitesparse/default.nix
+++ b/pkgs/development/libraries/science/math/suitesparse/default.nix
@@ -6,7 +6,8 @@
 , fixDarwinDylibNames
 , gmp
 , mpfr
-, enableCuda ? false
+, config
+, enableCuda ? config.cudaSupport or false
 , cudatoolkit
 }:
 

--- a/pkgs/development/libraries/science/math/suitesparse/default.nix
+++ b/pkgs/development/libraries/science/math/suitesparse/default.nix
@@ -7,7 +7,7 @@
 , gmp
 , mpfr
 , config
-, enableCuda ? config.cudaSupport or false
+, enableCuda ? config.cudaSupport
 , cudatoolkit
 }:
 

--- a/pkgs/development/libraries/ucc/default.nix
+++ b/pkgs/development/libraries/ucc/default.nix
@@ -1,5 +1,6 @@
 { stdenv, lib, fetchFromGitHub, libtool, automake, autoconf, ucx
-, enableCuda ? false
+, config
+, enableCuda ? config.cudaSupport or false
 , cudatoolkit
 , enableAvx ? stdenv.hostPlatform.avxSupport
 , enableSse41 ? stdenv.hostPlatform.sse4_1Support

--- a/pkgs/development/libraries/ucc/default.nix
+++ b/pkgs/development/libraries/ucc/default.nix
@@ -1,6 +1,6 @@
 { stdenv, lib, fetchFromGitHub, libtool, automake, autoconf, ucx
 , config
-, enableCuda ? config.cudaSupport or false
+, enableCuda ? config.cudaSupport
 , cudatoolkit
 , enableAvx ? stdenv.hostPlatform.avxSupport
 , enableSse41 ? stdenv.hostPlatform.sse4_1Support

--- a/pkgs/development/libraries/ucx/default.nix
+++ b/pkgs/development/libraries/ucx/default.nix
@@ -1,6 +1,7 @@
 { lib, stdenv, fetchFromGitHub, autoreconfHook, doxygen, numactl
 , rdma-core, libbfd, libiberty, perl, zlib, symlinkJoin, pkg-config
-, enableCuda ? false
+, config
+, enableCuda ? config.cudaSupport or false
 , cudatoolkit
 , enableRocm ? false
 , rocm-core, rocm-runtime, rocm-device-libs, hip

--- a/pkgs/development/libraries/ucx/default.nix
+++ b/pkgs/development/libraries/ucx/default.nix
@@ -1,7 +1,7 @@
 { lib, stdenv, fetchFromGitHub, autoreconfHook, doxygen, numactl
 , rdma-core, libbfd, libiberty, perl, zlib, symlinkJoin, pkg-config
 , config
-, enableCuda ? config.cudaSupport or false
+, enableCuda ? config.cudaSupport
 , cudatoolkit
 , enableRocm ? false
 , rocm-core, rocm-runtime, rocm-device-libs, hip

--- a/pkgs/development/libraries/xgboost/default.nix
+++ b/pkgs/development/libraries/xgboost/default.nix
@@ -5,7 +5,7 @@
 , cmake
 , gtest
 , doCheck ? true
-, cudaSupport ? config.cudaSupport or false
+, cudaSupport ? config.cudaSupport
 , ncclSupport ? false
 , rLibrary ? false
 , cudaPackages

--- a/pkgs/development/python-modules/chainer/default.nix
+++ b/pkgs/development/python-modules/chainer/default.nix
@@ -1,7 +1,7 @@
 { lib
 , buildPythonPackage
 , config
-, cudaSupport ? config.cudaSupport or false
+, cudaSupport ? config.cudaSupport
 , cupy
 , fetchFromGitHub
 , filelock

--- a/pkgs/development/python-modules/jaxlib/bin.nix
+++ b/pkgs/development/python-modules/jaxlib/bin.nix
@@ -27,7 +27,7 @@
 , scipy
 , stdenv
   # Options:
-, cudaSupport ? config.cudaSupport or false
+, cudaSupport ? config.cudaSupport
 , cudaPackages ? {}
 }:
 

--- a/pkgs/development/python-modules/jaxlib/default.nix
+++ b/pkgs/development/python-modules/jaxlib/default.nix
@@ -40,8 +40,9 @@
 , snappy
 , zlib
 
+, config
   # CUDA flags:
-, cudaSupport ? false
+, cudaSupport ? config.cudaSupport or false
 , cudaPackages ? {}
 
   # MKL:

--- a/pkgs/development/python-modules/jaxlib/default.nix
+++ b/pkgs/development/python-modules/jaxlib/default.nix
@@ -42,7 +42,7 @@
 
 , config
   # CUDA flags:
-, cudaSupport ? config.cudaSupport or false
+, cudaSupport ? config.cudaSupport
 , cudaPackages ? {}
 
   # MKL:

--- a/pkgs/development/python-modules/libgpuarray/default.nix
+++ b/pkgs/development/python-modules/libgpuarray/default.nix
@@ -9,7 +9,9 @@
 , six
 , nose
 , mako
-, cudaSupport ? false, cudaPackages
+, config
+, cudaSupport ? config.cudaSupport or false
+, cudaPackages ? { }
 , openclSupport ? true, ocl-icd, clblas
 }:
 

--- a/pkgs/development/python-modules/libgpuarray/default.nix
+++ b/pkgs/development/python-modules/libgpuarray/default.nix
@@ -10,7 +10,7 @@
 , nose
 , mako
 , config
-, cudaSupport ? config.cudaSupport or false
+, cudaSupport ? config.cudaSupport
 , cudaPackages ? { }
 , openclSupport ? true, ocl-icd, clblas
 }:

--- a/pkgs/development/python-modules/numba/default.nix
+++ b/pkgs/development/python-modules/numba/default.nix
@@ -14,12 +14,14 @@
 , runCommand
 , fetchpatch
 
+, config
+
 # CUDA-only dependencies:
 , addOpenGLRunpath ? null
 , cudaPackages ? {}
 
 # CUDA flags:
-, cudaSupport ? false
+, cudaSupport ? config.cudaSupport or false
 }:
 
 let

--- a/pkgs/development/python-modules/numba/default.nix
+++ b/pkgs/development/python-modules/numba/default.nix
@@ -21,7 +21,7 @@
 , cudaPackages ? {}
 
 # CUDA flags:
-, cudaSupport ? config.cudaSupport or false
+, cudaSupport ? config.cudaSupport
 }:
 
 let

--- a/pkgs/development/python-modules/tensorflow/bin.nix
+++ b/pkgs/development/python-modules/tensorflow/bin.nix
@@ -21,7 +21,8 @@
 , backports_weakref
 , tensorflow-estimator-bin
 , tensorboard
-, cudaSupport ? false
+, config
+, cudaSupport ? config.cudaSupport or false
 , cudaPackages ? {}
 , zlib
 , python

--- a/pkgs/development/python-modules/tensorflow/bin.nix
+++ b/pkgs/development/python-modules/tensorflow/bin.nix
@@ -22,7 +22,7 @@
 , tensorflow-estimator-bin
 , tensorboard
 , config
-, cudaSupport ? config.cudaSupport or false
+, cudaSupport ? config.cudaSupport
 , cudaPackages ? {}
 , zlib
 , python

--- a/pkgs/development/python-modules/tensorflow/default.nix
+++ b/pkgs/development/python-modules/tensorflow/default.nix
@@ -17,7 +17,8 @@
 # that in nix as well. It would make some things easier and less confusing, but
 # it would also make the default tensorflow package unfree. See
 # https://groups.google.com/a/tensorflow.org/forum/#!topic/developers/iRCt5m4qUz0
-, cudaSupport ? false
+, config
+, cudaSupport ? config.cudaSupport or false
 , cudaPackages ? { }
 , cudaCapabilities ? cudaPackages.cudaFlags.cudaCapabilities
 , mklSupport ? false, mkl

--- a/pkgs/development/python-modules/tensorflow/default.nix
+++ b/pkgs/development/python-modules/tensorflow/default.nix
@@ -18,7 +18,7 @@
 # it would also make the default tensorflow package unfree. See
 # https://groups.google.com/a/tensorflow.org/forum/#!topic/developers/iRCt5m4qUz0
 , config
-, cudaSupport ? config.cudaSupport or false
+, cudaSupport ? config.cudaSupport
 , cudaPackages ? { }
 , cudaCapabilities ? cudaPackages.cudaFlags.cudaCapabilities
 , mklSupport ? false, mkl

--- a/pkgs/development/python-modules/theano/default.nix
+++ b/pkgs/development/python-modules/theano/default.nix
@@ -11,8 +11,9 @@
 , setuptools
 , six
 , libgpuarray
-, cudaSupport ? false, cudaPackages ? {}
-, cudnnSupport ? false
+, config
+, cudaSupport ? config.cudaSupport or false, cudaPackages ? {}
+, cudnnSupport ? cudaSupport
 }:
 
 let

--- a/pkgs/development/python-modules/theano/default.nix
+++ b/pkgs/development/python-modules/theano/default.nix
@@ -12,7 +12,7 @@
 , six
 , libgpuarray
 , config
-, cudaSupport ? config.cudaSupport or false, cudaPackages ? {}
+, cudaSupport ? config.cudaSupport, cudaPackages ? { }
 , cudnnSupport ? cudaSupport
 }:
 

--- a/pkgs/development/python-modules/torch/default.nix
+++ b/pkgs/development/python-modules/torch/default.nix
@@ -1,5 +1,5 @@
 { stdenv, lib, fetchFromGitHub, buildPythonPackage, python,
-  cudaSupport ? false, cudaPackages, magma,
+  config, cudaSupport ? config.cudaSupport or false, cudaPackages, magma,
   useSystemNccl ? true,
   MPISupport ? false, mpi,
   buildDocs ? false,

--- a/pkgs/development/python-modules/torch/default.nix
+++ b/pkgs/development/python-modules/torch/default.nix
@@ -1,5 +1,5 @@
 { stdenv, lib, fetchFromGitHub, buildPythonPackage, python,
-  config, cudaSupport ? config.cudaSupport or false, cudaPackages, magma,
+  config, cudaSupport ? config.cudaSupport, cudaPackages, magma,
   useSystemNccl ? true,
   MPISupport ? false, mpi,
   buildDocs ? false,

--- a/pkgs/games/katago/default.nix
+++ b/pkgs/games/katago/default.nix
@@ -1,6 +1,7 @@
 { stdenv
 , boost
 , cmake
+, config
 , cudaPackages
 , eigen
 , fetchFromGitHub
@@ -14,7 +15,7 @@
 , openssl
 , writeShellScriptBin
 , enableAVX2 ? stdenv.hostPlatform.avx2Support
-, backend ? "opencl"
+, backend ? if (config.cudaSupport or false) then "cuda" else "opencl"
 , enableBigBoards ? false
 , enableContrib ? false
 , enableTcmalloc ? true

--- a/pkgs/games/katago/default.nix
+++ b/pkgs/games/katago/default.nix
@@ -15,7 +15,7 @@
 , openssl
 , writeShellScriptBin
 , enableAVX2 ? stdenv.hostPlatform.avx2Support
-, backend ? if (config.cudaSupport or false) then "cuda" else "opencl"
+, backend ? if config.cudaSupport then "cuda" else "opencl"
 , enableBigBoards ? false
 , enableContrib ? false
 , enableTcmalloc ? true

--- a/pkgs/servers/sunshine/default.nix
+++ b/pkgs/servers/sunshine/default.nix
@@ -30,7 +30,8 @@
 , svt-av1
 , vulkan-loader
 , libappindicator
-, cudaSupport ? false
+, config
+, cudaSupport ? config.cudaSupport or false
 , cudaPackages ? {}
 }:
 let

--- a/pkgs/servers/sunshine/default.nix
+++ b/pkgs/servers/sunshine/default.nix
@@ -31,7 +31,7 @@
 , vulkan-loader
 , libappindicator
 , config
-, cudaSupport ? config.cudaSupport or false
+, cudaSupport ? config.cudaSupport
 , cudaPackages ? {}
 }:
 let

--- a/pkgs/tools/compression/zfp/default.nix
+++ b/pkgs/tools/compression/zfp/default.nix
@@ -1,6 +1,7 @@
 { cmake, cudatoolkit, fetchFromGitHub, gfortran, lib, llvmPackages, python3Packages, stdenv
+, config
 , enableCfp ? true
-, enableCuda ? false
+, enableCuda ? config.cudaSupport or false
 , enableFortran ? builtins.elem stdenv.targetPlatform.system gfortran.meta.platforms
 , enableOpenMP ? true
 , enablePython ? true

--- a/pkgs/tools/compression/zfp/default.nix
+++ b/pkgs/tools/compression/zfp/default.nix
@@ -1,7 +1,7 @@
 { cmake, cudatoolkit, fetchFromGitHub, gfortran, lib, llvmPackages, python3Packages, stdenv
 , config
 , enableCfp ? true
-, enableCuda ? config.cudaSupport or false
+, enableCuda ? config.cudaSupport
 , enableFortran ? builtins.elem stdenv.targetPlatform.system gfortran.meta.platforms
 , enableOpenMP ? true
 , enablePython ? true

--- a/pkgs/tools/graphics/waifu2x-converter-cpp/default.nix
+++ b/pkgs/tools/graphics/waifu2x-converter-cpp/default.nix
@@ -1,5 +1,6 @@
 { cmake, fetchFromGitHub, makeWrapper, opencv3, lib, stdenv, ocl-icd, opencl-headers, OpenCL
-, cudaSupport ? false, cudatoolkit ? null
+, config
+, cudaSupport ? config.cudaSupport or false, cudatoolkit ? null
 }:
 
 stdenv.mkDerivation rec {

--- a/pkgs/tools/graphics/waifu2x-converter-cpp/default.nix
+++ b/pkgs/tools/graphics/waifu2x-converter-cpp/default.nix
@@ -1,6 +1,6 @@
 { cmake, fetchFromGitHub, makeWrapper, opencv3, lib, stdenv, ocl-icd, opencl-headers, OpenCL
 , config
-, cudaSupport ? config.cudaSupport or false, cudatoolkit ? null
+, cudaSupport ? config.cudaSupport, cudatoolkit ? null
 }:
 
 stdenv.mkDerivation rec {

--- a/pkgs/tools/security/hashcat/default.nix
+++ b/pkgs/tools/security/hashcat/default.nix
@@ -2,7 +2,7 @@
 , addOpenGLRunpath
 , config
 , cudaPackages ? {}
-, cudaSupport ? config.cudaSupport or false
+, cudaSupport ? config.cudaSupport
 , fetchurl
 , makeWrapper
 , opencl-headers

--- a/pkgs/tools/security/truecrack/default.nix
+++ b/pkgs/tools/security/truecrack/default.nix
@@ -1,5 +1,6 @@
 { lib, gccStdenv, fetchFromGitLab, cudatoolkit
-, cudaSupport ? false
+, config
+, cudaSupport ? config.cudaSupport or false
 , pkg-config }:
 
 gccStdenv.mkDerivation rec {

--- a/pkgs/tools/security/truecrack/default.nix
+++ b/pkgs/tools/security/truecrack/default.nix
@@ -1,6 +1,6 @@
 { lib, gccStdenv, fetchFromGitLab, cudatoolkit
 , config
-, cudaSupport ? config.cudaSupport or false
+, cudaSupport ? config.cudaSupport
 , pkg-config }:
 
 gccStdenv.mkDerivation rec {

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4162,7 +4162,7 @@ with pkgs;
   libtensorflow = python3.pkgs.tensorflow.libtensorflow;
 
   libtorch-bin = callPackage ../development/libraries/science/math/libtorch/bin.nix {
-    cudaSupport = config.cudaSupport or false;
+    inherit (config) cudaSupport;
   };
 
   tensorflow-lite = callPackage ../development/libraries/science/math/tensorflow-lite { };
@@ -10825,7 +10825,7 @@ with pkgs;
 
   nvidia-thrust-intel = callPackage ../development/libraries/nvidia-thrust {
     hostSystem = "TBB";
-    deviceSystem = if config.cudaSupport or false then "CUDA" else "TBB";
+    deviceSystem = if config.cudaSupport then "CUDA" else "TBB";
   };
 
   nvidia-thrust-cuda = callPackage ../development/libraries/nvidia-thrust {
@@ -15070,7 +15070,7 @@ with pkgs;
 
   colm = callPackage ../development/compilers/colm { };
 
-  colmap = libsForQt5.callPackage ../applications/science/misc/colmap { cudaSupport = config.cudaSupport or false; };
+  colmap = libsForQt5.callPackage ../applications/science/misc/colmap { inherit (config) cudaSupport; };
   colmapWithCuda = colmap.override { cudaSupport = true; };
 
   chickenPackages_4 = callPackage ../development/compilers/chicken/4 { };
@@ -39195,7 +39195,7 @@ with pkgs;
   ### SCIENCE / MATH
 
   caffe = callPackage ../applications/science/math/caffe ({
-    cudaSupport = config.cudaSupport or false;
+    inherit (config) cudaSupport;
     cudaPackages = cudaPackages_10_1;
     opencv3 = opencv3WithoutCuda; # Used only for image loading.
     blas = openblas;
@@ -39210,7 +39210,7 @@ with pkgs;
     stdenv = gcc7Stdenv;
     inherit (linuxPackages) nvidia_x11;
     opencv3 = opencv3WithoutCuda; # Used only for image loading.
-    cudaSupport = config.cudaSupport or false;
+    inherit (config) cudaSupport;
   };
 
   dap = callPackage ../applications/science/math/dap { };

--- a/pkgs/top-level/config.nix
+++ b/pkgs/top-level/config.nix
@@ -117,6 +117,12 @@ let
       '';
     };
 
+    cudaSupport = mkMassRebuild {
+      type = types.bool;
+      default = false;
+      feature = "build packages with CUDA support by default";
+    };
+
     showDerivationWarnings = mkOption {
       type = types.listOf (types.enum [ "maintainerless" ]);
       default = [];

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1816,7 +1816,7 @@ self: super: with self; {
   chai = callPackage ../development/python-modules/chai { };
 
   chainer = callPackage ../development/python-modules/chainer {
-    cudaSupport = pkgs.config.cudaSupport or false;
+    inherit (pkgs.config) cudaSupport;
   };
 
   chainmap = callPackage ../development/python-modules/chainmap { };
@@ -5256,13 +5256,13 @@ self: super: with self; {
   jax-jumpy = callPackage ../development/python-modules/jax-jumpy { };
 
   jaxlib-bin = callPackage ../development/python-modules/jaxlib/bin.nix {
-    cudaSupport = pkgs.config.cudaSupport or false;
+    inherit (pkgs.config) cudaSupport;
   };
 
   jaxlib-build = callPackage ../development/python-modules/jaxlib rec {
     inherit (pkgs.darwin) cctools;
     # Some platforms don't have `cudaSupport` defined, hence the need for 'or false'.
-    cudaSupport = pkgs.config.cudaSupport or false;
+    inherit (pkgs.config) cudaSupport;
     IOKit = pkgs.darwin.apple_sdk_11_0.IOKit;
     protobuf = pkgs.protobuf3_20; # jaxlib-build 0.3.15 won't build with protobuf 3.21
   };
@@ -5803,7 +5803,7 @@ self: super: with self; {
 
   libgpuarray = callPackage ../development/python-modules/libgpuarray {
     clblas = pkgs.clblas.override { inherit (self) boost; };
-    cudaSupport = pkgs.config.cudaSupport or false;
+    inherit (pkgs.config) cudaSupport;
   };
 
   libiio = (toPythonModule (pkgs.libiio.override { inherit python; })).python;
@@ -7105,7 +7105,7 @@ self: super: with self; {
   num2words = callPackage ../development/python-modules/num2words { };
 
   numba = callPackage ../development/python-modules/numba {
-    cudaSupport = pkgs.config.cudaSupport or false;
+    inherit (pkgs.config) cudaSupport;
   };
 
   numbaWithCuda = self.numba.override {
@@ -7273,7 +7273,7 @@ self: super: with self; {
   openai-triton-bin = callPackage ../development/python-modules/openai-triton/bin.nix { };
 
   openai-whisper = callPackage ../development/python-modules/openai-whisper {
-    cudaSupport = pkgs.config.cudaSupport or false;
+    inherit (pkgs.config) cudaSupport;
   };
 
   openant = callPackage ../development/python-modules/openant { };
@@ -12304,12 +12304,12 @@ self: super: with self; {
   tensorboardx = callPackage ../development/python-modules/tensorboardx { };
 
   tensorflow-bin = callPackage ../development/python-modules/tensorflow/bin.nix {
-    cudaSupport = pkgs.config.cudaSupport or false;
+    inherit (pkgs.config) cudaSupport;
   };
 
   tensorflow-build = callPackage ../development/python-modules/tensorflow {
     inherit (pkgs.darwin) cctools;
-    cudaSupport = pkgs.config.cudaSupport or false;
+    inherit (pkgs.config) cudaSupport;
     inherit (self.tensorflow-bin) cudaPackages;
     inherit (pkgs.darwin.apple_sdk.frameworks) Foundation Security;
     flatbuffers-core = pkgs.flatbuffers;
@@ -12428,7 +12428,7 @@ self: super: with self; {
   theano-pymc = callPackage ../development/python-modules/theano-pymc { };
 
   theano = callPackage ../development/python-modules/theano rec {
-    cudaSupport = pkgs.config.cudaSupport or false;
+    inherit (pkgs.config) cudaSupport;
     cudnnSupport = cudaSupport;
   };
 
@@ -12595,9 +12595,9 @@ self: super: with self; {
   toposort = callPackage ../development/python-modules/toposort { };
 
   torch = callPackage ../development/python-modules/torch {
-    cudaSupport = pkgs.config.cudaSupport or false;
+    inherit (pkgs.config) cudaSupport;
     magma =
-      if pkgs.config.cudaSupport or false
+      if pkgs.config.cudaSupport
       then pkgs.magma-cuda-static
       else pkgs.magma;
     inherit (pkgs.darwin.apple_sdk.frameworks) Accelerate CoreServices;


### PR DESCRIPTION
###### Description of changes

Make nixpkgs respect `config.cudaSupport` to reduce divergence in outPaths caused by out-of-tree overlays.

Also proposing a new practice: require derivations to consume `config` and write `cudaSupport ? config.cudaSupport`, instead of checking `config` outside in `all-packages.nix` or such.

Rationale: we had quite a few packages not respecting `config.cudaSupport`, resulting in people (including me) adopting overlays that "fix" them. Overlays mean diverging hashes, which means we can't share cache. The easiest way to check if there are packages that don't respect `config.cudaSupport` is to grep: ```❯ ag 'enableCuda \? false'```. Checking `config` in `all-packages.nix` means grep produces false-positives

TBD: add links to example overlays, but some are [SomeoneSerge/nixpkgs-unfree](https://github.com/SomeoneSerge/nixpkgs-unfree/blob/b8685f9d290118ee7b3dece0008706637f0c14e3/nix/overlays.nix#L29), and there are more in NixOS-QChem, and `numtide/nixpkgs-unfree`

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->


CC @NixOS/cuda-maintainers 