### PR TITLE
earthly: 0.6.23 -> 0.7.2

### DIFF
--- a/pkgs/development/tools/earthly/default.nix
+++ b/pkgs/development/tools/earthly/default.nix
@@ -2,21 +2,27 @@
 
 buildGoModule rec {
   pname = "earthly";
-  version = "0.6.23";
+  version = "0.7.2";
 
   src = fetchFromGitHub {
     owner = "earthly";
     repo = "earthly";
     rev = "v${version}";
-    sha256 = "sha256-RbLAnk2O7wqY0OQLprWuRDUWMicqcLOPia+7aRuXbsk=";
+    sha256 = "sha256-b7at8Hjt3ZH7UjD1FLgQ4C1TE+XLqm7+WI4aBn1tikI=";
   };
 
-  vendorSha256 = "sha256-MDyQ9Wn5A5F5CQCfEXzkXZi/Fg6sT/Ikv+Y7fvLY8LA=";
+  vendorSha256 = "sha256-CXbS7MSq2fwm5M325szZogW+qDEMuDidlMt89Cm3Gg4=";
 
   ldflags = [
     "-s" "-w"
     "-X main.Version=v${version}"
     "-X main.DefaultBuildkitdImage=earthly/buildkitd:v${version}"
+  ];
+
+  # These packages should not be required for the CLI binary to build, without these the CLI seems to work as expected
+  excludedPackages = [
+    "ast"
+    "util/deltautil"
   ];
 
   BUILDTAGS = "dfrunmount dfrunsecurity dfsecrets dfssh dfrunnetwork";
@@ -29,7 +35,6 @@ buildGoModule rec {
 
   postInstall = ''
     mv $out/bin/debugger $out/bin/earthly-debugger
-    mv $out/bin/shellrepeater $out/bin/earthly-shellrepeater
   '';
 
   meta = with lib; {


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->


1. Excluded `./ast` and `./utils/deltautil` from build due to package not building with these
2. Excluded binary `earthly-shellrepeater` which appears to have been remove when moving from earthly 0.6.x to 0.7

Changelog for Earthly 0.7.2 in [earthly/earthly/CHANGELOG.md](https://github.com/earthly/earthly/blob/main/CHANGELOG.md#v072---2023-03-14)

I'm new to patching nix packages and am happy to revert on things I missed. Following as best I could from existing closed PRs bumping earthly in this repository: https://github.com/NixOS/nixpkgs/pulls?q=is%3Apr+earthly+is%3Aclosed

Thanks!


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

#### Local Testing Details


```sh
nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"
cat report.json
{
    "blacklisted": [],
    "broken": [],
    "built": [],
    "extra-nixpkgs-config": null,
    "failed": [],
    "non-existant": [],
    "pr": null,
    "system": "aarch64-darwin",
    "tests": []
}
```

Build and run CLI locally on existing project using an Earthfile

```sh
nix-collect-garbage && nix-build -A earthly
ls ./result/bin
docker2earth     earthly          earthly-debugger

./result/bin/earthly --version
earthly version v0.7.2  darwin/arm64; macOS 13.3


NIX_BUILD_EARTHLY=~/nixpkgs/result/bin/earthly 

$NIX_BUILD_EARTHLY --ci +ci
```
