### PR TITLE
ocamlPackages.ctypes: 0.20.1 → 0.20.2

### DIFF
--- a/pkgs/development/ocaml-modules/ctypes/default.nix
+++ b/pkgs/development/ocaml-modules/ctypes/default.nix
@@ -6,13 +6,13 @@ else
 
 stdenv.mkDerivation rec {
   pname = "ocaml${ocaml.version}-ctypes";
-  version = "0.20.1";
+  version = "0.20.2";
 
   src = fetchFromGitHub {
     owner = "ocamllabs";
     repo = "ocaml-ctypes";
     rev = version;
-    sha256 = "sha256-H1QR0MJCqRdXxRufCA663wzTNWQ8MYYAy2nz/XHCn0Y=";
+    hash = "sha256-LzUrR8K88CjY/R5yUK3y6KG85hUMjbzuebHGqI8KhhM=";
   };
 
   nativeBuildInputs = [ pkg-config ocaml findlib ];
@@ -21,14 +21,22 @@ stdenv.mkDerivation rec {
 
   strictDeps = true;
 
+  preConfigure = ''
+    substituteInPlace META --replace ' bytes ' ' '
+  '';
+
   buildPhase = ''
+    runHook preBuild
     make XEN=false libffi.config ctypes-base ctypes-stubs
     make XEN=false ctypes-foreign
+    runHook postBuild
   '';
 
   installPhase = ''
+    runHook preInstall
     mkdir -p $out/lib/ocaml/${ocaml.version}/site-lib/stublibs
     make install XEN=false
+    runHook postInstall
   '';
 
   meta = with lib; {


### PR DESCRIPTION
###### Description of changes

Fixes for OCaml 5.0
https://github.com/yallop/ocaml-ctypes/blob/0.20.2/CHANGES.md

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
