### PR TITLE
jetbrains.jcef: 611 -> 654 

### DIFF
--- a/pkgs/development/compilers/jetbrains-jdk/jcef.nix
+++ b/pkgs/development/compilers/jetbrains-jdk/jcef.nix
@@ -76,8 +76,11 @@ buildType = if debugBuild then "Debug" else "Release";
 
 in stdenv.mkDerivation rec {
   name = "jcef-jetbrains";
-  rev = "153d40c761a25a745d7ebf0ee3a024bbc2c840b5";
-  commit-num = "611";  # Run `git rev-list --count HEAD`
+  rev = "3dfde2a70f1f914c6a84ba967123a0e38f51053f";
+  # This is the commit number
+  # Currently from the 231 branch: https://github.com/JetBrains/jcef/tree/231
+  # Run `git rev-list --count HEAD`
+  version = "654";
 
   nativeBuildInputs = [ cmake python3 jdk17 git rsync ant ninja ];
   buildInputs = [ libX11 libXdamage nss nspr ];
@@ -86,7 +89,7 @@ in stdenv.mkDerivation rec {
     owner = "jetbrains";
     repo = "jcef";
     inherit rev;
-    hash = "sha256-Vud4nIT2c7uOK7GKKw3plf41WzKqhg+2xpIwB/LyqnE=";
+    hash = "sha256-g8jWzRI2uYzu8O7JHENn0u9yY08fvY6g0Uym02oYUMI=";
   };
   cef-bin = let
     fileName = "cef_binary_104.4.26+g4180781+chromium-104.0.5112.102_linux64_minimal";
@@ -116,7 +119,7 @@ in stdenv.mkDerivation rec {
       -e 's|os.path.isdir(os.path.join(path, \x27.git\x27))|True|' \
       -e 's|"%s rev-parse %s" % (git_exe, branch)|"echo '${rev}'"|' \
       -e 's|"%s config --get remote.origin.url" % git_exe|"echo 'https://github.com/jetbrains/jcef'"|' \
-      -e 's|"%s rev-list --count %s" % (git_exe, branch)|"echo '${commit-num}'"|' \
+      -e 's|"%s rev-list --count %s" % (git_exe, branch)|"echo '${version}'"|' \
       -i tools/git_util.py
 
     cp ${clang-fmt} tools/buildtools/linux64/clang-format

--- a/pkgs/development/compilers/jetbrains-jdk/jcef.nix
+++ b/pkgs/development/compilers/jetbrains-jdk/jcef.nix
@@ -75,7 +75,7 @@ let rpath = lib.makeLibraryPath [
 buildType = if debugBuild then "Debug" else "Release";
 
 in stdenv.mkDerivation rec {
-  name = "jcef-jetbrains";
+  pname = "jcef-jetbrains";
   rev = "3dfde2a70f1f914c6a84ba967123a0e38f51053f";
   # This is the commit number
   # Currently from the 231 branch: https://github.com/JetBrains/jcef/tree/231


### PR DESCRIPTION
###### Description of changes

With #223149, most Jetbrains IDEs have been moved to 231.*. These IDEs need a newer version of JCEF to work properly (e.g. Markdown previews). This PR switches the JCEF version of the Jetbrains JDK to the [231 branch](https://github.com/JetBrains/jcef/tree/231).

I've also tested Goland (which is not yet on 231.*) and it also works.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
