### PR TITLE
upspin-ui: init at unstable-2021-07-01

### DIFF
--- a/pkgs/applications/file-managers/upspin-ui/default.nix
+++ b/pkgs/applications/file-managers/upspin-ui/default.nix
@@ -1,0 +1,27 @@
+{ buildGoModule, fetchFromGitHub, lib }:
+
+buildGoModule rec {
+  pname = "upspin-ui";
+  version = "2021-07-01";
+
+  src = fetchFromGitHub {
+    owner = "upspin";
+    repo = "augie";
+    rev = "798945a1f13394a5ab2d79bfdf1a68d87b797151";
+    sha256 = "sha256-lDmYb2C5dSrjFYcEEp/PK1J3rq6LVGlOGQM242tD+4M=";
+  };
+
+  vendorSha256 = "sha256-JARX6yptKvYddli8Kw0PZd627nKiNyrTtXqnAR6o6rE=";
+
+  # No upstream tests
+  doCheck = false;
+
+  meta = with lib; {
+    description = "upspin-ui presents a web interface to the Upspin name space, and also provides a facility to sign up an Upspin user and deploy an upspinserver to Google Cloud Platform";
+    homepage = "https://upspin.io";
+    license = licenses.bsd3;
+    maintainers = with maintainers; [ orthros ];
+    platforms = platforms.linux;
+    mainProgram = "upspin-ui";
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -38913,6 +38913,8 @@ with pkgs;
 
   unityhub = callPackage ../development/tools/unityhub { };
 
+  upspin-ui = callPackage ../applications/file-managers/upspin-ui { };
+
   urbit = callPackage ../misc/urbit { };
 
   usb-reset = callPackage ../applications/misc/usb-reset { };


### PR DESCRIPTION
###### Description of changes
Adds new package upspin-ui.

Homepage: https://upspin.io/

Description from their website:

upspin-ui presents a web interface to the Upspin name space, and also provides a facility to sign up an Upspin user and deploy an upspinserver to Google Cloud Platform.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).