### PR TITLE
network_cmds: unconditionally exclude Unbound

### DIFF
--- a/pkgs/os-specific/darwin/apple-source-releases/network_cmds/default.nix
+++ b/pkgs/os-specific/darwin/apple-source-releases/network_cmds/default.nix
@@ -1,9 +1,9 @@
 { lib, appleDerivation, xcbuildHook, stdenv
-, libressl_3_4, Librpcsvc, xnu, libpcap, developer_cmds }:
+, Librpcsvc, xnu, libpcap, developer_cmds }:
 
 appleDerivation {
   nativeBuildInputs = [ xcbuildHook ];
-  buildInputs = [ libressl_3_4 xnu Librpcsvc libpcap developer_cmds ];
+  buildInputs = [ xnu Librpcsvc libpcap developer_cmds ];
 
   # Work around error from <stdio.h> on aarch64-darwin:
   #     error: 'TARGET_OS_IPHONE' is not defined, evaluates to 0 [-Werror,-Wundef-prefix=TARGET_OS_]
@@ -12,15 +12,13 @@ appleDerivation {
   # "spray" requires some files that aren't compiling correctly in xcbuild.
   # "rtadvd" seems to fail with some missing constants.
   # "traceroute6" and "ping6" require ipsec which doesn't build correctly
+  # "unbound" doesn’t build against supported versions of OpenSSL or LibreSSL
   patchPhase = ''
     substituteInPlace network_cmds.xcodeproj/project.pbxproj \
       --replace "7294F0EA0EE8BAC80052EC88 /* PBXTargetDependency */," "" \
       --replace "7216D34D0EE89FEC00AE70E4 /* PBXTargetDependency */," "" \
       --replace "72CD1D9C0EE8C47C005F825D /* PBXTargetDependency */," "" \
-      --replace "7216D2C20EE89ADF00AE70E4 /* PBXTargetDependency */," ""
-  '' + lib.optionalString stdenv.isAarch64 ''
-    # "unbound" does not build on aarch64
-    substituteInPlace network_cmds.xcodeproj/project.pbxproj \
+      --replace "7216D2C20EE89ADF00AE70E4 /* PBXTargetDependency */," "" \
       --replace "71D958C51A9455A000C9B286 /* PBXTargetDependency */," ""
   '';
 


### PR DESCRIPTION
###### Description of changes

Unbound doesn’t build with newer versions of OpenSSL or LibreSSL, so it is pinned to LibreSSL 3.4. This is causing problems now that LibreSSL 3.4 is marked as insecure and is slated to be dropped.

The easy fix is to disable Unbound unconditionally:
* aarch64-darwin already doesn’t build it;
* Apple dropped it from newer versions of the source releases; and
* Unbound is already packaged in nixpkgs and builds on both Darwin architectures.

Fixes #223977 and removes `darwin.network_cmds` as a blocker for #216207.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
