### PR TITLE
freeimage: add patch for CVE-2021-33367

### DIFF
--- a/pkgs/development/libraries/freeimage/CVE-2021-33367.patch
+++ b/pkgs/development/libraries/freeimage/CVE-2021-33367.patch
@@ -1,0 +1,19 @@
+diff --git a/Source/Metadata/Exif.cpp b/Source/Metadata/Exif.cpp
+index 62af18c..cac0e46 100644
+--- a/Source/Metadata/Exif.cpp
++++ b/Source/Metadata/Exif.cpp
+@@ -719,8 +719,13 @@ jpeg_read_exif_dir(FIBITMAP *dib, const BYTE *tiffp, DWORD dwOffsetIfd0, DWORD d
+ 	//
+ 
+ 	const WORD entriesCount0th = ReadUint16(msb_order, ifd0th);
++
++	const BYTE* de_addr = DIR_ENTRY_ADDR(ifd0th, entriesCount0th);
++	if(de_addr+4 >= (BYTE*)(dwLength + ifd0th - tiffp)) {
++		return TRUE; //< no thumbnail
++	}
+ 	
+-	DWORD next_offset = ReadUint32(msb_order, DIR_ENTRY_ADDR(ifd0th, entriesCount0th));
++	DWORD next_offset = ReadUint32(msb_order, de_addr);
+ 	if((next_offset == 0) || (next_offset >= dwLength)) {
+ 		return TRUE; //< no thumbnail
+ 	}

--- a/pkgs/development/libraries/freeimage/default.nix
+++ b/pkgs/development/libraries/freeimage/default.nix
@@ -21,6 +21,7 @@ stdenv.mkDerivation {
   patches = [
     ./unbundle.diff
     ./libtiff-4.4.0.diff
+    ./CVE-2021-33367.patch
   ];
 
   postPatch = ''


### PR DESCRIPTION
###### Description of changes

https://nvd.nist.gov/vuln/detail/CVE-2021-33367

Wrote patch myself, am hoping original reporter will test it https://sourceforge.net/p/freeimage/discussion/36109/thread/1a4db03d58/

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
