### PR TITLE
openroad: unstable-2022-07-19 -> unstable-2023-03-31

### DIFF
--- a/pkgs/applications/science/electronics/openroad/0001-Fix-string-formatting-in-tests.patch
+++ b/pkgs/applications/science/electronics/openroad/0001-Fix-string-formatting-in-tests.patch
@@ -1,0 +1,53 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Nicolas Benes <nbenes.gh@xandea.de>
+Date: Sun, 2 Apr 2023 01:24:51 +0200
+Subject: [PATCH] Fix string formatting in tests
+
+Hide the decimal point and digits after the decimal point when they are
+not needed.
+
+diff --git a/src/par/test/partition_gcd.ok b/src/par/test/partition_gcd.ok
+index 6c40c14..b9a42f6 100644
+--- a/src/par/test/partition_gcd.ok
++++ b/src/par/test/partition_gcd.ok
+@@ -9,7 +9,7 @@
+ ========================================
+ [INFO] Partitioning parameters**** 
+ [PARAM] Number of partitions = 2
+-[PARAM] UBfactor = 1.0
++[PARAM] UBfactor = 1
+ [PARAM] Vertex dimensions = 1
+ [PARAM] Hyperedge dimensions = 1
+ ========================================
+@@ -118,7 +118,7 @@ After Hyperedge Reduction :  num_vertices = 137, num_hyperedges = 251
+ [V-Refine] Level 2 :: 207, 301, 154.65254
+ [V-Refine] Level 3 :: 312, 370, 154.65254
+ [V-Refine] Level 4 :: 469, 451, 154.65254
+-[INFO] V-cycle refinement 1 delta cost 0.0
++[INFO] V-cycle refinement 1 delta cost 0
+ =========================================
+ [STATUS] Running FC multilevel coarsening 
+ =========================================
+@@ -133,7 +133,7 @@ After Hyperedge Reduction :  num_vertices = 137, num_hyperedges = 251
+ [V-Refine] Level 2 :: 207, 301, 154.65254
+ [V-Refine] Level 3 :: 312, 370, 154.65254
+ [V-Refine] Level 4 :: 469, 451, 154.65254
+-[INFO] V-cycle refinement 2 delta cost 0.0
++[INFO] V-cycle refinement 2 delta cost 0
+ [Cutcost of partition : 154.65254]
+ [Vertex balance of block_0 : 0.59249  ( 327.17993 )    
+ [Vertex balance of block_1 : 0.40751  ( 225.03609 )    
+diff --git a/src/pdn/test/design_width.ok b/src/pdn/test/design_width.ok
+index 381dca1..a102974 100644
+--- a/src/pdn/test/design_width.ok
++++ b/src/pdn/test/design_width.ok
+@@ -9,5 +9,5 @@
+ [INFO ODB-0130]     Created 54 pins.
+ [INFO ODB-0131]     Created 406 components and 1816 component-terminals.
+ [INFO ODB-0133]     Created 361 nets and 1004 connections.
+-[ERROR PDN-0185] Insufficient width (14.04 um) to add straps on layer M8 in grid "Core" with total strap width 6.0 um and offset 10.0 um.
++[ERROR PDN-0185] Insufficient width (14.04 um) to add straps on layer M8 in grid "Core" with total strap width 6 um and offset 10 um.
+ PDN-0185
+-- 
+2.38.4
+

--- a/pkgs/applications/science/electronics/openroad/0002-Ignore-warning-on-stderr.patch
+++ b/pkgs/applications/science/electronics/openroad/0002-Ignore-warning-on-stderr.patch
@@ -1,0 +1,41 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Nicolas Benes <nbenes.gh@xandea.de>
+Date: Sun, 2 Apr 2023 04:57:17 +0200
+Subject: [PATCH] Ignore warning on stderr
+
+The following warning is written to stderr, which causes the overall
+test to fail:
+
+```
+sh: warning: setlocale: LC_ALL: cannot change locale (en_US.UTF-8)
+```
+
+diff --git a/src/dst/test/cpp_tests.tcl b/src/dst/test/cpp_tests.tcl
+index 9087c2c..63d0cb7 100644
+--- a/src/dst/test/cpp_tests.tcl
++++ b/src/dst/test/cpp_tests.tcl
+@@ -4,7 +4,7 @@ set test_dir [pwd]
+ set openroad_dir [file dirname [file dirname [file dirname $test_dir]]]
+ set tests_path [file join $openroad_dir "build" "src" "dst" "test" "cpp"]
+ 
+-set tests_list [split [exec sh -c "find $tests_path -maxdepth 1 -name 'Test*'"] \n]
++set tests_list [split [exec -ignorestderr sh -c "find $tests_path -maxdepth 1 -name 'Test*'"] \n]
+ 
+ foreach test $tests_list {
+     set test_name [file tail $test]
+diff --git a/src/odb/test/cpp_tests.tcl b/src/odb/test/cpp_tests.tcl
+index 091d576..6811760 100644
+--- a/src/odb/test/cpp_tests.tcl
++++ b/src/odb/test/cpp_tests.tcl
+@@ -4,7 +4,7 @@ set test_dir [pwd]
+ set openroad_dir [file dirname [file dirname [file dirname $test_dir]]]
+ set tests_path [file join $openroad_dir "build" "src" "odb" "test" "cpp"]
+ 
+-set tests_list [split [exec sh -c "find $tests_path -maxdepth 1 -name 'Test*' ! -name '*.cmake'"] \n]
++set tests_list [split [exec -ignorestderr sh -c "find $tests_path -maxdepth 1 -name 'Test*' ! -name '*.cmake'"] \n]
+ 
+ foreach test $tests_list {
+     set test_name [file tail $test]
+-- 
+2.38.4
+


### PR DESCRIPTION
###### Description of changes

Update to the latest upstream commit.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
