### PR TITLE
functiontrace: add functiontrace-server dependency

### DIFF
--- a/pkgs/development/python-modules/functiontrace/default.nix
+++ b/pkgs/development/python-modules/functiontrace/default.nix
@@ -1,6 +1,7 @@
 { lib
 , buildPythonPackage
 , fetchPypi
+, functiontrace-server
 , setuptools
 , toml
 }:
@@ -20,12 +21,16 @@ buildPythonPackage rec {
     toml
   ];
 
+  # `functiontrace` needs `functiontrace-server` in its PATH, both when run as
+  # a standalone application and when imported as a python module.
+  propagatedBuildInputs = [ functiontrace-server ];
+
   pythonImportsCheck = [ "functiontrace" ];
 
   meta = with lib; {
     homepage = "https://functiontrace.com";
     description = "The Python module for Functiontrace";
     license = licenses.prosperity30;
-    maintainers = with maintainers; [ mathiassven ];
+    maintainers = with maintainers; [ mathiassven tehmatt ];
   };
 }


### PR DESCRIPTION
###### Description of changes

This is needed for `functiontrace foo.py` to work, as `functiontrace-server` must be in your path.

###### Things done


- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).