### PR TITLE
gobject-introspection: fix pkgsCross.gnu32.gobject-introspection from…

### DIFF
--- a/pkgs/development/libraries/gobject-introspection/default.nix
+++ b/pkgs/development/libraries/gobject-introspection/default.nix
@@ -79,7 +79,8 @@ stdenv.mkDerivation (finalAttrs: {
     # Build definition checks for the Python modules needed at runtime by importing them.
     (buildPackages.python3.withPackages pythonModules)
     finalAttrs.setupHook # move .gir files
-  ] ++ lib.optionals (!stdenv.buildPlatform.canExecute stdenv.hostPlatform) [ gobject-introspection-unwrapped ];
+    # can't use canExecute, we need prebuilt when cross
+  ] ++ lib.optionals (stdenv.buildPlatform != stdenv.hostPlatform) [ gobject-introspection-unwrapped ];
 
   buildInputs = [
     (python3.withPackages pythonModules)
@@ -106,8 +107,10 @@ stdenv.mkDerivation (finalAttrs: {
       inherit (buildPackages) bash;
       buildlddtree = "${buildPackages.pax-utils}/bin/lddtree";
     }}"
-    "-Dgi_cross_use_prebuilt_gi=true"
     "-Dgi_cross_binary_wrapper=${stdenv.hostPlatform.emulator buildPackages}"
+    # can't use canExecute, we need prebuilt when cross
+  ] ++ lib.optionals (stdenv.buildPlatform != stdenv.hostPlatform) [
+    "-Dgi_cross_use_prebuilt_gi=true"
   ];
 
   doCheck = !stdenv.isAarch64;


### PR DESCRIPTION
… x86_64-linux
```
gobject-introspection-i686-unknown-linux-gnu> FAILED: gir/GLib-2.0.gir gobject-introspection-i686-unknown-linux-gnu> /build/gobject-introspection-1.74.0/build/tools/g-ir-scanner --output=gir/GLib-2.0.gir --no-libtool --quiet --reparse-validate --add-include-path /build/gobject-introspection-1.74.0/build/gir --add-include-path /build/gobject-introspectio ... gobject-introspection-i686-unknown-linux-gnu> Traceback (most recent call last):
gobject-introspection-i686-unknown-linux-gnu>   File "/build/gobject-introspection-1.74.0/build/tools/g-ir-scanner", line 98, in <module>
gobject-introspection-i686-unknown-linux-gnu>     from giscanner.scannermain import scanner_main
gobject-introspection-i686-unknown-linux-gnu>   File "/build/gobject-introspection-1.74.0/build/giscanner/scannermain.py", line 35, in <module>
gobject-introspection-i686-unknown-linux-gnu>     from giscanner.ast import Include, Namespace
gobject-introspection-i686-unknown-linux-gnu>   File "/build/gobject-introspection-1.74.0/build/giscanner/ast.py", line 29, in <module>
gobject-introspection-i686-unknown-linux-gnu>     from .sourcescanner import CTYPE_TYPEDEF, CSYMBOL_TYPE_TYPEDEF
gobject-introspection-i686-unknown-linux-gnu>   File "/build/gobject-introspection-1.74.0/build/giscanner/sourcescanner.py", line 34, in <module>
gobject-introspection-i686-unknown-linux-gnu>     from giscanner._giscanner import SourceScanner as CSourceScanner
gobject-introspection-i686-unknown-linux-gnu> ImportError: /build/gobject-introspection-1.74.0/build/giscanner/_giscanner.cpython-310-x86_64-linux-gnu.so: wrong ELF class: ELFCLASS32
gobject-introspection-i686-unknown-linux-gnu> ninja: build stopped: subcommand failed.
```
fixes https://github.com/NixOS/nixpkgs/issues/224987
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
