### PR TITLE
blast-bin: init at 2.13.0

### DIFF
--- a/pkgs/applications/science/biology/blast/bin.nix
+++ b/pkgs/applications/science/biology/blast/bin.nix
@@ -1,0 +1,60 @@
+{ lib
+, stdenv
+, fetchurl
+, python3
+, perl
+, blast
+, autoPatchelfHook
+, zlib
+, bzip2
+, glib
+, libxml2
+, coreutils
+}:
+let
+  pname = "blast-bin";
+  version = "2.13.0";
+
+  srcs = rec {
+    x86_64-linux = fetchurl {
+      url = "https://ftp.ncbi.nlm.nih.gov/blast/executables/blast+/${version}/ncbi-blast-${version}+-x64-linux.tar.gz";
+      hash = "sha256-QPK3OdT++GoNI1NHyEpu2/hB2hqHYPQ/vNXFAVCwVEc=";
+    };
+    aarch64-linux = fetchurl {
+      url = "https://ftp.ncbi.nlm.nih.gov/blast/executables/blast+/${version}/ncbi-blast-${version}+-x64-arm-linux.tar.gz";
+      hash = "sha256-vY8K66k7KunpBUjFsJTTb+ur5n1XmU0/mYxhZsi9ycs=";
+    };
+    x86_64-darwin = fetchurl {
+      url = "https://ftp.ncbi.nlm.nih.gov/blast/executables/blast+/${version}/ncbi-blast-${version}+-x64-macosx.tar.gz";
+      hash = "sha256-Y0JlOUl9Ego6LTxTCNny3P5c1H3fApPXQm7Z6Zhq9RA=";
+    };
+    aarch64-darwin = x86_64-darwin;
+  };
+  src = srcs.${stdenv.hostPlatform.system};
+in
+stdenv.mkDerivation {
+  inherit pname version src;
+
+  nativeBuildInputs = lib.optional stdenv.isLinux [ autoPatchelfHook ];
+
+  buildInputs = [ python3 perl ] ++ lib.optionals stdenv.isLinux [ zlib bzip2 glib libxml2 ];
+
+  installPhase = ''
+    runHook preInstall
+
+    install -Dm755 bin/* -t $out/bin
+
+    runHook postInstall
+  '';
+
+  preFixup = ''
+    substituteInPlace $out/bin/get_species_taxids.sh \
+      --replace /bin/rm ${coreutils}/bin/rm
+  '';
+
+  meta = with lib; {
+    inherit (blast.meta) description homepage license;
+    platforms = [ "x86_64-linux" "aarch64-linux" "x86_64-darwin" "aarch64-darwin" ];
+    maintainers = with maintainers; [ natsukium ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -36778,6 +36778,8 @@ with pkgs;
     inherit (darwin.apple_sdk.frameworks) ApplicationServices;
   };
 
+  blast-bin = callPackage ../applications/science/biology/blast/bin.nix { };
+
   bpp-core = callPackage ../development/libraries/science/biology/bpp-core {
     stdenv = gcc10StdenvCompat;
   };


### PR DESCRIPTION
###### Description of changes

NCBI BLAST is one of the most basic and important tools for bioinformatics.
I have been trying to build it from the source on darwin for over a year, but it is too hard to build with Nix on darwin.
The configure file and other scripts depend heavily on the build environment.

I have provided a precompiled binary for darwin, as I don't think I will be able to build it for a while. I would like to build it from source someday, but I believe there is great value in having a working one available from nixpkgs.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
