### PR TITLE
python310Packages.cython: 0.29.33 -> 0.29.34; Add setup hook to force regeneration of generated code in sdists

### DIFF
--- a/pkgs/development/python-modules/Cython/default.nix
+++ b/pkgs/development/python-modules/Cython/default.nix
@@ -24,12 +24,12 @@ let
 
 in buildPythonPackage rec {
   pname = "cython";
-  version = "0.29.33";
+  version = "0.29.34";
 
   src = fetchPypi {
     pname = "Cython";
     inherit version;
-    hash = "sha256-UEB2TEpNLOlko5XaJPDRrlgUSZXauSxrlvRMP01yKGo=";
+    hash = "sha256-GQloj117Uhpgw5bSC7qeR6Gy0nhL+whUAeHh59KaKag=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/development/python-modules/Cython/default.nix
+++ b/pkgs/development/python-modules/Cython/default.nix
@@ -74,6 +74,10 @@ in buildPythonPackage rec {
   doCheck = false;
   # doCheck = !stdenv.isDarwin;
 
+  # force regeneration of generated code in source distributions
+  # https://github.com/cython/cython/issues/5089
+  setupHook = ./setup-hook.sh;
+
   meta = {
     changelog = "https://github.com/cython/cython/blob/${version}/CHANGES.rst";
     description = "An optimising static compiler for both the Python programming language and the extended Cython programming language";

--- a/pkgs/development/python-modules/Cython/setup-hook.sh
+++ b/pkgs/development/python-modules/Cython/setup-hook.sh
@@ -1,0 +1,3 @@
+if [ -z "${dontForceRegenCython-}"]; then
+  export CYTHON_FORCE_REGEN=1
+fi


### PR DESCRIPTION
https://github.com/cython/cython/blob/0.29.34/CHANGES.rst

Lots of python packages seem to ship their source distributions with
generated code. In recent cython versions there is a way to force a
regeneration of these files and using it sounds generally sounds like a
good thing.

If it turns out, that this causes problems on individual packages,
setting `dontForceRegenCython` will prevent the regeneration.

Added in 3.0.0a11 and backported to 2.9.34, so both cython versions we
ship right now support this flag.

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
