### PR TITLE
fishPlugins.fzf-fish: 9.3 -> 9.7

### DIFF
--- a/pkgs/shells/fish/plugins/fzf-fish.nix
+++ b/pkgs/shells/fish/plugins/fzf-fish.nix
@@ -39,6 +39,6 @@ buildFishPlugin rec {
     description = "Augment your fish command line with fzf key bindings";
     homepage = "https://github.com/PatrickF1/fzf.fish";
     license = licenses.mit;
-    maintainers = with maintainers; [ pacien ];
+    maintainers = with maintainers; [ pacien natsukium ];
   };
 }

--- a/pkgs/shells/fish/plugins/fzf-fish.nix
+++ b/pkgs/shells/fish/plugins/fzf-fish.nix
@@ -1,31 +1,35 @@
-{ lib, stdenv, buildFishPlugin, fetchFromGitHub, fd, fzf, util-linux, clownfish, fishtape_3 }:
-
+{ lib, stdenv, pkgs, buildFishPlugin, fetchFromGitHub, fd, util-linux, procps, clownfish, fishtape_3, }:
+let
+  # we want `pkgs.fzf`, not `fishPlugins.fzf`
+  inherit (pkgs) fzf;
+in
 buildFishPlugin rec {
   pname = "fzf.fish";
-  version = "9.2";
+  version = "9.7";
 
   src = fetchFromGitHub {
     owner = "PatrickF1";
     repo = "fzf.fish";
     rev = "v${version}";
-    sha256 = "sha256-XmRGe39O3xXmTvfawwT2mCwLIyXOlQm7f40mH5tzz+s=";
+    sha256 = "sha256-haNSqXJzLL3JGvD4JrASVmhLJz6i9lna6/EdojXdFOo=";
   };
 
-  nativeCheckInputs = [ fzf fd util-linux ];
+  nativeCheckInputs = [ fzf fd util-linux procps ];
   checkPlugins = [ clownfish fishtape_3 ];
   checkFunctionDirs = [ "./functions" ];
   checkPhase = ''
     # Disable git tests which inspect the project's git repo, which isn't
     # possible since we strip the impure .git from our build input
     rm -r tests/*git*
+    rm -r tests/preview_changed_file/modified_path_with_spaces.fish
+    rm -r tests/preview_changed_file/renamed_path_modifications.fish
 
     # Disable tests that are failing, probably because of our wrappers
     rm -r tests/configure_bindings
-    rm -r tests/search_shell_variables
+    rm -r tests/search_variables
 
     # Disable tests that are failing, because there is not 'rev' command
     rm tests/preview_file/custom_file_preview.fish
-
   '' + (
     if stdenv.isDarwin then ''script /dev/null fish -c "fishtape tests/*/*.fish"''
     else ''script -c 'fish -c "fishtape tests/*/*.fish"' ''


### PR DESCRIPTION
https://github.com/PatrickF1/fzf.fish/releases/tag/v9.4
https://github.com/PatrickF1/fzf.fish/releases/tag/v9.5
https://github.com/PatrickF1/fzf.fish/releases/tag/v9.6
https://github.com/PatrickF1/fzf.fish/releases/tag/v9.7

###### Description of changes

fixes #194226

Because buildFishPlugin calls fishPlugins.fzf which was introduced by #220384, I added pkgs to inputs and inherit pkgs.fzf explicitly.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
