### PR TITLE
mesa: fix zink by patching RPATH so it finds libvulkan.so

### DIFF
--- a/pkgs/development/libraries/mesa/generic.nix
+++ b/pkgs/development/libraries/mesa/generic.nix
@@ -322,6 +322,10 @@ self = stdenv.mkDerivation {
         patchelf --set-rpath "$(patchelf --print-rpath $lib):$drivers/lib" "$lib"
       fi
     done
+    # add RPATH here so Zink can find libvulkan.so
+    ${lib.optionalString haveZink ''
+      patchelf --add-rpath ${vulkan-loader}/lib $drivers/lib/dri/zink_dri.so
+    ''}
   '';
 
   env.NIX_CFLAGS_COMPILE = toString (lib.optionals stdenv.isDarwin [ "-fno-common" ] ++ lib.optionals enableOpenCL [


### PR DESCRIPTION
###### Description of changes

Currently zink can't find libvulkan.so, so it won't work when you try to use it, you can verify that using strace, patching RPATH fixes this.

Closes #187791

Test that Zink works now by applying the following NixOS config:
```
{ pkgs, ... }: {
  nixpkgs.overlays = [(final: prev: {
    mesa-fix = let
      nixpkgs-fix = builtins.fetchTarball {
        url = "https://github.com/nixos/nixpkgs/tarball/19be5ac0119740b050ddcfd8608691ebf65abf9e";
        sha256 = "0z38lf6gq8ciq5nlw9ziryi9j9klhwzz2xims10pgcwllbn3acw7";
      };
    in (import nixpkgs-fix { inherit (pkgs) system; }).mesa;
  } )];
  hardware.opengl = {
    package = pkgs.mesa-fix.drivers;
    package32 = pkgs.pkgsi686Linux.mesa-fix.drivers;
  };
}
```

And verifying the result:
```
$ MESA_LOADER_DRIVER_OVERRIDE=zink glxinfo | grep zink 
    Device: zink (Intel(R) UHD Graphics 630 (CFL GT2)) (0x3e9b)
OpenGL renderer string: zink (Intel(R) UHD Graphics 630 (CFL GT2))

$ MESA_LOADER_DRIVER_OVERRIDE=zink es2_info | grep zink
GL_RENDERER: zink (Intel(R) UHD Graphics 630 (CFL GT2))

$ MESA_LOADER_DRIVER_OVERRIDE=zink glxgears            
Running synchronized to the vertical refresh.  The framerate should be
approximately the same as the monitor refresh rate.
```

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
