### PR TITLE
python310Packages.ancp-bids: init at 0.2.1

### DIFF
--- a/pkgs/development/python-modules/ancp-bids/default.nix
+++ b/pkgs/development/python-modules/ancp-bids/default.nix
@@ -1,0 +1,41 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, pythonOlder
+, pytestCheckHook
+, setuptools
+, numpy
+, pandas
+}:
+
+buildPythonPackage rec {
+  pname = "ancp-bids";
+  version = "0.2.1";
+  disabled = pythonOlder "3.7";
+  format = "pyproject";
+
+  # `tests/data` dir missing from PyPI dist
+  src = fetchFromGitHub {
+     owner = "ANCPLabOldenburg";
+     repo = pname;
+     rev = "refs/tags/${version}";
+     hash = "sha256-Nu9pulVSZysgm/F7jl+VpoqMCiHeysZjQDQ1dT7AnpE=";
+  };
+
+  nativeBuildInputs = [ setuptools ] ;
+
+  checkInputs = [ numpy pandas pytestCheckHook ];
+  pythonImportsCheck = [
+    "ancpbids"
+  ];
+
+  pytestFlagsArray = [ "tests/auto" ];
+  disabledTests = [ "test_fetch_dataset" ];
+
+  meta = with lib; {
+    homepage = "https://ancpbids.readthedocs.io";
+    description = "Read/write/validate/query BIDS datasets";
+    license = licenses.mit;
+    maintainers = with maintainers; [ bcdarwin ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -456,6 +456,8 @@ self: super: with self; {
 
   amqtt = callPackage ../development/python-modules/amqtt { };
 
+  ancp-bids = callPackage ../development/python-modules/ancp-bids { };
+
   android-backup = callPackage ../development/python-modules/android-backup { };
 
   androidtv = callPackage ../development/python-modules/androidtv { };


### PR DESCRIPTION
###### Description of changes

Init `ancp-bids`, a Python package for manipulating BIDS layout, since `pybids` is broken in Nixpkgs due to pinning an older version of `sqlalchemy`.

###### Things done


- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [NA] (Module updates) Added a release notes entry if the change is significant
  - [NA] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).


