### PR TITLE
fuse-7z-ng: add patch to zero-init `struct fuse_operations`

### DIFF
--- a/pkgs/tools/filesystems/fuse-7z-ng/default.nix
+++ b/pkgs/tools/filesystems/fuse-7z-ng/default.nix
@@ -16,6 +16,7 @@ stdenv.mkDerivation rec {
     ./no-pthread.patch
     # Zero-initialize unset fields of `struct fuse_operations` so that
     # garbage values don't cause segfault.
+    # <https://github.com/kedazo/fuse-7z-ng/pull/8>
     ./zero-init-fuse-operations.patch
   ];
 

--- a/pkgs/tools/filesystems/fuse-7z-ng/default.nix
+++ b/pkgs/tools/filesystems/fuse-7z-ng/default.nix
@@ -14,6 +14,9 @@ stdenv.mkDerivation rec {
     # Drop unused pthread library. pthread_yield()
     # fails the configure.
     ./no-pthread.patch
+    # Zero-initialize unset fields of `struct fuse_operations` so that
+    # garbage values don't cause segfault.
+    ./zero-init-fuse-operations.patch
   ];
 
   nativeBuildInputs = [ pkg-config makeWrapper autoconf automake ];

--- a/pkgs/tools/filesystems/fuse-7z-ng/zero-init-fuse-operations.patch
+++ b/pkgs/tools/filesystems/fuse-7z-ng/zero-init-fuse-operations.patch
@@ -1,4 +1,5 @@
 Zero-initialize unset fields of `struct fuse_operations`.
+<https://github.com/kedazo/fuse-7z-ng/pull/8>
 --- a/src/main.cpp
 +++ b/src/main.cpp
 @@ -195,7 +195,7 @@ main (int argc, char **argv)

--- a/pkgs/tools/filesystems/fuse-7z-ng/zero-init-fuse-operations.patch
+++ b/pkgs/tools/filesystems/fuse-7z-ng/zero-init-fuse-operations.patch
@@ -1,0 +1,12 @@
+Zero-initialize unset fields of `struct fuse_operations`.
+--- a/src/main.cpp
++++ b/src/main.cpp
+@@ -195,7 +195,7 @@ main (int argc, char **argv)
+         mkdir(param.mountpoint, 0750);
+     }
+ 
+-    struct fuse_operations fuse7z_oper;
++    struct fuse_operations fuse7z_oper = {0};
+     fuse7z_oper.init = fuse7z_init;
+     fuse7z_oper.destroy = fuse7z_destroy;
+     fuse7z_oper.readdir = fuse7z_readdir;


### PR DESCRIPTION
###### Description of changes

Fixes segfault when accessing archive files. 

`struct fuse_operations` contains function pointers specifying a filesystem's behavior for each operation. For unimplemented operations, they must be set to null so that libfuse can fall back to a default implementation or return an error. In fuse-7z-ng, however, they were left uninitialized, causing segfault due to garbage values stored in them.

Upstream PR: <https://github.com/kedazo/fuse-7z-ng/pull/8>

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

