### PR TITLE
phpactor: init at 2023.01.21

### DIFF
--- a/pkgs/development/tools/phpactor/default.nix
+++ b/pkgs/development/tools/phpactor/default.nix
@@ -1,0 +1,79 @@
+{ lib, stdenvNoCC, fetchFromGitHub, php, phpPackages }:
+
+let
+  version = "2023.01.21";
+
+  src = fetchFromGitHub {
+    owner = "phpactor";
+    repo = "phpactor";
+    rev = version;
+    hash = "sha256-jWZgBEaffjQ5wCStSEe+eIi7BJt6XAQFEjmq5wvW5V8=";
+  };
+
+  vendor = stdenvNoCC.mkDerivation rec {
+    pname = "phpactor-vendor";
+    inherit src version;
+
+
+    # See https://github.com/NixOS/nix/issues/6660
+    dontPatchShebangs = true;
+
+    nativeBuildInputs = [
+      php
+      phpPackages.composer
+    ];
+
+    buildPhase = ''
+      runHook preBuild
+
+      substituteInPlace composer.json \
+        --replace '"config": {' '"config": { "autoloader-suffix": "Phpactor",' \
+        --replace '"name": "phpactor/phpactor",' '"name": "phpactor/phpactor", "version": "${version}",'
+      composer install --no-interaction --optimize-autoloader --no-dev --no-scripts
+
+      runHook postBuild
+    '';
+
+    installPhase = ''
+      runHook preInstall
+
+      mkdir -p $out
+      cp -ar ./vendor $out/
+
+      runHook postInstall
+    '';
+
+    outputHashMode = "recursive";
+    outputHashAlgo = "sha256";
+    outputHash = "sha256-7R6nadWFv7A5Hv14D9egsTD/zcKK5uK9LQlHmwtbKdE=";
+  };
+in
+stdenvNoCC.mkDerivation {
+  pname = "phpactor";
+  inherit src version;
+
+  buildInputs = [
+    php
+  ];
+
+  dontBuild = true;
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/share/php/phpactor $out/bin
+    cp -r . $out/share/php/phpactor
+    cp -r ${vendor}/vendor $out/share/php/phpactor
+    ln -s $out/share/php/phpactor/bin/phpactor $out/bin/phpactor
+
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "Mainly a PHP Language Server";
+    homepage = "https://github.com/phpactor/phpactor";
+    license = lib.licenses.mit;
+    maintainers = lib.teams.php.members ++ [ lib.maintainers.ryantm ];
+  };
+
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -16755,6 +16755,7 @@ with pkgs;
   php80Extensions = recurseIntoAttrs php80.extensions;
   php80Packages = recurseIntoAttrs php80.packages;
 
+  phpactor = callPackage ../development/tools/phpactor { };
 
   picoc = callPackage ../development/interpreters/picoc { };
 


### PR DESCRIPTION
###### Description of changes

Initialized as a fixed output derivation because composer needs to access the internet to download dependencies. I've tested the reproducibility of it following my steps here:

https://discourse.nixos.org/t/reproducibility-checking-with-new-cli-and-fixed-output-derivations/27053

composer2nix didn't work for this package and it seemed simpler to do this.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
