### PR TITLE
nixos/darwin-builder: add disk space options

### DIFF
--- a/doc/builders/special/darwin-builder.section.md
+++ b/doc/builders/special/darwin-builder.section.md
@@ -90,8 +90,8 @@ $ sudo launchctl kickstart -k system/org.nixos.nix-daemon
     };
   in {
 
-    darwinConfigurations = rec {
-      machine1 = darwinSystem rec {
+    darwinConfigurations = {
+      machine1 = darwinSystem {
         inherit system;
         modules = [
           {

--- a/doc/builders/special/darwin-builder.section.md
+++ b/doc/builders/special/darwin-builder.section.md
@@ -77,8 +77,8 @@ $ sudo launchctl kickstart -k system/org.nixos.nix-daemon
   let
 
     inherit (darwin.lib) darwinSystem;
-    pkgs = nixpkgs.legacyPackages.aarch64-darwin;
-    system = pkgs.stdenv.hostPlatform.system;
+    system = "aarch64-darwin";
+    pkgs = nixpkgs.legacyPackages."${system}";
     linuxSystem = builtins.replaceStrings [ "darwin" ] [ "linux" ] system;
 
     darwin-builder = import "${nixpkgs}/nixos" {

--- a/doc/builders/special/darwin-builder.section.md
+++ b/doc/builders/special/darwin-builder.section.md
@@ -100,7 +100,7 @@ $ sudo launchctl kickstart -k system/org.nixos.nix-daemon
               hostName = "ssh://builder@localhost";
               system = linuxSystem;
               maxJobs = 4;
-              supportedFeatures = [ "kvm" "benchmark" "bigparallel" ];
+              supportedFeatures = [ "kvm" "benchmark" "big-parallel" ];
             }];
 
             launchd.daemons.darwin-builder = {

--- a/doc/builders/special/darwin-builder.section.md
+++ b/doc/builders/special/darwin-builder.section.md
@@ -81,14 +81,12 @@ $ sudo launchctl kickstart -k system/org.nixos.nix-daemon
     pkgs = nixpkgs.legacyPackages."${system}";
     linuxSystem = builtins.replaceStrings [ "darwin" ] [ "linux" ] system;
 
-    darwin-builder = import "${nixpkgs}/nixos" {
+    darwin-builder = nixpkgs.nixosSystem {
       system = linuxSystem;
-      configuration = {
-        imports = [
-          "${nixpkgs}/nixos/modules/profiles/macos-builder.nix"
-        ];
-        virtualisation.host.pkgs = pkgs;
-      };
+      modules = [
+        "${nixpkgs}/nixos/modules/profiles/macos-builder.nix"
+        { virtualisation.host.pkgs = pkgs; }
+      ];
     };
   in {
 

--- a/nixos/modules/profiles/macos-builder.nix
+++ b/nixos/modules/profiles/macos-builder.nix
@@ -24,156 +24,191 @@ in
     }
   ];
 
-  # The builder is not intended to be used interactively
-  documentation.enable = false;
-
-  environment.etc = {
-    "ssh/ssh_host_ed25519_key" = {
-      mode = "0600";
-
-      source = ./keys/ssh_host_ed25519_key;
+  options.virtualisation.darwin-builder = with lib; {
+    diskSize = mkOption {
+      default = 20 * 1024;
+      type = types.int;
+      example = 30720;
+      description = "The maximum disk space allocated to the runner in MB";
     };
-
-    "ssh/ssh_host_ed25519_key.pub" = {
-      mode = "0644";
-
-      source = ./keys/ssh_host_ed25519_key.pub;
+    memorySize = mkOption {
+      default = 3 * 1024;
+      type = types.int;
+      example = 8192;
+      description = "The runner's memory in MB";
     };
-  };
-
-  # DNS fails for QEMU user networking (SLiRP) on macOS.  See:
-  #
-  # https://github.com/utmapp/UTM/issues/2353
-  #
-  # This works around that by using a public DNS server other than the DNS
-  # server that QEMU provides (normally 10.0.2.3)
-  networking.nameservers = [ "8.8.8.8" ];
-
-  nix.settings = {
-    auto-optimise-store = true;
-
-    min-free = 1024 * 1024 * 1024;
-
-    max-free = 3 * 1024 * 1024 * 1024;
-
-    trusted-users = [ "root" user ];
-  };
-
-  services = {
-    getty.autologinUser = user;
-
-    openssh = {
-      enable = true;
-
-      authorizedKeysFiles = [ "${keysDirectory}/%u_${keyType}.pub" ];
-    };
-  };
-
-  system.build.macos-builder-installer =
-    let
-      privateKey = "/etc/nix/${user}_${keyType}";
-
-      publicKey = "${privateKey}.pub";
-
-      # This installCredentials script is written so that it's as easy as
-      # possible for a user to audit before confirming the `sudo`
-      installCredentials = hostPkgs.writeShellScript "install-credentials" ''
-        KEYS="''${1}"
-        INSTALL=${hostPkgs.coreutils}/bin/install
-        "''${INSTALL}" -g nixbld -m 600 "''${KEYS}/${user}_${keyType}" ${privateKey}
-        "''${INSTALL}" -g nixbld -m 644 "''${KEYS}/${user}_${keyType}.pub" ${publicKey}
+    min-free = mkOption {
+      default = 1024 * 1024 * 1024;
+      type = types.int;
+      example = 1073741824;
+      description = ''
+        The threshold (in bytes) of free disk space left at which to
+        start garbage collection on the runner
       '';
-
-      hostPkgs = config.virtualisation.host.pkgs;
-
-      script = hostPkgs.writeShellScriptBin "create-builder" ''
-        KEYS="''${KEYS:-./keys}"
-        ${hostPkgs.coreutils}/bin/mkdir --parent "''${KEYS}"
-        PRIVATE_KEY="''${KEYS}/${user}_${keyType}"
-        PUBLIC_KEY="''${PRIVATE_KEY}.pub"
-        if [ ! -e "''${PRIVATE_KEY}" ] || [ ! -e "''${PUBLIC_KEY}" ]; then
-            ${hostPkgs.coreutils}/bin/rm --force -- "''${PRIVATE_KEY}" "''${PUBLIC_KEY}"
-            ${hostPkgs.openssh}/bin/ssh-keygen -q -f "''${PRIVATE_KEY}" -t ${keyType} -N "" -C 'builder@localhost'
-        fi
-        if ! ${hostPkgs.diffutils}/bin/cmp "''${PUBLIC_KEY}" ${publicKey}; then
-          (set -x; sudo --reset-timestamp ${installCredentials} "''${KEYS}")
-        fi
-        KEYS="$(nix-store --add "$KEYS")" ${config.system.build.vm}/bin/run-nixos-vm
+    };
+    max-free = mkOption {
+      default = 3 * 1024 * 1024 * 1024;
+      type = types.int;
+      example = 3221225472;
+      description = ''
+        The threshold (in bytes) of free disk space left at which to
+        stop garbage collection on the runner
       '';
+    };
+  };
 
-    in
-    script.overrideAttrs (old: {
-      meta = (old.meta or { }) // {
-        platforms = lib.platforms.darwin;
+  config = {
+    # The builder is not intended to be used interactively
+    documentation.enable = false;
+
+    environment.etc = {
+      "ssh/ssh_host_ed25519_key" = {
+        mode = "0600";
+
+        source = ./keys/ssh_host_ed25519_key;
       };
-    });
 
-  system = {
-    # To prevent gratuitous rebuilds on each change to Nixpkgs
-    nixos.revision = null;
+      "ssh/ssh_host_ed25519_key.pub" = {
+        mode = "0644";
 
-    stateVersion = lib.mkDefault (throw ''
-      The macOS linux builder should not need a stateVersion to be set, but a module
-      has accessed stateVersion nonetheless.
-      Please inspect the trace of the following command to figure out which module
-      has a dependency on stateVersion.
-
-        nix-instantiate --attr darwin.builder --show-trace
-    '');
-  };
-
-  users.users."${user}" = {
-    isNormalUser = true;
-  };
-
-  security.polkit.enable = true;
-
-  security.polkit.extraConfig = ''
-    polkit.addRule(function(action, subject) {
-      if (action.id === "org.freedesktop.login1.power-off" && subject.user === "${user}") {
-        return "yes";
-      } else {
-        return "no";
-      }
-    })
-  '';
-
-  virtualisation = {
-    diskSize = 20 * 1024;
-
-    memorySize = 3 * 1024;
-
-    forwardPorts = [
-      { from = "host"; guest.port = 22; host.port = 22; }
-    ];
-
-    # Disable graphics for the builder since users will likely want to run it
-    # non-interactively in the background.
-    graphics = false;
-
-    sharedDirectories.keys = {
-      source = "\"$KEYS\"";
-      target = keysDirectory;
+        source = ./keys/ssh_host_ed25519_key.pub;
+      };
     };
 
-    # If we don't enable this option then the host will fail to delegate builds
-    # to the guest, because:
+    # DNS fails for QEMU user networking (SLiRP) on macOS.  See:
     #
-    # - The host will lock the path to build
-    # - The host will delegate the build to the guest
-    # - The guest will attempt to lock the same path and fail because
-    #   the lockfile on the host is visible on the guest
+    # https://github.com/utmapp/UTM/issues/2353
     #
-    # Snapshotting the host's /nix/store as an image isolates the guest VM's
-    # /nix/store from the host's /nix/store, preventing this problem.
-    useNixStoreImage = true;
+    # This works around that by using a public DNS server other than the DNS
+    # server that QEMU provides (normally 10.0.2.3)
+    networking.nameservers = [ "8.8.8.8" ];
 
-    # Obviously the /nix/store needs to be writable on the guest in order for it
-    # to perform builds.
-    writableStore = true;
+    nix.settings = {
+      auto-optimise-store = true;
 
-    # This ensures that anything built on the guest isn't lost when the guest is
-    # restarted.
-    writableStoreUseTmpfs = false;
+      min-free = config.virtualisation.darwin-builder.min-free;
+
+      max-free = config.virtualisation.darwin-builder.max-free;
+
+      trusted-users = [ "root" user ];
+    };
+
+    services = {
+      getty.autologinUser = user;
+
+      openssh = {
+        enable = true;
+
+        authorizedKeysFiles = [ "${keysDirectory}/%u_${keyType}.pub" ];
+      };
+    };
+
+    system.build.macos-builder-installer =
+      let
+        privateKey = "/etc/nix/${user}_${keyType}";
+
+        publicKey = "${privateKey}.pub";
+
+        # This installCredentials script is written so that it's as easy as
+        # possible for a user to audit before confirming the `sudo`
+        installCredentials = hostPkgs.writeShellScript "install-credentials" ''
+          KEYS="''${1}"
+          INSTALL=${hostPkgs.coreutils}/bin/install
+          "''${INSTALL}" -g nixbld -m 600 "''${KEYS}/${user}_${keyType}" ${privateKey}
+          "''${INSTALL}" -g nixbld -m 644 "''${KEYS}/${user}_${keyType}.pub" ${publicKey}
+        '';
+
+        hostPkgs = config.virtualisation.host.pkgs;
+
+        script = hostPkgs.writeShellScriptBin "create-builder" ''
+          KEYS="''${KEYS:-./keys}"
+          ${hostPkgs.coreutils}/bin/mkdir --parent "''${KEYS}"
+          PRIVATE_KEY="''${KEYS}/${user}_${keyType}"
+          PUBLIC_KEY="''${PRIVATE_KEY}.pub"
+          if [ ! -e "''${PRIVATE_KEY}" ] || [ ! -e "''${PUBLIC_KEY}" ]; then
+              ${hostPkgs.coreutils}/bin/rm --force -- "''${PRIVATE_KEY}" "''${PUBLIC_KEY}"
+              ${hostPkgs.openssh}/bin/ssh-keygen -q -f "''${PRIVATE_KEY}" -t ${keyType} -N "" -C 'builder@localhost'
+          fi
+          if ! ${hostPkgs.diffutils}/bin/cmp "''${PUBLIC_KEY}" ${publicKey}; then
+            (set -x; sudo --reset-timestamp ${installCredentials} "''${KEYS}")
+          fi
+          KEYS="$(nix-store --add "$KEYS")" ${config.system.build.vm}/bin/run-nixos-vm
+        '';
+
+      in
+      script.overrideAttrs (old: {
+        meta = (old.meta or { }) // {
+          platforms = lib.platforms.darwin;
+        };
+      });
+
+    system = {
+      # To prevent gratuitous rebuilds on each change to Nixpkgs
+      nixos.revision = null;
+
+      stateVersion = lib.mkDefault (throw ''
+        The macOS linux builder should not need a stateVersion to be set, but a module
+        has accessed stateVersion nonetheless.
+        Please inspect the trace of the following command to figure out which module
+        has a dependency on stateVersion.
+
+          nix-instantiate --attr darwin.builder --show-trace
+      '');
+    };
+
+    users.users."${user}" = {
+      isNormalUser = true;
+    };
+
+    security.polkit.enable = true;
+
+    security.polkit.extraConfig = ''
+      polkit.addRule(function(action, subject) {
+        if (action.id === "org.freedesktop.login1.power-off" && subject.user === "${user}") {
+          return "yes";
+        } else {
+          return "no";
+        }
+      })
+    '';
+
+    virtualisation = {
+      diskSize = config.virtualisation.darwin-builder.diskSize;
+
+      memorySize = config.virtualisation.darwin-builder.memorySize;
+
+      forwardPorts = [
+        { from = "host"; guest.port = 22; host.port = 22; }
+      ];
+
+      # Disable graphics for the builder since users will likely want to run it
+      # non-interactively in the background.
+      graphics = false;
+
+      sharedDirectories.keys = {
+        source = "\"$KEYS\"";
+        target = keysDirectory;
+      };
+
+      # If we don't enable this option then the host will fail to delegate builds
+      # to the guest, because:
+      #
+      # - The host will lock the path to build
+      # - The host will delegate the build to the guest
+      # - The guest will attempt to lock the same path and fail because
+      #   the lockfile on the host is visible on the guest
+      #
+      # Snapshotting the host's /nix/store as an image isolates the guest VM's
+      # /nix/store from the host's /nix/store, preventing this problem.
+      useNixStoreImage = true;
+
+      # Obviously the /nix/store needs to be writable on the guest in order for it
+      # to perform builds.
+      writableStore = true;
+
+      # This ensures that anything built on the guest isn't lost when the guest is
+      # restarted.
+      writableStoreUseTmpfs = false;
+    };
   };
 }


### PR DESCRIPTION
###### Description of changes
Add options to configure diskSize and memorySize of the darwin-builder VM, as well as some additional documentation.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin (via aarch64-linux VM)
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x]  Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

