### PR TITLE
nixos/cifs: Configure cifs.upcall/idmap to be used when needed

### DIFF
--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -189,6 +189,7 @@
   ./programs/kbdlight.nix
   ./programs/kclock.nix
   ./programs/kdeconnect.nix
+  ./programs/keyutils.nix
   ./programs/less.nix
   ./programs/liboping.nix
   ./programs/light.nix

--- a/nixos/modules/programs/keyutils.nix
+++ b/nixos/modules/programs/keyutils.nix
@@ -1,0 +1,81 @@
+{ config, lib, pkgs, ... }:
+
+let
+  cfg = config.programs.keyutils;
+
+  keyProgram = with lib;
+    types.submodule {
+      options = {
+        op = mkOption {
+          type = types.str;
+          example = "create";
+          description = mdDoc "The requested key operation to match.";
+        };
+        type = mkOption {
+          type = types.str;
+          default = "*";
+          example = "user";
+          description = mdDoc "The requested key type to match.";
+        };
+        description = mkOption {
+          type = types.str;
+          default = "*";
+          example = "debug:*";
+          description = mdDoc "The requested key description to match.";
+        };
+        calloutInfo = mkOption {
+          type = types.str;
+          default = "*";
+          example = "negate";
+          description = mdDoc "The requested key callout info to match.";
+        };
+        command = mkOption {
+          type = types.str;
+          example = literalExpression
+            ''"''${pkgs.keyutils}/bin/keyctl negate %k 30 %S"'';
+          description = mdDoc ''
+            The command to execute to generate the key.
+
+            See {manpage}`request-key.conf(5)` for information on available substitutions.
+          '';
+        };
+      };
+    };
+in {
+  options.programs.keyutils = with lib; {
+    enable = mkEnableOption (mdDoc
+      "configuration of userspace utilities for Linux keyring management");
+
+    package = mkPackageOptionMD pkgs "keyutils" { };
+
+    keyPrograms = mkOption {
+      type = types.listOf keyProgram;
+      default = [ ];
+      description = mdDoc ''
+        A list of attrsets describing what programs to use to instantiate keys.
+
+        See {manpage}`request-key.conf(5)`.
+      '';
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    environment.systemPackages = [ cfg.package ];
+
+    environment.etc."request-key.conf".text = let
+      configLines = lib.concatStringsSep "\n" (builtins.map
+        (p: "${p.op} ${p.type} ${p.description} ${p.calloutInfo} ${p.command}")
+        cfg.keyPrograms);
+    in ''
+      create user         debug:loop:* *        |${pkgs.coreutils}/bin/cat
+      create user         debug:*      negate   ${cfg.package}/bin/keyctl negate %k 30 %S
+      create user         debug:*      rejected ${cfg.package}/bin/keyctl reject %k 30 %c %S
+      create user         debug:*      expired  ${cfg.package}/bin/keyctl reject %k 30 %c %S
+      create user         debug:*      revoked  ${cfg.package}/bin/keyctl reject %k 30 %c %S
+      create user         debug:*      *        ${cfg.package}/share/keyutils/request-key-debug.sh %k %d %c %S
+      create dns_resolver *            *        ${cfg.package}/bin/key.dns_resolver %k
+
+      ${configLines}
+    '';
+  };
+}

--- a/nixos/modules/tasks/filesystems/cifs.nix
+++ b/nixos/modules/tasks/filesystems/cifs.nix
@@ -4,6 +4,8 @@ with lib;
 
 let
 
+  enabled = any (fs: fs == "cifs") config.boot.supportedFilesystems;
+
   inInitrd = any (fs: fs == "cifs") config.boot.initrd.supportedFilesystems;
 
 in
@@ -11,7 +13,7 @@ in
 {
   config = {
 
-    system.fsPackages = mkIf (any (fs: fs == "cifs") config.boot.supportedFilesystems) [ pkgs.cifs-utils ];
+    system.fsPackages = mkIf enabled [ pkgs.cifs-utils ];
 
     boot.initrd.availableKernelModules = mkIf inInitrd
       [ "cifs" "nls_utf8" "hmac" "md4" "ecb" "des_generic" "sha256" ];
@@ -20,6 +22,22 @@ in
       ''
         copy_bin_and_libs ${pkgs.cifs-utils}/sbin/mount.cifs
       '';
+
+    programs.keyutils = mkIf enabled {
+      enable = true;
+      keyPrograms = [
+        {
+          op = "create";
+          type = "cifs.spnego";
+          command = "${pkgs.cifs-utils}/bin/cifs.upcall %k";
+        }
+        {
+          op = "create";
+          type = "cifs.idmap";
+          command = "${pkgs.cifs-utils}/bin/cifs.idmap %k";
+        }
+      ];
+    };
 
   };
 }

--- a/pkgs/os-specific/linux/cifs-utils/default.nix
+++ b/pkgs/os-specific/linux/cifs-utils/default.nix
@@ -1,5 +1,5 @@
 { stdenv, lib, fetchurl, autoreconfHook, docutils, pkg-config
-, libkrb5, keyutils, pam, talloc, python3 }:
+, libkrb5, keyutils, pam, talloc, python3, samba }:
 
 stdenv.mkDerivation rec {
   pname = "cifs-utils";
@@ -12,7 +12,7 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ autoreconfHook docutils pkg-config ];
 
-  buildInputs = [ libkrb5 keyutils pam talloc python3 ];
+  buildInputs = [ libkrb5 keyutils pam talloc python3 samba ];
 
   configureFlags = [ "ROOTSBINDIR=$(out)/sbin" ] ++ lib.optionals (stdenv.hostPlatform != stdenv.buildPlatform) [
     # AC_FUNC_MALLOC is broken on cross builds.


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

- Adds `samba` to `cifs-utils`' `buildInputs`, since some binaries (namely, `cifs.idmap`) were not being produced without it
- Creates a new `programs.keyutils` module to allow for configuration of `request-key.conf`
  - Also updates the NFS module to use it, since it was writing to the `request-key.conf` file
- Updates the existing CIFS module to create entries in `request-key.conf` for some of it's functionality (`sec=krb5` mounts, ID mapping with `cifsacl`)

Fixes #34638.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
