### PR TITLE
python310Packages.mlflow: unbreak

### DIFF
--- a/pkgs/development/python-modules/mlflow/default.nix
+++ b/pkgs/development/python-modules/mlflow/default.nix
@@ -13,6 +13,8 @@
 , gorilla
 , gunicorn
 , importlib-metadata
+, markdown
+, matplotlib
 , numpy
 , packaging
 , pandas
@@ -20,27 +22,36 @@
 , protobuf
 , python-dateutil
 , pythonOlder
+, pythonRelaxDepsHook
+, pyarrow
 , pyyaml
 , querystring_parser
 , requests
+, scikit-learn
 , scipy
+, shap
 , simplejson
-, six
 , sqlalchemy
 , sqlparse
 }:
 
 buildPythonPackage rec {
   pname = "mlflow";
-  version = "2.1.1";
+  version = "2.2.2";
   format = "setuptools";
 
   disabled = pythonOlder "3.7";
 
   src = fetchPypi {
     inherit pname version;
-    hash = "sha256-oRazzUW7+1CaFyO/1DiL21ZqPlBF483lOQ5mf1kUmKY=";
+    hash = "sha256-PvLC7iDJp63t/zTnVsbtrGLPTZBXZa0OgHS8naoMWAw";
   };
+
+  # Remove currently broken dependency `shap`, a model explainability package.
+  # This seems quite unprincipled especially with tests not being enabled,
+  # but not mlflow has a 'skinny' install option which does not require `shap`.
+  nativeBuildInputs = [ pythonRelaxDepsHook ];
+  pythonRemoveDeps = [ "shap" ];
 
   propagatedBuildInputs = [
     alembic
@@ -54,18 +65,22 @@ buildPythonPackage rec {
     gorilla
     gunicorn
     importlib-metadata
+    markdown
+    matplotlib
     numpy
     packaging
     pandas
     prometheus-flask-exporter
     protobuf
     python-dateutil
+    pyarrow
     pyyaml
     querystring_parser
     requests
+    scikit-learn
     scipy
+    #shap
     simplejson
-    six
     sqlalchemy
     sqlparse
   ];
@@ -74,6 +89,7 @@ buildPythonPackage rec {
     "mlflow"
   ];
 
+  # no tests in PyPI dist
   # run into https://stackoverflow.com/questions/51203641/attributeerror-module-alembic-context-has-no-attribute-config
   # also, tests use conda so can't run on NixOS without buildFHSUserEnv
   doCheck = false;
@@ -84,9 +100,5 @@ buildPythonPackage rec {
     changelog = "https://github.com/mlflow/mlflow/blob/v${version}/CHANGELOG.md";
     license = licenses.asl20;
     maintainers = with maintainers; [ tbenst ];
-    knownVulnerabilities = [
-      "CVE-2023-1176"
-      "CVE-2023-1177"
-    ];
   };
 }


### PR DESCRIPTION
###### Description of changes

Unbreak the package by adding missing dependencies and removing a recently added but broken semi-optional dependency.

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
