### PR TITLE
foomatic-db: unstable-2022-10-03 -> unstable-2023-03-30

### DIFF
--- a/pkgs/misc/cups/drivers/foomatic-db-engine/default.nix
+++ b/pkgs/misc/cups/drivers/foomatic-db-engine/default.nix
@@ -15,7 +15,7 @@
 , makeWrapper
 }:
 
-perlPackages.buildPerlPackage {
+perlPackages.buildPerlPackage rec {
   pname = "foomatic-db-engine";
   version = "unstable-2022-05-03";
 
@@ -79,6 +79,7 @@ perlPackages.buildPerlPackage {
   doCheck = false;  # no tests, would fail
 
   meta = {
+    changelog = "https://github.com/OpenPrinting/foomatic-db-engine/blob/${src.rev}/ChangeLog";
     description = "OpenPrinting printer support database engine";
     downloadPage = "https://www.openprinting.org/download/foomatic/";
     homepage = "https://openprinting.github.io/projects/02-foomatic/";

--- a/pkgs/misc/cups/drivers/foomatic-db-nonfree/default.nix
+++ b/pkgs/misc/cups/drivers/foomatic-db-nonfree/default.nix
@@ -6,7 +6,7 @@
 , perl
 }:
 
-stdenv.mkDerivation {
+stdenv.mkDerivation rec {
   pname = "foomatic-db-nonfree";
   version = "unstable-2015-06-05";
 
@@ -60,6 +60,7 @@ stdenv.mkDerivation {
   '';
 
   meta = {
+    changelog = "https://github.com/OpenPrinting/foomatic-db-nonfree/blob/${src.rev}/ChangeLog";
     description = "OpenPrinting printer support database (unfree content)";
     downloadPage = "https://www.openprinting.org/download/foomatic/";
     homepage = "https://openprinting.github.io/projects/02-foomatic/";

--- a/pkgs/misc/cups/drivers/foomatic-db/default.nix
+++ b/pkgs/misc/cups/drivers/foomatic-db/default.nix
@@ -11,7 +11,7 @@
 , patchPpdFilesHook
 }:
 
-stdenv.mkDerivation {
+stdenv.mkDerivation rec {
   pname = "foomatic-db";
   version = "unstable-2022-10-03";
 
@@ -79,6 +79,7 @@ stdenv.mkDerivation {
   '';
 
   meta = {
+    changelog = "https://github.com/OpenPrinting/foomatic-db/blob/${src.rev}/ChangeLog";
     description = "OpenPrinting printer support database (free content)";
     downloadPage = "https://www.openprinting.org/download/foomatic/";
     homepage = "https://openprinting.github.io/projects/02-foomatic/";

--- a/pkgs/misc/cups/drivers/foomatic-db/default.nix
+++ b/pkgs/misc/cups/drivers/foomatic-db/default.nix
@@ -13,15 +13,15 @@
 
 stdenv.mkDerivation rec {
   pname = "foomatic-db";
-  version = "unstable-2022-10-03";
+  version = "unstable-2023-03-30";
 
   src = fetchFromGitHub {
     # there is also a daily snapshot at the `downloadPage`,
     # but it gets deleted quickly and would provoke 404 errors
     owner = "OpenPrinting";
     repo = "foomatic-db";
-    rev = "2a3c4d1bf7eadc42f936ce8989c1dd2973ea9669";
-    hash = "sha256-in0/j1nAQvM0NowBIBx3jj5WVMPIfZAeAk1SkuA3tjA=";
+    rev = "d883a215dc062e478c64d4e2eee9b0e39e6c629d";
+    hash = "sha256-eFgHTbj4pNfLG2ftU29FQ8rgRMbX+44UytfoZ4vdgZ4=";
   };
 
   buildInputs = [ cups cups-filters ghostscript gnused perl ];
@@ -94,7 +94,7 @@ stdenv.mkDerivation rec {
       PPD files generated from the XML files in this package
       are contained in the package 'foomatic-db-ppds'.
       Besides the XML files, this package contains
-      about 6,600 PPD files, for printers from
+      about 6,700 PPD files, for printers from
       Brother, Canon, Epson, Gestetner, HP, InfoPrint,
       Infotec, KONICA_MINOLTA, Kyocera, Lanier, Lexmark, NRG,
       Oce, Oki, Ricoh, Samsung, Savin, Sharp, Toshiba and Utax.


### PR DESCRIPTION
###### Description of changes

Routine update, introduces a couple of ppd files for Ricoh printers.

Also adds `meta.changelog` for `foomatic-db{,-nonfree,-engine}`.


###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).


###### Result of `nixpkgs-review` run on x86_64-linux [1](https://github.com/Mic92/nixpkgs-review)

<details>
  <summary>3 packages built:</summary>
  <ul>
    <li>foomatic-db</li>
    <li>foomatic-db-ppds</li>
    <li>foomatic-db-ppds-withNonfreeDb</li>
  </ul>
</details>
