### PR TITLE
ocamlPackages.atdgen: 2.10.0 → 2.11.0

### DIFF
--- a/pkgs/development/ocaml-modules/atdgen/codec-runtime.nix
+++ b/pkgs/development/ocaml-modules/atdgen/codec-runtime.nix
@@ -2,11 +2,13 @@
 
 buildDunePackage rec {
   pname = "atdgen-codec-runtime";
-  version = "2.10.0";
+  version = "2.11.0";
+
+  duneVersion = "3";
 
   src = fetchurl {
     url = "https://github.com/ahrefs/atd/releases/download/${version}/atdts-${version}.tbz";
-    sha256 = "sha256-d9J0CaTp2sQbnKLp6mCDbGwYAIsioVer7ftaLSSFCZg=";
+    hash = "sha256-TTTuSxNKydPmTmztUapLoxntBIrAo8aWYIJ/G5cok1Y=";
   };
 
   meta = {

--- a/pkgs/development/ocaml-modules/atdgen/default.nix
+++ b/pkgs/development/ocaml-modules/atdgen/default.nix
@@ -6,6 +6,8 @@ buildDunePackage {
   pname = "atdgen";
   inherit (atdgen-codec-runtime) version src;
 
+  duneVersion = "3";
+
   buildInputs = [ atd re ];
 
   propagatedBuildInputs = [ atdgen-runtime ];

--- a/pkgs/development/ocaml-modules/atdgen/runtime.nix
+++ b/pkgs/development/ocaml-modules/atdgen/runtime.nix
@@ -5,6 +5,7 @@ buildDunePackage rec {
   inherit (atdgen-codec-runtime) version src;
 
   minimalOCamlVersion = "4.08";
+  duneVersion = "3";
 
   propagatedBuildInputs = [ biniou yojson ];
 

--- a/pkgs/development/ocaml-modules/elpi/default.nix
+++ b/pkgs/development/ocaml-modules/elpi/default.nix
@@ -35,6 +35,7 @@ buildDunePackage rec {
     ./atd_2_10.patch;
 
   minimalOCamlVersion = "4.04";
+  duneVersion = "3";
 
   # atdgen is both a library and executable
   nativeBuildInputs = [ perl ]


### PR DESCRIPTION
###### Description of changes

https://github.com/ahrefs/atd/blob/2.11.0/CHANGES.md

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
