### PR TITLE
apptainer: 1.1.5 -> 1.1.7, singularity: 3.10.4 -> 3.11.1 and add test image-hello-cowsay

### DIFF
--- a/pkgs/applications/virtualization/singularity/generic.nix
+++ b/pkgs/applications/virtualization/singularity/generic.nix
@@ -148,6 +148,7 @@ in
     bash
     coreutils
     cryptsetup # cryptsetup
+    fakeroot
     go
     privileged-un-utils
     squashfsTools # mksquashfs unsquashfs # Make / unpack squashfs image
@@ -195,10 +196,7 @@ in
     substituteInPlace "$out/bin/run-singularity" \
       --replace "/usr/bin/env ${projectName}" "$out/bin/${projectName}"
     wrapProgram "$out/bin/${projectName}" \
-      --prefix PATH : "${lib.makeBinPath [
-        fakeroot
-        squashfsTools # Singularity (but not Apptainer) expects unsquashfs from the host PATH
-      ]}"
+      --prefix PATH : "''${defaultPathInputs// /\/bin:}"
     # Make changes in the config file
     ${lib.optionalString enableNvidiaContainerCli ''
       substituteInPlace "$out/etc/${projectName}/${projectName}.conf" \

--- a/pkgs/applications/virtualization/singularity/generic.nix
+++ b/pkgs/applications/virtualization/singularity/generic.nix
@@ -46,6 +46,10 @@ in
 , openssl
 , squashfsTools
 , squashfuse
+  # Test dependencies
+, singularity-tools
+, cowsay
+, hello
   # Overridable configurations
 , enableNvidiaContainerCli ? true
   # Compile with seccomp support
@@ -83,7 +87,7 @@ let
     ln -s ${lib.escapeShellArg newgidmapPath} "$out/bin/newgidmap"
   '');
 in
-buildGoModule {
+(buildGoModule {
   inherit pname version src;
 
   # Override vendorHash with the output got from
@@ -235,4 +239,14 @@ buildGoModule {
     maintainers = with maintainers; [ jbedo ShamrockLee ];
     mainProgram = projectName;
   } // extraMeta;
-}
+}).overrideAttrs (finalAttrs: prevAttrs: {
+  passthru = prevAttrs.passthru or { } // {
+    tests = {
+      image-hello-cowsay = singularity-tools.buildImage {
+        name = "hello-cowsay";
+        contents = [ hello cowsay ];
+        singularity = finalAttrs.finalPackage;
+      };
+    };
+  };
+})

--- a/pkgs/applications/virtualization/singularity/generic.nix
+++ b/pkgs/applications/virtualization/singularity/generic.nix
@@ -36,7 +36,9 @@ in
 , conmon
 , coreutils
 , cryptsetup
+, e2fsprogs
 , fakeroot
+, fuse2fs ? e2fsprogs.fuse2fs
 , go
 , gpgme
 , libseccomp
@@ -117,6 +119,12 @@ in
     which
   ];
 
+  # Search inside the project sources
+  # and see the `control` file of the Debian package from upstream repos
+  # for build-time dependencies and run-time utilities
+  # apptainer/apptainer: https://github.com/apptainer/apptainer/blob/main/dist/debian/control
+  # sylabs/singularity: https://github.com/sylabs/singularity/blob/main/debian/control
+
   buildInputs = [
     bash # To patch /bin/sh shebangs.
     conmon
@@ -124,8 +132,7 @@ in
     gpgme
     libuuid
     openssl
-    squashfsTools
-    squashfuse
+    squashfsTools # Required at build time by SingularityCE
   ]
   ++ lib.optional enableNvidiaContainerCli nvidia-docker
   ++ lib.optional enableSeccomp libseccomp
@@ -149,6 +156,7 @@ in
     coreutils
     cryptsetup # cryptsetup
     fakeroot
+    fuse2fs # Mount ext3 filesystems
     go
     privileged-un-utils
     squashfsTools # mksquashfs unsquashfs # Make / unpack squashfs image

--- a/pkgs/applications/virtualization/singularity/packages.nix
+++ b/pkgs/applications/virtualization/singularity/packages.nix
@@ -7,20 +7,20 @@ let
   apptainer = callPackage
     (import ./generic.nix rec {
       pname = "apptainer";
-      version = "1.1.5";
+      version = "1.1.7";
       projectName = "apptainer";
 
       src = fetchFromGitHub {
         owner = "apptainer";
         repo = "apptainer";
         rev = "v${version}";
-        hash = "sha256-onJkpHJNsO0cQO2m+TmdMuMkuvH178mDhOeX41bYFic=";
+        hash = "sha256-3F8qwP27IXcnnEYMnLzkCOxQDx7yej6QIZ40Wb5pk34=";
       };
 
       # Update by running
       # nix-prefetch -E "{ sha256 }: ((import ./. { }).apptainer.override { vendorHash = sha256; }).go-modules"
       # at the root directory of the Nixpkgs repository
-      vendorHash = "sha256-tAnh7A8Lw5KtY7hq+sqHMEUlgXvgeeCKKIfRZFoRtug=";
+      vendorHash = "sha256-PfFubgR/W1WBXIsRO+Kg7hA6ebeAcRiJlTlAZbnl19A=";
 
       extraDescription = " (previously known as Singularity)";
       extraMeta.homepage = "https://apptainer.org";
@@ -38,20 +38,20 @@ let
   singularity = callPackage
     (import ./generic.nix rec {
       pname = "singularity-ce";
-      version = "3.10.4";
+      version = "3.11.1";
       projectName = "singularity";
 
       src = fetchFromGitHub {
         owner = "sylabs";
         repo = "singularity";
         rev = "v${version}";
-        hash = "sha256-bUnQXQVwaVA3Lkw3X9TBWqNBgiPxAVCHnkq0vc+CIsM=";
+        hash = "sha256-gdgg6VN3Ily+2Remz6dZBhhfWIxyaBa4bIlFcgrA/uY=";
       };
 
       # Update by running
       # nix-prefetch -E "{ sha256 }: ((import ./. { }).singularity.override { vendorHash = sha256; }).go-modules"
       # at the root directory of the Nixpkgs repository
-      vendorHash = "sha256-K8helLcOuz3E4LzBE9y3pnZqwdwhO/iMPTN1o22ipVg=";
+      vendorHash = "sha256-mBhlH6LSmcJuc6HbU/3Q9ii7vJkW9jcikBWCl8oeMOk=";
 
       # Do not build conmon from the Git submodule source,
       # Use Nixpkgs provided version


### PR DESCRIPTION
###### Description of changes

Apptainer 1.1.6 brings a fix for [CVE-2022-23538](https://github.com/sylabs/scs-library-client/security/advisories/GHSA-7p8m-22h4-9pj7)

Adjust dependencies according to the Debian `control` file in the upstream repositories.

Add package test to build image with `singularity-tools.buildImage`.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [X] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
