### PR TITLE
nginxMainline: 1.23.3 -> 1.23.4

### DIFF
--- a/pkgs/build-support/fetchhg/default.nix
+++ b/pkgs/build-support/fetchhg/default.nix
@@ -4,11 +4,14 @@
 , rev ? null
 , md5 ? null
 , sha256 ? null
+, hash ? null
 , fetchSubrepos ? false
 , preferLocalBuild ? true }:
 
 if md5 != null then
-  throw "fetchhg does not support md5 anymore, please use sha256"
+  throw "fetchhg does not support md5 anymore, please use sha256 or hash"
+else if hash != null && sha256 != null then
+  throw "Only one of sha256 or hash can be set"
 else
 # TODO: statically check if mercurial as the https support if the url starts woth https.
 stdenvNoCC.mkDerivation {
@@ -20,9 +23,14 @@ stdenvNoCC.mkDerivation {
 
   subrepoClause = lib.optionalString fetchSubrepos "S";
 
-  outputHashAlgo = "sha256";
+  outputHashAlgo = if hash != null then null else "sha256";
   outputHashMode = "recursive";
-  outputHash = sha256;
+  outputHash = if hash != null then
+    hash
+  else if sha256 != null then
+    sha256
+  else
+    lib.fakeSha256;
 
   inherit url rev;
   inherit preferLocalBuild;

--- a/pkgs/servers/http/nginx/generic.nix
+++ b/pkgs/servers/http/nginx/generic.nix
@@ -17,7 +17,7 @@ outer@{ lib, stdenv, fetchurl, fetchpatch, openssl, zlib, pcre, libxml2, libxslt
 , version
 , nginxVersion ? version
 , src ? null # defaults to upstream nginx ${version}
-, sha256 ? null # when not specifying src
+, hash ? null # when not specifying src
 , configureFlags ? []
 , nativeBuildInputs ? []
 , buildInputs ? []
@@ -55,7 +55,7 @@ stdenv.mkDerivation {
 
   src = if src != null then src else fetchurl {
     url = "https://nginx.org/download/nginx-${version}.tar.gz";
-    inherit sha256;
+    inherit hash;
   };
 
   nativeBuildInputs = [ removeReferencesTo ]

--- a/pkgs/servers/http/nginx/mainline.nix
+++ b/pkgs/servers/http/nginx/mainline.nix
@@ -1,6 +1,6 @@
 { callPackage, ... }@args:
 
 callPackage ./generic.nix args {
-  version = "1.23.3";
-  sha256 = "sha256-dctXh9u5+uGLFIEPkcxDQ/ZM5MJOJzAhNvtSSYBCulQ=";
+  version = "1.23.4";
+  sha256 = "sha256-1DMA42uySafm7cYLyhsPw3Kguvzi80bXas+2d6h5D8A=";
 }

--- a/pkgs/servers/http/nginx/mainline.nix
+++ b/pkgs/servers/http/nginx/mainline.nix
@@ -2,5 +2,5 @@
 
 callPackage ./generic.nix args {
   version = "1.23.4";
-  sha256 = "sha256-1DMA42uySafm7cYLyhsPw3Kguvzi80bXas+2d6h5D8A=";
+  hash = "sha256-1DMA42uySafm7cYLyhsPw3Kguvzi80bXas+2d6h5D8A=";
 }

--- a/pkgs/servers/http/nginx/quic.nix
+++ b/pkgs/servers/http/nginx/quic.nix
@@ -9,7 +9,7 @@ callPackage ./generic.nix args {
   src = fetchhg {
     url = "https://hg.nginx.org/nginx-quic";
     rev = "0af598651e33"; # branch=quic
-    sha256 = "sha256-rG0jXA+ci7anUxZCBhXZLZKwnTtzzDEAViuoImKpALA=";
+    hash = "sha256-rG0jXA+ci7anUxZCBhXZLZKwnTtzzDEAViuoImKpALA=";
   };
 
   preConfigure = ''

--- a/pkgs/servers/http/nginx/stable.nix
+++ b/pkgs/servers/http/nginx/stable.nix
@@ -2,5 +2,5 @@
 
 callPackage ./generic.nix args {
   version = "1.22.1";
-  sha256 = "sha256-nrszOp6CuVKs0+K0rrHU/2QG9ySRurbNn+afDepzfzE=";
+  hash = "sha256-nrszOp6CuVKs0+K0rrHU/2QG9ySRurbNn+afDepzfzE=";
 }


### PR DESCRIPTION
###### Description of changes
https://nginx.org/en/CHANGES

###### Things done
- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).