### PR TITLE
coq: add support for -native-compiler yes

### DIFF
--- a/doc/languages-frameworks/coq.section.md
+++ b/doc/languages-frameworks/coq.section.md
@@ -7,6 +7,7 @@ The Coq derivation is overridable through the `coq.override overrides`, where ov
 * `version` (optional, defaults to the latest version of Coq selected for nixpkgs, see `pkgs/top-level/coq-packages` to witness this choice), which follows the conventions explained in the `coqPackages` section below,
 * `customOCamlPackages` (optional, defaults to `null`, which lets Coq choose a version automatically), which can be set to any of the ocaml packages attribute of `ocaml-ng` (such as `ocaml-ng.ocamlPackages_4_10` which is the default for Coq 8.11 for example).
 * `coq-version` (optional, defaults to the short version e.g. "8.10"), is a version number of the form "x.y" that indicates which Coq's version build behavior to mimic when using a source which is not a release. E.g. `coq.override { version = "d370a9d1328a4e1cdb9d02ee032f605a9d94ec7a"; coq-version = "8.10"; }`.
+* `native-compiler` (optional, defaults to `false`), enables or disables compilation of Coq files to natively executable code. Coq with this enabled is available through the `coq_native` package.
 
 The associated package set can be obtained using `mkCoqPackages coq`, where `coq` is the derivation to use.
 
@@ -88,6 +89,10 @@ with lib; mkCoqDerivation {
   };
 }
 ```
+
+## Native compilation {#coq-native-compilation}
+
+Variants of the `coq` and `coqPackages` derivations, for each version of Coq, with `native-compilation` enabled are available. These are called `coq_native` and `coq_nativePackages` respectively.
 
 ## Three ways of overriding Coq packages {#coq-overriding-packages}
 

--- a/pkgs/applications/science/logic/coq/default.nix
+++ b/pkgs/applications/science/logic/coq/default.nix
@@ -10,6 +10,7 @@
 , ocamlPackages_4_05, ocamlPackages_4_09, ocamlPackages_4_10, ocamlPackages_4_12
 , ocamlPackages_4_14
 , ncurses
+, native-compiler ? false # Whether to build with -native-compiler yes
 , buildIde ? null # default is true for Coq < 8.14 and false for Coq >= 8.14
 , glib, gnome, wrapGAppsHook, makeDesktopItem, copyDesktopItems
 , csdp ? null
@@ -66,6 +67,7 @@ let
   buildIde = args.buildIde or (!coqAtLeast "8.14");
   ideFlags = optionalString (buildIde && !coqAtLeast "8.10")
     "-lablgtkdir ${ocamlPackages.lablgtk}/lib/ocaml/*/site-lib/lablgtk2 -coqide opt";
+  nativeFlags = optionalString native-compiler "-native-compiler yes";
   csdpPatch = lib.optionalString (csdp != null) ''
     substituteInPlace plugins/micromega/sos.ml --replace "; csdp" "; ${csdp}/bin/csdp"
     substituteInPlace plugins/micromega/coq_micromega.ml --replace "System.is_in_system_path \"csdp\"" "true"
@@ -81,6 +83,7 @@ let
   ocamlNativeBuildInputs = with ocamlPackages; [ ocaml findlib ]
     ++ optional (coqAtLeast "8.14") dune_2;
   ocamlPropagatedBuildInputs = [ ]
+    ++ optional native-compiler [ ocamlPackages.ocaml ]
     ++ optional (!coqAtLeast "8.10") ocamlPackages.camlp5
     ++ optional (!coqAtLeast "8.13") ocamlPackages.num
     ++ optional (coqAtLeast "8.13") ocamlPackages.zarith;
@@ -174,9 +177,13 @@ self = stdenv.mkDerivation {
 
   preConfigure = if coqAtLeast "8.10" then ''
     patchShebangs dev/tools/
+    configureFlagsArray=(
+      ${nativeFlags}
+    )
   '' else ''
     configureFlagsArray=(
       ${ideFlags}
+      ${nativeFlags}
     )
   '';
 
@@ -218,7 +225,7 @@ self = stdenv.mkDerivation {
     homepage = "http://coq.inria.fr";
     license = licenses.lgpl21;
     branch = coq-version;
-    maintainers = with maintainers; [ roconnor thoughtpolice vbgl Zimmi48 ];
+    maintainers = with maintainers; [ alizter roconnor thoughtpolice vbgl Zimmi48 ];
     platforms = platforms.unix;
     mainProgram = "coqide";
   };

--- a/pkgs/development/coq-modules/compcert/default.nix
+++ b/pkgs/development/coq-modules/compcert/default.nix
@@ -1,11 +1,13 @@
-{ lib, fetchzip, mkCoqDerivation
-, coq, flocq, compcert
-, ocamlPackages, fetchpatch, makeWrapper, coq2html
+{ lib, mkCoqDerivation
+, coq, flocq
+, fetchpatch, makeWrapper, coq2html
 , stdenv, tools ? stdenv.cc
 , version ? null
 }:
 
-let compcert = mkCoqDerivation rec {
+let compcert = 
+  let ocamlPackages = coq.ocamlPackages; in
+  mkCoqDerivation {
 
   pname = "compcert";
   owner = "AbsInt";

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -37493,20 +37493,20 @@ with pkgs;
       ocamlPackages_4_14
     ;
   }) mkCoqPackages
-    coqPackages_8_5  coq_8_5
-    coqPackages_8_6  coq_8_6
-    coqPackages_8_7  coq_8_7
-    coqPackages_8_8  coq_8_8
-    coqPackages_8_9  coq_8_9
-    coqPackages_8_10 coq_8_10
-    coqPackages_8_11 coq_8_11
-    coqPackages_8_12 coq_8_12
-    coqPackages_8_13 coq_8_13
-    coqPackages_8_14 coq_8_14
-    coqPackages_8_15 coq_8_15
-    coqPackages_8_16 coq_8_16
-    coqPackages_8_17 coq_8_17
-    coqPackages      coq
+    coqPackages_8_5  coq_8_5  coq_nativePackages_8_5  coq_native_8_5
+    coqPackages_8_6  coq_8_6  coq_nativePackages_8_6  coq_native_8_6
+    coqPackages_8_7  coq_8_7  coq_nativePackages_8_7  coq_native_8_7
+    coqPackages_8_8  coq_8_8  coq_nativePackages_8_8  coq_native_8_8
+    coqPackages_8_9  coq_8_9  coq_nativePackages_8_9  coq_native_8_9
+    coqPackages_8_10 coq_8_10 coq_nativePackages_8_10 coq_native_8_10
+    coqPackages_8_11 coq_8_11 coq_nativePackages_8_11 coq_native_8_11
+    coqPackages_8_12 coq_8_12 coq_nativePackages_8_12 coq_native_8_12
+    coqPackages_8_13 coq_8_13 coq_nativePackages_8_13 coq_native_8_13
+    coqPackages_8_14 coq_8_14 coq_nativePackages_8_14 coq_native_8_14
+    coqPackages_8_15 coq_8_15 coq_nativePackages_8_15 coq_native_8_15
+    coqPackages_8_16 coq_8_16 coq_nativePackages_8_16 coq_native_8_16
+    coqPackages_8_17 coq_8_17 coq_nativePackages_8_17 coq_native_8_17
+    coqPackages      coq      coq_nativePackages      coq_native
   ;
 
   coq2html = callPackage ../tools/typesetting/coq2html { };

--- a/pkgs/top-level/coq-packages.nix
+++ b/pkgs/top-level/coq-packages.nix
@@ -133,14 +133,13 @@ let
               else v))
       ) (lib.attrNames set)
     );
-  mkCoq = version: callPackage ../applications/science/logic/coq {
-    inherit version
+  mkCoq = {version, native-compiler ? false}: callPackage ../applications/science/logic/coq {
+    inherit version native-compiler
       ocamlPackages_4_05
       ocamlPackages_4_09
       ocamlPackages_4_10
       ocamlPackages_4_12
-      ocamlPackages_4_14
-    ;
+      ocamlPackages_4_14;
   };
 in rec {
 
@@ -156,25 +155,25 @@ in rec {
     let self = lib.makeScope newScope (lib.flip mkCoqPackages' coq); in
     self.filterPackages (! coq.dontFilter or false);
 
-  coq_8_5  = mkCoq "8.5";
-  coq_8_6  = mkCoq "8.6";
-  coq_8_7  = mkCoq "8.7";
-  coq_8_8  = mkCoq "8.8";
-  coq_8_9  = mkCoq "8.9";
-  coq_8_10 = mkCoq "8.10";
-  coq_8_11 = mkCoq "8.11";
-  coq_8_12 = mkCoq "8.12";
-  coq_8_13 = mkCoq "8.13";
-  coq_8_14 = mkCoq "8.14";
-  coq_8_15 = mkCoq "8.15";
-  coq_8_16 = mkCoq "8.16";
-  coq_8_17 = mkCoq "8.17";
+  coq_8_5  = mkCoq { version = "8.5"; };
+  coq_8_6  = mkCoq { version = "8.6"; };
+  coq_8_7  = mkCoq { version = "8.7"; };
+  coq_8_8  = mkCoq { version = "8.8"; };
+  coq_8_9  = mkCoq { version = "8.9"; };
+  coq_8_10 = mkCoq { version = "8.10"; };
+  coq_8_11 = mkCoq { version = "8.11"; };
+  coq_8_12 = mkCoq { version = "8.12"; };
+  coq_8_13 = mkCoq { version = "8.13"; };
+  coq_8_14 = mkCoq { version = "8.14"; };
+  coq_8_15 = mkCoq { version = "8.15"; };
+  coq_8_16 = mkCoq { version = "8.16"; };
+  coq_8_17 = mkCoq { version = "8.17"; };
 
-  coqPackages_8_5 = mkCoqPackages coq_8_5;
-  coqPackages_8_6 = mkCoqPackages coq_8_6;
-  coqPackages_8_7 = mkCoqPackages coq_8_7;
-  coqPackages_8_8 = mkCoqPackages coq_8_8;
-  coqPackages_8_9 = mkCoqPackages coq_8_9;
+  coqPackages_8_5  = mkCoqPackages coq_8_5;
+  coqPackages_8_6  = mkCoqPackages coq_8_6;
+  coqPackages_8_7  = mkCoqPackages coq_8_7;
+  coqPackages_8_8  = mkCoqPackages coq_8_8;
+  coqPackages_8_9  = mkCoqPackages coq_8_9;
   coqPackages_8_10 = mkCoqPackages coq_8_10;
   coqPackages_8_11 = mkCoqPackages coq_8_11;
   coqPackages_8_12 = mkCoqPackages coq_8_12;
@@ -186,4 +185,34 @@ in rec {
   coqPackages = recurseIntoAttrs coqPackages_8_16;
   coq = coqPackages.coq;
 
+  # Coq + native-compiler
+  coq_native_8_5  = mkCoq { version = "8.5";  native-compiler = true; };
+  coq_native_8_6  = mkCoq { version = "8.6";  native-compiler = true; };
+  coq_native_8_7  = mkCoq { version = "8.7";  native-compiler = true; };
+  coq_native_8_8  = mkCoq { version = "8.8";  native-compiler = true; };
+  coq_native_8_9  = mkCoq { version = "8.9";  native-compiler = true; };
+  coq_native_8_10 = mkCoq { version = "8.10"; native-compiler = true; };
+  coq_native_8_11 = mkCoq { version = "8.11"; native-compiler = true; };
+  coq_native_8_12 = mkCoq { version = "8.12"; native-compiler = true; };
+  coq_native_8_13 = mkCoq { version = "8.13"; native-compiler = true; };
+  coq_native_8_14 = mkCoq { version = "8.14"; native-compiler = true; };
+  coq_native_8_15 = mkCoq { version = "8.15"; native-compiler = true; };
+  coq_native_8_16 = mkCoq { version = "8.16"; native-compiler = true; };
+  coq_native_8_17 = mkCoq { version = "8.17"; native-compiler = true; };
+
+  coq_nativePackages_8_5  = mkCoqPackages coq_native_8_5;
+  coq_nativePackages_8_6  = mkCoqPackages coq_native_8_6;
+  coq_nativePackages_8_7  = mkCoqPackages coq_native_8_7;
+  coq_nativePackages_8_8  = mkCoqPackages coq_native_8_8;
+  coq_nativePackages_8_9  = mkCoqPackages coq_native_8_9;
+  coq_nativePackages_8_10 = mkCoqPackages coq_native_8_10;
+  coq_nativePackages_8_11 = mkCoqPackages coq_native_8_11;
+  coq_nativePackages_8_12 = mkCoqPackages coq_native_8_12;
+  coq_nativePackages_8_13 = mkCoqPackages coq_native_8_13;
+  coq_nativePackages_8_14 = mkCoqPackages coq_native_8_14;
+  coq_nativePackages_8_15 = mkCoqPackages coq_native_8_15;
+  coq_nativePackages_8_16 = mkCoqPackages coq_native_8_16;
+  coq_nativePackages_8_17 = mkCoqPackages coq_native_8_17;
+  coq_nativePackages = recurseIntoAttrs coq_nativePackages_8_17;
+  coq_native = coq_nativePackages.coq;
 }


### PR DESCRIPTION
###### Description of changes

This patch adds support for enabling `-native-compiler yes` for Coq. As a result I have duplicated all the Coq packages for when we have the native compiler enabled. This is somewhat analogous to enabling flambda for OCaml, although there we don't have such a package set.

I am still uncertain if we want the extra package sets and I think we could probably deduplicate some things, but I am not sure if that is something we would want to do.

cc @NixOS/coq and perhaps @CohenCyril and @proux01 if they are interested.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
