### PR TITLE
platformio: make multi-output

### DIFF
--- a/pkgs/development/embedded/platformio/chrootenv.nix
+++ b/pkgs/development/embedded/platformio/chrootenv.nix
@@ -1,4 +1,4 @@
-{ lib, buildFHSUserEnv, version, src }:
+{ lib, buildFHSUserEnv, platformio-core }:
 
 let
   pio-pkgs = pkgs:
@@ -34,10 +34,8 @@ buildFHSUserEnv {
   };
 
   extraInstallCommands = ''
-    mkdir -p $out/lib/udev/rules.d
-
     ln -s $out/bin/platformio $out/bin/pio
-    ln -s ${src}/platformio/assets/system/99-platformio-udev.rules $out/lib/udev/rules.d/99-platformio-udev.rules
+    ln -s ${platformio-core.udev}/lib $out/lib
   '';
 
   runScript = "platformio";

--- a/pkgs/development/embedded/platformio/chrootenv.nix
+++ b/pkgs/development/embedded/platformio/chrootenv.nix
@@ -3,7 +3,7 @@
 let
   pio-pkgs = pkgs:
     let
-      python = pkgs.python3;
+      inherit (platformio-core) python;
     in
     (with pkgs; [
       platformio-core

--- a/pkgs/development/embedded/platformio/core.nix
+++ b/pkgs/development/embedded/platformio/core.nix
@@ -10,6 +10,8 @@ with python3.pkgs; buildPythonApplication rec {
   pname = "platformio";
   inherit version src;
 
+  outputs = [ "out" "udev" ];
+
   patches = [
     ./fix-searchpath.patch
     ./use-local-spdx-license-list.patch
@@ -59,6 +61,13 @@ with python3.pkgs; buildPythonApplication rec {
     jsondiff
     pytestCheckHook
   ];
+
+  # Install udev rules into a separate output so all of platformio-core is not a dependency if
+  # you want to use the udev rules on NixOS but not install platformio in your system packages.
+  postInstall = ''
+    mkdir -p $udev/lib/udev/rules.d/99-platformio-udev.rules
+    cp platformio/assets/system/99-platformio-udev.rules $udev/lib/udev/rules.d/99-platformio-udev.rules
+  '';
 
   disabledTestPaths = [
     "tests/commands/pkg/test_install.py"

--- a/pkgs/development/embedded/platformio/core.nix
+++ b/pkgs/development/embedded/platformio/core.nix
@@ -3,12 +3,20 @@
 , fetchPypi
 , git
 , spdx-license-list-data
-, version, src
 }:
 
 with python3.pkgs; buildPythonApplication rec {
   pname = "platformio";
-  inherit version src;
+
+  version = "6.1.6";
+
+  # pypi tarballs don't contain tests - https://github.com/platformio/platformio-core/issues/1964
+  src = fetchFromGitHub {
+    owner = "platformio";
+    repo = "platformio-core";
+    rev = "v${version}";
+    sha256 = "sha256-BEeMfdmAWqFbQUu8YKKrookQVgmhfZBqXnzeb2gfhms=";
+  };
 
   outputs = [ "out" "udev" ];
 

--- a/pkgs/development/embedded/platformio/core.nix
+++ b/pkgs/development/embedded/platformio/core.nix
@@ -162,6 +162,10 @@ with python3.pkgs; buildPythonApplication rec {
     "test_pkgmanifest.py::test_packages"
   ]);
 
+  passthru = {
+    python = python3;
+  };
+
   meta = with lib; {
     description = "An open source ecosystem for IoT development";
     homepage = "https://platformio.org";

--- a/pkgs/development/embedded/platformio/default.nix
+++ b/pkgs/development/embedded/platformio/default.nix
@@ -3,18 +3,8 @@
 let
   callPackage = newScope self;
 
-  version = "6.1.6";
-
-  # pypi tarballs don't contain tests - https://github.com/platformio/platformio-core/issues/1964
-  src = fetchFromGitHub {
-    owner = "platformio";
-    repo = "platformio-core";
-    rev = "v${version}";
-    sha256 = "sha256-BEeMfdmAWqFbQUu8YKKrookQVgmhfZBqXnzeb2gfhms=";
-  };
-
   self = {
-    platformio-core = python3Packages.callPackage ./core.nix { inherit version src; };
+    platformio-core = python3Packages.callPackage ./core.nix { };
 
     platformio-chrootenv = callPackage ./chrootenv.nix { };
   };

--- a/pkgs/development/embedded/platformio/default.nix
+++ b/pkgs/development/embedded/platformio/default.nix
@@ -16,7 +16,7 @@ let
   self = {
     platformio-core = python3Packages.callPackage ./core.nix { inherit version src; };
 
-    platformio-chrootenv = callPackage ./chrootenv.nix { inherit version src; };
+    platformio-chrootenv = callPackage ./chrootenv.nix { };
   };
 
 in

--- a/pkgs/development/embedded/platformio/missing-udev-rules-nixos.patch
+++ b/pkgs/development/embedded/platformio/missing-udev-rules-nixos.patch
@@ -6,7 +6,5 @@ index ef1d3bab..445174fc 100644
      MESSAGE = (
          "Warning! Please install `99-platformio-udev.rules`. \nMore details: "
          "https://docs.platformio.org/en/latest/core/installation/udev-rules.html"
-+        "On NixOS add the platformio package to services.udev.packages"
++        "On NixOS add the platformio-core.udev package to services.udev.packages"
      )
- 
- 


### PR DESCRIPTION
###### Description of changes

Currently udev rules symlinks against platformio sources, pulling in the platformio source tree into the runtime closure.
Previous to platformio-core being exposed separately from platformio (#166366) this also meant that you had no ergonomic way to avoid platformio in the system closure, even though you only wanted the udev rules.

We can avoid this by making platformio-core multi output, making it trivial to depend only on the udev rules.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
