### PR TITLE
wmbusmeters: init at 1.12.0

### DIFF
--- a/pkgs/applications/radio/wmbusmeters/default.nix
+++ b/pkgs/applications/radio/wmbusmeters/default.nix
@@ -1,0 +1,51 @@
+{ lib, stdenv, fetchFromGitHub
+, bash, libusb1, ncurses, rtl-sdr
+}:
+
+stdenv.mkDerivation rec {
+  version = "1.12.0";
+  pname = "wmbusmeters";
+
+  src = fetchFromGitHub {
+    owner = pname;
+    repo = pname;
+    rev = version;
+    sha256 = "sha256-3y9YTUXfFyZ4PqG4refwBhdnuHAp3FcEcDEQ/BVtT/U";
+  };
+
+  buildInputs = [ libusb1 ncurses rtl-sdr ];
+
+  makeFlags = [
+    "COMMIT_HASH="
+    "TAG=${version}"
+    "BRANCH="
+    "CHANGES="
+  ];
+
+  preBuild = ''
+    substituteInPlace scripts/*.sh \
+      --replace "#!/bin/bash" "#!${bash}/bin/bash"
+  '';
+
+  installPhase = ''
+    mkdir -p $out/bin
+    mkdir -p $out/share/man/man1
+
+    cp build/wmbusmeters build/wmbusmeters-admin $out/bin
+    ln -s wmbusmeters $out/bin/wmbusmetersd
+
+    gzip -v9 -n -c wmbusmeters.1 >$out/share/man/man1/wmbusmeters.1.gz
+    gzip -v9 -n -c wmbusmeters-admin.1 >$out/share/man/man1/wmbusmeters-admin.1.gz
+    ln -s wmbusmeters.1.gz $out/share/man/man1/wmbusmetersd.1.gz
+  '';
+
+  enableParallelBuilding = true;
+
+  meta = with lib; {
+    description = "Acquires utility meter readings from wired M-BUS or wireless WM-BUS meters";
+    homepage = "https://github.com/wmbusmeters/wmbusmeters";
+    license = licenses.gpl3Only;
+    maintainers = with maintainers; [ snicket2100 ];
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -34668,6 +34668,8 @@ with pkgs;
 
   wllvm = callPackage  ../development/tools/wllvm { };
 
+  wmbusmeters = callPackage ../applications/radio/wmbusmeters { };
+
   wmname = callPackage ../applications/misc/wmname { };
 
   wmctrl = callPackage ../tools/X11/wmctrl { };


### PR DESCRIPTION
###### Description of changes

New package, supports parsing MBUS / WMBUS datagrams from smart meters, as well as can manage connected (W)MBUS adapters.

https://github.com/wmbusmeters/wmbusmeters

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
