### PR TITLE
python310Packages.torchaudio: init at 2.0.1

### DIFF
--- a/pkgs/development/python-modules/torchaudio/default.nix
+++ b/pkgs/development/python-modules/torchaudio/default.nix
@@ -1,0 +1,63 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, cmake
+, pkg-config
+, ninja
+, pybind11
+, torch
+, cudaSupport ? false
+, cudaPackages
+}:
+
+buildPythonPackage rec {
+  pname = "torchaudio";
+  version = "2.0.1";
+
+  src = fetchFromGitHub {
+    owner = "pytorch";
+    repo = "audio";
+    rev = "v${version}";
+    hash = "sha256-qrDWFY+6eVV9prUzUzb5yzyFYtEvaSyEW0zeKqAg2Vk=";
+  };
+
+  postPatch = ''
+    substituteInPlace setup.py \
+      --replace 'print(" --- Initializing submodules")' "return" \
+      --replace "_fetch_archives(_parse_sources())" "pass"
+  '';
+
+  nativeBuildInputs = [
+    cmake
+    pkg-config
+    ninja
+  ] ++ lib.optionals cudaSupport [
+    cudaPackages.cudatoolkit
+  ];
+  buildInputs = [
+    pybind11
+  ] ++ lib.optionals cudaSupport [
+    cudaPackages.cudnn
+  ];
+  propagatedBuildInputs = [
+    torch
+  ];
+
+  BUILD_SOX=0;
+  BUILD_KALDI=0;
+  BUILD_RNNT=0;
+  BUILD_CTC_DECODER=0;
+
+  dontUseCmakeConfigure = true;
+
+  doCheck = false; # requires sox backend
+
+  meta = with lib; {
+    description = "PyTorch audio library";
+    homepage = "https://pytorch.org/";
+    changelog = "https://github.com/pytorch/audio/releases/tag/v${version}";
+    license = licenses.bsd2;
+    platforms = platforms.unix;
+    maintainers = with maintainers; [ junjihashimoto ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -11850,6 +11850,8 @@ self: super: with self; {
 
   torch-tb-profiler = callPackage ../development/python-modules/torch-tb-profiler/default.nix { };
 
+  torchaudio = callPackage ../development/python-modules/torchaudio { };
+
   torchaudio-bin = callPackage ../development/python-modules/torchaudio/bin.nix { };
 
   torchgpipe = callPackage ../development/python-modules/torchgpipe { };


### PR DESCRIPTION
###### Description of changes

We already have `torchaudio-bin`, this adds a source build version (a minimal one, for now).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
