### PR TITLE
lisp-modules: remove use of alias 'mysql-client'

### DIFF
--- a/pkgs/development/lisp-modules/ql.nix
+++ b/pkgs/development/lisp-modules/ql.nix
@@ -56,7 +56,7 @@ let
       nativeLibs = [ pkgs.glib pkgs.gobject-introspection ];
     });
     cl-mysql = super.cl-mysql.overrideLispAttrs (o: {
-      nativeLibs = [ pkgs.mysql-client ];
+      nativeLibs = [ pkgs.mariadb.client ];
     });
     clsql-postgresql = super.clsql-postgresql.overrideLispAttrs (o: {
       nativeLibs = [ pkgs.postgresql.lib ];
@@ -68,7 +68,7 @@ let
       nativeLibs = [ pkgs.webkitgtk ];
     });
     dbd-mysql = super.dbd-mysql.overrideLispAttrs (o: {
-      nativeLibs = [ pkgs.mysql-client ];
+      nativeLibs = [ pkgs.mariadb.client ];
     });
     lla = super.lla.overrideLispAttrs (o: {
       nativeLibs = [ pkgs.openblas ];


### PR DESCRIPTION
###### Description of changes

While working on a different PR I ran into `error: attribute 'mysql-client' missing`; `mysql-client` is an alias which I don't think is allowed inside nixpkgs? I don't know anything about the lisp part though, so please correct me if I'm wrong either way.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
