### PR TITLE
sweet-nova: init at unstable-2023-04-02

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -4041,6 +4041,15 @@
     githubId = 108501;
     name = "David Pflug";
   };
+  dr460nf1r3 = {
+    email = "root@dr460nf1r3.org";
+    github = "dr460nf1r3";
+    githubId = 12834713;
+    name = "Nico Jensch";
+    keys = [{
+      fingerprint = "D245 D484 F357 8CB1 7FD6  DA6B 67DB 29BF F3C9 6757";
+    }];
+  };
   dramaturg = {
     email = "seb@ds.ag";
     github = "dramaturg";

--- a/pkgs/data/themes/sweet-nova/default.nix
+++ b/pkgs/data/themes/sweet-nova/default.nix
@@ -1,0 +1,51 @@
+{ fetchFromGitHub
+, gitUpdater
+, lib
+, stdenvNoCC
+}:
+
+stdenvNoCC.mkDerivation {
+  pname = "sweet-nova";
+  version = "unstable-2023-04-02";
+
+  src = fetchFromGitHub {
+    owner = "EliverLara";
+    repo = "Sweet";
+    rev = "8a5d5a7d975567b5ae101b9f9d436fb1db2d9b24";
+    hash = "sha256-FVcXBxcS5oFsvAUDcwit7EIfgIQznl8AYYxqQ797ddU=";
+  };
+
+  buildPhase = ''
+    runHook preBuild
+    cd kde
+    mkdir -p aurorae/themes
+    mv aurorae/Sweet-Dark aurorae/themes/Sweet-Dark
+    mv aurorae/Sweet-Dark-transparent aurorae/themes/Sweet-Dark-transparent
+    rm aurorae/.shade.svg
+    mv colorschemes color-schemes
+    mkdir -p plasma/look-and-feel
+    mv look-and-feel plasma/look-and-feel/com.github.eliverlara.sweet
+    mv sddm sddm-Sweet
+    mkdir -p sddm/themes
+    mv sddm-Sweet sddm/themes/Sweet
+    mv cursors icons
+    runHook postBuild
+  '';
+
+  installPhase = ''
+    runHook preInstall
+    install -d $out/share
+    cp -r Kvantum aurorae color-schemes icons konsole plasma sddm $out/share
+    runHook postInstall
+  '';
+
+  passthru.updateScript = gitUpdater { };
+
+  meta = with lib; {
+    description = "A dark and colorful, blurry theme for the KDE Plasma desktop";
+    homepage = "https://github.com/EliverLara/Sweet";
+    license = licenses.gpl3Only;
+    maintainers = [ maintainers.dr460nf1r3 ];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -28366,6 +28366,8 @@ with pkgs;
 
   sweet = callPackage ../data/themes/sweet { };
 
+  sweet-nova = callPackage ../data/themes/sweet-nova { };
+
   shared-mime-info = callPackage ../data/misc/shared-mime-info { };
 
   shared_desktop_ontologies = callPackage ../data/misc/shared-desktop-ontologies { };


### PR DESCRIPTION
###### Description of changes

This package contains the KDE variation of the Sweet theme. While `sweet` is already available, it refers to just the GTK theme.

https://github.com/EliverLara/Sweet/tree/nova/kde

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
