### PR TITLE
systray-x: init at 0.9.2

### DIFF
--- a/pkgs/applications/networking/mailreaders/systray-x/default.nix
+++ b/pkgs/applications/networking/mailreaders/systray-x/default.nix
@@ -1,0 +1,47 @@
+{
+  lib,
+  stdenv,
+  fetchgit,
+  qtbase,
+  wrapQtAppsHook,
+  knotifications,
+  zip,
+  which,
+  git,
+}:
+stdenv.mkDerivation rec {
+  name = "systray-x";
+
+  src = fetchgit {
+    url = "https://github.com/Ximi1970/systray-x.git";
+    rev = "0.9.2";
+    sha256 = "sha256-rRTyM8dJTfVyPYa43E461yxrUpjvOxGzWz+3IafvOxs=";
+    leaveDotGit = true;
+  };
+
+  buildInputs = [qtbase knotifications];
+  nativeBuildInputs = [zip wrapQtAppsHook which git];
+
+  installPhase = ''
+    mkdir -p $out/bin
+    mkdir -p $out/lib/mozilla/native-messaging-hosts
+    mkdir -p $out/lib/mozilla/thunderbird-addons/extensions
+    mv systray-x@Ximi1970.xpi $out/lib/mozilla/thunderbird-addons/extensions
+    mv SysTray-X $out/bin
+    sed -i s@/path/to/native-messaging/app@$out/bin@ app/SysTray_X.json
+    mv app/SysTray_X.json $out/lib/mozilla/native-messaging-hosts
+  '';
+
+  meta = with lib; {
+    description = "A system tray extension for Thunderbird 68+";
+    longDescription = ''
+      The addon uses the WebExtension API's to control an external system dependent system tray application.
+      Needs both the addon AND the companion app installed to work.
+      Will not work with full wayland desktops.
+    '';
+    homepage = "https://github.com/Ximi1970/systray-x";
+    license = licenses.mpl20;
+    maintainers = [maintainers.zahrun];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -34093,6 +34093,8 @@ with pkgs;
 
   synergyWithoutGUI = synergy.override { withGUI = false; };
 
+  systray-x = libsForQt5.callPackage ../applications/networking/mailreaders/systray-x { } ;
+
   tabbed = callPackage ../applications/window-managers/tabbed {
     # if you prefer a custom config, write the config.h in tabbed.config.h
     # and enable


### PR DESCRIPTION
###### Description of changes

Closes https://github.com/NixOS/nixpkgs/issues/212815

The only catch and last mile I didn't figure out is that thunderbird seems to ignore the files in `/run/current-system/sw/lib/mozilla`. So after installation, I manually did the following commands and could confirm it works properly:
```
cp /run/current-system/sw/lib/mozilla/native-messaging-hosts/SysTray_X.json ~/.mozilla/native-messaging-hosts
cp /run/current-system/sw/lib/mozilla/thunderbird-addons/extensions/systray-x@Ximi1970.xpi ~/.thunderbird/${myprofile}/extensions/
```
Any ideas @edolstra @lovesegfault @nbp @vcunat ?

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
