### PR TITLE
invidious: allow for easy overriding of versions

### DIFF
--- a/pkgs/servers/invidious/default.nix
+++ b/pkgs/servers/invidious/default.nix
@@ -1,5 +1,5 @@
-{ lib, stdenv, crystal, fetchFromGitea, librsvg, pkg-config, libxml2, openssl, shards, sqlite, lsquic, videojs, nixosTests }:
-let
+{
+  callPackage,
   # All versions, revisions, and checksums are stored in ./versions.json.
   # The update process is the following:
   #   * pick the latest commit
@@ -12,113 +12,13 @@ let
   #     * update lsquic and boringssl if necessarry, lsquic.cr depends on
   #       the same version of lsquic and lsquic requires the boringssl
   #       commit mentioned in its README
-  versions = lib.importJSON ./versions.json;
-in
-crystal.buildCrystalPackage rec {
-  pname = "invidious";
-  inherit (versions.invidious) version;
+  versions ? (builtins.fromJSON (builtins.readFile ./versions.json))
+}:
 
-  src = fetchFromGitea {
-    domain = "gitea.invidious.io";
-    owner = "iv-org";
-    repo = pname;
-    fetchSubmodules = true;
-    inherit (versions.invidious) rev sha256;
-  };
-
-  postPatch =
-    let
-      # Replacing by the value (templates) of the variables ensures that building
-      # fails if upstream changes the way the metadata is formatted.
-      branchTemplate = ''{{ "#{`git branch | sed -n '/* /s///p'`.strip}" }}'';
-      commitTemplate = ''{{ "#{`git rev-list HEAD --max-count=1 --abbrev-commit`.strip}" }}'';
-      versionTemplate = ''{{ "#{`git log -1 --format=%ci | awk '{print $1}' | sed s/-/./g`.strip}" }}'';
-      # This always uses the latest commit which invalidates the cache even if
-      # the assets were not changed
-      assetCommitTemplate = ''{{ "#{`git rev-list HEAD --max-count=1 --abbrev-commit -- assets`.strip}" }}'';
-    in
-    ''
-      for d in ${videojs}/*; do ln -s "$d" assets/videojs; done
-
-      # Use the version metadata from the derivation instead of using git at
-      # build-time
-      substituteInPlace src/invidious.cr \
-          --replace ${lib.escapeShellArg branchTemplate} '"master"' \
-          --replace ${lib.escapeShellArg commitTemplate} '"${lib.substring 0 7 versions.invidious.rev}"' \
-          --replace ${lib.escapeShellArg versionTemplate} '"${lib.replaceStrings ["-"] ["."] (lib.substring 9 10 version)}"' \
-          --replace ${lib.escapeShellArg assetCommitTemplate} '"${lib.substring 0 7 versions.invidious.rev}"'
-
-      # Patch the assets and locales paths to be absolute
-      substituteInPlace src/invidious.cr \
-          --replace 'public_folder "assets"' 'public_folder "${placeholder "out"}/share/invidious/assets"'
-      substituteInPlace src/invidious/helpers/i18n.cr \
-          --replace 'File.read("locales/' 'File.read("${placeholder "out"}/share/invidious/locales/'
-
-      # Reference sql initialisation/migration scripts by absolute path
-      substituteInPlace src/invidious/database/base.cr \
-            --replace 'config/sql' '${placeholder "out"}/share/invidious/config/sql'
-
-      substituteInPlace src/invidious/user/captcha.cr \
-          --replace 'Process.run(%(rsvg-convert' 'Process.run(%(${lib.getBin librsvg}/bin/rsvg-convert'
-    '';
-
-  nativeBuildInputs = [ pkg-config shards ];
-  buildInputs = [ libxml2 openssl sqlite ];
-
-  format = "crystal";
-  shardsFile = ./shards.nix;
-  crystalBinaries.invidious = {
-    src = "src/invidious.cr";
-    options = [
-      "--release"
-      "--progress"
-      "--verbose"
-      "--no-debug"
-      "-Dskip_videojs_download"
-      "-Ddisable_quic"
-    ];
-  };
-
-  postConfigure = ''
-    # lib includes nix store paths which can’t be patched, so the links have to
-    # be dereferenced first.
-    cp -rL lib lib2
-    rm -r lib
-    mv lib2 lib
-    chmod +w -R lib
-    cp ${lsquic}/lib/liblsquic.a lib/lsquic/src/lsquic/ext
-  '';
-
-  postInstall = ''
-    mkdir -p $out/share/invidious/config
-
-    # Copy static parts
-    cp -r assets locales $out/share/invidious
-    cp -r config/sql $out/share/invidious/config
-  '';
-
-  # Invidious tries to open and validate config/config.yml, even when
-  # running --help. This specifies a minimal configuration in an
-  # environment variable. Even though the database and hmac_key are
-  # bogus, --help still works.
-  installCheckPhase = ''
-    INVIDIOUS_CONFIG="$(cat <<EOF
-    database_url: sqlite3:///dev/null
-    hmac_key: "this-is-required"
-    EOF
-    )" $out/bin/invidious --help
-  '';
-
-  passthru = {
-    inherit lsquic;
-    tests = { inherit (nixosTests) invidious; };
-    updateScript = ./update.sh;
-  };
-
-  meta = with lib; {
-    description = "An open source alternative front-end to YouTube";
-    homepage = "https://invidious.io/";
-    license = licenses.agpl3;
-    maintainers = with maintainers; [ infinisil sbruder ];
-  };
+callPackage ./invidious.nix {
+  inherit versions;
+  # needs a specific version of lsquic
+  lsquic = callPackage ./lsquic.nix { inherit versions; };
+  # normally video.js is downloaded at build time
+  videojs = callPackage ./videojs.nix { inherit versions; };
 }

--- a/pkgs/servers/invidious/invidious.nix
+++ b/pkgs/servers/invidious/invidious.nix
@@ -1,0 +1,113 @@
+{
+  lib, stdenv, crystal, fetchFromGitea, librsvg, pkg-config, libxml2, openssl, shards, sqlite, lsquic, videojs, nixosTests,
+  versions ? (builtins.fromJSON (builtins.readFile ./versions.json))
+}:
+
+crystal.buildCrystalPackage rec {
+  pname = "invidious";
+  inherit (versions.invidious) version;
+
+  src = fetchFromGitea {
+    domain = "gitea.invidious.io";
+    owner = "iv-org";
+    repo = pname;
+    fetchSubmodules = true;
+    inherit (versions.invidious) rev sha256;
+  };
+
+  postPatch =
+    let
+      # Replacing by the value (templates) of the variables ensures that building
+      # fails if upstream changes the way the metadata is formatted.
+      branchTemplate = ''{{ "#{`git branch | sed -n '/* /s///p'`.strip}" }}'';
+      commitTemplate = ''{{ "#{`git rev-list HEAD --max-count=1 --abbrev-commit`.strip}" }}'';
+      versionTemplate = ''{{ "#{`git log -1 --format=%ci | awk '{print $1}' | sed s/-/./g`.strip}" }}'';
+      # This always uses the latest commit which invalidates the cache even if
+      # the assets were not changed
+      assetCommitTemplate = ''{{ "#{`git rev-list HEAD --max-count=1 --abbrev-commit -- assets`.strip}" }}'';
+    in
+    ''
+      for d in ${videojs}/*; do ln -s "$d" assets/videojs; done
+
+      # Use the version metadata from the derivation instead of using git at
+      # build-time
+      substituteInPlace src/invidious.cr \
+          --replace ${lib.escapeShellArg branchTemplate} '"master"' \
+          --replace ${lib.escapeShellArg commitTemplate} '"${lib.substring 0 7 versions.invidious.rev}"' \
+          --replace ${lib.escapeShellArg versionTemplate} '"${lib.replaceStrings ["-"] ["."] (lib.substring 9 10 version)}"' \
+          --replace ${lib.escapeShellArg assetCommitTemplate} '"${lib.substring 0 7 versions.invidious.rev}"'
+
+      # Patch the assets and locales paths to be absolute
+      substituteInPlace src/invidious.cr \
+          --replace 'public_folder "assets"' 'public_folder "${placeholder "out"}/share/invidious/assets"'
+      substituteInPlace src/invidious/helpers/i18n.cr \
+          --replace 'File.read("locales/' 'File.read("${placeholder "out"}/share/invidious/locales/'
+
+      # Reference sql initialisation/migration scripts by absolute path
+      substituteInPlace src/invidious/database/base.cr \
+            --replace 'config/sql' '${placeholder "out"}/share/invidious/config/sql'
+
+      substituteInPlace src/invidious/user/captcha.cr \
+          --replace 'Process.run(%(rsvg-convert' 'Process.run(%(${lib.getBin librsvg}/bin/rsvg-convert'
+    '';
+
+  nativeBuildInputs = [ pkg-config shards ];
+  buildInputs = [ libxml2 openssl sqlite ];
+
+  format = "crystal";
+  shardsFile = ./shards.nix;
+  crystalBinaries.invidious = {
+    src = "src/invidious.cr";
+    options = [
+      "--release"
+      "--progress"
+      "--verbose"
+      "--no-debug"
+      "-Dskip_videojs_download"
+      "-Ddisable_quic"
+    ];
+  };
+
+  postConfigure = ''
+    # lib includes nix store paths which can’t be patched, so the links have to
+    # be dereferenced first.
+    cp -rL lib lib2
+    rm -r lib
+    mv lib2 lib
+    chmod +w -R lib
+    cp ${lsquic}/lib/liblsquic.a lib/lsquic/src/lsquic/ext
+  '';
+
+  postInstall = ''
+    mkdir -p $out/share/invidious/config
+
+    # Copy static parts
+    cp -r assets locales $out/share/invidious
+    cp -r config/sql $out/share/invidious/config
+  '';
+
+  # Invidious tries to open and validate config/config.yml, even when
+  # running --help. This specifies a minimal configuration in an
+  # environment variable. Even though the database and hmac_key are
+  # bogus, --help still works.
+  installCheckPhase = ''
+    INVIDIOUS_CONFIG="$(cat <<EOF
+    database_url: sqlite3:///dev/null
+    hmac_key: "this-is-required"
+    EOF
+    )" $out/bin/invidious --help
+  '';
+
+  passthru = {
+    inherit lsquic;
+    tests = { inherit (nixosTests) invidious; };
+    updateScript = ./update.sh;
+  };
+
+  meta = with lib; {
+    description = "An open source alternative front-end to YouTube";
+    homepage = "https://invidious.io/";
+    license = licenses.agpl3;
+    maintainers = with maintainers; [ infinisil sbruder ];
+  };
+}

--- a/pkgs/servers/invidious/lsquic.nix
+++ b/pkgs/servers/invidious/lsquic.nix
@@ -1,7 +1,9 @@
-{ lib, boringssl, stdenv, fetchgit, fetchFromGitHub, fetchurl, cmake, zlib, perl, libevent }:
-let
-  versions = lib.importJSON ./versions.json;
+{
+  lib, boringssl, stdenv, fetchgit, fetchFromGitHub, fetchurl, cmake, zlib, perl, libevent,
+  versions ? (builtins.fromJSON (builtins.readFile ./versions.json))
+}:
 
+let
   fetchGitilesPatch = { name, url, sha256 }:
     fetchurl {
       url = "${url}%5E%21?format=TEXT";

--- a/pkgs/servers/invidious/videojs.nix
+++ b/pkgs/servers/invidious/videojs.nix
@@ -1,8 +1,8 @@
-{ lib, stdenvNoCC, cacert, crystal, openssl, pkg-config, invidious }:
+{
+  lib, stdenvNoCC, cacert, crystal, openssl, pkg-config, invidious,
+  versions ? (builtins.fromJSON (builtins.readFile ./versions.json))
+}:
 
-let
-  versions = lib.importJSON ./versions.json;
-in
 stdenvNoCC.mkDerivation {
   name = "videojs";
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9441,12 +9441,7 @@ with pkgs;
 
   internetarchive = with python3Packages; toPythonApplication internetarchive;
 
-  invidious = callPackage ../servers/invidious {
-    # needs a specific version of lsquic
-    lsquic = callPackage ../servers/invidious/lsquic.nix { };
-    # normally video.js is downloaded at build time
-    videojs = callPackage ../servers/invidious/videojs.nix { };
-  };
+  invidious = callPackage ../servers/invidious { };
 
   invoice2data  = callPackage ../tools/text/invoice2data  { };
 


### PR DESCRIPTION
###### Description of changes
Loading `versions` in `let` block makes overriding it difficult. In order to make this possible we need a `default.nix` that provides `versions` to `videojs` and `lsquic` packages as well.

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).