### PR TITLE
nixos/nginx: adding advanced logs configuration

### DIFF
--- a/nixos/modules/services/web-servers/nginx/location-options.nix
+++ b/nixos/modules/services/web-servers/nginx/location-options.nix
@@ -111,6 +111,52 @@ with lib;
       '';
     };
 
+    accessLogs = mkOption {
+      type = with types; listOf (submodule { options = {
+        file = mkOption {
+          type = types.nullOr types.path;
+          default = null;
+          description = lib.mdDoc "Set the file for a log write.";
+        };
+        format = mkOption {
+          type = str;
+          default = "combined";
+          description = lib.mdDoc "Set the format for a log write.";
+        };
+        buffer = mkOption {
+          type = types.nullOr types.str;
+          default = null;
+          description = lib.mdDoc "Set the buffer size for a log write.";
+        };
+        gzip = mkOption {
+          type = types.nullOr types.int;
+          default = null;
+          description = lib.mdDoc "Set the compression level for a log write.";
+        };
+        flush = mkOption {
+          type = types.nullOr types.str;
+          default = null;
+          description = lib.mdDoc "Set the flush time for a log write.";
+        };
+        off = mkOption {
+          type = bool;
+          default = false;
+          description = lib.mdDoc "Cancels all access_log directives on the current level.";
+        };
+      }; });
+      default = [];
+      description = lib.mdDoc ''
+        Sets the path, format, and configuration for a buffered log write.
+        Several logs can be specified on the same configuration level.
+        If either the buffer or gzip parameter is used, writes to log will be buffered.
+        If the gzip parameter is used, then the buffered data will be compressed before
+        writing to the file. The compression level can be set between 1 (fastest,
+        less compression) and 9 (slowest, best compression).
+        By default, the buffer size is equal to 64K bytes, and the compression
+        level is set to 1.
+      '';
+    };
+
     extraConfig = mkOption {
       type = types.lines;
       default = "";

--- a/nixos/modules/services/web-servers/nginx/location-options.nix
+++ b/nixos/modules/services/web-servers/nginx/location-options.nix
@@ -157,6 +157,32 @@ with lib;
       '';
     };
 
+    errorLogs = mkOption {
+      type = with types; listOf (submodule { options = {
+        file = mkOption {
+          type = types.nullOr types.path;
+          default = null;
+          description = lib.mdDoc "Set the file for a log write.";
+        };
+        logLevel = mkOption {
+          type = types.enum [ "debug" "info" "notice" "warn" "error" "crit" "alert" "emerg" ];
+          default = "error";
+          description = lib.mdDoc "Set the level for a log write.";
+        };
+        stderr = mkOption {
+          type = bool;
+          default = false;
+          description = lib.mdDoc "Selects the standard error file.";
+        };
+      }; });
+      default = [];
+      description = lib.mdDoc ''
+        Configures logging. Several logs can be specified on the same configuration level.
+        The second parameter determines the level of logging.
+        If this parameter is omitted then `error` is used.
+      '';
+    };
+
     extraConfig = mkOption {
       type = types.lines;
       default = "";

--- a/nixos/modules/services/web-servers/nginx/vhost-options.nix
+++ b/nixos/modules/services/web-servers/nginx/vhost-options.nix
@@ -359,6 +359,32 @@ with lib;
       '';
     };
 
+    errorLogs = mkOption {
+      type = with types; listOf (submodule { options = {
+        file = mkOption {
+          type = types.nullOr types.path;
+          default = null;
+          description = lib.mdDoc "Set the file for a log write.";
+        };
+        logLevel = mkOption {
+          type = types.enum [ "debug" "info" "notice" "warn" "error" "crit" "alert" "emerg" ];
+          default = "error";
+          description = lib.mdDoc "Set the level for a log write.";
+        };
+        stderr = mkOption {
+          type = bool;
+          default = false;
+          description = lib.mdDoc "Selects the standard error file.";
+        };
+      }; });
+      default = [];
+      description = lib.mdDoc ''
+        Configures logging. Several logs can be specified on the same configuration level.
+        The second parameter determines the level of logging.
+        If this parameter is omitted then `error` is used.
+      '';
+    };
+
     locations = mkOption {
       type = types.attrsOf (types.submodule (import ./location-options.nix {
         inherit lib config;

--- a/nixos/modules/services/web-servers/nginx/vhost-options.nix
+++ b/nixos/modules/services/web-servers/nginx/vhost-options.nix
@@ -313,6 +313,52 @@ with lib;
       '';
     };
 
+    accessLogs = mkOption {
+      type = with types; listOf (submodule { options = {
+        file = mkOption {
+          type = types.nullOr types.path;
+          default = null;
+          description = lib.mdDoc "Set the file for a log write.";
+        };
+        format = mkOption {
+          type = str;
+          default = "combined";
+          description = lib.mdDoc "Set the format for a log write.";
+        };
+        buffer = mkOption {
+          type = types.nullOr types.str;
+          default = null;
+          description = lib.mdDoc "Set the buffer size for a log write.";
+        };
+        gzip = mkOption {
+          type = types.nullOr types.int;
+          default = null;
+          description = lib.mdDoc "Set the compression level for a log write.";
+        };
+        flush = mkOption {
+          type = types.nullOr types.str;
+          default = null;
+          description = lib.mdDoc "Set the flush time for a log write.";
+        };
+        off = mkOption {
+          type = bool;
+          default = false;
+          description = lib.mdDoc "Cancels all access_log directives on the current level.";
+        };
+      }; });
+      default = [];
+      description = lib.mdDoc ''
+        Sets the path, format, and configuration for a buffered log write.
+        Several logs can be specified on the same configuration level.
+        If either the buffer or gzip parameter is used, writes to log will be buffered.
+        If the gzip parameter is used, then the buffered data will be compressed before
+        writing to the file. The compression level can be set between 1 (fastest,
+        less compression) and 9 (slowest, best compression).
+        By default, the buffer size is equal to 64K bytes, and the compression
+        level is set to 1.
+      '';
+    };
+
     locations = mkOption {
       type = types.attrsOf (types.submodule (import ./location-options.nix {
         inherit lib config;


### PR DESCRIPTION
###### Description of changes
Adding advanced log configuration

Example:
```
...
  services.nginx.accessLogs = [
    { file = "/var/log/nginx/all_access.log"; gzip = 5; flush = "3m"; }
  ];
  services.nginx.errorLogs = [
    { file = "/var/log/nginx/all_error.log"; logLevel = "notice"; }
  ];
...
  services.nginx.virtualHosts."example.com" = {
..
    accessLogs = [
      { file = "/var/log/nginx/example.com_access.log"; }
      { file = "/path/to/access.log";  gzip = 9; flush = "5m"; }
    ];
    errorLogs = [
      { file = "/var/log/nginx/example.com_error.log"; logLevel = "info"; }
      { stderr = true; }
    ];
..
      locations."/example/" = {
...
        accessLogs = [
          { file = "/var/log/nginx/locationa_access.log"; buffer = "512k";  gzip = 1; flush = "10m"; }
        ];
        errorLogs = [
          { file = "/var/log/nginx/locations_error.log"; logLevel = "warn"; }
        ];
...
      };
...
  };
...

```

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
