### PR TITLE
truvari: 2.1.1 -> 4.0.0

### DIFF
--- a/pkgs/applications/science/biology/truvari/default.nix
+++ b/pkgs/applications/science/biology/truvari/default.nix
@@ -1,45 +1,74 @@
 { lib
 , fetchFromGitHub
 , python3Packages
+, runtimeShell
+, bcftools
+, htslib
 }:
 
-python3Packages.buildPythonApplication rec {
+let
+  ssshtest = fetchFromGitHub {
+    owner = "ryanlayer";
+    repo = "ssshtest";
+    rev = "d21f7f928a167fca6e2eb31616673444d15e6fd0";
+    hash = "sha256-zecZHEnfhDtT44VMbHLHOhRtNsIMWeaBASupVXtmrks=";
+  };
+in python3Packages.buildPythonApplication rec {
   pname = "truvari";
-  version = "2.1.1";
+  version = "4.0.0";
 
   src = fetchFromGitHub {
-    owner = "spiralgenetics";
+    owner = "ACEnglish";
     repo = "truvari";
     rev = "v${version}";
-    sha256 = "14nsdbj063qm175xxixs34cihvsiskc9gym8pg7gbwsh13k5a00h";
+    hash = "sha256-UJNMKEV5m2jFqnWvkVAtymkcE2TjPIXp7JqRZpMSqsE=";
   };
 
   postPatch = ''
     substituteInPlace setup.py \
-      --replace 'python-Levenshtein==0.12.1' 'python-Levenshtein>=0.12.1'
+      --replace "rich==" "rich>="
+    substituteInPlace truvari/utils.py \
+      --replace "/bin/bash" "${runtimeShell}"
+    patchShebangs repo_utils/test_files
   '';
 
   propagatedBuildInputs = with python3Packages; [
-    pyvcf
-    levenshtein
-    progressbar2
+    rich
+    edlib
     pysam
-    pyfaidx
     intervaltree
-    pytabix
-    acebinf
-    bwapy
     joblib
+    numpy
+    pytabix
+    bwapy
     pandas
   ];
 
-  # no tests
-  doCheck = false;
+  makeWrapperArgs = [
+    "--prefix" "PATH" ":" (lib.makeBinPath [ bcftools htslib ])
+  ];
+
   pythonImportsCheck = [ "truvari" ];
+
+  nativeCheckInputs = [
+    bcftools
+    htslib
+  ] ++ (with python3Packages; [
+    coverage
+  ]);
+
+  checkPhase = ''
+    runHook preCheck
+
+    ln -s ${ssshtest}/ssshtest .
+    bash repo_utils/truvari_ssshtests.sh
+
+    runHook postCheck
+  '';
 
   meta = with lib; {
     description = "Structural variant comparison tool for VCFs";
-    homepage = "https://github.com/spiralgenetics/truvari";
+    homepage = "https://github.com/ACEnglish/truvari";
     license = licenses.mit;
     maintainers = with maintainers; [ scalavision ];
     longDescription = ''

--- a/pkgs/applications/science/biology/truvari/default.nix
+++ b/pkgs/applications/science/biology/truvari/default.nix
@@ -70,7 +70,7 @@ in python3Packages.buildPythonApplication rec {
     description = "Structural variant comparison tool for VCFs";
     homepage = "https://github.com/ACEnglish/truvari";
     license = licenses.mit;
-    maintainers = with maintainers; [ scalavision ];
+    maintainers = with maintainers; [ natsukium scalavision ];
     longDescription = ''
       Truvari is a benchmarking tool for comparison sets of SVs.
       It can calculate the recall, precision, and f-measure of a


### PR DESCRIPTION
Diff: https://github.com/spiralgenetics/truvari/compare/v2.1.1...v4.0.0

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
cc @scalavision 