### PR TITLE
python310Packages.tensorflow: mark insecure

### DIFF
--- a/pkgs/development/python-modules/tensorflow/bin.nix
+++ b/pkgs/development/python-modules/tensorflow/bin.nix
@@ -201,5 +201,26 @@ in buildPythonPackage {
     license = licenses.asl20;
     maintainers = with maintainers; [ jyp abbradar cdepillabout ];
     platforms = [ "x86_64-linux" "x86_64-darwin" ];
+    knownVulnerabilities = optionals (versionOlder packages.version "2.12.0") [
+      "CVE-2023-27579"
+      "CVE-2023-25801"
+      "CVE-2023-25676"
+      "CVE-2023-25675"
+      "CVE-2023-25674"
+      "CVE-2023-25673"
+      "CVE-2023-25671"
+      "CVE-2023-25670"
+      "CVE-2023-25669"
+      "CVE-2023-25668"
+      "CVE-2023-25667"
+      "CVE-2023-25665"
+      "CVE-2023-25666"
+      "CVE-2023-25664"
+      "CVE-2023-25663"
+      "CVE-2023-25662"
+      "CVE-2023-25660"
+      "CVE-2023-25659"
+      "CVE-2023-25658"
+    ];
   };
 }

--- a/pkgs/development/python-modules/tensorflow/default.nix
+++ b/pkgs/development/python-modules/tensorflow/default.nix
@@ -448,6 +448,27 @@ let
       maintainers = with maintainers; [ jyp abbradar ];
       platforms = with platforms; linux ++ darwin;
       broken = !(xlaSupport -> cudaSupport);
+      knownVulnerabilities = [
+        "CVE-2023-27579"
+        "CVE-2023-25801"
+        "CVE-2023-25676"
+        "CVE-2023-25675"
+        "CVE-2023-25674"
+        "CVE-2023-25673"
+        "CVE-2023-25671"
+        "CVE-2023-25670"
+        "CVE-2023-25669"
+        "CVE-2023-25668"
+        "CVE-2023-25667"
+        "CVE-2023-25665"
+        "CVE-2023-25666"
+        "CVE-2023-25664"
+        "CVE-2023-25663"
+        "CVE-2023-25662"
+        "CVE-2023-25660"
+        "CVE-2023-25659"
+        "CVE-2023-25658"
+      ];
     } // lib.optionalAttrs stdenv.isDarwin {
       timeout = 86400; # 24 hours
       maxSilent = 14400; # 4h, double the default of 7200s


### PR DESCRIPTION
###### Description of changes
See https://github.com/tensorflow/tensorflow/blob/v2.12.0/RELEASE.md#security.
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
