### PR TITLE
python310Packages.dicomweb-client: init at 0.59.1

### DIFF
--- a/pkgs/development/python-modules/dicomweb-client/default.nix
+++ b/pkgs/development/python-modules/dicomweb-client/default.nix
@@ -1,0 +1,51 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, pythonOlder
+, pytestCheckHook
+, pytest-localserver
+, numpy
+, pillow
+, pydicom
+, requests
+, retrying
+}:
+
+buildPythonPackage rec {
+  pname = "dicomweb-client";
+  version = "0.59.1";
+  disabled = pythonOlder "3.6";
+  format = "setuptools";
+
+  src = fetchFromGitHub {
+    owner = "ImagingDataCommons";
+    repo = pname;
+    rev = "refs/tags/v${version}";
+    hash = "sha256-h9gFCBmutTGNJ3wP2AGPfiUtA49yywUlNKiSh/x9kFE=";
+  };
+
+  propagatedBuildInputs = [
+    numpy
+    pillow
+    pydicom
+    requests
+    retrying
+  ];
+
+  nativeCheckInputs = [
+    pytestCheckHook
+    pytest-localserver
+  ];
+
+  pythonImportsCheck = [
+    "dicomweb_client"
+  ];
+
+  meta = with lib; {
+    description = "Python client for DICOMweb RESTful services";
+    homepage = "https://dicomweb-client.readthedocs.io";
+    license = licenses.mit;
+    maintainers = with maintainers; [ bcdarwin ];
+    mainProgram = "dicomweb_client";
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2456,6 +2456,8 @@ self: super: with self; {
 
   dicom-numpy = callPackage ../development/python-modules/dicom-numpy { };
 
+  dicomweb-client = callPackage ../development/python-modules/dicomweb-client { };
+
   dict2xml = callPackage ../development/python-modules/dict2xml { };
 
   dictdiffer = callPackage ../development/python-modules/dictdiffer { };


### PR DESCRIPTION
###### Description of changes

Add a package.

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
