### PR TITLE
mailutils: fix testsuite failure caused by unsupported weak hashes

### DIFF
--- a/pkgs/tools/networking/mailutils/default.nix
+++ b/pkgs/tools/networking/mailutils/default.nix
@@ -23,6 +23,7 @@
 , sasl
 , system-sendmail
 , libxcrypt
+, mkpasswd
 
 , pythonSupport ? true
 , guileSupport ? true
@@ -79,6 +80,9 @@ stdenv.mkDerivation rec {
       url = "https://lists.gnu.org/archive/html/bug-mailutils/2020-11/txtiNjqcNpqOk.txt";
       sha256 = "0ghzqb8qx2q8cffbvqzw19mivv7r5f16whplzhm7hdj0j2i6xf6s";
     })
+    # https://github.com/NixOS/nixpkgs/issues/223967
+    # https://lists.gnu.org/archive/html/bug-mailutils/2023-04/msg00000.html
+    ./don-t-use-descrypt-password-in-the-test-suite.patch
   ];
 
   enableParallelBuilding = true;
@@ -94,7 +98,7 @@ stdenv.mkDerivation rec {
   ] ++ lib.optional (!pythonSupport) "--without-python"
     ++ lib.optional (!guileSupport) "--without-guile";
 
-  nativeCheckInputs = [ dejagnu ];
+  nativeCheckInputs = [ dejagnu mkpasswd ];
   doCheck = !stdenv.isDarwin; # ERROR: All 46 tests were run, 46 failed unexpectedly.
   doInstallCheck = false; # fails
 

--- a/pkgs/tools/networking/mailutils/don-t-use-descrypt-password-in-the-test-suite.patch
+++ b/pkgs/tools/networking/mailutils/don-t-use-descrypt-password-in-the-test-suite.patch
@@ -1,0 +1,59 @@
+From 59a1abfa7b339bccfc228f38cc791cdacf4010d4 Mon Sep 17 00:00:00 2001
+From: Michal Sojka <michal.sojka@cvut.cz>
+Date: Sat, 1 Apr 2023 10:59:00 +0200
+Subject: [PATCH] Don't use descrypt password in the test suite
+
+The descrypt method is not considered strong and some
+distributions (like NixOS) start compiling libxcrypt without it [1].
+
+To start using different hash methods, it is not sufficient to replace
+the password hash in testsuite/etc/passwd.in, because differently
+hashed passwords contain '$' characters (e.g.
+$y$j9T$lP8UWS9GZ4zfeTVDpmtbr1$dVozXOvWQXLQyhWGX7YyW8TIQTg8EfQLUzYPp3WCWo9)
+and the test suite replaces '$'-starting strings with values of the
+corresponding variables. Since I've not found a way to escape dollars
+for TCL's subst function, we do not hardcode the passwd hash directly
+to the file, but generate it dynamically and replace it in the file
+via a variable.
+
+[1]: https://github.com/NixOS/nixpkgs/pull/220557
+---
+ pop3d/testsuite/lib/pop3d.exp | 1 +
+ testsuite/etc/passwd.in       | 2 +-
+ testsuite/lib/mailutils.exp   | 1 +
+ 3 files changed, 3 insertions(+), 1 deletion(-)
+
+diff --git a/pop3d/testsuite/lib/pop3d.exp b/pop3d/testsuite/lib/pop3d.exp
+index 930861d8a..3b67844d2 100644
+--- a/pop3d/testsuite/lib/pop3d.exp
++++ b/pop3d/testsuite/lib/pop3d.exp
+@@ -26,6 +26,7 @@ if ![mu_check_capability ENABLE_VIRTUAL_DOMAINS] {
+ }
+ 
+ set POP3D_ETC_DIR "$MU_DATA_DIR/etc"
++set MU_PASSWD_HASH [exec mkpasswd --method=yescrypt guessme]
+ mu_makespool "$MU_RC_DIR" "$POP3D_ETC_DIR"
+ mu_create_config pop3d
+ 
+diff --git a/testsuite/etc/passwd.in b/testsuite/etc/passwd.in
+index c4e471b09..b13a75238 100644
+--- a/testsuite/etc/passwd.in
++++ b/testsuite/etc/passwd.in
+@@ -1 +1 @@
+-user:abld/G2Q2Le2w:1000:1000:Test User:$MU_SPOOL_DIR:/bin/sh
++user:$MU_PASSWD_HASH:1000:1000:Test User:$MU_SPOOL_DIR:/bin/sh
+diff --git a/testsuite/lib/mailutils.exp b/testsuite/lib/mailutils.exp
+index e4d45c85b..725ccf259 100644
+--- a/testsuite/lib/mailutils.exp
++++ b/testsuite/lib/mailutils.exp
+@@ -39,6 +39,7 @@ proc mu_copy_file {src dst} {
+     global MU_FOLDER_DIR
+     global MU_RC_DIR 
+     global MU_DATA_DIR
++    global MU_PASSWD_HASH
+     
+     set input [open $src r]
+     set output [open $dst w]
+-- 
+2.39.2
+


### PR DESCRIPTION
###### Description of changes

Alternative to #224194 with proper patch. I've also sent the patch to mailutils mailing list. Once it appears in their archives, I'll link the patch from there.

Fixes #223967. 
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
