### PR TITLE
python3.pkgs.jinja2: build offline documentation

### DIFF
--- a/pkgs/applications/misc/privacyidea/default.nix
+++ b/pkgs/applications/misc/privacyidea/default.nix
@@ -51,7 +51,7 @@ let
         doCheck = false;
       });
       # Required by flask-1.1
-      jinja2 = super.jinja2.overridePythonAttrs (old: rec {
+      jinja2 = (super.jinja2.override { enableDocumentation = false; }).overridePythonAttrs (old: rec {
         version = "2.11.3";
         src = old.src.override {
           inherit version;

--- a/pkgs/development/python-modules/jinja2/default.nix
+++ b/pkgs/development/python-modules/jinja2/default.nix
@@ -6,11 +6,17 @@
 , babel
 , markupsafe
 , pytestCheckHook
+, sphinxHook
+, pallets-sphinx-themes
+, sphinxcontrib-log-cabinet
+, sphinx-issues
+, enableDocumentation ? true
 }:
 
 buildPythonPackage rec {
   pname = "Jinja2";
   version = "3.1.2";
+  outputs = [ "out" ] ++ lib.optional enableDocumentation "doc";
 
   disabled = pythonOlder "3.7";
 
@@ -19,9 +25,18 @@ buildPythonPackage rec {
     hash = "sha256-MTUacCpAip51laj8YVD8P0O7a/fjGXcMvA2535Q36FI=";
   };
 
+  patches = lib.optionals enableDocumentation [ ./patches/import-order.patch ];
+
   propagatedBuildInputs = [
     babel
     markupsafe
+  ];
+
+  nativeBuildInputs = lib.optionals enableDocumentation [
+    sphinxHook
+    sphinxcontrib-log-cabinet
+    pallets-sphinx-themes
+    sphinx-issues
   ];
 
   # Multiple tests run out of stack space on 32bit systems with python2.

--- a/pkgs/development/python-modules/jinja2/patches/import-order.patch
+++ b/pkgs/development/python-modules/jinja2/patches/import-order.patch
@@ -1,0 +1,27 @@
+Sphinx changed something between sphinx=4.5.0 and sphinx=5.3 that broke
+"sphinxcontrib.log_cabinet" plugin.
+
+When Sphinx tries to importlib.import_module("sphinxcontrib.log_cabinet"), it
+has couple other sphinxcontrib.* libraries in sys.path, and they seem to cause
+conflict. So here I purge sys.path from sphixcontrib-related things, import
+log_cabinet and put everything back, so when Sphinx will do "import_module",
+"sphinxcontrib.log_cabinet" will be already imported and cached.
+
+All this is quite hacky, but we are talking about merely building documentation
+here. If resulting html looks good, what happened in Nix sandbox stays in Nix
+sandbox.
+
+--- a/docs/conf.py	1970-01-01 00:00:00.000000000 -0000
++++ b/docs/conf.py	1970-01-01 00:00:00.000000000 -0000
+@@ -1,5 +1,12 @@
+ from pallets_sphinx_themes import get_version
+ from pallets_sphinx_themes import ProjectLink
++import importlib
++import sys
++
++saved_path = sys.path
++sys.path = [x for x in sys.path if "sphinxcontrib" not in x or "cabinet" in x]
++import sphinxcontrib.log_cabinet
++sys.path = saved_path
+ 
+ # Project --------------------------------------------------------------

--- a/pkgs/development/python-modules/sphinx-issues/default.nix
+++ b/pkgs/development/python-modules/sphinx-issues/default.nix
@@ -1,0 +1,36 @@
+{ lib, buildPythonPackage, sphinx, fetchFromGitHub, pandoc }:
+
+buildPythonPackage rec {
+  pname = "sphinx-issues";
+  version = "3.0.1";
+  outputs = [ "out" "doc" ];
+
+  src = fetchFromGitHub {
+    owner = "sloria";
+    repo = "sphinx-issues";
+    rev = version;
+    sha256 = "1lns6isq9kwcw8z4jwgy927f7idx9srvri5adaa5zmypw5x47hha";
+  };
+
+  pythonImportsCheck = [ "sphinx_issues" ];
+
+  propagatedBuildInputs = [ sphinx ];
+
+  nativeBuildInputs = [ pandoc ];
+
+  postBuild = ''
+    pandoc -f rst -t html --standalone < README.rst > README.html
+  '';
+
+  postInstall = ''
+    mkdir -p $doc/share/doc/$name/html
+    cp README.html $doc/share/doc/$name/html
+  '';
+
+  meta = with lib; {
+    homepage = "https://github.com/sloria/sphinx-issues";
+    description = "Sphinx extension for linking to your project's issue tracker.";
+    license = licenses.mit;
+    maintainers = with maintainers; [ kaction ];
+  };
+}

--- a/pkgs/development/python-modules/sphinx/default.nix
+++ b/pkgs/development/python-modules/sphinx/default.nix
@@ -64,7 +64,7 @@ buildPythonPackage rec {
     alabaster
     docutils
     imagesize
-    jinja2
+    (jinja2.override { enableDocumentation = false; })
     packaging
     pygments
     requests

--- a/pkgs/development/python-modules/sphinxcontrib-log-cabinet/default.nix
+++ b/pkgs/development/python-modules/sphinxcontrib-log-cabinet/default.nix
@@ -1,0 +1,27 @@
+{ lib, buildPythonPackage, fetchFromGitHub, sphinx }:
+
+buildPythonPackage rec {
+  pname = "sphinxcontrib-log-cabinet";
+  version = "1.0.1";
+  format = "setuptools";
+
+  src = fetchFromGitHub {
+    owner = "davidism";
+    repo = "sphinxcontrib-log-cabinet";
+    rev = "refs/tags/${version}";
+    sha256 = "03cxspgqsap9q74sqkdx6r6b4gs4hq6dpvx4j58hm50yfhs06wn1";
+  };
+
+  propagatedBuildInputs = [ sphinx ];
+
+  pythonImportsCheck = [ "sphinxcontrib.log_cabinet" ];
+
+  doCheck = false; # no tests
+
+  meta = with lib; {
+    homepage = "https://github.com/davidism/sphinxcontrib-log-cabinet";
+    description = "Sphinx extension to organize changelogs";
+    license = licenses.mit;
+    maintainers = with maintainers; [ kaction ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -11168,6 +11168,8 @@ self: super: with self; {
 
   sphinx-inline-tabs = callPackage ../development/python-modules/sphinx-inline-tabs { };
 
+  sphinx-issues = callPackage ../development/python-modules/sphinx-issues { };
+
   sphinx-jinja = callPackage ../development/python-modules/sphinx-jinja { };
 
   sphinx-markdown-parser = callPackage ../development/python-modules/sphinx-markdown-parser { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -11122,6 +11122,8 @@ self: super: with self; {
     inherit (pkgs) mscgen;
   };
 
+  sphinxcontrib-log-cabinet = callPackage ../development/python-modules/sphinxcontrib-log-cabinet { };
+
   sphinxcontrib-nwdiag = callPackage ../development/python-modules/sphinxcontrib-nwdiag { };
 
   sphinxcontrib_newsfeed = callPackage ../development/python-modules/sphinxcontrib_newsfeed { };


### PR DESCRIPTION
- python3.pkgs.sphinxcontrib-log-cabinet: init at 1.0.1
- python3.pkgs.sphinx-issues: init at 3.0.1
- python3.pkgs.jinja2: build offline documentation
