### PR TITLE
python3Packages.latex2mathml: init at 3.75.2

### DIFF
--- a/pkgs/development/python-modules/latex2mathml/default.nix
+++ b/pkgs/development/python-modules/latex2mathml/default.nix
@@ -1,0 +1,27 @@
+{ lib, buildPythonPackage, fetchFromGitHub, poetry-core, setuptools
+, multidict, pytestCheckHook, pytest-cov, xmljson }:
+
+buildPythonPackage rec {
+  pname = "latex2mathml";
+  version = "3.75.2";
+  format = "pyproject";
+
+  src = fetchFromGitHub {
+    owner = "roniemartinez";
+    repo = pname;
+    rev = version;
+    hash = "sha256-i/F1B/Rndg66tiKok1PDMK/rT5c2e8upnQrMSCTUzpU=";
+  };
+
+  nativeBuildInputs = [ poetry-core ];
+  propagatedBuildInputs = [ setuptools ];
+  nativeCheckInputs = [ multidict pytestCheckHook pytest-cov xmljson ];
+
+  meta = with lib; {
+    description = "Pure Python library for LaTeX to MathML conversion";
+    homepage = "https://github.com/roniemartinez/latex2mathml";
+    changelog = "https://github.com/roniemartinez/latex2mathml/releases/tag/${version}";
+    license = licenses.mit;
+    maintainers = with maintainers; [ McSinyx ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5333,6 +5333,8 @@ self: super: with self; {
 
   laszip = callPackage ../development/python-modules/laszip { };
 
+  latex2mathml = callPackage ../development/python-modules/latex2mathml { };
+
   latexcodec = callPackage ../development/python-modules/latexcodec { };
 
   latexify-py = callPackage ../development/python-modules/latexify-py { };


### PR DESCRIPTION
###### Description of changes

[latex2mathml](https://github.com/roniemartinez/latex2mathml) is a pure Python library for LaTeX to MathML conversion

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).