### PR TITLE
neovim.tests.nvim_with_opt_plugin: fixed

### DIFF
--- a/pkgs/applications/editors/neovim/tests/default.nix
+++ b/pkgs/applications/editors/neovim/tests/default.nix
@@ -58,12 +58,12 @@ let
   };
 
   # this plugin checks that it's ftplugin/vim.tex is loaded before $VIMRUNTIME/ftplugin/vim.tex
-  # the answer is store in `plugin_was_loaded_too_late` in the cwd
+  # $VIMRUNTIME/ftplugin/vim.tex sources $VIMRUNTIME/ftplugin/initex.vim which sets b:did_ftplugin
+  # we save b:did_ftplugin's value in a `plugin_was_loaded_too_late` file
   texFtplugin = (pkgs.runCommandLocal "tex-ftplugin" {} ''
     mkdir -p $out/ftplugin
-    echo 'call system("echo ". exists("b:did_ftplugin") . " > plugin_was_loaded_too_late")' > $out/ftplugin/tex.vim
+    echo 'call system("echo ". exists("b:did_ftplugin") . " > plugin_was_loaded_too_late")' >> $out/ftplugin/tex.vim
     echo ':q!' >> $out/ftplugin/tex.vim
-    echo '\documentclass{article}' > $out/main.tex
   '') // { pname = "test-ftplugin"; };
 
   # neovim-drv must be a wrapped neovim
@@ -141,10 +141,12 @@ rec {
   # files from $VIMRUNTIME
   run_nvim_with_ftplugin = runTest nvim_with_ftplugin ''
     export HOME=$TMPDIR
-    ${nvim_with_ftplugin}/bin/nvim ${texFtplugin}/main.tex
-    result="$(cat plugin_was_loaded_too_late)"
-    echo $result
-    [ "$result" = 0 ]
+    echo '\documentclass{article}' > main.tex
+
+    ${nvim_with_ftplugin}/bin/nvim main.tex -c "set ft?" -c quit
+    ls -l $TMPDIR
+    # if the file exists, then our plugin has been loaded instead of neovim's
+    [ ! -f plugin_was_loaded_too_late ]
   '';
 
 
@@ -169,7 +171,7 @@ rec {
 
   nvim_with_gitsigns_plugin = neovim.override {
     extraName = "-with-gitsigns-plugin";
-   configure.packages.plugins = {
+    configure.packages.plugins = {
       start = [
         vimPlugins.gitsigns-nvim
       ];

--- a/pkgs/applications/editors/neovim/tests/default.nix
+++ b/pkgs/applications/editors/neovim/tests/default.nix
@@ -169,7 +169,7 @@ rec {
 
   nvim_with_gitsigns_plugin = neovim.override {
     extraName = "-with-gitsigns-plugin";
-    configure.packages.plugins = {
+   configure.packages.plugins = {
       start = [
         vimPlugins.gitsigns-nvim
       ];
@@ -260,13 +260,12 @@ rec {
       packadd dashboard-nvim-unique-for-tests-please-dont-use-opt
 
       " Try to run Dashboard again, and throw if it fails
-      try
-        Dashboard
-        echo "Dashboard found"
-      catch /^Vim\%((\a\+)\)\=:E492/
+      let res = exists(':Dashboard')
+      if res == 0
         echo "Dashboard not found, throwing error"
         cquit 1
-      endtry
+      endif
+      cquit 0
     '';
   };
 


### PR DESCRIPTION
once :Dashboard succeeded, the script would close neovim and thus never
terminate. We instead check if the command ":Dashboard" exists.

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
