### PR TITLE
fishPlugins.forgit: unstable-2022-10-14 -> 23.04.0 

### DIFF
--- a/pkgs/shells/fish/plugins/build-fish-plugin.nix
+++ b/pkgs/shells/fish/plugins/build-fish-plugin.nix
@@ -45,9 +45,11 @@ stdenv.mkDerivation (drvAttrs // {
         source="$1"
         target="$out/share/fish/vendor_$2.d"
 
-        [ -d $source ] || return 0
+        # Check if any .fish file exists in $source
+        [ -n "$(shopt -s nullglob; echo $source/*.fish)" ] || return 0
+
         mkdir -p $target
-        cp -r $source/*.fish "$target/"
+        cp $source/*.fish "$target/"
       }
 
       install_vendor_files completions completions

--- a/pkgs/shells/fish/plugins/forgit.nix
+++ b/pkgs/shells/fish/plugins/forgit.nix
@@ -1,21 +1,19 @@
-{ lib, buildFishPlugin, fetchFromGitHub, git, fzf }:
+{ lib, buildFishPlugin, fetchFromGitHub }:
 
 buildFishPlugin rec {
   pname = "forgit";
-  version = "unstable-2022-10-14";
-
-  preFixup = ''
-    substituteInPlace $out/share/fish/vendor_conf.d/forgit.plugin.fish \
-      --replace "fzf " "${fzf}/bin/fzf " \
-      --replace "git " "${git}/bin/git "
-  '';
+  version = "23.04.0";
 
   src = fetchFromGitHub {
     owner = "wfxr";
     repo = "forgit";
-    rev = "2872548075e63bc83a0b960e2813b16571998563";
-    sha256 = "sha256-NKL4c4k9Nath8NQ3sWUTGUzp517jRX4v0qVaKMJSMrw=";
+    rev = version;
+    sha256 = "sha256-3lvYIuzuJw0CQlaAQG6hAyfUgSXM+3BOmKRVDNFUN/U=";
   };
+
+  postInstall = ''
+    cp -r bin $out/share/fish/vendor_conf.d/
+  '';
 
   meta = with lib; {
     description = "A utility tool powered by fzf for using git interactively.";


### PR DESCRIPTION
###### Description of changes

Updates the Fish plugin forgit to the latest version.
I removed the preFixup that substituted the `fzf` and `git` for two reasons:
- It was taking the `fzf` plugin instead of the application, which made it not work. (And I don't know how to make it take the correct one)
- No other Fish plugin does this, so... laziness.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
