### PR TITLE
isoimagewriter: init at 0.9.1

### DIFF
--- a/pkgs/tools/misc/isoimagewriter/default.nix
+++ b/pkgs/tools/misc/isoimagewriter/default.nix
@@ -1,0 +1,30 @@
+{ lib, mkDerivation, fetchurl, cmake, extra-cmake-modules, wrapQtAppsHook,
+karchive, kcoreaddons, kcrash, kiconthemes, kwidgetsaddons, solid, qgpgme }:
+mkDerivation rec {
+  pname = "isoimagewriter";
+  version = "0.9.1";
+
+  src = fetchurl {
+    url = "mirror://kde/unstable/${pname}/${version}/${pname}-${version}.tar.xz";
+    hash = "sha256-09e9R8OvMTlBlETM7/DIFYc86ROw7wBzdus+Zo1TO7M=";
+  };
+
+  nativeBuildInputs = [ cmake extra-cmake-modules wrapQtAppsHook ];
+  buildInputs = [
+    karchive
+    kcoreaddons
+    kcrash
+    kiconthemes
+    kwidgetsaddons
+    solid
+    qgpgme
+  ];
+
+  meta = {
+    description = "ISO Image Writer is a tool to write a .iso file to a USB disk.";
+    homepage = "https://invent.kde.org/utilities/isoimagewriter";
+    platforms = lib.platforms.linux;
+    license = lib.licenses.gpl3Plus;
+    maintainers = with lib.maintainers; [ k900 ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -20835,6 +20835,8 @@ with pkgs;
 
   iso-flags = callPackage ../data/icons/iso-flags { };
 
+  isoimagewriter = libsForQt5.callPackage ../tools/misc/isoimagewriter {};
+
   isort = with python3Packages; toPythonApplication isort;
 
   ispc = callPackage ../development/compilers/ispc {


### PR DESCRIPTION
###### Description of changes

Because we don't need 300MB of balena-etcher to burn a USB stick.

I mean just look at this thing.

![image](https://user-images.githubusercontent.com/386765/229200251-d27b34e3-c910-4f28-adca-b1d55d7bb5b6.png)

Isn't it adorable?

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
