### PR TITLE
tuba: 0.1.0 -> 0.2.0

### DIFF
--- a/pkgs/applications/misc/tuba/default.nix
+++ b/pkgs/applications/misc/tuba/default.nix
@@ -6,16 +6,17 @@
 , ninja
 , python3
 , pkg-config
-, wrapGAppsHook
+, wrapGAppsHook4
 , desktop-file-utils
 , gtk4
 , libadwaita
 , json-glib
 , glib
 , glib-networking
+, gtksourceview5
 , libxml2
 , libgee
-, libsoup
+, libsoup_3
 , libsecret
 , gst_all_1
 , nix-update-script
@@ -23,12 +24,12 @@
 
 stdenv.mkDerivation rec {
   pname = "tuba";
-  version = "0.1.0";
+  version = "0.2.0";
   src = fetchFromGitHub {
     owner = "GeopJr";
     repo = "Tuba";
     rev = "v${version}";
-    hash = "sha256-dkURVzbDBrE4bBUvf2fPqvgLKE07tn7jl3OudZpEWUo=";
+    hash = "sha256-LPhGGIHvN/hc71PL50TBw1Q0ysubdtJaEiUEI29HRrE=";
   };
 
   nativeBuildInputs = [
@@ -37,17 +38,18 @@ stdenv.mkDerivation rec {
     pkg-config
     vala
     python3
-    wrapGAppsHook
+    wrapGAppsHook4
     desktop-file-utils
   ];
 
   buildInputs = [
     glib
     glib-networking
+    gtksourceview5
     json-glib
     libxml2
     libgee
-    libsoup
+    libsoup_3
     gtk4
     libadwaita
     libsecret
@@ -68,7 +70,9 @@ stdenv.mkDerivation rec {
   meta = with lib; {
     description = "Browse the Fediverse";
     homepage = "https://tuba.geopjr.dev/";
+    mainProgram = "dev.geopjr.Tuba";
     license = licenses.gpl3Only;
+    changelog = "https://github.com/GeopJr/Tuba/releases/tag/v${version}";
     maintainers = with maintainers; [ chuangzhu ];
   };
 }


### PR DESCRIPTION
###### Description of changes

https://github.com/GeopJr/Tuba/releases/tag/v0.2.0

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).