### PR TITLE
rPackages: Content Addressing

### DIFF
--- a/pkgs/development/r-modules/generic-builder.nix
+++ b/pkgs/development/r-modules/generic-builder.nix
@@ -3,6 +3,8 @@
 { name, buildInputs ? [], requireX ? false, ... } @ attrs:
 
 stdenv.mkDerivation ({
+  __contentAddressed = true;
+
   buildInputs = buildInputs ++ [R gettext] ++
                 lib.optionals requireX [util-linux xvfb-run] ++
                 lib.optionals stdenv.isDarwin [Cocoa Foundation gfortran libiconv];


### PR DESCRIPTION
###### Description of changes

This draft PR enables [content-addressed derivations](https://www.tweag.io/blog/2020-09-10-nix-cas/) for R Packages in r-modules. CA Derivations for R Packages would be a good default features for several reasons:

- R Packages naturally form complex dependency chains, and CA's [early cutoff](https://nixos.wiki/wiki/Ca-derivations) feature would be a good fit for Hydra and local builds and storage
- Private CRAN and Bioconductor mirrors are common in enterprise settings, and the default input-addressing means the private mirrors result in different store paths

@alexvorobiev @jbedo 

## Some Questions

- Is there any precedent for enabling CA Derivations early for specific packages like this?
- Could/Should have an optional argument to opt-in or out in this particular case?
- Would we expect any issues with Hydra on the cut over?

## Example

Without CA, we have:

```
➜ nix build -f default.nix rPackages.dplyr
➜ nix path-info --sigs ./result
/nix/store/5gx4m16ffxa7v960ixa8y2ccy4c1yaay-r-dplyr-1.0.10	cache.nixos.org-1:YiToJBODCEFbR4c7EYihJcP4hdX5iar57kLHWzDSfvx0WuwbhYrdaJB1FwlZyRL3S1ZuXWgPEcknTQdhgiC0Dw==
```

With CA enabled as is done in this PR, we have:

```
➜ nix build -f default.nix rPackages.dplyr
➜ nix path-info --sigs ./result
/nix/store/4m9pndyhk435fyxml4gfdrx6v9s355nz-r-dplyr-1.0.10	ultimate ca:fixed:r:sha256:0dair5p7dzi11miixcaskn4pa1vds3sf6fp0s68v6hj3yqb86h5v
```

###### Things done

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
