### PR TITLE
libdeltachat: 1.112.4 -> 1.112.5

### DIFF
--- a/pkgs/development/libraries/libdeltachat/Cargo.lock
+++ b/pkgs/development/libraries/libdeltachat/Cargo.lock
@@ -1061,7 +1061,7 @@ dependencies = [
 
 [[package]]
 name = "deltachat"
-version = "1.112.4"
+version = "1.112.5"
 dependencies = [
  "ansi_term",
  "anyhow",
@@ -1135,7 +1135,7 @@ dependencies = [
 
 [[package]]
 name = "deltachat-jsonrpc"
-version = "1.112.4"
+version = "1.112.5"
 dependencies = [
  "anyhow",
  "async-channel",
@@ -1158,7 +1158,7 @@ dependencies = [
 
 [[package]]
 name = "deltachat-repl"
-version = "1.112.4"
+version = "1.112.5"
 dependencies = [
  "ansi_term",
  "anyhow",
@@ -1173,7 +1173,7 @@ dependencies = [
 
 [[package]]
 name = "deltachat-rpc-server"
-version = "1.112.4"
+version = "1.112.5"
 dependencies = [
  "anyhow",
  "deltachat",
@@ -1197,7 +1197,7 @@ dependencies = [
 
 [[package]]
 name = "deltachat_ffi"
-version = "1.112.4"
+version = "1.112.5"
 dependencies = [
  "anyhow",
  "deltachat",

--- a/pkgs/development/libraries/libdeltachat/default.nix
+++ b/pkgs/development/libraries/libdeltachat/default.nix
@@ -18,13 +18,13 @@
 
 stdenv.mkDerivation rec {
   pname = "libdeltachat";
-  version = "1.112.4";
+  version = "1.112.5";
 
   src = fetchFromGitHub {
     owner = "deltachat";
     repo = "deltachat-core-rust";
     rev = "v${version}";
-    hash = "sha256-Z6Hs8NYqMyXyTyUsR9N0Eghgh8Ltrt1uMGKuz0aCRdQ=";
+    hash = "sha256-me09xhsaiJr2i6kdB62suS5LBf3gr4vL3dHgdPMbD1g=";
   };
 
   patches = [


### PR DESCRIPTION
###### Description of changes
Diff: https://github.com/deltachat/deltachat-core-rust/compare/v1.112.4...v1.112.5

Changelog: https://github.com/deltachat/deltachat-core-rust/blob/v1.112.5/CHANGELOG.md


<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
