### PR TITLE
tsm-client: use `libxcrypt-legacy`, drop `openssl_1_1`, use `concatLines` in module

### DIFF
--- a/nixos/modules/programs/tsm-client.nix
+++ b/nixos/modules/programs/tsm-client.nix
@@ -6,7 +6,7 @@ let
   inherit (lib.attrsets) attrNames filterAttrs hasAttr mapAttrs mapAttrsToList optionalAttrs;
   inherit (lib.modules) mkDefault mkIf;
   inherit (lib.options) literalExpression mkEnableOption mkOption;
-  inherit (lib.strings) concatStringsSep optionalString toLower;
+  inherit (lib.strings) concatLines optionalString toLower;
   inherit (lib.types) addCheck attrsOf lines nonEmptyStr nullOr package path port str strMatching submodule;
 
   # Checks if given list of strings contains unique
@@ -164,7 +164,7 @@ let
         mkLine = k: v: k + optionalString (v!="") "  ${v}";
         lines = mapAttrsToList mkLine attrset;
       in
-        concatStringsSep "\n" lines;
+        concatLines lines;
     config.stanza = ''
       server  ${config.name}
       ${config.text}
@@ -263,7 +263,7 @@ let
 
     ${optionalString (cfg.defaultServername!=null) "defaultserver  ${cfg.defaultServername}"}
 
-    ${concatStringsSep "\n" (mapAttrsToList (k: v: v.stanza) cfg.servers)}
+    ${concatLines (mapAttrsToList (k: v: v.stanza) cfg.servers)}
   '';
 
 in

--- a/pkgs/tools/backup/tsm-client/default.nix
+++ b/pkgs/tools/backup/tsm-client/default.nix
@@ -6,7 +6,6 @@
 , autoPatchelfHook
 , rpmextract
 , libxcrypt-legacy
-, openssl
 , zlib
 , lvm2  # LVM image backup and restore functions (optional)
 , acl  # EXT2/EXT3/XFS ACL support (optional)
@@ -118,7 +117,6 @@ let
     ];
     buildInputs = [
       libxcrypt-legacy
-      openssl
       stdenv.cc.cc
       zlib
     ];
@@ -146,7 +144,8 @@ let
       runHook postInstall
     '';
 
-    # Fix relative symlinks after `/usr` was moved up one level
+    # fix relative symlinks after `/usr` was moved up one level,
+    # fix absolute symlinks pointing to `/opt`
     preFixup = ''
       for link in $out/lib{,64}/* $out/bin/*
       do
@@ -157,6 +156,10 @@ let
           exit 1
         fi
         ln --symbolic --force --no-target-directory "$out/$(cut -b 7- <<< "$target")" "$link"
+      done
+      for link in $(find $out -type l -lname '/opt/*')
+      do
+        ln --symbolic --force --no-target-directory "$out$(readlink "$link")" "$link"
       done
     '';
   };

--- a/pkgs/tools/backup/tsm-client/default.nix
+++ b/pkgs/tools/backup/tsm-client/default.nix
@@ -5,7 +5,7 @@
 , fetchurl
 , autoPatchelfHook
 , rpmextract
-, libxcrypt
+, libxcrypt-legacy
 , openssl
 , zlib
 , lvm2  # LVM image backup and restore functions (optional)
@@ -117,7 +117,7 @@ let
       rpmextract
     ];
     buildInputs = [
-      libxcrypt
+      libxcrypt-legacy
       openssl
       stdenv.cc.cc
       zlib

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7027,13 +7027,8 @@ with pkgs;
 
   timeline = callPackage ../applications/office/timeline { };
 
-  tsm-client = callPackage ../tools/backup/tsm-client {
-    openssl = openssl_1_1;
-  };
-  tsm-client-withGui = callPackage ../tools/backup/tsm-client {
-    openssl = openssl_1_1;
-    enableGui = true;
-  };
+  tsm-client = callPackage ../tools/backup/tsm-client { };
+  tsm-client-withGui = callPackage ../tools/backup/tsm-client { enableGui = true; };
 
   tracker = callPackage ../development/libraries/tracker { };
 


### PR DESCRIPTION
###### Description of changes

The main purpose of the pull request at hand is to fix `tsm-client`: We have to switch from `libxcrypt` to `libxcrypt-legacy` as `tsm-client` still needs `libcrypt.so.1`.

The pull request also fixes a mistake I did long ago which lead to the inclusion of `openssl` 1.1 as dependency.  Reverting that mistake also facilitates the efforts of https://github.com/NixOS/nixpkgs/issues/210452 .

Finally, I'm using the opportunity to replace occurences of `lib.concatStringsSep "\n"` by the new `lib.concatLines` in the `tsm-client` NixOS module.


###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

More:

- Both tests derivations (cli and gui) build/pass.
- Also successfully tested with a real tsm-server (uploaded some files for backup without errors/problems).  The connection is encrypted, which indicates that `tsm-client` again successfully uses its own `lib{crypto,ssl}.so` implementation.
- To ensure the new `lib.concatLines` doesn't introduce errors in the generated config file, I declared two server entries and compared the generated config files before and after the change.  The results match, up to insignificant empty lines.


###### Result of `nixpkgs-review` run on x86_64-linux [1](https://github.com/Mic92/nixpkgs-review)

<details>
  <summary>1 package blacklisted:</summary>
  <ul>
    <li>nixos-install-tools</li>
  </ul>
</details>
<details>
  <summary>2 packages built:</summary>
  <ul>
    <li>tsm-client</li>
    <li>tsm-client-withGui</li>
  </ul>
</details>
