### PR TITLE
fcitx5-mozc: wrapQtApp for mozc_tool

### DIFF
--- a/pkgs/tools/inputmethods/fcitx5/fcitx5-mozc.nix
+++ b/pkgs/tools/inputmethods/fcitx5/fcitx5-mozc.nix
@@ -103,6 +103,10 @@ in clangStdenv.mkDerivation rec {
     ../scripts/install_fcitx5
   '';
 
+  preFixup = ''
+    wrapQtApp $out/lib/mozc/mozc_tool
+  '';
+
   meta = with lib; {
     description = "Fcitx5 Module of A Japanese Input Method for Chromium OS, Windows, Mac and Linux (the Open Source Edition of Google Japanese Input)";
     homepage = "https://github.com/fcitx/mozc";

--- a/pkgs/tools/inputmethods/fcitx5/fcitx5-mozc.nix
+++ b/pkgs/tools/inputmethods/fcitx5/fcitx5-mozc.nix
@@ -84,13 +84,19 @@ in clangStdenv.mkDerivation rec {
   '';
 
   buildPhase = ''
+    runHook preBuild
+
     python build_mozc.py build -c Release \
       server/server.gyp:mozc_server \
       gui/gui.gyp:mozc_tool \
       unix/fcitx5/fcitx5.gyp:fcitx5-mozc
+
+    runHook postBuild
   '';
 
   installPhase = ''
+    runHook preInstall
+
     export PREFIX=$out
     export _bldtype=Release
     ../scripts/install_server
@@ -101,6 +107,8 @@ in clangStdenv.mkDerivation rec {
     install -d $out/share/fcitx5/inputmethod
     install -d $out/lib/fcitx5
     ../scripts/install_fcitx5
+
+    runHook postInstall
   '';
 
   preFixup = ''


### PR DESCRIPTION
###### Description of changes
fixes #221958 

I found that this derivation has no `runHook`, but it is not related to this PR.
It is better to create a separate PR to add `runHook`, right?

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
