### PR TITLE
darwin.builder: provide NixOS module options for macos-builder.nix

### DIFF
--- a/doc/builders/special/darwin-builder.section.md
+++ b/doc/builders/special/darwin-builder.section.md
@@ -7,7 +7,7 @@ This requires macOS version 12.4 or later.
 This also requires that port 22 on your machine is free (since Nix does not
 permit specifying a non-default SSH port for builders).
 
-You will also need to be a trusted user for your Nix installation.  In other
+You will also need to be a trusted user for your Nix installation. In other
 words, your `/etc/nix/nix.conf` should have something like:
 
 ```
@@ -60,4 +60,38 @@ builders-use-substitutes = true
 
 ```ShellSession
 $ sudo launchctl kickstart -k system/org.nixos.nix-daemon
+```
+
+## As a NixOS module
+
+The `darwin.builder` bootstrapper runs a NixOS module with sensible defaults for
+two settings:
+
+- `services.macos-builder.diskSize` &mdash; The disk space used by the VM in MB,
+  with a default of 20 \* 1024 (20 GB).
+- `services.macos-builder.memorySize` &mdash; The memory used by the VM in MB,
+  with a default of 3 \* 1024 (3 GB).
+
+To provide different values for these settings, you need to use the builder as a
+NixOS VM on your own. Here's an example configuration:
+
+```nix
+{ modulesPath, pkgs, ... }:
+
+{
+  imports = [
+    # The builder module
+    "${modulesPath}/profiles/macos-builder.nix"
+    # Other modules
+  ];
+
+  services.macos-builder = {
+    enable = true; # Run the builder
+    services.macos-builder.diskSize = 50 * 1024; # 50 GB instead of 20
+    services.macos-builder.memorySize = 8 * 1024; # 8 GB instead of 3
+  };
+  virtualisation.host = { inherit pkgs; };
+
+  # Other settings
+}
 ```

--- a/nixos/modules/profiles/macos-builder.nix
+++ b/nixos/modules/profiles/macos-builder.nix
@@ -1,14 +1,14 @@
 { config, lib, pkgs, ... }:
 
 let
+  inherit (lib) mkEnableOption mkIf mkOption types;
+  cfg = config.services.macos-builder;
+
+  # Constants
   keysDirectory = "/var/keys";
-
   user = "builder";
-
   keyType = "ed25519";
-
 in
-
 {
   imports = [
     ../virtualisation/qemu-vm.nix
@@ -24,156 +24,171 @@ in
     }
   ];
 
-  # The builder is not intended to be used interactively
-  documentation.enable = false;
+  options.services.macos-builder = {
+    enable = mkEnableOption ''
+      Run a Linux builder on macOS.
+    '';
 
-  environment.etc = {
-    "ssh/ssh_host_ed25519_key" = {
-      mode = "0600";
-
-      source = ./keys/ssh_host_ed25519_key;
+    diskSize = mkOption {
+      type = types.ints.positive;
+      description = "Disk size of the Linux builder's VM (in megabytes).";
+      default = 20 * 1024;
     };
 
-    "ssh/ssh_host_ed25519_key.pub" = {
-      mode = "0644";
-
-      source = ./keys/ssh_host_ed25519_key.pub;
-    };
-  };
-
-  # DNS fails for QEMU user networking (SLiRP) on macOS.  See:
-  #
-  # https://github.com/utmapp/UTM/issues/2353
-  #
-  # This works around that by using a public DNS server other than the DNS
-  # server that QEMU provides (normally 10.0.2.3)
-  networking.nameservers = [ "8.8.8.8" ];
-
-  nix.settings = {
-    auto-optimise-store = true;
-
-    min-free = 1024 * 1024 * 1024;
-
-    max-free = 3 * 1024 * 1024 * 1024;
-
-    trusted-users = [ "root" user ];
-  };
-
-  services = {
-    getty.autologinUser = user;
-
-    openssh = {
-      enable = true;
-
-      authorizedKeysFiles = [ "${keysDirectory}/%u_${keyType}.pub" ];
+    memorySize = mkOption {
+      type = types.ints.positive;
+      description = "Memory size of the Linux builder's VM (in megabytes).";
+      default = 3 * 1024;
     };
   };
 
-  system.build.macos-builder-installer =
-    let
-      privateKey = "/etc/nix/${user}_${keyType}";
+  config = mkIf cfg.enable {
+    # The builder is not intended to be used interactively
+    documentation.enable = false;
 
-      publicKey = "${privateKey}.pub";
+    environment.etc = {
+      "ssh/ssh_host_ed25519_key" = {
+        mode = "0600";
 
-      # This installCredentials script is written so that it's as easy as
-      # possible for a user to audit before confirming the `sudo`
-      installCredentials = hostPkgs.writeShellScript "install-credentials" ''
-        KEYS="''${1}"
-        INSTALL=${hostPkgs.coreutils}/bin/install
-        "''${INSTALL}" -g nixbld -m 600 "''${KEYS}/${user}_${keyType}" ${privateKey}
-        "''${INSTALL}" -g nixbld -m 644 "''${KEYS}/${user}_${keyType}.pub" ${publicKey}
-      '';
-
-      hostPkgs = config.virtualisation.host.pkgs;
-
-      script = hostPkgs.writeShellScriptBin "create-builder" ''
-        KEYS="''${KEYS:-./keys}"
-        ${hostPkgs.coreutils}/bin/mkdir --parent "''${KEYS}"
-        PRIVATE_KEY="''${KEYS}/${user}_${keyType}"
-        PUBLIC_KEY="''${PRIVATE_KEY}.pub"
-        if [ ! -e "''${PRIVATE_KEY}" ] || [ ! -e "''${PUBLIC_KEY}" ]; then
-            ${hostPkgs.coreutils}/bin/rm --force -- "''${PRIVATE_KEY}" "''${PUBLIC_KEY}"
-            ${hostPkgs.openssh}/bin/ssh-keygen -q -f "''${PRIVATE_KEY}" -t ${keyType} -N "" -C 'builder@localhost'
-        fi
-        if ! ${hostPkgs.diffutils}/bin/cmp "''${PUBLIC_KEY}" ${publicKey}; then
-          (set -x; sudo --reset-timestamp ${installCredentials} "''${KEYS}")
-        fi
-        KEYS="$(nix-store --add "$KEYS")" ${config.system.build.vm}/bin/run-nixos-vm
-      '';
-
-    in
-    script.overrideAttrs (old: {
-      meta = (old.meta or { }) // {
-        platforms = lib.platforms.darwin;
+        source = ./keys/ssh_host_ed25519_key;
       };
-    });
 
-  system = {
-    # To prevent gratuitous rebuilds on each change to Nixpkgs
-    nixos.revision = null;
+      "ssh/ssh_host_ed25519_key.pub" = {
+        mode = "0644";
 
-    stateVersion = lib.mkDefault (throw ''
-      The macOS linux builder should not need a stateVersion to be set, but a module
-      has accessed stateVersion nonetheless.
-      Please inspect the trace of the following command to figure out which module
-      has a dependency on stateVersion.
-
-        nix-instantiate --attr darwin.builder --show-trace
-    '');
-  };
-
-  users.users."${user}" = {
-    isNormalUser = true;
-  };
-
-  security.polkit.enable = true;
-
-  security.polkit.extraConfig = ''
-    polkit.addRule(function(action, subject) {
-      if (action.id === "org.freedesktop.login1.power-off" && subject.user === "${user}") {
-        return "yes";
-      } else {
-        return "no";
-      }
-    })
-  '';
-
-  virtualisation = {
-    diskSize = 20 * 1024;
-
-    memorySize = 3 * 1024;
-
-    forwardPorts = [
-      { from = "host"; guest.port = 22; host.port = 22; }
-    ];
-
-    # Disable graphics for the builder since users will likely want to run it
-    # non-interactively in the background.
-    graphics = false;
-
-    sharedDirectories.keys = {
-      source = "\"$KEYS\"";
-      target = keysDirectory;
+        source = ./keys/ssh_host_ed25519_key.pub;
+      };
     };
 
-    # If we don't enable this option then the host will fail to delegate builds
-    # to the guest, because:
+    # DNS fails for QEMU user networking (SLiRP) on macOS.  See:
     #
-    # - The host will lock the path to build
-    # - The host will delegate the build to the guest
-    # - The guest will attempt to lock the same path and fail because
-    #   the lockfile on the host is visible on the guest
+    # https://github.com/utmapp/UTM/issues/2353
     #
-    # Snapshotting the host's /nix/store as an image isolates the guest VM's
-    # /nix/store from the host's /nix/store, preventing this problem.
-    useNixStoreImage = true;
+    # This works around that by using a public DNS server other than the DNS
+    # server that QEMU provides (normally 10.0.2.3)
+    networking.nameservers = [ "8.8.8.8" ];
 
-    # Obviously the /nix/store needs to be writable on the guest in order for it
-    # to perform builds.
-    writableStore = true;
+    nix.settings = {
+      auto-optimise-store = true;
+      min-free = 1024 * 1024 * 1024;
+      max-free = 3 * 1024 * 1024 * 1024;
+      trusted-users = [ "root" user ];
+    };
 
-    # This ensures that anything built on the guest isn't lost when the guest is
-    # restarted.
-    writableStoreUseTmpfs = false;
+    services = {
+      getty.autologinUser = user;
+
+      openssh = {
+        enable = true;
+        authorizedKeysFiles = [ "${keysDirectory}/%u_${keyType}.pub" ];
+      };
+    };
+
+    system.build.macos-builder-installer =
+      let
+        privateKey = "/etc/nix/${user}_${keyType}";
+
+        publicKey = "${privateKey}.pub";
+
+        # This installCredentials script is written so that it's as easy as
+        # possible for a user to audit before confirming the `sudo`
+        installCredentials = hostPkgs.writeShellScript "install-credentials" ''
+          KEYS="''${1}"
+          INSTALL=${hostPkgs.coreutils}/bin/install
+          "''${INSTALL}" -g nixbld -m 600 "''${KEYS}/${user}_${keyType}" ${privateKey}
+          "''${INSTALL}" -g nixbld -m 644 "''${KEYS}/${user}_${keyType}.pub" ${publicKey}
+        '';
+
+        hostPkgs = config.virtualisation.host.pkgs;
+
+        script = hostPkgs.writeShellScriptBin "create-builder" ''
+          KEYS="''${KEYS:-./keys}"
+          ${hostPkgs.coreutils}/bin/mkdir --parent "''${KEYS}"
+          PRIVATE_KEY="''${KEYS}/${user}_${keyType}"
+          PUBLIC_KEY="''${PRIVATE_KEY}.pub"
+          if [ ! -e "''${PRIVATE_KEY}" ] || [ ! -e "''${PUBLIC_KEY}" ]; then
+              ${hostPkgs.coreutils}/bin/rm --force -- "''${PRIVATE_KEY}" "''${PUBLIC_KEY}"
+              ${hostPkgs.openssh}/bin/ssh-keygen -q -f "''${PRIVATE_KEY}" -t ${keyType} -N "" -C 'builder@localhost'
+          fi
+          if ! ${hostPkgs.diffutils}/bin/cmp "''${PUBLIC_KEY}" ${publicKey}; then
+            (set -x; sudo --reset-timestamp ${installCredentials} "''${KEYS}")
+          fi
+          KEYS="$(nix-store --add "$KEYS")" ${config.system.build.vm}/bin/run-nixos-vm
+        '';
+
+      in
+      script.overrideAttrs (old: {
+        meta = (old.meta or { }) // {
+          platforms = lib.platforms.darwin;
+        };
+      });
+
+    system = {
+      # To prevent gratuitous rebuilds on each change to Nixpkgs
+      nixos.revision = null;
+
+      stateVersion = lib.mkDefault (throw ''
+        The macOS linux builder should not need a stateVersion to be set, but a module
+        has accessed stateVersion nonetheless.
+        Please inspect the trace of the following command to figure out which module
+        has a dependency on stateVersion.
+
+          nix-instantiate --attr darwin.builder --show-trace
+      '');
+    };
+
+    users.users."${user}" = {
+      isNormalUser = true;
+    };
+
+    security.polkit.enable = true;
+
+    security.polkit.extraConfig = ''
+      polkit.addRule(function(action, subject) {
+        if (action.id === "org.freedesktop.login1.power-off" && subject.user === "${user}") {
+          return "yes";
+        } else {
+          return "no";
+        }
+      })
+    '';
+
+    virtualisation = {
+      diskSize = cfg.diskSize;
+      memorySize = cfg.memorySize;
+
+      forwardPorts = [
+        { from = "host"; guest.port = 22; host.port = 22; }
+      ];
+
+      # Disable graphics for the builder since users will likely want to run it
+      # non-interactively in the background.
+      graphics = false;
+
+      sharedDirectories.keys = {
+        source = "\"$KEYS\"";
+        target = keysDirectory;
+      };
+
+      # If we don't enable this option then the host will fail to delegate builds
+      # to the guest, because:
+      #
+      # - The host will lock the path to build
+      # - The host will delegate the build to the guest
+      # - The guest will attempt to lock the same path and fail because
+      #   the lockfile on the host is visible on the guest
+      #
+      # Snapshotting the host's /nix/store as an image isolates the guest VM's
+      # /nix/store from the host's /nix/store, preventing this problem.
+      useNixStoreImage = true;
+
+      # Obviously the /nix/store needs to be writable on the guest in order for it
+      # to perform builds.
+      writableStore = true;
+
+      # This ensures that anything built on the guest isn't lost when the guest is
+      # restarted.
+      writableStoreUseTmpfs = false;
+    };
   };
 }

--- a/pkgs/top-level/darwin-packages.nix
+++ b/pkgs/top-level/darwin-packages.nix
@@ -235,12 +235,17 @@ impure-cmds // appleSourcePackages // chooseLibs // {
             ../../nixos/modules/profiles/macos-builder.nix
           ];
 
+          services.macos-builder = {
+            enable = true;
+            diskSize = 20 * 1024; # 20 GB (this is also the default)
+            memorySize = 3 * 1024; # 3 GB (this is also the default)
+          };
+
           virtualisation.host = { inherit pkgs; };
         };
 
         system = toGuest stdenv.hostPlatform.system;
       };
-
     in
       nixos.config.system.build.macos-builder-installer;
 })


### PR DESCRIPTION
###### Description of changes

The addition of `darwin.builder` has been great for running Linux builds on macOS. This PR adds some configuration options to the `macos-builder.nix` module on which the builder is based. More specifically, it makes the disk and RAM used by the builder configurable rather than constant. My goal is to make a `nix-darwin` module to complement this work and would like to have some additional configuration hooks.

As far as I can tell, this shouldn't break anything, as the behavior of `nix run nixpkgs#darwin.builder` remains the same. But please do let me know if that is not the case.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

