### PR TITLE
pkgs-lib.formats: consistent comment support

### DIFF
--- a/pkgs/pkgs-lib/formats/java-properties/default.nix
+++ b/pkgs/pkgs-lib/formats/java-properties/default.nix
@@ -4,7 +4,7 @@ let
   inherit (types) attrsOf oneOf coercedTo str bool int float package;
 in
 {
-  javaProperties = { comment ? "Generated with Nix", boolToString ? lib.boolToString }: {
+  javaProperties = { comment ? "Generated with Nix", boolToString ? lib.boolToString, ... }: {
 
     # Design note:
     # A nested representation of inevitably leads to bad UX:

--- a/pkgs/pkgs-lib/tests/formats.nix
+++ b/pkgs/pkgs-lib/tests/formats.nix
@@ -36,7 +36,7 @@ let
 in runBuildTests {
 
   testJsonAtoms = {
-    drv = evalFormat formats.json {} {
+    drv = evalFormat formats.json { comment = throw "The JSON generator should not evaluate a comment attribute."; } {
       null = null;
       false = false;
       true = true;
@@ -79,6 +79,8 @@ in runBuildTests {
       path = ./formats.nix;
     };
     expected = ''
+      # Generated with Nix
+
       attrs:
         foo: null
       'false': false
@@ -103,6 +105,8 @@ in runBuildTests {
       };
     };
     expected = ''
+      # Generated with Nix
+
       [foo]
       bool=true
       float=3.141000
@@ -120,6 +124,8 @@ in runBuildTests {
       };
     };
     expected = ''
+      # Generated with Nix
+
       [foo]
       bar=null
       bar=true
@@ -140,6 +146,8 @@ in runBuildTests {
       };
     };
     expected = ''
+      # Generated with Nix
+
       [foo]
       bar=null, true, test, 1.200000, 10
       baz=false
@@ -155,6 +163,8 @@ in runBuildTests {
       str = "string";
     };
     expected = ''
+      # Generated with Nix
+
       bool=true
       float=3.141000
       int=10
@@ -169,6 +179,8 @@ in runBuildTests {
       qux = "qux";
     };
     expected = ''
+      # Generated with Nix
+
       bar=null
       bar=true
       bar=test
@@ -186,6 +198,8 @@ in runBuildTests {
       qux = "qux";
     };
     expected = ''
+      # Generated with Nix
+
       bar=null, true, test, 1.200000, 10
       baz=false
       qux=qux
@@ -204,6 +218,8 @@ in runBuildTests {
       level1.level2.level3.level4 = "deep";
     };
     expected = ''
+      # Generated with Nix
+
       false = false
       float = 3.141
       int = 10
@@ -249,6 +265,18 @@ in runBuildTests {
       tautologies = true
       \u00fctf\ 8 = d\u00fbh
       \u0627\u0644\u062c\u0628\u0631 = \u0623\u0643\u062b\u0631 \u0645\u0646 \u0645\u062c\u0631\u062f \u0623\u0631\u0642\u0627\u0645
+    '';
+  };
+
+  testMultiLineYamlComment = {
+    drv = evalFormat formats.yaml { comment = "One line\nAnother line"; } {
+      foo = "bar";
+    };
+    expected = ''
+      # One line
+      # Another line
+
+      foo: bar
     '';
   };
 }


### PR DESCRIPTION
###### Description of changes

This adds start-of-file comment support for most of pkgs-lib's formats.

I also make sure all of them have `...` on the argument attrset, so that they can be used in a "polymorphic" way

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
