### PR TITLE
[22.11] prismlauncher: use jdk17 instead of jdk, prismlauncher: 6.1 -> 6.3, prismlauncher: use qtWrapperArgs, prismlauncher: use ninja

### DIFF
--- a/pkgs/games/prismlauncher/default.nix
+++ b/pkgs/games/prismlauncher/default.nix
@@ -22,6 +22,8 @@
 , ghc_filesystem
 , msaClientID ? ""
 , jdks ? [ jdk17 jdk8 ]
+, gamemodeSupport ? true
+, gamemode
 }:
 
 let
@@ -52,7 +54,9 @@ stdenv.mkDerivation rec {
     quazip
     ghc_filesystem
     tomlplusplus
-  ] ++ lib.optional (lib.versionAtLeast qtbase.version "6") qtwayland;
+  ]
+  ++ lib.optional (lib.versionAtLeast qtbase.version "6") qtwayland
+  ++ lib.optional gamemodeSupport gamemode.dev;
 
   cmakeFlags = lib.optionals (msaClientID != "") [ "-DLauncher_MSA_CLIENT_ID=${msaClientID}" ]
     ++ lib.optionals (lib.versionAtLeast qtbase.version "6") [ "-DLauncher_QT_VERSION_MAJOR=6" ];
@@ -68,7 +72,7 @@ stdenv.mkDerivation rec {
   qtWrapperArgs =
     let
       libpath = with xorg;
-        lib.makeLibraryPath [
+        lib.makeLibraryPath ([
           libX11
           libXext
           libXcursor
@@ -79,7 +83,7 @@ stdenv.mkDerivation rec {
           glfw
           openal
           stdenv.cc.cc.lib
-        ];
+        ] ++ lib.optional gamemodeSupport gamemode.lib);
     in
     [
       "--set LD_LIBRARY_PATH /run/opengl-driver/lib:${libpath}"

--- a/pkgs/games/prismlauncher/default.nix
+++ b/pkgs/games/prismlauncher/default.nix
@@ -2,6 +2,7 @@
 , stdenv
 , fetchFromGitHub
 , cmake
+, ninja
 , jdk8
 , jdk17
 , zlib
@@ -43,7 +44,7 @@ stdenv.mkDerivation rec {
     sha256 = "sha256-7tptHKWkbdxTn6VIPxXE1K3opKRiUW2zv9r6J05dcS8=";
   };
 
-  nativeBuildInputs = [ extra-cmake-modules cmake file jdk17 wrapQtAppsHook ];
+  nativeBuildInputs = [ extra-cmake-modules cmake file jdk17 ninja wrapQtAppsHook ];
   buildInputs = [
     qtbase
     qtsvg

--- a/pkgs/games/prismlauncher/default.nix
+++ b/pkgs/games/prismlauncher/default.nix
@@ -34,13 +34,13 @@ in
 
 stdenv.mkDerivation rec {
   pname = "prismlauncher";
-  version = "5.2";
+  version = "6.3";
 
   src = fetchFromGitHub {
     owner = "PrismLauncher";
     repo = "PrismLauncher";
     rev = version;
-    sha256 = "sha256-sKAhcbDoRbWf/DuwcBmDjb+VSMM0K2C33gu1K9AlPoQ=";
+    sha256 = "sha256-7tptHKWkbdxTn6VIPxXE1K3opKRiUW2zv9r6J05dcS8=";
   };
 
   nativeBuildInputs = [ extra-cmake-modules cmake file jdk17 wrapQtAppsHook ];

--- a/pkgs/games/prismlauncher/default.nix
+++ b/pkgs/games/prismlauncher/default.nix
@@ -3,7 +3,7 @@
 , fetchFromGitHub
 , cmake
 , jdk8
-, jdk
+, jdk17
 , zlib
 , file
 , wrapQtAppsHook
@@ -20,7 +20,7 @@
 , tomlplusplus
 , ghc_filesystem
 , msaClientID ? ""
-, jdks ? [ jdk jdk8 ]
+, jdks ? [ jdk17 jdk8 ]
 }:
 
 let
@@ -43,7 +43,7 @@ stdenv.mkDerivation rec {
     sha256 = "sha256-sKAhcbDoRbWf/DuwcBmDjb+VSMM0K2C33gu1K9AlPoQ=";
   };
 
-  nativeBuildInputs = [ extra-cmake-modules cmake file jdk wrapQtAppsHook ];
+  nativeBuildInputs = [ extra-cmake-modules cmake file jdk17 wrapQtAppsHook ];
   buildInputs = [
     qtbase
     qtsvg


### PR DESCRIPTION
###### Description of changes
this is a backport of multiple commits:
https://github.com/NixOS/nixpkgs/pull/206806
https://github.com/NixOS/nixpkgs/pull/214393
https://github.com/NixOS/nixpkgs/pull/220126
https://github.com/NixOS/nixpkgs/pull/224260

see the changelogs for [6.0](https://github.com/PrismLauncher/PrismLauncher/releases/tag/6.0), [6.1](https://github.com/PrismLauncher/PrismLauncher/releases/tag/6.1), [6.2](https://github.com/PrismLauncher/PrismLauncher/releases/tag/6.2), and [6.3](https://github.com/PrismLauncher/PrismLauncher/releases/tag/6.3). most notably these [fix](https://github.com/PrismLauncher/PrismLauncher/security/advisories/GHSA-wxgx-8v36-mj2m) [two](https://github.com/PrismLauncher/PrismLauncher/security/advisories/GHSA-gq28-qx55-mh2r) high severity vulnerabilities. this also fixes issues with path detection, using jdk17 specifically for compatibility in game, and matches changes from upstream

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
