### PR TITLE
sparrow: 1.7.3 -> 1.7.4

### DIFF
--- a/pkgs/applications/blockchains/sparrow/default.nix
+++ b/pkgs/applications/blockchains/sparrow/default.nix
@@ -158,7 +158,8 @@ let
   };
 in
 stdenv.mkDerivation rec {
-  inherit pname version src;
+  inherit version src;
+  pname = "sparrow-unwrapped";
   nativeBuildInputs = [ makeWrapper copyDesktopItems ];
 
   desktopItems = [

--- a/pkgs/applications/blockchains/sparrow/default.nix
+++ b/pkgs/applications/blockchains/sparrow/default.nix
@@ -16,15 +16,16 @@
 , openimajgrabber
 , hwi
 , imagemagick
+, gzip
 }:
 
 let
   pname = "sparrow";
-  version = "1.7.3";
+  version = "1.7.4";
 
   src = fetchurl {
     url = "https://github.com/sparrowwallet/${pname}/releases/download/${version}/${pname}-${version}-x86_64.tar.gz";
-    sha256 = "sha256-/tKct73v0zWAjY4kTllnb/+SB/8ENgVl8Yh/LErKTxY=";
+    sha256 = "08ircrc93gsf3vgqn07gjwmy4bs3jds9rg184pihyymm7g9girfb";
   };
 
   launcher = writeScript "sparrow" ''
@@ -93,7 +94,7 @@ let
   sparrow-modules = stdenv.mkDerivation {
     pname = "sparrow-modules";
     inherit version src;
-    nativeBuildInputs = [ makeWrapper gnugrep openjdk autoPatchelfHook stdenv.cc.cc.lib zlib ];
+    nativeBuildInputs = [ makeWrapper gzip gnugrep openjdk autoPatchelfHook stdenv.cc.cc.lib zlib ];
 
     buildPhase = ''
       # Extract Sparrow's JIMAGE and generate a list of them.
@@ -143,9 +144,9 @@ let
 
       # Replace the embedded Tor binary (which is in a Tar archive)
       # with one from Nixpkgs.
-      cp ${torWrapper} ./tor
-      tar -cJf tor.tar.xz tor
-      cp tor.tar.xz modules/netlayer.jpms/native/linux/x64/tor.tar.xz
+      gzip -c ${torWrapper}  > tor.gz
+      cp tor.gz modules/kmp.tor.binary.linuxx64/kmptor/linux/x64/tor.gz
+      find modules
     '';
 
     installPhase = ''

--- a/pkgs/applications/blockchains/sparrow/update.sh
+++ b/pkgs/applications/blockchains/sparrow/update.sh
@@ -23,4 +23,4 @@ sha256sum -c --ignore-missing manifest.txt
 sha256=$(nix-prefetch-url --type sha256 "file://$PWD/$depname")
 popd
 
-update-source-version sparrow "$version" "$sha256"
+update-source-version sparrow-unwrapped "$version" "$sha256"


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

This PR updates sparrow from 1.7.3 to 1.7.4. See release notes https://github.com/sparrowwallet/sparrow/releases/tag/1.7.4

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- When I created sparrow-unwrapped during the last sparrow PR to account for some native libraries that were being loaded dynamically from a fixed path, I unknowingly broke the sparrow update script. This PR contains a commit to fix the update script.
- The Java package used to interact with the Tor executable was changed from netlayer to kmp-tor. Since we use Tor from Nixpkgs instead, I updated the sparrow package to account for the change to kmp-tor; Namely, the Tor executable (which for us is a script) is compressed with gzip instead ot being archived with Tar.


- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
