### PR TITLE
WIP: python3Packages.load_libstdcxx: init at 0.0.1

### DIFF
--- a/pkgs/development/compilers/cudatoolkit/common.nix
+++ b/pkgs/development/compilers/cudatoolkit/common.nix
@@ -29,6 +29,7 @@ args@
 , python3 # FIXME: CUDAToolkit 10 may still need python27
 , pulseaudio
 , requireFile
+, stdenv
 , backendStdenv # E.g. gcc11Stdenv, set in extension.nix
 , unixODBC
 , wayland
@@ -121,8 +122,8 @@ backendStdenv.mkDerivation rec {
     (placeholder "lib")
     (placeholder "out")
     "${placeholder "out"}/nvvm"
-    # Is it not handled by autoPatchelf automatically?
-    "${lib.getLib backendStdenv.cc.cc}/lib64"
+    # NOTE: use the same libstdc++ as the rest of nixpkgs, not from backendStdenv
+    "${lib.getLib stdenv.cc.cc}/lib64"
     "${placeholder "out"}/jre/lib/amd64/jli"
     "${placeholder "out"}/lib64"
     "${placeholder "out"}/nvvm/lib64"

--- a/pkgs/development/compilers/cudatoolkit/extension.nix
+++ b/pkgs/development/compilers/cudatoolkit/extension.nix
@@ -10,11 +10,16 @@ final: prev: let
   finalVersion = cudatoolkitVersions.${final.cudaVersion};
 
   # Exposed as cudaPackages.backendStdenv.
-  # We don't call it just "stdenv" to avoid confusion: e.g. this toolchain doesn't contain nvcc.
-  # Instead, it's the back-end toolchain for nvcc to use.
-  # We also use this to link a compatible libstdc++ (backendStdenv.cc.cc.lib)
+  # This is what nvcc uses as a backend,
+  # and it has to be an officially supported one (e.g. gcc11 for cuda11).
+  #
+  # It, however, propagates current stdenv's libstdc++ to avoid "GLIBCXX_* not found errors"
+  # when linked with other C++ libraries.
+  # E.g. for cudaPackages_11_8 we use gcc11 with gcc12's libstdc++
   # Cf. https://github.com/NixOS/nixpkgs/pull/218265 for context
-  backendStdenv = prev.pkgs."${finalVersion.gcc}Stdenv";
+  backendStdenv = final.callPackage ./stdenv.nix {
+    compatibleStdenv = prev.pkgs.buildPackages."${finalVersion.gcc}Stdenv";
+  };
 
   ### Add classic cudatoolkit package
   cudatoolkit =

--- a/pkgs/development/compilers/cudatoolkit/redist/build-cuda-redist-package.nix
+++ b/pkgs/development/compilers/cudatoolkit/redist/build-cuda-redist-package.nix
@@ -1,4 +1,5 @@
 { lib
+, stdenv
 , backendStdenv
 , fetchurl
 , autoPatchelfHook
@@ -30,11 +31,11 @@ backendStdenv.mkDerivation {
   ];
 
   buildInputs = [
-    # autoPatchelfHook will search for a libstdc++ and we're giving it a
-    # "compatible" libstdc++ from the same toolchain that NVCC uses.
-    #
+    # autoPatchelfHook will search for a libstdc++ and we're giving it
+    # one that is compatible with the rest of nixpkgs, even when
+    # nvcc forces us to use an older gcc
     # NB: We don't actually know if this is the right thing to do
-    backendStdenv.cc.cc.lib
+    stdenv.cc.cc.lib
   ];
 
   dontBuild = true;

--- a/pkgs/development/compilers/cudatoolkit/stdenv.nix
+++ b/pkgs/development/compilers/cudatoolkit/stdenv.nix
@@ -1,0 +1,10 @@
+{ overrideCC
+, wrapCCWith
+, stdenv
+, compatibleStdenv
+}:
+
+overrideCC stdenv (wrapCCWith rec {
+  cc = compatibleStdenv.cc.cc;
+  libcxx = stdenv.cc.cc.lib;
+})

--- a/pkgs/development/libraries/science/math/cudnn/generic.nix
+++ b/pkgs/development/libraries/science/math/cudnn/generic.nix
@@ -1,4 +1,4 @@
-{
+{ stdenv,
   backendStdenv,
   lib,
   zlib,
@@ -26,7 +26,6 @@
   maxCudaVersion,
 }:
 assert useCudatoolkitRunfile || (libcublas != null); let
-  inherit (backendStdenv) cc;
   inherit (lib) lists strings trivial versions;
 
   # majorMinorPatch :: String -> String
@@ -63,7 +62,10 @@ in
 
     # Used by autoPatchelfHook
     buildInputs = [
-      cc.cc.lib # libstdc++
+      # Note this libstdc++ isn't from the (possibly older) nvcc-compatible
+      # stdenv, but from the (newer) stdenv that the rest of nixpkgs uses
+      stdenv.cc.cc.lib
+
       zlib
       cudatoolkit_root
     ];

--- a/pkgs/development/python-modules/python-imports-check-libstdcxx/CMakeLists.txt
+++ b/pkgs/development/python-modules/python-imports-check-libstdcxx/CMakeLists.txt
@@ -1,0 +1,27 @@
+cmake_minimum_required(VERSION 3.14)
+
+project(PythonImportsCheckLibstdcxx LANGUAGES CXX)
+
+find_package(Python REQUIRED COMPONENTS Development Interpreter)
+find_package(pybind11 CONFIG REQUIRED)
+
+option(LOAD_LIBSTDCXX_INSTALL_SITE_PACKAGES "Path to the install location"
+       ${Python_SITEARCH})
+
+   # CMake seems to ignore the default value specified by option(), somehow:
+set(LOAD_LIBSTDCXX_MODULE_NAME "load_libstdcxx" CACHE BOOL "Name of the python module")
+option(LOAD_LIBSTDCXX_MODULE_NAME "Name of the python module" "load_libstdcxx")
+
+python_add_library(load_libstdcxx MODULE WITH_SOABI main.cc)
+target_link_libraries(load_libstdcxx PRIVATE pybind11::headers)
+target_compile_features(load_libstdcxx PRIVATE cxx_std_20)
+target_compile_definitions(
+  load_libstdcxx
+  PRIVATE -DLOAD_LIBSTDCXX_MODULE_NAME=${LOAD_LIBSTDCXX_MODULE_NAME})
+set_target_properties(load_libstdcxx PROPERTIES OUTPUT_NAME
+                                                ${LOAD_LIBSTDCXX_MODULE_NAME})
+
+install(
+  TARGETS load_libstdcxx
+  COMPONENT python
+  DESTINATION ${LOAD_LIBSTDCXX_INSTALL_SITE_PACKAGES}/)

--- a/pkgs/development/python-modules/python-imports-check-libstdcxx/basic.nix
+++ b/pkgs/development/python-modules/python-imports-check-libstdcxx/basic.nix
@@ -1,0 +1,37 @@
+{ lib
+, cmake
+, pybind11
+, buildPythonPackage
+, python3
+, callPackage
+}:
+
+buildPythonPackage {
+  pname = "load_libstdcxx";
+  version = "0.0.1";
+
+  format = "other";
+
+  src = lib.sourceFilesBySuffices ./. [ ".txt" ".cc" ];
+
+  nativeBuildInputs = [
+    cmake
+  ];
+  buildInputs = [
+    pybind11
+  ];
+
+  cmakeFlags = [
+    "-DLOAD_LIBSTDCXX_INSTALL_SITE_PACKAGES=${placeholder "out"}/${python3.sitePackages}"
+  ];
+
+  pythonImportsCheck = [
+    "load_libstdcxx"
+  ];
+
+  meta = with lib; {
+    license = licenses.lgpl2Plus;
+    maintainers = with maintainers; [ SomeoneSerge ];
+  };
+
+}

--- a/pkgs/development/python-modules/python-imports-check-libstdcxx/default.nix
+++ b/pkgs/development/python-modules/python-imports-check-libstdcxx/default.nix
@@ -1,0 +1,85 @@
+{ lib
+, gcc12Stdenv # The last release
+, gcc11Stdenv # Second-to-last, don't forget to bump
+, buildPythonPackage
+, python3
+, callPackage
+, psutil
+}:
+
+let
+  basic = callPackage ./basic.nix { };
+
+  # We could expose just "basic", but we want to hydra to fail if the following
+  # sanity checks do not pass:
+
+  loadOld = basic.overridePythonAttrs (a: {
+    pname = "${basic.pname}-load-old";
+    buildInputs = a.buildInputs ++ [
+      gcc11Stdenv.cc.cc.lib
+    ];
+    nativeBuildInputs = a.nativeBuildInputs ++ [
+      gcc11Stdenv.cc
+    ];
+    cmakeFlags = a.cmakeFlags ++ [
+      "-DLOAD_LIBSTDCXX_MODULE_NAME=load_libstdcxx_old"
+    ];
+    pythonImportsCheck = [
+      "load_libstdcxx_old"
+    ];
+  });
+
+  # The mistake we're trying to avoid is linking things in a way that we can
+  # accidentally load an old libstdc++ before we import another python module
+  # that needs symbols from a newer libstdc++. We do that by appending
+  # load_libstdcxx at the end of pythonImportsCheck: e.g. if after importing
+  # tensorflow we spoil the namespace with an old libstdc++, load_libstdcxx
+  # should fail.
+
+  # The following derivation verifies that if we first import
+  # load_libstdcxx_old and then import load_libstdcxx_new, we do indeed get an
+  # ImportError.
+  checkFails = basic.overridePythonAttrs (a: {
+    pname = "${basic.pname}-check-fails";
+    src = lib.sourceFilesBySuffices ./. [ ".txt" ".cc" ".py" ];
+
+    buildInputs = a.buildInputs ++ [
+      gcc12Stdenv.cc.cc.lib
+    ];
+    nativeBuildInputs = a.nativeBuildInputs ++ [
+      gcc12Stdenv.cc
+    ];
+
+    dontUseCmakeBuildDir = true;
+    cmakeFlags = a.cmakeFlags ++ [
+      "-DLOAD_LIBSTDCXX_MODULE_NAME=load_libstdcxx_new"
+    ];
+
+    nativeCheckInputs = [
+      loadOld
+      psutil
+    ];
+
+    # Verify backward compatibility
+    pythonImportsCheck = [
+      "load_libstdcxx_new"
+      "load_libstdcxx_old"
+    ];
+
+    # This variable is read by ./test_forward_compatibility_fails.py 
+    EXPECTED_LIBSTDCXX = "${gcc11Stdenv.cc.cc.lib}";
+
+    # Now verify there's no forward compatibility
+    preInstallCheck = ''
+      ${python3.interpreter} test_forward_compatibility_fails.py
+    '';
+  });
+in
+basic.overridePythonAttrs (a: {
+  nativeCheckInputs = [
+    # Make hydra run checks
+    checkFails
+  ];
+
+  passthru.tests = { inherit basic loadOld checkFails; };
+})

--- a/pkgs/development/python-modules/python-imports-check-libstdcxx/main.cc
+++ b/pkgs/development/python-modules/python-imports-check-libstdcxx/main.cc
@@ -1,0 +1,51 @@
+#include <pybind11/pybind11.h>
+#include <pybind11/stl.h>
+
+#include <condition_variable>
+#include <mutex>
+#include <thread>
+
+#ifndef LOAD_LIBSTDCXX_MODULE_NAME
+#error Missing -DLOAD_LIBSTDCXX_MODULE_NAME
+#endif
+
+PYBIND11_MODULE(LOAD_LIBSTDCXX_MODULE_NAME, m) {
+  m.doc() = R"pbdoc(
+        This module doesn't do anything,
+        it only makes the python interpreter load a libstdc++.
+        Nixpkgs uses this to ensure that their python packages do not segfault just because of order of imports
+    )pbdoc";
+
+  // Make sure we actually require some symbols from libstdc++
+  // E.g. earlier we've observed the combination of [ "torch" "zmq" ]  fail
+  // because of std::condition_variable
+  m.def("dummy", []() {
+    // Copy-pasted from
+    // https://en.cppreference.com/w/cpp/thread/condition_variable
+    //
+    std::mutex mutex;
+    std::condition_variable cv;
+    bool ready = false;
+    bool processed = false;
+
+    std::thread worker([&]() {
+      std::unique_lock guard(mutex);
+      cv.wait(guard, [&] { return ready; });
+      processed = true;
+      guard.unlock();
+      cv.notify_one();
+    });
+
+    {
+      std::scoped_lock guard(mutex);
+      ready = true;
+    }
+    cv.notify_one();
+    {
+      std::unique_lock guard(mutex);
+      cv.wait(guard, [&] { return processed; });
+    }
+
+    worker.join();
+  });
+}

--- a/pkgs/development/python-modules/python-imports-check-libstdcxx/test_forward_compatibility_fails.py
+++ b/pkgs/development/python-modules/python-imports-check-libstdcxx/test_forward_compatibility_fails.py
@@ -1,0 +1,43 @@
+"""
+TODO: explain why we want this to fail and how
+"""
+
+import os
+import sys
+
+assert (
+    "EXPECTED_LIBSTDCXX" in os.environ
+), "The derivation failed to export EXPECTED_LIBSTDCXX"
+
+expected_libstdcxx_root = os.environ["EXPECTED_LIBSTDCXX"]
+
+import load_libstdcxx_old
+import psutil
+
+try:
+    import load_libstdcxx_new
+except ImportError:
+    print(f"python-imports-check-load-libstdcxx successfuly fails", file=sys.stderr)
+    sys.exit(0)
+print(
+    "python-imports-check-load-libstdcxx doesn't fail the naive forward"
+    " compatibility test, it probably needs to be updated.",
+    file=sys.stderr,
+)
+
+loaded_libraries = [x.path for x in psutil.Process(os.getpid()).memory_maps()]
+loaded_libraries = [x for x in loaded_libraries if "libstdc++" in x]
+
+assert loaded_libraries, "Didn't load either version of libstdc++"
+
+assert all(x.startswith(expected_libstdcxx_root) for x in loaded_libraries), (
+    "The python interpreter didn't load the old version of libstdc++:"
+    f" {loaded_libraries=}. Expected one from {expected_libstdcxx_root}"
+)
+
+print(
+    "The python interpreter has correctly loaded the old version of"
+    f" libstdc++ as expected: {loaded_libraries}",
+    file=sys.stderr,
+)
+sys.exit(1)

--- a/pkgs/development/python-modules/tensorflow/default.nix
+++ b/pkgs/development/python-modules/tensorflow/default.nix
@@ -20,6 +20,7 @@
 , cudaSupport ? false
 , cudaPackages ? { }
 , cudaCapabilities ? cudaPackages.cudaFlags.cudaCapabilities
+, load_libstdcxx
 , mklSupport ? false, mkl
 , tensorboardSupport ? true
 # XLA without CUDA is broken
@@ -529,7 +530,15 @@ in buildPythonPackage {
     keras
     portpicker
     tblib
+    load_libstdcxx
   ];
+
+  pythonImportsCheck = [
+    "tensorflow"
+    "tensorflow.compat.v1"
+    "load_libstdcxx"
+  ];
+
   checkPhase = ''
     ${python.interpreter} <<EOF
     # A simple "Hello world"

--- a/pkgs/development/python-modules/torch/default.nix
+++ b/pkgs/development/python-modules/torch/default.nix
@@ -1,4 +1,5 @@
 { stdenv, lib, fetchFromGitHub, fetchpatch, buildPythonPackage, python,
+  load_libstdcxx,
   cudaSupport ? false, cudaPackages, magma,
   useSystemNccl ? true,
   MPISupport ? false, mpi,
@@ -297,9 +298,20 @@ in buildPythonPackage rec {
 
   pythonImportsCheck = [
     "torch"
+
+    # Verify we can load a library built against the normal stdenv's libstdc++
+    # after loading `torch`
+    # This is important when e.g. building pytorch with the older
+    # nvcc-compatible gcc
+    "load_libstdcxx"
   ];
 
-  nativeCheckInputs = [ hypothesis ninja psutil ];
+  nativeCheckInputs = [
+    hypothesis
+    load_libstdcxx
+    ninja
+    psutil
+  ];
 
   checkPhase = with lib.versions; with lib.strings; concatStringsSep " " [
     "runHook preCheck"

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5652,6 +5652,8 @@ self: super: with self; {
 
   lmtpd = callPackage ../development/python-modules/lmtpd { };
 
+  load_libstdcxx = callPackage ../development/python-modules/python-imports-check-libstdcxx { };
+
   loca = callPackage ../development/python-modules/loca { };
 
   localimport = callPackage ../development/python-modules/localimport { };


### PR DESCRIPTION
###### Description of changes

A helper for verifying that python packages built with a non-standard stdenv (e.g. cuda-enabled packages overriding the stdenv to satisfy nvcc) do not cause libstdc++ mismatch errors at runtime. Just append this module to `pythonImportsCheck`
