### PR TITLE
forgejo: 1.19.0-2 -> 1.19.0-3, use "predictable URLs" in `src.url` 

### DIFF
--- a/pkgs/applications/version-management/forgejo/default.nix
+++ b/pkgs/applications/version-management/forgejo/default.nix
@@ -25,11 +25,11 @@
 
 buildGoModule rec {
   pname = "forgejo";
-  version = "1.19.0-2";
+  version = "1.19.0-3";
 
   src = fetchurl {
     url = "https://codeberg.org/forgejo/forgejo/releases/download/v${version}/forgejo-src-${version}.tar.gz";
-    hash = "sha256-neDIT+V3qHR8xgP4iy4TJQ6PCWO3svpSA7FLCacQSMI=";
+    hash = "sha256-u27DDw3JUtVJ2nvkKfaGzpYP8bpRnwc1LUVra8Epkjc=";
   };
 
   vendorHash = null;

--- a/pkgs/applications/version-management/forgejo/default.nix
+++ b/pkgs/applications/version-management/forgejo/default.nix
@@ -28,9 +28,7 @@ buildGoModule rec {
   version = "1.19.0-2";
 
   src = fetchurl {
-    name = "${pname}-src-${version}.tar.gz";
-    # see https://codeberg.org/forgejo/forgejo/releases
-    url = "https://codeberg.org/attachments/2bf497db-fa91-4260-9c98-5c791b6b397c";
+    url = "https://codeberg.org/forgejo/forgejo/releases/download/v${version}/forgejo-src-${version}.tar.gz";
     hash = "sha256-neDIT+V3qHR8xgP4iy4TJQ6PCWO3svpSA7FLCacQSMI=";
   };
 
@@ -105,7 +103,6 @@ buildGoModule rec {
           | { $version, html_url } + (.assets | map(select(.name | startswith($filename)) | {(.name | split(".") | last): .browser_download_url}) | add)' \
           <<< "$releases")
 
-        archive_url=$(jq -r .gz <<< "$stable")
         checksum_url=$(jq -r .sha256 <<< "$stable")
         release_url=$(jq -r .html_url <<< "$stable")
         version=$(jq -r .version <<< "$stable")
@@ -120,7 +117,7 @@ buildGoModule rec {
         sha256=$(curl "$checksum_url" --silent | cut --delimiter " " --fields 1)
         sri_hash=$(nix hash to-sri --type sha256 "$sha256")
 
-        update-source-version "${pname}" "$version" "$sri_hash" "$archive_url"
+        update-source-version "${pname}" "$version" "$sri_hash"
       '';
     });
   };


### PR DESCRIPTION
###### Description of changes

release notes: https://codeberg.org/forgejo/forgejo/src/commit/4c132e77ea2cba9a1161f4cfc18b82b9e2e1b35f/RELEASE-NOTES.md#1-19-0-3

The security section in those release notes does not apply to nixpkgs :)
Or rather isn't specific to forgejo, as #224714 hasn't landed in nixos-unstable yet /shrug 

Also changed the `src.url` to use a predictable URL instead of `https://codeberg.org/attachments/$uuid`.

Not sure how long codeberg.org already supports this.
I only just found out about them after a maintainer mentioned them in https://matrix.to/#/#forgejo-chat:matrix.org
Similar URLs are also used at https://forgejo.org/download/

cc @mweinelt as I've spotted you in https://matrix.to/#/#forgejo-chat:matrix.org :eyes: 

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

