### PR TITLE
flexget: pin transmission-rpc version to fix compatibility issue

### DIFF
--- a/pkgs/applications/networking/flexget/default.nix
+++ b/pkgs/applications/networking/flexget/default.nix
@@ -14,6 +14,18 @@ let
           hash = "sha256-lfwC9/wfMZmqpHqKdXQ3E0z2GOnZlMhO/9U/Uww4WG8=";
         };
       });
+
+      # Flexget's transmission plugin is not currently compatible with the 4.x
+      # branch for transmission-rpc.
+      transmission-rpc = super.transmission-rpc.overridePythonAttrs (old: rec {
+        version = "3.4.2";
+        src = fetchFromGitHub {
+          owner = "Trim21";
+          repo = "transmission-rpc";
+          rev = "refs/tags/v${version}";
+          hash = "sha256-7XbL6plIPZHQ/0Z+7bvtj8hqkh4klFyIV73DnrUAkps=";
+        };
+      });
     };
   };
 in


### PR DESCRIPTION
###### Description of changes

Flexget's Transmission plugin does not support transmission-rpc 4.x which is now the version provided in pythonPackages.

```
Apr 05 23:05:00 smol flexget[1947619]: 2023-04-05 23:05:00 CRITICAL task          xxxxxx BUG: Unhandled error in plugin transmission: 'Torrent' object has no attribute 'totalSize'
Apr 05 23:05:00 smol flexget[1947619]: Traceback (most recent call last):
[...]
Apr 05 23:05:00 smol flexget[1947619]:   File "/nix/store/wif7z86gik8jkp0ab2crhirsq04dp0kx-flexget-3.5.33/lib/python3.10/site-packages/flexget/plugins/clients/transmission.py", line 454, in on_task_output
Apr 05 23:05:00 smol flexget[1947619]:     total_size = torrent_info.totalSize
Apr 05 23:05:00 smol flexget[1947619]:                  └ <Torrent 2458 "xxxxx">
Apr 05 23:05:00 smol flexget[1947619]: AttributeError: 'Torrent' object has no attribute 'totalSize'
```

See also https://github.com/Flexget/Flexget/issues/3699

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
