### PR TITLE
hex-a-hop: init at 1.1.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -12728,6 +12728,13 @@
     githubId = 14829269;
     name = "Ram Kromberg";
   };
+  rampoina = {
+    email = "rampoina@protonmail.com";
+    matrix = "@rampoina:matrix.org";
+    github = "Rampoina";
+    githubId = 5653911;
+    name = "Rampoina";
+  };
   ranfdev = {
     email = "ranfdev@gmail.com";
     name = "Lorenzo Miglietta";

--- a/pkgs/games/hex-a-hop/default.nix
+++ b/pkgs/games/hex-a-hop/default.nix
@@ -1,0 +1,45 @@
+{ lib, stdenv, fetchurl, fetchzip, SDL, SDL_mixer, SDL_ttf }:
+
+stdenv.mkDerivation rec {
+  pname = "hex-a-hop";
+  version = "1.1.0";
+
+  src = fetchzip {
+    url = "https://downloads.sourceforge.net/project/hexahop/${version}/hex-a-hop-${version}.tar.gz";
+    sha256 = "sha256-fBSvNtgNR0aNofbvoYpM1e8ww4ARlXIvrQUvJqVGLlY=";
+  };
+
+  icon = fetchurl {
+    # Fetched from dfa365a90be5c52ef21235a9e90a865b04da3ad4, remove in the next version when the file is included
+    url = "https://sourceforge.net/p/hexahop/code/ci/dfa365a90be5c52ef21235a9e90a865b04da3ad4/tree/data/hex-a-hop.png?format=raw";
+    sha256 = "sha256-Vh/1wwRmC2eSD/+mk1Oqt7EX4a4k++nUAbWQD2P2hNA=";
+  };
+
+  desktop = fetchurl {
+    # Fetched from e67385078e4f248a3877ee1066613d231c0d0eee, remove in the next version when the file is included
+    url = "https://sourceforge.net/p/hexahop/code/ci/e67385078e4f248a3877ee1066613d231c0d0eee/tree/data/hex-a-hop.desktop?format=raw";
+    sha256 = "sha256-j6gKRq+8b1NDwP1WcCaScfmwNxAl78CfK6pemROrRak=";
+  };
+
+  buildInputs = [ SDL SDL_mixer SDL_ttf ];
+
+  makeFlags = [ "PREFIX=$(out)" ];
+
+  postFixup = ''
+    install -Dm644 ${icon} $out/share/icons/${pname}.png
+    install -Dm644 ${desktop} $out/share/applications/${pname}.desktop
+  '';
+
+  meta = {
+    description = "A puzzle game based on hexagonal tiles";
+    homepage = "http://hexahop.sourceforge.net";
+    license = with lib.licenses; [
+      gpl2Plus # Main code
+      cc-by-30 # Assets
+      lgpl2Plus # i18n
+      lgpl3Plus # source files from Lips of Suna
+    ];
+    platforms = lib.platforms.linux;
+    maintainers = with lib.maintainers; [ rampoina ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -30737,6 +30737,8 @@ with pkgs;
 
   herbstluftwm = callPackage ../applications/window-managers/herbstluftwm { };
 
+  hex-a-hop = callPackage ../games/hex-a-hop { };
+
   hexchat = callPackage ../applications/networking/irc/hexchat { };
 
   hexcurse = callPackage ../applications/editors/hexcurse { };


### PR DESCRIPTION
###### Description of changes
Package the [hex-a-hop](https://hexahop.sourceforge.net/) game

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).