### PR TITLE
python310Packages.kornia: init at 0.6.11

### DIFF
--- a/pkgs/development/python-modules/kornia/default.nix
+++ b/pkgs/development/python-modules/kornia/default.nix
@@ -1,0 +1,54 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, pythonOlder
+, pytestCheckHook
+, packaging
+, torch
+}:
+
+buildPythonPackage rec {
+  pname = "kornia";
+  version = "0.6.11";
+  format = "pyproject";
+  disabled = pythonOlder "3.7";
+
+  src = fetchFromGitHub {
+    owner = pname;
+    repo = pname;
+    rev = "refs/tags/v${version}";
+    hash = "sha256-APqITIt2P+16qp27dwLoAq9vY5CYpd49IWfYHTcZTSI=";
+  };
+
+  propagatedBuildInputs = [
+    packaging
+    torch
+  ];
+
+  pythonImportsCheck = [
+    "kornia"
+    "kornia.augmentation"
+    "kornia.color"
+    "kornia.contrib"
+    "kornia.enhance"
+    "kornia.feature"
+    "kornia.filters"
+    "kornia.geometry"
+    "kornia.io"
+    "kornia.losses"
+    "kornia.metrics"
+    "kornia.morphology"
+    "kornia.tracking"
+    "kornia.testing"
+    "kornia.utils"
+  ];
+
+  doCheck = false;  # tests hang with no single test clearly responsible
+
+  meta = with lib; {
+    homepage = "https://kornia.github.io/kornia";
+    description = "Differentiable computer vision library";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ bcdarwin ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5313,6 +5313,8 @@ self: super: with self; {
 
   korean-lunar-calendar = callPackage ../development/python-modules/korean-lunar-calendar { };
 
+  kornia = callPackage ../development/python-modules/kornia { };
+
   krakenex = callPackage ../development/python-modules/krakenex { };
 
   kubernetes = callPackage ../development/python-modules/kubernetes { };


### PR DESCRIPTION
###### Description of changes

Add a package.

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [NA] (Module updates) Added a release notes entry if the change is significant
  - [NA] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
