### PR TITLE
xgboost: 1.7.4 -> 1.7.5

### DIFF
--- a/pkgs/development/libraries/xgboost/default.nix
+++ b/pkgs/development/libraries/xgboost/default.nix
@@ -12,7 +12,7 @@
 , llvmPackages
 , R
 , rPackages
-}:
+}@inputs:
 
 assert ncclSupport -> cudaSupport;
 # Disable regular tests when building the R package
@@ -21,6 +21,14 @@ assert ncclSupport -> cudaSupport;
 # object that isn't compatible with the regular CLI
 # tests.
 assert rLibrary -> doCheck != true;
+
+let
+  # This ensures xgboost gets the correct libstdc++ when
+  # built with cuda support. This may be removed once
+  # #226165 rewrites cudaStdenv
+  inherit (cudaPackages) backendStdenv;
+  stdenv = if cudaSupport then backendStdenv else inputs.stdenv;
+in
 
 stdenv.mkDerivation rec {
   pnameBase = "xgboost";
@@ -37,14 +45,14 @@ stdenv.mkDerivation rec {
   #   in \
   #   rWrapper.override{ packages = [ xgb ]; }"
   pname = lib.optionalString rLibrary "r-" + pnameBase;
-  version = "1.7.4";
+  version = "1.7.5";
 
   src = fetchFromGitHub {
     owner = "dmlc";
     repo = pnameBase;
     rev = "v${version}";
     fetchSubmodules = true;
-    hash = "sha256-HGS9w4g2+Aw5foKjHK/XQvSCnFHUswhzAsQf6XkdvOI=";
+    hash = "sha256-IBqtyz40VVHdncibnZQAe5oDsjb5isWBYQ6pGx/zt38=";
   };
 
   nativeBuildInputs = [ cmake ]


### PR DESCRIPTION
###### Description of changes

WIP. Updating xgboost to  latest version, including a bump to cudaPackages_11_8. C++ library builds with and without Cuda support, but the R library fails on the error below:

```
➜ nix-build -E "with (import $NIXPKGS{}); let xgb = xgboost.override{rLibrary = true; cudaSupport = true; cudaPackages = cudaPackages_11_8; doCheck = false;}; in rWrapper.override{ packages = [ xgb ]; }"
...
[ 98%] Built target objxgboost
[ 99%] Building CXX object CMakeFiles/runxgboost.dir/src/cli_main.cc.o
[ 99%] Linking CXX executable /build/source/xgboost
/nix/store/8qm6sjqa09a03glzmafprpp69k74l4lm-binutils-2.40/bin/ld: /nix/store/vl893j5kphwcnqyf3qrxcmmjc8zrfa5q-icu4c-72.1/lib/libicuuc.so.72: undefined reference to `std::condition_variable::wait(std::unique_lock<std::mutex>&)@GLIBCXX_3.4.30'
collect2: error: ld returned 1 exit status
make[2]: *** [CMakeFiles/runxgboost.dir/build.make:325: /build/source/xgboost] Error 1
make[1]: *** [CMakeFiles/Makefile2:224: CMakeFiles/runxgboost.dir/all] Error 2
make: *** [Makefile:156: all] Error 2
```

@trivialfis - any suggestions on what I can try next?

###### Things done

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin