### PR TITLE
mozart: use llvmPackages_8 instead of llvmPackages_5

### DIFF
--- a/pkgs/development/compilers/mozart/default.nix
+++ b/pkgs/development/compilers/mozart/default.nix
@@ -7,7 +7,7 @@
 , boost169
 , pinnedBoost ? boost169
 , llvmPackages
-, llvmPackages_5
+, llvmPackages_8
 , gmp
 , emacs
 , jre_headless
@@ -50,7 +50,7 @@ in stdenv.mkDerivation rec {
     "-DCMAKE_C_COMPILER=${llvmPackages.clang}/bin/clang"
     "-DBoost_USE_STATIC_LIBS=OFF"
     "-DMOZART_BOOST_USE_STATIC_LIBS=OFF"
-    "-DCMAKE_PROGRAM_PATH=${llvmPackages_5.clang}/bin"
+    "-DCMAKE_PROGRAM_PATH=${llvmPackages_8.clang}/bin"
     # Rationale: Nix's cc-wrapper needs to see a compile flag (like -c) to
     # infer that it is not a linking call, and stop trashing the command line
     # with linker flags.
@@ -71,9 +71,9 @@ in stdenv.mkDerivation rec {
 
   buildInputs = [
     pinnedBoost
-    llvmPackages_5.llvm
-    llvmPackages_5.clang
-    llvmPackages_5.clang-unwrapped
+    llvmPackages_8.llvm
+    llvmPackages_8.clang
+    llvmPackages_8.clang-unwrapped
     gmp
     emacs
     jre_headless

--- a/pkgs/development/compilers/mozart/default.nix
+++ b/pkgs/development/compilers/mozart/default.nix
@@ -7,7 +7,6 @@
 , boost169
 , pinnedBoost ? boost169
 , llvmPackages
-, llvmPackages_8
 , gmp
 , emacs
 , jre_headless
@@ -42,23 +41,9 @@ in stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ cmake makeWrapper unzip ];
 
-  # We cannot compile with both gcc and clang, but we need clang during the
-  # process, so we compile everything with clang.
-  # BUT, we need clang4 for parsing, and a more recent clang for compiling.
   cmakeFlags = [
-    "-DCMAKE_CXX_COMPILER=${llvmPackages.clang}/bin/clang++"
-    "-DCMAKE_C_COMPILER=${llvmPackages.clang}/bin/clang"
     "-DBoost_USE_STATIC_LIBS=OFF"
     "-DMOZART_BOOST_USE_STATIC_LIBS=OFF"
-    "-DCMAKE_PROGRAM_PATH=${llvmPackages_8.clang}/bin"
-    # Rationale: Nix's cc-wrapper needs to see a compile flag (like -c) to
-    # infer that it is not a linking call, and stop trashing the command line
-    # with linker flags.
-    # As it does not recognise -emit-ast, we pass -c immediately overridden
-    # by -emit-ast.
-    # The remaining is just the default flags that we cannot reuse and need
-    # to repeat here.
-    "-DMOZART_GENERATOR_FLAGS='-c;-emit-ast;--std=c++0x;-Wno-invalid-noreturn;-Wno-return-type;-Wno-braced-scalar-init'"
     # We are building with clang, as nix does not support having clang and
     # gcc together as compilers and we need clang for the sources generation.
     # However, clang emits tons of warnings about gcc's atomic-base library.
@@ -71,9 +56,6 @@ in stdenv.mkDerivation rec {
 
   buildInputs = [
     pinnedBoost
-    llvmPackages_8.llvm
-    llvmPackages_8.clang
-    llvmPackages_8.clang-unwrapped
     gmp
     emacs
     jre_headless


### PR DESCRIPTION
###### Description of changes

Following issue #44372 logic, we want to get rid of older LLVMs.

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
