### PR TITLE
python312Packages.ydata-profiling: init at 4.8.3

### DIFF
--- a/pkgs/development/python-modules/visions/default.nix
+++ b/pkgs/development/python-modules/visions/default.nix
@@ -1,0 +1,70 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, pythonOlder
+, pytestCheckHook
+, setuptools
+, attrs
+, imagehash
+, matplotlib
+, multimethod
+, networkx
+, numpy
+, pandas
+, pillow
+, pydot
+, pygraphviz
+, shapely
+}:
+
+buildPythonPackage rec {
+  pname = "visions";
+  version = "0.7.6";
+  pyproject = true;
+
+  disabled = pythonOlder "3.8";
+
+  src = fetchFromGitHub {
+    owner = "dylan-profiler";
+    repo = "visions";
+    rev = "5fe9dd0c2a5ada0162a005c880bac5296686a5aa";  # no 0.7.6 tag in github
+    hash = "sha256-SZzDXm+faAvrfSOT0fwwAf9IH7upNybwKxbjw1CrHj8=";
+  };
+
+  nativeBuildInputs = [ setuptools ];
+
+  propagatedBuildInputs = [
+    attrs
+    imagehash
+    multimethod
+    networkx
+    numpy
+    pandas
+  ];
+
+  passthru.optional-dependencies = {
+    type-geometry = [ shapely ];
+    type-image-path = [ imagehash pillow ];
+    plotting = [ matplotlib pydot pygraphviz ];
+  };
+
+  nativeCheckInputs = [
+    pytestCheckHook
+  ] ++ lib.flatten (builtins.attrValues passthru.optional-dependencies);
+
+  disabledTestPaths = [
+    # requires running Apache Spark:
+    "tests/spark_/typesets/test_spark_standard_set.py"
+  ];
+
+  pythonImportsCheck = [
+    "visions"
+  ];
+
+  meta = with lib; {
+    description = "Type system for data analysis in Python";
+    homepage = "https://dylan-profiler.github.io/visions";
+    license = licenses.bsdOriginal;
+    maintainers = with maintainers; [ bcdarwin ];
+  };
+}

--- a/pkgs/development/python-modules/ydata-profiling/default.nix
+++ b/pkgs/development/python-modules/ydata-profiling/default.nix
@@ -1,0 +1,103 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, pythonOlder
+, pytestCheckHook
+, dacite
+, htmlmin
+, imagehash
+, jinja2
+, matplotlib
+, multimethod
+, numba
+, numpy
+, pandas
+, phik
+, pyarrow
+, pydantic
+, pyyaml
+, requests
+, scipy
+, seaborn
+, statsmodels
+, tqdm
+, typeguard
+, visions
+, wordcloud
+}:
+
+buildPythonPackage rec {
+  pname = "ydata-profiling";
+  version = "4.8.3";
+  pyproject = true;
+
+  disabled = pythonOlder "3.7";
+
+  src = fetchFromGitHub {
+    owner = "ydataai";
+    repo = pname;
+    rev = "refs/tags/${version}";
+    hash = "sha256-tMwhoVnn65EvZK5NBvh/G36W8tH7I9qaL+NTK3IZVdI=";
+  };
+
+  preBuild = ''
+    echo ${version} > VERSION
+  '';
+
+  propagatedBuildInputs = [
+    dacite
+    htmlmin
+    imagehash
+    jinja2
+    matplotlib
+    multimethod
+    numba
+    numpy
+    pandas
+    phik
+    pydantic
+    pyyaml
+    requests
+    scipy
+    seaborn
+    statsmodels
+    tqdm
+    typeguard
+    visions
+    wordcloud
+  ];
+
+  nativeCheckInputs = [
+    pytestCheckHook
+    pyarrow
+  ];
+  disabledTestPaths = [
+    # needs Spark:
+    "tests/backends/spark_backend"
+    # try to download data:
+    "tests/issues"
+    "tests/unit/test_console.py"
+    "tests/unit/test_dataset_schema.py"
+    "tests/unit/test_modular.py"
+  ];
+  disabledTests = [
+    # try to download data:
+    "test_decorator"
+    "test_example"
+    "test_load"
+    "test_urls"
+  ];
+
+  pythonImportsCheck = [
+    "ydata_profiling"
+  ];
+
+  meta = with lib; {
+    description = "Create HTML profiling reports from Pandas DataFrames";
+    homepage = "https://ydata-profiling.ydata.ai";
+    changelog = "https://github.com/ydataai/ydata-profiling/releases/tag/${version}";
+    license = licenses.mit;
+    maintainers = with maintainers; [ bcdarwin ];
+    mainProgram = "ydata_profiling";
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -17207,6 +17207,8 @@ self: super: with self; {
 
   yacs = callPackage ../development/python-modules/yacs { };
 
+  ydata-profiling = callPackage ../development/python-modules/ydata-profiling { };
+
   ydiff = callPackage ../development/python-modules/ydiff { };
 
   yeelight = callPackage ../development/python-modules/yeelight { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -16678,6 +16678,8 @@ self: super: with self; {
 
   virtualenvwrapper = callPackage ../development/python-modules/virtualenvwrapper { };
 
+  visions = callPackage ../development/python-modules/visions { };
+
   visitor = callPackage ../development/python-modules/visitor { };
 
   vispy = callPackage ../development/python-modules/vispy { };


### PR DESCRIPTION
python312Packages.visions: init at 0.7.6

###### Description of changes

Add python312Packages.ydata-profiling, a package for exploratory data analysis, and a dependency.

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [NA] (Module updates) Added a release notes entry if the change is significant
  - [NA] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

