### PR TITLE
cudaPackages_12.cudatoolkit: hotfix after switching to autoPatchelfHook

### DIFF
--- a/pkgs/development/compilers/cudatoolkit/common.nix
+++ b/pkgs/development/compilers/cudatoolkit/common.nix
@@ -73,7 +73,11 @@ backendStdenv.mkDerivation rec {
   ] ++ lib.optionals (lib.versionOlder version "11") [
     libsForQt5.wrapQtAppsHook
   ];
-  buildInputs = [
+  buildInputs = lib.optionals (lib.versionOlder version "11") [
+    libsForQt5.qt5.qtwebengine
+    freeglut
+    libGLU
+  ] ++ [
     # To get $GDK_PIXBUF_MODULE_FILE via setup-hook
     gdk-pixbuf
 
@@ -109,10 +113,6 @@ backendStdenv.mkDerivation rec {
     unixODBC
     alsa-lib
     wayland
-  ] ++ lib.optionals (lib.versionOlder version "11") [
-    libsForQt5.qt5.qtwebengine
-    freeglut
-    libGLU
   ];
 
   # Prepended to runpaths by autoPatchelf.

--- a/pkgs/development/compilers/cudatoolkit/common.nix
+++ b/pkgs/development/compilers/cudatoolkit/common.nix
@@ -78,7 +78,7 @@ backendStdenv.mkDerivation rec {
     autoAddOpenGLRunpathHook
   ] ++ lib.optionals (lib.versionOlder version "11") [
     libsForQt5.wrapQtAppsHook
-  ] ++ lib.optionals (lib.versions.major version == "12") [
+  ] ++ lib.optionals (lib.versionAtLeast version "11.8") [
     qt6Packages.wrapQtAppsHook
   ];
   buildInputs = lib.optionals (lib.versionOlder version "11") [
@@ -121,7 +121,7 @@ backendStdenv.mkDerivation rec {
     unixODBC
     alsa-lib
     wayland
-  ] ++ lib.optionals (lib.versions.major version == "12") [
+  ] ++ lib.optionals (lib.versionAtLeast version "11.8") [
     (lib.getLib libtiff)
     qt6Packages.qtwayland
     rdma-core
@@ -220,8 +220,8 @@ backendStdenv.mkDerivation rec {
       mv pkg/builds/nsight_systems/target-linux-x64 $out/target-linux-x64
       mv pkg/builds/nsight_systems/host-linux-x64 $out/host-linux-x64
     ''}
-      ${lib.optionalString (lib.versions.major version == "12")
-      # error: auto-patchelf could not satisfy dependency libtiff.so.5 wanted by /nix/store/ivw2ss2ppafxww0f935dvqij5xkgvczz-cudatoolkit-12.0.1/host-linux-x64/Plugins/imageformats/libqtiff.so
+      ${lib.optionalString (lib.versionAtLeast version "11.8")
+      # error: auto-patchelf could not satisfy dependency libtiff.so.5 wanted by /nix/store/.......-cudatoolkit-12.0.1/host-linux-x64/Plugins/imageformats/libqtiff.so
       # we only ship libtiff.so.6, so let's use qt plugins built by Nix.
       # TODO: don't copy, come up with a symlink-based "merge"
     ''

--- a/pkgs/development/compilers/cudatoolkit/common.nix
+++ b/pkgs/development/compilers/cudatoolkit/common.nix
@@ -37,6 +37,11 @@ args@
 , freeglut
 , libGLU
 , libsForQt5
+, libtiff
+, qt6Packages
+, rdma-core
+, ucx
+, rsync
 }:
 
 backendStdenv.mkDerivation rec {
@@ -67,11 +72,14 @@ backendStdenv.mkDerivation rec {
   nativeBuildInputs = [
     perl
     makeWrapper
+    rsync
     addOpenGLRunpath
     autoPatchelfHook
     autoAddOpenGLRunpathHook
   ] ++ lib.optionals (lib.versionOlder version "11") [
     libsForQt5.wrapQtAppsHook
+  ] ++ lib.optionals (lib.versions.major version == "12") [
+    qt6Packages.wrapQtAppsHook
   ];
   buildInputs = lib.optionals (lib.versionOlder version "11") [
     libsForQt5.qt5.qtwebengine
@@ -113,6 +121,13 @@ backendStdenv.mkDerivation rec {
     unixODBC
     alsa-lib
     wayland
+  ] ++ lib.optionals (lib.versions.major version == "12") [
+    (lib.getLib libtiff)
+    qt6Packages.qtwayland
+    rdma-core
+    ucx
+    xorg.libxshmfence
+    xorg.libxkbfile
   ];
 
   # Prepended to runpaths by autoPatchelf.
@@ -204,6 +219,13 @@ backendStdenv.mkDerivation rec {
 
       mv pkg/builds/nsight_systems/target-linux-x64 $out/target-linux-x64
       mv pkg/builds/nsight_systems/host-linux-x64 $out/host-linux-x64
+    ''}
+      ${lib.optionalString (lib.versions.major version == "12")
+      # error: auto-patchelf could not satisfy dependency libtiff.so.5 wanted by /nix/store/ivw2ss2ppafxww0f935dvqij5xkgvczz-cudatoolkit-12.0.1/host-linux-x64/Plugins/imageformats/libqtiff.so
+      # we only ship libtiff.so.6, so let's use qt plugins built by Nix.
+      # TODO: don't copy, come up with a symlink-based "merge"
+    ''
+      rsync ${lib.getLib qt6Packages.qtimageformats}/lib/qt-6/plugins/ $out/host-linux-x64/Plugins/ -aP
     ''}
 
     rm -f $out/tools/CUDA_Occupancy_Calculator.xls # FIXME: why?


### PR DESCRIPTION
###### Description of changes

"Regression" introduced in https://github.com/NixOS/nixpkgs/pull/178440, I forgot to test `cudaPackages_12`
Error reported in the comment: https://github.com/NixOS/nixpkgs/issues/224646#issuecomment-1498385913

I had to do something ugly about the qt dependencies, because NVidia builds against an out-of-date libtiff which we haven't got. Once we have a proper solution to https://github.com/NixOS/nixpkgs/issues/224646 we can remove that hack from the `installPhase`. Obviously, we need to verify if we this work at runtime as well.

For more context: this errors shows that `cudaPackages_12.cudatoolkit` and `cudaPackages_11_8.cudatoolkit` have technically always been "broken", since they shipped executables and/or libraries that weren't properly patchelf-ed. What https://github.com/NixOS/nixpkgs/issues/224646 changes is that this kind of omissions cannot go unnoticed

The legacy `cudaPackages.cudatoolkit` getting uglier is also "OK": one more reason to migrate to the redist `cudaPackages.{cuda_,lib}*`

CC @aaronmondal CC @NixOS/cuda-maintainers 
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
