### PR TITLE
raycast: 1.49.0 -> 1.49.2

### DIFF
--- a/pkgs/os-specific/darwin/raycast/default.nix
+++ b/pkgs/os-specific/darwin/raycast/default.nix
@@ -6,7 +6,7 @@
 
 stdenvNoCC.mkDerivation rec {
   pname = "raycast";
-  version = "1.49.0";
+  version = "1.49.2";
 
   src = fetchurl {
     # https://github.com/NixOS/nixpkgs/pull/223495
@@ -17,7 +17,7 @@ stdenvNoCC.mkDerivation rec {
     # to host GitHub Actions to periodically check for updates
     # and re-release the `.dmg` file to Internet Archive (https://archive.org/details/raycast)
     url = "https://archive.org/download/raycast/raycast-${version}.dmg";
-    sha256 = "sha256-6j5PyzJ7g3p+5gE2CQHlZrLj5b3rLdpodl+By7xxcjo=";
+    sha256 = "sha256-3evuSRSCZkhxRy/85ohzIVF1tKRlWy+G5BOmuCWF2hU=";
   };
 
   dontPatch = true;

--- a/pkgs/os-specific/darwin/raycast/update.sh
+++ b/pkgs/os-specific/darwin/raycast/update.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env nix-shell
+#!nix-shell -I nixpkgs=../../../../. -i bash -p common-updater-scripts internetarchive
+
+set -eo pipefail
+
+new_version="$(ia list raycast | grep -Eo '^raycast-.*\.dmg$' | sort -r | head -n1 | sed -E 's/^raycast-([0-9]+\.[0-9]+\.[0-9]+)\.dmg$/\1/')"
+old_version="$(sed -nE 's/\s*version = "(.*)".*/\1/p' ./default.nix)"
+
+if [[ "$new_version" == "$old_version" ]]; then
+    echo "Already up to date."
+    exit 0
+else
+    echo "raycast: $old_version -> $new_version"
+    sed -Ei.bak '/ *version = "/s/".+"/"'"$new_version"'"/' ./default.nix
+    rm ./default.nix.bak
+fi
+
+hash="$(nix --extra-experimental-features nix-command store prefetch-file --json --hash-type sha256 "https://archive.org/download/raycast/raycast-$new_version.dmg" | jq -r '.hash')"
+sed -Ei.bak '/ *sha256 = /{N;N; s@("sha256-)[^;"]+@"'"$hash"'@}' ./default.nix
+rm ./default.nix.bak


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

raycast: 1.49.0 -> 1.49.2

```diff
 stdenvNoCC.mkDerivation rec {
   pname = "raycast";
-  version = "1.49.0";
+  version = "1.49.2";

   src = fetchurl {
     # https://github.com/NixOS/nixpkgs/pull/223495
@@ -17,7 +17,7 @@ stdenvNoCC.mkDerivation rec {
     # to host GitHub Actions to periodically check for updates
     # and re-release the `.dmg` file to Internet Archive (https://archive.org/details/raycast)
     url = "https://archive.org/download/raycast/raycast-${version}.dmg";
-    sha256 = "sha256-6j5PyzJ7g3p+5gE2CQHlZrLj5b3rLdpodl+By7xxcjo=";
+    sha256 = "sha256-3evuSRSCZkhxRy/85ohzIVF1tKRlWy+G5BOmuCWF2hU=";
   };
```

Also added
1. made [my updater repo](https://github.com/StepBroBD/Raycast-Overlay) publish tags on new releases
2. update script

Related: https://github.com/NixOS/nixpkgs/pull/223495#issuecomment-1490130600

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
