### PR TITLE
libwtk-sdl2: init at unstable-2023-02-28

### DIFF
--- a/pkgs/applications/audio/mpd-touch-screen-gui/default.nix
+++ b/pkgs/applications/audio/mpd-touch-screen-gui/default.nix
@@ -1,0 +1,63 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, autoreconfHook
+, pkg-config
+, SDL2
+, SDL2_ttf
+, SDL2_image
+, boost
+, libmpdclient
+, libwtk-sdl2
+, icu
+, libconfig
+, dejavu_fonts
+}:
+
+stdenv.mkDerivation rec {
+  pname = "mpd-touch-screen-gui";
+  version = "unstable-2022-12-30";
+
+  src = fetchFromGitHub {
+    owner = "muesli4";
+    repo = pname;
+    rev = "156eaebede89da2b83a98d8f9dfa46af12282fb4";
+    sha256 = "sha256-vr/St4BghrndjUQ0nZI/uJq+F/MjEj6ulc4DYwQ/pgU=";
+  };
+
+  nativeBuildInputs = [
+    pkg-config
+    autoreconfHook
+  ];
+
+  postPatch = ''
+    sed -i s#/usr/share/fonts/TTF#${dejavu_fonts}/share/fonts/truetype#g data/program.conf
+  '';
+
+  buildInputs = [
+    SDL2
+    SDL2_ttf
+    SDL2_image
+    boost
+    libmpdclient
+    libwtk-sdl2
+    icu
+    libconfig
+  ];
+
+  # https://stackoverflow.com/questions/53089494/configure-error-could-not-find-a-version-of-the-library
+  configureFlags = [
+    "--with-boost-libdir=${boost.out}/lib"
+  ];
+
+  doCheck = true;
+
+  meta = with lib; {
+    description = "A small MPD client that let's you view covers and has controls suitable for small touchscreens";
+    homepage = "https://github.com/muesli4/mpd-touch-screen-gui";
+    # See: https://github.com/muesli4/mpd-touch-screen-gui/tree/master/LICENSES
+    license = licenses.lgpl3Plus;
+    maintainers = with maintainers; [ doronbehar ];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/development/libraries/libwtk-sdl2/default.nix
+++ b/pkgs/development/libraries/libwtk-sdl2/default.nix
@@ -1,0 +1,51 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, autoreconfHook
+, pkg-config
+, boost
+, SDL2
+, SDL2_ttf
+, SDL2_image
+}:
+
+stdenv.mkDerivation rec {
+  pname = "libwtk-sdl2";
+  version = "unstable-2023-02-28";
+
+  src = fetchFromGitHub {
+    owner = "muesli4";
+    repo = pname;
+    rev = "0504f8342c8c97d0c8b43d33751427c564ad8d44";
+    sha256 = "sha256-NAjsDQ4/hklYRfa85uleOr50tmc6UJVo2xiDnEbmIxk=";
+  };
+
+  nativeBuildInputs = [
+    pkg-config
+    autoreconfHook
+  ];
+  buildInputs = [
+    boost
+    SDL2
+    SDL2_ttf
+    SDL2_image
+  ];
+  # From some reason, this is needed as otherwise SDL.h is not found
+  NIX_CFLAGS_COMPILE = "-I${SDL2.dev}/include/SDL2";
+
+  outputs = [ "out" "dev" "lib" ];
+
+  meta = with lib; {
+    description = "Simplistic SDL2 GUI framework in early developement";
+    homepage = "https://github.com/muesli4/libwtk-sdl2";
+    # See: https://github.com/muesli4/mpd-touch-screen-gui/tree/master/LICENSES
+    license = licenses.lgpl3Plus;
+    maintainers = with maintainers; [ doronbehar ];
+    /* Partial darwin build failure log (from ofborg):
+    geometry.cpp:95:34: error: no member named 'abs' in namespace 'std'
+       >     return { std::abs(v.w), std::abs(v.h) };
+       >                             ~~~~~^
+    */
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -18427,6 +18427,8 @@ with pkgs;
 
   libwhich = callPackage ../development/tools/misc/libwhich { };
 
+  libwtk-sdl2 = callPackage ../development/libraries/libwtk-sdl2 { };
+
   linuxkit = callPackage ../development/tools/misc/linuxkit {
     inherit (darwin.apple_sdk_11_0.frameworks) Virtualization;
   };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5376,6 +5376,8 @@ with pkgs;
 
   mpris-scrobbler = callPackage ../tools/audio/mpris-scrobbler { };
 
+  mpd-touch-screen-gui = callPackage ../applications/audio/mpd-touch-screen-gui { };
+
   mq-cli = callPackage ../tools/system/mq-cli { };
 
   mrkd = with python3Packages; toPythonApplication mrkd;


### PR DESCRIPTION
###### Motivation for this change


###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
