### PR TITLE
proteus: init at 1.2

### DIFF
--- a/pkgs/applications/audio/proteus/default.nix
+++ b/pkgs/applications/audio/proteus/default.nix
@@ -1,0 +1,52 @@
+{ lib, stdenv, fetchFromGitHub, autoPatchelfHook, cmake, pkg-config
+, alsa-lib, freetype, libjack2
+, libX11, libXext, libXcursor, libXinerama, libXrandr, libXrender
+}:
+
+stdenv.mkDerivation rec {
+  pname = "proteus";
+  version = "1.2";
+
+  src = fetchFromGitHub {
+    owner = "GuitarML";
+    repo = "Proteus";
+    rev = "v${version}";
+    fetchSubmodules = true;
+    hash = "sha256-WhJh+Sx64JYxQQ1LXpDUwXeodFU1EZ0TmMhn+6w0hQg=";
+  };
+
+  nativeBuildInputs = [ autoPatchelfHook cmake pkg-config ];
+  buildInputs = [
+    alsa-lib freetype libjack2
+    libX11 libXext libXcursor libXinerama libXrandr libXrender
+  ];
+  # JUCE loads most dependencies at runtime:
+  runtimeDependencies = map lib.getLib buildInputs;
+
+  env.NIX_CFLAGS_COMPILE = toString [
+    # Support JACK output in the standalone application:
+    "-DJUCE_JACK"
+    # Accomodate -flto:
+    "-ffat-lto-objects"
+  ];
+
+  # The default "make install" only installs JUCE, which should not be installed, and does not install proteus.
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/lib
+    cp -rT Proteus_artefacts/*/Standalone $out/bin
+    cp -rT Proteus_artefacts/*/LV2 $out/lib/lv2
+    cp -rT Proteus_artefacts/*/VST3 $out/lib/vst3
+
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    description = "Guitar amp and pedal capture plugin using neural networks";
+    homepage = "https://github.com/GuitarML/Proteus";
+    license = licenses.gpl3;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ orivej ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -32913,6 +32913,8 @@ with pkgs;
 
   properties-cpp = callPackage ../development/libraries/properties-cpp { };
 
+  proteus = callPackage ../applications/audio/proteus { };
+
   protonmail-bridge = callPackage ../applications/networking/protonmail-bridge {
     buildGoModule = buildGo119Module; # go 1.20 build failure
   };


### PR DESCRIPTION
###### Description of changes

A good sounding guitar distortion plugin with many captured presets and the ability to capture your own equipment.

https://github.com/GuitarML/Proteus/
https://guitarml.com/

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
