### PR TITLE
gotestwaf: 0.3.1 -> 0.4.0, fix version self-reporting

### DIFF
--- a/pkgs/tools/security/gotestwaf/default.nix
+++ b/pkgs/tools/security/gotestwaf/default.nix
@@ -1,6 +1,8 @@
 { lib
 , buildGoModule
 , fetchFromGitHub
+, gotestwaf
+, testers
 }:
 
 buildGoModule rec {
@@ -19,10 +21,20 @@ buildGoModule rec {
   # Some tests require networking as of v0.4.0
   doCheck = false;
 
+  ldflags = [
+    "-X github.com/wallarm/gotestwaf/internal/version.Version=v${version}"
+  ];
+
   postFixup = ''
     # Rename binary
     mv $out/bin/cmd $out/bin/${pname}
   '';
+
+  passthru.tests.version = testers.testVersion {
+    command = "gotestwaf --version";
+    package = gotestwaf;
+    version = "v${version}";
+  };
 
   meta = with lib; {
     description = "Tool for API and OWASP attack simulation";

--- a/pkgs/tools/security/gotestwaf/default.nix
+++ b/pkgs/tools/security/gotestwaf/default.nix
@@ -5,16 +5,19 @@
 
 buildGoModule rec {
   pname = "gotestwaf";
-  version = "0.3.1";
+  version = "0.4.0";
 
   src = fetchFromGitHub {
     owner = "wallarm";
     repo = pname;
     rev = "v${version}";
-    sha256 = "0c627bxx0mlxhc1fsd2k3x1lm5855pl215m88la662d70559z6k8";
+    hash = "sha256-waYX7DMyLW0eSzpFRyiCJQdYLFGaAKSlvGYrdcRfCl4=";
   };
 
-  vendorSha256 = null;
+  vendorHash = null;
+
+  # Some tests require networking as of v0.4.0
+  doCheck = false;
 
   postFixup = ''
     # Rename binary


### PR DESCRIPTION
###### Description of changes

Upstream does not seem to provide changelogs (or at least I couldn't find them), so just the diff:
diff: https://github.com/wallarm/gotestwaf/compare/v0.3.1...v0.4.0

Also fixes the version self-reporting, e.g. in `gotestwaf --version`.

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).