### PR TITLE
architectures: add x86_64 microarchitecture levels

### DIFF
--- a/lib/systems/architectures.nix
+++ b/lib/systems/architectures.nix
@@ -4,6 +4,10 @@ rec {
   # gcc.arch to its features (as in /proc/cpuinfo)
   features = {
     default        = [ ];
+    # x86_64 Generic
+    x86-64-v2      = [ "sse3" "ssse3" "sse4_1" "sse4_2"                                                  ];
+    x86-64-v3      = [ "sse3" "ssse3" "sse4_1" "sse4_2"               "avx" "avx2"          "fma"        ];
+    x86-64-v4      = [ "sse3" "ssse3" "sse4_1" "sse4_2"               "avx" "avx2" "avx512" "fma"        ];
     # x86_64 Intel
     westmere       = [ "sse3" "ssse3" "sse4_1" "sse4_2"         "aes"                                    ];
     sandybridge    = [ "sse3" "ssse3" "sse4_1" "sse4_2"         "aes" "avx"                              ];
@@ -39,9 +43,15 @@ rec {
 
   # a superior CPU has all the features of an inferior and is able to build and test code for it
   inferiors = {
+    default        = [ ];
+
+    # x86_64 Generic
+    x86-64-v2      = [ ];
+    x86-64-v3      = [ "x86-64-v2"      ] ++ inferiors.x86-64-v2;
+    x86-64-v4      = [ "x86-64-v3"      ] ++ inferiors.x86-64-v3;
+
     # x86_64 Intel
     # https://gcc.gnu.org/onlinedocs/gcc/x86-Options.html
-    default        = [ ];
     westmere       = [ ];
     sandybridge    = [ "westmere"       ] ++ inferiors.westmere;
     ivybridge      = [ "sandybridge"    ] ++ inferiors.sandybridge;

--- a/pkgs/build-support/cc-wrapper/default.nix
+++ b/pkgs/build-support/cc-wrapper/default.nix
@@ -75,7 +75,11 @@ let
   isGccArchSupported = arch:
     if targetPlatform.isPower then false else # powerpc does not allow -march=
     if isGNU then
-      { # Intel
+      { # Generic
+        x86-64-v2      = versionAtLeast ccVersion "11.0";
+        x86-64-v3      = versionAtLeast ccVersion "11.0";
+        x86-64-v4      = versionAtLeast ccVersion "11.0";
+        # Intel
         skylake        = versionAtLeast ccVersion "6.0";
         skylake-avx512 = versionAtLeast ccVersion "6.0";
         cannonlake     = versionAtLeast ccVersion "8.0";
@@ -91,7 +95,11 @@ let
         znver3         = versionAtLeast ccVersion "11.0";
       }.${arch} or true
     else if isClang then
-      { # Intel
+      { # Generic
+        x86-64-v2      = versionAtLeast ccVersion "12.0";
+        x86-64-v3      = versionAtLeast ccVersion "12.0";
+        x86-64-v4      = versionAtLeast ccVersion "12.0";
+        # Intel
         cannonlake     = versionAtLeast ccVersion "5.0";
         icelake-client = versionAtLeast ccVersion "7.0";
         icelake-server = versionAtLeast ccVersion "7.0";


### PR DESCRIPTION
###### Description of changes

Add support for x86_64 microarchitecture levels (x86-64-v2, x86-64-v3 and x86-64-v4) introduced in LLVM 12 and GCC 11.

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).