### PR TITLE
buildEnv: allow arbitrary arguments

### DIFF
--- a/pkgs/build-support/buildenv/default.nix
+++ b/pkgs/build-support/buildenv/default.nix
@@ -42,7 +42,8 @@ lib.makeOverridable
 
 , passthru ? {}
 , meta ? {}
-}:
+, ...
+}@args:
 
 let
   builder = substituteAll {
@@ -51,7 +52,10 @@ let
   };
 in
 
-runCommand name
+runCommand name ({
+    preferLocalBuild = true;
+    allowSubstitutes = false;
+  } // (removeAttrs args [ "extraOutputsToInstall" "name" "passAsFile" "paths" ]) //
   rec {
     inherit manifest ignoreCollisions checkCollisionContents passthru
             meta pathsToLink extraPrefix postBuild
@@ -71,11 +75,10 @@ runCommand name
           (builtins.map (outName: drv.${outName} or null) extraOutputsToInstall);
       priority = drv.meta.priority or 5;
     }) paths);
-    preferLocalBuild = true;
-    allowSubstitutes = false;
     # XXX: The size is somewhat arbitrary
-    passAsFile = if builtins.stringLength pkgs >= 128*1024 then [ "pkgs" ] else [ ];
-  }
+    passAsFile = lib.optional (builtins.stringLength pkgs >= 128*1024) "pkgs"
+      ++ (lib.remove "pkgs" args.passAsFile or [ ]);
+  })
   ''
     ${buildPackages.perl}/bin/perl -w ${builder}
     eval "$postBuild"


### PR DESCRIPTION
###### Description of changes
Allow arbitrary arguments in `buildEnv`, as suggested by @SuperSandro2000 in https://github.com/NixOS/nixpkgs/pull/119362#discussion_r1125703182

`texlive.combine` would surely benefit from this.

I have written the PR so that evaluation remains identical, but one can also drop the manual list of arguments – e.g. there is no more need to manually inherit `meta`, `passthru`. Except that changing the arguments causes a massive rebuild.

###### Things done
- Built on platform(s) – nothing to build in theory
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).