### PR TITLE
squeezelite: 1.9.9.1419 -> 1.9.9.1428

### DIFF
--- a/pkgs/applications/audio/squeezelite/default.nix
+++ b/pkgs/applications/audio/squeezelite/default.nix
@@ -34,13 +34,13 @@ stdenv.mkDerivation {
   pname = binName;
   # versions are specified in `squeezelite.h`
   # see https://github.com/ralph-irving/squeezelite/issues/29
-  version = "1.9.9.1419";
+  version = "1.9.9.1428";
 
   src = fetchFromGitHub {
     owner = "ralph-irving";
     repo = "squeezelite";
-    rev = "226efa300c4cf037e8486bad635e9deb3104636f";
-    hash = "sha256-ZZWliw1prFbBZMFp0QmXg6MKuHPNuFh2lFxQ8bbuWAM=";
+    rev = "74fe7934ec60cc31565f088796f56e911f51679c";
+    hash = "sha256-85Pz6psyK3VXOIrINcoIeHZT5j9UfJqWIxTavwqHx04=";
   };
 
   buildInputs = [ flac libmad libvorbis mpg123 ]

--- a/pkgs/applications/audio/squeezelite/default.nix
+++ b/pkgs/applications/audio/squeezelite/default.nix
@@ -78,6 +78,8 @@ stdenv.mkDerivation {
     runHook postInstall
   '';
 
+  passthru.updateScript = ./update.sh;
+
   meta = with lib; {
     description = "Lightweight headless squeezebox client emulator";
     homepage = "https://github.com/ralph-irving/squeezelite";

--- a/pkgs/applications/audio/squeezelite/update.sh
+++ b/pkgs/applications/audio/squeezelite/update.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env nix-shell
+#!nix-shell -i bash -p common-updater-scripts coreutils curl gnused jq nix nix-prefetch-github ripgrep
+
+set -euo pipefail
+
+latestRev="$(curl -s "https://api.github.com/repos/ralph-irving/squeezelite/commits?per_page=1" | jq -r ".[0].sha")"
+latestVersion="$( curl -s https://raw.githubusercontent.com/ralph-irving/squeezelite/${latestRev}/squeezelite.h | rg 'define (MAJOR|MINOR|MICRO)_VERSION' | sed 's/#.*VERSION //' | tr '\n' '.' | sed  -e 's/"//g' -e 's/\.$//')"
+currentVersion=$(nix-instantiate --eval -E "with import ./. {}; squeezelite.version or (lib.getVersion squeezelite)" | tr -d '"')
+
+if [[ "$currentVersion" == "$latestVersion" ]]; then
+  echo "squeezelite is up-to-date: $currentVersion"
+  exit 0
+fi
+
+srcHash=$(nix-prefetch-github ralph-irving squeezelite --rev "$latestRev" | jq -r .sha256)
+srcHash=$(nix hash to-sri --type sha256 "$srcHash")
+
+
+update-source-version squeezelite "$latestVersion" "$srcHash" --rev="${latestRev}"


### PR DESCRIPTION
- squeezelite: add passthru.updateScript
- squeezelite: 1.9.9.1419 -> 1.9.9.1428

###### Description of changes

https://github.com/ralph-irving/squeezelite/commit/74fe7934ec60cc31565f088796f56e911f51679c

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
