### PR TITLE
ocamlPackages.qcheck: fix for OCaml ≥ 5.0

### DIFF
--- a/pkgs/development/ocaml-modules/caqti/async.nix
+++ b/pkgs/development/ocaml-modules/caqti/async.nix
@@ -4,6 +4,8 @@ buildDunePackage {
   pname = "caqti-async";
   inherit (caqti) version src;
 
+  duneVersion = "3";
+
   propagatedBuildInputs = [ async_kernel async_unix caqti core_kernel ];
 
   meta = caqti.meta // { description = "Async support for Caqti"; };

--- a/pkgs/development/ocaml-modules/caqti/default.nix
+++ b/pkgs/development/ocaml-modules/caqti/default.nix
@@ -8,6 +8,7 @@ buildDunePackage rec {
   version = "1.9.1";
 
   minimalOCamlVersion = "4.04";
+  duneVersion = "3";
 
   src = fetchurl {
     url = "https://github.com/paurkedal/ocaml-caqti/releases/download/v${version}/caqti-v${version}.tbz";

--- a/pkgs/development/ocaml-modules/caqti/driver-mariadb.nix
+++ b/pkgs/development/ocaml-modules/caqti/driver-mariadb.nix
@@ -6,6 +6,8 @@ buildDunePackage {
 
   propagatedBuildInputs = [ caqti mariadb ];
 
+  duneVersion = "3";
+
   meta = caqti.meta // {
     description = "MariaDB driver for Caqti using C bindings";
   };

--- a/pkgs/development/ocaml-modules/caqti/driver-postgresql.nix
+++ b/pkgs/development/ocaml-modules/caqti/driver-postgresql.nix
@@ -4,6 +4,8 @@ buildDunePackage {
   pname = "caqti-driver-postgresql";
   inherit (caqti) version src;
 
+  duneVersion = "3";
+
   propagatedBuildInputs = [ caqti postgresql ];
 
   meta = caqti.meta // {

--- a/pkgs/development/ocaml-modules/caqti/dynload.nix
+++ b/pkgs/development/ocaml-modules/caqti/dynload.nix
@@ -1,10 +1,12 @@
-{ lib, buildDunePackage, caqti }:
+{ lib, buildDunePackage, caqti, findlib }:
 
 buildDunePackage {
   pname = "caqti-dynload";
   inherit (caqti) version src;
 
-  propagatedBuildInputs = [ caqti ];
+  duneVersion = "3";
+
+  propagatedBuildInputs = [ caqti findlib ];
 
   meta = caqti.meta // {
     description = "Dynamic linking of Caqti drivers using findlib.dynload";

--- a/pkgs/development/ocaml-modules/caqti/lwt.nix
+++ b/pkgs/development/ocaml-modules/caqti/lwt.nix
@@ -4,6 +4,8 @@ buildDunePackage {
   pname = "caqti-lwt";
   inherit (caqti) version src;
 
+  duneVersion = "3";
+
   propagatedBuildInputs = [ caqti logs lwt ];
 
   meta = caqti.meta // { description = "Lwt support for Caqti"; };

--- a/pkgs/development/ocaml-modules/caqti/type-calendar.nix
+++ b/pkgs/development/ocaml-modules/caqti/type-calendar.nix
@@ -4,6 +4,8 @@ buildDunePackage {
   pname = "caqti-type-calendar";
   inherit (caqti) src version;
 
+  duneVersion = "3";
+
   propagatedBuildInputs = [ calendar caqti ];
 
   meta = caqti.meta // {

--- a/pkgs/development/ocaml-modules/iter/default.nix
+++ b/pkgs/development/ocaml-modules/iter/default.nix
@@ -7,6 +7,8 @@ buildDunePackage rec {
   pname = "iter";
   version = "1.6";
 
+  duneVersion = "3";
+
   src = fetchFromGitHub {
     owner = "c-cube";
     repo = pname;

--- a/pkgs/development/ocaml-modules/pratter/default.nix
+++ b/pkgs/development/ocaml-modules/pratter/default.nix
@@ -12,6 +12,7 @@ buildDunePackage rec {
   pname = "pratter";
 
   minimalOCamlVersion = "4.08";
+  duneVersion = "3";
 
   src = fetchFromGitHub {
     owner = "gabrielhdt";

--- a/pkgs/development/ocaml-modules/qcheck/alcotest.nix
+++ b/pkgs/development/ocaml-modules/qcheck/alcotest.nix
@@ -3,7 +3,9 @@
 buildDunePackage {
   pname = "qcheck-alcotest";
 
-  inherit (qcheck-core) version src;
+  inherit (qcheck-core) version src patches;
+
+  duneVersion = "3";
 
   propagatedBuildInputs = [ qcheck-core alcotest ];
 

--- a/pkgs/development/ocaml-modules/qcheck/bytes.patch
+++ b/pkgs/development/ocaml-modules/qcheck/bytes.patch
@@ -1,0 +1,36 @@
+diff --git a/src/alcotest/dune b/src/alcotest/dune
+index 220a8b3..df1ffe0 100644
+--- a/src/alcotest/dune
++++ b/src/alcotest/dune
+@@ -3,6 +3,6 @@
+   (name qcheck_alcotest)
+   (public_name qcheck-alcotest)
+   (wrapped false)
+-  (libraries unix bytes qcheck-core qcheck-core.runner alcotest)
++  (libraries unix qcheck-core qcheck-core.runner alcotest)
+   (flags :standard -w +a-4-42-44-48-50-58-32-60@8 -safe-string)
+   )
+diff --git a/src/core/dune b/src/core/dune
+index ad0939f..42dc8ac 100644
+--- a/src/core/dune
++++ b/src/core/dune
+@@ -3,6 +3,6 @@
+   (name qcheck_core)
+   (public_name qcheck-core)
+   (wrapped false)
+-  (libraries unix bytes)
++  (libraries unix)
+   (flags :standard -w +a-4-42-44-48-50-58-32-60@8 -safe-string)
+   )
+diff --git a/src/ounit/dune b/src/ounit/dune
+index 2fadb7a..41f8d4b 100644
+--- a/src/ounit/dune
++++ b/src/ounit/dune
+@@ -3,6 +3,6 @@
+   (name qcheck_ounit)
+   (public_name qcheck-ounit)
+   (wrapped false)
+-  (libraries unix bytes qcheck-core qcheck-core.runner ounit2)
++  (libraries unix qcheck-core qcheck-core.runner ounit2)
+   (flags :standard -w +a-4-42-44-48-50-58-32-60@8 -safe-string)
+   )

--- a/pkgs/development/ocaml-modules/qcheck/core.nix
+++ b/pkgs/development/ocaml-modules/qcheck/core.nix
@@ -5,6 +5,7 @@ buildDunePackage rec {
   version = "0.20";
 
   minimalOCamlVersion = "4.08";
+  duneVersion = "3";
 
   src = fetchFromGitHub {
     owner = "c-cube";
@@ -12,6 +13,8 @@ buildDunePackage rec {
     rev = "v${version}";
     sha256 = "sha256-d3gleiaPEDJTbHtieL4oAq1NlA/0NtzdW9SA1sItFeQ=";
   };
+
+  patches = [ ./bytes.patch ];
 
   meta = {
     description = "Core qcheck library";

--- a/pkgs/development/ocaml-modules/qcheck/default.nix
+++ b/pkgs/development/ocaml-modules/qcheck/default.nix
@@ -3,7 +3,9 @@
 buildDunePackage {
   pname = "qcheck";
 
-  inherit (qcheck-ounit) version src;
+  inherit (qcheck-ounit) version src patches;
+
+  duneVersion = "3";
 
   propagatedBuildInputs = [ qcheck-ounit ];
 

--- a/pkgs/development/ocaml-modules/qcheck/ounit.nix
+++ b/pkgs/development/ocaml-modules/qcheck/ounit.nix
@@ -3,7 +3,9 @@
 buildDunePackage {
   pname = "qcheck-ounit";
 
-  inherit (qcheck-core) version src;
+  inherit (qcheck-core) version src patches;
+
+  duneVersion = "3";
 
   propagatedBuildInputs = [ qcheck-core ounit ];
 

--- a/pkgs/development/ocaml-modules/qtest/default.nix
+++ b/pkgs/development/ocaml-modules/qtest/default.nix
@@ -4,7 +4,7 @@ buildDunePackage rec {
   pname = "qtest";
   version = "2.11.2";
 
-  useDune2 = true;
+  duneVersion = "3";
 
   src = fetchFromGitHub {
     owner = "vincent-hugot";

--- a/pkgs/development/ocaml-modules/stringext/default.nix
+++ b/pkgs/development/ocaml-modules/stringext/default.nix
@@ -8,7 +8,7 @@ let version = "1.6.0"; in
 buildDunePackage {
   pname = "stringext";
   version = version;
-  useDune2 = true;
+  duneVersion = "3";
   src = fetchurl {
     url = "https://github.com/rgrinberg/stringext/releases/download/${version}/stringext-${version}.tbz";
     sha256 = "1sh6nafi3i9773j5mlwwz3kxfzdjzsfqj2qibxhigawy5vazahfv";

--- a/pkgs/development/ocaml-modules/syslog-message/default.nix
+++ b/pkgs/development/ocaml-modules/syslog-message/default.nix
@@ -1,5 +1,4 @@
 { lib, buildDunePackage, fetchurl
-, ocaml
 , astring, ptime, rresult, qcheck
 }:
 
@@ -7,13 +6,12 @@ buildDunePackage rec {
   pname = "syslog-message";
   version = "1.1.0";
 
-  minimumOCamlVersion = "4.03";
-
-  useDune2 = true;
+  minimalOCamlVersion = "4.08";
+  duneVersion = "3";
 
   src = fetchurl {
     url = "https://github.com/verbosemode/${pname}/releases/download/${version}/${pname}-${version}.tbz";
-    sha256 = "0vy4dkl2q2fa6rzyfsvjyc9r1b9ymfqd6j35z2kp5vdc4r87053g";
+    hash = "sha256:0vy4dkl2q2fa6rzyfsvjyc9r1b9ymfqd6j35z2kp5vdc4r87053g";
   };
 
   propagatedBuildInputs = [
@@ -22,7 +20,7 @@ buildDunePackage rec {
     rresult
   ];
 
-  doCheck = lib.versionAtLeast ocaml.version "4.08";
+  doCheck = true;
   checkInputs = [
     qcheck
   ];

--- a/pkgs/development/ocaml-modules/uri/default.nix
+++ b/pkgs/development/ocaml-modules/uri/default.nix
@@ -3,11 +3,11 @@
 }:
 
 buildDunePackage rec {
-  minimumOCamlVersion = "4.03";
+  minimalOCamlVersion = "4.03";
   pname = "uri";
   version = "4.2.0";
 
-  useDune2 = true;
+  duneVersion = "3";
 
   src = fetchurl {
     url = "https://github.com/mirage/ocaml-${pname}/releases/download/v${version}/${pname}-v${version}.tbz";

--- a/pkgs/development/ocaml-modules/uri/sexp.nix
+++ b/pkgs/development/ocaml-modules/uri/sexp.nix
@@ -6,7 +6,9 @@ else
 
 buildDunePackage {
   pname = "uri-sexp";
-  inherit (uri) version useDune2 src meta;
+  inherit (uri) version src meta;
+
+  duneVersion = "3";
 
   checkInputs = [ ounit ];
   propagatedBuildInputs = [ ppx_sexp_conv sexplib0 uri ];


### PR DESCRIPTION
###### Description of changes

Quick fix waiting for a new release.

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
