### PR TITLE
pyinstaller-hooks-contrib: init at 2023.1

### DIFF
--- a/pkgs/development/python-modules/pyinstaller-hooks-contrib/default.nix
+++ b/pkgs/development/python-modules/pyinstaller-hooks-contrib/default.nix
@@ -1,0 +1,34 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+}:
+
+buildPythonPackage rec {
+  pname = "pyinstaller-hooks-contrib";
+  version = "2023.1";
+
+  format = "setuptools";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "ab56c192e7cd4472ff6b840cda4fc42bceccc7fb4234f064fc834a3248c0afdd";
+  };
+
+
+  doCheck = false;
+
+  meta = with lib; {
+    description = "PyInstaller community hooks";
+    longDescription = ''
+    A "hook" file extends PyInstaller to adapt it to the special needs and methods used by a Python package.
+    The word "hook" is used for two kinds of files. A runtime hook helps the bootloader to launch an app,
+    setting up the environment. A package hook (there are several types of those) tells PyInstaller
+    what to include in the final app - such as the data files and (hidden) imports mentioned above.
+    This repository is a collection of hooks for many packages, and allows PyInstaller to work with these packages seamlessly.
+    '';
+    homepage = "https://github.com/pyinstaller/pyinstaller-hooks-contrib";
+    downloadPage = "https://pypi.org/project/pyinstaller-hooks-contrib";
+    license = with licenses; [ gpl2Plus asl20 ];
+    maintainers = with maintainers; [ septem9er ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -8372,6 +8372,8 @@ self: super: with self; {
 
   pyinputevent = callPackage ../development/python-modules/pyinputevent { };
 
+  pyinstaller-hooks-contrib = callPackage ../development/python-modules/pyinstaller-hooks-contrib { };
+
   pyinsteon = callPackage ../development/python-modules/pyinsteon { };
 
   pyinstrument = callPackage ../development/python-modules/pyinstrument { };


### PR DESCRIPTION
###### Description of changes

Adding package pyinstaller-hooks-contrib. These are community maintained hooks for PyInstaller, and are a dependency of pyinstaller itself. I will create a pull request for pyinstaller later.

Commit to add myself to the maintainer llist is in #224856.

One thing I am unsure about: The package is partly licenses unter APL, partly under GPL. I added both of those in the metadata, but I am unsure if that is the right way or if that would rather mean that the complete code is licenses under both licenses.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
