### PR TITLE
glusterfs: 10.1 -> 10.3

### DIFF
--- a/pkgs/tools/filesystems/glusterfs/default.nix
+++ b/pkgs/tools/filesystems/glusterfs/default.nix
@@ -55,13 +55,13 @@ let
   ];
 in stdenv.mkDerivation rec {
   pname = "glusterfs";
-  version = "10.1";
+  version = "10.3";
 
   src = fetchFromGitHub {
     owner = "gluster";
     repo = pname;
     rev = "v${version}";
-    sha256 = "sha256-vVFC2kQNneaOwrezPehOX32dpJb88ZhGHBApEXc9MOg=";
+    sha256 = "sha256-2+zdEbvXwfjAyeWpy0TAWRE0kvqSUqebmRyuhdfzYd0=";
   };
   inherit buildInputs propagatedBuildInputs;
 

--- a/pkgs/tools/filesystems/glusterfs/ssl_cert_path.patch
+++ b/pkgs/tools/filesystems/glusterfs/ssl_cert_path.patch
@@ -7,7 +7,7 @@ index fb8db11e9e..4c40683057 100644
  dnl Find out OpenSSL trusted certificates path
  AC_MSG_CHECKING([for OpenSSL trusted certificates path])
 -SSL_CERT_PATH=$(openssl version -d | sed -e 's|OPENSSLDIR: "\(.*\)".*|\1|')
--if test -d $SSL_CERT_PATH 1>/dev/null 2>&1; then
+-if test -d "${SSL_CERT_PATH}" 1>/dev/null 2>&1; then
 -   AC_MSG_RESULT([$SSL_CERT_PATH])
 -   AC_DEFINE_UNQUOTED(SSL_CERT_PATH, ["$SSL_CERT_PATH"], [Path to OpenSSL trusted certificates.])
 -   AC_SUBST(SSL_CERT_PATH)


### PR DESCRIPTION
###### Description of changes

[The release notes mention 11.0](https://docs.gluster.org/en/main/release-notes/), but it's probably worthwhile to incrementally move up one minor version before the major version jump.

[This PR](https://github.com/NixOS/nixpkgs/pull/174688) moves to 10.2, but it seems sort of stuck. This moves up two versions from 10.1 to 10.3 and applies the update to the patch file that applies cleanly onto the 10.3 tag (apologies if I should've collaborated on #174688, this seemed like it may be easier to just close the other and merge this assuming it builds and tests cleanly).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
