### PR TITLE
upspin: init at unstable-2023-02-05

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -11360,6 +11360,11 @@
     githubId = 357005;
     name = "Marco Orovecchia";
   };
+  orthros = {
+    github = "orthros";
+    githubId = 7820716;
+    name = "orthros";
+  };
   osener = {
     email = "ozan@ozansener.com";
     github = "osener";

--- a/pkgs/tools/filesystems/upspin/default.nix
+++ b/pkgs/tools/filesystems/upspin/default.nix
@@ -1,0 +1,26 @@
+{ buildGoModule, fetchFromGitHub, lib }:
+
+buildGoModule rec {
+  pname = "upspin";
+  version = "unstable-2023-02-05";
+
+  src = fetchFromGitHub {
+    owner = "upspin";
+    repo = "upspin";
+    rev = "67e250ec27d8878c0009213b8e32c6803f2727ea";
+    sha256 = "sha256-1pFDJSCUDKn4CTAg3wdB8oYPyrmd8B62zNl3m5YAqVM=";
+  };
+
+  vendorSha256 = "sha256-Jl++FvKyqz5WFa/Eoly+UnFsoC9Qwdaizhkq6LyJ+XQ=";
+
+  # No upstream tests
+  doCheck = false;
+
+  meta = with lib; {
+    description = "A global name space for storing data akin to a filesystem";
+    homepage = "https://upspin.io";
+    license = licenses.bsd3;
+    maintainers = with maintainers; [ orthros ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -38913,6 +38913,8 @@ with pkgs;
 
   unityhub = callPackage ../development/tools/unityhub { };
 
+  upspin = callPackage ../tools/filesystems/upspin { };
+
   urbit = callPackage ../misc/urbit { };
 
   usb-reset = callPackage ../applications/misc/usb-reset { };


### PR DESCRIPTION
###### Description of changes
Adds new package upspin. 

Homepage: https://upspin.io

Description from their website:

Upspin is an [open-source project](https://github.com/upspin/upspin) that comprises two main design elements:

1. a set of protocols enabling secure, federated sharing using a global naming system; and
1. reference implementations of tools and services that demonstrate the capabilities.

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
