### PR TITLE
python3.pkgs.picobox: 2.2.0 -> 3.0.0

### DIFF
--- a/pkgs/development/python-modules/picobox/default.nix
+++ b/pkgs/development/python-modules/picobox/default.nix
@@ -3,15 +3,17 @@
 , fetchFromGitHub
 , fetchpatch
 , flask
+, hatchling
+, hatch-vcs
 , isPy27
 , pytestCheckHook
-, pythonAtLeast
-, setuptools-scm
 }:
 
 buildPythonPackage rec {
   pname = "picobox";
-  version = "2.2.0";
+  version = "3.0.0";
+
+  format = "pyproject";
 
   disabled = isPy27;
 
@@ -19,26 +21,14 @@ buildPythonPackage rec {
     owner = "ikalnytskyi";
     repo = pname;
     rev = "refs/tags/${version}";
-    hash = "sha256-B2A8GMhBFU/mb/JiiqtP+HvpPj5FYwaYO3gQN2QI6z0=";
+    hash = "sha256-LQiSurL+eFRJ9iQheoo66o44BlfBtAatk8deuMFROcc=";
   };
-
-  patches = [
-    (fetchpatch {
-      # already in master, but no new release yet.
-      # https://github.com/ikalnytskyi/picobox/issues/55
-      url = "https://github.com/ikalnytskyi/picobox/commit/1fcc4a0c26a7cd50ee3ef6694139177b5dfb2be0.patch";
-      hash = "sha256-/NIEzTFlZ5wG7jHT/YdySYoxT/UhSk29Up9/VqjG/jg=";
-      includes = [
-        "tests/test_box.py"
-        "tests/test_stack.py"
-      ];
-    })
-  ];
 
   SETUPTOOLS_SCM_PRETEND_VERSION = version;
 
   nativeBuildInputs = [
-    setuptools-scm
+    hatchling
+    hatch-vcs
   ];
 
   nativeCheckInputs = [


### PR DESCRIPTION
This brings python 3.11 support. Upstream also switched to pyproject and hatch, which still needs SETUPTOOLS_SCM_PRETEND_VERSION to be set.

New release was reported in https://github.com/ikalnytskyi/picobox/issues/55

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
