### PR TITLE
anki-bin: set version with buildFHSUserEnv argument instead of override

### DIFF
--- a/pkgs/games/anki/bin.nix
+++ b/pkgs/games/anki/bin.nix
@@ -53,6 +53,8 @@ let
   fhsUserEnvAnki = buildFHSUserEnv (appimageTools.defaultFhsEnvArgs // {
     name = "anki";
 
+    inherit version;
+
     # Dependencies of anki
     targetPkgs = pkgs: (with pkgs; [ xorg.libxkbfile krb5 ]);
 
@@ -70,17 +72,9 @@ let
 
     inherit meta passthru;
   });
-
-  fhsUserEnvAnkiWithVersion = fhsUserEnvAnki.overrideAttrs (oldAttrs: {
-    # buildFHSUserEnv doesn't have an easy way to set the version of the
-    # resulting derivation, so we manually override it here.  This makes
-    # it clear to end users the version of anki-bin.  Without this, users
-    # might assume anki-bin is an old version of Anki.
-    name = "${pname}-${version}";
-  });
 in
 
-if stdenv.isLinux then fhsUserEnvAnkiWithVersion
+if stdenv.isLinux then fhsUserEnvAnki
 else stdenv.mkDerivation {
   inherit pname version passthru;
 


### PR DESCRIPTION
###### Description of changes

Update `anki-bin` to set the version number using an argument to `buildFHSUserEnv`, instead of just with an override.  The `version` argument was added to `buildFHSUserEnv` in https://github.com/NixOS/nixpkgs/pull/219091.

This is the last step in the proposed sequence here: https://github.com/NixOS/nixpkgs/pull/218162#issuecomment-1445038571

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
