### PR TITLE
pjsip: add tests and darwin compatiblity

### DIFF
--- a/pkgs/applications/networking/pjsip/default.nix
+++ b/pkgs/applications/networking/pjsip/default.nix
@@ -11,17 +11,16 @@
 , Security
 , python3
 , pythonSupport ? true
-, pjsip
 , runCommand
 }:
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "pjsip";
   version = "2.13";
 
   src = fetchFromGitHub {
-    owner = pname;
+    owner = finalAttrs.pname;
     repo = "pjproject";
-    rev = version;
+    rev = finalAttrs.version;
     sha256 = "sha256-yzszmm3uIyXtYFgZtUP3iswLx4u/8UbFt80Ln25ToFE=";
   };
 
@@ -64,8 +63,8 @@ stdenv.mkDerivation rec {
   postInstall = ''
     mkdir -p $out/bin
     cp pjsip-apps/bin/pjsua-* $out/bin/pjsua
-    mkdir -p $out/share/${pname}-${version}/samples
-    cp pjsip-apps/bin/samples/*/* $out/share/${pname}-${version}/samples
+    mkdir -p $out/share/${finalAttrs.pname}-${finalAttrs.version}/samples
+    cp pjsip-apps/bin/samples/*/* $out/share/${finalAttrs.pname}-${finalAttrs.version}/samples
   '' + lib.optionalString pythonSupport ''
     (cd pjsip-apps/src/swig/python && \
       python setup.py install --prefix=$py
@@ -115,4 +114,4 @@ stdenv.mkDerivation rec {
     mainProgram = "pjsua";
     platforms = platforms.linux ++ platforms.darwin;
   };
-}
+})

--- a/pkgs/applications/networking/pjsip/default.nix
+++ b/pkgs/applications/networking/pjsip/default.nix
@@ -1,4 +1,5 @@
 { lib
+, testers
 , stdenv
 , fetchFromGitHub
 , fetchpatch
@@ -101,6 +102,16 @@ stdenv.mkDerivation (finalAttrs: {
 
   # We need the libgcc_s.so.1 loadable (for pthread_cancel to work)
   dontPatchELF = true;
+
+  passthru.tests.version = testers.testVersion {
+    package = finalAttrs.finalPackage;
+    command = "pjsua --version";
+  };
+
+  passthru.tests.pkg-config = testers.hasPkgConfigModule {
+    package = finalAttrs.finalPackage;
+    moduleName = "libpjproject";
+  };
 
   passthru.tests.python-pjsua2 = runCommand "python-pjsua2" { } ''
     ${(python3.withPackages (pkgs: [ pkgs.pjsua2 ])).interpreter} -c "import pjsua2" > $out

--- a/pkgs/applications/networking/pjsip/default.nix
+++ b/pkgs/applications/networking/pjsip/default.nix
@@ -98,6 +98,11 @@ stdenv.mkDerivation (finalAttrs: {
         install_name_tool -id $lib "''${change_args[@]}" $lib
       fi
     done
+
+    # Rewrite library references for all executables.
+    find "$out" -executable -type f | while read executable; do
+      install_name_tool "''${change_args[@]}" "$executable"
+    done
   '';
 
   # We need the libgcc_s.so.1 loadable (for pthread_cancel to work)


### PR DESCRIPTION
###### Description of changes

Currently pjsip only has tests for checking the whether Python can load the pjsua2 libraries. However, there are no tests that check the executables themselves. Colleagues ran into the `pjsua` executable not working on MacOS.

This PRs goal is to fix Darwin support for pjsip executables and to avoid this in the future.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
