### PR TITLE
blahtexml: 0.9+date=2020-05-16 -> 1.0

### DIFF
--- a/pkgs/tools/typesetting/tex/blahtexml/default.nix
+++ b/pkgs/tools/typesetting/tex/blahtexml/default.nix
@@ -1,19 +1,19 @@
 { fetchFromGitHub, lib, stdenv, libiconv, texlive, xercesc }:
 
-stdenv.mkDerivation {
+stdenv.mkDerivation rec {
   pname = "blahtexml";
-  version = "0.9+date=2020-05-16";
+  version = "1.0";
 
   src = fetchFromGitHub {
     owner = "gvanas";
     repo = "blahtexml";
-    rev = "92f2c5ff1f2b00a541b2222facc51ec72e5f6559";
-    hash = "sha256-ts+2gWsp7+rQu1US2/qEdbttB2Ps12efTSrcioZYsmE=";
+    rev = "v${version}";
+    hash = "sha256-DL5DyfARHHbwWBVHSa/VwHzNaAx/v7EDdnw1GLOk+y0=";
   };
 
   outputs = [ "out" "doc" ];
 
-  nativeBuildInputs = [ texlive.combined.scheme-full ];
+  nativeBuildInputs = [ texlive.combined.scheme-full ]; # scheme-full needed for ucs package
   buildInputs = [ xercesc ] ++ lib.optionals stdenv.isDarwin [ libiconv ];
 
   buildFlags =


### PR DESCRIPTION
###### Description of changes
https://github.com/gvanas/blahtexml/releases/tag/v1.0

###### Things done

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [X] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).