### PR TITLE
perl536Packages: cross fixes

### DIFF
--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -305,7 +305,7 @@ let
       hash = "sha256-c7RSRPC1w25TMsM1abgqGrLDPiY/HQB4XSADvK7GjbM=";
     };
     strictDeps = true;
-    nativeBuildInputs = [ pkgs.pkg-config ];
+    nativeBuildInputs = [ buildPackages.perl buildPackages.pkg-config ];
     propagatedBuildInputs = [ AlienBuild ];
     buildInputs = [ pkgs.libxml2 MojoDOM58 SortVersions Test2Suite URI ];
     meta = {

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -27367,7 +27367,18 @@ let
       url = "mirror://cpan/authors/id/S/SH/SHLOMIF/XML-LibXSLT-1.99.tar.gz";
       hash = "sha256-En4XqHf7YeR7nouHv42q0xM5pioAEh+XUdUitDiw9/A=";
     };
-    nativeBuildInputs = [ pkgs.pkg-config ];
+    patches = lib.optional (!stdenv.buildPlatform.canExecute stdenv.hostPlatform)
+      (fetchpatch {
+        # Remove the 'have_library()' check. It breaks cross compilation.
+        # The checked for libxslt and libexslt are pulled in via buildInputs and
+        # therefore do exist, anyway.
+        url = "https://raw.githubusercontent.com/void-linux/void-packages/5c37bd5f21c4be14761d85c98c996b2d11ae80c4/srcpkgs/perl-XML-LibXSLT/patches/fix-cross-remove-have_library.patch";
+        hash = "sha256-ejSdl3HVrMgWLmJK9YEioeheTVJ1J4OHMiQP1oZAsqI=";
+      });
+    preConfigure = lib.optionalString (!stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
+      makeMakerFlags="CC=$CC LD=$LD INC=-I${pkgs.libxml2.dev}/include/libxml2";
+    '';
+    nativeBuildInputs = [ buildPackages.perl buildPackages.pkg-config ];
     buildInputs = [ pkgs.zlib pkgs.libxml2 pkgs.libxslt ];
     propagatedBuildInputs = [ XMLLibXML ];
     meta = {

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -9599,6 +9599,7 @@ let
       url = "mirror://cpan/authors/id/R/RE/REHSACK/File-ShareDir-1.118.tar.gz";
       hash = "sha256-O7KiC6Nd+VjcCk8jBvwF2QPYuMTePIvu/OF3OdKByVg=";
     };
+    nativeBuildInputs = [ buildPackages.perl ];
     propagatedBuildInputs = [ ClassInspector ];
     buildInputs = [ FileShareDirInstall ];
     meta = {

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -13269,6 +13269,7 @@ let
       url = "mirror://cpan/authors/id/A/AL/ALINKE/Lingua-Translit-0.28.tar.gz";
       hash = "sha256-ET+R2PwsYwQ3FTpJ+3pSsCOvj2J47ZbAcLH2CCS46uE=";
     };
+    nativeBuildInputs = [ buildPackages.perl ];
     doCheck = false;
     meta = {
       description = "Transliterates text between writing systems";

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -6408,6 +6408,7 @@ let
       url = "mirror://cpan/authors/id/D/DR/DROLSKY/DateTime-Locale-1.28.tar.gz";
       hash = "sha256-bGBNjFycJzm3jgU4pAIoO4Kx30GeYL7yCwSEPkWEut4=";
     };
+    nativeBuildInputs = [ buildPackages.perl ];
     buildInputs = [ CPANMetaCheck FileShareDirInstall IPCSystemSimple PathTiny Test2PluginNoWarnings Test2Suite TestFileShareDir ];
     propagatedBuildInputs = [ FileShareDir ParamsValidationCompiler Specio namespaceautoclean ];
     meta = {

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -13490,6 +13490,7 @@ let
       url = "mirror://cpan/authors/id/P/PE/PEVANS/List-UtilsBy-0.11.tar.gz";
       hash = "sha256-+t30O0vCHbjkwOiaJuXyP+YmzeNJHsZRtqozhif1d1o=";
     };
+    nativeBuildInputs = [ buildPackages.perl ];
     meta = {
       description = "Higher-order list utility functions";
       license = with lib.licenses; [ artistic1 gpl1Plus ];

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -25163,6 +25163,7 @@ let
       url = "mirror://cpan/authors/id/I/IS/ISHIGAKI/Text-CSV-2.00.tar.gz";
       hash = "sha256-jMvZGVgFIi2ZWEQRTQ5ZW7JM4Yj4UoTb8lYIAxHLssI=";
     };
+    nativeBuildInputs = [ buildPackages.perl ];
     meta = {
       description = "Comma-separated values manipulator (using XS or PurePerl)";
       license = with lib.licenses; [ artistic1 gpl1Plus ];

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -27336,6 +27336,10 @@ let
     buildInputs = [ AlienBuild AlienLibxml2 ]
       ++ lib.optionals stdenv.isDarwin (with pkgs; [ libiconv zlib ]);
     propagatedBuildInputs = [ XMLSAX ];
+    nativeBuildInputs = [ buildPackages.perl ];
+    preConfigure = ''
+      makeMakerFlags="CC=$CC LD=$LD";
+    '';
     meta = {
       description = "Perl Binding for libxml2";
       license = with lib.licenses; [ artistic1 gpl1Plus ];

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -15270,6 +15270,7 @@ let
       url = "mirror://cpan/authors/id/L/LE/LEONT/Module-Build-0.4231.tar.gz";
       hash = "sha256-fg9MaSwXQMGshOoU1+o9i8eYsvsmwJh3Ip4E9DCytxc=";
     };
+    nativeBuildInputs = [ buildPackages.perl ];
     meta = {
       description = "Build and install Perl modules";
       license = with lib.licenses; [ artistic1 gpl1Plus ];

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -18738,6 +18738,7 @@ let
       url = "mirror://cpan/authors/id/E/ET/ETHER/Package-Stash-0.39.tar.gz";
       hash = "sha256-kWX1VREuCASTzg6RKd4Ihtowslk/s1Oiq9HHay0mIbU=";
     };
+    nativeBuildInputs = [ buildPackages.perl ];
     buildInputs = [ CPANMetaCheck TestFatal TestNeeds TestRequires ];
     propagatedBuildInputs = [ DistCheckConflicts ModuleImplementation ];
     meta = {

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -8797,6 +8797,7 @@ let
       url = "mirror://cpan/authors/id/A/AM/AMBS/ExtUtils-LibBuilder-0.08.tar.gz";
       hash = "sha256-xRFx4G3lMDnwvKHZemRx7DeUH/Weij0csXDr3SVztdI=";
     };
+    nativeBuildInputs = [ buildPackages.perl ];
     perlPreHook = "export LD=$CC";
     meta = {
       description = "A tool to build C libraries";

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -19034,6 +19034,7 @@ let
       url = "mirror://cpan/authors/id/J/JT/JTBRAUN/Parse-RecDescent-1.967015.tar.gz";
       hash = "sha256-GUMzaky1TxeIpzPwgnwMVdtDENXq4V5UJjnJ3YVlbjc=";
     };
+    nativeBuildInputs = [ buildPackages.perl ];
     meta = {
       description = "Generate Recursive-Descent Parsers";
       license = with lib.licenses; [ artistic1 gpl1Plus ];

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -18240,7 +18240,7 @@ let
     preConfigure = ''
       mkdir openssl
       ln -s ${lib.getLib pkgs.openssl}/lib openssl
-      ln -s ${pkgs.openssl.bin}/bin openssl
+      ln -s ${buildPackages.openssl.bin}/bin openssl
       ln -s ${pkgs.openssl.dev}/include openssl
       export OPENSSL_PREFIX=$(realpath openssl)
     '';

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -13473,6 +13473,7 @@ let
       url = "mirror://cpan/authors/id/D/DR/DROLSKY/List-SomeUtils-0.58.tar.gz";
       hash = "sha256-lur7NZM50ivyot5CEpiEejxA9qKLbUQAXQll2oalRp0=";
     };
+    nativeBuildInputs = [ buildPackages.perl ];
     buildInputs = [ TestLeakTrace ];
     propagatedBuildInputs = [ ModuleImplementation ];
     meta = {

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -27542,6 +27542,7 @@ let
       url = "mirror://cpan/authors/id/G/GR/GRANTM/XML-SAX-1.02.tar.gz";
       hash = "sha256-RQbDhwQ6pqd7RV8A9XQJ83IKp+VTSVqyU1JjtO0eoSo=";
     };
+    nativeBuildInputs = [ buildPackages.perl ];
     propagatedBuildInputs = [ XMLNamespaceSupport XMLSAXBase ];
     postInstall = ''
       perl -MXML::SAX -e "XML::SAX->add_parser(q(XML::SAX::PurePerl))->save_parsers()"

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -15027,6 +15027,7 @@ let
       url = "mirror://cpan/authors/id/N/NE/NEZUMI/MIME-Charset-1.012.2.tar.gz";
       hash = "sha256-h4x3nAJWxZFma9BsDN5MDXgg7uuY/RGDCCrumh57HRM=";
     };
+    nativeBuildInputs = [ buildPackages.perl ];
     meta = {
       description = "Charset Information for MIME";
       license = with lib.licenses; [ artistic1 gpl1Plus ];

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -15700,6 +15700,7 @@ let
       url = "mirror://cpan/authors/id/Z/ZE/ZEFRAM/Module-Runtime-0.016.tar.gz";
       hash = "sha256-aDAuxkaDNUfUEL4o4JZ223UAb0qlihHzvbRP/pnw8CQ=";
     };
+    nativeBuildInputs = [ buildPackages.perl ];
     meta = {
       description = "Runtime module handling";
       license = with lib.licenses; [ artistic1 gpl1Plus ];

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -20740,6 +20740,7 @@ let
       url = "mirror://cpan/authors/id/S/SA/SANKO/Readonly-2.05.tar.gz";
       hash = "sha256-SyNUJJGvAQ1EpcfIYSRHOKzHSrq65riDjTVN+xlGK14=";
     };
+    nativeBuildInputs = [ buildPackages.perl ];
     buildInputs = [ ModuleBuildTiny ];
     meta = {
       description = "Facility for creating read-only scalars, arrays, hashes";

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -255,6 +255,7 @@ let
       url = "mirror://cpan/authors/id/P/PL/PLICEASE/Alien-Build-2.37.tar.gz";
       hash = "sha256-MAC8vphIJkP3a7z/zkL9SPJMY6ZFf4qiwWlfSBrJ7VE=";
     };
+    nativeBuildInputs = [ buildPackages.perl ];
     propagatedBuildInputs = [ CaptureTiny FFICheckLib FileWhich Filechdir PathTiny PkgConfig ];
     buildInputs = [ DevelHide Test2Suite ];
     meta = {

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -18864,7 +18864,10 @@ let
     };
     buildInputs = [ TestFatal TestRequires ];
     propagatedBuildInputs = [ ModuleImplementation ];
-    perlPreHook = "export LD=$CC";
+    nativeBuildInputs = [ buildPackages.perl ];
+    preConfigure = ''
+      makeMakerFlags="CC=$CC LD=$CC";
+    '';
     meta = {
       description = "Validate method/function parameters";
       homepage = "https://metacpan.org/release/Params-Validate";

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -25123,6 +25123,7 @@ let
     };
     # libbtparse.so: cannot open shared object file (aarch64 only)
     patches = [ ../development/perl-modules/TextBibTeX-use-lib-on-aarch64.patch ];
+    nativeBuildInputs = [ buildPackages.perl ];
     perlPreHook = "export LD=$CC";
     perlPostHook = lib.optionalString stdenv.isDarwin ''
       oldPath="$(pwd)/btparse/src/libbtparse.dylib"

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -25795,6 +25795,7 @@ let
       url = "mirror://cpan/authors/id/M/MA/MARKF/Test-utf8-1.02.tar.gz";
       hash = "sha256-34LwnFlAgwslpJ8cgWL6JNNx5gKIDt742aTUv9Zri9c=";
     };
+    nativeBuildInputs = [ buildPackages.perl ];
     meta = {
       description = "Handy utf8 tests";
       homepage = "https://github.com/2shortplanks/Test-utf8/tree";

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -1586,6 +1586,7 @@ let
       url = "mirror://cpan/authors/id/E/ET/ETHER/B-Hooks-EndOfScope-0.24.tar.gz";
       hash = "sha256-A6o9/l0KpkcalvQ/6DGBedGXlNSmQHCPAoj5IW7HrMY=";
     };
+    nativeBuildInputs = [ buildPackages.perl ];
     propagatedBuildInputs = [ ModuleImplementation SubExporterProgressive ];
     meta = {
       description = "Execute code after a scope finished compilation";

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -13439,6 +13439,7 @@ let
       url = "mirror://cpan/authors/id/R/RE/REHSACK/List-MoreUtils-0.430.tar.gz";
       hash = "sha256-Y7H3hCzULZtTjR404DMN5f8VWeTCc3NCUGQYJ29kZSc=";
     };
+    nativeBuildInputs = [ buildPackages.perl ];
     propagatedBuildInputs = [ ExporterTiny ListMoreUtilsXS ];
     buildInputs = [ TestLeakTrace ];
     meta = {

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -15346,6 +15346,7 @@ let
       url = "mirror://cpan/authors/id/L/LE/LEONT/Module-Build-Tiny-0.039.tar.gz";
       hash = "sha256-fVgP9qzgy+VVvza4bcjqIyWBUwy+quoJvMtXtVeX8Rw=";
     };
+    nativeBuildInputs = [ buildPackages.perl ];
     buildInputs = [ FileShareDir ];
     propagatedBuildInputs = [ ExtUtilsHelpers ExtUtilsInstallPaths ];
     meta = {

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -24000,6 +24000,10 @@ let
       url = "mirror://cpan/authors/id/L/LE/LEEJO/Test-LeakTrace-0.16.tar.gz";
       hash = "sha256-Xwie7ZFfHsjHQ/bSd3w+zQygHfL3ueEAONMWlSWD5AM=";
     };
+    nativeBuildInputs = [ buildPackages.perl ];
+    preConfigure = ''
+      makeMakerFlags="CC=$CC LD=$CC";
+    '';
     meta = {
       description = "Traces memory leaks";
       homepage = "https://metacpan.org/release/Test-LeakTrace";

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -13456,8 +13456,9 @@ let
       hash = "sha256-6M5G1XwXnuzYdYKT6UAP8wCq8g/v4KnRW5/iMCucskI=";
     };
     preConfigure = ''
-      export LD=$CC
+      makeMakerFlags="CC=$CC LD=$CC";
     '';
+    nativeBuildInputs = [ buildPackages.perl ];
     meta = {
       description = "Provide the stuff missing in List::Util in XS";
       homepage = "https://metacpan.org/release/List-MoreUtils-XS";


### PR DESCRIPTION
###### Description of changes

This fixes the cross compilation of several perl packages that are in the closure of `biber`.

Most of these fixes are simply adding `buildPackages.perl` to `nativeBuildInputs`. This doesn't change anything for native builds since these [pull in perl anyway](https://github.com/NixOS/nixpkgs/blob/772d05f31d5169f414659217b98907916f5f14fa/pkgs/development/perl-modules/generic/default.nix#L46). Cross builds use a minimal perl copy `perl.mini` (this does not exist for native), which suffices for bootstrapping perl and running simple build scripts, but not for the builds scripts of the derivations changed here: They mostly fail with error messages like
```
perl says : Can't load module B, dynamic loading not available in this perl
  (You may need to build a new perl executable which either supports
  dynamic loading or has the B module statically linked into it.)
 at (eval 11) line 1.
```

I can split this into multiple PRs if desirable, but most of the builds cannot be tested indepentently because of many inter-dependencies.
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux (native and for aarch64).
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
