### PR TITLE
neovim: more flexibility in startup commands

### DIFF
--- a/pkgs/applications/editors/neovim/utils.nix
+++ b/pkgs/applications/editors/neovim/utils.nix
@@ -77,18 +77,6 @@ let
 
       luaEnv = neovim-unwrapped.lua.withPackages(extraLuaPackages);
 
-      # Mapping a boolean argument to a key that tells us whether to add or not to
-      # add to nvim's 'embedded rc' this:
-      #    let g:<key>_host_prog=$out/bin/nvim-<key>
-      # Or this:
-      #    let g:loaded_${prog}_provider=0
-      # While the latter tells nvim that this provider is not available
-      hostprog_check_table = {
-        node = withNodeJs;
-        python = false;
-        python3 = withPython3;
-        ruby = withRuby;
-      };
       # as expected by packdir
       packpathDirs.myNeovimPackages = myVimPackage;
       ## Here we calculate all of the arguments to the 1st call of `makeWrapper`
@@ -98,22 +86,9 @@ let
       makeWrapperArgs =
         let
           binPath = lib.makeBinPath (lib.optionals withRuby [ rubyEnv ] ++ lib.optionals withNodeJs [ nodejs ]);
-
-          hostProviderViml = lib.mapAttrsToList genProviderSettings hostprog_check_table;
-
-          # as expected by packdir
-          packDirArgs.myNeovimPackages = myVimPackage;
-
-          # vim accepts a limited number of commands so we join them all
-          flags = [
-            "--cmd" (lib.intersperse "|" hostProviderViml)
-          ] ++ lib.optionals (myVimPackage.start != [] || myVimPackage.opt != []) [
-            "--cmd" "set packpath^=${vimUtils.packDir packDirArgs}"
-            "--cmd" "set rtp^=${vimUtils.packDir packDirArgs}"
-          ];
         in
         [
-          "--inherit-argv0" "--add-flags" (lib.escapeShellArgs flags)
+          "--inherit-argv0"
         ] ++ lib.optionals withRuby [
           "--set" "GEM_HOME" "${rubyEnv}/${rubyEnv.ruby.gemPath}"
         ] ++ lib.optionals (binPath != "") [
@@ -144,12 +119,6 @@ let
       inherit rubyEnv;
     };
 
-    genProviderSettings = prog: withProg:
-      if withProg then
-        "let g:${prog}_host_prog='${placeholder "out"}/bin/nvim-${prog}'"
-      else
-        "let g:loaded_${prog}_provider=0"
-    ;
 
   # to keep backwards compatibility for people using neovim.override
   legacyWrapper = neovim: {
@@ -191,9 +160,43 @@ let
       wrapperArgs = lib.escapeShellArgs res.wrapperArgs + " " + extraMakeWrapperArgs;
       wrapRc = (configure != {});
   });
+
+  /* Generate vim.g.<LANG>_host_prog lua rc to setup host providers
+
+  Mapping a boolean argument to a key that tells us whether to add
+      vim.g.<LANG>_host_prog=$out/bin/nvim-<LANG>
+  Or this:
+      let g:loaded_${prog}_provider=0
+  While the latter tells nvim that this provider is not available */
+  generateProviderRc = {
+      withPython3 ? true
+    , withNodeJs ? false
+    , withRuby ? true
+
+    # so that we can pass the full neovim config while ignoring it
+    , ...
+    }: let
+      hostprog_check_table = {
+        node = withNodeJs;
+        python = false;
+        python3 = withPython3;
+        ruby = withRuby;
+      };
+
+      genProviderCommand = prog: withProg:
+        if withProg then
+          "vim.g.${prog}_host_prog='${placeholder "out"}/bin/nvim-${prog}'"
+        else
+          "vim.g.loaded_${prog}_provider=0";
+
+      hostProviderLua = lib.mapAttrsToList genProviderCommand hostprog_check_table;
+    in
+        lib.concatStringsSep ";" hostProviderLua;
+
 in
 {
   inherit makeNeovimConfig;
+  inherit generateProviderRc;
   inherit legacyWrapper;
 
   buildNeovimPluginFrom2Nix = callPackage ./build-neovim-plugin.nix {

--- a/pkgs/applications/editors/neovim/wrapper.nix
+++ b/pkgs/applications/editors/neovim/wrapper.nix
@@ -4,6 +4,8 @@
 , python3
 , python3Packages
 , callPackage
+, neovimUtils
+, vimUtils
 }:
 neovim:
 
@@ -12,6 +14,7 @@ let
       extraName ? ""
     # should contain all args but the binary. Can be either a string or list
     , wrapperArgs ? []
+    # a limited RC script used only to generate the manifest for remote plugins
     , manifestRc ? null
     , withPython2 ? false
     , withPython3 ? true,  python3Env ? python3
@@ -26,11 +29,29 @@ let
     # (e.g., in ~/.config/init.vim or project/.nvimrc)
     , wrapRc ? true
     , neovimRcContent ? ""
+    # entry to load in packpath
+    , packpathDirs
     , ...
   }@args:
   let
 
     wrapperArgsStr = if lib.isString wrapperArgs then wrapperArgs else lib.escapeShellArgs wrapperArgs;
+
+    # "--add-flags" (lib.escapeShellArgs flags)
+    # wrapper args used both when generating the manifest and in the final neovim executable
+    commonWrapperArgs = (lib.optionals (lib.isList wrapperArgs) wrapperArgs)
+      # vim accepts a limited number of commands so we join them all
+          ++ [
+            "--add-flags" ''--cmd "lua ${providerLuaRc}"''
+            # (lib.intersperse "|" hostProviderViml)
+          ] ++ lib.optionals (packpathDirs.myNeovimPackages.start != [] || packpathDirs.myNeovimPackages.opt != []) [
+            "--add-flags" ''--cmd "set packpath^=${vimUtils.packDir packpathDirs}"''
+            "--add-flags" ''--cmd "set rtp^=${vimUtils.packDir packpathDirs}"''
+          ]
+          ;
+
+    providerLuaRc = neovimUtils.generateProviderRc args;
+    # providerLuaRc = "toto";
 
     # If configure != {}, we can't generate the rplugin.vim file with e.g
     # NVIM_SYSTEM_RPLUGIN_MANIFEST *and* NVIM_RPLUGIN_MANIFEST env vars set in
@@ -42,6 +63,7 @@ let
       [ "${neovim}/bin/nvim" "${placeholder "out"}/bin/nvim" ]
       ++ [ "--set" "NVIM_SYSTEM_RPLUGIN_MANIFEST" "${placeholder "out"}/rplugin.vim" ]
       ++ lib.optionals wrapRc [ "--add-flags" "-u ${writeText "init.vim" neovimRcContent}" ]
+      ++ commonWrapperArgs
       ;
   in
   assert withPython2 -> throw "Python2 support has been removed from the neovim wrapper, please remove withPython2 and python2Env.";
@@ -72,7 +94,7 @@ let
       ''
       + lib.optionalString (manifestRc != null) (let
         manifestWrapperArgs =
-          [ "${neovim}/bin/nvim" "${placeholder "out"}/bin/nvim-wrapper" ];
+          [ "${neovim}/bin/nvim" "${placeholder "out"}/bin/nvim-wrapper" ] ++ commonWrapperArgs;
       in ''
         echo "Generating remote plugin manifest"
         export NVIM_RPLUGIN_MANIFEST=$out/rplugin.vim
@@ -116,6 +138,7 @@ let
 
     nativeBuildInputs = [ makeWrapper ];
     passthru = {
+      inherit providerLuaRc packpathDirs;
       unwrapped = neovim;
       initRc = neovimRcContent;
 


### PR DESCRIPTION
the neovim mechanisms generate provider rc configuration such as: vim.g.<LANG>_host_prog=$out/bin/nvim-<LANG>

In home-manager, we want more control over it, e.g., to pass it via command line or in init.lua.

We also want to retrieve the generated packpathDirs so that we can link it in the expected $XDG_DATA_HOME folder so that we then dont have to tell neovim where look for it anymore.


marking as draft until https://github.com/NixOS/nixpkgs/pull/224268 gets merged.
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
