### PR TITLE
maintainers: fix typo

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -4152,7 +4152,7 @@
   };
   dylanmtaylor = {
     email = "dylan@dylanmtaylor.com";
-    github = "dylamtaylor";
+    github = "dylanmtaylor";
     githubId = 277927;
     name = "Dylan Taylor";
   };


### PR DESCRIPTION
###### Description of changes

Trivial; this fixes a typo in my username. It was pointed out to me that this was wrong on a scalr-cli PR.