### PR TITLE
vulkan-sdk: 1.3.239 -> 1.3.243

### DIFF
--- a/pkgs/development/compilers/glslang/default.nix
+++ b/pkgs/development/compilers/glslang/default.nix
@@ -10,13 +10,13 @@
 }:
 stdenv.mkDerivation rec {
   pname = "glslang";
-  version = "1.3.239.0";
+  version = "1.3.243.0";
 
   src = fetchFromGitHub {
     owner = "KhronosGroup";
     repo = "glslang";
     rev = "sdk-${version}";
-    hash = "sha256-P2HG/oJXdB5nvU3zVnj2vSLJGQuDcZiQBfBBvuR66Kk=";
+    hash = "sha256-U45/7G02o82EP4zh7i2Go0VCnsO1B7vxDwIokjyo5Rk=";
   };
 
   # These get set at all-packages, keep onto them for child drvs
@@ -28,11 +28,8 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ cmake python3 bison jq ];
 
   patches = [
-    (fetchpatch {
-      name = "Use-CMAKE_INSTALL_FULL_LIBDIR-in-compat-cmake-files.patch";
-      url = "https://github.com/KhronosGroup/glslang/commit/7627bd89583c5aafb8b38c81c15494019271fabf.patch";
-      hash = "sha256-1Dwhn78PG4gAGgEwTXpC+mkZRyvy8sTIsEvihXFeNaQ=";
-    })
+    # Related PR: https://github.com/KhronosGroup/glslang/pull/3067
+    ./use-CMAKE_INSTALL_FULL_LIBDIR-in-compat-cmake-files.patch
     # Upstream tries to detect the Darwin linker by checking for AppleClang, but it’s just Clang in nixpkgs.
     # Revert the commit to allow the build to work on Darwin with the nixpkg Darwin Clang toolchain.
     (fetchpatch {

--- a/pkgs/development/compilers/glslang/use-CMAKE_INSTALL_FULL_LIBDIR-in-compat-cmake-files.patch
+++ b/pkgs/development/compilers/glslang/use-CMAKE_INSTALL_FULL_LIBDIR-in-compat-cmake-files.patch
@@ -1,0 +1,139 @@
+commit 0bcfd795469c6067d1e891198d9177afa5cce1c9
+Author: Chuang Zhu <git@chuang.cz>
+Date:   Sat Nov 19 12:03:20 2022 +0800
+
+    Use CMAKE_INSTALL_FULL_LIBDIR in compat cmake files
+    
+    According to
+    https://cmake.org/cmake/help/v3.25/module/GNUInstallDirs.html,
+    CMAKE_INSTALL_LIBDIR can be an absolute path. For instance, Nixpkgs
+    [defined it to an absolute path in /nix/store](https://github.com/NixOS/nixpkgs/blob/3d17b4c305cefef284109fa9d426b00f3e5072c6/pkgs/development/tools/build-managers/cmake/setup-hook.sh#L101).
+    The output in this case is:
+    
+            # result-glslang/lib/cmake/glslangTargets.cmake:5
+            include("${CMAKE_CURRENT_LIST_DIR}/../..//nix/store/3mif2zibig0cilk5dbz334278n0vlq9s-glslang-1.3.231.0/lib/glslang/glslang-targets.cmake")
+    
+    Signed-off-by: Chuang Zhu <git@chuang.cz>
+
+diff --git a/OGLCompilersDLL/CMakeLists.txt b/OGLCompilersDLL/CMakeLists.txt
+index 33f16b0d..71a5675d 100644
+--- a/OGLCompilersDLL/CMakeLists.txt
++++ b/OGLCompilersDLL/CMakeLists.txt
+@@ -49,7 +49,7 @@ if(ENABLE_GLSLANG_INSTALL AND NOT BUILD_SHARED_LIBS)
+         message(WARNING \"Using `OGLCompilerTargets.cmake` is deprecated: use `find_package(glslang)` to find glslang CMake targets.\")
+ 
+         if (NOT TARGET glslang::OGLCompiler)
+-            include(\"\${CMAKE_CURRENT_LIST_DIR}/../../${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME}/glslang-targets.cmake\")
++            include(\"${CMAKE_INSTALL_FULL_LIBDIR}/cmake/${PROJECT_NAME}/glslang-targets.cmake\")
+         endif()
+ 
+         add_library(OGLCompiler ALIAS glslang::OGLCompiler)
+diff --git a/SPIRV/CMakeLists.txt b/SPIRV/CMakeLists.txt
+index 35b74621..b31bdd63 100644
+--- a/SPIRV/CMakeLists.txt
++++ b/SPIRV/CMakeLists.txt
+@@ -125,7 +125,7 @@ if(ENABLE_GLSLANG_INSTALL)
+             message(WARNING \"Using `SPVRemapperTargets.cmake` is deprecated: use `find_package(glslang)` to find glslang CMake targets.\")
+ 
+             if (NOT TARGET glslang::SPVRemapper)
+-                include(\"\${CMAKE_CURRENT_LIST_DIR}/../../${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME}/glslang-targets.cmake\")
++                include(\"${CMAKE_INSTALL_FULL_LIBDIR}/cmake/${PROJECT_NAME}/glslang-targets.cmake\")
+             endif()
+ 
+             add_library(SPVRemapper ALIAS glslang::SPVRemapper)
+@@ -137,7 +137,7 @@ if(ENABLE_GLSLANG_INSTALL)
+         message(WARNING \"Using `SPIRVTargets.cmake` is deprecated: use `find_package(glslang)` to find glslang CMake targets.\")
+ 
+         if (NOT TARGET glslang::SPIRV)
+-            include(\"\${CMAKE_CURRENT_LIST_DIR}/../../${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME}/glslang-targets.cmake\")
++            include(\"${CMAKE_INSTALL_FULL_LIBDIR}/cmake/${PROJECT_NAME}/glslang-targets.cmake\")
+         endif()
+ 
+         add_library(SPIRV ALIAS glslang::SPIRV)
+diff --git a/StandAlone/CMakeLists.txt b/StandAlone/CMakeLists.txt
+index b1ba18f6..8ddef104 100644
+--- a/StandAlone/CMakeLists.txt
++++ b/StandAlone/CMakeLists.txt
+@@ -101,7 +101,7 @@ if(ENABLE_GLSLANG_INSTALL)
+         message(WARNING \"Using `glslangValidatorTargets.cmake` is deprecated: use `find_package(glslang)` to find glslang CMake targets.\")
+ 
+         if (NOT TARGET glslang::glslangValidator)
+-            include(\"\${CMAKE_CURRENT_LIST_DIR}/../../${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME}/glslang-targets.cmake\")
++            include(\"${CMAKE_INSTALL_FULL_LIBDIR}/cmake/${PROJECT_NAME}/glslang-targets.cmake\")
+         endif()
+ 
+         add_library(glslangValidator ALIAS glslang::glslangValidator)
+@@ -116,7 +116,7 @@ if(ENABLE_GLSLANG_INSTALL)
+             message(WARNING \"Using `spirv-remapTargets.cmake` is deprecated: use `find_package(glslang)` to find glslang CMake targets.\")
+ 
+             if (NOT TARGET glslang::spirv-remap)
+-                include(\"\${CMAKE_CURRENT_LIST_DIR}/../../${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME}/glslang-targets.cmake\")
++                include(\"${CMAKE_INSTALL_FULL_LIBDIR}/cmake/${PROJECT_NAME}/glslang-targets.cmake\")
+             endif()
+ 
+             add_library(spirv-remap ALIAS glslang::spirv-remap)
+diff --git a/glslang/CMakeLists.txt b/glslang/CMakeLists.txt
+index 7d8790c4..4d8a537b 100644
+--- a/glslang/CMakeLists.txt
++++ b/glslang/CMakeLists.txt
+@@ -234,7 +234,7 @@ if(ENABLE_GLSLANG_INSTALL)
+             message(WARNING \"Using `glslangTargets.cmake` is deprecated: use `find_package(glslang)` to find glslang CMake targets.\")
+ 
+             if (NOT TARGET glslang::glslang)
+-                include(\"\${CMAKE_CURRENT_LIST_DIR}/../../${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME}/glslang-targets.cmake\")
++                include(\"${CMAKE_INSTALL_FULL_LIBDIR}/cmake/${PROJECT_NAME}/glslang-targets.cmake\")
+             endif()
+ 
+             if(${BUILD_SHARED_LIBS})
+diff --git a/glslang/OSDependent/Unix/CMakeLists.txt b/glslang/OSDependent/Unix/CMakeLists.txt
+index 7ed71fbf..acb74275 100644
+--- a/glslang/OSDependent/Unix/CMakeLists.txt
++++ b/glslang/OSDependent/Unix/CMakeLists.txt
+@@ -60,7 +60,7 @@ if(ENABLE_GLSLANG_INSTALL AND NOT BUILD_SHARED_LIBS)
+         message(WARNING \"Using `OSDependentTargets.cmake` is deprecated: use `find_package(glslang)` to find glslang CMake targets.\")
+ 
+         if (NOT TARGET glslang::OSDependent)
+-            include(\"\${CMAKE_CURRENT_LIST_DIR}/../../${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME}/glslang-targets.cmake\")
++            include(\"${CMAKE_INSTALL_FULL_LIBDIR}/cmake/${PROJECT_NAME}/glslang-targets.cmake\")
+         endif()
+ 
+         add_library(OSDependent ALIAS glslang::OSDependent)
+diff --git a/glslang/OSDependent/Windows/CMakeLists.txt b/glslang/OSDependent/Windows/CMakeLists.txt
+index 67976da8..882133ab 100644
+--- a/glslang/OSDependent/Windows/CMakeLists.txt
++++ b/glslang/OSDependent/Windows/CMakeLists.txt
+@@ -55,7 +55,7 @@ if(ENABLE_GLSLANG_INSTALL)
+         message(WARNING \"Using `OSDependentTargets.cmake` is deprecated: use `find_package(glslang)` to find glslang CMake targets.\")
+ 
+         if (NOT TARGET glslang::OSDependent)
+-            include(\"\${CMAKE_CURRENT_LIST_DIR}/../../${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME}/glslang-targets.cmake\")
++            include(\"${CMAKE_INSTALL_FULL_LIBDIR}/cmake/${PROJECT_NAME}/glslang-targets.cmake\")
+         endif()
+ 
+         add_library(OSDependent ALIAS glslang::OSDependent)
+diff --git a/gtests/CMakeLists.txt b/gtests/CMakeLists.txt
+index 203812d8..408a92db 100644
+--- a/gtests/CMakeLists.txt
++++ b/gtests/CMakeLists.txt
+@@ -76,7 +76,7 @@ if(BUILD_TESTING)
+                 message(WARNING \"Using `glslangtestsTargets.cmake` is deprecated: use `find_package(glslang)` to find glslang CMake targets.\")
+ 
+                 if (NOT TARGET glslang::glslangtests)
+-                    include(\"\${CMAKE_CURRENT_LIST_DIR}/../../${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME}/glslang-targets.cmake\")
++                    include(\"${CMAKE_INSTALL_FULL_LIBDIR}/cmake/${PROJECT_NAME}/glslang-targets.cmake\")
+                 endif()
+ 
+                 add_library(glslangtests ALIAS glslang::glslangtests)
+diff --git a/hlsl/CMakeLists.txt b/hlsl/CMakeLists.txt
+index 4d5f15fd..16c82a67 100644
+--- a/hlsl/CMakeLists.txt
++++ b/hlsl/CMakeLists.txt
+@@ -53,7 +53,7 @@ if(ENABLE_GLSLANG_INSTALL)
+         message(WARNING \"Using `HLSLTargets.cmake` is deprecated: use `find_package(glslang)` to find glslang CMake targets.\")
+ 
+         if (NOT TARGET glslang::HLSL)
+-            include(\"\${CMAKE_CURRENT_LIST_DIR}/../../${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME}/glslang-targets.cmake\")
++            include(\"${CMAKE_INSTALL_FULL_LIBDIR}/cmake/${PROJECT_NAME}/glslang-targets.cmake\")
+         endif()
+ 
+         add_library(HLSL ALIAS glslang::HLSL)

--- a/pkgs/development/libraries/spirv-headers/default.nix
+++ b/pkgs/development/libraries/spirv-headers/default.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation rec {
   pname = "spirv-headers";
-  version = "1.3.239.0";
+  version = "1.3.243.0";
 
   src = fetchFromGitHub {
     owner = "KhronosGroup";
     repo = "SPIRV-Headers";
     rev = "sdk-${version}";
-    hash = "sha256-bjiWGSmpEbydXtCLP8fRZfPBvdCzBoJxKXTx3BroQbg=";
+    hash = "sha256-VOq3r6ZcbDGGxjqC4IoPMGC5n1APUPUAs9xcRzxdyfk=";
   };
 
   nativeBuildInputs = [ cmake ];

--- a/pkgs/development/libraries/vulkan-headers/default.nix
+++ b/pkgs/development/libraries/vulkan-headers/default.nix
@@ -1,7 +1,7 @@
 { lib, stdenv, fetchFromGitHub, cmake }:
 stdenv.mkDerivation rec {
   pname = "vulkan-headers";
-  version = "1.3.239.0";
+  version = "1.3.243.0";
 
   nativeBuildInputs = [ cmake ];
 
@@ -9,7 +9,7 @@ stdenv.mkDerivation rec {
     owner = "KhronosGroup";
     repo = "Vulkan-Headers";
     rev = "sdk-${version}";
-    hash = "sha256-mzxT6s4ZHShB9tGyyf8jDtVWVEclHPYW+9oKy7v0bC4=";
+    hash = "sha256-iitEA/x9QpbQrYTcV0OzBgnY6bQFhIm+mVq1ryIQ3+0=";
   };
 
   meta = with lib; {

--- a/pkgs/development/libraries/vulkan-loader/default.nix
+++ b/pkgs/development/libraries/vulkan-loader/default.nix
@@ -3,14 +3,14 @@
 
 stdenv.mkDerivation rec {
   pname = "vulkan-loader";
-  version = "1.3.239.0";
+  version = "1.3.243.0";
 
   src = (assert version == vulkan-headers.version;
     fetchFromGitHub {
       owner = "KhronosGroup";
       repo = "Vulkan-Loader";
       rev = "sdk-${version}";
-      hash = "sha256-4oxynsbFLmsrpI5NEs7gI50g0XVcaUWuZRn6JKB/+hA=";
+      hash = "sha256-DqgIg0jZxzhoyYrATDQMoNN/Pav9deKdltB7L0XDqPE=";
     });
 
   patches = [ ./fix-pkgconfig.patch ];

--- a/pkgs/development/tools/spirv-tools/default.nix
+++ b/pkgs/development/tools/spirv-tools/default.nix
@@ -2,14 +2,14 @@
 
 stdenv.mkDerivation rec {
   pname = "spirv-tools";
-  version = "1.3.239.0";
+  version = "1.3.243.0";
 
   src = (assert version == spirv-headers.version;
     fetchFromGitHub {
       owner = "KhronosGroup";
       repo = "SPIRV-Tools";
       rev = "sdk-${version}";
-      hash = "sha256-xLYykbCHb6OH5wUSgheAfReXhxZtI3RqBJ+PxDZx58s=";
+      hash = "sha256-l44Ru0WjROQEDNU/2YQJGti1uDZP9osRdfsXus5EGX0=";
     }
   );
 

--- a/pkgs/development/tools/vulkan-validation-layers/default.nix
+++ b/pkgs/development/tools/vulkan-validation-layers/default.nix
@@ -23,7 +23,7 @@ let
 in
 stdenv.mkDerivation rec {
   pname = "vulkan-validation-layers";
-  version = "1.3.239.0";
+  version = "1.3.243.0";
 
   # If we were to use "dev" here instead of headers, the setupHook would be
   # placed in that output instead of "out".
@@ -35,7 +35,7 @@ stdenv.mkDerivation rec {
       owner = "KhronosGroup";
       repo = "Vulkan-ValidationLayers";
       rev = "sdk-${version}";
-      hash = "sha256-k/A0TaERQAHSM0Fal2IOaRvTz3FV2Go/17P12FSBG1s=";
+      hash = "sha256-viVceH8qFz6Cl/RlMMWZnMIdzULELlnIvtPZ87ySs2M=";
     });
 
   nativeBuildInputs = [

--- a/pkgs/os-specific/darwin/moltenvk/default.nix
+++ b/pkgs/os-specific/darwin/moltenvk/default.nix
@@ -23,7 +23,7 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "MoltenVK";
-  version = "1.2.2";
+  version = "1.2.3";
 
   buildInputs = [
     AppKit
@@ -46,7 +46,7 @@ stdenv.mkDerivation (finalAttrs: {
     owner = "KhronosGroup";
     repo = "MoltenVK";
     rev = "v${finalAttrs.version}";
-    hash = "sha256-XowMXhGqPcxJ0DS3G41tpBO68va94a7SZHOOgguCxy0=";
+    hash = "sha256-GPOF2lyo1eDf1GrPjcj0y1OuUHI/c80L9gSQM+4wEp0=";
   };
 
   patches = [

--- a/pkgs/tools/graphics/spirv-cross/default.nix
+++ b/pkgs/tools/graphics/spirv-cross/default.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "spirv-cross";
-  version = "1.3.239.0";
+  version = "1.3.243.0";
 
   src = fetchFromGitHub {
     owner = "KhronosGroup";
     repo = "SPIRV-Cross";
     rev = "sdk-${finalAttrs.version}";
-    hash = "sha256-Awtsz4iMuS3JuvaYHRxjo56EnnZPjo9YGfeYAi7lmJY=";
+    hash = "sha256-snxbTI4q0YQq8T5NQD3kcsN59iJnhlLiu1Fvr+fCDeQ=";
   };
 
   nativeBuildInputs = [ cmake python3 ];

--- a/pkgs/tools/graphics/vulkan-extension-layer/default.nix
+++ b/pkgs/tools/graphics/vulkan-extension-layer/default.nix
@@ -2,14 +2,14 @@
 
 stdenv.mkDerivation rec {
   pname = "vulkan-extension-layer";
-  version = "1.3.239.0";
+  version = "1.3.243.0";
 
   src = (assert version == vulkan-headers.version;
     fetchFromGitHub {
       owner = "KhronosGroup";
       repo = "Vulkan-ExtensionLayer";
       rev = "sdk-${version}";
-      hash = "sha256-0t9HGyiYk3twYQLFCcWsrPiXY1dqjdCadjP4yMLoFwA=";
+      hash = "sha256-hxlfSnH4M3ui5nW0Ll5rhto0DnJIHW0tJzS+p4KV0R4=";
     });
 
   nativeBuildInputs = [ cmake jq ];

--- a/pkgs/tools/graphics/vulkan-tools-lunarg/default.nix
+++ b/pkgs/tools/graphics/vulkan-tools-lunarg/default.nix
@@ -25,14 +25,14 @@
 stdenv.mkDerivation rec {
   pname = "vulkan-tools-lunarg";
   # The version must match that in vulkan-headers
-  version = "1.3.239.0";
+  version = "1.3.243.0";
 
   src = (assert version == vulkan-headers.version;
     fetchFromGitHub {
       owner = "LunarG";
       repo = "VulkanTools";
       rev = "sdk-${version}";
-      hash = "sha256-zgkuTy9ccg8D/riA1CM/PnbXW1R0jWEINtcEVilETwk=";
+      hash = "sha256-mvBP6wD1Z0VNLZ0mC4bA3i2IaBDtDr7K6XjHz4S3UA4=";
       fetchSubmodules = true;
     });
 

--- a/pkgs/tools/graphics/vulkan-tools/default.nix
+++ b/pkgs/tools/graphics/vulkan-tools/default.nix
@@ -21,7 +21,7 @@
 
 stdenv.mkDerivation rec {
   pname = "vulkan-tools";
-  version = "1.3.239.0";
+  version = "1.3.243.0";
 
   # It's not strictly necessary to have matching versions here, however
   # since we're using the SDK version we may as well be consistent with
@@ -31,7 +31,7 @@ stdenv.mkDerivation rec {
       owner = "KhronosGroup";
       repo = "Vulkan-Tools";
       rev = "sdk-${version}";
-      hash = "sha256-DQGwxTZzS0eATKodMpeJaQdXADvomiqPOspDYoPFZjI=";
+      hash = "sha256-8XJON+iBEPRtuQWf1bPXyOJHRkuRLnLXgTIjk7gYQwE=";
     });
 
   nativeBuildInputs = [


### PR DESCRIPTION
###### Description of changes

- Bumps to the latest tags as seen in https://vulkan.lunarg.com/doc/sdk/1.3.243.0/linux/release_notes.html

- One of the GLSLANG patches needed to be rebased, I've included it, and added comments mentioning the upstream PR (https://github.com/KhronosGroup/glslang/pull/3067).

###### Things done

On an x86_64-linux: Tested building `vulkan-tools`, which built `vulkan-headers, vulkan-loader, spirv-headers, spirv-tools` and `glslang`. Building `vulkan-tools-lunarg` builds `vulkan-validation-layers`. I've built `vulkan-extension-layer`, then `spirv-cross` and finished by running `vkcube-wayland`.

I didn't test the `moltenvk` update (Cc @reckenrode).