### PR TITLE
hare: unstable-2023-02-08 -> unstable-2023-03-15

### DIFF
--- a/pkgs/development/compilers/hare/hare/default.nix
+++ b/pkgs/development/compilers/hare/hare/default.nix
@@ -14,13 +14,13 @@ let
 in
 stdenv.mkDerivation (self: {
   pname = "hare";
-  version = "unstable-2023-02-10";
+  version = "unstable-2023-03-15";
 
   src = fetchFromSourcehut {
     owner = "~sircmpwn";
     repo = "hare";
-    rev = "52b3f2d0c7a85e04a79666a954101e527b7f1272";
-    hash = "sha256-/zP8LbZ113Ar06MZF1zP20LKMGko+4HcOXSntLVAQAU=";
+    rev = "488771bc8cef15557a44815eb6f7808df40a09f7";
+    hash = "sha256-1cSXWD8jpW1VJZDTDOkIabczqbaDCOWsyaUSGtsKsUM=";
   };
 
   patches = [

--- a/pkgs/development/compilers/hare/harec/default.nix
+++ b/pkgs/development/compilers/hare/harec/default.nix
@@ -6,13 +6,13 @@
 
 stdenv.mkDerivation (self: {
   pname = "harec";
-  version = "unstable-2023-02-08";
+  version = "unstable-2023-02-18";
 
   src = fetchFromSourcehut {
     owner = "~sircmpwn";
     repo = "harec";
-    rev = "4730fa6b835f08c44bd7991cc8b264fbc27d752b";
-    hash = "sha256-XOhZWdmkMAuXbj7svILJI3wI7RF9OAb/OE1uGel4/vE=";
+    rev = "dd50ca7740408e3c6e41c0ca48b59b9f7f5911f2";
+    hash = "sha256-616mPMdy4yHHuwGcq+aDdEOteEiWgufRzreXHGhmHr0=";
   };
 
   nativeBuildInputs = [


### PR DESCRIPTION
###### Description of changes

This is mainly for building latest Helios kernel.

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).