### PR TITLE
mfcj5620dw: init at 3.0.1-1

### DIFF
--- a/pkgs/misc/cups/drivers/brother/mfcj5620dw/cupswrapper.nix
+++ b/pkgs/misc/cups/drivers/brother/mfcj5620dw/cupswrapper.nix
@@ -1,0 +1,64 @@
+{ lib, stdenv, fetchurl, mfcj5620dwlpr, makeWrapper }:
+
+stdenv.mkDerivation rec {
+  pname = "mfcj5620dw-cupswrapper";
+  version = "3.0.1-1";
+
+  src = fetchurl {
+    url =
+      "https://download.brother.com/welcome/dlf101201/brother_mfcj5620dw_GPL_source_${version}.tar.gz";
+    sha256 = "sha256-CnmBpzW/eeeXWCq8CMaErQb8m4RDjLuV6vjzjumr8/8=";
+  };
+
+  nativeBuildInputs = [ makeWrapper ];
+  buildInputs = [ mfcj5620dwlpr ];
+
+  patchPhase = ''
+    WRAPPER=cupswrapper/cupswrappermfcj5620dw
+
+    substituteInPlace $WRAPPER \
+    --replace /opt "${mfcj5620dwlpr}/opt" \
+    --replace /usr "${mfcj5620dwlpr}/usr" \
+    --replace /etc "$out/etc"
+
+    substituteInPlace $WRAPPER \
+    --replace "cp " "cp -p "
+  '';
+
+  buildPhase = ''
+    cd brcupsconfig
+    make all
+    cd ..
+  '';
+
+  installPhase = ''
+    TARGETFOLDER=$out/opt/brother/Printers/mfcj5620dw/cupswrapper/
+    PPDFOLDER=$out/share/cups/model/
+    FILTERFOLDER=$out/lib/cups/filter/
+
+    mkdir -p $TARGETFOLDER
+    mkdir -p $PPDFOLDER
+    mkdir -p $FILTERFOLDER
+
+    cp brcupsconfig/brcupsconfig $TARGETFOLDER
+    cp cupswrapper/cupswrappermfcj5620dw $TARGETFOLDER
+    cp ppd/brother_mfcj5620dw_printer_en.ppd $PPDFOLDER
+
+    ln -s ${mfcj5620dwlpr}/lib/cups/filter/brother_lpdwrapper_mfcj5620dw $FILTERFOLDER/
+  '';
+
+  cleanPhase = ''
+    cd brcupsconfig
+    make clean
+  '';
+
+  meta = {
+    homepage = "http://www.brother.com/";
+    description = "Brother MFC-J5620DW CUPS wrapper driver";
+    license = lib.licenses.gpl2;
+    platforms = lib.platforms.linux;
+    downloadPage =
+      "http://support.brother.com/g/b/downloadlist.aspx?c=us&lang=en&prod=mfcj5620dw_us_eu_as&os=128";
+    maintainers = [ lib.maintainers.leifhelm ];
+  };
+}

--- a/pkgs/misc/cups/drivers/brother/mfcj5620dw/lpr.nix
+++ b/pkgs/misc/cups/drivers/brother/mfcj5620dw/lpr.nix
@@ -1,0 +1,93 @@
+{ lib, stdenv, fetchurl, cups, dpkg, ghostscript, a2ps, coreutils, gnused, gawk
+, file, util-linux, xxd, runtimeShell, makeWrapper }:
+
+stdenv.mkDerivation rec {
+  pname = "mfcj5620dw-lpr";
+  version = "3.0.1-1";
+
+  src = fetchurl {
+    url =
+      "https://download.brother.com/welcome/dlf101194/mfcj5620dwlpr-${version}.i386.deb";
+    sha256 = "sha256-45q7Y5GX6kXtlBjOuUx/k3Jo+J3FIdRFxTUCouleDz0=";
+  };
+
+  nativeBuildInputs = [ makeWrapper ];
+  buildInputs = [ cups ghostscript dpkg a2ps ];
+
+  dontUnpack = true;
+
+  brprintconf_mfcj5620dw_script = ''
+    #!${runtimeShell}
+    cd $(mktemp -d)
+    ln -s @out@/usr/bin/brprintconf_mfcj5620dw_patched brprintconf_mfcj5620dw_patched
+    ln -s @out@/opt/brother/Printers/mfcj5620dw/inf/brmfcj5620dwfunc brmfcj5620dwfunc
+    ln -s @out@/opt/brother/Printers/mfcj5620dw/inf/brmfcj5620dwrc brmfcj5620dwrc
+    ./brprintconf_mfcj5620dw_patched "$@"
+  '';
+
+  brmfcj5620dwfilter_script = ''
+    #!${runtimeShell}
+    cd $(mktemp -d)
+    ln -s @out@/opt/brother/Printers/mfcj5620dw/lpd/brmfcj5620dwfilter_patched brmfc5620dwfilter_patched
+    ln -s @out@/opt/brother/Printers/mfcj5620dw/inf/ImagingArea ImagingArea
+    ln -s @out@/opt/brother/Printers/mfcj5620dw/inf/PaperDimension PaperDimension
+    ./brmfc5620dwfilter_patched "$@"
+  '';
+
+  installPhase = ''
+    dpkg-deb -x $src $out
+    substituteInPlace $out/opt/brother/Printers/mfcj5620dw/lpd/filtermfcj5620dw \
+      --replace /opt "$out/opt"
+    substituteInPlace $out/opt/brother/Printers/mfcj5620dw/lpd/psconvertij2 \
+      --replace "GHOST_SCRIPT=`which gs`" "GHOST_SCRIPT=${ghostscript}/bin/gs"
+    substituteInPlace $out/opt/brother/Printers/mfcj5620dw/inf/setupPrintcapij \
+      --replace "/opt/brother/Printers" "$out/opt/brother/Printers" \
+      --replace "printcap.local" "printcap"
+
+    patchelf --set-interpreter ${stdenv.cc.libc.out}/lib/ld-linux.so.2 \
+      --set-rpath $out/opt/brother/Printers/mfcj5620dw/inf:$out/opt/brother/Printers/mfcj5620dw/lpd \
+      $out/opt/brother/Printers/mfcj5620dw/lpd/brmfcj5620dwfilter
+    patchelf --set-interpreter ${stdenv.cc.libc.out}/lib/ld-linux.so.2 $out/usr/bin/brprintconf_mfcj5620dw
+
+    #stripping the hardcoded path.
+    ${util-linux}/bin/hexdump -ve '1/1 "%.2X"' $out/usr/bin/brprintconf_mfcj5620dw | \
+    sed 's.2F6F70742F62726F746865722F5072696E746572732F25732F696E662F6272257366756E6300.62726d66636a36353130647766756e6300000000000000000000000000000000000000000000.' | \
+    sed 's.2F6F70742F62726F746865722F5072696E746572732F25732F696E662F62722573726300.62726D66636A363531306477726300000000000000000000000000000000000000000000.' | \
+    ${xxd}/bin/xxd -r -p > $out/usr/bin/brprintconf_mfcj5620dw_patched
+    chmod +x $out/usr/bin/brprintconf_mfcj5620dw_patched
+    #executing from current dir. segfaults if it's not r\w.
+    mkdir -p $out/bin
+    echo -n "$brprintconf_mfcj5620dw_script" > $out/bin/brprintconf_mfcj5620dw
+    chmod +x $out/bin/brprintconf_mfcj5620dw
+    substituteInPlace $out/bin/brprintconf_mfcj5620dw --replace @out@ $out
+
+    ${util-linux}/bin/hexdump -ve '1/1 "%.2X"' $out/opt/brother/Printers/mfcj5620dw/lpd/brmfcj5620dwfilter | \
+    sed 's.2F6F70742F62726F746865722F5072696E746572732F25732F696E662F496D6167696E674172656100.496D6167696E6741726561000000000000000000000000000000000000000000000000000000000000.' | \
+    sed 's.2F6F70742F62726F746865722F5072696E746572732F25732F696E662F506170657244696D656E73696F6E00.506170657244696D656E73696F6E000000000000000000000000000000000000000000000000000000000000.' | \
+    ${xxd}/bin/xxd -r -p > $out/opt/brother/Printers/mfcj5620dw/lpd/brmfcj5620dwfilter_patched
+    chmod +x $out/opt/brother/Printers/mfcj5620dw/lpd/brmfcj5620dwfilter_patched
+    #executing from current dir. segfaults if it's not r\w.
+    echo -n "$brmfcj5620dwfilter_script" > $out/opt/brother/Printers/mfcj5620dw/lpd/brmfcj5620dwfilter
+    chmod +x $out/opt/brother/Printers/mfcj5620dw/lpd/brmfcj5620dwfilter
+    substituteInPlace $out/opt/brother/Printers/mfcj5620dw/lpd/brmfcj5620dwfilter --replace @out@ $out
+
+    mkdir -p $out/lib/cups/filter/
+    ln -s $out/opt/brother/Printers/mfcj5620dw/lpd/filtermfcj5620dw $out/lib/cups/filter/brother_lpdwrapper_mfcj5620dw
+
+    wrapProgram $out/opt/brother/Printers/mfcj5620dw/lpd/psconvertij2 \
+      --prefix PATH ":" ${lib.makeBinPath [ coreutils gnused gawk ]}
+    wrapProgram $out/opt/brother/Printers/mfcj5620dw/lpd/filtermfcj5620dw \
+      --prefix PATH ":" ${lib.makeBinPath [ coreutils gnused file ghostscript a2ps ]}
+  '';
+
+  meta = {
+    homepage = "http://www.brother.com/";
+    description = "Brother MFC-J5620DW LPR driver";
+    sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
+    license = lib.licenses.unfree;
+    platforms = lib.platforms.linux;
+    downloadPage =
+      "https://support.brother.com/g/b/downloadlist.aspx?c=us&lang=en&prod=mfcj5620dw_us_eu&os=128";
+    maintainers = [ lib.maintainers.leifhelm ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -38939,6 +38939,9 @@ with pkgs;
   mfcj470dw-cupswrapper = callPackage ../misc/cups/drivers/mfcj470dwcupswrapper { };
   mfcj470dwlpr = pkgsi686Linux.callPackage ../misc/cups/drivers/mfcj470dwlpr { };
 
+  mfcj5620dw-cupswrapper = callPackage ../misc/cups/drivers/brother/mfcj5620dw/cupswrapper.nix { };
+  mfcj5620dwlpr = pkgsi686Linux.callPackage ../misc/cups/drivers/brother/mfcj5620dw/lpr.nix { };
+
   mfcj6510dw-cupswrapper = callPackage ../misc/cups/drivers/mfcj6510dwcupswrapper { };
   mfcj6510dwlpr = pkgsi686Linux.callPackage ../misc/cups/drivers/mfcj6510dwlpr { };
 


### PR DESCRIPTION
###### Description of changes
Add printer drivers for Brother MFC-J5620DW.
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
