### PR TITLE
Add Chili sddm theme

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -13687,6 +13687,13 @@
     githubId = 1286668;
     name = "Thilo Uttendorfer";
   };
+  sents = {
+    email = "finn@krein.moe";
+    github = "sents";
+    githubId = 26575793;
+    matrix = "@sents:matrix.org";
+    name = "Finn Krein";
+  };
   sephalon = {
     email = "me@sephalon.net";
     github = "sephalon";

--- a/pkgs/data/themes/chili-sddm/default.nix
+++ b/pkgs/data/themes/chili-sddm/default.nix
@@ -1,0 +1,61 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, qtgraphicaleffects
+, themeConfig ? { }
+}:
+let
+  customToString = x: if builtins.isBool x then lib.boolToString x else toString x;
+  configLines = lib.mapAttrsToList (name: value: lib.nameValuePair name value) themeConfig;
+  configureTheme = "cp theme.conf theme.conf.orig \n" +
+    (lib.concatMapStringsSep "\n"
+      (configLine:
+        "grep -q '^${configLine.name}=' theme.conf || echo '${configLine.name}=' >> \"$1\"\n" +
+          "sed -i -e 's/^${configLine.name}=.*$/${configLine.name}=${
+        lib.escape [ "/" "&" "\\"] (customToString configLine.value)
+      }/' theme.conf"
+      )
+      configLines);
+in
+stdenv.mkDerivation {
+  pname = "sddm-chili-theme";
+  version = "0.1.5";
+
+  src = fetchFromGitHub {
+    owner = "MarianArlt";
+    repo = "sddm-chili";
+    rev = "6516d50176c3b34df29003726ef9708813d06271";
+    sha256 = "036fxsa7m8ymmp3p40z671z163y6fcsa9a641lrxdrw225ssq5f3";
+  };
+
+  propagatedBuildInputs = [
+    qtgraphicaleffects
+  ];
+
+  dontWrapQtApps = true;
+
+  preInstall = configureTheme;
+
+  postInstall = ''
+    mkdir -p $out/share/sddm/themes/chili
+
+    mv * $out/share/sddm/themes/chili/
+  '';
+
+  postFixup = ''
+    mkdir -p $out/nix-support
+
+    echo ${qtgraphicaleffects} >> $out/nix-support/propagated-user-env-packages
+  '';
+  meta = with lib; {
+    license = licenses.gpl3;
+    maintainers = with lib.maintainers; [ sents ];
+    homepage = "https://github.com/MarianArlt/sddm-chili";
+    description = "The chili login theme for SDDM";
+    longDescription = ''
+      Chili is hot, just like a real chili!
+      Spice up the login experience for your users, your family and yourself.
+      Chili reduces all the clutter and leaves you with a clean, easy to use, login interface with a modern yet classy touch.
+    '';
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -27060,6 +27060,8 @@ with pkgs;
 
   schedtool = callPackage ../os-specific/linux/schedtool { };
 
+  sddm-chili-theme = libsForQt5.callPackage ../data/themes/chili-sddm { };
+
   sdparm = callPackage ../os-specific/linux/sdparm { };
 
   sdrangel = libsForQt5.callPackage ../applications/radio/sdrangel { };


### PR DESCRIPTION
###### Description of changes
Adds the chili sddm theme
There were two previous pull requests for this theme:
 - #59016 for the non-plasma version
 - #70495 for the plasma version

**This PR adds the non-plasma version of the theme**

Because most people want to customize the them with their own backgrounds, etc., I added
a parameter `themeConfig`, that users can set by overriding the package. 

In my opinion there should be a sddm module option for this, but as that doesn't exist right now, I think this is
a good compromise.
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
