### PR TITLE
sherlock:  0.14.0 -> 0.14.3

### DIFF
--- a/pkgs/tools/security/sherlock/default.nix
+++ b/pkgs/tools/security/sherlock/default.nix
@@ -5,6 +5,7 @@ let
     certifi
     colorama
     lxml
+    pandas
     pysocks
     requests
     requests-futures
@@ -15,13 +16,13 @@ let
 in
 stdenv.mkDerivation rec {
   pname = "sherlock";
-  version = "0.14.0";
+  version = "0.14.3";
 
   src = fetchFromGitHub {
     owner = "sherlock-project";
     repo = pname;
-    rev = "f8566960d461783558b7bcba5c818d9275de492a";
-    sha256 = "sha256-6jG/SmsiEL63EcBrx2fcQDYbmMCA+A7Jsc3E4f5NGts=";
+    rev = "ab2f6788340903df797d8c336a97fa6e742daf77";
+    hash = "sha256-AbWZa33DNrDM0FdjoFSVMnz4Ph7mUiUe/erhI3w7GQQ";
   };
 
   nativeBuildInputs = [ makeWrapper ];


### PR DESCRIPTION
###### Description of changes
Updating the currently outdated / broken `sherlock` package with the intention of making it functional again! Also, the package `rev` has been set to the latest rev of the project repository, which still falls under version `0.14.3`.

Reason for this change is because of the recently added:
1. feature implementations in master compared to the version change commit. (still = same version according to `--version`)
2. performance improvements.
3. false positive returned by tinder + site list additions.

Changelog:
- https://github.com/sherlock-project/sherlock/compare/ab2f678..1ffcaa5

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
