### PR TITLE
flake.nix: provide nixpkgs used to build nixos to modules

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -26,6 +26,18 @@
                   ".${final.substring 0 8 (self.lastModifiedDate or self.lastModified or "19700101")}.${self.shortRev or "dirty"}";
                 system.nixos.revision = final.mkIf (self ? rev) self.rev;
               }];
+
+              # Provide an `inputs` argument to all modules, containing the nixpkgs flake itself.
+              #
+              # Merge specialArgs with those provided by the caller,
+              # in order to allow the caller to provide its own
+              # specialArgs, including replacing inputs if desired.
+              specialArgs = {
+                inputs = {
+                  nixpkgs = self;
+                } // args.specialArgs.inputs or {};
+              } // args.specialArgs or {};
+
             } // lib.optionalAttrs (! args?system) {
               # Allow system to be set modularly in nixpkgs.system.
               # We set it to null, to remove the "legacy" entrypoint's


### PR DESCRIPTION
###### Description of changes

This allows NixOS modules to take `inputs` as an extra argument. This may be useful for feeding version information into other config.

For example, I use this to inform a module which exposes a prometheus metric on the date of the nixpkgs version used to build the system (slightly abridged):

```
{ pkgs, config, inputs, ... }: {
  services.nginx.enable = true;
  services.nginx.virtualHosts."prometheus".root = pkgs.writeTextDir "/metrics" ''
    # HELP nixpkgs_date The timestamp of the last modification on the nixpkgs flake input used to build the system.
    # TYPE nixpkgs_date gauge
    nixpkgs_date ${toString inputs.nixpkgs.sourceInfo.lastModified}
  '';
}
```

This is mostly a convenience feature. Downstream flakes were already able to set specialArgs.inputs themselves, but this makes obtaining correct nixpkgs version information even in a flake which uses multiple different nixpkgs versions a little more elegant.


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
