### PR TITLE
Update Clp/Osi and add new CoinUtils dependency

### DIFF
--- a/pkgs/applications/science/math/clp/default.nix
+++ b/pkgs/applications/science/math/clp/default.nix
@@ -1,14 +1,18 @@
-{ lib, stdenv, fetchurl, zlib }:
+{ lib, stdenv, fetchFromGitHub, pkg-config, coin-utils, zlib, osi }:
 
 stdenv.mkDerivation rec {
-  version = "1.17.6";
+  version = "1.17.7";
   pname = "clp";
-  src = fetchurl {
-    url = "https://www.coin-or.org/download/source/Clp/Clp-${version}.tgz";
-    sha256 = "0ap1f0lxppa6pnbc4bg7ih7a96avwaki482nig8w5fr3vg9wvkzr";
+  src = fetchFromGitHub {
+    owner = "coin-or";
+    repo = "Clp";
+    rev = "releases/${version}";
+    hash = "sha256-CfAK/UbGaWvyk2ZxKEgziVruzZfz7WMJVi/YvdR/UNA=";
   };
 
-  propagatedBuildInputs = [ zlib ];
+  nativeBuildInputs = [ pkg-config ];
+
+  propagatedBuildInputs = [ zlib coin-utils osi ];
 
   doCheck = true;
 

--- a/pkgs/applications/science/math/clp/default.nix
+++ b/pkgs/applications/science/math/clp/default.nix
@@ -17,7 +17,7 @@ stdenv.mkDerivation rec {
   doCheck = true;
 
   meta = with lib; {
-    license = licenses.epl10;
+    license = licenses.epl20;
     homepage = "https://github.com/coin-or/Clp";
     description = "An open-source linear programming solver written in C++";
     platforms = platforms.darwin ++ [ "x86_64-linux" ];

--- a/pkgs/development/libraries/science/math/coin-utils/default.nix
+++ b/pkgs/development/libraries/science/math/coin-utils/default.nix
@@ -1,0 +1,22 @@
+{ lib, stdenv, fetchFromGitHub, pkg-config }:
+
+stdenv.mkDerivation rec {
+  version = "2.11.6";
+  pname = "coinutils";
+
+  src = fetchFromGitHub {
+    owner = "coin-or";
+    repo = "CoinUtils";
+    rev = "releases/${version}";
+    hash = "sha256-avXp7eKSZ/Fe1QmSJiNDMnPQ70LlOHrBeUYb9lhka8c=";
+  };
+
+  doCheck = true;
+
+  meta = with lib; {
+    license = licenses.epl20;
+    homepage = "https://github.com/coin-or/CoinUtils";
+    description = "Collection of classes and helper functions that are generally useful to multiple COIN-OR projects";
+    maintainers = with maintainers; [ tmarkus ];
+  };
+}

--- a/pkgs/development/libraries/science/math/osi/default.nix
+++ b/pkgs/development/libraries/science/math/osi/default.nix
@@ -1,19 +1,21 @@
-{ stdenv, lib, fetchurl, gfortran, pkg-config
-, blas, zlib, bzip2
+{ stdenv, lib, fetchFromGitHub, gfortran, pkg-config
+, blas, zlib, bzip2, coin-utils
 , withGurobi ? false, gurobi
 , withCplex ? false, cplex }:
 
 stdenv.mkDerivation rec {
   pname = "osi";
-  version = "0.108.6";
+  version = "0.108.7";
 
-  src = fetchurl {
-    url = "https://www.coin-or.org/download/source/Osi/Osi-${version}.tgz";
-    sha256 = "1n2jlpq4aikbp0ncs16f7q1pj7yk6kny1bh4fmjaqnwrjw63zvsp";
+  src = fetchFromGitHub {
+    owner = "coin-or";
+    repo = "Osi";
+    rev = "releases/${version}";
+    hash = "sha256-MTmt/MgsfEAXor2EZXJX05bQg5oOtMaN7oNxGv2PHJg=";
   };
 
   buildInputs =
-    [ blas zlib bzip2 ]
+    [ blas zlib bzip2 coin-utils ]
     ++ lib.optional withGurobi gurobi
     ++ lib.optional withCplex cplex;
   nativeBuildInputs = [ gfortran pkg-config ];

--- a/pkgs/development/libraries/science/math/osi/default.nix
+++ b/pkgs/development/libraries/science/math/osi/default.nix
@@ -37,7 +37,7 @@ stdenv.mkDerivation rec {
   meta = with lib; {
     description = "An abstract base class to a generic linear programming (LP) solver";
     homepage = "https://github.com/coin-or/Osi";
-    license = licenses.epl10;
+    license = licenses.epl20;
     platforms = platforms.unix;
     maintainers = with maintainers; [ abbradar ];
   };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -37054,6 +37054,8 @@ with pkgs;
 
   cliquer = callPackage ../development/libraries/science/math/cliquer { };
 
+  coin-utils = callPackage ../development/libraries/science/math/coin-utils { };
+
   ecos = callPackage ../development/libraries/science/math/ecos { };
 
   flintqs = callPackage ../development/libraries/science/math/flintqs { };


### PR DESCRIPTION
###### Description of changes

Osi 0.108.7 and Clp 1.17.7 bring a new CoinUtils dependency. This PR contains the aforementioned updates and packages the new CoinUtils dependency. Apart from that, the download location apparently changed (the old download URLs aren't used for newer versions). Furthermore, Clp and Osi apparently changed to EPL v2 in 2020 ([Clp commit](https://github.com/coin-or/Clp/commit/51fe3bd8ee9ae1411bbc68ed6ab3e581d5a27457), [Osi commit](https://github.com/coin-or/Osi/commit/726fe2c7f4d4998152aaafb2494f735a1243d40d))
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
