### PR TITLE
gcc-arm-embedded: fix arm-none-eabi-gdb missing lib and python path

### DIFF
--- a/pkgs/development/compilers/gcc-arm-embedded/10/default.nix
+++ b/pkgs/development/compilers/gcc-arm-embedded/10/default.nix
@@ -47,7 +47,7 @@ stdenv.mkDerivation rec {
     description = "Pre-built GNU toolchain from ARM Cortex-M & Cortex-R processors";
     homepage = "https://developer.arm.com/open-source/gnu-toolchain/gnu-rm";
     license = with licenses; [ bsd2 gpl2 gpl3 lgpl21 lgpl3 mit ];
-    maintainers = with maintainers; [ prusnak ];
+    maintainers = with maintainers; [ prusnak prtzl ];
     platforms = [ "x86_64-linux" "aarch64-linux" "x86_64-darwin" ];
     sourceProvenance = with sourceTypes; [ binaryNativeCode ];
   };

--- a/pkgs/development/compilers/gcc-arm-embedded/11/default.nix
+++ b/pkgs/development/compilers/gcc-arm-embedded/11/default.nix
@@ -3,6 +3,8 @@
 , fetchurl
 , ncurses5
 , python38
+, libxcrypt-legacy
+, runtimeShell
 }:
 
 stdenv.mkDerivation rec {
@@ -38,8 +40,19 @@ stdenv.mkDerivation rec {
     find $out -type f | while read f; do
       patchelf "$f" > /dev/null 2>&1 || continue
       patchelf --set-interpreter $(cat ${stdenv.cc}/nix-support/dynamic-linker) "$f" || true
-      patchelf --set-rpath ${lib.makeLibraryPath [ "$out" stdenv.cc.cc ncurses5 python38 ]} "$f" || true
+      patchelf --set-rpath ${lib.makeLibraryPath [ "$out" stdenv.cc.cc ncurses5 python38 libxcrypt-legacy ]} "$f" || true
     done
+  '';
+
+  postFixup = ''
+    mv $out/bin/arm-none-eabi-gdb $out/bin/arm-none-eabi-gdb-unwrapped
+    cat <<EOF > $out/bin/arm-none-eabi-gdb
+    #!${runtimeShell}
+    export PYTHONPATH=${python38}/lib/python3.8
+    export PYTHONHOME=${python38}/bin/python3.8
+    $out/bin/arm-none-eabi-gdb-unwrapped
+    EOF
+    chmod +x $out/bin/arm-none-eabi-gdb
   '';
 
   meta = with lib; {

--- a/pkgs/development/compilers/gcc-arm-embedded/12/default.nix
+++ b/pkgs/development/compilers/gcc-arm-embedded/12/default.nix
@@ -3,6 +3,8 @@
 , fetchurl
 , ncurses5
 , python38
+, libxcrypt-legacy
+, runtimeShell
 }:
 
 stdenv.mkDerivation rec {
@@ -40,8 +42,19 @@ stdenv.mkDerivation rec {
     find $out -type f | while read f; do
       patchelf "$f" > /dev/null 2>&1 || continue
       patchelf --set-interpreter $(cat ${stdenv.cc}/nix-support/dynamic-linker) "$f" || true
-      patchelf --set-rpath ${lib.makeLibraryPath [ "$out" stdenv.cc.cc ncurses5 python38 ]} "$f" || true
+      patchelf --set-rpath ${lib.makeLibraryPath [ "$out" stdenv.cc.cc ncurses5 python38 libxcrypt-legacy ]} "$f" || true
     done
+  '';
+
+  postFixup = ''
+    mv $out/bin/arm-none-eabi-gdb $out/bin/arm-none-eabi-gdb-unwrapped
+    cat <<EOF > $out/bin/arm-none-eabi-gdb
+    #!${runtimeShell}
+    export PYTHONPATH=${python38}/lib/python3.8
+    export PYTHONHOME=${python38}/bin/python3.8
+    $out/bin/arm-none-eabi-gdb-unwrapped
+    EOF
+    chmod +x $out/bin/arm-none-eabi-gdb
   '';
 
   meta = with lib; {

--- a/pkgs/development/compilers/gcc-arm-embedded/12/default.nix
+++ b/pkgs/development/compilers/gcc-arm-embedded/12/default.nix
@@ -61,7 +61,7 @@ stdenv.mkDerivation rec {
     description = "Pre-built GNU toolchain from ARM Cortex-M & Cortex-R processors";
     homepage = "https://developer.arm.com/open-source/gnu-toolchain/gnu-rm";
     license = with licenses; [ bsd2 gpl2 gpl3 lgpl21 lgpl3 mit ];
-    maintainers = with maintainers; [ prusnak ];
+    maintainers = with maintainers; [ prusnak prtzl ];
     platforms = [ "x86_64-linux" "aarch64-linux" "x86_64-darwin" "aarch64-darwin" ];
     sourceProvenance = with sourceTypes; [ binaryNativeCode ];
   };


### PR DESCRIPTION
###### Description of changes
Fix the following error:
```shell
error while loading shared libraries: libcrypt.so.1
```
by adding `libxcrypt-legacy` to rpath, which provides `libcrypt.so.1`.

When fixed, it complains about python paths:
```shell
Could not find platform independent libraries <prefix>
Could not find platform dependent libraries <exec_prefix>
Consider setting $PYTHONHOME to <prefix>[:<exec_prefix>]
Python path configuration:
  PYTHONHOME = (not set)
  PYTHONPATH = (not set)
  program name = '/usr/local/bld-tools/bld-tools-virtual-env/bin/python'
  isolated = 0
  environment = 1
  user site = 1
  import site = 1
  sys._base_executable = '/usr/local/bld-tools/bld-tools-virtual-env/bin/python'
  sys.base_prefix = '/usr'
  sys.base_exec_prefix = '/usr'
  sys.executable = '/usr/local/bld-tools/bld-tools-virtual-env/bin/python'
  sys.prefix = '/usr'
  sys.exec_prefix = '/usr'
  sys.path = [
    '/usr/lib/python38.zip',
    '/usr/lib/python3.8',
    '/usr/lib/lib-dynload',
  ]
Fatal Python error: init_fs_encoding: failed to get the Python codec of the filesystem encoding
Python runtime state: core initialized
ModuleNotFoundError: No module named 'encodings'

Current thread 0x00007f685e47a040 (most recent call first):
<no Python frame>
```

I renamed `arm-none-eabi-gdb` to `arm-none-eabi-gdb-unwrapped` and replaced the original executable with shell script, which exports PYTHONPATH and PYTHONHOME before launching unwrapped version. I found the solution [here](https://community.arm.com/support-forums/f/dev-platforms-forum/53938/fatal-python-error-on-fedora-linux-for-arm-none-eabi-gdb). This is the simplest implementation I could think of (only one).

###### Things done
Update `gcc-arm-embedded-{11,12}` packages to include libxcrypt in executable runtime path along with a wrapper script for `arm-none-eabi-gdb` that exports python env variables.

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

Maintainer: @prusnak
