### PR TITLE
aaaaxy: 1.3.372 -> 1.3.421

### DIFF
--- a/pkgs/games/aaaaxy/default.nix
+++ b/pkgs/games/aaaaxy/default.nix
@@ -16,17 +16,17 @@
 
 buildGoModule rec {
   pname = "aaaaxy";
-  version = "1.3.372";
+  version = "1.3.421";
 
   src = fetchFromGitHub {
     owner = "divVerent";
     repo = pname;
     rev = "v${version}";
-    hash = "sha256-vm3wA8lzoaJ5iGwf2nZ0EvoSATHGftQ77lwdEjGe2RU=";
+    hash = "sha256-MZXnIkOVv49HEkatLEGbIxeJyaiOrh2XLTp5TdvMhk8=";
     fetchSubmodules = true;
   };
 
-  vendorHash = "sha256-WEK7j7FMiue0Fl1R+To5GKwvM03pjc1nKig/wePEAAY=";
+  vendorHash = "sha256-TPm2X0QERJ5lBfojOAWIS60CeAz+Ps2REFtNIT2zGnY=";
 
   buildInputs = [
     alsa-lib


### PR DESCRIPTION
###### Description of changes
https://github.com/divVerent/aaaaxy/releases/tag/v1.3.421

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).