### PR TITLE
Add Lisp team as maintainers of Lisp packages

### DIFF
--- a/maintainers/team-list.nix
+++ b/maintainers/team-list.nix
@@ -426,6 +426,21 @@ with lib.maintainers; {
     shortName = "Linux Kernel";
   };
 
+  lisp = {
+    members = [
+      raskin
+      lukego
+      nagy
+      uthar
+    ];
+    githubTeams = [
+      "lisp"
+    ];
+    scope = "Maintain the Lisp ecosystem.";
+    shortName = "lisp";
+    enableFeatureFreezePing = true;
+  };
+
   llvm = {
     members = [
       dtzWill

--- a/pkgs/development/compilers/abcl/default.nix
+++ b/pkgs/development/compilers/abcl/default.nix
@@ -36,7 +36,7 @@ stdenv.mkDerivation rec {
   meta = {
     description = "A JVM-based Common Lisp implementation";
     license = lib.licenses.gpl3 ;
-    maintainers = [lib.maintainers.raskin];
+    maintainers = lib.teams.lisp.members;
     platforms = lib.platforms.linux;
     homepage = "https://common-lisp.net/project/armedbear/";
   };

--- a/pkgs/development/compilers/ccl/default.nix
+++ b/pkgs/development/compilers/ccl/default.nix
@@ -119,7 +119,7 @@ stdenv.mkDerivation rec {
   meta = with lib; {
     description = "Clozure Common Lisp";
     homepage    = "https://ccl.clozure.com/";
-    maintainers = with maintainers; [ raskin ];
+    maintainers = lib.teams.lisp.members;
     platforms   = attrNames options;
     # assembler failures during build, x86_64-darwin broken since 2020-10-14
     broken      = (stdenv.isDarwin && stdenv.isx86_64);

--- a/pkgs/development/compilers/clasp/default.nix
+++ b/pkgs/development/compilers/clasp/default.nix
@@ -89,7 +89,7 @@ in llvmPackages_15.stdenv.mkDerivation {
   meta = {
     description = "A Common Lisp implementation based on LLVM with C++ integration";
     license = lib.licenses.lgpl21Plus ;
-    maintainers = [lib.maintainers.raskin lib.maintainers.uthar];
+    maintainers = lib.teams.lisp.members;
     platforms = ["x86_64-linux" "x86_64-darwin"];
     # Upstream claims support, but breaks with:
     # error: use of undeclared identifier 'aligned_alloc'

--- a/pkgs/development/compilers/cmucl/binary.nix
+++ b/pkgs/development/compilers/cmucl/binary.nix
@@ -56,7 +56,7 @@ stdenv.mkDerivation (finalAttrs: {
       ANSI Common Lisp standard.
     '';
     license = licenses.publicDomain;
-    maintainers = [ ];
+    maintainers = lib.teams.lisp.members;
     platforms = [ "i686-linux" "x86_64-linux" ];
   };
 })

--- a/pkgs/development/compilers/ecl/16.1.2.nix
+++ b/pkgs/development/compilers/ecl/16.1.2.nix
@@ -91,7 +91,7 @@ stdenv.mkDerivation rec {
   meta = with lib; {
     description = "Lisp implementation aiming to be small, fast and easy to embed";
     license = licenses.mit;
-    maintainers = with maintainers; [ raskin ];
+    maintainers = lib.teams.lisp.members;
     platforms = platforms.unix;
     # never built on aarch64-darwin since first introduction in nixpkgs
     broken = stdenv.isDarwin && stdenv.isAarch64;

--- a/pkgs/development/compilers/ecl/default.nix
+++ b/pkgs/development/compilers/ecl/default.nix
@@ -79,7 +79,7 @@ stdenv.mkDerivation rec {
     description = "Lisp implementation aiming to be small, fast and easy to embed";
     homepage = "https://common-lisp.net/project/ecl/";
     license = licenses.mit;
-    maintainers = with maintainers; [ raskin ];
+    maintainers = lib.teams.lisp.members;
     platforms = platforms.unix;
     changelog = "https://gitlab.com/embeddable-common-lisp/ecl/-/raw/${version}/CHANGELOG";
   };

--- a/pkgs/development/compilers/gcl/2.6.13-pre.nix
+++ b/pkgs/development/compilers/gcl/2.6.13-pre.nix
@@ -43,7 +43,7 @@ stdenv.mkDerivation rec {
 
   meta = {
     description = "GNU Common Lisp compiler working via GCC";
-    maintainers = [ lib.maintainers.raskin ];
+    maintainers = lib.teams.lisp.members;
     platforms = lib.platforms.linux;
   };
 }

--- a/pkgs/development/compilers/gcl/default.nix
+++ b/pkgs/development/compilers/gcl/default.nix
@@ -47,7 +47,7 @@ stdenv.mkDerivation rec {
 
   meta = with lib; {
     description = "GNU Common Lisp compiler working via GCC";
-    maintainers = [ maintainers.raskin ];
+    maintainers = lib.teams.lisp.members;
     license = licenses.gpl2;
     platforms = platforms.linux;
   };

--- a/pkgs/development/compilers/mkcl/default.nix
+++ b/pkgs/development/compilers/mkcl/default.nix
@@ -60,6 +60,6 @@ stdenv.mkDerivation rec {
     homepage = "https://common-lisp.net/project/mkcl/";
     license = licenses.lgpl2Plus;
     platforms = platforms.linux;
-    maintainers = with maintainers; [ ];
+    maintainers = lib.teams.lisp.members;
   };
 }

--- a/pkgs/development/compilers/sbcl/bootstrap.nix
+++ b/pkgs/development/compilers/sbcl/bootstrap.nix
@@ -78,7 +78,7 @@ stdenv.mkDerivation rec {
     description = "Lisp compiler";
     homepage = "http://www.sbcl.org";
     license = licenses.publicDomain; # and FreeBSD
-    maintainers = [ maintainers.raskin ];
+    maintainers = lib.teams.lisp.members;
     platforms = attrNames options;
   };
 }

--- a/pkgs/development/interpreters/clisp/default.nix
+++ b/pkgs/development/interpreters/clisp/default.nix
@@ -99,7 +99,7 @@ stdenv.mkDerivation rec {
   meta = {
     description = "ANSI Common Lisp Implementation";
     homepage = "http://clisp.cons.org";
-    maintainers = with lib.maintainers; [ raskin ];
+    maintainers = lib.teams.lisp.members;
     platforms = lib.platforms.unix;
     # problems on Darwin: https://github.com/NixOS/nixpkgs/issues/20062
     broken = stdenv.hostPlatform.isDarwin || stdenv.hostPlatform.isAarch64;

--- a/pkgs/development/interpreters/clisp/hg.nix
+++ b/pkgs/development/interpreters/clisp/hg.nix
@@ -91,7 +91,7 @@ stdenv.mkDerivation rec {
   meta = {
     description = "ANSI Common Lisp Implementation";
     homepage = "http://clisp.cons.org";
-    maintainers = with lib.maintainers; [ raskin ];
+    maintainers = lib.teams.lisp.members;
     # problems on Darwin: https://github.com/NixOS/nixpkgs/issues/20062
     platforms = lib.platforms.linux;
   };

--- a/pkgs/development/lisp-modules/nix-cl.nix
+++ b/pkgs/development/lisp-modules/nix-cl.nix
@@ -222,6 +222,9 @@ let
       patches = [];
       propagatedBuildInputs = args.propagatedBuildInputs or []
           ++ lispLibs ++ javaLibs ++ nativeLibs;
+      meta = (args.meta or {}) // {
+        maintainers = args.meta.maintainers or lib.teams.lisp.members;
+      };
     })));
 
   # Build the set of lisp packages using `lisp`


### PR DESCRIPTION
Set the default value of the `meta.maintainers` attribute to the Lisp team for all packages in the Lisp ecosystem. Is this what we want?

This will apply to all "libraries" i.e. `sbclPackages.*`. "Programs" such as stumpwm or Nyxt, or the Lisp compilers themselves, already have maintainers

See #218870