### PR TITLE
Enable tests for Halide; replace llvmPackages.stdenv with stdenv

### DIFF
--- a/pkgs/development/compilers/halide/default.nix
+++ b/pkgs/development/compilers/halide/default.nix
@@ -25,12 +25,14 @@ stdenv.mkDerivation rec {
     sha256 = "sha256-te9Yn/rmA0YSulnxXL/y5d8PFphjQPgZUDWHNn7oqMg=";
   };
 
-  cmakeFlags = [ "-DWARNINGS_AS_ERRORS=OFF" "-DWITH_PYTHON_BINDINGS=OFF" "-DTARGET_WEBASSEMBLY=OFF" ];
+  cmakeFlags = [
+    "-DWARNINGS_AS_ERRORS=OFF"
+    "-DWITH_PYTHON_BINDINGS=OFF"
+    "-DTARGET_WEBASSEMBLY=OFF"
+    # Disable performance tests since they may fail on busy machines
+    "-DWITH_TEST_PERFORMANCE=OFF"
+  ];
 
-  postPatch = ''
-    substituteInPlace test/performance/CMakeLists.txt \
-      --replace 'memcpy.cpp' '# memcpy.cpp'
-  '';
   doCheck = true;
 
   # Note: only openblas and not atlas part of this Nix expression

--- a/pkgs/development/compilers/halide/default.nix
+++ b/pkgs/development/compilers/halide/default.nix
@@ -27,6 +27,10 @@ stdenv.mkDerivation rec {
 
   cmakeFlags = [ "-DWARNINGS_AS_ERRORS=OFF" "-DWITH_PYTHON_BINDINGS=OFF" "-DTARGET_WEBASSEMBLY=OFF" ];
 
+  postPatch = ''
+    substituteInPlace test/performance/CMakeLists.txt \
+      --replace 'memcpy.cpp' '# memcpy.cpp'
+  '';
   doCheck = true;
 
   # Note: only openblas and not atlas part of this Nix expression

--- a/pkgs/development/compilers/halide/default.nix
+++ b/pkgs/development/compilers/halide/default.nix
@@ -1,4 +1,5 @@
-{ llvmPackages
+{ stdenv
+, llvmPackages
 , lib
 , fetchFromGitHub
 , cmake
@@ -13,7 +14,7 @@
 
 assert blas.implementation == "openblas" && lapack.implementation == "openblas";
 
-llvmPackages.stdenv.mkDerivation rec {
+stdenv.mkDerivation rec {
   pname = "halide";
   version = "15.0.0";
 
@@ -25,6 +26,8 @@ llvmPackages.stdenv.mkDerivation rec {
   };
 
   cmakeFlags = [ "-DWARNINGS_AS_ERRORS=OFF" "-DWITH_PYTHON_BINDINGS=OFF" "-DTARGET_WEBASSEMBLY=OFF" ];
+
+  doCheck = true;
 
   # Note: only openblas and not atlas part of this Nix expression
   # see pkgs/development/libraries/science/math/liblapack/3.5.0.nix


### PR DESCRIPTION
###### Description of changes

Fixes errors in Nix-built Halide (see https://github.com/halide/Halide/issues/7442 for more info about the failures) by replacing `llvmPackages.stdenv` with `stdenv`.

Enables tests for the package (these were failing before this PR and pass now).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [X] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [X] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
