### PR TITLE
gst_all_1.gst-plugins-rs: init at 0.10.7, mopidy-spotify: re-init at unstable-2023-04-21

### DIFF
--- a/pkgs/applications/audio/mopidy/default.nix
+++ b/pkgs/applications/audio/mopidy/default.nix
@@ -37,6 +37,8 @@ lib.makeScope newScope (self: with self; {
 
   mopidy-soundcloud = callPackage ./soundcloud.nix { };
 
+  mopidy-spotify = callPackage ./spotify.nix { };
+
   mopidy-tidal = callPackage ./tidal.nix { };
 
   mopidy-tunein = callPackage ./tunein.nix { };

--- a/pkgs/applications/audio/mopidy/mopidy.nix
+++ b/pkgs/applications/audio/mopidy/mopidy.nix
@@ -21,6 +21,7 @@ pythonPackages.buildPythonApplication rec {
     gst-plugins-base
     gst-plugins-good
     gst-plugins-ugly
+    gst-plugins-rs
   ];
 
   propagatedBuildInputs = [

--- a/pkgs/applications/audio/mopidy/spotify.nix
+++ b/pkgs/applications/audio/mopidy/spotify.nix
@@ -1,0 +1,31 @@
+{ lib, fetchFromGitHub, pythonPackages, mopidy }:
+
+pythonPackages.buildPythonApplication rec {
+  pname = "mopidy-spotify";
+  version = "unstable-2023-04-21";
+
+  src = fetchFromGitHub {
+    owner = "mopidy";
+    repo = "mopidy-spotify";
+    rev = "984151ac96c5f9c35892055bff20cc11f46092d5";
+    hash = "sha256-4e9Aj0AOFR4/FK54gr1ZyPt0nYZDMrMetV4FPtBxapU=";
+  };
+
+  propagatedBuildInputs = [
+    mopidy
+    pythonPackages.responses
+  ];
+
+  nativeBuildInputs = [
+    pythonPackages.pytestCheckHook
+  ];
+
+  pythonImportsCheck = [ "mopidy_spotify" ];
+
+  meta = with lib; {
+    homepage = "https://github.com/mopidy/mopidy-spotify";
+    description = "Mopidy extension for playing music from Spotify";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ lilyinstarlight ];
+  };
+}

--- a/pkgs/development/libraries/gstreamer/default.nix
+++ b/pkgs/development/libraries/gstreamer/default.nix
@@ -11,6 +11,7 @@
 , IOKit
 , MediaToolbox
 , OpenGL
+, Security
 , VideoToolbox
 , ipu6ep-camera-hal
 }:
@@ -29,6 +30,8 @@
   gst-plugins-ugly = callPackage ./ugly { inherit CoreFoundation DiskArbitration IOKit; };
 
   gst-plugins-viperfx = callPackage ./viperfx { };
+
+  gst-plugins-rs = callPackage ./rs { inherit Security; };
 
   gst-rtsp-server = callPackage ./rtsp-server { };
 

--- a/pkgs/development/libraries/gstreamer/rs/Cargo.lock
+++ b/pkgs/development/libraries/gstreamer/rs/Cargo.lock
@@ -1,0 +1,3766 @@
+version = 3
+[[package]]
+name = "addr2line"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a76fd60b23679b7d19bd066031410fb7e458ccc5e958eb5c325888ce4baedc97"
+dependencies = [ "gimli",]
+
+[[package]]
+name = "adler"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
+
+[[package]]
+name = "aes"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "884391ef1066acaa41e766ba8f596341b96e93ce34f9a43e7d24bf0a0eaf0561"
+dependencies = [ "aes-soft", "aesni", "cipher",]
+
+[[package]]
+name = "aes-ctr"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7729c3cde54d67063be556aeac75a81330d802f0259500ca40cb52967f975763"
+dependencies = [ "aes-soft", "aesni", "cipher", "ctr",]
+
+[[package]]
+name = "aes-soft"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be14c7498ea50828a38d0e24a765ed2effe92a705885b57d029cd67d45744072"
+dependencies = [ "cipher", "opaque-debug",]
+
+[[package]]
+name = "aesni"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea2e11f5e94c2f7d386164cc2aa1f97823fed6f259e486940a71c174dd01b0ce"
+dependencies = [ "cipher", "opaque-debug",]
+
+[[package]]
+name = "ahash"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fcb51a0695d8f838b1ee009b3fbf66bda078cd64590202a864a8f3e8c4315c47"
+dependencies = [ "getrandom", "once_cell", "version_check",]
+
+[[package]]
+name = "aho-corasick"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67fc08ce920c31afb70f013dcce1bfc3a3195de6a228474e45e1f145b36f8d04"
+dependencies = [ "memchr",]
+
+[[package]]
+name = "android_system_properties"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
+dependencies = [ "libc",]
+
+[[package]]
+name = "anstream"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ca84f3628370c59db74ee214b3263d58f9aadd9b4fe7e711fd87dc452b7f163"
+dependencies = [ "anstyle", "anstyle-parse", "anstyle-query", "anstyle-wincon", "colorchoice", "is-terminal", "utf8parse",]
+
+[[package]]
+name = "anstyle"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41ed9a86bf92ae6580e0a31281f65a1b1d867c0cc68d5346e2ae128dddfa6a7d"
+
+[[package]]
+name = "anstyle-parse"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e765fd216e48e067936442276d1d57399e37bce53c264d6fefbe298080cb57ee"
+dependencies = [ "utf8parse",]
+
+[[package]]
+name = "anstyle-query"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ca11d4be1bab0c8bc8734a9aa7bf4ee8316d462a08c6ac5052f888fef5b494b"
+dependencies = [ "windows-sys 0.48.0",]
+
+[[package]]
+name = "anstyle-wincon"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "180abfa45703aebe0093f79badacc01b8fd4ea2e35118747e5811127f926e188"
+dependencies = [ "anstyle", "windows-sys 0.48.0",]
+
+[[package]]
+name = "anyhow"
+version = "1.0.71"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c7d0618f0e0b7e8ff11427422b64564d5fb0be1940354bfe2e0529b18a9d9b8"
+
+[[package]]
+name = "arbitrary"
+version = "0.4.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db55d72333851e17d572bec876e390cd3b11eb1ef53ae821dd9f3b653d2b4569"
+
+[[package]]
+name = "arg_enum_proc_macro"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7c29b43ee8654590587cd033b3eca2f9c4f8cdff945ec0e6ee91ceb057d87f3"
+dependencies = [ "proc-macro2", "quote", "syn 1.0.109",]
+
+[[package]]
+name = "arrayvec"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8da52d66c7071e2e3fa2a1e5c6d088fec47b593032b254f5e980de8ea54454d6"
+dependencies = [ "serde",]
+
+[[package]]
+name = "async-compression"
+version = "0.3.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "942c7cd7ae39e91bde4820d74132e9862e62c2f386c3aa90ccf55949f5bad63a"
+dependencies = [ "flate2", "futures-core", "memchr", "pin-project-lite", "tokio",]
+
+[[package]]
+name = "async-recursion"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e97ce7de6cf12de5d7226c73f5ba9811622f4db3a5b91b55c53e987e5f91cba"
+dependencies = [ "proc-macro2", "quote", "syn 2.0.15",]
+
+[[package]]
+name = "async-task"
+version = "4.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ecc7ab41815b3c653ccd2978ec3255c81349336702dfdf62ee6f7069b12a3aae"
+
+[[package]]
+name = "async-trait"
+version = "0.1.68"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9ccdd8f2a161be9bd5c023df56f1b2a0bd1d83872ae53b71a84a12c9bf6e842"
+dependencies = [ "proc-macro2", "quote", "syn 2.0.15",]
+
+[[package]]
+name = "async-tungstenite"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a48bf42ab2178374a79853bceef600e279258c75049b20481b022d73c908882"
+dependencies = [ "futures-io", "futures-util", "log", "native-tls", "pin-project-lite", "tokio", "tokio-native-tls", "tungstenite",]
+
+[[package]]
+name = "atomic_refcell"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "79d6dc922a2792b006573f60b2648076355daeae5ce9cb59507e5908c9625d31"
+
+[[package]]
+name = "atty"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
+dependencies = [ "hermit-abi 0.1.19", "libc", "winapi",]
+
+[[package]]
+name = "autocfg"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
+
+[[package]]
+name = "av1-grain"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f6ca6f0c18c02c2fbfc119df551b8aeb8a385f6d5980f1475ba0255f1e97f1e"
+dependencies = [ "anyhow", "arrayvec", "itertools", "log", "nom", "num-rational", "serde", "v_frame",]
+
+[[package]]
+name = "aws-config"
+version = "0.55.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc00553f5f3c06ffd4510a9d576f92143618706c45ea6ff81e84ad9be9588abd"
+dependencies = [ "aws-credential-types", "aws-http", "aws-sdk-sso", "aws-sdk-sts", "aws-smithy-async", "aws-smithy-client", "aws-smithy-http", "aws-smithy-http-tower", "aws-smithy-json", "aws-smithy-types", "aws-types", "bytes", "fastrand", "hex", "http", "hyper", "ring", "time 0.3.20", "tokio", "tower", "tracing", "zeroize",]
+
+[[package]]
+name = "aws-credential-types"
+version = "0.55.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cb57ac6088805821f78d282c0ba8aec809f11cbee10dda19a97b03ab040ccc2"
+dependencies = [ "aws-smithy-async", "aws-smithy-types", "fastrand", "tokio", "tracing", "zeroize",]
+
+[[package]]
+name = "aws-endpoint"
+version = "0.55.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c5f6f84a4f46f95a9bb71d9300b73cd67eb868bc43ae84f66ad34752299f4ac"
+dependencies = [ "aws-smithy-http", "aws-smithy-types", "aws-types", "http", "regex", "tracing",]
+
+[[package]]
+name = "aws-http"
+version = "0.55.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a754683c322f7dc5167484266489fdebdcd04d26e53c162cad1f3f949f2c5671"
+dependencies = [ "aws-credential-types", "aws-smithy-http", "aws-smithy-types", "aws-types", "bytes", "http", "http-body", "lazy_static", "percent-encoding", "pin-project-lite", "tracing",]
+
+[[package]]
+name = "aws-sdk-s3"
+version = "0.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37c77060408d653d3efa6ea7b66c1389bc35a0342352984c8bf8bcb814a8fc27"
+dependencies = [ "aws-credential-types", "aws-endpoint", "aws-http", "aws-sig-auth", "aws-sigv4", "aws-smithy-async", "aws-smithy-checksums", "aws-smithy-client", "aws-smithy-eventstream", "aws-smithy-http", "aws-smithy-http-tower", "aws-smithy-json", "aws-smithy-types", "aws-smithy-xml", "aws-types", "bytes", "http", "http-body", "once_cell", "percent-encoding", "regex", "tokio-stream", "tower", "tracing", "url",]
+
+[[package]]
+name = "aws-sdk-sso"
+version = "0.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "babfd626348836a31785775e3c08a4c345a5ab4c6e06dfd9167f2bee0e6295d6"
+dependencies = [ "aws-credential-types", "aws-endpoint", "aws-http", "aws-sig-auth", "aws-smithy-async", "aws-smithy-client", "aws-smithy-http", "aws-smithy-http-tower", "aws-smithy-json", "aws-smithy-types", "aws-types", "bytes", "http", "regex", "tokio-stream", "tower", "tracing",]
+
+[[package]]
+name = "aws-sdk-sts"
+version = "0.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d0fbe3c2c342bc8dfea4bb43937405a8ec06f99140a0dcb9c7b59e54dfa93a1"
+dependencies = [ "aws-credential-types", "aws-endpoint", "aws-http", "aws-sig-auth", "aws-smithy-async", "aws-smithy-client", "aws-smithy-http", "aws-smithy-http-tower", "aws-smithy-json", "aws-smithy-query", "aws-smithy-types", "aws-smithy-xml", "aws-types", "bytes", "http", "regex", "tower", "tracing",]
+
+[[package]]
+name = "aws-sdk-transcribe"
+version = "0.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9793902457988cb3915eb9e57b509c8da10aa3a89a8949eabe4ebbb5f6625a40"
+dependencies = [ "aws-credential-types", "aws-endpoint", "aws-http", "aws-sig-auth", "aws-smithy-async", "aws-smithy-client", "aws-smithy-http", "aws-smithy-http-tower", "aws-smithy-json", "aws-smithy-types", "aws-types", "bytes", "http", "regex", "tokio-stream", "tower", "tracing",]
+
+[[package]]
+name = "aws-sig-auth"
+version = "0.55.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "84dc92a63ede3c2cbe43529cb87ffa58763520c96c6a46ca1ced80417afba845"
+dependencies = [ "aws-credential-types", "aws-sigv4", "aws-smithy-eventstream", "aws-smithy-http", "aws-types", "http", "tracing",]
+
+[[package]]
+name = "aws-sigv4"
+version = "0.55.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "392fefab9d6fcbd76d518eb3b1c040b84728ab50f58df0c3c53ada4bea9d327e"
+dependencies = [ "aws-smithy-eventstream", "aws-smithy-http", "bytes", "form_urlencoded", "hex", "hmac 0.12.1", "http", "once_cell", "percent-encoding", "regex", "sha2", "time 0.3.20", "tracing",]
+
+[[package]]
+name = "aws-smithy-async"
+version = "0.55.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae23b9fe7a07d0919000116c4c5c0578303fbce6fc8d32efca1f7759d4c20faf"
+dependencies = [ "futures-util", "pin-project-lite", "tokio", "tokio-stream",]
+
+[[package]]
+name = "aws-smithy-checksums"
+version = "0.55.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6367acbd6849b8c7c659e166955531274ae147bf83ab4312885991f6b6706cb"
+dependencies = [ "aws-smithy-http", "aws-smithy-types", "bytes", "crc32c", "crc32fast", "hex", "http", "http-body", "md-5", "pin-project-lite", "sha1", "sha2", "tracing",]
+
+[[package]]
+name = "aws-smithy-client"
+version = "0.55.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5230d25d244a51339273b8870f0f77874cd4449fb4f8f629b21188ae10cfc0ba"
+dependencies = [ "aws-smithy-async", "aws-smithy-http", "aws-smithy-http-tower", "aws-smithy-types", "bytes", "fastrand", "http", "http-body", "hyper", "hyper-rustls", "lazy_static", "pin-project-lite", "rustls", "tokio", "tower", "tracing",]
+
+[[package]]
+name = "aws-smithy-eventstream"
+version = "0.55.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22d2a2bcc16e5c4d949ffd2b851da852b9bbed4bb364ed4ae371b42137ca06d9"
+dependencies = [ "aws-smithy-types", "bytes", "crc32fast",]
+
+[[package]]
+name = "aws-smithy-http"
+version = "0.55.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b60e2133beb9fe6ffe0b70deca57aaeff0a35ad24a9c6fab2fd3b4f45b99fdb5"
+dependencies = [ "aws-smithy-eventstream", "aws-smithy-types", "bytes", "bytes-utils", "futures-core", "http", "http-body", "hyper", "once_cell", "percent-encoding", "pin-project-lite", "pin-utils", "tokio", "tokio-util", "tracing",]
+
+[[package]]
+name = "aws-smithy-http-tower"
+version = "0.55.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a4d94f556c86a0dd916a5d7c39747157ea8cb909ca469703e20fee33e448b67"
+dependencies = [ "aws-smithy-http", "aws-smithy-types", "bytes", "http", "http-body", "pin-project-lite", "tower", "tracing",]
+
+[[package]]
+name = "aws-smithy-json"
+version = "0.55.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ce3d6e6ebb00b2cce379f079ad5ec508f9bcc3a9510d9b9c1840ed1d6f8af39"
+dependencies = [ "aws-smithy-types",]
+
+[[package]]
+name = "aws-smithy-query"
+version = "0.55.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d58edfca32ef9bfbc1ca394599e17ea329cb52d6a07359827be74235b64b3298"
+dependencies = [ "aws-smithy-types", "urlencoding",]
+
+[[package]]
+name = "aws-smithy-types"
+version = "0.55.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "58db46fc1f4f26be01ebdb821751b4e2482cd43aa2b64a0348fb89762defaffa"
+dependencies = [ "base64-simd", "itoa", "num-integer", "ryu", "time 0.3.20",]
+
+[[package]]
+name = "aws-smithy-xml"
+version = "0.55.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb557fe4995bd9ec87fb244bbb254666a971dc902a783e9da8b7711610e9664c"
+dependencies = [ "xmlparser",]
+
+[[package]]
+name = "aws-types"
+version = "0.55.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de0869598bfe46ec44ffe17e063ed33336e59df90356ca8ff0e8da6f7c1d994b"
+dependencies = [ "aws-credential-types", "aws-smithy-async", "aws-smithy-client", "aws-smithy-http", "aws-smithy-types", "http", "rustc_version", "tracing",]
+
+[[package]]
+name = "backoff"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b62ddb9cb1ec0a098ad4bbf9344d0713fa193ae1a80af55febcff2627b6a00c1"
+dependencies = [ "futures-core", "getrandom", "instant", "pin-project-lite", "rand", "tokio",]
+
+[[package]]
+name = "backtrace"
+version = "0.3.67"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "233d376d6d185f2a3093e58f283f60f880315b6c60075b01f36b3b85154564ca"
+dependencies = [ "addr2line", "cc", "cfg-if", "libc", "miniz_oxide 0.6.2", "object", "rustc-demangle",]
+
+[[package]]
+name = "base32"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23ce669cd6c8588f79e15cf450314f9638f967fc5770ff1c7c1deb0925ea7cfa"
+
+[[package]]
+name = "base64"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
+
+[[package]]
+name = "base64"
+version = "0.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4a4ddaa51a5bc52a6948f74c06d20aaaddb71924eab79b8c97a8c556e942d6a"
+
+[[package]]
+name = "base64-simd"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "339abbe78e73178762e23bea9dfd08e697eb3f3301cd4be981c0f78ba5859195"
+dependencies = [ "outref", "vsimd",]
+
+[[package]]
+name = "bincode"
+version = "1.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1f45e9417d87227c7a56d22e471c6206462cba514c7590c09aff4cf6d1ddcad"
+dependencies = [ "serde",]
+
+[[package]]
+name = "bit_field"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc827186963e592360843fb5ba4b973e145841266c1357f7180c43526f2e5b61"
+
+[[package]]
+name = "bitflags"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+
+[[package]]
+name = "bitstream-io"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d28070975aaf4ef1fd0bd1f29b739c06c2cdd9972e090617fb6dca3b2cb564e"
+
+[[package]]
+name = "block-buffer"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4152116fd6e9dadb291ae18fc1ec3575ed6d84c29642d97890f4b4a3417297e4"
+dependencies = [ "generic-array",]
+
+[[package]]
+name = "block-buffer"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+dependencies = [ "generic-array",]
+
+[[package]]
+name = "build_const"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4ae4235e6dac0694637c763029ecea1a2ec9e4e06ec2729bd21ba4d9c863eb7"
+
+[[package]]
+name = "built"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b9c056b9ed43aee5e064b683aa1ec783e19c6acec7559e3ae931b7490472fbe"
+dependencies = [ "cargo-lock",]
+
+[[package]]
+name = "bumpalo"
+version = "3.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b1ce199063694f33ffb7dd4e0ee620741495c32833cde5aa08f02a0bf96f0c8"
+
+[[package]]
+name = "byte-slice-cast"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3ac9f8b63eca6fd385229b3675f6cc0dc5c8a5c8a54a59d4f52ffd670d87b0c"
+
+[[package]]
+name = "bytemuck"
+version = "1.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "17febce684fd15d89027105661fec94afb475cb995fbc59d2865198446ba2eea"
+
+[[package]]
+name = "byteorder"
+version = "1.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
+
+[[package]]
+name = "bytes"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "89b2fd2a0dcf38d7971e2194b6b6eebab45ae01067456a7fd93d5547a61b70be"
+
+[[package]]
+name = "bytes-utils"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e47d3a8076e283f3acd27400535992edb3ba4b5bb72f8891ad8fbe7932a7d4b9"
+dependencies = [ "bytes", "either",]
+
+[[package]]
+name = "cairo-rs"
+version = "0.17.9"
+source = "git+https://github.com/gtk-rs/gtk-rs-core?branch=0.17#3ad562c758bf7b2452827c2e6d35e4effce23f71"
+dependencies = [ "bitflags", "cairo-sys-rs", "glib", "libc", "once_cell", "thiserror",]
+
+[[package]]
+name = "cairo-sys-rs"
+version = "0.17.9"
+source = "git+https://github.com/gtk-rs/gtk-rs-core?branch=0.17#3ad562c758bf7b2452827c2e6d35e4effce23f71"
+dependencies = [ "glib-sys", "libc", "system-deps",]
+
+[[package]]
+name = "cargo-lock"
+version = "8.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "031718ddb8f78aa5def78a09e90defe30151d1f6c672f937af4dd916429ed996"
+dependencies = [ "semver", "serde", "toml 0.5.11", "url",]
+
+[[package]]
+name = "cc"
+version = "1.0.79"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50d30906286121d95be3d479533b458f87493b30a4b5f79a607db8f5d11aa91f"
+dependencies = [ "jobserver",]
+
+[[package]]
+name = "cdg"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d254b2c9fc971518da5d652aee7edc6b9bb96fa32de28f166895faf69d9926e6"
+
+[[package]]
+name = "cdg_renderer"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3753104c2ef8672021f3355a59ab5944d7aa5472f970b5d97e93bd741d79af96"
+dependencies = [ "cdg", "image",]
+
+[[package]]
+name = "cfg-expr"
+version = "0.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8790cf1286da485c72cf5fc7aeba308438800036ec67d89425924c4807268c9"
+dependencies = [ "smallvec", "target-lexicon",]
+
+[[package]]
+name = "cfg-if"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+
+[[package]]
+name = "chrono"
+version = "0.4.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e3c5919066adf22df73762e50cffcde3a758f2a848b113b586d1f86728b673b"
+dependencies = [ "iana-time-zone", "js-sys", "num-integer", "num-traits", "time 0.1.45", "wasm-bindgen", "winapi",]
+
+[[package]]
+name = "cipher"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12f8e7987cbd042a63249497f41aed09f8e65add917ea6566effbc56578d6801"
+dependencies = [ "generic-array",]
+
+[[package]]
+name = "clap"
+version = "4.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34d21f9bf1b425d2968943631ec91202fe5e837264063503708b83013f8fc938"
+dependencies = [ "clap_builder", "clap_derive", "once_cell",]
+
+[[package]]
+name = "clap_builder"
+version = "4.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "914c8c79fb560f238ef6429439a30023c862f7a28e688c58f7203f12b29970bd"
+dependencies = [ "anstream", "anstyle", "bitflags", "clap_lex", "strsim",]
+
+[[package]]
+name = "clap_derive"
+version = "4.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f9644cd56d6b87dbe899ef8b053e331c0637664e9e21a33dfcdc36093f5c5c4"
+dependencies = [ "heck", "proc-macro2", "quote", "syn 2.0.15",]
+
+[[package]]
+name = "clap_lex"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a2dd5a6fe8c6e3502f568a6353e5273bbb15193ad9a89e457b9970798efbea1"
+
+[[package]]
+name = "claxon"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4bfbf56724aa9eca8afa4fcfadeb479e722935bb2a0900c2d37e0cc477af0688"
+
+[[package]]
+name = "codespan-reporting"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3538270d33cc669650c4b093848450d380def10c331d38c768e34cac80576e6e"
+dependencies = [ "termcolor", "unicode-width",]
+
+[[package]]
+name = "color-name"
+version = "1.1.0"
+source = "git+https://github.com/lilyinstarlight/color-name#cac0ed5b7d2e0682c08c9bfd13089d5494e81b9a"
+
+[[package]]
+name = "color-thief"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6460d760cf38ce67c9e0318f896538820acc54f2d0a3bfc5b2c557211066c98"
+dependencies = [ "rgb",]
+
+[[package]]
+name = "color_quant"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d7b894f5411737b7867f4827955924d7c254fc9f4d91a6aad6b097804b1018b"
+
+[[package]]
+name = "colorchoice"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acbf1af155f9b9ef647e42cdc158db4b64a1b61f743629225fde6f3e0be2a7c7"
+
+[[package]]
+name = "concurrent-queue"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62ec6771ecfa0762d24683ee5a32ad78487a3d3afdc0fb8cae19d2c5deb50b7c"
+dependencies = [ "crossbeam-utils",]
+
+[[package]]
+name = "cookie"
+version = "0.16.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e859cd57d0710d9e06c381b550c06e76992472a8c6d527aecd2fc673dcc231fb"
+dependencies = [ "percent-encoding", "time 0.3.20", "version_check",]
+
+[[package]]
+name = "cookie_store"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e4b6aa369f41f5faa04bb80c9b1f4216ea81646ed6124d76ba5c49a7aafd9cd"
+dependencies = [ "cookie", "idna 0.2.3", "log", "publicsuffix", "serde", "serde_json", "time 0.3.20", "url",]
+
+[[package]]
+name = "core-foundation"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "194a7a9e6de53fa55116934067c844d9d749312f75c6f6d0980e8c252f8c2146"
+dependencies = [ "core-foundation-sys", "libc",]
+
+[[package]]
+name = "core-foundation-sys"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e496a50fda8aacccc86d7529e2c1e0892dbd0f898a6b5645b5561b89c3210efa"
+
+[[package]]
+name = "cpufeatures"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e4c1eaa2012c47becbbad2ab175484c2a84d1185b566fb2cc5b8707343dfe58"
+dependencies = [ "libc",]
+
+[[package]]
+name = "crc"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d663548de7f5cca343f1e0a48d14dcfb0e9eb4e079ec58883b7251539fa10aeb"
+dependencies = [ "build_const",]
+
+[[package]]
+name = "crc"
+version = "3.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "86ec7a15cbe22e59248fc7eadb1907dab5ba09372595da4d73dd805ed4417dfe"
+dependencies = [ "crc-catalog",]
+
+[[package]]
+name = "crc-catalog"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9cace84e55f07e7301bae1c519df89cdad8cc3cd868413d3fdbdeca9ff3db484"
+
+[[package]]
+name = "crc32c"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3dfea2db42e9927a3845fb268a10a72faed6d416065f77873f05e411457c363e"
+dependencies = [ "rustc_version",]
+
+[[package]]
+name = "crc32fast"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b540bd8bc810d3885c6ea91e2018302f68baba2129ab3e88f32389ee9370880d"
+dependencies = [ "cfg-if",]
+
+[[package]]
+name = "crossbeam-channel"
+version = "0.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a33c2bf77f2df06183c3aa30d1e96c0695a313d4f9c453cc3762a6db39f99200"
+dependencies = [ "cfg-if", "crossbeam-utils",]
+
+[[package]]
+name = "crossbeam-deque"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce6fd6f855243022dcecf8702fef0c297d4338e226845fe067f6341ad9fa0cef"
+dependencies = [ "cfg-if", "crossbeam-epoch", "crossbeam-utils",]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46bd5f3f85273295a9d14aedfb86f6aadbff6d8f5295c4a9edb08e819dcf5695"
+dependencies = [ "autocfg", "cfg-if", "crossbeam-utils", "memoffset 0.8.0", "scopeguard",]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c063cd8cc95f5c377ed0d4b49a4b21f632396ff690e8470c29b3359b346984b"
+dependencies = [ "cfg-if",]
+
+[[package]]
+name = "crunchy"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a81dae078cea95a014a339291cec439d2f232ebe854a9d672b796c6afafa9b7"
+
+[[package]]
+name = "crypto-common"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
+dependencies = [ "generic-array", "typenum",]
+
+[[package]]
+name = "crypto-mac"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1d1a86f49236c215f271d40892d5fc950490551400b02ef360692c29815c714"
+dependencies = [ "generic-array", "subtle",]
+
+[[package]]
+name = "csound"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8d49045d7365f5c2cadb1f20932189a0da101ac86c8dbe891975814b2348d57d"
+dependencies = [ "bitflags", "csound-sys", "libc", "va_list",]
+
+[[package]]
+name = "csound-sys"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "86b11869eaed111b64d29e66cc5c7de9f172d5b623b716eb74c5dd841dbcfe39"
+dependencies = [ "libc", "va_list",]
+
+[[package]]
+name = "ctor"
+version = "0.1.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d2301688392eb071b0bf1a37be05c469d3cc4dbbd95df672fe28ab021e6a096"
+dependencies = [ "quote", "syn 1.0.109",]
+
+[[package]]
+name = "ctr"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb4a30d54f7443bf3d6191dcd486aca19e67cb3c49fa7a06a319966346707e7f"
+dependencies = [ "cipher",]
+
+[[package]]
+name = "cxx"
+version = "1.0.94"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f61f1b6389c3fe1c316bf8a4dccc90a38208354b330925bce1f74a6c4756eb93"
+dependencies = [ "cc", "cxxbridge-flags", "cxxbridge-macro", "link-cplusplus",]
+
+[[package]]
+name = "cxx-build"
+version = "1.0.94"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12cee708e8962df2aeb38f594aae5d827c022b6460ac71a7a3e2c3c2aae5a07b"
+dependencies = [ "cc", "codespan-reporting", "once_cell", "proc-macro2", "quote", "scratch", "syn 2.0.15",]
+
+[[package]]
+name = "cxxbridge-flags"
+version = "1.0.94"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7944172ae7e4068c533afbb984114a56c46e9ccddda550499caa222902c7f7bb"
+
+[[package]]
+name = "cxxbridge-macro"
+version = "1.0.94"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2345488264226bf682893e25de0769f3360aac9957980ec49361b083ddaa5bc5"
+dependencies = [ "proc-macro2", "quote", "syn 2.0.15",]
+
+[[package]]
+name = "dasp_frame"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2a3937f5fe2135702897535c8d4a5553f8b116f76c1529088797f2eee7c5cd6"
+dependencies = [ "dasp_sample",]
+
+[[package]]
+name = "dasp_sample"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c87e182de0887fd5361989c677c4e8f5000cd9491d6d563161a8f3a5519fc7f"
+
+[[package]]
+name = "data-encoding"
+version = "2.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23d8666cb01533c39dde32bcbab8e227b4ed6679b2c925eba05feabea39508fb"
+
+[[package]]
+name = "dav1d"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c02ab20a37bcd596fb85c3185c3286f983fc6125755c74625c7849c2ba0b7bb3"
+dependencies = [ "bitflags", "dav1d-sys",]
+
+[[package]]
+name = "dav1d-sys"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "615542bb14c18b795f46aba92258902168218d714090f5fff47e68c9a352ea2d"
+dependencies = [ "libc", "system-deps",]
+
+[[package]]
+name = "diff"
+version = "0.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56254986775e3233ffa9c4d7d3faaf6d36a2c09d30b20687e9f88bc8bafc16c8"
+
+[[package]]
+name = "digest"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3dd60d1080a57a05ab032377049e0591415d2b31afd7028356dbf3cc6dcb066"
+dependencies = [ "generic-array",]
+
+[[package]]
+name = "digest"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8168378f4e5023e7218c89c891c0fd8ecdb5e5e4f18cb78f38cf245dd021e76f"
+dependencies = [ "block-buffer 0.10.4", "crypto-common", "subtle",]
+
+[[package]]
+name = "dssim-core"
+version = "3.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60aa0237471586cfb40481b3855a897b86d380eae78fe852d844ab1e3d1d896b"
+dependencies = [ "imgref", "itertools", "rayon", "rgb",]
+
+[[package]]
+name = "ebur128"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12aebdd6b6b47b5880c049efb0e77f8762178a0745ef778878908f5981c05f52"
+dependencies = [ "bitflags", "dasp_frame", "dasp_sample", "smallvec",]
+
+[[package]]
+name = "ed25519"
+version = "1.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91cff35c70bba8a626e3185d8cd48cc11b5437e1a5bcd15b9b5fa3c64b6dfee7"
+dependencies = [ "signature",]
+
+[[package]]
+name = "either"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7fcaabb2fef8c910e7f4c7ce9f67a1283a1715879a7c230ca9d6d1ae31f16d91"
+
+[[package]]
+name = "encoding_rs"
+version = "0.8.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "071a31f4ee85403370b58aca746f01041ede6f0da2730960ad001edc2b71b394"
+dependencies = [ "cfg-if",]
+
+[[package]]
+name = "env_logger"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a12e6657c4c97ebab115a42dcee77225f7f482cdd841cf7088c657a42e9e00e7"
+dependencies = [ "atty", "humantime", "log", "termcolor",]
+
+[[package]]
+name = "env_logger"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85cdab6a89accf66733ad5a1693a4dcced6aeff64602b634530dd73c1f3ee9f0"
+dependencies = [ "humantime", "is-terminal", "log", "regex", "termcolor",]
+
+[[package]]
+name = "errno"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4bcfec3a70f97c962c307b2d2c56e358cf1d00b558d74262b5f929ee8cc7e73a"
+dependencies = [ "errno-dragonfly", "libc", "windows-sys 0.48.0",]
+
+[[package]]
+name = "errno-dragonfly"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa68f1b12764fab894d2755d2518754e71b4fd80ecfb822714a1206c2aab39bf"
+dependencies = [ "cc", "libc",]
+
+[[package]]
+name = "exr"
+version = "1.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bdd2162b720141a91a054640662d3edce3d50a944a50ffca5313cd951abb35b4"
+dependencies = [ "bit_field", "flume", "half", "lebe", "miniz_oxide 0.6.2", "rayon-core", "smallvec", "zune-inflate",]
+
+[[package]]
+name = "fastrand"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e51093e27b0797c359783294ca4f0a911c270184cb10f85783b118614a1501be"
+dependencies = [ "instant",]
+
+[[package]]
+name = "fdeflate"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d329bdeac514ee06249dabc27877490f17f5d371ec693360768b838e19f3ae10"
+dependencies = [ "simd-adler32",]
+
+[[package]]
+name = "ffv1"
+version = "0.0.0"
+source = "git+https://github.com/rust-av/ffv1.git?rev=2afb025a327173ce891954c052e804d0f880368a#2afb025a327173ce891954c052e804d0f880368a"
+dependencies = [ "crc 1.8.1", "num-traits", "thiserror",]
+
+[[package]]
+name = "field-offset"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a3cf3a800ff6e860c863ca6d4b16fd999db8b752819c1606884047b73e468535"
+dependencies = [ "memoffset 0.8.0", "rustc_version",]
+
+[[package]]
+name = "fixedbitset"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
+
+[[package]]
+name = "flate2"
+version = "1.0.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b9429470923de8e8cbd4d2dc513535400b4b3fef0319fb5c4e1f520a7bef743"
+dependencies = [ "crc32fast", "miniz_oxide 0.7.1",]
+
+[[package]]
+name = "flavors"
+version = "0.2.0"
+source = "git+https://github.com/rust-av/flavors#833508af656d298c269f2397c8541a084264d992"
+dependencies = [ "nom",]
+
+[[package]]
+name = "flume"
+version = "0.10.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1657b4441c3403d9f7b3409e47575237dac27b1b5726df654a6ecbf92f0f7577"
+dependencies = [ "futures-core", "futures-sink", "nanorand", "pin-project", "spin 0.9.8",]
+
+[[package]]
+name = "fnv"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
+name = "foreign-types"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
+dependencies = [ "foreign-types-shared",]
+
+[[package]]
+name = "foreign-types-shared"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
+
+[[package]]
+name = "form_urlencoded"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9c384f161156f5260c24a097c56119f9be8c798586aecc13afbcbe7b7e26bf8"
+dependencies = [ "percent-encoding",]
+
+[[package]]
+name = "fst"
+version = "0.4.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ab85b9b05e3978cc9a9cf8fea7f01b494e1a09ed3037e16ba39edc7a29eb61a"
+
+[[package]]
+name = "futures"
+version = "0.3.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23342abe12aba583913b2e62f22225ff9c950774065e4bfb61a19cd9770fec40"
+dependencies = [ "futures-channel", "futures-core", "futures-executor", "futures-io", "futures-sink", "futures-task", "futures-util",]
+
+[[package]]
+name = "futures-channel"
+version = "0.3.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "955518d47e09b25bbebc7a18df10b81f0c766eaf4c4f1cccef2fca5f2a4fb5f2"
+dependencies = [ "futures-core", "futures-sink",]
+
+[[package]]
+name = "futures-core"
+version = "0.3.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4bca583b7e26f571124fe5b7561d49cb2868d79116cfa0eefce955557c6fee8c"
+
+[[package]]
+name = "futures-executor"
+version = "0.3.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ccecee823288125bd88b4d7f565c9e58e41858e47ab72e8ea2d64e93624386e0"
+dependencies = [ "futures-core", "futures-task", "futures-util",]
+
+[[package]]
+name = "futures-io"
+version = "0.3.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fff74096e71ed47f8e023204cfd0aa1289cd54ae5430a9523be060cdb849964"
+
+[[package]]
+name = "futures-macro"
+version = "0.3.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "89ca545a94061b6365f2c7355b4b32bd20df3ff95f02da9329b34ccc3bd6ee72"
+dependencies = [ "proc-macro2", "quote", "syn 2.0.15",]
+
+[[package]]
+name = "futures-sink"
+version = "0.3.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f43be4fe21a13b9781a69afa4985b0f6ee0e1afab2c6f454a8cf30e2b2237b6e"
+
+[[package]]
+name = "futures-task"
+version = "0.3.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76d3d132be6c0e6aa1534069c705a74a5997a356c0dc2f86a47765e5617c5b65"
+
+[[package]]
+name = "futures-util"
+version = "0.3.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26b01e40b772d54cf6c6d721c1d1abd0647a0106a12ecaa1c186273392a69533"
+dependencies = [ "futures-channel", "futures-core", "futures-io", "futures-macro", "futures-sink", "futures-task", "memchr", "pin-project-lite", "pin-utils", "slab",]
+
+[[package]]
+name = "gdk-pixbuf"
+version = "0.17.9"
+source = "git+https://github.com/gtk-rs/gtk-rs-core?branch=0.17#3ad562c758bf7b2452827c2e6d35e4effce23f71"
+dependencies = [ "bitflags", "gdk-pixbuf-sys", "gio", "glib", "libc", "once_cell",]
+
+[[package]]
+name = "gdk-pixbuf-sys"
+version = "0.17.9"
+source = "git+https://github.com/gtk-rs/gtk-rs-core?branch=0.17#3ad562c758bf7b2452827c2e6d35e4effce23f71"
+dependencies = [ "gio-sys", "glib-sys", "gobject-sys", "libc", "system-deps",]
+
+[[package]]
+name = "gdk4"
+version = "0.6.6"
+source = "git+https://github.com/gtk-rs/gtk4-rs?branch=0.6#484447e0f3614466591534783979677fb089a740"
+dependencies = [ "bitflags", "cairo-rs", "gdk-pixbuf", "gdk4-sys", "gio", "glib", "libc", "pango",]
+
+[[package]]
+name = "gdk4-sys"
+version = "0.6.6"
+source = "git+https://github.com/gtk-rs/gtk4-rs?branch=0.6#484447e0f3614466591534783979677fb089a740"
+dependencies = [ "cairo-sys-rs", "gdk-pixbuf-sys", "gio-sys", "glib-sys", "gobject-sys", "libc", "pango-sys", "pkg-config", "system-deps",]
+
+[[package]]
+name = "gdk4-wayland"
+version = "0.6.6"
+source = "git+https://github.com/gtk-rs/gtk4-rs?branch=0.6#484447e0f3614466591534783979677fb089a740"
+dependencies = [ "gdk4", "gdk4-wayland-sys", "gio", "glib", "libc",]
+
+[[package]]
+name = "gdk4-wayland-sys"
+version = "0.6.6"
+source = "git+https://github.com/gtk-rs/gtk4-rs?branch=0.6#484447e0f3614466591534783979677fb089a740"
+dependencies = [ "glib-sys", "libc", "system-deps",]
+
+[[package]]
+name = "gdk4-x11"
+version = "0.6.6"
+source = "git+https://github.com/gtk-rs/gtk4-rs?branch=0.6#484447e0f3614466591534783979677fb089a740"
+dependencies = [ "gdk4", "gdk4-x11-sys", "gio", "glib", "libc",]
+
+[[package]]
+name = "gdk4-x11-sys"
+version = "0.6.6"
+source = "git+https://github.com/gtk-rs/gtk4-rs?branch=0.6#484447e0f3614466591534783979677fb089a740"
+dependencies = [ "gdk4-sys", "glib-sys", "libc", "system-deps",]
+
+[[package]]
+name = "generic-array"
+version = "0.14.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+dependencies = [ "typenum", "version_check",]
+
+[[package]]
+name = "getopts"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "14dbbfd5c71d70241ecf9e6f13737f7b5ce823821063188d7e46c41d371eebd5"
+dependencies = [ "unicode-width",]
+
+[[package]]
+name = "getrandom"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c85e1d9ab2eadba7e5040d4e09cbd6d072b76a557ad64e797c2cb9d4da21d7e4"
+dependencies = [ "cfg-if", "js-sys", "libc", "wasi 0.11.0+wasi-snapshot-preview1", "wasm-bindgen",]
+
+[[package]]
+name = "gif"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "80792593675e051cf94a4b111980da2ba60d4a83e43e0048c5693baab3977045"
+dependencies = [ "color_quant", "weezl",]
+
+[[package]]
+name = "gimli"
+version = "0.27.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad0a93d233ebf96623465aad4046a8d3aa4da22d4f4beba5388838c8a434bbb4"
+
+[[package]]
+name = "gio"
+version = "0.17.9"
+source = "git+https://github.com/gtk-rs/gtk-rs-core?branch=0.17#3ad562c758bf7b2452827c2e6d35e4effce23f71"
+dependencies = [ "bitflags", "futures-channel", "futures-core", "futures-io", "futures-util", "gio-sys", "glib", "libc", "once_cell", "pin-project-lite", "smallvec", "thiserror",]
+
+[[package]]
+name = "gio-sys"
+version = "0.17.9"
+source = "git+https://github.com/gtk-rs/gtk-rs-core?branch=0.17#3ad562c758bf7b2452827c2e6d35e4effce23f71"
+dependencies = [ "glib-sys", "gobject-sys", "libc", "system-deps", "winapi",]
+
+[[package]]
+name = "glib"
+version = "0.17.9"
+source = "git+https://github.com/gtk-rs/gtk-rs-core?branch=0.17#3ad562c758bf7b2452827c2e6d35e4effce23f71"
+dependencies = [ "bitflags", "futures-channel", "futures-core", "futures-executor", "futures-task", "futures-util", "gio-sys", "glib-macros", "glib-sys", "gobject-sys", "libc", "memchr", "once_cell", "smallvec", "thiserror",]
+
+[[package]]
+name = "glib-macros"
+version = "0.17.9"
+source = "git+https://github.com/gtk-rs/gtk-rs-core?branch=0.17#3ad562c758bf7b2452827c2e6d35e4effce23f71"
+dependencies = [ "anyhow", "heck", "proc-macro-crate", "proc-macro-error", "proc-macro2", "quote", "syn 1.0.109",]
+
+[[package]]
+name = "glib-sys"
+version = "0.17.9"
+source = "git+https://github.com/gtk-rs/gtk-rs-core?branch=0.17#3ad562c758bf7b2452827c2e6d35e4effce23f71"
+dependencies = [ "libc", "system-deps",]
+
+[[package]]
+name = "glob"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
+
+[[package]]
+name = "gobject-sys"
+version = "0.17.9"
+source = "git+https://github.com/gtk-rs/gtk-rs-core?branch=0.17#3ad562c758bf7b2452827c2e6d35e4effce23f71"
+dependencies = [ "glib-sys", "libc", "system-deps",]
+
+[[package]]
+name = "graphene-rs"
+version = "0.17.9"
+source = "git+https://github.com/gtk-rs/gtk-rs-core?branch=0.17#3ad562c758bf7b2452827c2e6d35e4effce23f71"
+dependencies = [ "glib", "graphene-sys", "libc",]
+
+[[package]]
+name = "graphene-sys"
+version = "0.17.9"
+source = "git+https://github.com/gtk-rs/gtk-rs-core?branch=0.17#3ad562c758bf7b2452827c2e6d35e4effce23f71"
+dependencies = [ "glib-sys", "libc", "pkg-config", "system-deps",]
+
+[[package]]
+name = "gsk4"
+version = "0.6.6"
+source = "git+https://github.com/gtk-rs/gtk4-rs?branch=0.6#484447e0f3614466591534783979677fb089a740"
+dependencies = [ "bitflags", "cairo-rs", "gdk4", "glib", "graphene-rs", "gsk4-sys", "libc", "pango",]
+
+[[package]]
+name = "gsk4-sys"
+version = "0.6.6"
+source = "git+https://github.com/gtk-rs/gtk4-rs?branch=0.6#484447e0f3614466591534783979677fb089a740"
+dependencies = [ "cairo-sys-rs", "gdk4-sys", "glib-sys", "gobject-sys", "graphene-sys", "libc", "pango-sys", "system-deps",]
+
+[[package]]
+name = "gst-plugin-audiofx"
+version = "0.10.7"
+dependencies = [ "anyhow", "atomic_refcell", "byte-slice-cast", "ebur128", "gst-plugin-version-helper", "gstreamer", "gstreamer-app", "gstreamer-audio", "gstreamer-base", "gstreamer-check", "hrtf", "nnnoiseless", "num-traits", "once_cell", "rayon", "smallvec",]
+
+[[package]]
+name = "gst-plugin-aws"
+version = "0.10.7"
+dependencies = [ "async-tungstenite", "atomic_refcell", "aws-config", "aws-credential-types", "aws-sdk-s3", "aws-sdk-transcribe", "aws-sig-auth", "aws-smithy-http", "aws-smithy-types", "aws-types", "backoff", "base32", "byteorder", "bytes", "chrono", "crc 3.0.1", "env_logger 0.10.0", "futures", "gio", "gst-plugin-version-helper", "gstreamer", "gstreamer-audio", "gstreamer-base", "gstreamer-check", "http", "nom", "once_cell", "percent-encoding", "rand", "serde", "serde_derive", "serde_json", "test-with", "tokio", "url",]
+
+[[package]]
+name = "gst-plugin-cdg"
+version = "0.10.7"
+dependencies = [ "cdg", "cdg_renderer", "gst-plugin-version-helper", "gstreamer", "gstreamer-app", "gstreamer-base", "gstreamer-video", "image", "muldiv", "once_cell",]
+
+[[package]]
+name = "gst-plugin-claxon"
+version = "0.10.7"
+dependencies = [ "atomic_refcell", "byte-slice-cast", "claxon", "gst-plugin-version-helper", "gstreamer", "gstreamer-audio", "gstreamer-check", "once_cell",]
+
+[[package]]
+name = "gst-plugin-closedcaption"
+version = "0.10.7"
+dependencies = [ "anyhow", "atomic_refcell", "byteorder", "cairo-rs", "cc", "chrono", "either", "gst-plugin-version-helper", "gstreamer", "gstreamer-base", "gstreamer-check", "gstreamer-video", "nom", "once_cell", "pango", "pangocairo", "pretty_assertions", "rand", "serde", "serde_json", "uuid",]
+
+[[package]]
+name = "gst-plugin-csound"
+version = "0.10.7"
+dependencies = [ "byte-slice-cast", "csound", "gst-plugin-version-helper", "gstreamer", "gstreamer-audio", "gstreamer-base", "gstreamer-check", "once_cell",]
+
+[[package]]
+name = "gst-plugin-dav1d"
+version = "0.10.7"
+dependencies = [ "dav1d", "gst-plugin-version-helper", "gstreamer", "gstreamer-base", "gstreamer-video", "num_cpus", "once_cell",]
+
+[[package]]
+name = "gst-plugin-fallbackswitch"
+version = "0.10.7"
+dependencies = [ "gio", "gst-plugin-gtk4", "gst-plugin-version-helper", "gstreamer", "gstreamer-app", "gstreamer-audio", "gstreamer-base", "gstreamer-check", "gstreamer-video", "gtk4", "once_cell", "parking_lot",]
+
+[[package]]
+name = "gst-plugin-ffv1"
+version = "0.10.7"
+dependencies = [ "byte-slice-cast", "ffv1", "gst-plugin-version-helper", "gstreamer", "gstreamer-check", "gstreamer-video", "once_cell",]
+
+[[package]]
+name = "gst-plugin-file"
+version = "0.10.7"
+dependencies = [ "gst-plugin-version-helper", "gstreamer", "gstreamer-base", "once_cell", "url",]
+
+[[package]]
+name = "gst-plugin-flavors"
+version = "0.10.7"
+dependencies = [ "byteorder", "flavors", "gst-plugin-version-helper", "gstreamer", "gstreamer-audio", "gstreamer-base", "muldiv", "nom", "num-rational", "once_cell", "smallvec",]
+
+[[package]]
+name = "gst-plugin-fmp4"
+version = "0.10.7"
+dependencies = [ "anyhow", "chrono", "gst-plugin-version-helper", "gstreamer", "gstreamer-app", "gstreamer-audio", "gstreamer-base", "gstreamer-check", "gstreamer-pbutils", "gstreamer-video", "m3u8-rs", "once_cell",]
+
+[[package]]
+name = "gst-plugin-gif"
+version = "0.10.7"
+dependencies = [ "atomic_refcell", "gif", "gst-plugin-version-helper", "gstreamer", "gstreamer-check", "gstreamer-video", "once_cell",]
+
+[[package]]
+name = "gst-plugin-gtk4"
+version = "0.10.7"
+dependencies = [ "gdk4-wayland", "gdk4-x11", "gst-plugin-version-helper", "gstreamer", "gstreamer-base", "gstreamer-gl", "gstreamer-gl-egl", "gstreamer-gl-wayland", "gstreamer-gl-x11", "gstreamer-video", "gtk4", "once_cell",]
+
+[[package]]
+name = "gst-plugin-hlssink3"
+version = "0.10.7"
+dependencies = [ "gio", "glib", "gst-plugin-version-helper", "gstreamer", "gstreamer-audio", "gstreamer-base", "gstreamer-check", "m3u8-rs", "once_cell", "regex",]
+
+[[package]]
+name = "gst-plugin-hsv"
+version = "0.10.7"
+dependencies = [ "byte-slice-cast", "gst-plugin-version-helper", "gstreamer", "gstreamer-audio", "gstreamer-base", "gstreamer-check", "gstreamer-video", "num-traits", "once_cell",]
+
+[[package]]
+name = "gst-plugin-json"
+version = "0.10.7"
+dependencies = [ "gst-plugin-version-helper", "gstreamer", "gstreamer-check", "once_cell", "serde", "serde_json",]
+
+[[package]]
+name = "gst-plugin-lewton"
+version = "0.10.7"
+dependencies = [ "atomic_refcell", "byte-slice-cast", "gst-plugin-version-helper", "gstreamer", "gstreamer-audio", "gstreamer-check", "lewton", "once_cell",]
+
+[[package]]
+name = "gst-plugin-livesync"
+version = "0.10.7"
+dependencies = [ "gio", "gst-plugin-gtk4", "gst-plugin-version-helper", "gstreamer", "gstreamer-audio", "gstreamer-check", "gtk4", "muldiv", "num-rational", "once_cell", "parking_lot",]
+
+[[package]]
+name = "gst-plugin-mp4"
+version = "0.10.7"
+dependencies = [ "anyhow", "gst-plugin-version-helper", "gstreamer", "gstreamer-audio", "gstreamer-base", "gstreamer-pbutils", "gstreamer-video", "once_cell", "tempfile", "url",]
+
+[[package]]
+name = "gst-plugin-ndi"
+version = "0.10.7"
+dependencies = [ "atomic_refcell", "byte-slice-cast", "byteorder", "glib", "gst-plugin-version-helper", "gstreamer", "gstreamer-audio", "gstreamer-base", "gstreamer-video", "libloading", "once_cell",]
+
+[[package]]
+name = "gst-plugin-onvif"
+version = "0.10.7"
+dependencies = [ "cairo-rs", "chrono", "gst-plugin-version-helper", "gstreamer", "gstreamer-base", "gstreamer-rtp", "gstreamer-video", "once_cell", "pango", "pangocairo", "xmlparser", "xmltree",]
+
+[[package]]
+name = "gst-plugin-png"
+version = "0.10.7"
+dependencies = [ "gst-plugin-version-helper", "gstreamer", "gstreamer-check", "gstreamer-video", "once_cell", "parking_lot", "png",]
+
+[[package]]
+name = "gst-plugin-raptorq"
+version = "0.10.7"
+dependencies = [ "gst-plugin-version-helper", "gstreamer", "gstreamer-base", "gstreamer-check", "gstreamer-rtp", "once_cell", "rand", "raptorq",]
+
+[[package]]
+name = "gst-plugin-rav1e"
+version = "0.10.7"
+dependencies = [ "atomic_refcell", "gst-plugin-version-helper", "gstreamer", "gstreamer-check", "gstreamer-video", "once_cell", "rav1e",]
+
+[[package]]
+name = "gst-plugin-regex"
+version = "0.10.7"
+dependencies = [ "gst-plugin-version-helper", "gstreamer", "gstreamer-check", "once_cell", "regex",]
+
+[[package]]
+name = "gst-plugin-reqwest"
+version = "0.10.7"
+dependencies = [ "futures", "gst-plugin-version-helper", "gstreamer", "gstreamer-base", "headers", "hyper", "mime", "once_cell", "reqwest", "tokio", "url",]
+
+[[package]]
+name = "gst-plugin-rtp"
+version = "0.10.7"
+dependencies = [ "bitstream-io", "chrono", "gst-plugin-version-helper", "gstreamer", "gstreamer-check", "gstreamer-rtp", "once_cell",]
+
+[[package]]
+name = "gst-plugin-sodium"
+version = "0.10.7"
+dependencies = [ "clap", "gst-plugin-version-helper", "gstreamer", "gstreamer-app", "gstreamer-base", "gstreamer-check", "hex", "once_cell", "pretty_assertions", "rand", "serde", "serde_json", "smallvec", "sodiumoxide",]
+
+[[package]]
+name = "gst-plugin-spotify"
+version = "0.10.7"
+dependencies = [ "anyhow", "futures", "gst-plugin-version-helper", "gstreamer", "gstreamer-base", "librespot", "once_cell", "tokio", "url",]
+
+[[package]]
+name = "gst-plugin-textahead"
+version = "0.10.7"
+dependencies = [ "gst-plugin-version-helper", "gstreamer", "once_cell",]
+
+[[package]]
+name = "gst-plugin-textwrap"
+version = "0.10.7"
+dependencies = [ "gst-plugin-version-helper", "gstreamer", "gstreamer-check", "hyphenation", "once_cell", "textwrap",]
+
+[[package]]
+name = "gst-plugin-threadshare"
+version = "0.10.7"
+dependencies = [ "async-task", "cc", "clap", "concurrent-queue", "flume", "futures", "gio", "gst-plugin-version-helper", "gstreamer", "gstreamer-app", "gstreamer-audio", "gstreamer-check", "gstreamer-net", "gstreamer-rtp", "libc", "once_cell", "pin-project-lite", "pkg-config", "polling", "rand", "slab", "socket2 0.5.2", "waker-fn", "winapi",]
+
+[[package]]
+name = "gst-plugin-togglerecord"
+version = "0.10.7"
+dependencies = [ "either", "gio", "gst-plugin-gtk4", "gst-plugin-version-helper", "gstreamer", "gstreamer-audio", "gstreamer-video", "gtk4", "once_cell", "parking_lot",]
+
+[[package]]
+name = "gst-plugin-tracers"
+version = "0.10.7"
+dependencies = [ "anyhow", "gst-plugin-version-helper", "gstreamer", "once_cell", "regex", "signal-hook",]
+
+[[package]]
+name = "gst-plugin-tutorial"
+version = "0.10.7"
+dependencies = [ "byte-slice-cast", "gst-plugin-version-helper", "gstreamer", "gstreamer-audio", "gstreamer-base", "gstreamer-video", "num-traits", "once_cell",]
+
+[[package]]
+name = "gst-plugin-uriplaylistbin"
+version = "0.10.7"
+dependencies = [ "anyhow", "clap", "gst-plugin-version-helper", "gstreamer", "gstreamer-app", "more-asserts", "once_cell", "url",]
+
+[[package]]
+name = "gst-plugin-version-helper"
+version = "0.7.5"
+dependencies = [ "chrono",]
+
+[[package]]
+name = "gst-plugin-videofx"
+version = "0.10.7"
+dependencies = [ "atomic_refcell", "cairo-rs", "color-name", "color-thief", "dssim-core", "gst-plugin-version-helper", "gstreamer", "gstreamer-base", "gstreamer-check", "gstreamer-video", "image", "image_hasher", "once_cell", "rgb",]
+
+[[package]]
+name = "gst-plugin-webp"
+version = "0.10.7"
+dependencies = [ "gst-plugin-version-helper", "gstreamer", "gstreamer-check", "gstreamer-video", "libwebp-sys2", "once_cell", "pretty_assertions",]
+
+[[package]]
+name = "gst-plugin-webrtc"
+version = "0.10.7"
+dependencies = [ "anyhow", "async-tungstenite", "clap", "fastrand", "futures", "gst-plugin-version-helper", "gst-plugin-webrtc-signalling-protocol", "gstreamer", "gstreamer-app", "gstreamer-base", "gstreamer-rtp", "gstreamer-sdp", "gstreamer-utils", "gstreamer-video", "gstreamer-webrtc", "human_bytes", "once_cell", "serde", "serde_json", "thiserror", "tokio", "tokio-native-tls", "tokio-stream", "tracing", "tracing-log", "tracing-subscriber", "url", "uuid",]
+
+[[package]]
+name = "gst-plugin-webrtc-signalling"
+version = "0.10.7"
+dependencies = [ "anyhow", "async-tungstenite", "clap", "futures", "gst-plugin-webrtc-signalling-protocol", "once_cell", "pin-project-lite", "serde", "serde_json", "test-log", "thiserror", "tokio", "tokio-native-tls", "tracing", "tracing-log", "tracing-subscriber", "uuid",]
+
+[[package]]
+name = "gst-plugin-webrtc-signalling-protocol"
+version = "0.10.7"
+dependencies = [ "serde", "serde_json",]
+
+[[package]]
+name = "gst-plugin-webrtchttp"
+version = "0.10.7"
+dependencies = [ "async-recursion", "bytes", "futures", "gst-plugin-version-helper", "gstreamer", "gstreamer-sdp", "gstreamer-webrtc", "once_cell", "parse_link_header", "reqwest", "tokio",]
+
+[[package]]
+name = "gstreamer"
+version = "0.20.5"
+source = "git+https://gitlab.freedesktop.org/gstreamer/gstreamer-rs?branch=0.20#50ec1922855441994c1cbe3e85a584cd91e72ddd"
+dependencies = [ "bitflags", "cfg-if", "futures-channel", "futures-core", "futures-util", "glib", "gstreamer-sys", "libc", "muldiv", "num-integer", "num-rational", "once_cell", "option-operations", "paste", "pretty-hex", "serde", "serde_bytes", "smallvec", "thiserror",]
+
+[[package]]
+name = "gstreamer-app"
+version = "0.20.5"
+source = "git+https://gitlab.freedesktop.org/gstreamer/gstreamer-rs?branch=0.20#50ec1922855441994c1cbe3e85a584cd91e72ddd"
+dependencies = [ "bitflags", "futures-core", "futures-sink", "glib", "gstreamer", "gstreamer-app-sys", "gstreamer-base", "libc", "once_cell",]
+
+[[package]]
+name = "gstreamer-app-sys"
+version = "0.20.5"
+source = "git+https://gitlab.freedesktop.org/gstreamer/gstreamer-rs?branch=0.20#50ec1922855441994c1cbe3e85a584cd91e72ddd"
+dependencies = [ "glib-sys", "gstreamer-base-sys", "gstreamer-sys", "libc", "system-deps",]
+
+[[package]]
+name = "gstreamer-audio"
+version = "0.20.5"
+source = "git+https://gitlab.freedesktop.org/gstreamer/gstreamer-rs?branch=0.20#50ec1922855441994c1cbe3e85a584cd91e72ddd"
+dependencies = [ "bitflags", "cfg-if", "glib", "gstreamer", "gstreamer-audio-sys", "gstreamer-base", "libc", "once_cell",]
+
+[[package]]
+name = "gstreamer-audio-sys"
+version = "0.20.5"
+source = "git+https://gitlab.freedesktop.org/gstreamer/gstreamer-rs?branch=0.20#50ec1922855441994c1cbe3e85a584cd91e72ddd"
+dependencies = [ "glib-sys", "gobject-sys", "gstreamer-base-sys", "gstreamer-sys", "libc", "system-deps",]
+
+[[package]]
+name = "gstreamer-base"
+version = "0.20.5"
+source = "git+https://gitlab.freedesktop.org/gstreamer/gstreamer-rs?branch=0.20#50ec1922855441994c1cbe3e85a584cd91e72ddd"
+dependencies = [ "atomic_refcell", "bitflags", "cfg-if", "glib", "gstreamer", "gstreamer-base-sys", "libc",]
+
+[[package]]
+name = "gstreamer-base-sys"
+version = "0.20.5"
+source = "git+https://gitlab.freedesktop.org/gstreamer/gstreamer-rs?branch=0.20#50ec1922855441994c1cbe3e85a584cd91e72ddd"
+dependencies = [ "glib-sys", "gobject-sys", "gstreamer-sys", "libc", "system-deps",]
+
+[[package]]
+name = "gstreamer-check"
+version = "0.20.5"
+source = "git+https://gitlab.freedesktop.org/gstreamer/gstreamer-rs?branch=0.20#50ec1922855441994c1cbe3e85a584cd91e72ddd"
+dependencies = [ "bitflags", "glib", "gstreamer", "gstreamer-check-sys",]
+
+[[package]]
+name = "gstreamer-check-sys"
+version = "0.20.5"
+source = "git+https://gitlab.freedesktop.org/gstreamer/gstreamer-rs?branch=0.20#50ec1922855441994c1cbe3e85a584cd91e72ddd"
+dependencies = [ "glib-sys", "gobject-sys", "gstreamer-sys", "libc", "system-deps",]
+
+[[package]]
+name = "gstreamer-gl"
+version = "0.20.5"
+source = "git+https://gitlab.freedesktop.org/gstreamer/gstreamer-rs?branch=0.20#50ec1922855441994c1cbe3e85a584cd91e72ddd"
+dependencies = [ "bitflags", "glib", "gstreamer", "gstreamer-base", "gstreamer-gl-sys", "gstreamer-video", "libc", "once_cell",]
+
+[[package]]
+name = "gstreamer-gl-egl"
+version = "0.20.5"
+source = "git+https://gitlab.freedesktop.org/gstreamer/gstreamer-rs?branch=0.20#50ec1922855441994c1cbe3e85a584cd91e72ddd"
+dependencies = [ "glib", "gstreamer", "gstreamer-gl", "gstreamer-gl-egl-sys", "libc",]
+
+[[package]]
+name = "gstreamer-gl-egl-sys"
+version = "0.20.5"
+source = "git+https://gitlab.freedesktop.org/gstreamer/gstreamer-rs?branch=0.20#50ec1922855441994c1cbe3e85a584cd91e72ddd"
+dependencies = [ "glib-sys", "gstreamer-gl-sys", "libc", "system-deps",]
+
+[[package]]
+name = "gstreamer-gl-sys"
+version = "0.20.5"
+source = "git+https://gitlab.freedesktop.org/gstreamer/gstreamer-rs?branch=0.20#50ec1922855441994c1cbe3e85a584cd91e72ddd"
+dependencies = [ "glib-sys", "gobject-sys", "gstreamer-base-sys", "gstreamer-sys", "gstreamer-video-sys", "libc", "system-deps",]
+
+[[package]]
+name = "gstreamer-gl-wayland"
+version = "0.20.5"
+source = "git+https://gitlab.freedesktop.org/gstreamer/gstreamer-rs?branch=0.20#50ec1922855441994c1cbe3e85a584cd91e72ddd"
+dependencies = [ "glib", "gstreamer", "gstreamer-gl", "gstreamer-gl-wayland-sys", "libc",]
+
+[[package]]
+name = "gstreamer-gl-wayland-sys"
+version = "0.20.5"
+source = "git+https://gitlab.freedesktop.org/gstreamer/gstreamer-rs?branch=0.20#50ec1922855441994c1cbe3e85a584cd91e72ddd"
+dependencies = [ "glib-sys", "gstreamer-gl-sys", "libc", "system-deps",]
+
+[[package]]
+name = "gstreamer-gl-x11"
+version = "0.20.5"
+source = "git+https://gitlab.freedesktop.org/gstreamer/gstreamer-rs?branch=0.20#50ec1922855441994c1cbe3e85a584cd91e72ddd"
+dependencies = [ "glib", "gstreamer", "gstreamer-gl", "gstreamer-gl-x11-sys", "libc",]
+
+[[package]]
+name = "gstreamer-gl-x11-sys"
+version = "0.20.5"
+source = "git+https://gitlab.freedesktop.org/gstreamer/gstreamer-rs?branch=0.20#50ec1922855441994c1cbe3e85a584cd91e72ddd"
+dependencies = [ "glib-sys", "gstreamer-gl-sys", "libc", "system-deps",]
+
+[[package]]
+name = "gstreamer-net"
+version = "0.20.5"
+source = "git+https://gitlab.freedesktop.org/gstreamer/gstreamer-rs?branch=0.20#50ec1922855441994c1cbe3e85a584cd91e72ddd"
+dependencies = [ "gio", "glib", "gstreamer", "gstreamer-net-sys",]
+
+[[package]]
+name = "gstreamer-net-sys"
+version = "0.20.5"
+source = "git+https://gitlab.freedesktop.org/gstreamer/gstreamer-rs?branch=0.20#50ec1922855441994c1cbe3e85a584cd91e72ddd"
+dependencies = [ "gio-sys", "glib-sys", "gstreamer-sys", "libc", "system-deps",]
+
+[[package]]
+name = "gstreamer-pbutils"
+version = "0.20.5"
+source = "git+https://gitlab.freedesktop.org/gstreamer/gstreamer-rs?branch=0.20#50ec1922855441994c1cbe3e85a584cd91e72ddd"
+dependencies = [ "bitflags", "glib", "gstreamer", "gstreamer-audio", "gstreamer-pbutils-sys", "gstreamer-video", "libc", "thiserror",]
+
+[[package]]
+name = "gstreamer-pbutils-sys"
+version = "0.20.5"
+source = "git+https://gitlab.freedesktop.org/gstreamer/gstreamer-rs?branch=0.20#50ec1922855441994c1cbe3e85a584cd91e72ddd"
+dependencies = [ "glib-sys", "gobject-sys", "gstreamer-audio-sys", "gstreamer-sys", "gstreamer-video-sys", "libc", "system-deps",]
+
+[[package]]
+name = "gstreamer-rtp"
+version = "0.20.5"
+source = "git+https://gitlab.freedesktop.org/gstreamer/gstreamer-rs?branch=0.20#50ec1922855441994c1cbe3e85a584cd91e72ddd"
+dependencies = [ "bitflags", "glib", "gstreamer", "gstreamer-rtp-sys", "libc", "once_cell",]
+
+[[package]]
+name = "gstreamer-rtp-sys"
+version = "0.20.5"
+source = "git+https://gitlab.freedesktop.org/gstreamer/gstreamer-rs?branch=0.20#50ec1922855441994c1cbe3e85a584cd91e72ddd"
+dependencies = [ "glib-sys", "gstreamer-base-sys", "gstreamer-sys", "libc", "system-deps",]
+
+[[package]]
+name = "gstreamer-sdp"
+version = "0.20.5"
+source = "git+https://gitlab.freedesktop.org/gstreamer/gstreamer-rs?branch=0.20#50ec1922855441994c1cbe3e85a584cd91e72ddd"
+dependencies = [ "glib", "gstreamer", "gstreamer-sdp-sys",]
+
+[[package]]
+name = "gstreamer-sdp-sys"
+version = "0.20.5"
+source = "git+https://gitlab.freedesktop.org/gstreamer/gstreamer-rs?branch=0.20#50ec1922855441994c1cbe3e85a584cd91e72ddd"
+dependencies = [ "glib-sys", "gstreamer-sys", "libc", "system-deps",]
+
+[[package]]
+name = "gstreamer-sys"
+version = "0.20.5"
+source = "git+https://gitlab.freedesktop.org/gstreamer/gstreamer-rs?branch=0.20#50ec1922855441994c1cbe3e85a584cd91e72ddd"
+dependencies = [ "glib-sys", "gobject-sys", "libc", "system-deps",]
+
+[[package]]
+name = "gstreamer-utils"
+version = "0.20.5"
+source = "git+https://gitlab.freedesktop.org/gstreamer/gstreamer-rs?branch=0.20#50ec1922855441994c1cbe3e85a584cd91e72ddd"
+dependencies = [ "gstreamer", "gstreamer-app", "gstreamer-video", "once_cell", "thiserror",]
+
+[[package]]
+name = "gstreamer-video"
+version = "0.20.5"
+source = "git+https://gitlab.freedesktop.org/gstreamer/gstreamer-rs?branch=0.20#50ec1922855441994c1cbe3e85a584cd91e72ddd"
+dependencies = [ "bitflags", "cfg-if", "futures-channel", "glib", "gstreamer", "gstreamer-base", "gstreamer-video-sys", "libc", "once_cell", "serde",]
+
+[[package]]
+name = "gstreamer-video-sys"
+version = "0.20.5"
+source = "git+https://gitlab.freedesktop.org/gstreamer/gstreamer-rs?branch=0.20#50ec1922855441994c1cbe3e85a584cd91e72ddd"
+dependencies = [ "glib-sys", "gobject-sys", "gstreamer-base-sys", "gstreamer-sys", "libc", "system-deps",]
+
+[[package]]
+name = "gstreamer-webrtc"
+version = "0.20.5"
+source = "git+https://gitlab.freedesktop.org/gstreamer/gstreamer-rs?branch=0.20#50ec1922855441994c1cbe3e85a584cd91e72ddd"
+dependencies = [ "glib", "gstreamer", "gstreamer-sdp", "gstreamer-webrtc-sys", "libc",]
+
+[[package]]
+name = "gstreamer-webrtc-sys"
+version = "0.20.5"
+source = "git+https://gitlab.freedesktop.org/gstreamer/gstreamer-rs?branch=0.20#50ec1922855441994c1cbe3e85a584cd91e72ddd"
+dependencies = [ "glib-sys", "gstreamer-sdp-sys", "gstreamer-sys", "libc", "system-deps",]
+
+[[package]]
+name = "gtk4"
+version = "0.6.6"
+source = "git+https://github.com/gtk-rs/gtk4-rs?branch=0.6#484447e0f3614466591534783979677fb089a740"
+dependencies = [ "bitflags", "cairo-rs", "field-offset", "futures-channel", "gdk-pixbuf", "gdk4", "gio", "glib", "graphene-rs", "gsk4", "gtk4-macros", "gtk4-sys", "libc", "once_cell", "pango",]
+
+[[package]]
+name = "gtk4-macros"
+version = "0.6.6"
+source = "git+https://github.com/gtk-rs/gtk4-rs?branch=0.6#484447e0f3614466591534783979677fb089a740"
+dependencies = [ "anyhow", "proc-macro-crate", "proc-macro-error", "proc-macro2", "quote", "syn 1.0.109",]
+
+[[package]]
+name = "gtk4-sys"
+version = "0.6.6"
+source = "git+https://github.com/gtk-rs/gtk4-rs?branch=0.6#484447e0f3614466591534783979677fb089a740"
+dependencies = [ "cairo-sys-rs", "gdk-pixbuf-sys", "gdk4-sys", "gio-sys", "glib-sys", "gobject-sys", "graphene-sys", "gsk4-sys", "libc", "pango-sys", "system-deps",]
+
+[[package]]
+name = "h2"
+version = "0.3.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "17f8a914c2987b688368b5138aa05321db91f4090cf26118185672ad588bce21"
+dependencies = [ "bytes", "fnv", "futures-core", "futures-sink", "futures-util", "http", "indexmap", "slab", "tokio", "tokio-util", "tracing",]
+
+[[package]]
+name = "half"
+version = "2.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02b4af3693f1b705df946e9fe5631932443781d0aabb423b62fcd4d73f6d2fd0"
+dependencies = [ "crunchy",]
+
+[[package]]
+name = "hashbrown"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
+dependencies = [ "ahash",]
+
+[[package]]
+name = "headers"
+version = "0.3.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3e372db8e5c0d213e0cd0b9be18be2aca3d44cf2fe30a9d46a65581cd454584"
+dependencies = [ "base64 0.13.1", "bitflags", "bytes", "headers-core", "http", "httpdate", "mime", "sha1",]
+
+[[package]]
+name = "headers-core"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7f66481bfee273957b1f20485a4ff3362987f85b2c236580d81b4eb7a326429"
+dependencies = [ "http",]
+
+[[package]]
+name = "heck"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
+
+[[package]]
+name = "hermit-abi"
+version = "0.1.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
+dependencies = [ "libc",]
+
+[[package]]
+name = "hermit-abi"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee512640fe35acbfb4bb779db6f0d80704c2cacfa2e39b601ef3e3f47d1ae4c7"
+dependencies = [ "libc",]
+
+[[package]]
+name = "hermit-abi"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fed44880c466736ef9a5c5b5facefb5ed0785676d0c02d612db14e54f0d84286"
+
+[[package]]
+name = "hex"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
+name = "hmac"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a2a2320eb7ec0ebe8da8f744d7812d9fc4cb4d09344ac01898dbcb6a20ae69b"
+dependencies = [ "crypto-mac", "digest 0.9.0",]
+
+[[package]]
+name = "hmac"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
+dependencies = [ "digest 0.10.6",]
+
+[[package]]
+name = "hostname"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c731c3e10504cc8ed35cfe2f1db4c9274c3d35fa486e3b31df46f068ef3e867"
+dependencies = [ "libc", "match_cfg", "winapi",]
+
+[[package]]
+name = "hrtf"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73088c4a5d7c9d21ee942a54611696f247c4bafc85e9261bf8c409b6857e75be"
+dependencies = [ "byteorder", "rubato", "rustfft",]
+
+[[package]]
+name = "http"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd6effc99afb63425aff9b05836f029929e345a6148a14b7ecd5ab67af944482"
+dependencies = [ "bytes", "fnv", "itoa",]
+
+[[package]]
+name = "http-body"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d5f38f16d184e36f2408a55281cd658ecbd3ca05cce6d6510a176eca393e26d1"
+dependencies = [ "bytes", "http", "pin-project-lite",]
+
+[[package]]
+name = "httparse"
+version = "1.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d897f394bad6a705d5f4104762e116a75639e470d80901eed05a860a95cb1904"
+
+[[package]]
+name = "httpdate"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4a1e36c821dbe04574f602848a19f742f4fb3c98d40449f11bcad18d6b17421"
+
+[[package]]
+name = "human_bytes"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27e2b089f28ad15597b48d8c0a8fe94eeb1c1cb26ca99b6f66ac9582ae10c5e6"
+
+[[package]]
+name = "humantime"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
+
+[[package]]
+name = "hyper"
+version = "0.14.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab302d72a6f11a3b910431ff93aae7e773078c769f0a3ef15fb9ec692ed147d4"
+dependencies = [ "bytes", "futures-channel", "futures-core", "futures-util", "h2", "http", "http-body", "httparse", "httpdate", "itoa", "pin-project-lite", "socket2 0.4.9", "tokio", "tower-service", "tracing", "want",]
+
+[[package]]
+name = "hyper-proxy"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca815a891b24fdfb243fa3239c86154392b0953ee584aa1a2a1f66d20cbe75cc"
+dependencies = [ "bytes", "futures", "headers", "http", "hyper", "tokio", "tower-service",]
+
+[[package]]
+name = "hyper-rustls"
+version = "0.23.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1788965e61b367cd03a62950836d5cd41560c3577d90e40e0819373194d1661c"
+dependencies = [ "http", "hyper", "log", "rustls", "rustls-native-certs", "tokio", "tokio-rustls",]
+
+[[package]]
+name = "hyper-tls"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6183ddfa99b85da61a140bea0efc93fdf56ceaa041b37d553518030827f9905"
+dependencies = [ "bytes", "hyper", "native-tls", "tokio", "tokio-native-tls",]
+
+[[package]]
+name = "hyphenation"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bcf4dd4c44ae85155502a52c48739c8a48185d1449fff1963cffee63c28a50f0"
+dependencies = [ "bincode", "fst", "hyphenation_commons", "pocket-resources", "serde",]
+
+[[package]]
+name = "hyphenation_commons"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5febe7a2ade5c7d98eb8b75f946c046b335324b06a14ea0998271504134c05bf"
+dependencies = [ "fst", "serde",]
+
+[[package]]
+name = "iana-time-zone"
+version = "0.1.56"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0722cd7114b7de04316e7ea5456a0bbb20e4adb46fd27a3697adb812cff0f37c"
+dependencies = [ "android_system_properties", "core-foundation-sys", "iana-time-zone-haiku", "js-sys", "wasm-bindgen", "windows",]
+
+[[package]]
+name = "iana-time-zone-haiku"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0703ae284fc167426161c2e3f1da3ea71d94b21bedbcc9494e92b28e334e3dca"
+dependencies = [ "cxx", "cxx-build",]
+
+[[package]]
+name = "idna"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "418a0a6fab821475f634efe3ccc45c013f742efe03d853e8d3355d5cb850ecf8"
+dependencies = [ "matches", "unicode-bidi", "unicode-normalization",]
+
+[[package]]
+name = "idna"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e14ddfc70884202db2244c223200c204c2bda1bc6e0998d11b5e024d657209e6"
+dependencies = [ "unicode-bidi", "unicode-normalization",]
+
+[[package]]
+name = "if-addrs"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cbc0fa01ffc752e9dbc72818cdb072cd028b86be5e09dd04c5a643704fe101a9"
+dependencies = [ "libc", "winapi",]
+
+[[package]]
+name = "image"
+version = "0.24.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "527909aa81e20ac3a44803521443a765550f09b5130c2c2fa1ea59c2f8f50a3a"
+dependencies = [ "bytemuck", "byteorder", "color_quant", "exr", "gif", "jpeg-decoder", "num-rational", "num-traits", "png", "qoi", "tiff",]
+
+[[package]]
+name = "image_hasher"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a465709ca502270eba7ae8129c6a680f5668748d7edafa85da0f8ceae596bb2b"
+dependencies = [ "base64 0.13.1", "image", "rustdct", "serde", "transpose",]
+
+[[package]]
+name = "imgref"
+version = "1.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2cf49df1085dcfb171460e4592597b84abe50d900fb83efb6e41b20fefd6c2c"
+
+[[package]]
+name = "indexmap"
+version = "1.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
+dependencies = [ "autocfg", "hashbrown",]
+
+[[package]]
+name = "instant"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a5bbe824c507c5da5956355e86a746d82e0e1464f65d862cc5e71da70e94b2c"
+dependencies = [ "cfg-if",]
+
+[[package]]
+name = "interpolate_name"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4b35f4a811037cfdcd44c5db40678464b2d5d248fc1abeeaaa125b370d47f17"
+dependencies = [ "proc-macro2", "quote", "syn 1.0.109",]
+
+[[package]]
+name = "io-lifetimes"
+version = "1.0.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c66c74d2ae7e79a5a8f7ac924adbe38ee42a859c6539ad869eb51f0b52dc220"
+dependencies = [ "hermit-abi 0.3.1", "libc", "windows-sys 0.48.0",]
+
+[[package]]
+name = "ipnet"
+version = "2.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12b6ee2129af8d4fb011108c73d99a1b83a85977f23b82460c0ae2e25bb4b57f"
+
+[[package]]
+name = "is-terminal"
+version = "0.4.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "adcf93614601c8129ddf72e2d5633df827ba6551541c6d8c59520a371475be1f"
+dependencies = [ "hermit-abi 0.3.1", "io-lifetimes", "rustix", "windows-sys 0.48.0",]
+
+[[package]]
+name = "itertools"
+version = "0.10.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
+dependencies = [ "either",]
+
+[[package]]
+name = "itoa"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "453ad9f582a441959e5f0d088b02ce04cfe8d51a8eaf077f12ac6d3e94164ca6"
+
+[[package]]
+name = "jobserver"
+version = "0.1.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "936cfd212a0155903bcbc060e316fb6cc7cbf2e1907329391ebadc1fe0ce77c2"
+dependencies = [ "libc",]
+
+[[package]]
+name = "jpeg-decoder"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc0000e42512c92e31c2252315bda326620a4e034105e900c98ec492fa077b3e"
+dependencies = [ "rayon",]
+
+[[package]]
+name = "js-sys"
+version = "0.3.61"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "445dde2150c55e483f3d8416706b97ec8e8237c307e5b7b4b8dd15e6af2a0730"
+dependencies = [ "wasm-bindgen",]
+
+[[package]]
+name = "lazy_static"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
+
+[[package]]
+name = "lebe"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "03087c2bad5e1034e8cace5926dec053fb3790248370865f5117a7d0213354c8"
+
+[[package]]
+name = "lewton"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "777b48df9aaab155475a83a7df3070395ea1ac6902f5cd062b8f2b028075c030"
+dependencies = [ "byteorder", "ogg", "tinyvec",]
+
+[[package]]
+name = "libc"
+version = "0.2.144"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b00cc1c228a6782d0f076e7b232802e0c5689d41bb5df366f2a6b6621cfdfe1"
+
+[[package]]
+name = "libfuzzer-sys"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fcf184a4b6b274f82a5df6b357da6055d3e82272327bba281c28bbba6f1664ef"
+dependencies = [ "arbitrary", "cc",]
+
+[[package]]
+name = "libloading"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d580318f95776505201b28cf98eb1fa5e4be3b689633ba6a3e6cd880ff22d8cb"
+dependencies = [ "cfg-if", "windows-sys 0.48.0",]
+
+[[package]]
+name = "libm"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "348108ab3fba42ec82ff6e9564fc4ca0247bdccdc68dd8af9764bbc79c3c8ffb"
+
+[[package]]
+name = "libmdns"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b04ae6b56b3b19ade26f0e7e7c1360a1713514f326c5ed0797cf2c109c9e010"
+dependencies = [ "byteorder", "futures-util", "hostname", "if-addrs", "log", "multimap", "nix", "rand", "socket2 0.4.9", "thiserror", "tokio", "winapi",]
+
+[[package]]
+name = "librespot"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea4c9952ef48968f8184a4a87f8576982426ebe623342d5a28f7d9c4978e4a44"
+dependencies = [ "base64 0.13.1", "env_logger 0.9.3", "futures-util", "getopts", "hex", "hyper", "librespot-audio", "librespot-connect", "librespot-core", "librespot-discovery", "librespot-metadata", "librespot-playback", "librespot-protocol", "log", "rpassword", "sha-1", "thiserror", "tokio", "url",]
+
+[[package]]
+name = "librespot-audio"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c176a31355e1ea8e0b9c4ced19df4947bfe4770661c25c142b6fba2365940d9d"
+dependencies = [ "aes-ctr", "byteorder", "bytes", "futures-util", "librespot-core", "log", "tempfile", "tokio",]
+
+[[package]]
+name = "librespot-connect"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ffafb6a443e9445ccb3d5d591573b5b1da3c89a9b8846c63ba2c3710210d3ec"
+dependencies = [ "form_urlencoded", "futures-util", "librespot-core", "librespot-discovery", "librespot-playback", "librespot-protocol", "log", "protobuf", "rand", "serde", "serde_json", "tokio", "tokio-stream",]
+
+[[package]]
+name = "librespot-core"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "046349f25888e644bf02d9c5de0164b2a493d29aa4ce18e1ad0b756da9b55d6d"
+dependencies = [ "aes", "base64 0.13.1", "byteorder", "bytes", "form_urlencoded", "futures-core", "futures-util", "hmac 0.11.0", "http", "httparse", "hyper", "hyper-proxy", "librespot-protocol", "log", "num-bigint", "num-integer", "num-traits", "once_cell", "pbkdf2", "priority-queue", "protobuf", "rand", "serde", "serde_json", "sha-1", "shannon", "thiserror", "tokio", "tokio-stream", "tokio-util", "url", "uuid", "vergen",]
+
+[[package]]
+name = "librespot-discovery"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2aa877d18f6150364012cb4be5682d62d7c712c88bae2d0d01720fd7c15e2f06"
+dependencies = [ "aes-ctr", "base64 0.13.1", "form_urlencoded", "futures-core", "hmac 0.11.0", "hyper", "libmdns", "librespot-core", "log", "rand", "serde_json", "sha-1", "thiserror", "tokio",]
+
+[[package]]
+name = "librespot-metadata"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b80361fcbcb5092056fd47c08c34d5d51b08385d8efb6941c0d3e46d032c21c"
+dependencies = [ "async-trait", "byteorder", "librespot-core", "librespot-protocol", "log", "protobuf",]
+
+[[package]]
+name = "librespot-playback"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5190a0b9bcc7f70ee4196a6b4a1c731d405ca130d4a6fcd4c561cfdde8b7cfb7"
+dependencies = [ "byteorder", "futures-executor", "futures-util", "lewton", "librespot-audio", "librespot-core", "librespot-metadata", "log", "ogg", "parking_lot", "rand", "rand_distr", "shell-words", "thiserror", "tokio", "zerocopy",]
+
+[[package]]
+name = "librespot-protocol"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d6d3ac6196ac0ea67bbe039f56d6730a5d8b31502ef9bce0f504ed729dcb39f"
+dependencies = [ "glob", "protobuf", "protobuf-codegen-pure",]
+
+[[package]]
+name = "libsodium-sys"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b779387cd56adfbc02ea4a668e704f729be8d6a6abd2c27ca5ee537849a92fd"
+dependencies = [ "cc", "libc", "pkg-config", "walkdir",]
+
+[[package]]
+name = "libwebp-sys2"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74f9c6964201c51319f16a796dc947a73961646eba49f584187b12de9970d077"
+dependencies = [ "cc", "cfg-if", "libc", "pkg-config", "vcpkg",]
+
+[[package]]
+name = "link-cplusplus"
+version = "1.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ecd207c9c713c34f95a097a5b029ac2ce6010530c7b49d7fea24d977dede04f5"
+dependencies = [ "cc",]
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ece97ea872ece730aed82664c424eb4c8291e1ff2480247ccf7409044bc6479f"
+
+[[package]]
+name = "lock_api"
+version = "0.4.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "435011366fe56583b16cf956f9df0095b405b82d76425bc8981c0e22e60ec4df"
+dependencies = [ "autocfg", "scopeguard",]
+
+[[package]]
+name = "log"
+version = "0.4.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "abb12e687cfb44aa40f41fc3978ef76448f9b6038cad6aef4259d3c095a2382e"
+dependencies = [ "cfg-if",]
+
+[[package]]
+name = "m3u8-rs"
+version = "5.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d39af8845edca961e3286dcbafeb9e6407d3df6a616ef086847162d46f438d75"
+dependencies = [ "chrono", "nom",]
+
+[[package]]
+name = "match_cfg"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ffbee8634e0d45d258acb448e7eaab3fce7a0a467395d4d9f228e3c1f01fb2e4"
+
+[[package]]
+name = "matchers"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8263075bb86c5a1b1427b5ae862e8889656f126e9f77c484496e8b47cf5c5558"
+dependencies = [ "regex-automata",]
+
+[[package]]
+name = "matches"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2532096657941c2fea9c289d370a250971c689d4f143798ff67113ec042024a5"
+
+[[package]]
+name = "maybe-rayon"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ea1f30cedd69f0a2954655f7188c6a834246d2bcf1e315e2ac40c4b24dc9519"
+dependencies = [ "cfg-if", "rayon",]
+
+[[package]]
+name = "md-5"
+version = "0.10.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6365506850d44bff6e2fbcb5176cf63650e48bd45ef2fe2665ae1570e0f4b9ca"
+dependencies = [ "digest 0.10.6",]
+
+[[package]]
+name = "memchr"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
+
+[[package]]
+name = "memoffset"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5aa361d4faea93603064a027415f07bd8e1d5c88c9fbf68bf56a285428fd79ce"
+dependencies = [ "autocfg",]
+
+[[package]]
+name = "memoffset"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d61c719bcfbcf5d62b3a09efa6088de8c54bc0bfcd3ea7ae39fcc186108b8de1"
+dependencies = [ "autocfg",]
+
+[[package]]
+name = "mime"
+version = "0.3.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
+
+[[package]]
+name = "minimal-lexical"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
+
+[[package]]
+name = "miniz_oxide"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b275950c28b37e794e8c55d88aeb5e139d0ce23fdbbeda68f8d7174abdf9e8fa"
+dependencies = [ "adler",]
+
+[[package]]
+name = "miniz_oxide"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7810e0be55b428ada41041c41f32c9f1a42817901b4ccf45fa3d4b6561e74c7"
+dependencies = [ "adler", "simd-adler32",]
+
+[[package]]
+name = "mio"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b9d9a46eff5b4ff64b45a9e316a6d1e0bc719ef429cbec4dc630684212bfdf9"
+dependencies = [ "libc", "log", "wasi 0.11.0+wasi-snapshot-preview1", "windows-sys 0.45.0",]
+
+[[package]]
+name = "more-asserts"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fafa6961cabd9c63bcd77a45d7e3b7f3b552b70417831fb0f56db717e72407e"
+
+[[package]]
+name = "muldiv"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "956787520e75e9bd233246045d19f42fb73242759cc57fba9611d940ae96d4b0"
+
+[[package]]
+name = "multimap"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5ce46fe64a9d73be07dcbe690a38ce1b293be448fd8ce1e6c1b8062c9f72c6a"
+dependencies = [ "serde",]
+
+[[package]]
+name = "nanorand"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a51313c5820b0b02bd422f4b44776fbf47961755c74ce64afc73bfad10226c3"
+dependencies = [ "getrandom",]
+
+[[package]]
+name = "nasm-rs"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe4d98d0065f4b1daf164b3eafb11974c94662e5e2396cf03f32d0bb5c17da51"
+dependencies = [ "rayon",]
+
+[[package]]
+name = "native-tls"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07226173c32f2926027b63cce4bcd8076c3552846cbe7925f3aaffeac0a3b92e"
+dependencies = [ "lazy_static", "libc", "log", "openssl", "openssl-probe", "openssl-sys", "schannel", "security-framework", "security-framework-sys", "tempfile",]
+
+[[package]]
+name = "new_debug_unreachable"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e4a24736216ec316047a1fc4252e27dabb04218aa4a3f37c6e7ddbf1f9782b54"
+
+[[package]]
+name = "nix"
+version = "0.23.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f3790c00a0150112de0f4cd161e3d7fc4b2d8a5542ffc35f099a2562aecb35c"
+dependencies = [ "bitflags", "cc", "cfg-if", "libc", "memoffset 0.6.5",]
+
+[[package]]
+name = "nnnoiseless"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23d377ce2fb579ed5c14cfa0d39e70849030fdf673d6d1a764cadb2dfbb02a50"
+dependencies = [ "once_cell", "rustfft",]
+
+[[package]]
+name = "nom"
+version = "7.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
+dependencies = [ "memchr", "minimal-lexical",]
+
+[[package]]
+name = "noop_proc_macro"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0676bb32a98c1a483ce53e500a81ad9c3d5b3f7c920c28c24e9cb0980d0b5bc8"
+
+[[package]]
+name = "nu-ansi-term"
+version = "0.46.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77a8165726e8236064dbb45459242600304b42a5ea24ee2948e18e023bf7ba84"
+dependencies = [ "overload", "winapi",]
+
+[[package]]
+name = "num-bigint"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f93ab6289c7b344a8a9f60f88d80aa20032336fe78da341afc91c8a2341fc75f"
+dependencies = [ "autocfg", "num-integer", "num-traits", "rand",]
+
+[[package]]
+name = "num-complex"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02e0d21255c828d6f128a1e41534206671e8c3ea0c62f32291e808dc82cff17d"
+dependencies = [ "num-traits",]
+
+[[package]]
+name = "num-derive"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "876a53fff98e03a936a674b29568b0e605f06b29372c2489ff4de23f1949743d"
+dependencies = [ "proc-macro2", "quote", "syn 1.0.109",]
+
+[[package]]
+name = "num-integer"
+version = "0.1.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "225d3389fb3509a24c93f5c29eb6bde2586b98d9f016636dff58d7c6f7569cd9"
+dependencies = [ "autocfg", "num-traits",]
+
+[[package]]
+name = "num-rational"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0638a1c9d0a3c0914158145bc76cff373a75a627e6ecbfb71cbe6f453a5a19b0"
+dependencies = [ "autocfg", "num-bigint", "num-integer", "num-traits", "serde",]
+
+[[package]]
+name = "num-traits"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "578ede34cf02f8924ab9447f50c28075b4d3e5b269972345e7e0372b38c6cdcd"
+dependencies = [ "autocfg", "libm",]
+
+[[package]]
+name = "num_cpus"
+version = "1.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fac9e2da13b5eb447a6ce3d392f23a29d8694bff781bf03a16cd9ac8697593b"
+dependencies = [ "hermit-abi 0.2.6", "libc",]
+
+[[package]]
+name = "object"
+version = "0.30.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea86265d3d3dcb6a27fc51bd29a4bf387fae9d2986b823079d4986af253eb439"
+dependencies = [ "memchr",]
+
+[[package]]
+name = "ogg"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6951b4e8bf21c8193da321bcce9c9dd2e13c858fe078bf9054a288b419ae5d6e"
+dependencies = [ "byteorder",]
+
+[[package]]
+name = "once_cell"
+version = "1.17.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7e5500299e16ebb147ae15a00a942af264cf3688f47923b8fc2cd5858f23ad3"
+
+[[package]]
+name = "opaque-debug"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
+
+[[package]]
+name = "openssl"
+version = "0.10.52"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "01b8574602df80f7b85fdfc5392fa884a4e3b3f4f35402c070ab34c3d3f78d56"
+dependencies = [ "bitflags", "cfg-if", "foreign-types", "libc", "once_cell", "openssl-macros", "openssl-sys",]
+
+[[package]]
+name = "openssl-macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
+dependencies = [ "proc-macro2", "quote", "syn 2.0.15",]
+
+[[package]]
+name = "openssl-probe"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
+
+[[package]]
+name = "openssl-sys"
+version = "0.9.87"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e17f59264b2809d77ae94f0e1ebabc434773f370d6ca667bd223ea10e06cc7e"
+dependencies = [ "cc", "libc", "pkg-config", "vcpkg",]
+
+[[package]]
+name = "option-operations"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c26d27bb1aeab65138e4bf7666045169d1717febcc9ff870166be8348b223d0"
+dependencies = [ "paste",]
+
+[[package]]
+name = "output_vt100"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "628223faebab4e3e40667ee0b2336d34a5b960ff60ea743ddfdbcf7770bcfb66"
+dependencies = [ "winapi",]
+
+[[package]]
+name = "outref"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4030760ffd992bef45b0ae3f10ce1aba99e33464c90d14dd7c039884963ddc7a"
+
+[[package]]
+name = "overload"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
+
+[[package]]
+name = "pango"
+version = "0.17.9"
+source = "git+https://github.com/gtk-rs/gtk-rs-core?branch=0.17#3ad562c758bf7b2452827c2e6d35e4effce23f71"
+dependencies = [ "bitflags", "gio", "glib", "libc", "once_cell", "pango-sys",]
+
+[[package]]
+name = "pango-sys"
+version = "0.17.9"
+source = "git+https://github.com/gtk-rs/gtk-rs-core?branch=0.17#3ad562c758bf7b2452827c2e6d35e4effce23f71"
+dependencies = [ "glib-sys", "gobject-sys", "libc", "system-deps",]
+
+[[package]]
+name = "pangocairo"
+version = "0.17.9"
+source = "git+https://github.com/gtk-rs/gtk-rs-core?branch=0.17#3ad562c758bf7b2452827c2e6d35e4effce23f71"
+dependencies = [ "bitflags", "cairo-rs", "glib", "libc", "pango", "pangocairo-sys",]
+
+[[package]]
+name = "pangocairo-sys"
+version = "0.17.9"
+source = "git+https://github.com/gtk-rs/gtk-rs-core?branch=0.17#3ad562c758bf7b2452827c2e6d35e4effce23f71"
+dependencies = [ "cairo-sys-rs", "glib-sys", "libc", "pango-sys", "system-deps",]
+
+[[package]]
+name = "parking_lot"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3742b2c103b9f06bc9fff0a37ff4912935851bee6d36f3c02bcc755bcfec228f"
+dependencies = [ "lock_api", "parking_lot_core",]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.9.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9069cbb9f99e3a5083476ccb29ceb1de18b9118cafa53e90c9551235de2b9521"
+dependencies = [ "backtrace", "cfg-if", "libc", "petgraph", "redox_syscall 0.2.16", "smallvec", "thread-id", "windows-sys 0.45.0",]
+
+[[package]]
+name = "parse_link_header"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3687fe9debbbf2a019f381a8bc6b42049b22647449b39af54b3013985c0cf6de"
+dependencies = [ "http", "lazy_static", "regex", "url",]
+
+[[package]]
+name = "paste"
+version = "1.0.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f746c4065a8fa3fe23974dd82f15431cc8d40779821001404d10d2e79ca7d79"
+
+[[package]]
+name = "pbkdf2"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d95f5254224e617595d2cc3cc73ff0a5eaf2637519e25f03388154e9378b6ffa"
+dependencies = [ "crypto-mac", "hmac 0.11.0",]
+
+[[package]]
+name = "percent-encoding"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "478c572c3d73181ff3c2539045f6eb99e5491218eae919370993b890cdbdd98e"
+
+[[package]]
+name = "petgraph"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4dd7d28ee937e54fe3080c91faa1c3a46c06de6252988a7f4592ba2310ef22a4"
+dependencies = [ "fixedbitset", "indexmap",]
+
+[[package]]
+name = "pin-project"
+version = "1.0.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad29a609b6bcd67fee905812e544992d216af9d755757c05ed2d0e15a74c6ecc"
+dependencies = [ "pin-project-internal",]
+
+[[package]]
+name = "pin-project-internal"
+version = "1.0.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "069bdb1e05adc7a8990dce9cc75370895fbe4e3d58b9b73bf1aee56359344a55"
+dependencies = [ "proc-macro2", "quote", "syn 1.0.109",]
+
+[[package]]
+name = "pin-project-lite"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0a7ae3ac2f1173085d398531c705756c94a4c56843785df85a60c1a0afac116"
+
+[[package]]
+name = "pin-utils"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+
+[[package]]
+name = "pkg-config"
+version = "0.3.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26072860ba924cbfa98ea39c8c19b4dd6a4a25423dbdf219c1eca91aa0cf6964"
+
+[[package]]
+name = "png"
+version = "0.17.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aaeebc51f9e7d2c150d3f3bfeb667f2aa985db5ef1e3d212847bdedb488beeaa"
+dependencies = [ "bitflags", "crc32fast", "fdeflate", "flate2", "miniz_oxide 0.7.1",]
+
+[[package]]
+name = "pocket-resources"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c135f38778ad324d9e9ee68690bac2c1a51f340fdf96ca13e2ab3914eb2e51d8"
+
+[[package]]
+name = "polling"
+version = "2.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b2d323e8ca7996b3e23126511a523f7e62924d93ecd5ae73b333815b0eb3dce"
+dependencies = [ "autocfg", "bitflags", "cfg-if", "concurrent-queue", "libc", "log", "pin-project-lite", "windows-sys 0.48.0",]
+
+[[package]]
+name = "ppv-lite86"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
+
+[[package]]
+name = "pretty-hex"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6fa0831dd7cc608c38a5e323422a0077678fa5744aa2be4ad91c4ece8eec8d5"
+
+[[package]]
+name = "pretty_assertions"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a25e9bcb20aa780fd0bb16b72403a9064d6b3f22f026946029acb941a50af755"
+dependencies = [ "ctor", "diff", "output_vt100", "yansi",]
+
+[[package]]
+name = "primal-check"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9df7f93fd637f083201473dab4fee2db4c429d32e55e3299980ab3957ab916a0"
+dependencies = [ "num-integer",]
+
+[[package]]
+name = "priority-queue"
+version = "1.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ca9c6be70d989d21a136eb86c2d83e4b328447fac4a88dace2143c179c86267"
+dependencies = [ "autocfg", "indexmap",]
+
+[[package]]
+name = "proc-macro-crate"
+version = "1.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f4c021e1093a56626774e81216a4ce732a735e5bad4868a03f3ed65ca0c3919"
+dependencies = [ "once_cell", "toml_edit",]
+
+[[package]]
+name = "proc-macro-error"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
+dependencies = [ "proc-macro-error-attr", "proc-macro2", "quote", "syn 1.0.109", "version_check",]
+
+[[package]]
+name = "proc-macro-error-attr"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
+dependencies = [ "proc-macro2", "quote", "version_check",]
+
+[[package]]
+name = "proc-macro2"
+version = "1.0.56"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b63bdb0cd06f1f4dedf69b254734f9b45af66e4a031e42a7480257d9898b435"
+dependencies = [ "unicode-ident",]
+
+[[package]]
+name = "protobuf"
+version = "2.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "106dd99e98437432fed6519dedecfade6a06a73bb7b2a1e019fdd2bee5778d94"
+
+[[package]]
+name = "protobuf-codegen"
+version = "2.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "033460afb75cf755fcfc16dfaed20b86468082a2ea24e05ac35ab4a099a017d6"
+dependencies = [ "protobuf",]
+
+[[package]]
+name = "protobuf-codegen-pure"
+version = "2.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95a29399fc94bcd3eeaa951c715f7bea69409b2445356b00519740bcd6ddd865"
+dependencies = [ "protobuf", "protobuf-codegen",]
+
+[[package]]
+name = "psl-types"
+version = "2.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33cb294fe86a74cbcf50d4445b37da762029549ebeea341421c7c70370f86cac"
+
+[[package]]
+name = "publicsuffix"
+version = "2.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96a8c1bda5ae1af7f99a2962e49df150414a43d62404644d98dd5c3a93d07457"
+dependencies = [ "idna 0.3.0", "psl-types",]
+
+[[package]]
+name = "qoi"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f6d64c71eb498fe9eae14ce4ec935c555749aef511cca85b5568910d6e48001"
+dependencies = [ "bytemuck",]
+
+[[package]]
+name = "quote"
+version = "1.0.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f4f29d145265ec1c483c7c654450edde0bfe043d3938d6972630663356d9500"
+dependencies = [ "proc-macro2",]
+
+[[package]]
+name = "rand"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+dependencies = [ "libc", "rand_chacha", "rand_core",]
+
+[[package]]
+name = "rand_chacha"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+dependencies = [ "ppv-lite86", "rand_core",]
+
+[[package]]
+name = "rand_core"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+dependencies = [ "getrandom",]
+
+[[package]]
+name = "rand_distr"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32cb0b9bc82b0a0876c2dd994a7e7a2683d3e7390ca40e6886785ef0c7e3ee31"
+dependencies = [ "num-traits", "rand",]
+
+[[package]]
+name = "raptorq"
+version = "1.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "655b020bbf5c89791160a30f0d4706d8ec7aa5718d6a198f6df19c400e4f4470"
+
+[[package]]
+name = "rav1e"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1958c98fa048e4a52218524b3688474943507e25caf29d333ad85aa8a43575de"
+dependencies = [ "arbitrary", "arg_enum_proc_macro", "arrayvec", "av1-grain", "bitstream-io", "built", "cc", "cfg-if", "interpolate_name", "itertools", "libc", "libfuzzer-sys", "log", "maybe-rayon", "nasm-rs", "new_debug_unreachable", "noop_proc_macro", "num-derive", "num-traits", "once_cell", "paste", "rand", "rand_chacha", "rust_hawktracer", "rustc_version", "simd_helpers", "system-deps", "thiserror", "v_frame",]
+
+[[package]]
+name = "rayon"
+version = "1.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d2df5196e37bcc87abebc0053e20787d73847bb33134a69841207dd0a47f03b"
+dependencies = [ "either", "rayon-core",]
+
+[[package]]
+name = "rayon-core"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b8f95bd6966f5c87776639160a66bd8ab9895d9d4ab01ddba9fc60661aebe8d"
+dependencies = [ "crossbeam-channel", "crossbeam-deque", "crossbeam-utils", "num_cpus",]
+
+[[package]]
+name = "realfft"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7695c87f31dc3644760f23fb59a3fed47659703abf76cf2d111f03b9e712342"
+dependencies = [ "rustfft",]
+
+[[package]]
+name = "redox_syscall"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb5a58c1855b4b6819d59012155603f0b22ad30cad752600aadfcb695265519a"
+dependencies = [ "bitflags",]
+
+[[package]]
+name = "redox_syscall"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "567664f262709473930a4bf9e51bf2ebf3348f2e748ccc50dea20646858f8f29"
+dependencies = [ "bitflags",]
+
+[[package]]
+name = "regex"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af83e617f331cc6ae2da5443c602dfa5af81e517212d9d611a5b3ba1777b5370"
+dependencies = [ "aho-corasick", "memchr", "regex-syntax 0.7.1",]
+
+[[package]]
+name = "regex-automata"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c230d73fb8d8c1b9c0b3135c5142a8acee3a0558fb8db5cf1cb65f8d7862132"
+dependencies = [ "regex-syntax 0.6.29",]
+
+[[package]]
+name = "regex-syntax"
+version = "0.6.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
+
+[[package]]
+name = "regex-syntax"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5996294f19bd3aae0453a862ad728f60e6600695733dd5df01da90c54363a3c"
+
+[[package]]
+name = "reqwest"
+version = "0.11.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13293b639a097af28fc8a90f22add145a9c954e49d77da06263d58cf44d5fb91"
+dependencies = [ "async-compression", "base64 0.21.0", "bytes", "cookie", "cookie_store", "encoding_rs", "futures-core", "futures-util", "h2", "http", "http-body", "hyper", "hyper-tls", "ipnet", "js-sys", "log", "mime", "native-tls", "once_cell", "percent-encoding", "pin-project-lite", "serde", "serde_json", "serde_urlencoded", "tokio", "tokio-native-tls", "tokio-util", "tower-service", "url", "wasm-bindgen", "wasm-bindgen-futures", "web-sys", "winreg",]
+
+[[package]]
+name = "rgb"
+version = "0.8.36"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "20ec2d3e3fc7a92ced357df9cebd5a10b6fb2aa1ee797bf7e9ce2f17dffc8f59"
+dependencies = [ "bytemuck",]
+
+[[package]]
+name = "ring"
+version = "0.16.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3053cf52e236a3ed746dfc745aa9cacf1b791d846bdaf412f60a8d7d6e17c8fc"
+dependencies = [ "cc", "libc", "once_cell", "spin 0.5.2", "untrusted", "web-sys", "winapi",]
+
+[[package]]
+name = "rpassword"
+version = "6.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2bf099a1888612545b683d2661a1940089f6c2e5a8e38979b2159da876bfd956"
+dependencies = [ "libc", "serde", "serde_json", "winapi",]
+
+[[package]]
+name = "rubato"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "610bbefcfef7f43cbe275995b6077b74f34480efce293c30327bf44fdad871ed"
+dependencies = [ "log", "num-complex", "num-integer", "num-traits", "realfft",]
+
+[[package]]
+name = "rust_hawktracer"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3480a29b927f66c6e06527be7f49ef4d291a01d694ec1fe85b0de71d6b02ac1"
+dependencies = [ "rust_hawktracer_normal_macro", "rust_hawktracer_proc_macro",]
+
+[[package]]
+name = "rust_hawktracer_normal_macro"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a570059949e1dcdc6f35228fa389f54c2c84dfe0c94c05022baacd56eacd2e9"
+
+[[package]]
+name = "rust_hawktracer_proc_macro"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb626abdbed5e93f031baae60d72032f56bc964e11ac2ff65f2ba3ed98d6d3e1"
+
+[[package]]
+name = "rustc-demangle"
+version = "0.1.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d626bb9dae77e28219937af045c257c28bfd3f69333c512553507f5f9798cb76"
+
+[[package]]
+name = "rustc_version"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfa0f585226d2e68097d4f95d113b15b83a82e819ab25717ec0590d9584ef366"
+dependencies = [ "semver",]
+
+[[package]]
+name = "rustdct"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b61555105d6a9bf98797c063c362a1d24ed8ab0431655e38f1cf51e52089551"
+dependencies = [ "rustfft",]
+
+[[package]]
+name = "rustfft"
+version = "6.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e17d4f6cbdb180c9f4b2a26bbf01c4e647f1e1dea22fe8eb9db54198b32f9434"
+dependencies = [ "num-complex", "num-integer", "num-traits", "primal-check", "strength_reduce", "transpose", "version_check",]
+
+[[package]]
+name = "rustix"
+version = "0.37.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acf8729d8542766f1b2cf77eb034d52f40d375bb8b615d0b147089946e16613d"
+dependencies = [ "bitflags", "errno", "io-lifetimes", "libc", "linux-raw-sys", "windows-sys 0.48.0",]
+
+[[package]]
+name = "rustls"
+version = "0.20.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fff78fc74d175294f4e83b28343315ffcfb114b156f0185e9741cb5570f50e2f"
+dependencies = [ "log", "ring", "sct", "webpki",]
+
+[[package]]
+name = "rustls-native-certs"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0167bac7a9f490495f3c33013e7722b53cb087ecbe082fb0c6387c96f634ea50"
+dependencies = [ "openssl-probe", "rustls-pemfile", "schannel", "security-framework",]
+
+[[package]]
+name = "rustls-pemfile"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d194b56d58803a43635bdc398cd17e383d6f71f9182b9a192c127ca42494a59b"
+dependencies = [ "base64 0.21.0",]
+
+[[package]]
+name = "ryu"
+version = "1.0.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f91339c0467de62360649f8d3e185ca8de4224ff281f66000de5eb2a77a79041"
+
+[[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [ "winapi-util",]
+
+[[package]]
+name = "schannel"
+version = "0.1.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "713cfb06c7059f3588fb8044c0fad1d09e3c01d225e25b9220dbfdcf16dbb1b3"
+dependencies = [ "windows-sys 0.42.0",]
+
+[[package]]
+name = "scopeguard"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
+
+[[package]]
+name = "scratch"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1792db035ce95be60c3f8853017b3999209281c24e2ba5bc8e59bf97a0c590c1"
+
+[[package]]
+name = "sct"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d53dcdb7c9f8158937a7981b48accfd39a43af418591a5d008c7b22b5e1b7ca4"
+dependencies = [ "ring", "untrusted",]
+
+[[package]]
+name = "security-framework"
+version = "2.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a332be01508d814fed64bf28f798a146d73792121129962fdf335bb3c49a4254"
+dependencies = [ "bitflags", "core-foundation", "core-foundation-sys", "libc", "security-framework-sys",]
+
+[[package]]
+name = "security-framework-sys"
+version = "2.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "31c9bb296072e961fcbd8853511dd39c2d8be2deb1e17c6860b1d30732b323b4"
+dependencies = [ "core-foundation-sys", "libc",]
+
+[[package]]
+name = "semver"
+version = "1.0.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bebd363326d05ec3e2f532ab7660680f3b02130d780c299bca73469d521bc0ed"
+dependencies = [ "serde",]
+
+[[package]]
+name = "serde"
+version = "1.0.162"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71b2f6e1ab5c2b98c05f0f35b236b22e8df7ead6ffbf51d7808da7f8817e7ab6"
+dependencies = [ "serde_derive",]
+
+[[package]]
+name = "serde_bytes"
+version = "0.11.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "416bda436f9aab92e02c8e10d49a15ddd339cea90b6e340fe51ed97abb548294"
+dependencies = [ "serde",]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.162"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2a0814352fd64b58489904a44ea8d90cb1a91dcb6b4f5ebabc32c8318e93cb6"
+dependencies = [ "proc-macro2", "quote", "syn 2.0.15",]
+
+[[package]]
+name = "serde_json"
+version = "1.0.96"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "057d394a50403bcac12672b2b18fb387ab6d289d957dab67dd201875391e52f1"
+dependencies = [ "itoa", "ryu", "serde",]
+
+[[package]]
+name = "serde_spanned"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0efd8caf556a6cebd3b285caf480045fcc1ac04f6bd786b09a6f11af30c4fcf4"
+dependencies = [ "serde",]
+
+[[package]]
+name = "serde_urlencoded"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
+dependencies = [ "form_urlencoded", "itoa", "ryu", "serde",]
+
+[[package]]
+name = "sha-1"
+version = "0.9.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "99cd6713db3cf16b6c84e06321e049a9b9f699826e16096d23bbcc44d15d51a6"
+dependencies = [ "block-buffer 0.9.0", "cfg-if", "cpufeatures", "digest 0.9.0", "opaque-debug",]
+
+[[package]]
+name = "sha1"
+version = "0.10.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f04293dc80c3993519f2d7f6f511707ee7094fe0c6d3406feb330cdb3540eba3"
+dependencies = [ "cfg-if", "cpufeatures", "digest 0.10.6",]
+
+[[package]]
+name = "sha2"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82e6b795fe2e3b1e845bafcb27aa35405c4d47cdfc92af5fc8d3002f76cebdc0"
+dependencies = [ "cfg-if", "cpufeatures", "digest 0.10.6",]
+
+[[package]]
+name = "shannon"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ea5b41c9427b56caa7b808cb548a04fb50bb5b9e98590b53f28064ff4174561"
+dependencies = [ "byteorder",]
+
+[[package]]
+name = "sharded-slab"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "900fba806f70c630b0a382d0d825e17a0f19fcd059a2ade1ff237bcddf446b31"
+dependencies = [ "lazy_static",]
+
+[[package]]
+name = "shell-words"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24188a676b6ae68c3b2cb3a01be17fbf7240ce009799bb56d5b1409051e78fde"
+
+[[package]]
+name = "signal-hook"
+version = "0.3.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "732768f1176d21d09e076c23a93123d40bba92d50c4058da34d45c8de8e682b9"
+dependencies = [ "libc", "signal-hook-registry",]
+
+[[package]]
+name = "signal-hook-registry"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8229b473baa5980ac72ef434c4415e70c4b5e71b423043adb4ba059f89c99a1"
+dependencies = [ "libc",]
+
+[[package]]
+name = "signature"
+version = "1.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74233d3b3b2f6d4b006dc19dee745e73e2a6bfb6f93607cd3b02bd5b00797d7c"
+
+[[package]]
+name = "simd-adler32"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "238abfbb77c1915110ad968465608b68e869e0772622c9656714e73e5a1a522f"
+
+[[package]]
+name = "simd_helpers"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95890f873bec569a0362c235787f3aca6e1e887302ba4840839bcc6459c42da6"
+dependencies = [ "quote",]
+
+[[package]]
+name = "slab"
+version = "0.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6528351c9bc8ab22353f9d776db39a20288e8d6c37ef8cfe3317cf875eecfc2d"
+dependencies = [ "autocfg",]
+
+[[package]]
+name = "smallvec"
+version = "1.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a507befe795404456341dfab10cef66ead4c041f62b8b11bbb92bffe5d0953e0"
+
+[[package]]
+name = "smawk"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f67ad224767faa3c7d8b6d91985b78e70a1324408abcb1cfcc2be4c06bc06043"
+
+[[package]]
+name = "socket2"
+version = "0.4.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64a4a911eed85daf18834cfaa86a79b7d266ff93ff5ba14005426219480ed662"
+dependencies = [ "libc", "winapi",]
+
+[[package]]
+name = "socket2"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d283f86695ae989d1e18440a943880967156325ba025f05049946bff47bcc2b"
+dependencies = [ "libc", "windows-sys 0.48.0",]
+
+[[package]]
+name = "sodiumoxide"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e26be3acb6c2d9a7aac28482586a7856436af4cfe7100031d219de2d2ecb0028"
+dependencies = [ "ed25519", "libc", "libsodium-sys", "serde",]
+
+[[package]]
+name = "spin"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
+
+[[package]]
+name = "spin"
+version = "0.9.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
+dependencies = [ "lock_api",]
+
+[[package]]
+name = "strength_reduce"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe895eb47f22e2ddd4dabc02bce419d2e643c8e3b585c78158b349195bc24d82"
+
+[[package]]
+name = "strsim"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
+
+[[package]]
+name = "subtle"
+version = "2.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6bdef32e8150c2a081110b42772ffe7d7c9032b606bc226c8260fd97e0976601"
+
+[[package]]
+name = "syn"
+version = "1.0.109"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
+dependencies = [ "proc-macro2", "quote", "unicode-ident",]
+
+[[package]]
+name = "syn"
+version = "2.0.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a34fcf3e8b60f57e6a14301a2e916d323af98b0ea63c599441eec8558660c822"
+dependencies = [ "proc-macro2", "quote", "unicode-ident",]
+
+[[package]]
+name = "system-deps"
+version = "6.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5fa6fb9ee296c0dc2df41a656ca7948546d061958115ddb0bcaae43ad0d17d2"
+dependencies = [ "cfg-expr", "heck", "pkg-config", "toml 0.7.3", "version-compare",]
+
+[[package]]
+name = "target-lexicon"
+version = "0.12.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd1ba337640d60c3e96bc6f0638a939b9c9a7f2c316a1598c279828b3d1dc8c5"
+
+[[package]]
+name = "tempfile"
+version = "3.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9fbec84f381d5795b08656e4912bec604d162bff9291d6189a78f4c8ab87998"
+dependencies = [ "cfg-if", "fastrand", "redox_syscall 0.3.5", "rustix", "windows-sys 0.45.0",]
+
+[[package]]
+name = "termcolor"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be55cf8942feac5c765c2c993422806843c9a9a45d4d5c407ad6dd2ea95eb9b6"
+dependencies = [ "winapi-util",]
+
+[[package]]
+name = "test-log"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38f0c854faeb68a048f0f2dc410c5ddae3bf83854ef0e4977d58306a5edef50e"
+dependencies = [ "proc-macro2", "quote", "syn 1.0.109",]
+
+[[package]]
+name = "test-with"
+version = "0.9.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca3e3e1275a1442b99772321d4a35e0622f7abc04f6af49bd801c7119645bc9e"
+dependencies = [ "proc-macro-error", "proc-macro2", "quote", "regex", "syn 2.0.15",]
+
+[[package]]
+name = "textwrap"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "222a222a5bfe1bba4a77b45ec488a741b3cb8872e5e499451fd7d0129c9c7c3d"
+dependencies = [ "hyphenation", "smawk", "unicode-linebreak", "unicode-width",]
+
+[[package]]
+name = "thiserror"
+version = "1.0.40"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "978c9a314bd8dc99be594bc3c175faaa9794be04a5a5e153caba6915336cebac"
+dependencies = [ "thiserror-impl",]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.40"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9456a42c5b0d803c8cd86e73dd7cc9edd429499f37a3550d286d5e86720569f"
+dependencies = [ "proc-macro2", "quote", "syn 2.0.15",]
+
+[[package]]
+name = "thread-id"
+version = "4.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fdfe0627923f7411a43ec9ec9c39c3a9b4151be313e0922042581fb6c9b717f"
+dependencies = [ "libc", "redox_syscall 0.2.16", "winapi",]
+
+[[package]]
+name = "thread_local"
+version = "1.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3fdd6f064ccff2d6567adcb3873ca630700f00b5ad3f060c25b5dcfd9a4ce152"
+dependencies = [ "cfg-if", "once_cell",]
+
+[[package]]
+name = "tiff"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7449334f9ff2baf290d55d73983a7d6fa15e01198faef72af07e2a8db851e471"
+dependencies = [ "flate2", "jpeg-decoder", "weezl",]
+
+[[package]]
+name = "time"
+version = "0.1.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b797afad3f312d1c66a56d11d0316f916356d11bd158fbc6ca6389ff6bf805a"
+dependencies = [ "libc", "wasi 0.10.0+wasi-snapshot-preview1", "winapi",]
+
+[[package]]
+name = "time"
+version = "0.3.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd0cbfecb4d19b5ea75bb31ad904eb5b9fa13f21079c3b92017ebdf4999a5890"
+dependencies = [ "itoa", "serde", "time-core", "time-macros",]
+
+[[package]]
+name = "time-core"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e153e1f1acaef8acc537e68b44906d2db6436e2b35ac2c6b42640fff91f00fd"
+
+[[package]]
+name = "time-macros"
+version = "0.2.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd80a657e71da814b8e5d60d3374fc6d35045062245d80224748ae522dd76f36"
+dependencies = [ "time-core",]
+
+[[package]]
+name = "tinyvec"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87cc5ceb3875bb20c2890005a4e226a4651264a5c75edb2421b52861a0a0cb50"
+dependencies = [ "tinyvec_macros",]
+
+[[package]]
+name = "tinyvec_macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
+
+[[package]]
+name = "tokio"
+version = "1.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3c786bf8134e5a3a166db9b29ab8f48134739014a3eca7bc6bfa95d673b136f"
+dependencies = [ "autocfg", "bytes", "libc", "mio", "num_cpus", "parking_lot", "pin-project-lite", "signal-hook-registry", "socket2 0.4.9", "tokio-macros", "windows-sys 0.48.0",]
+
+[[package]]
+name = "tokio-macros"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "630bdcf245f78637c13ec01ffae6187cca34625e8c63150d424b59e55af2675e"
+dependencies = [ "proc-macro2", "quote", "syn 2.0.15",]
+
+[[package]]
+name = "tokio-native-tls"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
+dependencies = [ "native-tls", "tokio",]
+
+[[package]]
+name = "tokio-rustls"
+version = "0.23.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c43ee83903113e03984cb9e5cebe6c04a5116269e900e3ddba8f068a62adda59"
+dependencies = [ "rustls", "tokio", "webpki",]
+
+[[package]]
+name = "tokio-stream"
+version = "0.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "397c988d37662c7dda6d2208364a706264bf3d6138b11d436cbac0ad38832842"
+dependencies = [ "futures-core", "pin-project-lite", "tokio",]
+
+[[package]]
+name = "tokio-util"
+version = "0.7.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "806fe8c2c87eccc8b3267cbae29ed3ab2d0bd37fca70ab622e46aaa9375ddb7d"
+dependencies = [ "bytes", "futures-core", "futures-sink", "pin-project-lite", "tokio", "tracing",]
+
+[[package]]
+name = "toml"
+version = "0.5.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f4f7f0dd8d50a853a531c426359045b1998f04219d88799810762cd4ad314234"
+dependencies = [ "serde",]
+
+[[package]]
+name = "toml"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b403acf6f2bb0859c93c7f0d967cb4a75a7ac552100f9322faf64dc047669b21"
+dependencies = [ "serde", "serde_spanned", "toml_datetime", "toml_edit",]
+
+[[package]]
+name = "toml_datetime"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ab8ed2edee10b50132aed5f331333428b011c99402b5a534154ed15746f9622"
+dependencies = [ "serde",]
+
+[[package]]
+name = "toml_edit"
+version = "0.19.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "239410c8609e8125456927e6707163a3b1fdb40561e4b803bc041f466ccfdc13"
+dependencies = [ "indexmap", "serde", "serde_spanned", "toml_datetime", "winnow",]
+
+[[package]]
+name = "tower"
+version = "0.4.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8fa9be0de6cf49e536ce1851f987bd21a43b771b09473c3549a6c853db37c1c"
+dependencies = [ "futures-core", "futures-util", "pin-project", "pin-project-lite", "tokio", "tower-layer", "tower-service", "tracing",]
+
+[[package]]
+name = "tower-layer"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c20c8dbed6283a09604c3e69b4b7eeb54e298b8a600d4d5ecb5ad39de609f1d0"
+
+[[package]]
+name = "tower-service"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6bc1c9ce2b5135ac7f93c72918fc37feb872bdc6a5533a8b85eb4b86bfdae52"
+
+[[package]]
+name = "tracing"
+version = "0.1.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ce8c33a8d48bd45d624a6e523445fd21ec13d3653cd51f681abf67418f54eb8"
+dependencies = [ "cfg-if", "log", "pin-project-lite", "tracing-attributes", "tracing-core",]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f57e3ca2a01450b1a921183a9c9cbfda207fd822cef4ccb00a65402cbba7a74"
+dependencies = [ "proc-macro2", "quote", "syn 2.0.15",]
+
+[[package]]
+name = "tracing-core"
+version = "0.1.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24eb03ba0eab1fd845050058ce5e616558e8f8d8fca633e6b163fe25c797213a"
+dependencies = [ "once_cell", "valuable",]
+
+[[package]]
+name = "tracing-log"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78ddad33d2d10b1ed7eb9d1f518a5674713876e97e5bb9b7345a7984fbb4f922"
+dependencies = [ "lazy_static", "log", "tracing-core",]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.3.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30a651bc37f915e81f087d86e62a18eec5f79550c7faff886f7090b4ea757c77"
+dependencies = [ "matchers", "nu-ansi-term", "once_cell", "regex", "sharded-slab", "smallvec", "thread_local", "tracing", "tracing-core", "tracing-log",]
+
+[[package]]
+name = "transpose"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6522d49d03727ffb138ae4cbc1283d3774f0d10aa7f9bf52e6784c45daf9b23"
+dependencies = [ "num-integer", "strength_reduce",]
+
+[[package]]
+name = "try-lock"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3528ecfd12c466c6f163363caf2d02a71161dd5e1cc6ae7b34207ea2d42d81ed"
+
+[[package]]
+name = "tungstenite"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15fba1a6d6bb030745759a9a2a588bfe8490fc8b4751a277db3a0be1c9ebbf67"
+dependencies = [ "byteorder", "bytes", "data-encoding", "http", "httparse", "log", "native-tls", "rand", "sha1", "thiserror", "url", "utf-8",]
+
+[[package]]
+name = "typenum"
+version = "1.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "497961ef93d974e23eb6f433eb5fe1b7930b659f06d12dec6fc44a8f554c0bba"
+
+[[package]]
+name = "unicode-bidi"
+version = "0.3.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92888ba5573ff080736b3648696b70cafad7d250551175acbaa4e0385b3e1460"
+
+[[package]]
+name = "unicode-ident"
+version = "1.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5464a87b239f13a63a501f2701565754bae92d243d4bb7eb12f6d57d2269bf4"
+
+[[package]]
+name = "unicode-linebreak"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c5faade31a542b8b35855fff6e8def199853b2da8da256da52f52f1316ee3137"
+dependencies = [ "hashbrown", "regex",]
+
+[[package]]
+name = "unicode-normalization"
+version = "0.1.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c5713f0fc4b5db668a2ac63cdb7bb4469d8c9fed047b1d0292cc7b0ce2ba921"
+dependencies = [ "tinyvec",]
+
+[[package]]
+name = "unicode-width"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0edd1e5b14653f783770bce4a4dabb4a5108a5370a5f5d8cfe8710c361f6c8b"
+
+[[package]]
+name = "untrusted"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
+
+[[package]]
+name = "url"
+version = "2.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d68c799ae75762b8c3fe375feb6600ef5602c883c5d21eb51c09f22b83c4643"
+dependencies = [ "form_urlencoded", "idna 0.3.0", "percent-encoding",]
+
+[[package]]
+name = "urlencoding"
+version = "2.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8db7427f936968176eaa7cdf81b7f98b980b18495ec28f1b5791ac3bfe3eea9"
+
+[[package]]
+name = "utf-8"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
+
+[[package]]
+name = "utf8parse"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a"
+
+[[package]]
+name = "uuid"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4dad5567ad0cf5b760e5665964bec1b47dfd077ba8a2544b513f3556d3d239a2"
+dependencies = [ "getrandom",]
+
+[[package]]
+name = "v_frame"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "148c23ce3c8dae5562911cba1c264eaa5e31e133e0d5d08455409de9dd540358"
+dependencies = [ "cfg-if", "new_debug_unreachable", "noop_proc_macro", "num-derive", "num-traits", "rust_hawktracer",]
+
+[[package]]
+name = "va_list"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "350bd5ef744f978a387cd08ce514be4e3766746496f355d59d68af36f52d36da"
+
+[[package]]
+name = "valuable"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "830b7e5d4d90034032940e4ace0d9a9a057e7a45cd94e6c007832e39edb82f6d"
+
+[[package]]
+name = "vcpkg"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
+
+[[package]]
+name = "vergen"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7141e445af09c8919f1d5f8a20dae0b20c3b57a45dee0d5823c6ed5d237f15a"
+dependencies = [ "bitflags", "chrono", "rustc_version",]
+
+[[package]]
+name = "version-compare"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "579a42fc0b8e0c63b76519a339be31bed574929511fa53c1a3acae26eb258f29"
+
+[[package]]
+name = "version_check"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
+
+[[package]]
+name = "vsimd"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c3082ca00d5a5ef149bb8b555a72ae84c9c59f7250f013ac822ac2e49b19c64"
+
+[[package]]
+name = "waker-fn"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d5b2c62b4012a3e1eca5a7e077d13b3bf498c4073e33ccd58626607748ceeca"
+
+[[package]]
+name = "walkdir"
+version = "2.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "36df944cda56c7d8d8b7496af378e6b16de9284591917d307c9b4d313c44e698"
+dependencies = [ "same-file", "winapi-util",]
+
+[[package]]
+name = "want"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ce8a968cb1cd110d136ff8b819a556d6fb6d919363c61534f6860c7eb172ba0"
+dependencies = [ "log", "try-lock",]
+
+[[package]]
+name = "wasi"
+version = "0.10.0+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a143597ca7c7793eff794def352d41792a93c481eb1042423ff7ff72ba2c31f"
+
+[[package]]
+name = "wasi"
+version = "0.11.0+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
+
+[[package]]
+name = "wasm-bindgen"
+version = "0.2.84"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "31f8dcbc21f30d9b8f2ea926ecb58f6b91192c17e9d33594b3df58b2007ca53b"
+dependencies = [ "cfg-if", "wasm-bindgen-macro",]
+
+[[package]]
+name = "wasm-bindgen-backend"
+version = "0.2.84"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95ce90fd5bcc06af55a641a86428ee4229e44e07033963a2290a8e241607ccb9"
+dependencies = [ "bumpalo", "log", "once_cell", "proc-macro2", "quote", "syn 1.0.109", "wasm-bindgen-shared",]
+
+[[package]]
+name = "wasm-bindgen-futures"
+version = "0.4.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f219e0d211ba40266969f6dbdd90636da12f75bee4fc9d6c23d1260dadb51454"
+dependencies = [ "cfg-if", "js-sys", "wasm-bindgen", "web-sys",]
+
+[[package]]
+name = "wasm-bindgen-macro"
+version = "0.2.84"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c21f77c0bedc37fd5dc21f897894a5ca01e7bb159884559461862ae90c0b4c5"
+dependencies = [ "quote", "wasm-bindgen-macro-support",]
+
+[[package]]
+name = "wasm-bindgen-macro-support"
+version = "0.2.84"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2aff81306fcac3c7515ad4e177f521b5c9a15f2b08f4e32d823066102f35a5f6"
+dependencies = [ "proc-macro2", "quote", "syn 1.0.109", "wasm-bindgen-backend", "wasm-bindgen-shared",]
+
+[[package]]
+name = "wasm-bindgen-shared"
+version = "0.2.84"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0046fef7e28c3804e5e38bfa31ea2a0f73905319b677e57ebe37e49358989b5d"
+
+[[package]]
+name = "web-sys"
+version = "0.3.61"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e33b99f4b23ba3eec1a53ac264e35a755f00e966e0065077d6027c0f575b0b97"
+dependencies = [ "js-sys", "wasm-bindgen",]
+
+[[package]]
+name = "webpki"
+version = "0.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f095d78192e208183081cc07bc5515ef55216397af48b873e5edcd72637fa1bd"
+dependencies = [ "ring", "untrusted",]
+
+[[package]]
+name = "weezl"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9193164d4de03a926d909d3bc7c30543cecb35400c02114792c2cae20d5e2dbb"
+
+[[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [ "winapi-i686-pc-windows-gnu", "winapi-x86_64-pc-windows-gnu",]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-util"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70ec6ce85bb158151cae5e5c87f95a8e97d2c0c4b001223f33a334e3ce5de178"
+dependencies = [ "winapi",]
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "windows"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e686886bc078bc1b0b600cac0147aadb815089b6e4da64016cbd754b6342700f"
+dependencies = [ "windows-targets 0.48.0",]
+
+[[package]]
+name = "windows-sys"
+version = "0.42.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a3e1820f08b8513f676f7ab6c1f99ff312fb97b553d30ff4dd86f9f15728aa7"
+dependencies = [ "windows_aarch64_gnullvm 0.42.2", "windows_aarch64_msvc 0.42.2", "windows_i686_gnu 0.42.2", "windows_i686_msvc 0.42.2", "windows_x86_64_gnu 0.42.2", "windows_x86_64_gnullvm 0.42.2", "windows_x86_64_msvc 0.42.2",]
+
+[[package]]
+name = "windows-sys"
+version = "0.45.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
+dependencies = [ "windows-targets 0.42.2",]
+
+[[package]]
+name = "windows-sys"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
+dependencies = [ "windows-targets 0.48.0",]
+
+[[package]]
+name = "windows-targets"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e5180c00cd44c9b1c88adb3693291f1cd93605ded80c250a75d472756b4d071"
+dependencies = [ "windows_aarch64_gnullvm 0.42.2", "windows_aarch64_msvc 0.42.2", "windows_i686_gnu 0.42.2", "windows_i686_msvc 0.42.2", "windows_x86_64_gnu 0.42.2", "windows_x86_64_gnullvm 0.42.2", "windows_x86_64_msvc 0.42.2",]
+
+[[package]]
+name = "windows-targets"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b1eb6f0cd7c80c79759c929114ef071b87354ce476d9d94271031c0497adfd5"
+dependencies = [ "windows_aarch64_gnullvm 0.48.0", "windows_aarch64_msvc 0.48.0", "windows_i686_gnu 0.48.0", "windows_i686_msvc 0.48.0", "windows_x86_64_gnu 0.48.0", "windows_x86_64_gnullvm 0.48.0", "windows_x86_64_msvc 0.48.0",]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91ae572e1b79dba883e0d315474df7305d12f569b400fcf90581b06062f7e1bc"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2ef27e0d7bdfcfc7b868b317c1d32c641a6fe4629c171b8928c7b08d98d7cf3"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "622a1962a7db830d6fd0a69683c80a18fda201879f0f447f065a3b7467daa241"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4542c6e364ce21bf45d69fdd2a8e455fa38d316158cfd43b3ac1c5b1b19f8e00"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca2b8a661f7628cbd23440e50b05d705db3686f894fc9580820623656af974b1"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7896dbc1f41e08872e9d5e8f8baa8fdd2677f29468c4e156210174edc7f7b953"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a515f5799fe4961cb532f983ce2b23082366b898e52ffbce459c86f67c8378a"
+
+[[package]]
+name = "winnow"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61de7bac303dc551fe038e2b3cef0f571087a47571ea6e79a87692ac99b99699"
+dependencies = [ "memchr",]
+
+[[package]]
+name = "winreg"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "80d0f4e272c85def139476380b12f9ac60926689dd2e01d4923222f40580869d"
+dependencies = [ "winapi",]
+
+[[package]]
+name = "xml-rs"
+version = "0.8.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f20f14e2bd1fef6ec891d50dbb37c7290a0568a6bbd9020bf62010d02b6f80e"
+
+[[package]]
+name = "xmlparser"
+version = "0.13.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d25c75bf9ea12c4040a97f829154768bbbce366287e2dc044af160cd79a13fd"
+
+[[package]]
+name = "xmltree"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7d8a75eaf6557bb84a65ace8609883db44a29951042ada9b393151532e41fcb"
+dependencies = [ "xml-rs",]
+
+[[package]]
+name = "yansi"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09041cd90cf85f7f8b2df60c646f853b7f535ce68f85244eb6731cf89fa498ec"
+
+[[package]]
+name = "zerocopy"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "332f188cc1bcf1fe1064b8c58d150f497e697f49774aa846f2dc949d9a25f236"
+dependencies = [ "byteorder", "zerocopy-derive",]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6505e6815af7de1746a08f69c69606bb45695a17149517680f3b2149713b19a3"
+dependencies = [ "proc-macro2", "quote", "syn 1.0.109",]
+
+[[package]]
+name = "zeroize"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a0956f1ba7c7909bfb66c2e9e4124ab6f6482560f6628b5aaeba39207c9aad9"
+
+[[package]]
+name = "zune-inflate"
+version = "0.2.54"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73ab332fe2f6680068f3582b16a24f90ad7096d5d39b974d1c0aff0125116f02"
+dependencies = [ "simd-adler32",]
+

--- a/pkgs/development/libraries/gstreamer/rs/default.nix
+++ b/pkgs/development/libraries/gstreamer/rs/default.nix
@@ -1,0 +1,230 @@
+{ lib
+, stdenv
+, fetchFromGitLab
+, fetchpatch
+, writeText
+, rustPlatform
+, meson
+, ninja
+, python3
+, pkg-config
+, rust
+, rustc
+, cargo
+, cargo-c
+, nasm
+, gstreamer
+, gst-plugins-base
+, gst-plugins-bad
+, gtk4
+, cairo
+, csound
+, dav1d
+, libsodium
+, libwebp
+, openssl
+, pango
+, Security
+, gst-plugins-good
+, nix-update-script
+# TODO: required for case-insensitivity hack below
+, yq
+, moreutils
+# specify a limited set of plugins to build if not all supported plugins
+, plugins ? null
+}:
+
+let
+  # populated from meson_options.txt (manually for now, but that might change in the future)
+  validPlugins = {
+    # audio
+    audiofx = [ ];
+    claxon = [ ];
+    csound = [ csound ];
+    lewton = [ ];
+    spotify = [ ];
+
+    # generic
+    file = [ ];
+    sodium = [ libsodium ];
+    threadshare = [ ];
+
+    # mux
+    flavors = [ ];
+    fmp4 = [ ];
+    mp4 = [ ];
+
+    # net
+    aws = [ openssl ] ++ lib.optionals stdenv.isDarwin [ Security ];
+    hlssink3 = [ ];
+    ndi = [ ];
+    onvif = [ pango ];
+    raptorq = [ ];
+    reqwest = [ openssl ] ++ lib.optionals stdenv.isDarwin [ Security ];
+    rtp = [ ];
+    webrtc = [ gst-plugins-bad openssl ] ++ lib.optionals stdenv.isDarwin [ Security ];
+    webrtchttp = [ gst-plugins-bad openssl ] ++ lib.optionals stdenv.isDarwin [ Security ];
+
+    # text
+    textahead = [ ];
+    json = [ ];
+    regex = [ ];
+    textwrap = [ ];
+
+    # utils
+    fallbackswitch = [ gtk4 ];
+    livesync = [ gtk4 ];
+    togglerecord = [ gtk4 ];
+    tracers = [ ];
+    uriplaylistbin = [ ];
+
+    # video
+    cdg = [ ];
+    closedcaption = [ pango ];
+    dav1d = [ dav1d ];
+    ffv1 = [ ];
+    gif = [ ];
+    gtk4 = [ gtk4 ];
+    hsv = [ ];
+    png = [ ];
+    rav1e = [ ];
+    videofx = [ cairo ];
+    webp = [ libwebp ];
+  };
+
+  selectedPlugins = if plugins != null then lib.unique (lib.sort lib.lessThan plugins) else lib.subtractLists (
+    [
+      "audiofx" # tests have race-y failure, see https://gitlab.freedesktop.org/gstreamer/gst-plugins-rs/-/issues/337
+      "csound" # tests have weird failure on x86, does not currently work on arm or darwin
+    ] ++ lib.optionals stdenv.isDarwin [
+      "reqwest" # tests hang on darwin
+      "threadshare" # tests cannot bind to localhost on darwin
+      "webp" # not supported on darwin (upstream crate issue)
+    ] ++ lib.optionals (stdenv.isDarwin && !stdenv.isAarch64) [
+      # these require gstreamer-gl which requires darwin sdk bump
+      "gtk4"
+      "livesync"
+      "fallbackswitch"
+      "togglerecord"
+    ]
+  ) (lib.attrNames validPlugins);
+
+  invalidPlugins = lib.subtractLists (lib.attrNames validPlugins) selectedPlugins;
+in
+  assert lib.assertMsg (invalidPlugins == [])
+    "Invalid gst-plugins-rs plugin${lib.optionalString (lib.length invalidPlugins > 1) "s"}: ${lib.concatStringsSep ", " invalidPlugins}";
+
+stdenv.mkDerivation rec {
+  pname = "gst-plugins-rs";
+  version = "0.10.7";
+
+  outputs = [ "out" "dev" ];
+
+  src = fetchFromGitLab {
+    domain = "gitlab.freedesktop.org";
+    owner = "gstreamer";
+    repo = "gst-plugins-rs";
+    rev = version;
+    hash = "sha256-b+j7nAMK66+msRnIaj1S1DSvES5Gid3QazXgqO1II/Q=";
+    # TODO: temporary workaround for case-insensitivity problems with color-name crate - https://github.com/annymosse/color-name/pull/2
+    nativeBuildInputs = [ yq moreutils ];
+    postFetch = ''
+      tomlq --toml-output '.package |= map(if .name == "color-name"
+        then (.source = "git+https://github.com/lilyinstarlight/color-name#cac0ed5b7d2e0682c08c9bfd13089d5494e81b9a" | del(.checksum))
+        else .
+      end)' $out/Cargo.lock | sponge $out/Cargo.lock
+    '';
+  };
+
+  cargoDeps = rustPlatform.importCargoLock {
+    lockFile = ./Cargo.lock;
+    outputHashes = {
+      "cairo-rs-0.17.9" = "sha256-LiIb6y/Ks/o+rZhU8RpXN7jSo7JzBGmcNumxyx/lZs0=";
+      "color-name-1.1.0" = "sha256-RfMStbe2wX5qjPARHIFHlSDKjzx8DwJ+RjzyltM5K7A=";
+      "ffv1-0.0.0" = "sha256-af2VD00tMf/hkfvrtGrHTjVJqbl+VVpLaR0Ry+2niJE=";
+      "flavors-0.2.0" = "sha256-zBa0X75lXnASDBam9Kk6w7K7xuH9fP6rmjWZBUB5hxk=";
+      "gdk4-0.6.6" = "sha256-TI4F9MjIpxFEZItoewP/Zem1vM4MsKNJTzfgah1vjmI=";
+      "gstreamer-0.20.5" = "sha256-IQ56Upe73egId1IJRfzvqrJIzTc1x5FgAEbva9kuqPE=";
+    };
+  };
+
+  strictDeps = true;
+
+  nativeBuildInputs = [
+    rustPlatform.cargoSetupHook
+    meson
+    ninja
+    python3
+    python3.pkgs.tomli
+    pkg-config
+    rustc
+    cargo
+    cargo-c
+    nasm
+  ];
+
+  buildInputs = [
+    gstreamer
+    gst-plugins-base
+  ] ++ lib.concatMap (plugin: lib.getAttr plugin validPlugins) selectedPlugins;
+
+  checkInputs = [
+    gst-plugins-good
+    gst-plugins-bad
+  ];
+
+  mesonFlags = (
+    map (plugin: lib.mesonEnable plugin true) selectedPlugins
+  ) ++ [
+    (lib.mesonOption "sodium-source" "system")
+    (lib.mesonEnable "doc" false) # `hotdoc` not packaged in nixpkgs as of writing
+  ] ++ (let
+    crossFile = writeText "cross-file.conf" ''
+      [binaries]
+      rust = [ 'rustc', '--target', '${rust.toRustTargetSpec stdenv.hostPlatform}' ]
+    '';
+  in lib.optionals (stdenv.buildPlatform != stdenv.hostPlatform) [
+    "--cross-file=${crossFile}"
+  ]);
+
+  # turn off all auto plugins if a list is specified
+  mesonAutoFeatures = "disabled";
+
+  doCheck = true;
+
+  # csound lib dir must be manually specified for it to build
+  # webrtc and webrtchttp plugins are the only that need gstreamer-webrtc (from gst-plugins-bad, a heavy set)
+  preConfigure = ''
+    export CARGO_BUILD_JOBS=$NIX_BUILD_CORES
+
+    patchShebangs dependencies.py
+  '' + lib.optionalString (lib.elem "csound" selectedPlugins) ''
+    export CSOUND_LIB_DIR=${lib.getLib csound}/lib
+  '' + lib.optionalString (lib.mutuallyExclusive [ "webrtc" "webrtchttp" ] selectedPlugins) ''
+    sed -i "/\['gstreamer-webrtc-1\.0', 'gst-plugins-bad', 'gstwebrtc_dep', 'gstwebrtc'\]/d" meson.build
+  '' + lib.optionalString (stdenv.isDarwin && !stdenv.isAarch64) ''
+    sed -i "/\['gstreamer-gl-1\.0', 'gst-plugins-base', 'gst_gl_dep', 'gstgl'\]/d" meson.build
+  '';
+
+  # run tests ourselves to avoid meson timing out by default
+  checkPhase = ''
+    runHook preCheck
+
+    meson test --no-rebuild --verbose --timeout-multiplier 6
+
+    runHook postCheck
+  '';
+
+  passthru.updateScript = nix-update-script {
+    # use numbered releases rather than gstreamer-* releases
+    extraArgs = [ "--version-regex" "([0-9.]+)" ];
+  };
+
+  meta = with lib; {
+    description = "GStreamer plugins written in Rust";
+    homepage = "https://gitlab.freedesktop.org/gstreamer/gst-plugins-rs";
+    license = with licenses; [ mpl20 asl20 mit lgpl21Plus ];
+    platforms = platforms.unix;
+    maintainers = with maintainers; [ lilyinstarlight ];
+  };
+}

--- a/pkgs/top-level/aliases.nix
+++ b/pkgs/top-level/aliases.nix
@@ -1029,7 +1029,6 @@ mapAliases ({
   mopidy-gmusic = throw "mopidy-gmusic has been removed because Google Play Music was discontinued"; # Added 2021-03-07
   mopidy-local-images = throw "mopidy-local-images has been removed as it's unmaintained. Its functionality has been merged into the mopidy-local extension"; # Added 2020-10-18
   mopidy-local-sqlite = throw "mopidy-local-sqlite has been removed as it's unmaintained. Its functionality has been merged into the mopidy-local extension"; # Added 2020-10-18
-  mopidy-spotify = throw "mopidy-spotify has been removed because Spotify stopped supporting libspotify"; # added 2022-05-29
   mopidy-spotify-tunigo = throw "mopidy-spotify-tunigo has been removed because Spotify stopped supporting libspotify"; # added 2022-05-29
 
   morituri = throw "'morituri' has been renamed to/replaced by 'whipper'"; # Converted to throw 2022-02-22

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -20397,7 +20397,7 @@ with pkgs;
 
   gst_all_1 = recurseIntoAttrs(callPackage ../development/libraries/gstreamer {
     callPackage = newScope (gst_all_1 // { libav = pkgs.ffmpeg-headless; });
-    inherit (darwin.apple_sdk.frameworks) AudioToolbox AVFoundation Cocoa CoreFoundation CoreMedia CoreServices CoreVideo DiskArbitration Foundation IOKit MediaToolbox OpenGL VideoToolbox;
+    inherit (darwin.apple_sdk.frameworks) AudioToolbox AVFoundation Cocoa CoreFoundation CoreMedia CoreServices CoreVideo DiskArbitration Foundation IOKit MediaToolbox OpenGL Security VideoToolbox;
   });
 
   gusb = callPackage ../development/libraries/gusb { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -32069,6 +32069,7 @@ with pkgs;
     mopidy-scrobbler
     mopidy-somafm
     mopidy-soundcloud
+    mopidy-spotify
     mopidy-subidy
     mopidy-tidal
     mopidy-tunein


### PR DESCRIPTION
###### Description of changes

Mopidy-Spotify is back!

This adds the [gst-plugins-rs](https://gitlab.freedesktop.org/gstreamer/gst-plugins-rs) package (for the spotify source) and adds it to Mopidy, so that those plugins are available to it

The hacky `postFetch` in gst-plugins-rs can be removed when annymosse/color-name#2 is merged (or gst-plugins-rs replaces the crate -- which I will try to make one or the other happen upstream soon, in the next month or so), and having several gstreamer-gl-based plugins from gst-plugins-rs on Darwin will depend on #223248 and the SDK bump (which I've subscribed to the relevant issues and will remove the TODO items in gst-plugins-rs as things get merged)

Given you were the maintainer of the previous `mopidy-spotify` derivation, would you like to be a maintainer on this one as well @rski?

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

###### nixpkgs-review

Result of `nixpkgs-review` run on x86_64-linux [1](https://github.com/Mic92/nixpkgs-review)
<details>
  <summary>46 packages built:</summary>
  <ul>
    <li>gst_all_1.gst-plugins-rs</li>
    <li>gst_all_1.gst-plugins-rs.dev</li>
    <li>mopidy</li>
    <li>mopidy-bandcamp</li>
    <li>mopidy-bandcamp.dist</li>
    <li>mopidy-iris</li>
    <li>mopidy-iris.dist</li>
    <li>mopidy-jellyfin</li>
    <li>mopidy-jellyfin.dist</li>
    <li>mopidy-local</li>
    <li>mopidy-local.dist</li>
    <li>mopidy-moped</li>
    <li>mopidy-moped.dist</li>
    <li>mopidy-mopify</li>
    <li>mopidy-mopify.dist</li>
    <li>mopidy-mpd</li>
    <li>mopidy-mpd.dist</li>
    <li>mopidy-mpris</li>
    <li>mopidy-mpris.dist</li>
    <li>mopidy-muse</li>
    <li>mopidy-muse.dist</li>
    <li>mopidy-musicbox-webclient</li>
    <li>mopidy-musicbox-webclient.dist</li>
    <li>mopidy-notify</li>
    <li>mopidy-notify.dist</li>
    <li>mopidy-podcast</li>
    <li>mopidy-podcast.dist</li>
    <li>mopidy-scrobbler</li>
    <li>mopidy-scrobbler.dist</li>
    <li>mopidy-somafm</li>
    <li>mopidy-somafm.dist</li>
    <li>mopidy-soundcloud</li>
    <li>mopidy-soundcloud.dist</li>
    <li>mopidy-spotify</li>
    <li>mopidy-spotify.dist</li>
    <li>mopidy-subidy</li>
    <li>mopidy-subidy.dist</li>
    <li>mopidy-tidal</li>
    <li>mopidy-tidal.dist</li>
    <li>mopidy-tunein</li>
    <li>mopidy-tunein.dist</li>
    <li>mopidy-youtube</li>
    <li>mopidy-youtube.dist</li>
    <li>mopidy-ytmusic</li>
    <li>mopidy-ytmusic.dist</li>
    <li>mopidy.dist</li>
  </ul>
</details>

---

Result of `nixpkgs-review` run on aarch64-linux [1](https://github.com/Mic92/nixpkgs-review)
<details>
  <summary>46 packages built:</summary>
  <ul>
    <li>gst_all_1.gst-plugins-rs</li>
    <li>gst_all_1.gst-plugins-rs.dev</li>
    <li>mopidy</li>
    <li>mopidy-bandcamp</li>
    <li>mopidy-bandcamp.dist</li>
    <li>mopidy-iris</li>
    <li>mopidy-iris.dist</li>
    <li>mopidy-jellyfin</li>
    <li>mopidy-jellyfin.dist</li>
    <li>mopidy-local</li>
    <li>mopidy-local.dist</li>
    <li>mopidy-moped</li>
    <li>mopidy-moped.dist</li>
    <li>mopidy-mopify</li>
    <li>mopidy-mopify.dist</li>
    <li>mopidy-mpd</li>
    <li>mopidy-mpd.dist</li>
    <li>mopidy-mpris</li>
    <li>mopidy-mpris.dist</li>
    <li>mopidy-muse</li>
    <li>mopidy-muse.dist</li>
    <li>mopidy-musicbox-webclient</li>
    <li>mopidy-musicbox-webclient.dist</li>
    <li>mopidy-notify</li>
    <li>mopidy-notify.dist</li>
    <li>mopidy-podcast</li>
    <li>mopidy-podcast.dist</li>
    <li>mopidy-scrobbler</li>
    <li>mopidy-scrobbler.dist</li>
    <li>mopidy-somafm</li>
    <li>mopidy-somafm.dist</li>
    <li>mopidy-soundcloud</li>
    <li>mopidy-soundcloud.dist</li>
    <li>mopidy-spotify</li>
    <li>mopidy-spotify.dist</li>
    <li>mopidy-subidy</li>
    <li>mopidy-subidy.dist</li>
    <li>mopidy-tidal</li>
    <li>mopidy-tidal.dist</li>
    <li>mopidy-tunein</li>
    <li>mopidy-tunein.dist</li>
    <li>mopidy-youtube</li>
    <li>mopidy-youtube.dist</li>
    <li>mopidy-ytmusic</li>
    <li>mopidy-ytmusic.dist</li>
    <li>mopidy.dist</li>
  </ul>
</details>

---

Result of `nixpkgs-review` run on x86_64-darwin [1](https://github.com/Mic92/nixpkgs-review)
<details>
  <summary>46 packages built:</summary>
  <ul>
    <li>gst_all_1.gst-plugins-rs</li>
    <li>gst_all_1.gst-plugins-rs.dev</li>
    <li>mopidy</li>
    <li>mopidy-bandcamp</li>
    <li>mopidy-bandcamp.dist</li>
    <li>mopidy-iris</li>
    <li>mopidy-iris.dist</li>
    <li>mopidy-jellyfin</li>
    <li>mopidy-jellyfin.dist</li>
    <li>mopidy-local</li>
    <li>mopidy-local.dist</li>
    <li>mopidy-moped</li>
    <li>mopidy-moped.dist</li>
    <li>mopidy-mopify</li>
    <li>mopidy-mopify.dist</li>
    <li>mopidy-mpd</li>
    <li>mopidy-mpd.dist</li>
    <li>mopidy-mpris</li>
    <li>mopidy-mpris.dist</li>
    <li>mopidy-muse</li>
    <li>mopidy-muse.dist</li>
    <li>mopidy-musicbox-webclient</li>
    <li>mopidy-musicbox-webclient.dist</li>
    <li>mopidy-notify</li>
    <li>mopidy-notify.dist</li>
    <li>mopidy-podcast</li>
    <li>mopidy-podcast.dist</li>
    <li>mopidy-scrobbler</li>
    <li>mopidy-scrobbler.dist</li>
    <li>mopidy-somafm</li>
    <li>mopidy-somafm.dist</li>
    <li>mopidy-soundcloud</li>
    <li>mopidy-soundcloud.dist</li>
    <li>mopidy-spotify</li>
    <li>mopidy-spotify.dist</li>
    <li>mopidy-subidy</li>
    <li>mopidy-subidy.dist</li>
    <li>mopidy-tidal</li>
    <li>mopidy-tidal.dist</li>
    <li>mopidy-tunein</li>
    <li>mopidy-tunein.dist</li>
    <li>mopidy-youtube</li>
    <li>mopidy-youtube.dist</li>
    <li>mopidy-ytmusic</li>
    <li>mopidy-ytmusic.dist</li>
    <li>mopidy.dist</li>
  </ul>
</details>

---

Result of `nixpkgs-review` run on aarch64-darwin [1](https://github.com/Mic92/nixpkgs-review)
<details>
  <summary>46 packages built:</summary>
  <ul>
    <li>gst_all_1.gst-plugins-rs</li>
    <li>gst_all_1.gst-plugins-rs.dev</li>
    <li>mopidy</li>
    <li>mopidy-bandcamp</li>
    <li>mopidy-bandcamp.dist</li>
    <li>mopidy-iris</li>
    <li>mopidy-iris.dist</li>
    <li>mopidy-jellyfin</li>
    <li>mopidy-jellyfin.dist</li>
    <li>mopidy-local</li>
    <li>mopidy-local.dist</li>
    <li>mopidy-moped</li>
    <li>mopidy-moped.dist</li>
    <li>mopidy-mopify</li>
    <li>mopidy-mopify.dist</li>
    <li>mopidy-mpd</li>
    <li>mopidy-mpd.dist</li>
    <li>mopidy-mpris</li>
    <li>mopidy-mpris.dist</li>
    <li>mopidy-muse</li>
    <li>mopidy-muse.dist</li>
    <li>mopidy-musicbox-webclient</li>
    <li>mopidy-musicbox-webclient.dist</li>
    <li>mopidy-notify</li>
    <li>mopidy-notify.dist</li>
    <li>mopidy-podcast</li>
    <li>mopidy-podcast.dist</li>
    <li>mopidy-scrobbler</li>
    <li>mopidy-scrobbler.dist</li>
    <li>mopidy-somafm</li>
    <li>mopidy-somafm.dist</li>
    <li>mopidy-soundcloud</li>
    <li>mopidy-soundcloud.dist</li>
    <li>mopidy-spotify</li>
    <li>mopidy-spotify.dist</li>
    <li>mopidy-subidy</li>
    <li>mopidy-subidy.dist</li>
    <li>mopidy-tidal</li>
    <li>mopidy-tidal.dist</li>
    <li>mopidy-tunein</li>
    <li>mopidy-tunein.dist</li>
    <li>mopidy-youtube</li>
    <li>mopidy-youtube.dist</li>
    <li>mopidy-ytmusic</li>
    <li>mopidy-ytmusic.dist</li>
    <li>mopidy.dist</li>
  </ul>
</details>
