### PR TITLE
team-list: add cuda team

### DIFF
--- a/maintainers/team-list.nix
+++ b/maintainers/team-list.nix
@@ -149,6 +149,15 @@ with lib.maintainers; {
     enableFeatureFreezePing = true;
   };
 
+  cuda = {
+    members = [
+      SomeoneSerge
+    ];
+    scope = "Maintain CUDA-enabled packages";
+    shortName = "Cuda";
+    githubTeams = [ "cuda-maintainers" ];
+  };
+
   darwin = {
     members = [
       toonn

--- a/pkgs/development/compilers/cudatoolkit/common.nix
+++ b/pkgs/development/compilers/cudatoolkit/common.nix
@@ -311,6 +311,7 @@ backendStdenv.mkDerivation rec {
     homepage = "https://developer.nvidia.com/cuda-toolkit";
     platforms = [ "x86_64-linux" ];
     license = licenses.unfree;
+    maintainers = teams.cuda.members;
   };
 }
 

--- a/pkgs/development/compilers/cudatoolkit/redist/build-cuda-redist-package.nix
+++ b/pkgs/development/compilers/cudatoolkit/redist/build-cuda-redist-package.nix
@@ -53,6 +53,7 @@ backendStdenv.mkDerivation {
   meta = {
     description = attrs.name;
     license = lib.licenses.unfree;
+    maintainers = lib.teams.cuda.members;
     platforms = lib.optionals (lib.hasAttr arch attrs) [ "x86_64-linux" ];
   };
 }


### PR DESCRIPTION
###### Description of changes

CC @NixOS/cuda-maintainers 


We can also consider adding

```nix
maintainers = [ ... ] ++ optionals cudaSupport teams.cuda.members;
```

to packages like tensorflow, so that we get notifications for `tensorflowWithCuda` &c. I'm not sure if conditional meta is a particularly bad practice