### PR TITLE
ocamlPackages.{bwd, yuujinchou}: 2.0.0 → 4.0.0

### DIFF
--- a/pkgs/development/ocaml-modules/algaeff/default.nix
+++ b/pkgs/development/ocaml-modules/algaeff/default.nix
@@ -1,0 +1,26 @@
+{ lib
+, buildDunePackage
+, fetchFromGitHub
+}:
+
+buildDunePackage rec {
+  pname = "algaeff";
+  version = "0.2.1";
+
+  minimalOCamlVersion = "5.0";
+  duneVersion = "3";
+
+  src = fetchFromGitHub {
+    owner = "RedPRL";
+    repo = pname;
+    rev = version;
+    hash = "sha256-jpnJhF+LN2ef6QPLcCHxcMg3Fr3GSLOnJkZ9ZUIOrlY=";
+  };
+
+  meta = {
+    description = "Reusable Effects-Based Components";
+    homepage = "https://github.com/RedPRL/algaeff";
+    license = lib.licenses.asl20;
+    maintainers = [ lib.maintainers.vbgl ];
+  };
+}

--- a/pkgs/development/ocaml-modules/bwd/default.nix
+++ b/pkgs/development/ocaml-modules/bwd/default.nix
@@ -2,15 +2,16 @@
 
 buildDunePackage rec {
   pname = "bwd";
-  version = "2.0.0";
+  version = "2.1.0";
 
   minimalOCamlVersion = "4.12";
+  duneVersion = "3";
 
   src = fetchFromGitHub {
     owner = "RedPRL";
     repo = "ocaml-bwd";
     rev = version;
-    sha256 = "sha256:0zgi8an53z6wr6nzz0zlmhx19zhqy1w2vfy1sq3sikjwh74jjq60";
+    hash = "sha256-ucXOBjD1behL2h8CZv64xtRjCPkajZic7G1oxxDmEXY=";
   };
 
   doCheck = true;

--- a/pkgs/development/ocaml-modules/cooltt/default.nix
+++ b/pkgs/development/ocaml-modules/cooltt/default.nix
@@ -49,6 +49,8 @@ let
       sha256 = "sha256:1xb754fha4s0bgjfqjxzqljvalmkfdwdn5y4ycsp51wiah235bsy";
     };
 
+    duneVersion = "3";
+
     propagatedBuildInputs = [ bwd ];
 
     doCheck = true;

--- a/pkgs/development/ocaml-modules/yuujinchou/default.nix
+++ b/pkgs/development/ocaml-modules/yuujinchou/default.nix
@@ -1,24 +1,41 @@
-{ lib, fetchFromGitHub, buildDunePackage, qcheck-alcotest }:
+{ lib, ocaml, fetchFromGitHub, buildDunePackage
+, algaeff, bwd
+, qcheck-alcotest
+}:
+
+let params = if lib.versionAtLeast ocaml.version "5.0" then {
+    version = "4.0.0";
+    hash = "sha256-yNLN5bBe4aft9Rl5VHmlOYTlnCdR2NgDWsc3uJHaZy4=";
+    propagatedBuildInputs = [ algaeff bwd ];
+  } else {
+    version = "2.0.0";
+    hash = "sha256:1nhz44cyipy922anzml856532m73nn0g7iwkg79yzhq6yb87109w";
+  }
+; in
 
 buildDunePackage rec {
   pname = "yuujinchou";
-  version = "2.0.0";
+  inherit (params) version;
 
   minimalOCamlVersion = "4.12";
+  duneVersion = "3";
 
   src = fetchFromGitHub {
     owner = "RedPRL";
     repo = pname;
     rev = version;
-    sha256 = "sha256:1nhz44cyipy922anzml856532m73nn0g7iwkg79yzhq6yb87109w";
+    inherit (params) hash;
   };
+
+  propagatedBuildInputs = params.propagatedBuildInputs or [];
+
 
   doCheck = true;
   checkInputs = [ qcheck-alcotest ];
 
   meta = {
     description = "Name pattern combinators";
-    inherit (src.meta) homepage;
+    homepage = "https://github.com/RedPRL/yuujinchou";
     license = lib.licenses.asl20;
     maintainers = [ lib.maintainers.vbgl ];
   };

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -18,6 +18,8 @@ let
 
     alcotest-mirage = callPackage ../development/ocaml-modules/alcotest/mirage.nix {};
 
+    algaeff = callPackage ../development/ocaml-modules/algaeff { };
+
     alsa = callPackage ../development/ocaml-modules/alsa { };
 
     angstrom = callPackage ../development/ocaml-modules/angstrom { };


### PR DESCRIPTION
###### Description of changes

Support for OCaml 5.0

Note that tests currently fail to execute with OCaml 5.0. Waiting for a proper fix to `qcheck` (PR in preparation), a workaround is to add `findlib` to the `checkInputs`.

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
