### PR TITLE
ocamlPackages.buildDunePackage: Drop support for useDune2

### DIFF
--- a/doc/languages-frameworks/ocaml.section.md
+++ b/doc/languages-frameworks/ocaml.section.md
@@ -38,12 +38,12 @@ Here is a simple package example.
 
 - It uses the `fetchFromGitHub` fetcher to get its source.
 
-- `duneVersion = "2"` ensures that Dune version 2 is used for the
-  build (this is the default; valid values are `"1"`, `"2"`, and `"3"`);
-  note that there is also a legacy `useDune2` boolean attribute:
-  set to `false` it corresponds to `duneVersion = "1"`; set to `true` it
-  corresponds to `duneVersion = "2"`. If both arguments (`duneVersion` and
-  `useDune2`) are given, the second one (`useDune2`) is silently ignored.
+- It also accept `duneVersion` parameter (valid value are `"1"`, `"2"`, and
+  `"3"`). The recommended practice it to set only if you don't want the default
+  value and/or it depends on something else like package version. You might see
+  a not-supported argument `useDune2`. The behavior was `useDune2 = true;` =>
+  `duneVersion = "2";` and `useDune2 = false;` => `duneVersion = "1";`. It was
+  used at the time when dune3 didn't existed.
 
 - It sets the optional `doCheck` attribute such that tests will be run with
   `dune runtest -p angstrom` after the build (`dune build -p angstrom`) is
@@ -71,7 +71,6 @@ Here is a simple package example.
 buildDunePackage rec {
   pname = "angstrom";
   version = "0.15.0";
-  duneVersion = "2";
 
   minimalOCamlVersion = "4.04";
 
@@ -103,8 +102,6 @@ Here is a second example, this time using a source archive generated with `dune-
 buildDunePackage rec {
   pname = "wtf8";
   version = "1.0.2";
-
-  useDune2 = true;
 
   minimalOCamlVersion = "4.02";
 

--- a/pkgs/build-support/ocaml/dune.nix
+++ b/pkgs/build-support/ocaml/dune.nix
@@ -3,7 +3,7 @@
 { pname, version, nativeBuildInputs ? [], enableParallelBuilding ? true, ... }@args:
 
 let Dune =
-  let dune-version = args . duneVersion or (if args.useDune2 or true then "2" else "1"); in
+  let dune-version = args.duneVersion or "2"; in
   { "1" = dune_1; "2" = dune_2; "3" = dune_3; }."${dune-version}"
 ; in
 
@@ -39,7 +39,7 @@ stdenv.mkDerivation ({
 
   strictDeps = true;
 
-} // (builtins.removeAttrs args [ "minimalOCamlVersion"  "duneVersion" ]) // {
+} // (builtins.removeAttrs args [ "minimalOCamlVersion" "duneVersion" ]) // {
 
   name = "ocaml${ocaml.version}-${pname}-${version}";
 


### PR DESCRIPTION
###### Description of changes

I add depreciation notice for useDune2. We will remove it on 23.05 ? or next release 23.11 ?

###### Things done

If commit contain cmd: then it is automated but reviewed with `git add -p`