### PR TITLE
svtplay-dl: 4.14 -> 4.20

### DIFF
--- a/pkgs/tools/misc/svtplay-dl/default.nix
+++ b/pkgs/tools/misc/svtplay-dl/default.nix
@@ -15,7 +15,7 @@ let
     python pytest nose cryptography pyyaml requests mock requests-mock
     python-dateutil setuptools;
 
-  version = "4.19";
+  version = "4.20";
 
 in
 
@@ -27,7 +27,7 @@ stdenv.mkDerivation rec {
     owner = "spaam";
     repo = "svtplay-dl";
     rev = version;
-    sha256 = "sha256-gGerRiFqfd6w3lDEN0z0SQkXuRxedagF8jWyT8tZmTs=";
+    sha256 = "sha256-nG4ErqQC7GZDLClqcE3cliXxowzCku/SnB39AVIqkNw=";
   };
 
   pythonPaths = [ cryptography pyyaml requests ];

--- a/pkgs/tools/misc/svtplay-dl/default.nix
+++ b/pkgs/tools/misc/svtplay-dl/default.nix
@@ -15,7 +15,7 @@ let
     python pytest nose cryptography pyyaml requests mock requests-mock
     python-dateutil setuptools;
 
-  version = "4.14";
+  version = "4.19";
 
 in
 
@@ -27,7 +27,7 @@ stdenv.mkDerivation rec {
     owner = "spaam";
     repo = "svtplay-dl";
     rev = version;
-    sha256 = "sha256-jfrzgWlEoct8BJLkteWlYjXR/D4J+ShQhsNPBCN+zeQ=";
+    sha256 = "sha256-gGerRiFqfd6w3lDEN0z0SQkXuRxedagF8jWyT8tZmTs=";
   };
 
   pythonPaths = [ cryptography pyyaml requests ];


### PR DESCRIPTION
Changed version number and sha256.

###### Description of changes
4.14 will not work with svt.se as they have implemented changes, 4.20 solves the problem.
Changelog: https://svtplay-dl.se/archive/

Release note for 4.20 is as follows:
- tv4: it should work again.
- svt: it should work again.
- urplay: they added 1080p video.
- svtplay: when we cant find any season number for a series, use the year instead.
- subtitles: some videos on svtplay have encrypted substitles. it should work now.
- utils.http: increase number of headers
- Update user-agent to something newer
- svtplay: improve detection of episode number
- stream.resolution: using config the value is int


###### Things done

- Built on platform(s)
  - [x] x86_64-linux

- [x] Tested, as applicable:
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev 
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
