### PR TITLE
elixir-ls: rename elixir_ls to elixir-ls

### DIFF
--- a/doc/languages-frameworks/beam.section.md
+++ b/doc/languages-frameworks/beam.section.md
@@ -128,7 +128,7 @@ You will need to run the build process once to fix the sha256 to correspond to y
 
 ###### FOD {#fixed-output-derivation}
 
-A fixed output derivation will download mix dependencies from the internet. To ensure reproducibility, a hash will be supplied. Note that mix is relatively reproducible. An FOD generating a different hash on each run hasn't been observed (as opposed to npm where the chances are relatively high). See [elixir_ls](https://github.com/NixOS/nixpkgs/blob/master/pkgs/development/beam-modules/elixir_ls.nix) for a usage example of FOD.
+A fixed output derivation will download mix dependencies from the internet. To ensure reproducibility, a hash will be supplied. Note that mix is relatively reproducible. An FOD generating a different hash on each run hasn't been observed (as opposed to npm where the chances are relatively high). See [elixir-ls](https://github.com/NixOS/nixpkgs/blob/master/pkgs/development/beam-modules/elixir-ls/default.nix) for a usage example of FOD.
 
 Practical steps
 

--- a/pkgs/development/beam-modules/default.nix
+++ b/pkgs/development/beam-modules/default.nix
@@ -72,7 +72,7 @@ let
       # Remove old versions of elixir, when the supports fades out:
       # https://hexdocs.pm/elixir/compatibility-and-deprecations.html
 
-      elixir_ls = callPackage ./elixir-ls { inherit elixir fetchMixDeps mixRelease; };
+      elixir-ls = callPackage ./elixir-ls { inherit elixir fetchMixDeps mixRelease; };
 
       lfe = lfe_1_3;
       lfe_1_3 = lib'.callLFE ../interpreters/lfe/1.3.nix { inherit erlang buildRebar3 buildHex; };

--- a/pkgs/development/beam-modules/elixir-ls/default.nix
+++ b/pkgs/development/beam-modules/elixir-ls/default.nix
@@ -23,7 +23,7 @@ mixRelease  {
     sha256 = pinData.depsSha256;
   };
 
-  # elixir_ls is an umbrella app
+  # elixir-ls is an umbrella app
   # override configurePhase to not skip umbrella children
   configurePhase = ''
     runHook preConfigure
@@ -31,12 +31,12 @@ mixRelease  {
     runHook postConfigure
   '';
 
-  # elixir_ls require a special step for release
+  # elixir-ls require a special step for release
   # compile and release need to be performed together because
   # of the no-deps-check requirement
   buildPhase = ''
     runHook preBuild
-    mix do compile --no-deps-check, elixir_ls.release
+    mix do compile --no-deps-check, elixir-ls.release
     runHook postBuild
   '';
 

--- a/pkgs/development/beam-modules/elixir-ls/update.sh
+++ b/pkgs/development/beam-modules/elixir-ls/update.sh
@@ -23,7 +23,7 @@ if ("$latest_version" === "$current_version") {
       .\"sha256\" = \"$tarball_hash\" | \
       .\"depsSha256\" = \"\"" $directory/pin.json | sponge $directory/pin.json
 
-  const new_mix_hash = $(nix-build -A elixir_ls.mixFodDeps 2>&1 | \
+  const new_mix_hash = $(nix-build -A elixir-ls.mixFodDeps 2>&1 | \
     tail -n 1 | \
     sd '\s+got:\s+' '')
 

--- a/pkgs/top-level/aliases.nix
+++ b/pkgs/top-level/aliases.nix
@@ -396,6 +396,8 @@ mapAliases ({
 
   electrum-dash = throw "electrum-dash has been removed from nixpkgs as the project is abandoned"; # Added 2022-01-01
 
+  elixir_ls = elixir-ls; # Added 2023-03-20
+
   # Emacs
   emacs28NativeComp = emacs28; # Added 2022-06-08
   emacs28Packages = emacs28.pkgs; # Added 2021-10-04

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -15654,7 +15654,7 @@ with pkgs;
     erlang erlangR25 erlangR24 erlangR23 erlangR22 erlangR21
     erlang_odbc erlang_javac erlang_odbc_javac
     elixir elixir_1_14 elixir_1_13 elixir_1_12 elixir_1_11 elixir_1_10
-    elixir_ls;
+    elixir-ls;
 
   erlang_nox = beam_nox.interpreters.erlang;
 

--- a/pkgs/top-level/beam-packages.nix
+++ b/pkgs/top-level/beam-packages.nix
@@ -108,7 +108,7 @@ in
     # access for example elixir built with different version of Erlang, use
     # `beam.packages.erlangR24.elixir`.
     inherit (self.packages.erlang)
-      elixir elixir_1_14 elixir_1_13 elixir_1_12 elixir_1_11 elixir_1_10 elixir_ls;
+      elixir elixir_1_14 elixir_1_13 elixir_1_12 elixir_1_11 elixir_1_10 elixir-ls;
 
     inherit (self.packages.erlang) lfe lfe_1_3;
   };


### PR DESCRIPTION
(cherry picked from commit 1f24ebb428c036ebc01b9da6b106b79f93957d6d)

Backport of #222248 to 22.11.

Reason: Make compatible to unstable nix channel (package naming).

###### Description of changes

See #222248.

