### PR TITLE
victoriametrics: 1.84.0 -> 1.89.1, add `meta.mainProgram`

### DIFF
--- a/pkgs/servers/nosql/victoriametrics/default.nix
+++ b/pkgs/servers/nosql/victoriametrics/default.nix
@@ -42,5 +42,6 @@ buildGoModule rec {
     license = licenses.asl20;
     maintainers = with maintainers; [ yorickvp ivan ];
     changelog = "https://github.com/VictoriaMetrics/VictoriaMetrics/releases/tag/v${version}";
+    mainProgram = "victoria-metrics";
   };
 }

--- a/pkgs/servers/nosql/victoriametrics/default.nix
+++ b/pkgs/servers/nosql/victoriametrics/default.nix
@@ -2,16 +2,16 @@
 
 buildGoModule rec {
   pname = "VictoriaMetrics";
-  version = "1.84.0";
+  version = "1.89.1";
 
   src = fetchFromGitHub {
     owner = pname;
     repo = pname;
     rev = "v${version}";
-    sha256 = "sha256-94QhjsCow1Ate/Bbia7KpWY3WgHk3oOarAY95Fq75hU=";
+    hash = "sha256-s5Fo0Bsy9cAoNLRMAYjNrSLJ0vX4HdbQ+T3cj6ebNPE=";
   };
 
-  vendorSha256 = null;
+  vendorHash = null;
 
   postPatch = ''
     # main module (github.com/VictoriaMetrics/VictoriaMetrics) does not contain package
@@ -23,10 +23,16 @@ buildGoModule rec {
     # Increase timeouts in tests to prevent failure on heavily loaded builders
     substituteInPlace lib/storage/storage_test.go \
       --replace "time.After(10 " "time.After(120 " \
-      --replace "time.After(30 " "time.After(120 "
+      --replace "time.NewTimer(30 " "time.NewTimer(120 " \
+      --replace "time.NewTimer(time.Second * 10)" "time.NewTimer(time.Second * 120)" \
   '';
 
   ldflags = [ "-s" "-w" "-X github.com/VictoriaMetrics/VictoriaMetrics/lib/buildinfo.Version=${version}" ];
+
+  preCheck = ''
+    # `lib/querytracer/tracer_test.go` expects `buildinfo.Version` to be unset
+    export ldflags=''${ldflags//=${version}/=}
+  '';
 
   passthru.tests = { inherit (nixosTests) victoriametrics; };
 


### PR DESCRIPTION
###### Description of changes
   
https://github.com/VictoriaMetrics/VictoriaMetrics/releases/tag/v1.89.1
https://github.com/VictoriaMetrics/VictoriaMetrics/releases/tag/v1.89.0
https://github.com/VictoriaMetrics/VictoriaMetrics/releases/tag/v1.88.1
https://github.com/VictoriaMetrics/VictoriaMetrics/releases/tag/v1.88.0
https://github.com/VictoriaMetrics/VictoriaMetrics/releases/tag/v1.87.4 (LTS, not sure if relevant)
https://github.com/VictoriaMetrics/VictoriaMetrics/releases/tag/v1.87.3 (LTS, not sure if relevant)
https://github.com/VictoriaMetrics/VictoriaMetrics/releases/tag/v1.87.2 (LTS, not sure if relevant)
https://github.com/VictoriaMetrics/VictoriaMetrics/releases/tag/v1.87.1 (LTS, not sure if relevant)
https://github.com/VictoriaMetrics/VictoriaMetrics/releases/tag/v1.87.0 (LTS, not sure if relevant)
https://github.com/VictoriaMetrics/VictoriaMetrics/releases/tag/v1.86.2 (very tiny security fix)
https://github.com/VictoriaMetrics/VictoriaMetrics/releases/tag/v1.86.1
https://github.com/VictoriaMetrics/VictoriaMetrics/releases/tag/v1.86.0
https://github.com/VictoriaMetrics/VictoriaMetrics/releases/tag/v1.85.3
https://github.com/VictoriaMetrics/VictoriaMetrics/releases/tag/v1.85.2
https://github.com/VictoriaMetrics/VictoriaMetrics/releases/tag/v1.85.1
https://github.com/VictoriaMetrics/VictoriaMetrics/releases/tag/v1.85.0
diff: https://github.com/VictoriaMetrics/VictoriaMetrics/compare/v1.84.0...v1.89.1

`lib/querytracer/tracer.go` uses `buildinfo.Version`, but its tests expect that value to be unset, which is why I had to add that preCheck phase.
Context:
https://github.com/VictoriaMetrics/VictoriaMetrics/commit/49ebc488094bfe637c01a56e7c39c4af08a6f731
https://github.com/VictoriaMetrics/VictoriaMetrics/commit/3019ec3da6404424ef1508a503b628f181b43468
https://github.com/VictoriaMetrics/VictoriaMetrics/commit/8434aa142d9fbf3a12c5277c77a6155f5efe0609

Also, `lib/storage/storage_test.go` switched to `time.NewTimer` in some places.

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).