### PR TITLE
maude: 3.1 -> 3.3

### DIFF
--- a/pkgs/development/interpreters/maude/default.nix
+++ b/pkgs/development/interpreters/maude/default.nix
@@ -4,11 +4,11 @@
 
 let
 
-  version = "3.1";
+  version = "3.3";
 
   fullMaude = fetchurl {
-    url = "http://maude.cs.illinois.edu/w/images/0/0a/Full-Maude-${version}.zip";
-    sha256 = "8b13af02c6243116c2ef9592622ecaa06d05dbe1dd6b1e595551ff33855948f2";
+    url = "https://maude.cs.illinois.edu/w/images/b/bc/Full-Maude-3.2.1.zip";
+    sha256 = "0751b3c4619283b3f0adf1c3aac113f1d4334a3ca859ed00d66de5f5857563ec";
   };
 
 in
@@ -18,8 +18,8 @@ stdenv.mkDerivation {
   inherit version;
 
   src = fetchurl {
-    url = "http://maude.cs.illinois.edu/w/images/d/d3/Maude-${version}.tar.gz";
-    sha256 = "b112d7843f65217e3b5a9d40461698ef8dab7cbbe830af21216dfb924dc88a2f";
+    url = "https://github.com/SRI-CSL/Maude/archive/refs/tags/Maude${version}.tar.gz";
+    sha256 = "aebf21523ba7999b4594e315d49b92c5feaef7ca5d176e2e62a8ee1b901380c6";
   };
 
   nativeBuildInputs = [ flex bison unzip makeWrapper ];
@@ -34,7 +34,10 @@ stdenv.mkDerivation {
   # https://gitweb.gentoo.org/repo/gentoo.git/commit/dev-lang/maude/maude-3.1-r1.ebuild?id=f021cc6cfa1e35eb9c59955830f1fd89bfcb26b4
   configureFlags = [ "--without-libsigsegv" ];
 
+  # Certain tests (in particular, Misc/fileTest) expect us to build in a subdirectory
+  # We'll use the directory Opt/ as suggested in INSTALL
   preConfigure = ''
+    mkdir Opt; cd Opt
     configureFlagsArray=(
       --datadir="$out/share/maude"
       TECLA_LIBS="-ltecla -lncursesw"
@@ -42,13 +45,14 @@ stdenv.mkDerivation {
       CFLAGS="-O3" CXXFLAGS="-O3"
     )
   '';
+  configureScript = "../configure";
 
   doCheck = true;
 
   postInstall = ''
     for n in "$out/bin/"*; do wrapProgram "$n" --suffix MAUDE_LIB ':' "$out/share/maude"; done
     unzip ${fullMaude}
-    install -D -m 444 full-maude31.maude $out/share/maude/full-maude.maude
+    install -D -m 444 full-maude.maude $out/share/maude/full-maude.maude
   '';
 
   # bison -dv surface.yy -o surface.c


### PR DESCRIPTION
###### Description of changes

Bumps the `maude` package to 3.3, [the latest available release](https://github.com/SRI-CSL/Maude/releases/tag/Maude3.3).

Also bumps Full Maude to 3.2.1, [the latest available release at this time](https://maude.cs.illinois.edu/w/index.php/Maude_download_and_installation).

Because of a new test (namely, [`tests/Misc/fileTest`](https://github.com/SRI-CSL/Maude/blob/ee2514f6fc0c3f082d8238a4ee6292bbacd42013/tests/Misc/fileTest.maude)) which expects the build to occur in a subdirectory and which fails otherwise, I've also modified the pre-configuration hook so that it creates and enters the `Opt/` subdirectory before beginning the build process. This is the subdirectory recommended in [the `INSTALL` document in the Maude repository](https://github.com/SRI-CSL/Maude/blob/ee2514f6fc0c3f082d8238a4ee6292bbacd42013/INSTALL#L178).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
