### PR TITLE
ipe: 7.2.24 -> 7.2.26

### DIFF
--- a/pkgs/applications/graphics/ipe/default.nix
+++ b/pkgs/applications/graphics/ipe/default.nix
@@ -1,5 +1,5 @@
 { lib
-, mkDerivation
+, stdenv
 , makeDesktopItem
 , fetchurl
 , pkg-config
@@ -14,21 +14,24 @@
 , lua5
 , qtbase
 , texlive
+, wrapQtAppsHook
 , zlib
+, withTeXLive ? true
 }:
 
-mkDerivation rec {
+stdenv.mkDerivation rec {
   pname = "ipe";
-  version = "7.2.24";
+  version = "7.2.26";
 
   src = fetchurl {
     url = "https://github.com/otfried/ipe/releases/download/v${version}/ipe-${version}-src.tar.gz";
-    sha256 = "sha256-/rh58k0dziWRB5B3BEbVCwPkbuLr19KBV7FwWXFkT28=";
+    sha256 = "sha256-5J0AV5E6SlFrIBfwDZrbJnkDUoVZ0fDH669s2RQ1CqU=";
   };
+  patches = [
+    ./headers-lookup.patch
+  ];
 
-  sourceRoot = "${pname}-${version}/src";
-
-  nativeBuildInputs = [ pkg-config copyDesktopItems ];
+  nativeBuildInputs = [ pkg-config copyDesktopItems wrapQtAppsHook ];
 
   buildInputs = [
     cairo
@@ -40,15 +43,19 @@ mkDerivation rec {
     libspiro
     lua5
     qtbase
-    texlive
     zlib
+  ] ++ (lib.optionals withTeXLive [
+    texlive
+  ]);
+
+  makeFlags = [
+    "-C src"
+    "IPEPREFIX=${placeholder "out"}"
+    "LUA_PACKAGE=lua"
+    "IPE_NO_SPELLCHECK=1" # qtSpell is not yet packaged
   ];
 
-  IPEPREFIX = placeholder "out";
-  URWFONTDIR = "${texlive}/texmf-dist/fonts/type1/urw/";
-  LUA_PACKAGE = "lua";
-
-  qtWrapperArgs = [ "--prefix PATH : ${lib.makeBinPath [ texlive ]}" ];
+  qtWrapperArgs = lib.optional withTeXLive [ "--prefix PATH : ${lib.makeBinPath [ texlive ]}" ];
 
   enableParallelBuilding = true;
 

--- a/pkgs/applications/graphics/ipe/headers-lookup.patch
+++ b/pkgs/applications/graphics/ipe/headers-lookup.patch
@@ -1,0 +1,13 @@
+diff --git a/src/ipepresenter/Makefile b/src/ipepresenter/Makefile
+index ae3664e..f4f74ff 100644
+--- a/src/ipepresenter/Makefile
++++ b/src/ipepresenter/Makefile
+@@ -8,7 +8,7 @@ include ../common.mak
+ 
+ TARGET = $(call exe_target,ipepresenter)
+ 
+-CXXFLAGS += -I../include -I../ipecanvas -I../ipecairo \
++CPPFLAGS += -I../include -I../ipecanvas -I../ipecairo \
+ 	$(UI_CFLAGS) $(CAIRO_CFLAGS) $(ZLIB_CFLAGS)
+ LIBS += -L$(buildlib) -lipecanvas -lipecairo -lipe \
+ 	$(UI_LIBS) $(CAIRO_LIBS) $(ZLIB_LIBS)


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

https://github.com/otfried/ipe/releases/tag/v7.2.25 (adds spellchecking using QtSpell, disabled at compile-time for now because QtSpell is not yet packaged in nixpkgs)
https://github.com/otfried/ipe/releases/tag/v7.2.26

This also introduces a new option to make TeX Live optional. Ipe tries to find LaTeX executables in PATH and some users might prefer to use their existing TeX Live installation.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
