### PR TITLE
cross compilation fixes

### DIFF
--- a/pkgs/applications/misc/fuzzel/default.nix
+++ b/pkgs/applications/misc/fuzzel/default.nix
@@ -34,6 +34,10 @@ stdenv.mkDerivation rec {
     hash = "sha256-Va/Rm35jqxDlIfQdrpZ41qrW8YzWmm1LWra76AW1xUw=";
   };
 
+  depsBuildBuild = [
+    pkg-config
+  ];
+
   nativeBuildInputs = [
     pkg-config
     wayland-scanner

--- a/pkgs/development/libraries/libHX/default.nix
+++ b/pkgs/development/libraries/libHX/default.nix
@@ -11,12 +11,11 @@ stdenv.mkDerivation rec {
 
   patches = [];
 
-  nativeBuildInputs = [ autoconf automake ];
-  buildInputs = [ libtool ];
+  nativeBuildInputs = [ autoconf automake libtool ];
 
   preConfigure = ''
     sh autogen.sh
-    '';
+  '';
 
   meta = with lib; {
     homepage = "https://libhx.sourceforge.net/";

--- a/pkgs/development/libraries/libchamplain/default.nix
+++ b/pkgs/development/libraries/libchamplain/default.nix
@@ -24,7 +24,8 @@ stdenv.mkDerivation rec {
   pname = "libchamplain";
   version = "0.12.21";
 
-  outputs = [ "out" "dev" "devdoc" ];
+  outputs = [ "out" "dev" ]
+    ++ lib.optionals (stdenv.buildPlatform == stdenv.hostPlatform) [ "devdoc" ];
 
   src = fetchurl {
     url = "mirror://gnome/sources/${pname}/${lib.versions.majorMinor version}/${pname}-${version}.tar.xz";
@@ -37,6 +38,7 @@ stdenv.mkDerivation rec {
     pkg-config
     gobject-introspection
     vala
+  ] ++ lib.optionals (stdenv.buildPlatform == stdenv.hostPlatform) [
     gtk-doc
     docbook_xsl
     docbook_xml_dtd_412
@@ -55,7 +57,7 @@ stdenv.mkDerivation rec {
   ];
 
   mesonFlags = [
-    "-Dgtk_doc=true"
+    (lib.mesonBool "gtk_doc" (stdenv.buildPlatform == stdenv.hostPlatform))
     "-Dvapi=true"
     (lib.mesonBool "libsoup3" withLibsoup3)
   ];

--- a/pkgs/development/libraries/libjcat/default.nix
+++ b/pkgs/development/libraries/libjcat/default.nix
@@ -43,6 +43,7 @@ stdenv.mkDerivation rec {
     docbook-xsl-nons
     gobject-introspection
     vala
+    gnutls
     gtk-doc
     python3
   ];

--- a/pkgs/development/libraries/librest/default.nix
+++ b/pkgs/development/libraries/librest/default.nix
@@ -26,6 +26,7 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [
     pkg-config
     gobject-introspection
+  ] ++ lib.optionals (stdenv.hostPlatform == stdenv.buildPlatform) [
     gtk-doc
     docbook-xsl-nons
     docbook_xml_dtd_412
@@ -38,7 +39,7 @@ stdenv.mkDerivation rec {
   ];
 
   configureFlags = [
-    "--enable-gtk-doc"
+    (lib.enableFeature (stdenv.hostPlatform == stdenv.buildPlatform) "gtk-doc")
     # Remove when https://gitlab.gnome.org/GNOME/librest/merge_requests/2 is merged.
     "--with-ca-certificates=/etc/ssl/certs/ca-certificates.crt"
   ];

--- a/pkgs/development/libraries/rapidfuzz-cpp/default.nix
+++ b/pkgs/development/libraries/rapidfuzz-cpp/default.nix
@@ -33,7 +33,7 @@ stdenv.mkDerivation rec {
     catch2_3
   ];
 
-  doCheck = true;
+  doCheck = stdenv.buildPlatform.canExecute stdenv.hostPlatform;
 
   meta = {
     description = "Rapid fuzzy string matching in C++ using the Levenshtein Distance";

--- a/pkgs/tools/security/tpm2-abrmd/default.nix
+++ b/pkgs/tools/security/tpm2-abrmd/default.nix
@@ -15,7 +15,14 @@ stdenv.mkDerivation rec {
     sha256 = "sha256-l0ncCMsStaeFACRU3Bt6F1zyiOTGY6wOHewA4AD58Ww=";
   };
 
-  nativeBuildInputs = [ pkg-config makeWrapper autoreconfHook autoconf-archive which ];
+  nativeBuildInputs = [
+    autoconf-archive
+    autoreconfHook
+    glib
+    makeWrapper
+    pkg-config
+    which
+  ];
   buildInputs = [ tpm2-tss glib dbus ];
   nativeCheckInputs = [ cmocka ];
 


### PR DESCRIPTION
###### Description of changes

the following packages which previously failed to build now build:
```
$ nix build '.#pkgsCross.aarch64-multiplatform.libjcat' '.#pkgsCross.aarch64-multiplatform.fuzzel' '.#pkgsCross.aarch64-multiplatform.libchamplain' '.#pkgsCross.aarch64-multiplatform.libHX' '.#pkgsCross.aarch64-multiplatform.librest' '.#pkgsCross.aarch64-multiplatform.rapidfuzz-cpp' '.#pkgsCross.aarch64-multiplatform.tpm2-abrmd'
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux  (i.e. native compilation)
  - [x] pkgsCross.aarch64-multiplatform  from x86_64-linux build machine 
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
