### PR TITLE
nixops_unstable: mark cryptography insecure

### DIFF
--- a/pkgs/applications/networking/cluster/nixops/default.nix
+++ b/pkgs/applications/networking/cluster/nixops/default.nix
@@ -69,6 +69,24 @@ let
           };
         })
 
+        (self: super: {
+          cryptography = super.cryptography.overridePythonAttrs (old: {
+            meta = old.meta // {
+              knownVulnerabilities = old.meta.knownVulnerabilities or [ ]
+                ++ lib.optionals (lib.versionOlder old.version "39.0.1") [
+                  "CVE-2022-4304"
+                  "CVE-2023-0215"
+                  "CVE-2023-0216"
+                  "CVE-2023-0217"
+                  "CVE-2023-0401"
+                  "CVE-2022-4203"
+                  "CVE-2022-4450"
+                  "CVE-2023-23931"
+                ];
+            };
+          });
+        })
+
       ];
     }
   ).python;


### PR DESCRIPTION
###### Description of changes
```
$ poetry audit -C pkgs/applications/networking/cluster/nixops
# poetry audit report
Loading...
Scanning 36 packages...

  • cryptography  installed 3.4.8  affected >=1.8,<39.0.1  CVE CVE-2023-23931
  • cryptography  installed 3.4.8  affected <39.0.1        CVE CVE-2023-0401
  • cryptography  installed 3.4.8  affected <39.0.1        CVE CVE-2022-4304
  • cryptography  installed 3.4.8  affected <39.0.1        CVE CVE-2023-0216
  • cryptography  installed 3.4.8  affected <39.0.1        CVE CVE-2022-4203
  • cryptography  installed 3.4.8  affected <39.0.1        CVE CVE-2022-4450
  • cryptography  installed 3.4.8  affected <39.0.1        CVE CVE-2023-0286
  • cryptography  installed 3.4.8  affected <39.0.1        CVE CVE-2023-0217
  • cryptography  installed 3.4.8  affected <39.0.1        CVE CVE-2023-0215
  • cryptography  installed 3.4.8  affected <39.0.1        CVE CVE-2022-3996

10 vulnerabilities found in 1 packages
```
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
