### PR TITLE
chatblade: init at 0.2.1

### DIFF
--- a/pkgs/applications/misc/chatblade/default.nix
+++ b/pkgs/applications/misc/chatblade/default.nix
@@ -1,0 +1,47 @@
+{ lib, python3Packages }:
+
+python3Packages.buildPythonApplication rec {
+  pname = "chatblade";
+  version = "0.2.1";
+  format = "setuptools";
+
+  src = python3Packages.fetchPypi {
+    inherit pname version;
+    sha256 = "sha256-1syZyqdv+0iyAOWDychv3bGnkHs9SCxsEotxQ+G1UPo=";
+  };
+
+  doCheck = false; # there are no tests
+
+  pythonImportsCheck = [ "chatblade" ];
+  propagatedBuildInputs = with python3Packages; [
+    aiohttp
+    aiosignal
+    async-timeout
+    attrs
+    certifi
+    charset-normalizer
+    frozenlist
+    idna
+    markdown-it-py
+    mdurl
+    multidict
+    openai
+    platformdirs
+    pygments
+    pyyaml
+    regex
+    requests
+    rich
+    tiktoken
+    tqdm
+    urllib3
+    yarl
+  ];
+
+  meta = with lib; {
+    homepage = "https://github.com/npiv/chatblade/";
+    description = "A CLI Swiss Army Knife for ChatGPT";
+    license = licenses.gpl3Only;
+    maintainers = with maintainers; [ deejayem ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6380,6 +6380,8 @@ with pkgs;
 
   changetower = callPackage ../tools/networking/changetower { };
 
+  chatblade = callPackage ../applications/misc/chatblade { };
+
   checkbashisms = callPackage ../development/tools/misc/checkbashisms { };
 
   checkmate = callPackage ../development/tools/checkmate { };


### PR DESCRIPTION
###### Description of changes

Add chatblade, a command line ChatGPT client: https://github.com/npiv/chatblade/

The useful functionality requires an API key to test, e.g.

```
$ OPENAI_API_KEY=<API KEY> ./results/chatblade/bin/chatblade "What is NixOS?"
───────────────────────────────────────── user ─────────────────────────────────────────
What is NixOS?
────────────────────────────────────────────────────────────────────────────────────────
────────────────────────────────────── assistant ───────────────────────────────────────
NixOS is a Linux distribution that is based on the Nix package manager. It is designed
to be a functional and declarative operating system, meaning that the entire system
configuration is defined in a single configuration file. This allows for easy
reproducibility and version control of the entire system. NixOS also has a unique
approach to package management, where packages are isolated from each other and can be
installed and managed independently of the system. This allows for a more reliable and
consistent system, as well as easier management of dependencies. NixOS is known for its
stability, security, and flexibility, and is popular among developers and system
administrators.
────────────────────────────────────────────────────────────────────────────────────────
```
but at least displaying a useage mesage (`chatblade -h`) works without.

Tested on `x86_64-linux`, `aarch64-linux` and `x86_64-darwin`

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
