### PR TITLE
Revert "bind: remove hard-coded `allow-query` config setting"

### DIFF
--- a/nixos/modules/services/networking/bind.nix
+++ b/nixos/modules/services/networking/bind.nix
@@ -87,6 +87,7 @@ let
                      };
                    ''
                 }
+                allow-query { any; };
                 ${extraConfig}
               };
             '')


### PR DESCRIPTION
Reverts NixOS/nixpkgs#221108

This broke the config of my own DNS and a friend's

The servers started responding with `recursion requested but not available` when authoritative zones were queried from outside the cachenetworks.

This is a _HUGE_ footgun