### PR TITLE
iptables: 1.8.8 -> 1.8.9; fix static

### DIFF
--- a/pkgs/os-specific/linux/iptables/default.nix
+++ b/pkgs/os-specific/linux/iptables/default.nix
@@ -5,29 +5,19 @@
 }:
 
 stdenv.mkDerivation rec {
-  version = "1.8.8";
+  version = "1.8.9";
   pname = "iptables";
 
   src = fetchurl {
-    url = "https://www.netfilter.org/projects/${pname}/files/${pname}-${version}.tar.bz2";
-    sha256 = "sha256-ccdYidxxBnZjFVPrFRHaAXe7qvG1USZbkS0jbD9RhZ8=";
+    url = "https://www.netfilter.org/projects/${pname}/files/${pname}-${version}.tar.xz";
+    sha256 = "72Y5pDvoMlpPjqaBI/+sI2y2lujHhQG2ToEGr7AIyH8=";
   };
 
   patches = [
-    # xshared: Fix build for -Werror=format-security
     (fetchpatch {
-      url = "https://git.netfilter.org/iptables/patch/?id=b72eb12ea5a61df0655ad99d5048994e916be83a";
-      sha256 = "sha256-pnamqOagwNWoiwlxPnKCqSc2N7MP/eZlT7JiE09c8OE=";
-    })
-    # treewide: use uint* instead of u_int*
-    (fetchpatch {
-      url = "https://git.netfilter.org/iptables/patch/?id=f319389525b066b7dc6d389c88f16a0df3b8f189";
-      sha256 = "sha256-rOxCEWZoI8Ac5fQDp286YHAwvreUAoDVAbomboKrGyM=";
-    })
-    # fix Musl build
-    (fetchpatch {
-      url = "https://git.netfilter.org/iptables/patch/?id=0e7cf0ad306cdf95dc3c28d15a254532206a888e";
-      sha256 = "18mnvqfxzd7ifq3zjb4vyifcyadpxdi8iqcj8wsjgw23n49lgrbj";
+      name = "format-security.patch";
+      url = "https://git.netfilter.org/iptables/patch/?id=ed4082a7405a5838c205a34c1559e289949200cc";
+      sha256 = "OdytFmHk+3Awu+sDQpGTl5/qip4doRblmW2vQzfNZiU=";
     })
   ];
 

--- a/pkgs/os-specific/linux/iptables/default.nix
+++ b/pkgs/os-specific/linux/iptables/default.nix
@@ -1,4 +1,5 @@
-{ lib, stdenv, fetchurl, pkg-config, pruneLibtoolFiles, flex, bison
+{ lib, stdenv, fetchurl
+, autoreconfHook, pkg-config, pruneLibtoolFiles, flex, bison
 , libmnl, libnetfilter_conntrack, libnfnetlink, libnftnl, libpcap
 , nftablesCompat ? true
 , fetchpatch
@@ -19,11 +20,18 @@ stdenv.mkDerivation rec {
       url = "https://git.netfilter.org/iptables/patch/?id=ed4082a7405a5838c205a34c1559e289949200cc";
       sha256 = "OdytFmHk+3Awu+sDQpGTl5/qip4doRblmW2vQzfNZiU=";
     })
+    (fetchurl {
+      name = "static.patch";
+      url = "https://lore.kernel.org/netfilter-devel/20230402232939.1060151-1-hi@alyssa.is/raw";
+      sha256 = "PkH+1HbJjBb3//ffBe0XUQok1lBwgj/STL8Ppu/28f4=";
+    })
   ];
 
   outputs = [ "out" "dev" "man" ];
 
-  nativeBuildInputs = [ pkg-config pruneLibtoolFiles flex bison ];
+  nativeBuildInputs = [
+    autoreconfHook pkg-config pruneLibtoolFiles flex bison
+  ];
 
   buildInputs = [ libmnl libnetfilter_conntrack libnfnetlink libnftnl libpcap ];
 


### PR DESCRIPTION
###### Description of changes

As a result of https://github.com/NixOS/nixpkgs/pull/221476, the static build started to fail, because iptables didn't know to link with libnl.  The patch makes iptables use pkg-config to find libpcap, which means it knows about other libraries that need to be linked when doing a static build.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
