### PR TITLE
deepin: don't need prefix qt5integration for all application

### DIFF
--- a/pkgs/desktops/deepin/apps/deepin-album/default.nix
+++ b/pkgs/desktops/deepin/apps/deepin-album/default.nix
@@ -8,6 +8,8 @@
 , dtkwidget
 , qt5integration
 , qt5platform-plugins
+, qtbase
+, qtsvg
 , udisks2-qt5
 , gio-qt
 , image-editor
@@ -16,7 +18,6 @@
 , opencv
 , ffmpeg
 , ffmpegthumbnailer
-, qtbase
 }:
 
 stdenv.mkDerivation rec {
@@ -35,9 +36,7 @@ stdenv.mkDerivation rec {
     substituteInPlace libUnionImage/CMakeLists.txt \
       --replace "/usr" "$out"
     substituteInPlace src/CMakeLists.txt \
-      --replace "set(PREFIX /usr)" "set(PREFIX $out)" \
-      --replace "/usr/bin" "$out/bin" \
-      --replace "/usr/share/deepin-manual/manual-assets/application/)" "share/deepin-manual/manual-assets/application/)"
+      --replace "/usr" "$out"
   '';
 
   nativeBuildInputs = [
@@ -49,7 +48,10 @@ stdenv.mkDerivation rec {
 
   buildInputs = [
     dtkwidget
+    qt5integration
     qt5platform-plugins
+    qtbase
+    qtsvg
     udisks2-qt5
     gio-qt
     image-editor
@@ -60,10 +62,7 @@ stdenv.mkDerivation rec {
     ffmpegthumbnailer
   ];
 
-  # qt5integration must be placed before qtsvg in QT_PLUGIN_PATH
-  qtWrapperArgs = [
-    "--prefix QT_PLUGIN_PATH : ${qt5integration}/${qtbase.qtPluginPrefix}"
-  ];
+  strictDeps = true;
 
   cmakeFlags = [ "-DVERSION=${version}" ];
 

--- a/pkgs/desktops/deepin/apps/deepin-calculator/default.nix
+++ b/pkgs/desktops/deepin/apps/deepin-calculator/default.nix
@@ -4,9 +4,10 @@
 , dtkwidget
 , qt5integration
 , qt5platform-plugins
+, qtbase
+, qtsvg
 , dde-qt-dbus-factory
 , cmake
-, qtbase
 , qttools
 , pkg-config
 , wrapQtAppsHook
@@ -33,14 +34,15 @@ stdenv.mkDerivation rec {
 
   buildInputs = [
     dtkwidget
+    qt5integration
+    qt5platform-plugins
+    qtbase
+    qtsvg
     dde-qt-dbus-factory
     gtest
   ];
 
-  qtWrapperArgs = [
-    "--prefix QT_PLUGIN_PATH : ${qt5integration}/${qtbase.qtPluginPrefix}"
-    "--prefix QT_QPA_PLATFORM_PLUGIN_PATH : ${qt5platform-plugins}/${qtbase.qtPluginPrefix}"
-  ];
+  strictDeps = true;
 
   cmakeFlags = [ "-DVERSION=${version}" ];
 

--- a/pkgs/desktops/deepin/apps/deepin-camera/default.nix
+++ b/pkgs/desktops/deepin/apps/deepin-camera/default.nix
@@ -36,11 +36,11 @@ stdenv.mkDerivation rec {
 
   postPatch = ''
     substituteInPlace src/CMakeLists.txt \
-      --replace "/usr/share/libimagevisualresult/filter_cube" "${image-editor}/share/libimagevisualresult/filter_cube" \
+      --replace "/usr/share/libimagevisualresult" "${image-editor}/share/libimagevisualresult" \
       --replace "/usr/include/libusb-1.0" "${lib.getDev libusb1}/include/libusb-1.0"
     substituteInPlace src/com.deepin.Camera.service \
       --replace "/usr/bin/qdbus" "${lib.getBin qttools}/bin/qdbus" \
-      --replace "/usr/share/applications/deepin-camera.desktop" "$out/share/applications/deepin-camera.desktop"
+      --replace "/usr/share" "$out/share"
   '';
 
   nativeBuildInputs = [
@@ -52,6 +52,7 @@ stdenv.mkDerivation rec {
 
   buildInputs = [
     dtkwidget
+    qt5integration
     qt5platform-plugins
     image-editor
     qtbase
@@ -70,14 +71,14 @@ stdenv.mkDerivation rec {
 
   cmakeFlags = [ "-DVERSION=${version}" ];
 
+  strictDeps = true;
+
   env.NIX_CFLAGS_COMPILE = toString [
     "-I${gst_all_1.gstreamer.dev}/include/gstreamer-1.0"
     "-I${gst_all_1.gst-plugins-base.dev}/include/gstreamer-1.0"
   ];
 
-  # qt5integration must be placed before qtsvg in QT_PLUGIN_PATH
   qtWrapperArgs = [
-    "--prefix QT_PLUGIN_PATH : ${qt5integration}/${qtbase.qtPluginPrefix}"
     "--prefix LD_LIBRARY_PATH : ${lib.makeLibraryPath [ ffmpeg ffmpegthumbnailer gst_all_1.gstreamer gst_all_1.gst-plugins-base libusb1 libv4l portaudio systemd ]}"
   ];
 

--- a/pkgs/desktops/deepin/apps/deepin-clone/default.nix
+++ b/pkgs/desktops/deepin/apps/deepin-clone/default.nix
@@ -49,6 +49,7 @@ stdenv.mkDerivation rec {
   buildInputs = [
     qtbase
     dtkwidget
+    qt5integration
     qt5platform-plugins
     libuuid
     parted
@@ -60,11 +61,6 @@ stdenv.mkDerivation rec {
   ];
 
   strictDeps = true;
-
-  # qt5integration must be placed before qtsvg in QT_PLUGIN_PATH
-  qtWrapperArgs = [
-    "--prefix QT_PLUGIN_PATH : ${qt5integration}/${qtbase.qtPluginPrefix}"
-  ];
 
   meta = with lib; {
     description = "Disk and partition backup/restore tool";

--- a/pkgs/desktops/deepin/apps/deepin-compressor/default.nix
+++ b/pkgs/desktops/deepin/apps/deepin-compressor/default.nix
@@ -44,6 +44,7 @@ stdenv.mkDerivation rec {
 
   buildInputs = [
     dtkwidget
+    qt5integration
     qt5platform-plugins
     udisks2-qt5
     kcodecs
@@ -59,11 +60,6 @@ stdenv.mkDerivation rec {
   ];
 
   strictDeps = true;
-
-  # qt5integration must be placed before qtsvg in QT_PLUGIN_PATH
-  qtWrapperArgs = [
-    "--prefix QT_PLUGIN_PATH : ${qt5integration}/${qtbase.qtPluginPrefix}"
-  ];
 
   meta = with lib; {
     description = "A fast and lightweight application for creating and extracting archives";

--- a/pkgs/desktops/deepin/apps/deepin-draw/default.nix
+++ b/pkgs/desktops/deepin/apps/deepin-draw/default.nix
@@ -46,6 +46,7 @@ stdenv.mkDerivation rec {
 
   buildInputs = [
     qtbase
+    qt5integration
     qtsvg
     dtkwidget
     qt5platform-plugins
@@ -54,11 +55,6 @@ stdenv.mkDerivation rec {
   cmakeFlags = [ "-DVERSION=${version}" ];
 
   strictDeps = true;
-
-  # qt5integration must be placed before qtsvg in QT_PLUGIN_PATH
-  qtWrapperArgs = [
-    "--prefix QT_PLUGIN_PATH : ${qt5integration}/${qtbase.qtPluginPrefix}"
-  ];
 
   meta = with lib; {
     description = "Lightweight drawing tool for users to freely draw and simply edit images";

--- a/pkgs/desktops/deepin/apps/deepin-editor/default.nix
+++ b/pkgs/desktops/deepin/apps/deepin-editor/default.nix
@@ -54,6 +54,7 @@ stdenv.mkDerivation rec {
     qtbase
     qtsvg
     dtkwidget
+    qt5integration
     qt5platform-plugins
     dde-qt-dbus-factory
     kcodecs
@@ -67,11 +68,6 @@ stdenv.mkDerivation rec {
   strictDeps = true;
 
   cmakeFlags = [ "-DVERSION=${version}" ];
-
-  # qt5integration must be placed before qtsvg in QT_PLUGIN_PATH
-  qtWrapperArgs = [
-    "--prefix QT_PLUGIN_PATH : ${qt5integration}/${qtbase.qtPluginPrefix}"
-  ];
 
   meta = with lib; {
     description = "A desktop text editor that supports common text editing features";

--- a/pkgs/desktops/deepin/apps/deepin-image-viewer/default.nix
+++ b/pkgs/desktops/deepin/apps/deepin-image-viewer/default.nix
@@ -59,6 +59,7 @@ stdenv.mkDerivation rec {
     qtbase
     qtsvg
     dtkwidget
+    qt5integration
     qt5platform-plugins
     gio-qt
     udisks2-qt5
@@ -70,11 +71,6 @@ stdenv.mkDerivation rec {
   strictDeps = true;
 
   cmakeFlags = [ "-DVERSION=${version}" ];
-
-  # qt5integration must be placed before qtsvg in QT_PLUGIN_PATH
-  qtWrapperArgs = [
-    "--prefix QT_PLUGIN_PATH : ${qt5integration}/${qtbase.qtPluginPrefix}"
-  ];
 
   meta = with lib; {
     description = "An image viewing tool with fashion interface and smooth performance";

--- a/pkgs/desktops/deepin/apps/deepin-movie-reborn/default.nix
+++ b/pkgs/desktops/deepin/apps/deepin-movie-reborn/default.nix
@@ -73,6 +73,7 @@ stdenv.mkDerivation rec {
 
   buildInputs = [
     dtkwidget
+    qt5integration
     qt5platform-plugins
     qtx11extras
     qtmultimedia
@@ -99,12 +100,6 @@ stdenv.mkDerivation rec {
     gst-plugins-base
   ]);
 
-  # qt5integration must be placed before qtsvg in QT_PLUGIN_PATH
-  qtWrapperArgs = [
-    "--prefix QT_PLUGIN_PATH : ${qt5integration}/${qtbase.qtPluginPrefix}"
-    "--prefix LD_LIBRARY_PATH : ${lib.makeLibraryPath [ mpv ffmpeg ffmpegthumbnailer gst_all_1.gstreamer gst_all_1.gst-plugins-base ]}"
-  ];
-
   env.NIX_CFLAGS_COMPILE = toString [
     "-I${gst_all_1.gstreamer.dev}/include/gstreamer-1.0"
     "-I${gst_all_1.gst-plugins-base.dev}/include/gstreamer-1.0"
@@ -112,6 +107,12 @@ stdenv.mkDerivation rec {
 
   cmakeFlags = [
     "-DVERSION=${version}"
+  ];
+
+  strictDeps = true;
+
+  qtWrapperArgs = [
+    "--prefix LD_LIBRARY_PATH : ${lib.makeLibraryPath [ mpv ffmpeg ffmpegthumbnailer gst_all_1.gstreamer gst_all_1.gst-plugins-base ]}"
   ];
 
   preFixup = ''

--- a/pkgs/desktops/deepin/apps/deepin-music/default.nix
+++ b/pkgs/desktops/deepin/apps/deepin-music/default.nix
@@ -38,8 +38,7 @@ stdenv.mkDerivation rec {
 
   postPatch = ''
     substituteInPlace src/music-player/CMakeLists.txt \
-      --replace "include_directories(/usr/include/vlc)" "include_directories(${libvlc}/include/vlc)" \
-      --replace "include_directories(/usr/include/vlc/plugins)" "include_directories(${libvlc}/include/vlc/plugins)" \
+      --replace "/usr/include/vlc" "${libvlc}/include/vlc" \
       --replace "/usr/share" "$out/share"
     substituteInPlace src/libmusic-plugin/CMakeLists.txt \
       --replace "/usr/lib/deepin-aiassistant" "$out/lib/deepin-aiassistant"
@@ -56,6 +55,7 @@ stdenv.mkDerivation rec {
 
   buildInputs = [
     dtkwidget
+    qt5integration
     qt5platform-plugins
     dde-qt-dbus-factory
     udisks2-qt5
@@ -76,14 +76,11 @@ stdenv.mkDerivation rec {
     gst-plugins-good
   ]);
 
-  # qt5integration must be placed before qtsvg in QT_PLUGIN_PATH
-  qtWrapperArgs = [
-    "--prefix QT_PLUGIN_PATH : ${qt5integration}/${qtbase.qtPluginPrefix}"
-  ];
-
   cmakeFlags = [
     "-DVERSION=${version}"
   ];
+
+  strictDeps = true;
 
   preFixup = ''
     qtWrapperArgs+=(--prefix GST_PLUGIN_SYSTEM_PATH_1_0 : "$GST_PLUGIN_SYSTEM_PATH_1_0")

--- a/pkgs/desktops/deepin/apps/deepin-reader/default.nix
+++ b/pkgs/desktops/deepin/apps/deepin-reader/default.nix
@@ -46,6 +46,7 @@ stdenv.mkDerivation rec {
 
   buildInputs = [
     dtkwidget
+    qt5integration
     qt5platform-plugins
     dde-qt-dbus-factory
     qtwebengine
@@ -59,11 +60,6 @@ stdenv.mkDerivation rec {
 
   qmakeFlags = [
     "DEFINES+=VERSION=${version}"
-  ];
-
-  # qt5integration must be placed before qtsvg in QT_PLUGIN_PATH
-  qtWrapperArgs = [
-    "--prefix QT_PLUGIN_PATH : ${qt5integration}/${qtbase.qtPluginPrefix}"
   ];
 
   meta = with lib; {

--- a/pkgs/desktops/deepin/apps/deepin-shortcut-viewer/default.nix
+++ b/pkgs/desktops/deepin/apps/deepin-shortcut-viewer/default.nix
@@ -32,17 +32,13 @@ stdenv.mkDerivation rec {
   buildInputs = [
     qtbase
     dtkwidget
+    qt5integration
     qt5platform-plugins
   ];
 
   qmakeFlags = [
     "VERSION=${version}"
     "PREFIX=${placeholder "out"}"
-  ];
-
-  # qt5integration must be placed before qtsvg in QT_PLUGIN_PATH
-  qtWrapperArgs = [
-    "--prefix QT_PLUGIN_PATH : ${qt5integration}/${qtbase.qtPluginPrefix}"
   ];
 
   meta = with lib; {

--- a/pkgs/desktops/deepin/apps/deepin-terminal/default.nix
+++ b/pkgs/desktops/deepin/apps/deepin-terminal/default.nix
@@ -53,6 +53,7 @@ stdenv.mkDerivation rec {
     qtbase
     qtsvg
     dtkwidget
+    qt5integration
     qt5platform-plugins
     dde-qt-dbus-factory
     qtx11extras
@@ -63,11 +64,6 @@ stdenv.mkDerivation rec {
   ];
 
   strictDeps = true;
-
-  # qt5integration must be placed before qtsvg in QT_PLUGIN_PATH
-  qtWrapperArgs = [
-    "--prefix QT_PLUGIN_PATH : ${qt5integration}/${qtbase.qtPluginPrefix}"
-  ];
 
   meta = with lib; {
     description = "Terminal emulator with workspace, multiple windows, remote management, quake mode and other features";

--- a/pkgs/desktops/deepin/apps/deepin-voice-note/default.nix
+++ b/pkgs/desktops/deepin/apps/deepin-voice-note/default.nix
@@ -44,6 +44,7 @@ stdenv.mkDerivation rec {
   buildInputs = [
     qtbase
     dtkwidget
+    qt5integration
     qt5platform-plugins
     dde-qt-dbus-factory
     qtmultimedia
@@ -61,11 +62,6 @@ stdenv.mkDerivation rec {
   cmakeFlags = [ "-DVERSION=${version}" ];
 
   env.NIX_CFLAGS_COMPILE = "-I${dde-qt-dbus-factory}/include/libdframeworkdbus-2.0";
-
-  # qt5integration must be placed before qtsvg in QT_PLUGIN_PATH
-  qtWrapperArgs = [
-    "--prefix QT_PLUGIN_PATH : ${qt5integration}/${qtbase.qtPluginPrefix}"
-  ];
 
   preFixup = ''
     qtWrapperArgs+=(--prefix GST_PLUGIN_SYSTEM_PATH_1_0 : "$GST_PLUGIN_SYSTEM_PATH_1_0")


### PR DESCRIPTION
Seems only in dde-dock/dde-launcher/dde-control-center/dde-session-ui/dde-session-shell qt5integration must be placed before qtsvg in QT_PLUGIN_PATH, otherwise part of the svg cannot be rendered correctly

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
