### PR TITLE
adoptopenjdk-bin/jdk17: Added jdk/jre-openj9 as throw-dummy

### DIFF
--- a/pkgs/development/compilers/adoptopenjdk-bin/jdk17-darwin.nix
+++ b/pkgs/development/compilers/adoptopenjdk-bin/jdk17-darwin.nix
@@ -6,4 +6,6 @@ in
 {
   jdk-hotspot = import ./jdk-darwin-base.nix { sourcePerArch = sources.openjdk17.mac.jdk.hotspot; };
   jre-hotspot = import ./jdk-darwin-base.nix { sourcePerArch = sources.openjdk17.mac.jre.hotspot; };
+  jdk-openj9 = throw "openjdk17 on darwin is missing jdk-openj9";
+  jre-openj9 = throw "openjdk17 on darwin is missing jre-openj9";
 }

--- a/pkgs/development/compilers/adoptopenjdk-bin/jdk17-linux.nix
+++ b/pkgs/development/compilers/adoptopenjdk-bin/jdk17-linux.nix
@@ -7,4 +7,6 @@ in
 {
   jdk-hotspot = import ./jdk-linux-base.nix { sourcePerArch = sources.openjdk17.${variant}.jdk.hotspot; };
   jre-hotspot = import ./jdk-linux-base.nix { sourcePerArch = sources.openjdk17.${variant}.jre.hotspot; };
+  jdk-openj9 = throw "openjdk17 on linux is missing jdk-openj9";
+  jre-openj9 = throw "openjdk17 on linux is missing jre-openj9";
 }


### PR DESCRIPTION
###### Description of changes

All other jdk-versions have `jdk/jre-openj9` set and `mkAdoptopenjdk` in `pkgs/top-level/java-packages.nix:31` expect it in lines 42–43. In contrast to throw, which can be catched in `tryEval`, accessing a missing attribute of a set aborts unrecoverable. Another solution would be to handle this in `mkAdoptopenjdk`.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
