### PR TITLE
ubpm: init at 1.7.3

### DIFF
--- a/pkgs/applications/misc/ubpm/default.nix
+++ b/pkgs/applications/misc/ubpm/default.nix
@@ -1,0 +1,51 @@
+{ stdenv, lib, fetchFromGitea, qmake, qttools, qtbase, qtserialport
+, qtconnectivity, qtcharts, qttranslations, wrapQtAppsHook }:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "ubpm";
+  version = "1.7.3";
+
+  src = fetchFromGitea {
+    domain = "codeberg.org";
+    owner = "LazyT";
+    repo = "ubpm";
+    rev = finalAttrs.version;
+    hash = "sha256-6lvDSU0ssfs71xrac6R6qlmE0QyVcAMTUf0xmJPVzhY=";
+  };
+
+  postPatch = ''
+    substituteInPlace sources/mainapp/mainapp.pro \
+      --replace '$$[QT_INSTALL_TRANSLATIONS]' '${qttranslations}/translations' \
+      --replace 'INSTALLDIR = /tmp/ubpm.AppDir' "INSTALLDIR = $out" \
+      --replace '/usr/bin' '/bin' \
+      --replace 'INSTALLS += target translations themes devices help lin' 'INSTALLS += target translations themes devices help'
+  '';
+
+  preConfigure = ''
+    cd ./sources/
+  '';
+
+  postInstall = ''
+    install -Dm644 ../package/lin/ubpm.desktop -t $out/share/applications/
+    install -Dm644 ../package/lin/de.lazyt.ubpm.appdata.xml -t $out/share/metainfo/
+    install -Dm644 ../sources/mainapp/res/ico/app.png $out/share/icons/hicolor/256x256/apps/ubpm.png
+  '';
+
+  postFixup = ''
+    wrapQtApp $out/bin/ubpm
+  '';
+
+  nativeBuildInputs = [ qmake qttools wrapQtAppsHook ];
+
+  # *.so plugins are being wrapped automatically which breaks them
+  dontWrapQtApps = true;
+
+  buildInputs = [ qtbase qtserialport qtconnectivity qtcharts qttranslations ];
+
+  meta = with lib; {
+    homepage = "https://codeberg.org/LazyT/ubpm";
+    description = "Universal Blood Pressure Manager";
+    license = licenses.gpl3Only;
+    maintainers = with maintainers; [ kurnevsky ];
+  };
+})

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -13619,6 +13619,8 @@ with pkgs;
 
   ubi_reader = callPackage ../tools/filesystems/ubi_reader { };
 
+  ubpm = libsForQt5.callPackage ../applications/misc/ubpm { };
+
   ubridge = callPackage ../tools/networking/ubridge { };
 
   ubertooth = callPackage ../applications/radio/ubertooth { };


### PR DESCRIPTION
###### Description of changes

Universal Blood Pressure Manager
https://codeberg.org/LazyT/ubpm

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).