### PR TITLE
Avoid deprecated GNOME Bugzilla server

### DIFF
--- a/pkgs/desktops/gnome/core/gnome-common/default.nix
+++ b/pkgs/desktops/gnome/core/gnome-common/default.nix
@@ -13,12 +13,6 @@ stdenv.mkDerivation rec {
     updateScript = gnome.updateScript { packageName = "gnome-common"; attrPath = "gnome.gnome-common"; };
   };
 
-  patches = [(fetchurl {
-    name = "gnome-common-patch";
-    url = "https://bug697543.bugzilla-attachments.gnome.org/attachment.cgi?id=240935";
-    sha256 = "17abp7czfzirjm7qsn2czd03hdv9kbyhk3lkjxg2xsf5fky7z7jl";
-  })];
-
   propagatedBuildInputs = [ which autoconf automake ]; # autogen.sh which is using gnome-common tends to require which
 
   meta = with lib; {

--- a/pkgs/development/libraries/cogl/default.nix
+++ b/pkgs/development/libraries/cogl/default.nix
@@ -37,18 +37,8 @@ stdenv.mkDerivation rec {
     # submitted by Fedora on the GNOME Bugzilla
     # (https://bugzilla.gnome.org/787443). Upstream thinks the patch
     # could be merged, but dev can not make a new release.
-
-    (fetchpatch {
-      url = "https://bug787443.bugzilla-attachments.gnome.org/attachment.cgi?id=359589";
-      sha256 = "0f0d9iddg8zwy853phh7swikg4yzhxxv71fcag36f8gis0j5p998";
-      decode = "xz -d";
-    })
-
-    (fetchpatch {
-      url = "https://bug787443.bugzilla-attachments.gnome.org/attachment.cgi?id=361056";
-      sha256 = "09fyrdci4727fg6qm5aaapsbv71sf4wgfaqz8jqlyy61dibgg490";
-      decode = "xz -d";
-    })
+    ./patches/gnome_bugzilla_787443_359589_deepin.patch
+    ./patches/gnome_bugzilla_787443_361056_deepin.patch
   ];
 
   outputs = [ "out" "dev" ];

--- a/pkgs/development/libraries/cogl/patches/gnome_bugzilla_787443_359589_deepin.patch
+++ b/pkgs/development/libraries/cogl/patches/gnome_bugzilla_787443_359589_deepin.patch
@@ -1,0 +1,93 @@
+From 78636289b073d67209a20145ef0dc003f2d77db6 Mon Sep 17 00:00:00 2001
+From: Sian Cao <yinshuiboy@gmail.com>
+Date: Tue, 12 Apr 2016 11:36:51 +0800
+Subject: [PATCH 1/2] Add GL_ARB_shader_texture_lod support
+
+The patch is used to do lod biased texturing. I can achieve
+faster blurring of images instead of using large blur radius.
+
+---
+ cogl/cogl-context.h                |  1 +
+ cogl/cogl-glsl-shader.c            | 13 +++++++++++--
+ cogl/cogl-types.h                  |  3 ++-
+ cogl/driver/gl/gl/cogl-driver-gl.c |  7 +++++++
+ 4 files changed, 21 insertions(+), 3 deletions(-)
+
+diff --git a/cogl/cogl-context.h b/cogl/cogl-context.h
+index 07badeb..261ce49 100644
+--- a/cogl/cogl-context.h
++++ b/cogl/cogl-context.h
+@@ -290,6 +290,7 @@ typedef enum _CoglFeatureID
+   COGL_FEATURE_ID_PER_VERTEX_POINT_SIZE,
+   COGL_FEATURE_ID_TEXTURE_RG,
+   COGL_FEATURE_ID_BUFFER_AGE,
++  COGL_FEATURE_ID_SHADER_TEXTURE_LOD,
+ 
+   /*< private >*/
+   _COGL_N_FEATURE_IDS   /*< skip >*/
+diff --git a/cogl/cogl-glsl-shader.c b/cogl/cogl-glsl-shader.c
+index 196e0c7..4fb0eb5 100644
+--- a/cogl/cogl-glsl-shader.c
++++ b/cogl/cogl-glsl-shader.c
+@@ -87,8 +87,8 @@ _cogl_glsl_shader_set_source_with_boilerplate (CoglContext *ctx,
+   const char *vertex_boilerplate;
+   const char *fragment_boilerplate;
+ 
+-  const char **strings = g_alloca (sizeof (char *) * (count_in + 4));
+-  GLint *lengths = g_alloca (sizeof (GLint) * (count_in + 4));
++  const char **strings = g_alloca (sizeof (char *) * (count_in + 5));
++  GLint *lengths = g_alloca (sizeof (GLint) * (count_in + 5));
+   char *version_string;
+   int count = 0;
+ 
+@@ -111,6 +111,15 @@ _cogl_glsl_shader_set_source_with_boilerplate (CoglContext *ctx,
+       lengths[count++] = sizeof (texture_3d_extension) - 1;
+     }
+ 
++  if (_cogl_has_private_feature (ctx, COGL_PRIVATE_FEATURE_GL_PROGRAMMABLE) &&
++      cogl_has_feature (ctx, COGL_FEATURE_ID_SHADER_TEXTURE_LOD))
++    {
++      static const char shader_texture_lod_ext[] =
++        "#extension GL_ARB_shader_texture_lod : enable\n";
++      strings[count] = shader_texture_lod_ext;
++      lengths[count++] = sizeof (shader_texture_lod_ext) - 1;
++    }
++
+   if (shader_gl_type == GL_VERTEX_SHADER)
+     {
+       strings[count] = vertex_boilerplate;
+diff --git a/cogl/cogl-types.h b/cogl/cogl-types.h
+index 6accf8d..77964c6 100644
+--- a/cogl/cogl-types.h
++++ b/cogl/cogl-types.h
+@@ -470,7 +470,8 @@ typedef enum
+   COGL_FEATURE_MAP_BUFFER_FOR_READ    = (1 << 21),
+   COGL_FEATURE_MAP_BUFFER_FOR_WRITE   = (1 << 22),
+   COGL_FEATURE_ONSCREEN_MULTIPLE      = (1 << 23),
+-  COGL_FEATURE_DEPTH_TEXTURE          = (1 << 24)
++  COGL_FEATURE_DEPTH_TEXTURE          = (1 << 24),
++  COGL_FEATURE_SHADER_TEXTURE_LOD     = (1 << 25)
+ } CoglFeatureFlags;
+ 
+ /**
+diff --git a/cogl/driver/gl/gl/cogl-driver-gl.c b/cogl/driver/gl/gl/cogl-driver-gl.c
+index 716d1dd..f305b6a 100644
+--- a/cogl/driver/gl/gl/cogl-driver-gl.c
++++ b/cogl/driver/gl/gl/cogl-driver-gl.c
+@@ -568,6 +568,13 @@ _cogl_driver_update_features (CoglContext *ctx,
+                       COGL_FEATURE_ID_TEXTURE_RECTANGLE, TRUE);
+     }
+ 
++  if (_cogl_check_extension ("GL_ARB_shader_texture_lod", gl_extensions))
++    {
++      flags |= COGL_FEATURE_SHADER_TEXTURE_LOD;
++      COGL_FLAGS_SET (ctx->features,
++                      COGL_FEATURE_ID_SHADER_TEXTURE_LOD, TRUE);
++    }
++
+   if (ctx->glTexImage3D)
+     {
+       flags |= COGL_FEATURE_TEXTURE_3D;
+-- 
+2.9.5
+

--- a/pkgs/development/libraries/cogl/patches/gnome_bugzilla_787443_361056_deepin.patch
+++ b/pkgs/development/libraries/cogl/patches/gnome_bugzilla_787443_361056_deepin.patch
@@ -1,0 +1,368 @@
+From d8b34ab0604d80d0be22b8b78e9aa6bf4fac7db0 Mon Sep 17 00:00:00 2001
+From: Sian Cao <yinshuiboy@gmail.com>
+Date: Thu, 27 Oct 2016 15:19:32 +0800
+Subject: [PATCH 2/2] texture: Support copy_sub_image
+
+We need copy_sub_image to implement blurring effects of partial framebuffer
+contents as texture sources.
+
+---
+ cogl/cogl-atlas-texture.c                   |  1 +
+ cogl/cogl-driver.h                          | 10 ++++++++
+ cogl/cogl-sub-texture.c                     |  1 +
+ cogl/cogl-texture-2d-sliced.c               |  1 +
+ cogl/cogl-texture-2d.c                      | 30 ++++++++++++++++++++++
+ cogl/cogl-texture-3d.c                      |  1 +
+ cogl/cogl-texture-private.h                 |  9 +++++++
+ cogl/cogl-texture-rectangle.c               |  1 +
+ cogl/cogl-texture.c                         | 33 ++++++++++++++++++++++++
+ cogl/cogl-texture.h                         |  9 +++++++
+ cogl/driver/gl/cogl-texture-2d-gl-private.h |  9 +++++++
+ cogl/driver/gl/cogl-texture-2d-gl.c         | 39 +++++++++++++++++++++++++++++
+ cogl/driver/gl/gl/cogl-driver-gl.c          |  1 +
+ cogl/driver/gl/gles/cogl-driver-gles.c      |  1 +
+ cogl/driver/nop/cogl-driver-nop.c           |  1 +
+ cogl/winsys/cogl-texture-pixmap-x11.c       |  1 +
+ 16 files changed, 148 insertions(+)
+
+diff --git a/cogl/cogl-atlas-texture.c b/cogl/cogl-atlas-texture.c
+index 1c8b569..e411302 100644
+--- a/cogl/cogl-atlas-texture.c
++++ b/cogl/cogl-atlas-texture.c
+@@ -1027,6 +1027,7 @@ cogl_atlas_texture_vtable =
+     FALSE, /* not primitive */
+     _cogl_atlas_texture_allocate,
+     _cogl_atlas_texture_set_region,
++    NULL, /* copy_sub_image */
+     NULL, /* get_data */
+     _cogl_atlas_texture_foreach_sub_texture_in_region,
+     _cogl_atlas_texture_get_max_waste,
+diff --git a/cogl/cogl-driver.h b/cogl/cogl-driver.h
+index 648228c..4a0aeaf 100644
+--- a/cogl/cogl-driver.h
++++ b/cogl/cogl-driver.h
+@@ -192,6 +192,16 @@ struct _CoglDriverVtable
+                                    int level,
+                                    CoglError **error);
+ 
++  CoglBool
++  (* texture_2d_copy_sub_image) (CoglTexture2D *tex_2d,
++                                 GLint xoffset,
++                                 GLint yoffset,
++                                 GLint x,
++                                 GLint y,
++                                 GLsizei width,
++                                 GLsizei height,
++                                 CoglError **error);
++
+   /* Reads back the full contents of the given texture and write it to
+    * @data in the given @format and with the given @rowstride.
+    *
+diff --git a/cogl/cogl-sub-texture.c b/cogl/cogl-sub-texture.c
+index 7baf95e..0a16193 100644
+--- a/cogl/cogl-sub-texture.c
++++ b/cogl/cogl-sub-texture.c
+@@ -460,6 +460,7 @@ cogl_sub_texture_vtable =
+     FALSE, /* not primitive */
+     _cogl_sub_texture_allocate,
+     _cogl_sub_texture_set_region,
++    NULL, /* copy_sub_image */
+     NULL, /* get_data */
+     _cogl_sub_texture_foreach_sub_texture_in_region,
+     _cogl_sub_texture_get_max_waste,
+diff --git a/cogl/cogl-texture-2d-sliced.c b/cogl/cogl-texture-2d-sliced.c
+index e76bef6..b0b099f 100644
+--- a/cogl/cogl-texture-2d-sliced.c
++++ b/cogl/cogl-texture-2d-sliced.c
+@@ -1526,6 +1526,7 @@ cogl_texture_2d_sliced_vtable =
+     FALSE, /* not primitive */
+     _cogl_texture_2d_sliced_allocate,
+     _cogl_texture_2d_sliced_set_region,
++    NULL, /* copy_sub_image */
+     NULL, /* get_data */
+     _cogl_texture_2d_sliced_foreach_sub_texture_in_region,
+     _cogl_texture_2d_sliced_get_max_waste,
+diff --git a/cogl/cogl-texture-2d.c b/cogl/cogl-texture-2d.c
+index cc28cd9..d9ab188 100644
+--- a/cogl/cogl-texture-2d.c
++++ b/cogl/cogl-texture-2d.c
+@@ -628,6 +628,35 @@ _cogl_texture_2d_set_region (CoglTexture *tex,
+ }
+ 
+ static CoglBool
++_cogl_texture_2d_copy_sub_image (CoglTexture *tex,
++                                 GLint xoffset,
++                                 GLint yoffset,
++                                 GLint x,
++                                 GLint y,
++                                 GLsizei width,
++                                 GLsizei height,
++                                 CoglError **error)
++{
++  CoglContext *ctx = tex->context;
++  CoglTexture2D *tex_2d = COGL_TEXTURE_2D (tex);
++
++  cogl_texture_allocate (tex, NULL); /* (abort on error) */
++
++  ctx->driver_vtable->texture_2d_copy_sub_image (tex_2d,
++                                                 xoffset,
++                                                 yoffset,
++                                                 x,
++                                                 y,
++                                                 width,
++                                                 height,
++                                                 error);
++
++  tex_2d->mipmaps_dirty = TRUE;
++
++  return TRUE;
++}
++
++static CoglBool
+ _cogl_texture_2d_get_data (CoglTexture *tex,
+                            CoglPixelFormat format,
+                            int rowstride,
+@@ -675,6 +704,7 @@ cogl_texture_2d_vtable =
+     TRUE, /* primitive */
+     _cogl_texture_2d_allocate,
+     _cogl_texture_2d_set_region,
++    _cogl_texture_2d_copy_sub_image,
+     _cogl_texture_2d_get_data,
+     NULL, /* foreach_sub_texture_in_region */
+     _cogl_texture_2d_get_max_waste,
+diff --git a/cogl/cogl-texture-3d.c b/cogl/cogl-texture-3d.c
+index 8e2ff08..a59d386 100644
+--- a/cogl/cogl-texture-3d.c
++++ b/cogl/cogl-texture-3d.c
+@@ -741,6 +741,7 @@ cogl_texture_3d_vtable =
+     TRUE, /* primitive */
+     _cogl_texture_3d_allocate,
+     _cogl_texture_3d_set_region,
++    NULL, /* copy_sub_image */
+     _cogl_texture_3d_get_data,
+     NULL, /* foreach_sub_texture_in_region */
+     _cogl_texture_3d_get_max_waste,
+diff --git a/cogl/cogl-texture-private.h b/cogl/cogl-texture-private.h
+index 472c41d..34ff81c 100644
+--- a/cogl/cogl-texture-private.h
++++ b/cogl/cogl-texture-private.h
+@@ -90,6 +90,15 @@ struct _CoglTextureVtable
+                            CoglBitmap *bitmap,
+                            CoglError **error);
+ 
++    CoglBool (* copy_sub_image) (CoglTexture *texture,
++                                 GLint xoffset,
++                                 GLint yoffset,
++                                 GLint x,
++                                 GLint y,
++                                 GLsizei width,
++                                 GLsizei height,
++                                 CoglError **error);
++
+   /* This should copy the image data of the texture into @data. The
+      requested format will have been first passed through
+      ctx->texture_driver->find_best_gl_get_data_format so it should
+diff --git a/cogl/cogl-texture-rectangle.c b/cogl/cogl-texture-rectangle.c
+index 65d2f06..9f533c9 100644
+--- a/cogl/cogl-texture-rectangle.c
++++ b/cogl/cogl-texture-rectangle.c
+@@ -761,6 +761,7 @@ cogl_texture_rectangle_vtable =
+     TRUE, /* primitive */
+     _cogl_texture_rectangle_allocate,
+     _cogl_texture_rectangle_set_region,
++    NULL, /* copy_sub_image */
+     _cogl_texture_rectangle_get_data,
+     NULL, /* foreach_sub_texture_in_region */
+     _cogl_texture_rectangle_get_max_waste,
+diff --git a/cogl/cogl-texture.c b/cogl/cogl-texture.c
+index d93db22..1f4b43c 100644
+--- a/cogl/cogl-texture.c
++++ b/cogl/cogl-texture.c
+@@ -514,6 +514,39 @@ cogl_texture_set_region (CoglTexture *texture,
+ }
+ 
+ CoglBool
++cogl_texture_copy_sub_image (CoglTexture *texture,
++                             int xoffset,
++                             int yoffset,
++                             int x,
++                             int y,
++                             size_t width,
++                             size_t height)
++{
++  CoglError *ignore_error = NULL;
++  CoglBool status;
++
++  if (!texture->allocated)
++    cogl_texture_allocate (texture, NULL);
++
++  if (!texture->vtable->copy_sub_image)
++    return FALSE;
++
++  status = texture->vtable->copy_sub_image (texture,
++                                            xoffset,
++                                            yoffset,
++                                            x,
++                                            y,
++                                            width,
++                                            height,
++                                            &ignore_error);
++
++  if (!status)
++    cogl_error_free (ignore_error);
++  return status;
++}
++
++
++CoglBool
+ cogl_texture_set_data (CoglTexture *texture,
+                        CoglPixelFormat format,
+                        int rowstride,
+diff --git a/cogl/cogl-texture.h b/cogl/cogl-texture.h
+index 2718830..81657d1 100644
+--- a/cogl/cogl-texture.h
++++ b/cogl/cogl-texture.h
+@@ -399,6 +399,15 @@ cogl_texture_set_region (CoglTexture *texture,
+                          unsigned int rowstride,
+                          const uint8_t *data);
+ 
++CoglBool
++cogl_texture_copy_sub_image (CoglTexture *texture,
++                             int xoffset,
++                             int yoffset,
++                             int x,
++                             int y,
++                             size_t width,
++                             size_t height);
++
+ #if defined (COGL_ENABLE_EXPERIMENTAL_API)
+ 
+ /**
+diff --git a/cogl/driver/gl/cogl-texture-2d-gl-private.h b/cogl/driver/gl/cogl-texture-2d-gl-private.h
+index e5c6585..d2f9985 100644
+--- a/cogl/driver/gl/cogl-texture-2d-gl-private.h
++++ b/cogl/driver/gl/cogl-texture-2d-gl-private.h
+@@ -109,6 +109,15 @@ _cogl_texture_2d_gl_copy_from_bitmap (CoglTexture2D *tex_2d,
+                                       int dst_y,
+                                       int level,
+                                       CoglError **error);
++CoglBool
++_cogl_texture_2d_gl_copy_sub_image (CoglTexture2D *tex_2d,
++                                    GLint xoffset,
++                                    GLint yoffset,
++                                    GLint x,
++                                    GLint y,
++                                    GLsizei width,
++                                    GLsizei height,
++                                    CoglError **error);
+ 
+ void
+ _cogl_texture_2d_gl_get_data (CoglTexture2D *tex_2d,
+diff --git a/cogl/driver/gl/cogl-texture-2d-gl.c b/cogl/driver/gl/cogl-texture-2d-gl.c
+index 8675f52..bc15ac5 100644
+--- a/cogl/driver/gl/cogl-texture-2d-gl.c
++++ b/cogl/driver/gl/cogl-texture-2d-gl.c
+@@ -35,6 +35,7 @@
+ #include <config.h>
+ 
+ #include <string.h>
++#include <stdio.h>
+ 
+ #include "cogl-private.h"
+ #include "cogl-texture-private.h"
+@@ -719,6 +720,44 @@ _cogl_texture_2d_gl_copy_from_bitmap (CoglTexture2D *tex_2d,
+   return status;
+ }
+ 
++CoglBool
++_cogl_texture_2d_gl_copy_sub_image (CoglTexture2D *tex_2d,
++                                    GLint xoffset,
++                                    GLint yoffset,
++                                    GLint x,
++                                    GLint y,
++                                    GLsizei width,
++                                    GLsizei height,
++                                    CoglError **error)
++{
++  CoglContext *ctx = COGL_TEXTURE (tex_2d)->context;
++
++  if (ctx->current_read_buffer == NULL)
++    return FALSE;
++
++  if (ctx->current_draw_buffer)
++    _cogl_framebuffer_flush_journal (ctx->current_draw_buffer);
++
++  if (ctx->current_read_buffer != NULL &&
++      ctx->current_read_buffer != ctx->current_draw_buffer)
++    _cogl_framebuffer_flush_journal (ctx->current_read_buffer);
++
++  _cogl_bind_gl_texture_transient (GL_TEXTURE_2D,
++                                   tex_2d->gl_texture,
++                                   tex_2d->is_foreign);
++
++  ctx->glCopyTexSubImage2D (GL_TEXTURE_2D,
++                            0,
++                            xoffset,
++                            yoffset,
++                            x,
++                            y,
++                            width,
++                            height);
++
++  return TRUE;
++}
++
+ void
+ _cogl_texture_2d_gl_get_data (CoglTexture2D *tex_2d,
+                               CoglPixelFormat format,
+diff --git a/cogl/driver/gl/gl/cogl-driver-gl.c b/cogl/driver/gl/gl/cogl-driver-gl.c
+index f305b6a..f7f5020 100644
+--- a/cogl/driver/gl/gl/cogl-driver-gl.c
++++ b/cogl/driver/gl/gl/cogl-driver-gl.c
+@@ -695,6 +695,7 @@ _cogl_driver_gl =
+     _cogl_texture_2d_gl_get_gl_handle,
+     _cogl_texture_2d_gl_generate_mipmap,
+     _cogl_texture_2d_gl_copy_from_bitmap,
++    _cogl_texture_2d_gl_copy_sub_image,
+     _cogl_texture_2d_gl_get_data,
+     _cogl_gl_flush_attributes_state,
+     _cogl_clip_stack_gl_flush,
+diff --git a/cogl/driver/gl/gles/cogl-driver-gles.c b/cogl/driver/gl/gles/cogl-driver-gles.c
+index e94449f..f5ac771 100644
+--- a/cogl/driver/gl/gles/cogl-driver-gles.c
++++ b/cogl/driver/gl/gles/cogl-driver-gles.c
+@@ -476,6 +476,7 @@ _cogl_driver_gles =
+     _cogl_texture_2d_gl_get_gl_handle,
+     _cogl_texture_2d_gl_generate_mipmap,
+     _cogl_texture_2d_gl_copy_from_bitmap,
++    _cogl_texture_2d_gl_copy_sub_image,
+     NULL, /* texture_2d_get_data */
+     _cogl_gl_flush_attributes_state,
+     _cogl_clip_stack_gl_flush,
+diff --git a/cogl/driver/nop/cogl-driver-nop.c b/cogl/driver/nop/cogl-driver-nop.c
+index 53f5975..9d88955 100644
+--- a/cogl/driver/nop/cogl-driver-nop.c
++++ b/cogl/driver/nop/cogl-driver-nop.c
+@@ -80,6 +80,7 @@ _cogl_driver_nop =
+     _cogl_texture_2d_nop_get_gl_handle,
+     _cogl_texture_2d_nop_generate_mipmap,
+     _cogl_texture_2d_nop_copy_from_bitmap,
++    NULL, /* texture_2d_copy_from_image */
+     NULL, /* texture_2d_get_data */
+     _cogl_nop_flush_attributes_state,
+     _cogl_clip_stack_nop_flush,
+diff --git a/cogl/winsys/cogl-texture-pixmap-x11.c b/cogl/winsys/cogl-texture-pixmap-x11.c
+index 398c357..a44cdaf 100644
+--- a/cogl/winsys/cogl-texture-pixmap-x11.c
++++ b/cogl/winsys/cogl-texture-pixmap-x11.c
+@@ -1164,6 +1164,7 @@ cogl_texture_pixmap_x11_vtable =
+     FALSE, /* not primitive */
+     _cogl_texture_pixmap_x11_allocate,
+     _cogl_texture_pixmap_x11_set_region,
++    NULL, /* copy_sub_image */
+     _cogl_texture_pixmap_x11_get_data,
+     _cogl_texture_pixmap_x11_foreach_sub_texture_in_region,
+     _cogl_texture_pixmap_x11_get_max_waste,
+-- 
+2.9.5
+

--- a/pkgs/development/libraries/gtk/2.x.nix
+++ b/pkgs/development/libraries/gtk/2.x.nix
@@ -46,10 +46,7 @@ stdenv.mkDerivation (finalAttrs: {
     ./patches/2.0-immodules.cache.patch
     ./patches/gtk2-theme-paths.patch
   ] ++ lib.optionals stdenv.isDarwin [
-    (fetchpatch {
-      url = "https://bug557780.bugzilla-attachments.gnome.org/attachment.cgi?id=306776";
-      sha256 = "0sp8f1r5c4j2nlnbqgv7s7nxa4cfwigvm033hvhb1ld652pjag4r";
-    })
+    ./patches/2.0-gnome_bugzilla_557780_306776_freeciv_darwin.patch
     ./patches/2.0-darwin-x11.patch
   ];
 

--- a/pkgs/development/libraries/gtk/patches/2.0-gnome_bugzilla_557780_306776_freeciv_darwin.patch
+++ b/pkgs/development/libraries/gtk/patches/2.0-gnome_bugzilla_557780_306776_freeciv_darwin.patch
@@ -1,0 +1,54 @@
+From 8b822ab0060acdf4217f589411fe71574cbb09c0 Mon Sep 17 00:00:00 2001
+From: Daniel Trebbien <dtrebbien@gmail.com>
+Date: Fri, 3 Jul 2015 12:08:18 -0400
+Subject: [PATCH] quartz: Bug 557780 - Missing support for depth == 1 in
+ gdk_image_new_for_depth()
+
+When the gtk2 client of Freeciv is started, an assertion failure is seen
+immediately and the client stops:
+"Gdk:ERROR:gdkimage-quartz.c:325:_gdk_image_new_for_depth: assertion
+failed: (depth == 24 || depth == 32)"
+
+In this case, _gdk_image_new_for_depth() is being called from
+_gdk_quartz_image_copy_to_image(). The GdkImage passed to this function
+is NULL so a new GdkImage is created. However, the depth of the passed
+GdkDrawable is 1 and this is passed directly as the `depth' parameter to
+_gdk_image_new_for_depth(), leading to the assertion failure.
+
+In _gdk_quartz_image_copy_to_image(), rather than directly pass the
+GdkDrawable's depth to _gdk_image_new_for_depth(), if the depth is 1,
+then create the new GdkImage with depth 24. The case where the depth is
+1 is already handled in _gdk_quartz_image_copy_to_image().
+
+This allows the Freeciv 2.5.0 gtk2 client to start and play a game.
+---
+ gdk/quartz/gdkimage-quartz.c | 13 +++++++++----
+ 1 file changed, 9 insertions(+), 4 deletions(-)
+
+diff --git a/gdk/quartz/gdkimage-quartz.c b/gdk/quartz/gdkimage-quartz.c
+index 493efba..853ef61 100644
+--- a/gdk/quartz/gdkimage-quartz.c
++++ b/gdk/quartz/gdkimage-quartz.c
+@@ -43,10 +43,15 @@ _gdk_quartz_image_copy_to_image (GdkDrawable *drawable,
+ 
+   screen = gdk_drawable_get_screen (drawable);
+   if (!image)
+-    image = _gdk_image_new_for_depth (screen, GDK_IMAGE_FASTEST, NULL, 
+-				      width, height,
+-				      gdk_drawable_get_depth (drawable));
+-  
++    {
++      gint drawable_depth = gdk_drawable_get_depth (drawable);
++      if (drawable_depth == 1)
++        drawable_depth = 24;
++      image = _gdk_image_new_for_depth (screen, GDK_IMAGE_FASTEST, NULL,
++                                        width, height,
++                                        drawable_depth);
++    }
++
+   if (GDK_IS_PIXMAP_IMPL_QUARTZ (drawable))
+     {
+       GdkPixmapImplQuartz *pix_impl;
+-- 
+2.3.2 (Apple Git-55)
+


### PR DESCRIPTION
###### Description of changes

Follow up to #222218. Instead of just adopting to the changed behavior of the GNOME Bugzilla turning on compression for patches, store patches locally in the nixpkgs repo in anticipation of the Bugzilla server some time going offline. (Also removes one patch which should no longer be needed, 416bb5e, **not sure why applying the patch was not failing** as the target code had changed).

Did **not test** GTK2/Darwin. FreeCiv uses GTK3 nowadays.

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).