### PR TITLE
paratype-pt-astra-{serif,sans}: init at 1.00[32]

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -10562,6 +10562,12 @@
     githubId = 38578268;
     name = "Morgan Wolfe";
   };
+  mxkrsv = {
+    email = "mxkrsv@disroot.org";
+    github = "mxkrsv";
+    githubId = 59313755;
+    name = "Maxim Karasev";
+  };
   myaats = {
     email = "mats@mats.sh";
     github = "Myaats";

--- a/pkgs/data/fonts/paratype-pt/astra-sans.nix
+++ b/pkgs/data/fonts/paratype-pt/astra-sans.nix
@@ -1,0 +1,32 @@
+{ lib, stdenvNoCC, fetchzip }:
+
+stdenvNoCC.mkDerivation rec {
+  pname = "paratype-pt-astra-sans";
+  version = "1.002";
+
+  src = fetchzip {
+    urls = [
+      "https://astralinux.ru/information/fonts-astra/font-ptastrasans-ttf-ver1002.zip"
+    ];
+    stripRoot = false;
+    hash = "sha256-Jm8CJzMPq6VgTXgbN6QU78PS3Y0ekM8cSnveuI6xG4E=";
+  };
+
+  installPhase = ''
+    runHook preInstall
+
+    install -Dm644 *.ttf -t $out/share/fonts/truetype
+
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    homepage = "https://www.paratype.ru/fonts/pt/pt-astra-sans";
+    description = "Sans font that is metrically coordinated with PT Astra Serif";
+
+    license = licenses.ofl;
+
+    platforms = platforms.all;
+    maintainers = with maintainers; [ mxkrsv ];
+  };
+}

--- a/pkgs/data/fonts/paratype-pt/astra-serif.nix
+++ b/pkgs/data/fonts/paratype-pt/astra-serif.nix
@@ -1,0 +1,32 @@
+{ lib, stdenvNoCC, fetchzip }:
+
+stdenvNoCC.mkDerivation rec {
+  pname = "paratype-pt-astra-serif";
+  version = "1.003";
+
+  src = fetchzip {
+    urls = [
+      "https://astralinux.ru/information/fonts-astra/font-ptastra-serif-ver1003.zip"
+    ];
+    stripRoot = false;
+    hash = "sha256-P8jJ8v1/NTY3mW6whMyQlW0uRkfHUAx5cl17lhw3aDE=";
+  };
+
+  installPhase = ''
+    runHook preInstall
+
+    install -Dm644 *.ttf -t $out/share/fonts/truetype
+
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    homepage = "https://www.paratype.ru/fonts/pt/pt-astra-serif";
+    description = "Serif font that is a metric analog of Times New Roman";
+
+    license = licenses.ofl;
+
+    platforms = platforms.all;
+    maintainers = with maintainers; [ mxkrsv ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -28159,6 +28159,7 @@ with pkgs;
   paratype-pt-mono = callPackage ../data/fonts/paratype-pt/mono.nix { };
   paratype-pt-sans = callPackage ../data/fonts/paratype-pt/sans.nix { };
   paratype-pt-serif = callPackage ../data/fonts/paratype-pt/serif.nix { };
+  paratype-pt-astra-sans = callPackage ../data/fonts/paratype-pt/astra-sans.nix { };
   paratype-pt-astra-serif = callPackage ../data/fonts/paratype-pt/astra-serif.nix { };
 
   pari-galdata = callPackage ../data/misc/pari-galdata { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -28159,6 +28159,7 @@ with pkgs;
   paratype-pt-mono = callPackage ../data/fonts/paratype-pt/mono.nix { };
   paratype-pt-sans = callPackage ../data/fonts/paratype-pt/sans.nix { };
   paratype-pt-serif = callPackage ../data/fonts/paratype-pt/serif.nix { };
+  paratype-pt-astra-serif = callPackage ../data/fonts/paratype-pt/astra-serif.nix { };
 
   pari-galdata = callPackage ../data/misc/pari-galdata { };
 


### PR DESCRIPTION
- maintainers: add mxkrsv
- paratype-pt-astra-serif: init at 1.003
- paratype-pt-astra-sans: init at 1.002

###### Description of changes

PT Astra Serif is a completely free (OFL) metric alternative to Times New Roman.

PT Astra Sans is a sans font metrically coordinated with PT Astra Serif.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
