### PR TITLE
ruff: 0.0.260 -> 0.0.261

### DIFF
--- a/pkgs/development/tools/ruff/Cargo.lock
+++ b/pkgs/development/tools/ruff/Cargo.lock
@@ -774,7 +774,7 @@ checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
 
 [[package]]
 name = "flake8-to-ruff"
-version = "0.0.260"
+version = "0.0.261"
 dependencies = [
  "anyhow",
  "clap 4.1.8",
@@ -1543,8 +1543,9 @@ checksum = "9fa00462b37ead6d11a82c9d568b26682d78e0477dc02d1966c013af80969739"
 
 [[package]]
 name = "pep440_rs"
-version = "0.2.0"
-source = "git+https://github.com/konstin/pep440-rs.git?rev=a8fef4ec47f4c25b070b39cdbe6a0b9847e49941#a8fef4ec47f4c25b070b39cdbe6a0b9847e49941"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d5daf676dd9ff1a39faf9c9da9c46f0dbb6211b21a1839a749f5510c24ceca3f"
 dependencies = [
  "lazy_static",
  "regex",
@@ -1976,7 +1977,7 @@ dependencies = [
 
 [[package]]
 name = "ruff"
-version = "0.0.260"
+version = "0.0.261"
 dependencies = [
  "anyhow",
  "bitflags",
@@ -2009,6 +2010,7 @@ dependencies = [
  "ruff_diagnostics",
  "ruff_macros",
  "ruff_python_ast",
+ "ruff_python_semantic",
  "ruff_python_stdlib",
  "ruff_rustpython",
  "rustc-hash",
@@ -2058,7 +2060,7 @@ dependencies = [
 
 [[package]]
 name = "ruff_cli"
-version = "0.0.260"
+version = "0.0.261"
 dependencies = [
  "annotate-snippets 0.9.1",
  "anyhow",
@@ -2086,6 +2088,7 @@ dependencies = [
  "ruff",
  "ruff_cache",
  "ruff_diagnostics",
+ "ruff_python_ast",
  "ruff_python_stdlib",
  "rustc-hash",
  "serde",
@@ -2168,16 +2171,15 @@ dependencies = [
  "is-macro",
  "itertools",
  "log",
- "nohash-hasher",
  "num-bigint",
  "num-traits",
  "once_cell",
  "regex",
- "ruff_python_stdlib",
  "ruff_rustpython",
  "rustc-hash",
  "rustpython-common",
  "rustpython-parser",
+ "serde",
  "smallvec",
 ]
 
@@ -2193,7 +2195,6 @@ dependencies = [
  "once_cell",
  "ruff_formatter",
  "ruff_python_ast",
- "ruff_python_stdlib",
  "ruff_rustpython",
  "ruff_testing_macros",
  "ruff_text_size",
@@ -2202,6 +2203,20 @@ dependencies = [
  "rustpython-parser",
  "similar",
  "test-case",
+]
+
+[[package]]
+name = "ruff_python_semantic"
+version = "0.0.0"
+dependencies = [
+ "bitflags",
+ "is-macro",
+ "nohash-hasher",
+ "ruff_python_ast",
+ "ruff_python_stdlib",
+ "rustc-hash",
+ "rustpython-parser",
+ "smallvec",
 ]
 
 [[package]]

--- a/pkgs/development/tools/ruff/default.nix
+++ b/pkgs/development/tools/ruff/default.nix
@@ -8,13 +8,13 @@
 
 rustPlatform.buildRustPackage rec {
   pname = "ruff";
-  version = "0.0.260";
+  version = "0.0.261";
 
   src = fetchFromGitHub {
     owner = "charliermarsh";
     repo = pname;
     rev = "v${version}";
-    hash = "sha256-n/b1L0qMyGzcDwXTLgiPrd4YgFDtxYyUKrgykkdBQWU=";
+    hash = "sha256-YFhMrmZ1Zv4nIWWxq6A7PU0VYayugmJKbbkz+AdGJ+I=";
   };
 
   # We have to use importCargoLock here because `cargo vendor` currently doesn't support workspace
@@ -23,7 +23,6 @@ rustPlatform.buildRustPackage rec {
     lockFile = ./Cargo.lock;
     outputHashes = {
       "libcst-0.1.0" = "sha256-jG9jYJP4reACkFLrQBWOYH6nbKniNyFVItD0cTZ+nW0=";
-      "pep440_rs-0.2.0" = "sha256-wDJGz7SbHItYsg0+EgIoH48WFdV6MEg+HkeE07JE6AU=";
       "rustpython-ast-0.2.0" = "sha256-0SHtycgDVOtiz7JZwd1v9lv2exxemcntm9lciih+pgc=";
       "unicode_names2-0.6.0" = "sha256-eWg9+ISm/vztB0KIdjhq5il2ZnwGJQCleCYfznCI3Wg=";
     };


### PR DESCRIPTION
Diff: https://github.com/charliermarsh/ruff/compare/v0.0.260...v0.0.261

Changelog: https://github.com/charliermarsh/ruff/releases/tag/v0.0.261

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
