### PR TITLE
quick-lint-js: support cross compiling

### DIFF
--- a/pkgs/development/tools/quick-lint-js/build-tools-install.patch
+++ b/pkgs/development/tools/quick-lint-js/build-tools-install.patch
@@ -1,0 +1,32 @@
+From 3923f0df76d24b73d57f15eec61ab190ea048093 Mon Sep 17 00:00:00 2001
+From: "Matthew \"strager\" Glazar" <strager.nds@gmail.com>
+Date: Thu, 26 Oct 2023 18:08:30 -0400
+Subject: [PATCH] fix(build): fix installing build tools for cross-compilation
+
+'cmake --install . --component build-tools' copies no files [1]. This
+was caused by commit 1f2e1a47 where the code calling install() became
+dead code on accident. Call install() so that 'cmake --install' copies
+the build artifacts as intended.
+
+[1] https://github.com/quick-lint/quick-lint-js/issues/1099
+
+Refs: 1f2e1a4701793cac24eaac44d7af81a8b820b1bc
+---
+ docs/CHANGELOG.md    | 7 +++++++
+ tools/CMakeLists.txt | 1 -
+ 2 files changed, 7 insertions(+), 1 deletion(-)
+
+ (docs/CHANGELOG.md changes omitted to reduce conflicts.)
+
+diff --git a/tools/CMakeLists.txt b/tools/CMakeLists.txt
+index 71ccbdf1b..b541afb52 100644
+--- a/tools/CMakeLists.txt
++++ b/tools/CMakeLists.txt
+@@ -68,7 +68,6 @@ if (QUICK_LINT_JS_ENABLE_BUILD_TOOLS)
+     COMMENT "Building all quick-lint-js build-time tools"
+     DEPENDS ${QUICK_LINT_JS_BUILD_TOOL_TARGETS}
+   )
+-elseif (QUICK_LINT_JS_ENABLE_BUILD_TOOLS)
+   install(
+     TARGETS ${QUICK_LINT_JS_BUILD_TOOL_TARGETS}
+     COMPONENT build-tools

--- a/pkgs/development/tools/quick-lint-js/default.nix
+++ b/pkgs/development/tools/quick-lint-js/default.nix
@@ -1,8 +1,6 @@
-{ cmake, fetchFromGitHub, lib, ninja, stdenv, testers, quick-lint-js }:
+{ buildPackages, cmake, fetchFromGitHub, lib, ninja, stdenv, testers, quick-lint-js }:
 
-
-stdenv.mkDerivation rec {
-  pname = "quick-lint-js";
+let
   version = "2.17.0";
 
   src = fetchFromGitHub {
@@ -12,11 +10,41 @@ stdenv.mkDerivation rec {
     sha256 = "sha256-5+Cyw1cLgBkTePNNFoNAF2oHnLQDHr4vHiaZHJrewug=";
   };
 
+  quick-lint-js-build-tools = buildPackages.stdenv.mkDerivation {
+    pname = "quick-lint-js-build-tools";
+    inherit version src;
+
+    patches = [ ./build-tools-install.patch ];
+
+    nativeBuildInputs = [ cmake ninja ];
+    doCheck = false;
+
+    cmakeFlags = [
+      "-DQUICK_LINT_JS_ENABLE_BUILD_TOOLS=ON"
+      # Temporary workaround for https://github.com/NixOS/nixpkgs/pull/108496#issuecomment-1192083379
+      "-DCMAKE_SKIP_BUILD_RPATH=ON"
+    ];
+    ninjaFlags = "quick-lint-js-build-tools";
+
+    installPhase = ''
+      runHook preInstall
+      cmake --install . --component build-tools
+      runHook postInstall
+    '';
+  };
+in
+stdenv.mkDerivation rec {
+  pname = "quick-lint-js";
+  inherit version src;
+
   nativeBuildInputs = [ cmake ninja ];
   doCheck = true;
 
-  # Temporary workaround for https://github.com/NixOS/nixpkgs/pull/108496#issuecomment-1192083379
-  cmakeFlags = [ "-DCMAKE_SKIP_BUILD_RPATH=ON" ];
+  cmakeFlags = [
+    "-DQUICK_LINT_JS_USE_BUILD_TOOLS=${quick-lint-js-build-tools}/bin"
+    # Temporary workaround for https://github.com/NixOS/nixpkgs/pull/108496#issuecomment-1192083379
+    "-DCMAKE_SKIP_BUILD_RPATH=ON"
+  ];
 
   passthru.tests = {
     version = testers.testVersion { package = quick-lint-js; };
@@ -29,4 +57,7 @@ stdenv.mkDerivation rec {
     maintainers = with maintainers; [ ratsclub ];
     platforms = platforms.all;
   };
+
+  # Expose quick-lint-js-build-tools to nix repl as quick-lint-js.build-tools.
+  passthru.build-tools = quick-lint-js-build-tools;
 }


### PR DESCRIPTION
quick-lint-js' build system supports cross compiling, but it's not
automatic.

Prior to quick-lint-js version 2.13, cross compiling with Nix works
because some build-time tools are optional. These build-time tools need
a compiler from buildPackages.stdenv. Version 2.13 made these build-time
tools required.

Refactor the quick-lint-js package to use quick-lint-js' cross
compilation support. This fixes cross compilation with Nix.

Upstream documentation for cross compiling:
https://quick-lint-js.com/contribute/build-from-source/cross-compiling/

Testing:

    # Test Linux x86_64 cross compiling for Linux AArch64:
    x86$ uname -a
    Linux strapurp 5.19.0-46-generic #47~22.04.1-Ubuntu SMP PREEMPT_DYNAMIC Wed Jun 21 15:35:31 UTC 2 x86_64 x86_64 x86_64 GNU/Linux
    x86$ nix-shell -p pkgsCross.aarch64-multiplatform.quick-lint-js --run 'file $(which quick-lint-js)'
    /nix/store/31npaid1hniy2bb745y9j56r8mm7kmds-quick-lint-js-aarch64-unknown-linux-gnu-2.15.0/bin/quick-lint-js: ELF 64-bit LSB executable, ARM aarch64, version 1 (GNU/Linux), dynamically linked, interpreter /nix/store/f1c3qv0miwni8hx6jm1ym30vfh423nwi-glibc-aarch64-unknown-linux-gnu-2.37-8/lib/ld-linux-aarch64.so.1, for GNU/Linux 3.10.0, not stripped

    # Test the binary on a Linux AArch64 machine:
    x86$ nix --extra-experimental-features nix-command copy --to ssh-ng://parallels@192.168.1.230 /nix/store/31npaid1hniy2bb745y9j56r8mm7kmds-quick-lint-js-aarch64-unknown-linux-gnu-2.15.0/
    arm$ /nix/store/31npaid1hniy2bb745y9j56r8mm7kmds-quick-lint-js-aarch64-unknown-linux-gnu-2.15.0/bin/quick-lint-js --version
    quick-lint-js version 2.15.0

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
