### PR TITLE
86Box: init at 3.11

### DIFF
--- a/pkgs/applications/emulators/86box/default.nix
+++ b/pkgs/applications/emulators/86box/default.nix
@@ -1,0 +1,74 @@
+{ stdenv, lib, fetchFromGitHub, cmake, pkg-config, makeWrapper, freetype, SDL2
+, glib, pcre2, openal, rtmidi, fluidsynth, jack2, alsa-lib, qt5, libvncserver
+, discord-gamesdk, libpcap
+
+, enableDynarec ? with stdenv.hostPlatform; isx86 || isAarch
+, enableNewDynarec ? enableDynarec && stdenv.hostPlatform.isAarch
+, enableVncRenderer ? false
+, unfreeEnableDiscord ? false
+}:
+
+stdenv.mkDerivation rec {
+  pname = "86Box";
+  version = "3.11";
+
+  src = fetchFromGitHub {
+    owner = "86Box";
+    repo = "86Box";
+    rev = "v${version}";
+    hash = "sha256-n3Q/NUiaC6/EZyBUn6jUomnQCqr8tvYKPI5JrRRFScI=";
+  };
+
+  nativeBuildInputs = [
+    cmake
+    pkg-config
+    makeWrapper
+    qt5.wrapQtAppsHook
+  ];
+
+  buildInputs = [
+    freetype
+    SDL2
+    glib
+    openal
+    rtmidi
+    pcre2
+    jack2
+    libpcap
+    qt5.qtbase
+    qt5.qttools
+  ] ++ lib.optional stdenv.isLinux alsa-lib
+    ++ lib.optional enableVncRenderer libvncserver;
+
+  cmakeFlags = lib.optional stdenv.isDarwin "-DCMAKE_MACOSX_BUNDLE=OFF"
+    ++ lib.optional enableNewDynarec "-DNEW_DYNAREC=ON"
+    ++ lib.optional enableVncRenderer "-DVNC=ON"
+    ++ lib.optional (!enableDynarec) "-DDYNAREC=OFF"
+    ++ lib.optional (!unfreeEnableDiscord) "-DDISCORD=OFF";
+
+  # Some libraries are loaded dynamically, but QLibrary doesn't seem to search
+  # the runpath, so use a wrapper instead.
+  postFixup = let
+    libPath = lib.makeLibraryPath ([
+      libpcap
+      fluidsynth
+    ] ++ lib.optional unfreeEnableDiscord discord-gamesdk);
+    libPathVar = if stdenv.isDarwin then "DYLD_LIBRARY_PATH" else "LD_LIBRARY_PATH";
+  in
+  ''
+    wrapProgram $out/bin/86Box \
+      "''${qtWrapperArgs[@]}" \
+      --prefix ${libPathVar} : "${libPath}"
+  '';
+
+  # Do not wrap twice.
+  dontWrapQtApps = true;
+
+  meta = with lib; {
+    description = "Emulator of x86-based machines based on PCem.";
+    homepage = "https://86box.net/";
+    license = with licenses; [ gpl2Only ] ++ optional unfreeEnableDiscord unfree;
+    maintainers = [ maintainers.jchw ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2128,6 +2128,8 @@ with pkgs;
 
   ### APPLICATIONS/EMULATORS
 
+  _86Box = callPackage ../applications/emulators/86box { };
+
   atari800 = callPackage ../applications/emulators/atari800 { };
 
   ataripp = callPackage ../applications/emulators/atari++ { };


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).