### PR TITLE
citra: nightly 1765 -> 1873, canary 2146 -> 2440

### DIFF
--- a/pkgs/applications/emulators/citra/default.nix
+++ b/pkgs/applications/emulators/citra/default.nix
@@ -15,13 +15,13 @@ let
 in {
   nightly = libsForQt5.callPackage ./generic.nix rec {
     pname = "citra-nightly";
-    version = "1765";
+    version = "1873";
 
     src = fetchFromGitHub {
       owner = "citra-emu";
       repo = "citra-nightly";
       rev = "nightly-${version}";
-      sha256 = "0d3dfh63cmsy5idbypdz3ibydmb4a35sfv7qmxxlcpc390pp9cvq";
+      sha256 = "1csn9n1s2mvxwk2mahwm8mc4zgn40im374hcsqgz8gaxjkmnx288";
       fetchSubmodules = true;
     };
 

--- a/pkgs/applications/emulators/citra/default.nix
+++ b/pkgs/applications/emulators/citra/default.nix
@@ -30,13 +30,13 @@ in {
 
   canary = libsForQt5.callPackage ./generic.nix rec {
     pname = "citra-canary";
-    version = "2146";
+    version = "2440";
 
     src = fetchFromGitHub {
       owner = "citra-emu";
       repo = "citra-canary";
       rev = "canary-${version}";
-      sha256 = "1wnym0nklngimf5gaaa2703nz4g5iy572wlgp88h67rrh9b4f04r";
+      sha256 = "06f2qnvywyaf8jc43jrzjhfshj3k21ggk8wdrvd9wjsmrryvqgbz";
       fetchSubmodules = true;
     };
 

--- a/pkgs/applications/emulators/citra/generic.nix
+++ b/pkgs/applications/emulators/citra/generic.nix
@@ -65,6 +65,10 @@ stdenv.mkDerivation rec {
     ++ lib.optional enableFdk "-DENABLE_FDK=ON";
 
   postPatch = ''
+    # Fix file not found when looking in var/empty instead of opt
+    mkdir externals/dynarmic/src/dynarmic/ir/var
+    ln -s ../opt externals/dynarmic/src/dynarmic/ir/var/empty
+
     # Prep compatibilitylist
     ln -s ${compat-list} ./dist/compatibility_list/compatibility_list.json
 

--- a/pkgs/applications/emulators/citra/generic.nix
+++ b/pkgs/applications/emulators/citra/generic.nix
@@ -49,7 +49,7 @@ stdenv.mkDerivation rec {
     "-DUSE_SYSTEM_BOOST=ON"
     "-DCITRA_USE_BUNDLED_FFMPEG=OFF"
     "-DCITRA_USE_BUNDLED_QT=OFF"
-    "-DCITRA_USE_BUNDLED_SDL2=OFF"
+    "-DUSE_SYSTEM_SDL2=ON"
 
     # We dont want to bother upstream with potentially outdated compat reports
     "-DCITRA_ENABLE_COMPATIBILITY_REPORTING=ON"


### PR DESCRIPTION
###### Description of changes

Bump versions.

Link `externals/dynarmic/src/dynarmic/ir/var/empty` -> `externals/dynarmic/src/dynarmic/ir/opt` which fixes an inexplicable error where CMake looks for a file in `ir/var/empty` when the `CMakeLists.txt` specifies `ir/opt`.

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md)