### PR TITLE
nixos/virtualisation/proxmox-image: fix SIGABRT during image generation

### DIFF
--- a/nixos/modules/virtualisation/proxmox-image.nix
+++ b/nixos/modules/virtualisation/proxmox-image.nix
@@ -128,6 +128,15 @@ with lib;
         any specific VMID.
       '';
     };
+    diskSize = mkOption {
+      type = with types; either (enum [ "auto" ]) int;
+      default = "auto";
+      example = 4096;
+      description = lib.mdDoc ''
+        Size of disk image. Unit is MB.
+      '';
+    };
+
   };
 
   config = let
@@ -140,7 +149,8 @@ with lib;
       ${lib.concatStrings (lib.mapAttrsToList cfgLine properties)}
       #qmdump#map:virtio0:drive-virtio0:local-lvm:raw:
     '';
-    inherit (cfg) partitionTableType;
+    inherit (cfg) partitionTableType diskSize;
+
     supportEfi = partitionTableType == "efi" || partitionTableType == "hybrid";
     supportBios = partitionTableType == "legacy" || partitionTableType == "hybrid" || partitionTableType == "legacy+gpt";
     hasBootPartition = partitionTableType == "efi" || partitionTableType == "hybrid";
@@ -166,7 +176,7 @@ with lib;
     ];
     system.build.VMA = import ../../lib/make-disk-image.nix {
       name = "proxmox-${cfg.filenameSuffix}";
-      inherit partitionTableType;
+      inherit partitionTableType diskSize;
       postVM = let
         # Build qemu with PVE's patch that adds support for the VMA format
         vma = (pkgs.qemu_kvm.override {
@@ -207,11 +217,13 @@ with lib;
         });
       in
       ''
-        ${vma}/bin/vma create "vzdump-qemu-${cfg.filenameSuffix}.vma" \
+        ${vma}/bin/vma create "$out/vzdump-qemu-${cfg.filenameSuffix}.vma" \
           -c ${cfgFile "qemu-server.conf" (cfg.qemuConf // cfg.qemuExtraConf)}/qemu-server.conf drive-virtio0=$diskImage
+        ${vma}/bin/vma list "$out/vzdump-qemu-${cfg.filenameSuffix}.vma"
+
         rm $diskImage
-        ${pkgs.zstd}/bin/zstd "vzdump-qemu-${cfg.filenameSuffix}.vma"
-        mv "vzdump-qemu-${cfg.filenameSuffix}.vma.zst" $out/
+        ${pkgs.zstd}/bin/zstd "$out/vzdump-qemu-${cfg.filenameSuffix}.vma"
+        rm "$out/vzdump-qemu-${cfg.filenameSuffix}.vma"
 
         mkdir -p $out/nix-support
         echo "file vma $out/vzdump-qemu-${cfg.filenameSuffix}.vma.zst" >> $out/nix-support/hydra-build-products


### PR DESCRIPTION
### generation of proxmox image bugfix

Error log with actual version:

<pre>
       > vma: ../util/error.c:59: error_setv: Assertion `*errp == NULL' failed.
       > /nix/store/3i2l6psna71r2jacfhm0b3yyki5905f8-vm-run: line 61:  1402 Aborted                 (core dumped) /nix/store/p1653ija0fjqfl6
</pre>

#### bugfix description

<pre>
vma create "vzdump-qemu-nixos-VERSION.dirty.vma" -c /nix/store/HASH-qemu-server.conf/qemu-server.conf drive-virtio0=$diskImage
</pre>

Change  create to **$out** directory  ($out/vzdump-qemu-nixos-VERSION.dirty.vma) fixes the error.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
