### PR TITLE
potreeconverter: fixes and update

### DIFF
--- a/pkgs/applications/graphics/potreeconverter/default.nix
+++ b/pkgs/applications/graphics/potreeconverter/default.nix
@@ -9,13 +9,13 @@
 
 stdenv.mkDerivation rec {
   pname = "PotreeConverter";
-  version = "unstable-2022-08-04";
+  version = "unstable-2023-02-27";
 
   src = fetchFromGitHub {
     owner = "potree";
     repo = "PotreeConverter";
-    rev = "758bbac98a662de5e57d2280675e11cc76241688";
-    sha256 = "sha256-pDdV2/edYhhBWs153hSy1evI3cXD0Xq9nrEsw3JNcH4=";
+    rev = "af4666fa1090983d8ce7c11dcf49ba19eda90995";
+    sha256 = "sha256-QYNY+/v6mBEJFiv3i2QS+zqkgWJqeqXSqNoh+ChAiQA=";
   };
 
   buildInputs = [

--- a/pkgs/applications/graphics/potreeconverter/default.nix
+++ b/pkgs/applications/graphics/potreeconverter/default.nix
@@ -48,6 +48,11 @@ stdenv.mkDerivation rec {
     runHook postInstall
   '';
 
+  fixupPhase = ''
+    runHook preFixup
+    ln -s $src/resources $out/bin/resources
+    runHook postFixup
+  '';
   meta = with lib; {
     description = "Create multi res point cloud to use with potree";
     homepage = "https://github.com/potree/PotreeConverter";


### PR DESCRIPTION
###### Description of changes

There are two issues with PotreeConverter prior to this PR:

1. It tries to copy templates from the `resources` directory which is present in its source code, it does not have access to these because it gets them from the exe location `$(which PotreeConverter)`, and finds that `resources` does not exist there. This PR fixes that by symlinking the resources directory from the source code into the closure
2. When copying these templates, the program inherits permissions as there is no way in the C Standard Library to prevent the `fs::copy` function from inheriting the permissions of files via `fs::copy_options`, meaning it cannot do anything with these templates after copying

This PR fixes both of these issues, and updates the package.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
