### PR TITLE
vultr-cli: 2.15.0 -> 2.16.2, enable tests

### DIFF
--- a/pkgs/development/tools/vultr-cli/default.nix
+++ b/pkgs/development/tools/vultr-cli/default.nix
@@ -13,8 +13,6 @@ buildGoModule rec {
 
   vendorHash = "sha256-P4xr7zVTwBRVoPxtKn3FNV7Vp6lI4uWdTJyXwex8Fe4=";
 
-  doCheck = false;
-
   meta = with lib; {
     description = "Official command line tool for Vultr services";
     homepage = "https://github.com/vultr/vultr-cli";

--- a/pkgs/development/tools/vultr-cli/default.nix
+++ b/pkgs/development/tools/vultr-cli/default.nix
@@ -2,16 +2,16 @@
 
 buildGoModule rec {
   pname = "vultr-cli";
-  version = "2.15.0";
+  version = "2.16.2";
 
   src = fetchFromGitHub {
     owner = "vultr";
     repo = pname;
     rev = "v${version}";
-    sha256 = "sha256-F2ZC8JC0PYY4u2to+QzQr2z2+tqOkx59lz8EHqqPotY=";
+    hash = "sha256-TugONG98MC1+B9kDLH9xeMmD41fHNV8VCWWWtOdlwys=";
   };
 
-  vendorSha256 = null;
+  vendorHash = "sha256-P4xr7zVTwBRVoPxtKn3FNV7Vp6lI4uWdTJyXwex8Fe4=";
 
   doCheck = false;
 


### PR DESCRIPTION
###### Description of changes

(v2.16.0 and v2.16.1 have no changelogs for whatever reason)
https://github.com/vultr/vultr-cli/releases/tag/v2.16.2
https://github.com/vultr/vultr-cli/releases/tag/v2.15.1
https://github.com/vultr/vultr-cli/blob/75ad0c5b13fb59d239fecb56cf4178cca3d7750f/CHANGELOG.md
diff: https://github.com/vultr/vultr-cli/compare/v2.15.0...v2.16.2

Also enabled the go tests, which run just fine.
Seems to be a leftover from #94632 (cea7cd902eb4cd87f0b8eac9ee08f6cd8b92635f), which changed the default of `doCheck` from `false` to `true`

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
