### PR TITLE
snobol4: init at 2.3.1

### DIFF
--- a/pkgs/development/interpreters/snobol4/default.nix
+++ b/pkgs/development/interpreters/snobol4/default.nix
@@ -1,0 +1,64 @@
+{ lib
+, fetchurl
+, stdenv
+, bzip2
+, gdbm
+, gnum4
+, gzip
+, libffi
+, openssl
+, readline
+, sqlite
+, tcl
+, xz
+, zlib
+}:
+
+stdenv.mkDerivation rec {
+  pname = "snobol4";
+  version = "2.3.1";
+
+  src = fetchurl {
+    urls = [
+      "https://ftp.regressive.org/snobol4/snobol4-${version}.tar.gz"
+      # fallback for when the current version is moved to the old folder
+      "https://ftp.regressive.org/snobol4/old/snobol4-${version}.tar.gz"
+    ];
+    hash = "sha256-kSRNZ9TinSqtzlZVvUOC/6tExiSn6krWQRQn86vxdTU=";
+  };
+
+  outputs = [ "out" "man" "doc" ];
+
+  # gzip used by Makefile to compress man pages
+  nativeBuildInputs = [ gnum4 gzip ];
+  # enable all features (undocumented, based on manual review of configure script)
+  buildInputs = [ bzip2 libffi openssl readline sqlite tcl xz zlib ]
+    # ndbm compat library
+    ++ lib.optional stdenv.isLinux gdbm;
+  configureFlags = lib.optional (tcl != null) "--with-tcl=${tcl}/lib/tclConfig.sh";
+
+  # INSTALL says "parallel make will fail"
+  enableParallelBuilding = false;
+
+  patches = [ ./fix-paths.patch ];
+
+  # configure does not support --sbindir and the likes (as introduced by multiple-outputs.sh)
+  # so man, doc outputs must be handled manually
+  preConfigurePhases = [ "prePreConfigurePhase" ];
+  prePreConfigurePhase = ''
+    preConfigureHooks="''${preConfigureHooks//_multioutConfig/}"
+    prependToVar configureFlags --mandir="$man"/share/man
+  '';
+
+  meta = with lib; {
+    description = "The Macro Implementation of SNOBOL4 in C";
+    longDescription = ''
+      An open source port of Macro SNOBOL4 (The original Bell Telephone Labs implementation, written in SIL macros) by Phil Budne.
+      Supports full SNOBOL4 language plus SPITBOL, [Blocks](https://www.regressive.org/snobol4/blocks/) and other extensions.
+    '';
+    homepage = "https://www.regressive.org/snobol4/csnobol4/";
+    license = licenses.bsd2;
+    platforms = platforms.all;
+    maintainers = with maintainers; [ xworld21 ];
+  };
+}

--- a/pkgs/development/interpreters/snobol4/fix-paths.patch
+++ b/pkgs/development/interpreters/snobol4/fix-paths.patch
@@ -1,0 +1,23 @@
+--- a/configure
++++ b/configure
+@@ -327,9 +327,9 @@
+ SNOLIB_LOCAL="$SNOLIB/local"
+ SNOLIB_DOC="$SNOLIB"
+ # XXX use $PREFIX/include/snobol4 ???
+-INCLUDE_DIR="$SNOLIB/include"
++INCLUDE_DIR="$PREFIX"/include/snolib4
+
+-DOC_DIR="$PREFIX/share/doc/snobol4-$VERSION"
++DOC_DIR="$doc/share/doc/snobol4-$VERSION"
+
+ echo 'BINDIR=$(DESTDIR)'"$BINDIR"    >> $CONFIG_M4
+ echo 'MANDIR=$(DESTDIR)'"$MANDIR"    >> $CONFIG_M4
+@@ -2110,7 +2110,7 @@
+ # IRIX /sbin/install
+
+ # should always find ./install-sh
+-for DIR in /usr/bin /usr/ucb /usr/local/bin /bin .; do
++for DIR in `echo $PATH | tr ':' ' '`; do
+     for INSTALL in install ginstall scoinst install-sh; do
+  IPATH=$DIR/$INSTALL
+  if [ -d $IPATH ]; then

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -12245,6 +12245,8 @@ with pkgs;
 
   sniffglue = callPackage ../tools/networking/sniffglue { };
 
+  snobol4 = callPackage ../development/interpreters/snobol4 { };
+
   snort = callPackage ../applications/networking/ids/snort { };
 
   so = callPackage ../development/tools/so {


### PR DESCRIPTION
###### Description of changes
Package [CSNOBOL4](https://www.regressive.org/snobol4/csnobol4/). Why? Well, a script in an obscure TeX Live package has a `snobol4` shebang...

Also, why not.

###### Things done
- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [X] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
