### PR TITLE
sniffnet: 1.1.2 -> 1.1.3

### DIFF
--- a/pkgs/applications/networking/sniffnet/default.nix
+++ b/pkgs/applications/networking/sniffnet/default.nix
@@ -3,6 +3,7 @@
 , fetchFromGitHub
 , pkg-config
 , libpcap
+, openssl
 , stdenv
 , alsa-lib
 , expat
@@ -14,21 +15,22 @@
 
 rustPlatform.buildRustPackage rec {
   pname = "sniffnet";
-  version = "1.1.2";
+  version = "1.1.3";
 
   src = fetchFromGitHub {
     owner = "gyulyvgc";
     repo = "sniffnet";
     rev = "refs/tags/v${version}";
-    hash = "sha256-QEMd/vOi0DFCq7AJHhii7rnBAHS89XP3/b2UIewAgLc=";
+    hash = "sha256-sJUc14MXaCS4OHtwdCuwI1b7NAlOnaGsXBNUYCEXJqQ=";
   };
 
-  cargoHash = "sha256-VcmiM7prK5l8Ow8K9TGUR2xfx9648IoU6i40hOGAqGQ=";
+  cargoHash = "sha256-neRVpJmI4TgzvIQqKNqBr61O7rR8246PcxG50IIKE/M=";
 
   nativeBuildInputs = [ pkg-config ];
 
   buildInputs = [
     libpcap
+    openssl
   ] ++ lib.optionals stdenv.isLinux [
     alsa-lib
     expat
@@ -41,6 +43,11 @@ rustPlatform.buildRustPackage rec {
   ] ++ lib.optionals stdenv.isDarwin [
     darwin.apple_sdk.frameworks.AppKit
     rustPlatform.bindgenHook
+  ];
+
+  # requires internet access
+  checkFlags = [
+    "--skip=secondary_threads::check_updates::tests::fetch_latest_release_from_github"
   ];
 
   postFixup = lib.optionalString stdenv.isLinux ''


### PR DESCRIPTION
Diff: https://github.com/gyulyvgc/sniffnet/compare/refs/tags/v1.1.2...v1.1.3

Changelog: https://github.com/gyulyvgc/sniffnet/blob/v1.1.3/CHANGELOG.md

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
