### PR TITLE
cppzmq: make zeromq propagatedBuildInput

### DIFF
--- a/pkgs/applications/blockchains/aeon/default.nix
+++ b/pkgs/applications/blockchains/aeon/default.nix
@@ -1,6 +1,6 @@
 { lib, stdenv, fetchFromGitHub, cmake, pkg-config, git, doxygen, graphviz
 , boost, miniupnpc, openssl, unbound, cppzmq
-, zeromq, pcsclite, readline, libsodium
+, pcsclite, readline, libsodium
 }:
 
 let
@@ -22,7 +22,7 @@ stdenv.mkDerivation {
 
   buildInputs = [
     boost miniupnpc openssl unbound
-    cppzmq zeromq pcsclite readline libsodium
+    cppzmq pcsclite readline libsodium
   ];
 
   cmakeFlags = [

--- a/pkgs/applications/blockchains/masari/default.nix
+++ b/pkgs/applications/blockchains/masari/default.nix
@@ -1,5 +1,5 @@
 { lib, stdenv, fetchFromGitHub, cmake, pkg-config, unbound, openssl, boost
-, lmdb, miniupnpc, readline, git, zeromq, libsodium, rapidjson, cppzmq }:
+, lmdb, miniupnpc, readline, git, libsodium, rapidjson, cppzmq }:
 
 stdenv.mkDerivation rec {
   pname = "masari";
@@ -21,7 +21,7 @@ stdenv.mkDerivation rec {
 
   buildInputs = [
     boost miniupnpc openssl unbound
-    zeromq  readline libsodium
+    readline libsodium
     rapidjson cppzmq
   ];
 

--- a/pkgs/applications/radio/gnuradio/3.8.nix
+++ b/pkgs/applications/radio/gnuradio/3.8.nix
@@ -25,7 +25,6 @@
 , SDL
 , gsl
 , cppzmq
-, zeromq
 # Needed only if qt-gui is disabled, from some reason
 , icu
 # GUI related
@@ -203,7 +202,7 @@ let
       runtime = [ gsl ];
     };
     gr-zeromq = {
-      runtime = [ cppzmq zeromq ];
+      runtime = [ cppzmq ];
       cmakeEnableFlag = "GR_ZEROMQ";
     };
   };

--- a/pkgs/applications/radio/gnuradio/3.9.nix
+++ b/pkgs/applications/radio/gnuradio/3.9.nix
@@ -28,7 +28,6 @@
 , libunwind
 , thrift
 , cppzmq
-, zeromq
 # Needed only if qt-gui is disabled, from some reason
 , icu
 # GUI related
@@ -228,7 +227,7 @@ let
       runtime = [ gsl libsodium ];
     };
     gr-zeromq = {
-      runtime = [ cppzmq zeromq ];
+      runtime = [ cppzmq ];
       cmakeEnableFlag = "GR_ZEROMQ";
     };
     gr-network = {

--- a/pkgs/applications/radio/gnuradio/default.nix
+++ b/pkgs/applications/radio/gnuradio/default.nix
@@ -30,7 +30,6 @@
 , libunwind
 , thrift
 , cppzmq
-, zeromq
 # Needed only if qt-gui is disabled, from some reason
 , icu
 # GUI related
@@ -247,7 +246,7 @@ let
       runtime = [ gsl libsodium ];
     };
     gr-zeromq = {
-      runtime = [ cppzmq zeromq ];
+      runtime = [ cppzmq ];
       cmakeEnableFlag = "GR_ZEROMQ";
     };
     gr-network = {

--- a/pkgs/applications/radio/qradiolink/default.nix
+++ b/pkgs/applications/radio/qradiolink/default.nix
@@ -19,7 +19,6 @@
 , speex
 , speexdsp
 , cppzmq
-, zeromq
 }:
 
 gnuradio3_8.pkgs.mkDerivation rec {
@@ -67,7 +66,6 @@ gnuradio3_8.pkgs.mkDerivation rec {
     libftdi
     libsndfile
     cppzmq
-    zeromq
     gnuradio3_8.qwt
   ] ++ lib.optionals (gnuradio3_8.hasFeature "gr-ctrlport") [
     thrift

--- a/pkgs/applications/science/electronics/horizon-eda/default.nix
+++ b/pkgs/applications/science/electronics/horizon-eda/default.nix
@@ -19,7 +19,6 @@
 , python3
 , sqlite
 , wrapGAppsHook
-, zeromq
 }:
 
 stdenv.mkDerivation rec {
@@ -48,7 +47,6 @@ stdenv.mkDerivation rec {
     podofo
     python3
     sqlite
-    zeromq
   ];
 
   nativeBuildInputs = [

--- a/pkgs/development/libraries/cppzmq/default.nix
+++ b/pkgs/development/libraries/cppzmq/default.nix
@@ -12,7 +12,7 @@ stdenv.mkDerivation rec {
   };
 
   nativeBuildInputs = [ cmake ];
-  buildInputs = [ zeromq ];
+  propagatedBuildInputs = [ zeromq ];
 
   cmakeFlags = [
     # Tests try to download googletest at compile time; there is no option


### PR DESCRIPTION
###### Description of changes

cppzmq is a header-only library. As such, it is not much useful without zeromq, whose headers it includes. By having zeromq in propagatedBuildInputs, we can simplify dependent expressions.

This change is motivated by
https://github.com/lopsided98/nix-ros-overlay/issues/255#issuecomment-1487590226. The expressions in nix-ros-overlay are automatically generated and since packages in other distributions where ROS runs need not to explicitly depend on zeromq, the Nix expression should behave the same. This way, nix-ros-overlay will not to have manually patch/overlay the automatically generated expressions.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
