### PR TITLE
ocamlPackages.json-data-encoding: 0.11 → 0.12.1

### DIFF
--- a/pkgs/development/ocaml-modules/json-data-encoding/bson.nix
+++ b/pkgs/development/ocaml-modules/json-data-encoding/bson.nix
@@ -5,6 +5,8 @@ buildDunePackage {
 
   inherit (json-data-encoding) version src doCheck;
 
+  duneVersion = "3";
+
   propagatedBuildInputs = [
     json-data-encoding
     ocplib-endian

--- a/pkgs/development/ocaml-modules/json-data-encoding/default.nix
+++ b/pkgs/development/ocaml-modules/json-data-encoding/default.nix
@@ -2,13 +2,14 @@
 
 buildDunePackage rec {
   pname = "json-data-encoding";
-  version = "0.11";
+  version = "0.12.1";
   minimalOCamlVersion = "4.10";
+  duneVersion = "3";
   src = fetchFromGitLab {
     owner = "nomadic-labs";
     repo = "json-data-encoding";
     rev = "${version}";
-    sha256 = "sha256-4FNUU82sq3ylgw0lxHlwi1OV58NRRh9zJqE47YyQZSc=";
+    hash = "sha256-ticulOKiFNQIZNFOQE9UQOw/wqRfygQwLVIc4kkmwg4=";
   };
 
   propagatedBuildInputs = [


### PR DESCRIPTION
###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
