### PR TITLE
patch-ppd-files: use `meta` and `passthru` directly

### DIFF
--- a/pkgs/build-support/setup-hooks/patch-ppd-files/default.nix
+++ b/pkgs/build-support/setup-hooks/patch-ppd-files/default.nix
@@ -4,22 +4,15 @@
 , callPackage
 }:
 
-let
-  patchPpdFilesHook = makeSetupHook
-    {
-      name = "patch-ppd-files";
-      substitutions.which = lib.attrsets.getBin which;
-      substitutions.awkscript = ./patch-ppd-lines.awk;
-    }
-    ./patch-ppd-hook.sh;
-in
-
-patchPpdFilesHook.overrideAttrs (
-  lib.trivial.flip
-  lib.attrsets.recursiveUpdate
-  {
-    passthru.tests.test = callPackage ./test.nix {};
-    meta.description = "setup hook to patch executable paths in ppd files";
-    meta.maintainers = [ lib.maintainers.yarny ];
-  }
-)
+makeSetupHook {
+  name = "patch-ppd-files";
+  substitutions = {
+    which = lib.getBin which;
+    awkscript = ./patch-ppd-lines.awk;
+  };
+  passthru.tests.test = callPackage ./test.nix {};
+  meta = {
+    description = "setup hook to patch executable paths in ppd files";
+    maintainers = [ lib.maintainers.yarny ];
+  };
+} ./patch-ppd-hook.sh


### PR DESCRIPTION
###### Description of changes

When I authored the nix file in 335a9083b02d2a7034dd98c8641f019e85e50426, `makeSetupHook` didn't know about `passthru` or `meta`.  So I foisted these attributes on the derivation with `.overrideAttrs`.

Commits ba895a7da8f86c6f924fc96026d8f1cb1ea2af1e and 48034046bf6271d44f7dea4c1ba97196b3b105a7 enabled `makeSetupHook` to receive these attributes directly.  It seems advisable to use that instead of `.overrideAttrs`.


###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).


###### Result of `nixpkgs-review` run on x86_64-linux [1](https://github.com/Mic92/nixpkgs-review)

(no output, as this pull request does not change any derivation's output)
