### PR TITLE
Revert "python3Packages.catboost: 1.0.5 -> 1.1.1"

### DIFF
--- a/pkgs/development/python-modules/catboost/default.nix
+++ b/pkgs/development/python-modules/catboost/default.nix
@@ -5,7 +5,8 @@
 
 buildPythonPackage rec {
   pname = "catboost";
-  version = "1.1.1";
+  # nixpkgs-update: no auto update
+  version = "1.0.5";
 
   disabled = pythonOlder "3.4";
 
@@ -13,7 +14,7 @@ buildPythonPackage rec {
     owner = "catboost";
     repo = "catboost";
     rev = "refs/tags/v${version}";
-    hash = "sha256-bqnUHTTRan/spA5y4LRt/sIUYpP3pxzdN/4wHjzgZVY=";
+    hash = "sha256-ILemeZUBI9jPb9G6F7QX/T1HaVhQ+g6y7YmsT6DFCJk";
   };
 
   nativeBuildInputs = [ clang_12 ];
@@ -40,6 +41,11 @@ buildPythonPackage rec {
   # Tests use custom "ya" tool, not yet supported.
   dontUseSetuptoolsCheck = true;
   pythonImportsCheck = [ "catboost" ];
+
+  passthru = {
+    # Do not update to catboost 1.1.x because the patch doesn't apply cleanly
+    skipBulkUpdate = true;
+  };
 
   meta = with lib; {
     description = "High-performance library for gradient boosting on decision trees.";


### PR DESCRIPTION
This reverts commit 3626e3084a65c2a36ab70420d9624d3449b1556b.

###### Description of changes

1.1.1 is unbuildable since the needed patch doesn't apply cleanly; see also #216863.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
