### PR TITLE
patchance, raysession: provide libjack2 at runtime

### DIFF
--- a/pkgs/applications/audio/patchance/default.nix
+++ b/pkgs/applications/audio/patchance/default.nix
@@ -1,4 +1,4 @@
-{ lib, fetchurl, buildPythonApplication, pyqt5, qttools, which }:
+{ lib, fetchurl, buildPythonApplication, libjack2, pyqt5, qttools, which }:
 
 buildPythonApplication rec {
   pname = "patchance";
@@ -16,12 +16,16 @@ buildPythonApplication rec {
     qttools # lrelease to build translations.
     which   # which to find lrelease.
   ];
-
+  buildInputs = [ libjack2 ];
   propagatedBuildInputs = [ pyqt5 ];
 
   dontWrapQtApps = true; # The program is a python script.
 
   installFlags = [ "PREFIX=$(out)" ];
+
+  makeWrapperArgs = [
+    "--prefix" "LD_LIBRARY_PATH" ":" (lib.makeLibraryPath [ libjack2 ])
+  ];
 
   postFixup = ''
     wrapPythonProgramsIn "$out/share/patchance/src" "$out $pythonPath"

--- a/pkgs/applications/audio/raysession/default.nix
+++ b/pkgs/applications/audio/raysession/default.nix
@@ -1,4 +1,4 @@
-{ lib, fetchurl, buildPythonApplication, pydbus, pyliblo, pyqt5, qttools, which }:
+{ lib, fetchurl, buildPythonApplication, libjack2, pydbus, pyliblo, pyqt5, qttools, which }:
 
 buildPythonApplication rec {
   pname = "raysession";
@@ -23,12 +23,16 @@ buildPythonApplication rec {
     qttools # lrelease to build translations.
     which   # which to find lrelease.
   ];
-
+  buildInputs = [ libjack2 ];
   propagatedBuildInputs = [ pydbus pyliblo pyqt5 ];
 
   dontWrapQtApps = true; # The program is a python script.
 
   installFlags = [ "PREFIX=$(out)" ];
+
+  makeWrapperArgs = [
+    "--prefix" "LD_LIBRARY_PATH" ":" (lib.makeLibraryPath [ libjack2 ])
+  ];
 
   postFixup = ''
     wrapPythonProgramsIn "$out/share/raysession/src" "$out $pythonPath"


### PR DESCRIPTION
###### Description of changes

These python programs open libjack at runtime.

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
