### PR TITLE
swift: 5.7.3 -> 5.8

### DIFF
--- a/pkgs/development/compilers/llvm/15/compiler-rt/default.nix
+++ b/pkgs/development/compilers/llvm/15/compiler-rt/default.nix
@@ -97,8 +97,6 @@ stdenv.mkDerivation {
     substituteInPlace cmake/builtin-config-ix.cmake \
       --replace 'set(X86 i386)' 'set(X86 i386 i486 i586 i686)'
   '' + lib.optionalString stdenv.isDarwin ''
-    substituteInPlace cmake/builtin-config-ix.cmake \
-      --replace 'set(ARM64 arm64 arm64e)' 'set(ARM64)'
     substituteInPlace cmake/config-ix.cmake \
       --replace 'set(COMPILER_RT_HAS_TSAN TRUE)' 'set(COMPILER_RT_HAS_TSAN FALSE)'
   '' + lib.optionalString (useLLVM) ''

--- a/pkgs/development/compilers/swift/compiler/default.nix
+++ b/pkgs/development/compilers/swift/compiler/default.nix
@@ -99,7 +99,6 @@ let
     # "clang-builtin-headers"
     "stdlib"
     "sdk-overlay"
-    "parser-lib"
     "static-mirror-lib"
     "editor-integration"
     # "tools"
@@ -257,6 +256,7 @@ in stdenv.mkDerivation {
     ${copySource "llvm-project"}
     ${copySource "swift"}
     ${copySource "swift-experimental-string-processing"}
+    ${copySource "swift-syntax"}
     ${lib.optionalString
       (!stdenv.isDarwin)
       (copySource "swift-corelibs-libdispatch")}
@@ -276,9 +276,13 @@ in stdenv.mkDerivation {
       -e 's|/bin/cp|${coreutils}/bin/cp|g' \
       -e 's|/usr/bin/file|${file}/bin/file|g'
 
+    patch -p1 -d swift -i ${./patches/swift-cmake-3.25-compat.patch}
     patch -p1 -d swift -i ${./patches/swift-wrap.patch}
     patch -p1 -d swift -i ${./patches/swift-nix-resource-root.patch}
+    patch -p1 -d swift -i ${./patches/swift-linux-fix-libc-paths.patch}
     patch -p1 -d swift -i ${./patches/swift-linux-fix-linking.patch}
+    patch -p1 -d swift -i ${./patches/swift-darwin-libcxx-flags.patch}
+    patch -p1 -d swift -i ${./patches/swift-darwin-link-cxxabi.patch}
     patch -p1 -d swift -i ${substituteAll {
       src = ./patches/swift-darwin-plistbuddy-workaround.patch;
       inherit swiftArch;
@@ -287,8 +291,6 @@ in stdenv.mkDerivation {
       src = ./patches/swift-prevent-sdk-dirs-warning.patch;
       inherit (builtins) storeDir;
     }}
-    substituteInPlace swift/cmake/modules/SwiftConfigureSDK.cmake \
-      --replace '/usr/include' "${stdenv.cc.libc_dev}/include"
 
     # This patch needs to know the lib output location, so must be substituted
     # in the same derivation as the compiler.
@@ -321,8 +323,8 @@ in stdenv.mkDerivation {
     ''}
 
     # Remove tests for cross compilation, which we don't currently support.
-    rm swift/test/Interop/Cxx/class/constructors-copy-irgen.swift
-    rm swift/test/Interop/Cxx/class/constructors-irgen.swift
+    rm swift/test/Interop/Cxx/class/constructors-copy-irgen-*.swift
+    rm swift/test/Interop/Cxx/class/constructors-irgen-*.swift
 
     # TODO: consider fixing and re-adding. This test fails due to a non-standard "install_prefix".
     rm swift/validation-test/Python/build_swift.swift
@@ -342,7 +344,7 @@ in stdenv.mkDerivation {
     rm swift/test/Serialization/restrict-swiftmodule-to-revision.swift
 
     # This test was flaky in ofborg, see #186476
-    rm swift/test/AutoDiff/compiler_crashers_fixed/sr14290-missing-debug-scopes-in-pullback-trampoline.swift
+    rm swift/test/AutoDiff/compiler_crashers_fixed/issue-56649-missing-debug-scopes-in-pullback-trampoline.swift
 
     patchShebangs .
 
@@ -446,7 +448,8 @@ in stdenv.mkDerivation {
       -DSWIFT_PATH_TO_CMARK_SOURCE=$SWIFT_SOURCE_ROOT/swift-cmark
       -DSWIFT_PATH_TO_CMARK_BUILD=$SWIFT_BUILD_ROOT/swift-cmark
       -DSWIFT_PATH_TO_LIBDISPATCH_SOURCE=$SWIFT_SOURCE_ROOT/swift-corelibs-libdispatch
-      -DEXPERIMENTAL_STRING_PROCESSING_SOURCE_DIR=$SWIFT_SOURCE_ROOT/swift-experimental-string-processing
+      -DSWIFT_PATH_TO_SWIFT_SYNTAX_SOURCE=$SWIFT_SOURCE_ROOT/swift-syntax
+      -DSWIFT_PATH_TO_STRING_PROCESSING_SOURCE=$SWIFT_SOURCE_ROOT/swift-experimental-string-processing
       -DSWIFT_INSTALL_COMPONENTS=${lib.concatStringsSep ";" swiftInstallComponents}
       -DSWIFT_STDLIB_ENABLE_OBJC_INTEROP=${if stdenv.isDarwin then "ON" else "OFF"}
     "
@@ -501,6 +504,7 @@ in stdenv.mkDerivation {
     cmakeFlags="
       -GNinja
       -DCMAKE_Swift_COMPILER=$SWIFT_BUILD_ROOT/swift/bin/swiftc
+      -DSWIFT_PATH_TO_SWIFT_SYNTAX_SOURCE=$SWIFT_SOURCE_ROOT/swift-syntax
 
       -DTOOLCHAIN_DIR=/var/empty
       -DSWIFT_NATIVE_LLVM_TOOLS_PATH=${stdenv.cc}/bin
@@ -579,7 +583,7 @@ in stdenv.mkDerivation {
     # Undo the clang and swift wrapping we did for the build.
     # (This happened via patches to cmake files.)
     cd $SWIFT_BUILD_ROOT
-    mv llvm/bin/clang-14{-unwrapped,}
+    mv llvm/bin/clang-15{-unwrapped,}
     mv swift/bin/swift-frontend{-unwrapped,}
 
     mkdir $out $lib

--- a/pkgs/development/compilers/swift/compiler/patches/swift-cmake-3.25-compat.patch
+++ b/pkgs/development/compilers/swift/compiler/patches/swift-cmake-3.25-compat.patch
@@ -1,0 +1,1509 @@
+Upstream PR: https://github.com/apple/swift/pull/65534
+
+commit 112681f7f5927588569b225d926ca9f5f9ec98b3
+Author: Stéphan Kochen <git@stephank.nl>
+Date:   Sat Apr 29 20:34:40 2023 +0200
+
+    build: fix accidental cmake expansions
+    
+    As of CMake 3.25, there are now global variables `LINUX=1`, `ANDROID=1`,
+    etc. These conflict with expressions that used these names as unquoted
+    strings in positions where CMake accepts 'variable|string', for example:
+    
+    - `if(sdk STREQUAL LINUX)` would fail, because `LINUX` is now defined and
+      expands to 1, where it would previously coerce to a string.
+    
+    - `if(${sdk} STREQUAL "LINUX")` would fail if `sdk=LINUX`, because the
+      left-hand side expands twice.
+    
+    In this patch, I looked for a number of patterns to fix up, sometimes a
+    little defensively:
+    
+    - Quoted right-hand side of `STREQUAL` where I was confident it was
+      intended to be a string literal.
+    
+    - Removed manual variable expansion on left-hand side of `STREQUAL`,
+      `MATCHES` and `IN_LIST` where I was confident it was unintended.
+    
+    Fixes #65028.
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index eaab71fbaf0..45aa5d65dd3 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -119,7 +119,7 @@ else()
+   if(CMAKE_SYSTEM_PROCESSOR MATCHES "x86_64|AMD64|amd64")
+     set(SWIFT_HOST_VARIANT_ARCH_default "x86_64")
+   elseif(CMAKE_SYSTEM_PROCESSOR MATCHES "aarch64|ARM64|arm64")
+-    if(SWIFT_HOST_VARIANT_SDK_default STREQUAL OSX)
++    if(SWIFT_HOST_VARIANT_SDK_default STREQUAL "OSX")
+       set(SWIFT_HOST_VARIANT_ARCH_default "arm64")
+     else()
+       set(SWIFT_HOST_VARIANT_ARCH_default "aarch64")
+@@ -336,7 +336,7 @@ set(SWIFT_STDLIB_BUILD_TYPE "${CMAKE_BUILD_TYPE}" CACHE STRING
+ #   - MultiThreadedDebug (/MTd)
+ #   - MultiThreadedDLL (/MD)
+ #   - MultiThreadedDebugDLL (/MDd)
+-if(CMAKE_BUILD_TYPE STREQUAL Debug)
++if(CMAKE_BUILD_TYPE STREQUAL "Debug")
+   set(SWIFT_STDLIB_MSVC_RUNTIME_LIBRARY_default MultiThreadedDebugDLL)
+ else()
+   set(SWIFT_STDLIB_MSVC_RUNTIME_LIBRARY_default MultiThreadedDLL)
+@@ -598,7 +598,7 @@ if(SWIFT_BUILT_STANDALONE)
+   project(Swift C CXX ASM)
+ endif()
+ 
+-if(MSVC OR "${CMAKE_SIMULATE_ID}" STREQUAL MSVC)
++if(MSVC OR "${CMAKE_SIMULATE_ID}" STREQUAL "MSVC")
+   include(ClangClCompileRules)
+ elseif(UNIX)
+   include(UnixCompileRules)
+@@ -627,7 +627,7 @@ if(SWIFT_ENABLE_EXPERIMENTAL_CONCURRENCY AND "${SWIFT_CONCURRENCY_GLOBAL_EXECUTO
+ endif()
+ 
+ set(SWIFT_BUILD_HOST_DISPATCH FALSE)
+-if(SWIFT_ENABLE_DISPATCH AND NOT CMAKE_SYSTEM_NAME STREQUAL Darwin)
++if(SWIFT_ENABLE_DISPATCH AND NOT CMAKE_SYSTEM_NAME STREQUAL "Darwin")
+   # Only build libdispatch for the host if the host tools are being built and
+   # specifically if these two libraries that depend on it are built.
+   if(SWIFT_INCLUDE_TOOLS AND SWIFT_BUILD_SOURCEKIT)
+@@ -801,11 +801,11 @@ endif()
+ # build environment.
+ if(LLVM_USE_LINKER)
+   set(SWIFT_USE_LINKER_default "${LLVM_USE_LINKER}")
+-elseif(${SWIFT_HOST_VARIANT_SDK} STREQUAL ANDROID)
++elseif(SWIFT_HOST_VARIANT_SDK STREQUAL "ANDROID")
+   set(SWIFT_USE_LINKER_default "lld")
+-elseif(CMAKE_SYSTEM_NAME STREQUAL Windows AND NOT CMAKE_HOST_SYSTEM_NAME STREQUAL Windows)
++elseif(CMAKE_SYSTEM_NAME STREQUAL "Windows" AND NOT CMAKE_HOST_SYSTEM_NAME STREQUAL "Windows")
+   set(SWIFT_USE_LINKER_default "lld")
+-elseif(CMAKE_SYSTEM_NAME STREQUAL Darwin)
++elseif(CMAKE_SYSTEM_NAME STREQUAL "Darwin")
+   set(SWIFT_USE_LINKER_default "")
+ else()
+   set(SWIFT_USE_LINKER_default "gold")
+diff --git a/SwiftCompilerSources/CMakeLists.txt b/SwiftCompilerSources/CMakeLists.txt
+index 225e72663a1..d14e0ccecac 100644
+--- a/SwiftCompilerSources/CMakeLists.txt
++++ b/SwiftCompilerSources/CMakeLists.txt
+@@ -80,7 +80,7 @@ function(add_swift_compiler_modules_library name)
+     list(APPEND swift_compile_options "-Xfrontend" "-disable-implicit-string-processing-module-import")
+   endif()
+ 
+-  if(CMAKE_BUILD_TYPE STREQUAL Debug)
++  if(CMAKE_BUILD_TYPE STREQUAL "Debug")
+     list(APPEND swift_compile_options "-g")
+   else()
+     list(APPEND swift_compile_options "-O" "-cross-module-optimization")
+@@ -98,7 +98,7 @@ function(add_swift_compiler_modules_library name)
+     set(deployment_version "${SWIFT_SDK_${SWIFT_HOST_VARIANT_SDK}_DEPLOYMENT_VERSION}")
+     set(sdk_path "${SWIFT_SDK_${SWIFT_HOST_VARIANT_SDK}_ARCH_${SWIFT_HOST_VARIANT_ARCH}_PATH}")
+     set(sdk_option "-sdk" "${sdk_path}")
+-    if(${BOOTSTRAPPING_MODE} STREQUAL "CROSSCOMPILE-WITH-HOSTLIBS")
++    if(BOOTSTRAPPING_MODE STREQUAL "CROSSCOMPILE-WITH-HOSTLIBS")
+       # Let the cross-compiled compile don't pick up the compiled stdlib by providing
+       # an (almost) empty resource dir.
+       # The compiler will instead pick up the stdlib from the SDK.
+@@ -117,7 +117,7 @@ function(add_swift_compiler_modules_library name)
+         message(ERROR "libc++ not found in the toolchain.")
+       endif()
+     endif()
+-  elseif(${BOOTSTRAPPING_MODE} STREQUAL "CROSSCOMPILE")
++  elseif(BOOTSTRAPPING_MODE STREQUAL "CROSSCOMPILE")
+     set(sdk_option "-sdk" "${SWIFT_SDK_${SWIFT_HOST_VARIANT_SDK}_ARCH_${SWIFT_HOST_VARIANT_ARCH}_PATH}")
+     get_filename_component(swift_exec_bin_dir ${ALS_SWIFT_EXEC} DIRECTORY)
+     set(sdk_option ${sdk_option} "-resource-dir" "${swift_exec_bin_dir}/../lib/swift")
+@@ -253,13 +253,13 @@ else()
+   add_dependencies(importedHeaderDependencies swift-ast-generated-headers)
+   target_include_directories(importedHeaderDependencies PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}/../include/swift")
+ 
+-  if(${BOOTSTRAPPING_MODE} MATCHES "HOSTTOOLS|CROSSCOMPILE")
++  if(BOOTSTRAPPING_MODE MATCHES "HOSTTOOLS|CROSSCOMPILE")
+ 
+     if (NOT SWIFT_EXEC_FOR_SWIFT_MODULES)
+       message(FATAL_ERROR "Need a swift toolchain building swift compiler sources")
+     endif()
+ 
+-    if(${BOOTSTRAPPING_MODE} STREQUAL "HOSTTOOLS")
++    if(BOOTSTRAPPING_MODE STREQUAL "HOSTTOOLS")
+       if(NOT SWIFT_EXEC_FOR_SWIFT_MODULES STREQUAL CMAKE_Swift_COMPILER)
+         message(FATAL_ERROR "The Swift compiler (${CMAKE_Swift_COMPILER}) differs from the Swift compiler in SWIFT_NATIVE_SWIFT_TOOLS_PATH (${SWIFT_NATIVE_SWIFT_TOOLS_PATH}/swiftc).")
+       endif()
+@@ -275,11 +275,11 @@ else()
+     add_swift_compiler_modules_library(swiftCompilerModules
+       SWIFT_EXEC "${SWIFT_EXEC_FOR_SWIFT_MODULES}")
+ 
+-  elseif(${BOOTSTRAPPING_MODE} MATCHES "BOOTSTRAPPING.*")
++  elseif(BOOTSTRAPPING_MODE MATCHES "BOOTSTRAPPING.*")
+ 
+     set(b0_deps swift-frontend-bootstrapping0 symlink-headers-bootstrapping0)
+     set(b1_deps swift-frontend-bootstrapping1 symlink-headers-bootstrapping1)
+-    if(${BOOTSTRAPPING_MODE} STREQUAL "BOOTSTRAPPING")
++    if(BOOTSTRAPPING_MODE STREQUAL "BOOTSTRAPPING")
+       list(APPEND b0_deps swiftCore-bootstrapping0)
+       list(APPEND b1_deps swiftCore-bootstrapping1)
+       if(CMAKE_BUILD_TYPE STREQUAL "Debug")
+@@ -290,7 +290,7 @@ else()
+         list(APPEND b0_deps swiftDarwin-bootstrapping0)
+         list(APPEND b1_deps swiftDarwin-bootstrapping1)
+       endif()
+-      if(${SWIFT_HOST_VARIANT_SDK} IN_LIST SWIFT_LIBSTDCXX_PLATFORMS)
++      if(SWIFT_HOST_VARIANT_SDK IN_LIST SWIFT_LIBSTDCXX_PLATFORMS)
+         list(APPEND b0_deps copy-libstdcxx-modulemap-bootstrapping0 copy-libstdcxx-header-bootstrapping0)
+         list(APPEND b1_deps copy-libstdcxx-modulemap-bootstrapping1 copy-libstdcxx-header-bootstrapping1)
+       endif()
+diff --git a/benchmark/cmake/modules/AddSwiftBenchmarkSuite.cmake b/benchmark/cmake/modules/AddSwiftBenchmarkSuite.cmake
+index dd989efe618..3ed37754214 100644
+--- a/benchmark/cmake/modules/AddSwiftBenchmarkSuite.cmake
++++ b/benchmark/cmake/modules/AddSwiftBenchmarkSuite.cmake
+@@ -21,7 +21,7 @@ macro(configure_build)
+     # thus allowing the --host-cc build-script argument to work here.
+     get_filename_component(c_compiler ${CMAKE_C_COMPILER} NAME)
+ 
+-    if(${c_compiler} STREQUAL "clang")
++    if(c_compiler STREQUAL "clang")
+       set(CLANG_EXEC ${CMAKE_C_COMPILER})
+     else()
+       if(NOT SWIFT_DARWIN_XCRUN_TOOLCHAIN)
+@@ -713,7 +713,7 @@ function(swift_benchmark_compile)
+ 
+   if(NOT SWIFT_BENCHMARK_BUILT_STANDALONE)
+     set(stdlib_dependencies "swift-frontend" "swiftCore-${SWIFT_SDK_${SWIFT_HOST_VARIANT_SDK}_LIB_SUBDIR}")
+-    if(${SWIFT_HOST_VARIANT_SDK} IN_LIST SWIFT_DARWIN_PLATFORMS)
++    if(SWIFT_HOST_VARIANT_SDK IN_LIST SWIFT_DARWIN_PLATFORMS)
+       list(APPEND stdlib_dependencies "swiftDarwin-${SWIFT_SDK_${SWIFT_HOST_VARIANT_SDK}_LIB_SUBDIR}")
+     endif()
+     foreach(stdlib_dependency ${UNIVERSAL_LIBRARY_NAMES_${SWIFT_BENCHMARK_COMPILE_PLATFORM}})
+diff --git a/cmake/modules/AddSwift.cmake b/cmake/modules/AddSwift.cmake
+index 58c7eb1bd4f..96c4fe804f9 100644
+--- a/cmake/modules/AddSwift.cmake
++++ b/cmake/modules/AddSwift.cmake
+@@ -63,16 +63,16 @@ function(_set_target_prefix_and_suffix target kind sdk)
+   precondition(kind MESSAGE "kind is required")
+   precondition(sdk MESSAGE "sdk is required")
+ 
+-  if(${sdk} STREQUAL ANDROID)
+-    if(${kind} STREQUAL STATIC)
++  if(sdk STREQUAL "ANDROID")
++    if(kind STREQUAL "STATIC")
+       set_target_properties(${target} PROPERTIES PREFIX "lib" SUFFIX ".a")
+-    elseif(${kind} STREQUAL SHARED)
++    elseif(kind STREQUAL "SHARED")
+       set_target_properties(${target} PROPERTIES PREFIX "lib" SUFFIX ".so")
+     endif()
+-  elseif(${sdk} STREQUAL WINDOWS)
+-    if(${kind} STREQUAL STATIC)
++  elseif(sdk STREQUAL "WINDOWS")
++    if(kind STREQUAL "STATIC")
+       set_target_properties(${target} PROPERTIES PREFIX "" SUFFIX ".lib")
+-    elseif(${kind} STREQUAL SHARED)
++    elseif(kind STREQUAL "SHARED")
+       set_target_properties(${target} PROPERTIES PREFIX "" SUFFIX ".dll")
+     endif()
+   endif()
+@@ -115,7 +115,7 @@ function(_add_host_variant_c_compile_link_flags name)
+     set(DEPLOYMENT_VERSION "${SWIFT_SDK_${SWIFT_HOST_VARIANT_SDK}_DEPLOYMENT_VERSION}")
+   endif()
+ 
+-  if(SWIFT_HOST_VARIANT_SDK STREQUAL ANDROID)
++  if(SWIFT_HOST_VARIANT_SDK STREQUAL "ANDROID")
+     set(DEPLOYMENT_VERSION ${SWIFT_ANDROID_API_LEVEL})
+   endif()
+ 
+@@ -151,7 +151,7 @@ function(_add_host_variant_c_compile_link_flags name)
+     target_compile_options(${name} PRIVATE $<$<COMPILE_LANGUAGE:C,CXX,OBJC,OBJCXX>:--sysroot=${_sysroot}>)
+   endif()
+ 
+-  if(SWIFT_HOST_VARIANT_SDK STREQUAL ANDROID)
++  if(SWIFT_HOST_VARIANT_SDK STREQUAL "ANDROID")
+     # Make sure the Android NDK lld is used.
+     swift_android_tools_path(${SWIFT_HOST_VARIANT_ARCH} tools_path)
+     target_compile_options(${name} PRIVATE $<$<COMPILE_LANGUAGE:C,CXX,OBJC,OBJCXX>:-B${tools_path}>)
+@@ -223,7 +223,7 @@ function(_add_host_variant_c_compile_flags target)
+     endif()
+   endif()
+ 
+-  if(SWIFT_HOST_VARIANT_SDK STREQUAL WINDOWS)
++  if(SWIFT_HOST_VARIANT_SDK STREQUAL "WINDOWS")
+     # MSVC/clang-cl don't support -fno-pic or -fms-compatibility-version.
+     if(NOT SWIFT_COMPILER_IS_MSVC_LIKE)
+       target_compile_options(${target} PRIVATE
+@@ -276,14 +276,14 @@ function(_add_host_variant_c_compile_flags target)
+     # NOTE(compnerd) workaround LLVM invoking `add_definitions(-D_DEBUG)` which
+     # causes failures for the runtime library when cross-compiling due to
+     # undefined symbols from the standard library.
+-    if(NOT CMAKE_BUILD_TYPE STREQUAL Debug)
++    if(NOT CMAKE_BUILD_TYPE STREQUAL "Debug")
+       target_compile_options(${target} PRIVATE
+         $<$<COMPILE_LANGUAGE:C,CXX,OBJC,OBJCXX>:-U_DEBUG>)
+     endif()
+   endif()
+ 
+-  if(SWIFT_HOST_VARIANT_SDK STREQUAL ANDROID)
+-    if(SWIFT_HOST_VARIANT_ARCH STREQUAL x86_64)
++  if(SWIFT_HOST_VARIANT_SDK STREQUAL "ANDROID")
++    if(SWIFT_HOST_VARIANT_ARCH STREQUAL "x86_64")
+       # NOTE(compnerd) Android NDK 21 or lower will generate library calls to
+       # `__sync_val_compare_and_swap_16` rather than lowering to the CPU's
+       # `cmpxchg16b` instruction as the `cx16` feature is disabled due to a bug
+@@ -317,15 +317,15 @@ function(_add_host_variant_c_compile_flags target)
+       $<$<COMPILE_LANGUAGE:C,CXX,OBJC,OBJCXX>:-fprofile-instr-generate -fcoverage-mapping>)
+   endif()
+ 
+-  if((SWIFT_HOST_VARIANT_ARCH STREQUAL armv7 OR
+-      SWIFT_HOST_VARIANT_ARCH STREQUAL aarch64) AND
+-     (SWIFT_HOST_VARIANT_SDK STREQUAL LINUX OR
+-      SWIFT_HOST_VARIANT_SDK STREQUAL ANDROID))
++  if((SWIFT_HOST_VARIANT_ARCH STREQUAL "armv7" OR
++      SWIFT_HOST_VARIANT_ARCH STREQUAL "aarch64") AND
++     (SWIFT_HOST_VARIANT_SDK STREQUAL "LINUX" OR
++      SWIFT_HOST_VARIANT_SDK STREQUAL "ANDROID"))
+     target_compile_options(${target} PRIVATE $<$<COMPILE_LANGUAGE:C,CXX,OBJC,OBJCXX>:-funwind-tables>)
+   endif()
+ 
+   if(SWIFT_HOST_VARIANT_SDK STREQUAL "LINUX")
+-    if(SWIFT_HOST_VARIANT_ARCH STREQUAL x86_64)
++    if(SWIFT_HOST_VARIANT_ARCH STREQUAL "x86_64")
+       # this is the minimum architecture that supports 16 byte CAS, which is
+       # necessary to avoid a dependency to libatomic
+       target_compile_options(${target} PRIVATE $<$<COMPILE_LANGUAGE:C,CXX,OBJC,OBJCXX>:-march=core2>)
+@@ -336,7 +336,7 @@ function(_add_host_variant_c_compile_flags target)
+   # llvm/llvm-project@66395c9, which can cause incompatibilities with the Swift
+   # frontend if not built the same way.
+   if("${SWIFT_HOST_VARIANT_ARCH}" MATCHES "armv6|armv7|i686" AND
+-     NOT (SWIFT_HOST_VARIANT_SDK STREQUAL ANDROID AND SWIFT_ANDROID_API_LEVEL LESS 24))
++     NOT (SWIFT_HOST_VARIANT_SDK STREQUAL "ANDROID" AND SWIFT_ANDROID_API_LEVEL LESS 24))
+     target_compile_definitions(${target} PRIVATE
+       $<$<COMPILE_LANGUAGE:C,CXX,OBJC,OBJCXX>:_LARGEFILE_SOURCE _FILE_OFFSET_BITS=64>)
+   endif()
+@@ -345,19 +345,19 @@ endfunction()
+ function(_add_host_variant_link_flags target)
+   _add_host_variant_c_compile_link_flags(${target})
+ 
+-  if(SWIFT_HOST_VARIANT_SDK STREQUAL LINUX)
++  if(SWIFT_HOST_VARIANT_SDK STREQUAL "LINUX")
+     target_link_libraries(${target} PRIVATE
+       pthread
+       dl)
+     if("${SWIFT_HOST_VARIANT_ARCH}" MATCHES "armv5|armv6|armv7|i686")
+       target_link_libraries(${target} PRIVATE atomic)
+     endif()
+-  elseif(SWIFT_HOST_VARIANT_SDK STREQUAL FREEBSD)
++  elseif(SWIFT_HOST_VARIANT_SDK STREQUAL "FREEBSD")
+     target_link_libraries(${target} PRIVATE
+       pthread)
+-  elseif(SWIFT_HOST_VARIANT_SDK STREQUAL CYGWIN)
++  elseif(SWIFT_HOST_VARIANT_SDK STREQUAL "CYGWIN")
+     # No extra libraries required.
+-  elseif(SWIFT_HOST_VARIANT_SDK STREQUAL WINDOWS)
++  elseif(SWIFT_HOST_VARIANT_SDK STREQUAL "WINDOWS")
+     # We don't need to add -nostdlib using MSVC or clang-cl, as MSVC and
+     # clang-cl rely on auto-linking entirely.
+     if(NOT SWIFT_COMPILER_IS_MSVC_LIKE)
+@@ -375,12 +375,12 @@ function(_add_host_variant_link_flags target)
+     # the Windows SDK on case sensitive file systems.
+     target_link_directories(${target} PRIVATE
+       ${CMAKE_BINARY_DIR}/winsdk_lib_${SWIFT_HOST_VARIANT_ARCH}_symlinks)
+-  elseif(SWIFT_HOST_VARIANT_SDK STREQUAL HAIKU)
++  elseif(SWIFT_HOST_VARIANT_SDK STREQUAL "HAIKU")
+     target_link_libraries(${target} PRIVATE
+       bsd)
+     target_link_options(${target} PRIVATE
+       "SHELL:-Xlinker -Bsymbolic")
+-  elseif(SWIFT_HOST_VARIANT_SDK STREQUAL ANDROID)
++  elseif(SWIFT_HOST_VARIANT_SDK STREQUAL "ANDROID")
+     target_link_libraries(${target} PRIVATE
+       dl
+       log
+@@ -422,7 +422,7 @@ function(_add_host_variant_link_flags target)
+   #
+   # TODO: Evaluate/enable -f{function,data}-sections --gc-sections for bfd,
+   # gold, and lld.
+-  if(NOT CMAKE_BUILD_TYPE STREQUAL Debug AND CMAKE_SYSTEM_NAME MATCHES Darwin)
++  if(NOT CMAKE_BUILD_TYPE STREQUAL "Debug" AND CMAKE_SYSTEM_NAME MATCHES Darwin)
+     if (NOT SWIFT_DISABLE_DEAD_STRIPPING)
+       # See rdar://48283130: This gives 6MB+ size reductions for swift and
+       # SourceKitService, and much larger size reductions for sil-opt etc.
+@@ -446,7 +446,7 @@ function(_add_swift_runtime_link_flags target relpath_to_lib_dir bootstrapping)
+   # RPATH where Swift runtime can be found.
+   set(swift_runtime_rpath)
+ 
+-  if(${SWIFT_HOST_VARIANT_SDK} IN_LIST SWIFT_DARWIN_PLATFORMS)
++  if(SWIFT_HOST_VARIANT_SDK IN_LIST SWIFT_DARWIN_PLATFORMS)
+ 
+     set(sdk_dir "${SWIFT_SDK_${SWIFT_HOST_VARIANT_SDK}_ARCH_${SWIFT_HOST_VARIANT_ARCH}_PATH}/usr/lib/swift")
+ 
+@@ -529,7 +529,7 @@ function(_add_swift_runtime_link_flags target relpath_to_lib_dir bootstrapping)
+ 
+   elseif(SWIFT_HOST_VARIANT_SDK MATCHES "LINUX|ANDROID|OPENBSD|FREEBSD")
+     set(swiftrt "swiftImageRegistrationObject${SWIFT_SDK_${SWIFT_HOST_VARIANT_SDK}_OBJECT_FORMAT}-${SWIFT_SDK_${SWIFT_HOST_VARIANT_SDK}_LIB_SUBDIR}-${SWIFT_HOST_VARIANT_ARCH}")
+-    if(${ASRLF_BOOTSTRAPPING_MODE} MATCHES "HOSTTOOLS|CROSSCOMPILE")
++    if(ASRLF_BOOTSTRAPPING_MODE MATCHES "HOSTTOOLS|CROSSCOMPILE")
+       # At build time and run time, link against the swift libraries in the
+       # installed host toolchain.
+       get_filename_component(swift_bin_dir ${SWIFT_EXEC_FOR_SWIFT_MODULES} DIRECTORY)
+@@ -575,7 +575,7 @@ function(_add_swift_runtime_link_flags target relpath_to_lib_dir bootstrapping)
+     # able to fall back to the SDK directory for libswiftCore et al.
+     if (BOOTSTRAPPING_MODE MATCHES "BOOTSTRAPPING.*")
+       if (NOT "${bootstrapping}" STREQUAL "1")
+-        if(${SWIFT_HOST_VARIANT_SDK} IN_LIST SWIFT_DARWIN_PLATFORMS)
++        if(SWIFT_HOST_VARIANT_SDK IN_LIST SWIFT_DARWIN_PLATFORMS)
+           target_link_directories(${target} PRIVATE "${sdk_dir}")
+ 
+           # Include the abi stable system stdlib in our rpath.
+@@ -706,10 +706,10 @@ function(add_swift_host_library name)
+   if(SWIFT_HOST_VARIANT_SDK IN_LIST SWIFT_DARWIN_PLATFORMS)
+     set_target_properties(${name} PROPERTIES
+       INSTALL_NAME_DIR "@rpath")
+-  elseif(SWIFT_HOST_VARIANT_SDK STREQUAL LINUX)
++  elseif(SWIFT_HOST_VARIANT_SDK STREQUAL "LINUX")
+     set_target_properties(${name} PROPERTIES
+       INSTALL_RPATH "$ORIGIN")
+-  elseif(SWIFT_HOST_VARIANT_SDK STREQUAL CYGWIN)
++  elseif(SWIFT_HOST_VARIANT_SDK STREQUAL "CYGWIN")
+     set_target_properties(${name} PROPERTIES
+       INSTALL_RPATH "$ORIGIN:/usr/lib/swift/cygwin")
+   elseif(SWIFT_HOST_VARIANT_SDK STREQUAL "ANDROID")
+@@ -731,18 +731,18 @@ function(add_swift_host_library name)
+   endif()
+ 
+   # Set compilation and link flags.
+-  if(SWIFT_HOST_VARIANT_SDK STREQUAL WINDOWS)
++  if(SWIFT_HOST_VARIANT_SDK STREQUAL "WINDOWS")
+     swift_windows_include_for_arch(${SWIFT_HOST_VARIANT_ARCH}
+       ${SWIFT_HOST_VARIANT_ARCH}_INCLUDE)
+     target_include_directories(${name} SYSTEM PRIVATE
+       ${${SWIFT_HOST_VARIANT_ARCH}_INCLUDE})
+ 
+-    if(libkind STREQUAL SHARED)
++    if(libkind STREQUAL "SHARED")
+       target_compile_definitions(${name} PRIVATE
+         _WINDLL)
+     endif()
+ 
+-    if(NOT ${CMAKE_C_COMPILER_ID} STREQUAL MSVC)
++    if(NOT CMAKE_C_COMPILER_ID STREQUAL "MSVC")
+       swift_windows_get_sdk_vfs_overlay(ASHL_VFS_OVERLAY)
+       # Both clang and clang-cl on Windows set CMAKE_C_SIMULATE_ID to MSVC.
+       # We are using CMAKE_C_COMPILER_FRONTEND_VARIANT to detect the correct
+@@ -770,7 +770,7 @@ function(add_swift_host_library name)
+ 
+   set_target_properties(${name} PROPERTIES LINKER_LANGUAGE CXX)
+ 
+-  if(${SWIFT_HOST_VARIANT_SDK} IN_LIST SWIFT_DARWIN_PLATFORMS)
++  if(SWIFT_HOST_VARIANT_SDK IN_LIST SWIFT_DARWIN_PLATFORMS)
+     target_link_options(${name} PRIVATE
+       "LINKER:-compatibility_version,1")
+     if(SWIFT_COMPILER_VERSION)
+@@ -856,7 +856,7 @@ function(add_swift_host_tool executable)
+     add_dependencies(${executable} ${LLVM_COMMON_DEPENDS})
+   endif()
+ 
+-  if(NOT ${ASHT_BOOTSTRAPPING} STREQUAL "")
++  if(NOT "${ASHT_BOOTSTRAPPING}" STREQUAL "")
+     # Strip the "-bootstrapping<n>" suffix from the target name to get the base
+     # executable name.
+     string(REGEX REPLACE "-bootstrapping.*" "" executable_filename ${executable})
+@@ -891,7 +891,7 @@ function(add_swift_host_tool executable)
+     BINARY_DIR ${out_bin_dir}
+     LIBRARY_DIR ${out_lib_dir})
+ 
+-  if(SWIFT_HOST_VARIANT_SDK STREQUAL WINDOWS)
++  if(SWIFT_HOST_VARIANT_SDK STREQUAL "WINDOWS")
+     swift_windows_include_for_arch(${SWIFT_HOST_VARIANT_ARCH}
+       ${SWIFT_HOST_VARIANT_ARCH}_INCLUDE)
+     target_include_directories(${executable} SYSTEM PRIVATE
+@@ -913,8 +913,8 @@ function(add_swift_host_tool executable)
+ 
+   if(SWIFT_SWIFT_PARSER)
+     set(extra_relative_rpath "")
+-    if(NOT ${ASHT_BOOTSTRAPPING} STREQUAL "")
+-      if (${executable} MATCHES "-bootstrapping")
++    if(NOT "${ASHT_BOOTSTRAPPING}" STREQUAL "")
++      if(executable MATCHES "-bootstrapping")
+         set(extra_relative_rpath "../")
+       endif()
+     endif()
+@@ -938,7 +938,7 @@ function(add_swift_host_tool executable)
+     target_link_options(${executable} PRIVATE "${lto_codegen_only_link_options}")
+   endif()
+ 
+-  if(NOT ${ASHT_SWIFT_COMPONENT} STREQUAL "no_component")
++  if(NOT ASHT_SWIFT_COMPONENT STREQUAL "no_component")
+     add_dependencies(${ASHT_SWIFT_COMPONENT} ${executable})
+     swift_install_in_component(TARGETS ${executable}
+                                RUNTIME
+diff --git a/cmake/modules/Libdispatch.cmake b/cmake/modules/Libdispatch.cmake
+index f0ea3577a2b..3fb0ecdce89 100644
+--- a/cmake/modules/Libdispatch.cmake
++++ b/cmake/modules/Libdispatch.cmake
+@@ -1,13 +1,13 @@
+ include(ExternalProject)
+ 
+-if(NOT CMAKE_SYSTEM_NAME STREQUAL Darwin)
+-  if(CMAKE_C_COMPILER_ID STREQUAL Clang AND
++if(NOT CMAKE_SYSTEM_NAME STREQUAL "Darwin")
++  if(CMAKE_C_COMPILER_ID STREQUAL "Clang" AND
+     CMAKE_C_COMPILER_VERSION VERSION_GREATER 3.8
+     OR LLVM_USE_SANITIZER)
+     set(SWIFT_LIBDISPATCH_C_COMPILER ${CMAKE_C_COMPILER})
+     set(SWIFT_LIBDISPATCH_CXX_COMPILER ${CMAKE_CXX_COMPILER})
+-  elseif(${CMAKE_SYSTEM_NAME} STREQUAL ${CMAKE_HOST_SYSTEM_NAME})
+-    if(CMAKE_SYSTEM_NAME STREQUAL Windows)
++  elseif(CMAKE_SYSTEM_NAME STREQUAL CMAKE_HOST_SYSTEM_NAME)
++    if(CMAKE_SYSTEM_NAME STREQUAL "Windows")
+       if(CMAKE_SYSTEM_PROCESSOR STREQUAL CMAKE_HOST_SYSTEM_PROCESSOR AND
+         TARGET clang)
+         set(SWIFT_LIBDISPATCH_C_COMPILER
+@@ -29,7 +29,7 @@ if(NOT CMAKE_SYSTEM_NAME STREQUAL Darwin)
+     message(SEND_ERROR "libdispatch requires a newer clang compiler (${CMAKE_C_COMPILER_VERSION} < 3.9)")
+   endif()
+ 
+-  if(SWIFT_HOST_VARIANT_SDK STREQUAL WINDOWS)
++  if(SWIFT_HOST_VARIANT_SDK STREQUAL "WINDOWS")
+     set(LIBDISPATCH_RUNTIME_DIR bin)
+   else()
+     set(LIBDISPATCH_RUNTIME_DIR lib)
+@@ -40,7 +40,7 @@ set(DISPATCH_SDKS)
+ 
+ # Build the host libdispatch if needed.
+ if(SWIFT_BUILD_HOST_DISPATCH)
+-  if(NOT CMAKE_SYSTEM_NAME STREQUAL Darwin)
++  if(NOT CMAKE_SYSTEM_NAME STREQUAL "Darwin")
+     if(NOT "${SWIFT_HOST_VARIANT_SDK}" IN_LIST SWIFT_SDKS)
+       list(APPEND DISPATCH_SDKS "${SWIFT_HOST_VARIANT_SDK}")
+     endif()
+@@ -52,20 +52,20 @@ foreach(sdk ${SWIFT_SDKS})
+   # Darwin targets have libdispatch available, do not build it.
+   # Wasm/WASI doesn't support libdispatch yet.
+   # See https://github.com/apple/swift/issues/54533 for more details.
+-  if(NOT "${sdk}" IN_LIST SWIFT_DARWIN_PLATFORMS AND NOT "${sdk}" STREQUAL WASI)
++  if(NOT "${sdk}" IN_LIST SWIFT_DARWIN_PLATFORMS AND NOT "${sdk}" STREQUAL "WASI")
+     list(APPEND DISPATCH_SDKS "${sdk}")
+   endif()
+ endforeach()
+ 
+ foreach(sdk ${DISPATCH_SDKS})
+   set(ARCHS ${SWIFT_SDK_${sdk}_ARCHITECTURES})
+-  if(${sdk} STREQUAL "${SWIFT_HOST_VARIANT_SDK}")
++  if(sdk STREQUAL "${SWIFT_HOST_VARIANT_SDK}")
+     if(NOT "${SWIFT_HOST_VARIANT_ARCH}" IN_LIST ARCHS)
+       list(APPEND ARCHS "${SWIFT_HOST_VARIANT_ARCH}")
+     endif()
+   endif()
+   
+-  if(sdk STREQUAL ANDROID)
++  if(sdk STREQUAL "ANDROID")
+     set(SWIFT_LIBDISPATCH_COMPILER_CMAKE_ARGS)
+   else()
+     set(SWIFT_LIBDISPATCH_COMPILER_CMAKE_ARGS -DCMAKE_C_COMPILER=${SWIFT_LIBDISPATCH_C_COMPILER};-DCMAKE_CXX_COMPILER=${SWIFT_LIBDISPATCH_CXX_COMPILER})
+diff --git a/cmake/modules/SwiftComponents.cmake b/cmake/modules/SwiftComponents.cmake
+index 6816b75e8a4..2ec225140dc 100644
+--- a/cmake/modules/SwiftComponents.cmake
++++ b/cmake/modules/SwiftComponents.cmake
+@@ -82,7 +82,7 @@ list(REMOVE_ITEM _SWIFT_DEFAULT_COMPONENTS "clang-builtin-headers-in-clang-resou
+ # This conflicts with LLVM itself when doing unified builds.
+ list(REMOVE_ITEM _SWIFT_DEFAULT_COMPONENTS "llvm-toolchain-dev-tools")
+ # The sourcekit install variants are currently mutually exclusive.
+-if(${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
++if(CMAKE_SYSTEM_NAME MATCHES "Darwin")
+   list(REMOVE_ITEM _SWIFT_DEFAULT_COMPONENTS "sourcekit-inproc")
+ else()
+   list(REMOVE_ITEM _SWIFT_DEFAULT_COMPONENTS "sourcekit-xpc-service")
+diff --git a/cmake/modules/SwiftConfigureSDK.cmake b/cmake/modules/SwiftConfigureSDK.cmake
+index d4cb352d658..5dd258cdd24 100644
+--- a/cmake/modules/SwiftConfigureSDK.cmake
++++ b/cmake/modules/SwiftConfigureSDK.cmake
+@@ -232,7 +232,7 @@ macro(configure_sdk_darwin
+     SWIFT_SDK_${prefix}_MODULE_ARCHITECTURES)     # result
+ 
+   # Determine whether this is a simulator SDK.
+-  if ( ${xcrun_name} MATCHES "simulator" )
++  if(xcrun_name MATCHES "simulator")
+     set(SWIFT_SDK_${prefix}_IS_SIMULATOR TRUE)
+   else()
+     set(SWIFT_SDK_${prefix}_IS_SIMULATOR FALSE)
+@@ -378,11 +378,11 @@ macro(configure_sdk_unix name architectures)
+           message(FATAL_ERROR "unknown arch for ${prefix}: ${arch}")
+         endif()
+       elseif("${prefix}" STREQUAL "FREEBSD")
+-        if(NOT arch STREQUAL x86_64)
++        if(NOT arch STREQUAL "x86_64")
+           message(FATAL_ERROR "unsupported arch for FreeBSD: ${arch}")
+         endif()
+ 
+-        if(NOT CMAKE_HOST_SYSTEM_NAME STREQUAL FreeBSD)
++        if(NOT CMAKE_HOST_SYSTEM_NAME STREQUAL "FreeBSD")
+           message(WARNING "CMAKE_SYSTEM_VERSION will not match target")
+         endif()
+ 
+@@ -391,7 +391,7 @@ macro(configure_sdk_unix name architectures)
+ 
+         set(SWIFT_SDK_FREEBSD_ARCH_x86_64_TRIPLE "x86_64-unknown-freebsd${freebsd_system_version}")
+       elseif("${prefix}" STREQUAL "OPENBSD")
+-        if(NOT arch STREQUAL amd64)
++        if(NOT arch STREQUAL "amd64")
+           message(FATAL_ERROR "unsupported arch for OpenBSD: ${arch}")
+         endif()
+ 
+@@ -404,17 +404,17 @@ macro(configure_sdk_unix name architectures)
+           set(SWIFT_SDK_OPENBSD_ARCH_${arch}_PATH "${CMAKE_SYSROOT}${SWIFT_SDK_OPENBSD_ARCH_${arch}_PATH}" CACHE INTERNAL "sysroot path" FORCE)
+         endif()
+       elseif("${prefix}" STREQUAL "CYGWIN")
+-        if(NOT arch STREQUAL x86_64)
++        if(NOT arch STREQUAL "x86_64")
+           message(FATAL_ERROR "unsupported arch for cygwin: ${arch}")
+         endif()
+         set(SWIFT_SDK_CYGWIN_ARCH_x86_64_TRIPLE "x86_64-unknown-windows-cygnus")
+       elseif("${prefix}" STREQUAL "HAIKU")
+-        if(NOT arch STREQUAL x86_64)
++        if(NOT arch STREQUAL "x86_64")
+           message(FATAL_ERROR "unsupported arch for Haiku: ${arch}")
+         endif()
+         set(SWIFT_SDK_HAIKU_ARCH_x86_64_TRIPLE "x86_64-unknown-haiku")
+       elseif("${prefix}" STREQUAL "WASI")
+-        if(NOT arch STREQUAL wasm32)
++        if(NOT arch STREQUAL "wasm32")
+           message(FATAL_ERROR "unsupported arch for WebAssembly: ${arch}")
+         endif()
+         set(SWIFT_SDK_WASI_ARCH_wasm32_PATH "${SWIFT_WASI_SYSROOT_PATH}")
+@@ -459,7 +459,7 @@ macro(configure_sdk_windows name environment architectures)
+   get_threading_package(${prefix} "win32" SWIFT_SDK_${prefix}_THREADING_PACKAGE)
+ 
+   foreach(arch ${architectures})
+-    if(arch STREQUAL armv7)
++    if(arch STREQUAL "armv7")
+       set(SWIFT_SDK_${prefix}_ARCH_${arch}_TRIPLE
+           "thumbv7-unknown-windows-${environment}")
+     else()
+diff --git a/cmake/modules/SwiftWindowsSupport.cmake b/cmake/modules/SwiftWindowsSupport.cmake
+index 6216b82c12b..a3432476658 100644
+--- a/cmake/modules/SwiftWindowsSupport.cmake
++++ b/cmake/modules/SwiftWindowsSupport.cmake
+@@ -2,13 +2,13 @@
+ include(SwiftUtils)
+ 
+ function(swift_windows_arch_spelling arch var)
+-  if(${arch} STREQUAL i686)
++  if(arch STREQUAL "i686")
+     set(${var} x86 PARENT_SCOPE)
+-  elseif(${arch} STREQUAL x86_64)
++  elseif(arch STREQUAL "x86_64")
+     set(${var} x64 PARENT_SCOPE)
+-  elseif(${arch} STREQUAL armv7)
++  elseif(arch STREQUAL "armv7")
+     set(${var} arm PARENT_SCOPE)
+-  elseif(${arch} STREQUAL aarch64)
++  elseif(arch STREQUAL "aarch64")
+     set(${var} arm64 PARENT_SCOPE)
+   else()
+     message(FATAL_ERROR "do not know MSVC spelling for ARCH: `${arch}`")
+@@ -33,7 +33,7 @@ function(swift_windows_lib_for_arch arch var)
+   # a directory called "Lib" rather than VS2017 which normalizes the layout and
+   # places them in a directory named "lib".
+   if(IS_DIRECTORY "${VCToolsInstallDir}/Lib")
+-    if(${ARCH} STREQUAL x86)
++    if(ARCH STREQUAL "x86")
+       list(APPEND paths "${VCToolsInstallDir}/Lib/")
+     else()
+       list(APPEND paths "${VCToolsInstallDir}/Lib/${ARCH}")
+diff --git a/include/swift/AST/CMakeLists.txt b/include/swift/AST/CMakeLists.txt
+index 869d96ba13b..050695f65c6 100644
+--- a/include/swift/AST/CMakeLists.txt
++++ b/include/swift/AST/CMakeLists.txt
+@@ -1,4 +1,4 @@
+-if(CMAKE_HOST_SYSTEM_NAME STREQUAL Windows)
++if(CMAKE_HOST_SYSTEM_NAME STREQUAL "Windows")
+   set(SWIFT_GYB_FLAGS --line-directive "^\"#line %(line)d \\\"%(file)s\\\"^\"")
+ else()
+   set(SWIFT_GYB_FLAGS --line-directive "\'#line" "%(line)d" "\"%(file)s\"\'")
+diff --git a/lib/AST/CMakeLists.txt b/lib/AST/CMakeLists.txt
+index a0011d8a68c..13363dea4aa 100644
+--- a/lib/AST/CMakeLists.txt
++++ b/lib/AST/CMakeLists.txt
+@@ -125,7 +125,7 @@ add_swift_host_library(swiftAST STATIC
+   )
+ 
+ if(SWIFT_FORCE_OPTIMIZED_TYPECHECKER)
+-  if(CMAKE_CXX_COMPILER_ID STREQUAL MSVC OR CMAKE_CXX_SIMULATE_ID STREQUAL MSVC)
++  if(CMAKE_CXX_COMPILER_ID STREQUAL "MSVC" OR CMAKE_CXX_SIMULATE_ID STREQUAL "MSVC")
+     target_compile_options(swiftAST PRIVATE /O2 /Ob2)
+   else()
+     target_compile_options(swiftAST PRIVATE -O3)
+diff --git a/lib/Migrator/CMakeLists.txt b/lib/Migrator/CMakeLists.txt
+index 1dfd089d21a..228baa470ed 100644
+--- a/lib/Migrator/CMakeLists.txt
++++ b/lib/Migrator/CMakeLists.txt
+@@ -23,7 +23,7 @@ set(outputs)
+ foreach(input ${datafiles})
+   set(source "${CMAKE_CURRENT_SOURCE_DIR}/${input}")
+   set(dest "${output_dir}/${input}")
+-  if(CMAKE_SYSTEM_NAME STREQUAL Windows)
++  if(CMAKE_SYSTEM_NAME STREQUAL "Windows")
+     set(CMAKE_SYMLINK_COMMAND copy)
+   else()
+     set(CMAKE_SYMLINK_COMMAND create_symlink)
+diff --git a/lib/Parse/CMakeLists.txt b/lib/Parse/CMakeLists.txt
+index b46a4b217c3..b8550c96b2a 100644
+--- a/lib/Parse/CMakeLists.txt
++++ b/lib/Parse/CMakeLists.txt
+@@ -1,6 +1,6 @@
+ 
+ 
+-if(CMAKE_HOST_SYSTEM_NAME STREQUAL Windows)
++if(CMAKE_HOST_SYSTEM_NAME STREQUAL "Windows")
+   set(SWIFT_GYB_FLAGS --line-directive "^\"#line %(line)d \\\"%(file)s\\\"^\"")
+ else()
+   set(SWIFT_GYB_FLAGS --line-directive "\'#line" "%(line)d" "\"%(file)s\"\'")
+diff --git a/lib/Sema/CMakeLists.txt b/lib/Sema/CMakeLists.txt
+index c0e3608d07a..bf70a33782d 100644
+--- a/lib/Sema/CMakeLists.txt
++++ b/lib/Sema/CMakeLists.txt
+@@ -74,7 +74,7 @@ add_swift_host_library(swiftSema STATIC
+   TypeChecker.cpp
+   IDETypeCheckingRequests.cpp)
+ if(SWIFT_FORCE_OPTIMIZED_TYPECHECKER)
+-  if(CMAKE_CXX_COMPILER_ID STREQUAL MSVC OR CMAKE_CXX_SIMULATE_ID STREQUAL MSVC)
++  if(CMAKE_CXX_COMPILER_ID STREQUAL "MSVC" OR CMAKE_CXX_SIMULATE_ID STREQUAL "MSVC")
+     target_compile_options(swiftSema PRIVATE /O2 /Ob2)
+   else()
+     target_compile_options(swiftSema PRIVATE -O3)
+diff --git a/lib/SwiftRemoteMirror/CMakeLists.txt b/lib/SwiftRemoteMirror/CMakeLists.txt
+index f774297e51c..da2248de9f7 100644
+--- a/lib/SwiftRemoteMirror/CMakeLists.txt
++++ b/lib/SwiftRemoteMirror/CMakeLists.txt
+@@ -3,6 +3,6 @@ add_swift_host_library(swiftRemoteMirror STATIC
+ target_link_libraries(swiftRemoteMirror PRIVATE
+   swiftDemangling)
+ 
+-if(CMAKE_SYSTEM_NAME STREQUAL Windows)
++if(CMAKE_SYSTEM_NAME STREQUAL "Windows")
+   target_compile_definitions(swiftRemoteMirror PRIVATE _LIB)
+ endif()
+diff --git a/stdlib/cmake/modules/AddSwiftStdlib.cmake b/stdlib/cmake/modules/AddSwiftStdlib.cmake
+index 25a79d145fb..781d6fd33cf 100644
+--- a/stdlib/cmake/modules/AddSwiftStdlib.cmake
++++ b/stdlib/cmake/modules/AddSwiftStdlib.cmake
+@@ -249,7 +249,7 @@ function(_add_target_variant_c_compile_flags)
+     # NOTE(compnerd) workaround LLVM invoking `add_definitions(-D_DEBUG)` which
+     # causes failures for the runtime library when cross-compiling due to
+     # undefined symbols from the standard library.
+-    if(NOT CMAKE_BUILD_TYPE STREQUAL Debug)
++    if(NOT CMAKE_BUILD_TYPE STREQUAL "Debug")
+       list(APPEND result "-U_DEBUG")
+     endif()
+   endif()
+@@ -258,7 +258,7 @@ function(_add_target_variant_c_compile_flags)
+   # uses a spin lock for this, so to get reasonable behavior we have to
+   # implement it ourselves using _InterlockedCompareExchange128.
+   # clang-cl requires us to enable the `cx16` feature to use this intrinsic.
+-  if(CFLAGS_ARCH STREQUAL x86_64)
++  if(CFLAGS_ARCH STREQUAL "x86_64")
+     if(SWIFT_COMPILER_IS_MSVC_LIKE)
+       list(APPEND result /clang:-mcx16)
+     else()
+@@ -287,7 +287,7 @@ function(_add_target_variant_c_compile_flags)
+   endif()
+ 
+   if("${CFLAGS_SDK}" STREQUAL "LINUX")
+-    if(${CFLAGS_ARCH} STREQUAL x86_64)
++    if("${CFLAGS_ARCH}" STREQUAL "x86_64")
+       # this is the minimum architecture that supports 16 byte CAS, which is necessary to avoid a dependency to libatomic
+       list(APPEND result "-march=core2")
+     endif()
+@@ -493,7 +493,7 @@ function(_add_target_variant_link_flags)
+     else()
+       set(linker "${SWIFT_USE_LINKER}")
+     endif()
+-    if(CMAKE_HOST_SYSTEM_NAME STREQUAL Windows)
++    if(CMAKE_HOST_SYSTEM_NAME STREQUAL "Windows")
+       list(APPEND result "-fuse-ld=${linker}.exe")
+     else()
+       list(APPEND result "-fuse-ld=${linker}")
+@@ -506,8 +506,8 @@ function(_add_target_variant_link_flags)
+   #
+   # TODO: Evaluate/enable -f{function,data}-sections --gc-sections for bfd,
+   # gold, and lld.
+-  if(NOT CMAKE_BUILD_TYPE STREQUAL Debug)
+-    if(${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
++  if(NOT CMAKE_BUILD_TYPE STREQUAL "Debug")
++    if(CMAKE_SYSTEM_NAME MATCHES "Darwin")
+       # See rdar://48283130: This gives 6MB+ size reductions for swift and
+       # SourceKitService, and much larger size reductions for sil-opt etc.
+       list(APPEND result "-Wl,-dead_strip")
+@@ -969,7 +969,7 @@ function(add_swift_target_library_single target name)
+   endif()
+ 
+   set(INCORPORATED_OBJECT_LIBRARIES_EXPRESSIONS ${SWIFTLIB_INCORPORATED_OBJECT_LIBRARIES_EXPRESSIONS})
+-  if(${libkind} STREQUAL "SHARED")
++  if(libkind STREQUAL "SHARED")
+     list(APPEND INCORPORATED_OBJECT_LIBRARIES_EXPRESSIONS
+          ${SWIFTLIB_INCORPORATED_OBJECT_LIBRARIES_EXPRESSIONS_SHARED_ONLY})
+   endif()
+@@ -991,7 +991,7 @@ function(add_swift_target_library_single target name)
+       # target_sources(${target}
+       #                PRIVATE
+       #                  $<TARGET_OBJECTS:swiftImageRegistrationObject${SWIFT_SDK_${SWIFTLIB_SINGLE_SDK}_OBJECT_FORMAT}-${SWIFT_SDK_${SWIFTLIB_SINGLE_SDK}_LIB_SUBDIR}-${SWIFTLIB_SINGLE_ARCHITECTURE}>)
+-      if(SWIFTLIB_SINGLE_SDK STREQUAL WINDOWS)
++      if(SWIFTLIB_SINGLE_SDK STREQUAL "WINDOWS")
+         set(extension .obj)
+       else()
+         set(extension .o)
+@@ -1059,8 +1059,8 @@ function(add_swift_target_library_single target name)
+   set_target_properties("${target}" PROPERTIES
+     LIBRARY_OUTPUT_DIRECTORY ${swiftlib_prefix}/${output_sub_dir}
+     ARCHIVE_OUTPUT_DIRECTORY ${swiftlib_prefix}/${output_sub_dir})
+-  if(SWIFTLIB_SINGLE_SDK STREQUAL WINDOWS AND SWIFTLIB_SINGLE_IS_STDLIB_CORE
+-      AND libkind STREQUAL SHARED)
++  if(SWIFTLIB_SINGLE_SDK STREQUAL "WINDOWS" AND SWIFTLIB_SINGLE_IS_STDLIB_CORE
++      AND libkind STREQUAL "SHARED")
+     add_custom_command(TARGET ${target} POST_BUILD
+       COMMAND ${CMAKE_COMMAND} -E copy_if_different $<TARGET_FILE:${target}> ${swiftlib_prefix}/${output_sub_dir})
+   endif()
+@@ -1264,8 +1264,8 @@ function(add_swift_target_library_single target name)
+     MACCATALYST_BUILD_FLAVOR "${SWIFTLIB_SINGLE_MACCATALYST_BUILD_FLAVOR}"
+     )
+ 
+-  if(SWIFTLIB_SINGLE_SDK STREQUAL WINDOWS)
+-    if(libkind STREQUAL SHARED)
++  if(SWIFTLIB_SINGLE_SDK STREQUAL "WINDOWS")
++    if(libkind STREQUAL "SHARED")
+       list(APPEND c_compile_flags -D_WINDLL)
+     endif()
+   endif()
+@@ -1324,13 +1324,13 @@ function(add_swift_target_library_single target name)
+   endif()
+ 
+   # Set compilation and link flags.
+-  if(SWIFTLIB_SINGLE_SDK STREQUAL WINDOWS)
++  if(SWIFTLIB_SINGLE_SDK STREQUAL "WINDOWS")
+     swift_windows_include_for_arch(${SWIFTLIB_SINGLE_ARCHITECTURE}
+       ${SWIFTLIB_SINGLE_ARCHITECTURE}_INCLUDE)
+     target_include_directories(${target} SYSTEM PRIVATE
+       ${${SWIFTLIB_SINGLE_ARCHITECTURE}_INCLUDE})
+ 
+-    if(NOT ${CMAKE_C_COMPILER_ID} STREQUAL MSVC)
++    if(NOT CMAKE_C_COMPILER_ID STREQUAL "MSVC")
+       swift_windows_get_sdk_vfs_overlay(SWIFTLIB_SINGLE_VFS_OVERLAY)
+       target_compile_options(${target} PRIVATE
+         "SHELL:-Xclang -ivfsoverlay -Xclang ${SWIFTLIB_SINGLE_VFS_OVERLAY}")
+@@ -1347,7 +1347,7 @@ function(add_swift_target_library_single target name)
+     ${c_compile_flags})
+   target_link_options(${target} PRIVATE
+     ${link_flags})
+-  if(${SWIFTLIB_SINGLE_SDK} IN_LIST SWIFT_DARWIN_PLATFORMS)
++  if(SWIFTLIB_SINGLE_SDK IN_LIST SWIFT_DARWIN_PLATFORMS)
+     target_link_options(${target} PRIVATE
+       "LINKER:-compatibility_version,1")
+     if(SWIFT_COMPILER_VERSION)
+@@ -1380,7 +1380,7 @@ function(add_swift_target_library_single target name)
+     list(APPEND swiftlib_link_flags_all "-Xlinker -no_warn_inits")
+   endif()
+ 
+-  if(${SWIFTLIB_SINGLE_SDK} IN_LIST SWIFT_APPLE_PLATFORMS)
++  if(SWIFTLIB_SINGLE_SDK IN_LIST SWIFT_APPLE_PLATFORMS)
+     # In the past, we relied on unsetting globally
+     # CMAKE_OSX_ARCHITECTURES to ensure that CMake
+     # would not add the -arch flag. This is no longer
+@@ -1403,7 +1403,7 @@ function(add_swift_target_library_single target name)
+   # doing so will result in incorrect symbol resolution and linkage.  We created
+   # import library targets when the library was added.  Use that to adjust the
+   # link libraries.
+-  if(SWIFTLIB_SINGLE_SDK STREQUAL WINDOWS AND NOT CMAKE_SYSTEM_NAME STREQUAL Windows)
++  if(SWIFTLIB_SINGLE_SDK STREQUAL "WINDOWS" AND NOT CMAKE_SYSTEM_NAME STREQUAL "Windows")
+     foreach(library_list LINK_LIBRARIES PRIVATE_LINK_LIBRARIES)
+       set(import_libraries)
+       foreach(library ${SWIFTLIB_SINGLE_${library_list}})
+@@ -1415,7 +1415,7 @@ function(add_swift_target_library_single target name)
+         set(import_library ${library})
+         if(TARGET ${library})
+           get_target_property(type ${library} TYPE)
+-          if(${type} STREQUAL "SHARED_LIBRARY")
++          if(type STREQUAL "SHARED_LIBRARY")
+             set(import_library ${library}_IMPLIB)
+           endif()
+         endif()
+@@ -1744,7 +1744,7 @@ function(add_swift_target_library name)
+     list(APPEND SWIFTLIB_SWIFT_MODULE_DEPENDS Core)
+ 
+     # swiftSwiftOnoneSupport does not depend on itself, obviously.
+-    if(NOT ${name} STREQUAL swiftSwiftOnoneSupport)
++    if(NOT name STREQUAL "swiftSwiftOnoneSupport")
+       # All Swift code depends on the SwiftOnoneSupport in non-optimized mode,
+       # except for the standard library itself.
+       is_build_type_optimized("${SWIFT_STDLIB_BUILD_TYPE}" optimized)
+@@ -1851,7 +1851,7 @@ function(add_swift_target_library name)
+ 
+     # Collect architecture agnostic SDK module dependencies
+     set(swiftlib_module_depends_flattened ${SWIFTLIB_SWIFT_MODULE_DEPENDS})
+-    if(${sdk} STREQUAL OSX)
++    if(sdk STREQUAL "OSX")
+        if(DEFINED maccatalyst_build_flavor AND NOT maccatalyst_build_flavor STREQUAL "macos-like")
+           list(APPEND swiftlib_module_depends_flattened
+             ${SWIFTLIB_SWIFT_MODULE_DEPENDS_MACCATALYST})
+@@ -1863,70 +1863,70 @@ function(add_swift_target_library name)
+         endif()
+       list(APPEND swiftlib_module_depends_flattened
+            ${SWIFTLIB_SWIFT_MODULE_DEPENDS_OSX})
+-    elseif(${sdk} STREQUAL IOS OR ${sdk} STREQUAL IOS_SIMULATOR)
++    elseif(sdk STREQUAL "IOS" OR sdk STREQUAL "IOS_SIMULATOR")
+       list(APPEND swiftlib_module_depends_flattened
+            ${SWIFTLIB_SWIFT_MODULE_DEPENDS_IOS})
+-    elseif(${sdk} STREQUAL TVOS OR ${sdk} STREQUAL TVOS_SIMULATOR)
++    elseif(sdk STREQUAL "TVOS" OR sdk STREQUAL "TVOS_SIMULATOR")
+       list(APPEND swiftlib_module_depends_flattened
+            ${SWIFTLIB_SWIFT_MODULE_DEPENDS_TVOS})
+-    elseif(${sdk} STREQUAL WATCHOS OR ${sdk} STREQUAL WATCHOS_SIMULATOR)
++    elseif(sdk STREQUAL "WATCHOS" OR sdk STREQUAL "WATCHOS_SIMULATOR")
+       list(APPEND swiftlib_module_depends_flattened
+            ${SWIFTLIB_SWIFT_MODULE_DEPENDS_WATCHOS})
+-    elseif(${sdk} STREQUAL FREESTANDING)
++    elseif(sdk STREQUAL "FREESTANDING")
+       list(APPEND swiftlib_module_depends_flattened
+            ${SWIFTLIB_SWIFT_MODULE_DEPENDS_FREESTANDING})
+-    elseif(${sdk} STREQUAL FREEBSD)
++    elseif(sdk STREQUAL "FREEBSD")
+       list(APPEND swiftlib_module_depends_flattened
+            ${SWIFTLIB_SWIFT_MODULE_DEPENDS_FREEBSD})
+-    elseif(${sdk} STREQUAL OPENBSD)
++    elseif(sdk STREQUAL "OPENBSD")
+       list(APPEND swiftlib_module_depends_flattened
+            ${SWIFTLIB_SWIFT_MODULE_DEPENDS_OPENBSD})
+-    elseif(${sdk} STREQUAL LINUX OR ${sdk} STREQUAL ANDROID)
++    elseif(sdk STREQUAL "LINUX" OR sdk STREQUAL "ANDROID")
+       list(APPEND swiftlib_module_depends_flattened
+            ${SWIFTLIB_SWIFT_MODULE_DEPENDS_LINUX})
+-    elseif(${sdk} STREQUAL CYGWIN)
++    elseif(sdk STREQUAL "CYGWIN")
+       list(APPEND swiftlib_module_depends_flattened
+            ${SWIFTLIB_SWIFT_MODULE_DEPENDS_CYGWIN})
+-    elseif(${sdk} STREQUAL HAIKU)
++    elseif(sdk STREQUAL "HAIKU")
+       list(APPEND swiftlib_module_depends_flattened
+            ${SWIFTLIB_SWIFT_MODULE_DEPENDS_HAIKU})
+-    elseif(${sdk} STREQUAL WASI)
++    elseif(sdk STREQUAL "WASI")
+       list(APPEND swiftlib_module_depends_flattened
+            ${SWIFTLIB_SWIFT_MODULE_DEPENDS_WASI})
+-    elseif(${sdk} STREQUAL WINDOWS)
++    elseif(sdk STREQUAL "WINDOWS")
+       list(APPEND swiftlib_module_depends_flattened
+            ${SWIFTLIB_SWIFT_MODULE_DEPENDS_WINDOWS})
+     endif()
+ 
+     # Collect architecture agnostic SDK framework dependencies
+     set(swiftlib_framework_depends_flattened ${SWIFTLIB_FRAMEWORK_DEPENDS})
+-    if(${sdk} STREQUAL OSX)
++    if(sdk STREQUAL "OSX")
+       list(APPEND swiftlib_framework_depends_flattened
+            ${SWIFTLIB_FRAMEWORK_DEPENDS_OSX})
+-    elseif(${sdk} STREQUAL IOS OR ${sdk} STREQUAL IOS_SIMULATOR OR
+-           ${sdk} STREQUAL TVOS OR ${sdk} STREQUAL TVOS_SIMULATOR)
++    elseif(sdk STREQUAL "IOS" OR sdk STREQUAL "IOS_SIMULATOR" OR
++           sdk STREQUAL "TVOS" OR sdk STREQUAL "TVOS_SIMULATOR")
+       list(APPEND swiftlib_framework_depends_flattened
+            ${SWIFTLIB_FRAMEWORK_DEPENDS_IOS_TVOS})
+     endif()
+ 
+     # Collect architecture agnostic swift compiler flags
+     set(swiftlib_swift_compile_flags_all ${SWIFTLIB_SWIFT_COMPILE_FLAGS})
+-    if(${sdk} STREQUAL OSX)
++    if(sdk STREQUAL "OSX")
+       list(APPEND swiftlib_swift_compile_flags_all
+            ${SWIFTLIB_SWIFT_COMPILE_FLAGS_OSX})
+-    elseif(${sdk} STREQUAL IOS OR ${sdk} STREQUAL IOS_SIMULATOR)
++    elseif(sdk STREQUAL "IOS" OR sdk STREQUAL "IOS_SIMULATOR")
+       list(APPEND swiftlib_swift_compile_flags_all
+            ${SWIFTLIB_SWIFT_COMPILE_FLAGS_IOS})
+-    elseif(${sdk} STREQUAL TVOS OR ${sdk} STREQUAL TVOS_SIMULATOR)
++    elseif(sdk STREQUAL "TVOS" OR sdk STREQUAL "TVOS_SIMULATOR")
+       list(APPEND swiftlib_swift_compile_flags_all
+            ${SWIFTLIB_SWIFT_COMPILE_FLAGS_TVOS})
+-    elseif(${sdk} STREQUAL WATCHOS OR ${sdk} STREQUAL WATCHOS_SIMULATOR)
++    elseif(sdk STREQUAL "WATCHOS" OR sdk STREQUAL "WATCHOS_SIMULATOR")
+       list(APPEND swiftlib_swift_compile_flags_all
+            ${SWIFTLIB_SWIFT_COMPILE_FLAGS_WATCHOS})
+-    elseif(${sdk} STREQUAL LINUX)
++    elseif(sdk STREQUAL "LINUX")
+       list(APPEND swiftlib_swift_compile_flags_all
+            ${SWIFTLIB_SWIFT_COMPILE_FLAGS_LINUX})
+-    elseif(${sdk} STREQUAL WINDOWS)
++    elseif(sdk STREQUAL "WINDOWS")
+       # FIXME: https://github.com/apple/swift/issues/44614
+       # static and shared are not mutually exclusive; however since we do a
+       # single build of the sources, this doesn't work for building both
+@@ -1945,7 +1945,7 @@ function(add_swift_target_library name)
+ 
+     # Collect architecture agnostic SDK linker flags
+     set(swiftlib_link_flags_all ${SWIFTLIB_LINK_FLAGS})
+-    if(${sdk} STREQUAL IOS_SIMULATOR AND ${name} STREQUAL swiftMediaPlayer)
++    if(sdk STREQUAL "IOS_SIMULATOR" AND name STREQUAL "swiftMediaPlayer")
+       # message("DISABLING AUTOLINK FOR swiftMediaPlayer")
+       list(APPEND swiftlib_link_flags_all "-Xlinker" "-ignore_auto_link")
+     endif()
+@@ -1959,8 +1959,8 @@ function(add_swift_target_library name)
+     # back to supported targets and libraries only.  This is needed for ELF
+     # targets only; however, RemoteMirror needs to build with undefined
+     # symbols.
+-    if(${SWIFT_SDK_${sdk}_OBJECT_FORMAT} STREQUAL ELF AND
+-       NOT ${name} STREQUAL swiftRemoteMirror)
++    if(SWIFT_SDK_${sdk}_OBJECT_FORMAT STREQUAL "ELF" AND
++       NOT name STREQUAL "swiftRemoteMirror")
+       list(APPEND swiftlib_link_flags_all "-Wl,-z,defs")
+     endif()
+     # Setting back linker flags which are not supported when making Android build on macOS cross-compile host.
+@@ -2067,22 +2067,22 @@ function(add_swift_target_library name)
+       set(swiftlib_link_flags_all ${SWIFTLIB_LINK_FLAGS})
+ 
+       # Collect architecture agnostic c compiler flags
+-      if(${sdk} STREQUAL OSX)
++      if(sdk STREQUAL "OSX")
+         list(APPEND swiftlib_c_compile_flags_all
+              ${SWIFTLIB_C_COMPILE_FLAGS_OSX})
+-      elseif(${sdk} STREQUAL IOS OR ${sdk} STREQUAL IOS_SIMULATOR)
++      elseif(sdk STREQUAL "IOS" OR sdk STREQUAL "IOS_SIMULATOR")
+         list(APPEND swiftlib_c_compile_flags_all
+              ${SWIFTLIB_C_COMPILE_FLAGS_IOS})
+-      elseif(${sdk} STREQUAL TVOS OR ${sdk} STREQUAL TVOS_SIMULATOR)
++      elseif(sdk STREQUAL "TVOS" OR sdk STREQUAL "TVOS_SIMULATOR")
+         list(APPEND swiftlib_c_compile_flags_all
+              ${SWIFTLIB_C_COMPILE_FLAGS_TVOS})
+-      elseif(${sdk} STREQUAL WATCHOS OR ${sdk} STREQUAL WATCHOS_SIMULATOR)
++      elseif(sdk STREQUAL "WATCHOS" OR sdk STREQUAL "WATCHOS_SIMULATOR")
+         list(APPEND swiftlib_c_compile_flags_all
+              ${SWIFTLIB_C_COMPILE_FLAGS_WATCHOS})
+-      elseif(${sdk} STREQUAL LINUX)
++      elseif(sdk STREQUAL "LINUX")
+         list(APPEND swiftlib_c_compile_flags_all
+              ${SWIFTLIB_C_COMPILE_FLAGS_LINUX})
+-      elseif(${sdk} STREQUAL WINDOWS)
++      elseif(sdk STREQUAL "WINDOWS")
+         list(APPEND swiftlib_c_compile_flags_all
+              ${SWIFTLIB_C_COMPILE_FLAGS_WINDOWS})
+       endif()
+@@ -2124,7 +2124,7 @@ function(add_swift_target_library name)
+       endif()
+ 
+       # Setting back linker flags which are not supported when making Android build on macOS cross-compile host.
+-      if(SWIFTLIB_SHARED AND ${sdk} STREQUAL ANDROID)
++      if(SWIFTLIB_SHARED AND sdk STREQUAL "ANDROID")
+         list(APPEND swiftlib_link_flags_all "-shared")
+         # TODO: Instead of `lib${name}.so` find variable or target property which already have this value.
+         list(APPEND swiftlib_link_flags_all "-Wl,-soname,lib${name}.so")
+@@ -2181,7 +2181,7 @@ function(add_swift_target_library name)
+       add_dependencies(${VARIANT_NAME} clang)
+     endif()
+ 
+-      if(sdk STREQUAL WINDOWS)
++      if(sdk STREQUAL "WINDOWS")
+         if(SWIFT_COMPILER_IS_MSVC_LIKE)
+           if (SWIFT_STDLIB_MSVC_RUNTIME_LIBRARY MATCHES MultiThreadedDebugDLL)
+             target_compile_options(${VARIANT_NAME} PRIVATE /MDd /D_DLL /D_DEBUG)
+@@ -2326,7 +2326,7 @@ function(add_swift_target_library name)
+         set(optional_arg "OPTIONAL")
+       endif()
+ 
+-      if(sdk STREQUAL WINDOWS AND CMAKE_SYSTEM_NAME STREQUAL Windows)
++      if(sdk STREQUAL "WINDOWS" AND CMAKE_SYSTEM_NAME STREQUAL "Windows")
+         add_dependencies(${SWIFTLIB_INSTALL_IN_COMPONENT} ${name}-windows-${SWIFT_PRIMARY_VARIANT_ARCH})
+         swift_install_in_component(TARGETS ${name}-windows-${SWIFT_PRIMARY_VARIANT_ARCH}
+                                    RUNTIME
+@@ -2357,7 +2357,7 @@ function(add_swift_target_library name)
+                                    PERMISSIONS ${file_permissions}
+                                    "${optional_arg}")
+       endif()
+-      if(sdk STREQUAL WINDOWS)
++      if(sdk STREQUAL "WINDOWS")
+         foreach(arch ${SWIFT_SDK_WINDOWS_ARCHITECTURES})
+           if(TARGET ${name}-windows-${arch}_IMPLIB)
+             get_target_property(import_library ${name}-windows-${arch}_IMPLIB IMPORTED_LOCATION)
+@@ -2558,13 +2558,13 @@ function(_add_swift_target_executable_single name)
+         ${SWIFTEXE_SINGLE_DEPENDS})
+   llvm_update_compile_flags("${name}")
+ 
+-  if(SWIFTEXE_SINGLE_SDK STREQUAL WINDOWS)
++  if(SWIFTEXE_SINGLE_SDK STREQUAL "WINDOWS")
+     swift_windows_include_for_arch(${SWIFTEXE_SINGLE_ARCHITECTURE}
+       ${SWIFTEXE_SINGLE_ARCHITECTURE}_INCLUDE)
+     target_include_directories(${name} SYSTEM PRIVATE
+       ${${SWIFTEXE_SINGLE_ARCHITECTURE}_INCLUDE})
+ 
+-    if(NOT ${CMAKE_C_COMPILER_ID} STREQUAL MSVC)
++    if(NOT CMAKE_C_COMPILER_ID STREQUAL "MSVC")
+       # MSVC doesn't support -Xclang. We don't need to manually specify
+       # the dependent libraries as `cl` does so.
+       target_compile_options(${name} PRIVATE
+@@ -2584,7 +2584,7 @@ function(_add_swift_target_executable_single name)
+   if (SWIFT_PARALLEL_LINK_JOBS)
+     set_property(TARGET ${name} PROPERTY JOB_POOL_LINK swift_link_job_pool)
+   endif()
+-  if(${SWIFTEXE_SINGLE_SDK} IN_LIST SWIFT_DARWIN_PLATFORMS)
++  if(SWIFTEXE_SINGLE_SDK IN_LIST SWIFT_DARWIN_PLATFORMS)
+     set_target_properties(${name} PROPERTIES
+       BUILD_WITH_INSTALL_RPATH YES
+       INSTALL_RPATH "@executable_path/../lib/swift/${SWIFT_SDK_${SWIFTEXE_SINGLE_SDK}_LIB_SUBDIR}")
+@@ -2596,7 +2596,7 @@ function(_add_swift_target_executable_single name)
+   # NOTE(compnerd) use the C linker language to invoke `clang` rather than
+   # `clang++` as we explicitly link against the C++ runtime.  We were previously
+   # actually passing `-nostdlib++` to avoid the C++ runtime linkage.
+-  if(${SWIFTEXE_SINGLE_SDK} STREQUAL ANDROID)
++  if(SWIFTEXE_SINGLE_SDK STREQUAL "ANDROID")
+     set_property(TARGET "${name}" PROPERTY
+       LINKER_LANGUAGE "C")
+   else()
+@@ -2666,7 +2666,7 @@ function(add_swift_target_executable name)
+           EXCLUDE_FROM_ALL TRUE)
+       endif()
+ 
+-      if(${sdk} IN_LIST SWIFT_APPLE_PLATFORMS)
++      if(sdk IN_LIST SWIFT_APPLE_PLATFORMS)
+         # In the past, we relied on unsetting globally
+         # CMAKE_OSX_ARCHITECTURES to ensure that CMake would
+         # not add the -arch flag
+diff --git a/stdlib/cmake/modules/SwiftSource.cmake b/stdlib/cmake/modules/SwiftSource.cmake
+index d5d57dfd18a..39c2e07860f 100644
+--- a/stdlib/cmake/modules/SwiftSource.cmake
++++ b/stdlib/cmake/modules/SwiftSource.cmake
+@@ -730,7 +730,7 @@ function(_compile_swift_files
+ 
+   set(line_directive_tool "${SWIFT_SOURCE_DIR}/utils/line-directive")
+ 
+-  if(CMAKE_HOST_SYSTEM_NAME STREQUAL Windows)
++  if(CMAKE_HOST_SYSTEM_NAME STREQUAL "Windows")
+     set(HOST_EXECUTABLE_SUFFIX .exe)
+   endif()
+   if(SWIFT_BUILD_RUNTIME_WITH_HOST_COMPILER)
+@@ -748,7 +748,7 @@ function(_compile_swift_files
+         "${SWIFT_NATIVE_SWIFT_TOOLS_PATH}/swiftc${HOST_EXECUTABLE_SUFFIX}"
+         "${SWIFTFILE_BOOTSTRAPPING}")
+ 
+-    if(NOT ${SWIFTFILE_BOOTSTRAPPING} STREQUAL "")
++    if(NOT "${SWIFTFILE_BOOTSTRAPPING}" STREQUAL "")
+       set(target_suffix "-bootstrapping${SWIFTFILE_BOOTSTRAPPING}")
+     endif()
+ 
+@@ -786,7 +786,7 @@ function(_compile_swift_files
+       # When building the stdlib with bootstrapping, the compiler needs
+       # to pick up the stdlib from the previous bootstrapping stage, because the
+       # stdlib in the current stage is not built yet.
+-      if(${SWIFT_HOST_VARIANT_SDK} IN_LIST SWIFT_APPLE_PLATFORMS)
++      if(SWIFT_HOST_VARIANT_SDK IN_LIST SWIFT_APPLE_PLATFORMS)
+         set(set_environment_args "${CMAKE_COMMAND}" "-E" "env" "DYLD_LIBRARY_PATH=${bs_lib_dir}")
+       elseif(SWIFT_HOST_VARIANT_SDK MATCHES "LINUX|ANDROID|OPENBSD|FREEBSD")
+         set(set_environment_args "${CMAKE_COMMAND}" "-E" "env" "LD_LIBRARY_PATH=${bs_lib_dir}")
+diff --git a/stdlib/public/Concurrency/CMakeLists.txt b/stdlib/public/Concurrency/CMakeLists.txt
+index ff614adce76..76e0694a731 100644
+--- a/stdlib/public/Concurrency/CMakeLists.txt
++++ b/stdlib/public/Concurrency/CMakeLists.txt
+@@ -26,14 +26,14 @@ set(SWIFT_RUNTIME_CONCURRENCY_C_FLAGS)
+ set(SWIFT_RUNTIME_CONCURRENCY_SWIFT_FLAGS)
+ 
+ set(swift_concurrency_private_link_libraries)
+-if(CMAKE_SYSTEM_NAME STREQUAL Windows)
++if(CMAKE_SYSTEM_NAME STREQUAL "Windows")
+   list(APPEND swift_concurrency_private_link_libraries Synchronization)
+ endif()
+ 
+ set(swift_concurrency_incorporate_object_libraries_so swiftThreading)
+ 
+ if("${SWIFT_CONCURRENCY_GLOBAL_EXECUTOR}" STREQUAL "dispatch")
+-  if(NOT CMAKE_SYSTEM_NAME STREQUAL Darwin)
++  if(NOT CMAKE_SYSTEM_NAME STREQUAL "Darwin")
+     include_directories(AFTER
+                           ${SWIFT_PATH_TO_LIBDISPATCH_SOURCE})
+ 
+@@ -61,7 +61,7 @@ endif()
+ 
+ # Don't emit extended frame info on platforms other than darwin, system
+ # backtracer and system debugger are unlikely to support it.
+-if(CMAKE_SYSTEM_NAME STREQUAL Darwin)
++if(CMAKE_SYSTEM_NAME STREQUAL "Darwin")
+   list(APPEND SWIFT_RUNTIME_CONCURRENCY_C_FLAGS
+     "-fswift-async-fp=${swift_concurrency_async_fp_mode}")
+   list(APPEND SWIFT_RUNTIME_CONCURRENCY_SWIFT_FLAGS
+diff --git a/stdlib/public/Cxx/std/CMakeLists.txt b/stdlib/public/Cxx/std/CMakeLists.txt
+index f24d08b6b62..b805b2ed6cb 100644
+--- a/stdlib/public/Cxx/std/CMakeLists.txt
++++ b/stdlib/public/Cxx/std/CMakeLists.txt
+@@ -1,6 +1,6 @@
+ set(libstdcxx_modulemap_target_list)
+ foreach(sdk ${SWIFT_SDKS})
+-  if(NOT ${sdk} IN_LIST SWIFT_LIBSTDCXX_PLATFORMS)
++  if(NOT sdk IN_LIST SWIFT_LIBSTDCXX_PLATFORMS)
+     continue()
+   endif()
+ 
+@@ -86,7 +86,7 @@ foreach(sdk ${SWIFT_SDKS})
+           COMPONENT sdk-overlay)
+     endif()
+ 
+-    if(${BOOTSTRAPPING_MODE} MATCHES "BOOTSTRAPPING.*")
++    if(BOOTSTRAPPING_MODE MATCHES "BOOTSTRAPPING.*")
+       foreach(bootstrapping "0" "1")
+         get_bootstrapping_path(bootstrapping_dir ${module_dir} ${bootstrapping})
+         set(libstdcxx_modulemap_out_bootstrapping "${bootstrapping_dir}/libstdcxx.modulemap")
+diff --git a/stdlib/public/Platform/CMakeLists.txt b/stdlib/public/Platform/CMakeLists.txt
+index 9063931bd20..757a89eb760 100644
+--- a/stdlib/public/Platform/CMakeLists.txt
++++ b/stdlib/public/Platform/CMakeLists.txt
+@@ -42,8 +42,8 @@ set(swiftDarwin_common_options
+       DEPENDS ${darwin_depends})
+ 
+ 
+-if(${BOOTSTRAPPING_MODE} STREQUAL "BOOTSTRAPPING" AND
+-   ${SWIFT_HOST_VARIANT_SDK} IN_LIST SWIFT_DARWIN_PLATFORMS)
++if(BOOTSTRAPPING_MODE STREQUAL "BOOTSTRAPPING" AND
++   SWIFT_HOST_VARIANT_SDK IN_LIST SWIFT_DARWIN_PLATFORMS)
+ 
+   set(swiftDarwin_common_bootstrapping_options
+       ${swiftDarwin_common_options}
+@@ -179,7 +179,7 @@ foreach(sdk ${SWIFT_SDKS})
+     # with its own native sysroot, create a native modulemap without a sysroot
+     # prefix. This is the one we'll install instead.
+     if(NOT "${SWIFT_SDK_${SWIFT_HOST_VARIANT_SDK}_ARCH_${arch}_PATH}" STREQUAL "/" AND
+-       NOT (${sdk} STREQUAL ANDROID AND NOT "${SWIFT_ANDROID_NATIVE_SYSROOT}" STREQUAL ""))
++       NOT (sdk STREQUAL "ANDROID" AND NOT "${SWIFT_ANDROID_NATIVE_SYSROOT}" STREQUAL ""))
+       set(glibc_sysroot_relative_modulemap_out "${module_dir}/sysroot-relative-modulemaps/glibc.modulemap")
+ 
+       handle_gyb_source_single(glibc_modulemap_native_target
+diff --git a/stdlib/public/SwiftOnoneSupport/CMakeLists.txt b/stdlib/public/SwiftOnoneSupport/CMakeLists.txt
+index 50efa52b7e1..cf6f09bcf69 100644
+--- a/stdlib/public/SwiftOnoneSupport/CMakeLists.txt
++++ b/stdlib/public/SwiftOnoneSupport/CMakeLists.txt
+@@ -10,7 +10,7 @@ set(swiftOnoneSupport_common_options
+   SWIFT_COMPILE_FLAGS "-parse-stdlib" "-Xllvm" "-sil-inline-generics=false" "-Xfrontend" "-validate-tbd-against-ir=none" "-Xfrontend" "-check-onone-completeness" "-Xfrontend" "-disable-access-control" "${SWIFT_RUNTIME_SWIFT_COMPILE_FLAGS}" "${SWIFT_STANDARD_LIBRARY_SWIFT_FLAGS}"
+   LINK_FLAGS "${SWIFT_RUNTIME_SWIFT_LINK_FLAGS}")
+ 
+-if(CMAKE_BUILD_TYPE STREQUAL "Debug" AND ${BOOTSTRAPPING_MODE} STREQUAL "BOOTSTRAPPING")
++if(CMAKE_BUILD_TYPE STREQUAL "Debug" AND BOOTSTRAPPING_MODE STREQUAL "BOOTSTRAPPING")
+ 
+   set(swiftOnoneSupport_common_bootstrapping_options
+     SHARED
+diff --git a/stdlib/public/SwiftShims/swift/shims/CMakeLists.txt b/stdlib/public/SwiftShims/swift/shims/CMakeLists.txt
+index c54b2cf84b2..f925940d8a2 100644
+--- a/stdlib/public/SwiftShims/swift/shims/CMakeLists.txt
++++ b/stdlib/public/SwiftShims/swift/shims/CMakeLists.txt
+@@ -152,7 +152,7 @@ if(NOT SWIFT_BUILT_STANDALONE)
+   endforeach()
+ endif()
+ 
+-if(${BOOTSTRAPPING_MODE} MATCHES "BOOTSTRAPPING.*")
++if(BOOTSTRAPPING_MODE MATCHES "BOOTSTRAPPING.*")
+   foreach(bootstrapping "0" "1")
+     get_bootstrapping_path(outdir ${SWIFTLIB_DIR} ${bootstrapping})
+     set(target_name "symlink-headers-bootstrapping${bootstrapping}")
+diff --git a/stdlib/public/core/CMakeLists.txt b/stdlib/public/core/CMakeLists.txt
+index c2217c9f294..be0d826b29d 100644
+--- a/stdlib/public/core/CMakeLists.txt
++++ b/stdlib/public/core/CMakeLists.txt
+@@ -251,18 +251,18 @@ set(swift_core_framework_depends)
+ set(swift_core_private_link_libraries)
+ set(swift_stdlib_compile_flags "${SWIFT_RUNTIME_SWIFT_COMPILE_FLAGS}")
+ 
+-if(SWIFT_PRIMARY_VARIANT_SDK STREQUAL CYGWIN)
++if(SWIFT_PRIMARY_VARIANT_SDK STREQUAL "CYGWIN")
+   # TODO(compnerd) cache this variable to permit re-configuration
+   execute_process(COMMAND "cygpath" "-u" "$ENV{SYSTEMROOT}" OUTPUT_VARIABLE ENV_SYSTEMROOT)
+   list(APPEND swift_core_private_link_libraries "${ENV_SYSTEMROOT}/system32/psapi.dll")
+-elseif(SWIFT_PRIMARY_VARIANT_SDK STREQUAL FREEBSD)
++elseif(SWIFT_PRIMARY_VARIANT_SDK STREQUAL "FREEBSD")
+   find_library(EXECINFO_LIBRARY execinfo)
+   list(APPEND swift_core_private_link_libraries ${EXECINFO_LIBRARY})
+-elseif(SWIFT_PRIMARY_VARIANT_SDK STREQUAL LINUX)
++elseif(SWIFT_PRIMARY_VARIANT_SDK STREQUAL "LINUX")
+   if(SWIFT_BUILD_STATIC_STDLIB)
+     list(APPEND swift_core_private_link_libraries)
+   endif()
+-elseif(SWIFT_PRIMARY_VARIANT_SDK STREQUAL WINDOWS)
++elseif(SWIFT_PRIMARY_VARIANT_SDK STREQUAL "WINDOWS")
+   list(APPEND swift_core_private_link_libraries shell32;DbgHelp;Synchronization)
+ endif()
+ 
+@@ -331,7 +331,7 @@ set(swiftCore_common_options
+ set(swiftCore_common_dependencies
+     copy_shim_headers "${SWIFTLIB_DIR}/shims" ${GROUP_INFO_JSON_FILE})
+ 
+-if(${BOOTSTRAPPING_MODE} STREQUAL "BOOTSTRAPPING")
++if(BOOTSTRAPPING_MODE STREQUAL "BOOTSTRAPPING")
+ 
+   set(b0_deps symlink-headers-bootstrapping0)
+   set(b1_deps symlink-headers-bootstrapping1)
+diff --git a/stdlib/public/runtime/CMakeLists.txt b/stdlib/public/runtime/CMakeLists.txt
+index e46c37d626b..db503543b6b 100644
+--- a/stdlib/public/runtime/CMakeLists.txt
++++ b/stdlib/public/runtime/CMakeLists.txt
+@@ -163,7 +163,7 @@ foreach(sdk ${SWIFT_SDKS})
+       # set(swiftrtObject "$<TARGET_OBJECTS:swiftImageRegistrationObject${SWIFT_SDK_${sdk}_OBJECT_FORMAT}-${arch_suffix}>")
+       set(swiftrtObject ${CMAKE_CURRENT_BINARY_DIR}/CMakeFiles/swiftImageRegistrationObject${SWIFT_SDK_${sdk}_OBJECT_FORMAT}-${arch_suffix}.dir/SwiftRT-${SWIFT_SDK_${sdk}_OBJECT_FORMAT}.cpp${CMAKE_C_OUTPUT_EXTENSION})
+ 
+-      if(sdk STREQUAL WINDOWS)
++      if(sdk STREQUAL "WINDOWS")
+         set(extension .obj)
+       else()
+         set(extension .o)
+@@ -209,12 +209,12 @@ foreach(sdk ${SWIFT_SDKS})
+ 
+     # Generate the static-stdlib-args.lnk file used by -static-stdlib option for
+     # 'GenericUnix' (eg linux)
+-    if(${SWIFT_SDK_${sdk}_OBJECT_FORMAT} STREQUAL ELF)
++    if(SWIFT_SDK_${sdk}_OBJECT_FORMAT STREQUAL "ELF")
+       string(TOLOWER "${sdk}" lowercase_sdk)
+       set(libpthread -lpthread)
+       set(concurrency_libs)
+       set(android_libraries)
+-      if(${sdk} STREQUAL ANDROID)
++      if(sdk STREQUAL "ANDROID")
+         set(android_libraries -llog)
+         set(libpthread)
+       elseif(SWIFT_CONCURRENCY_USES_DISPATCH)
+diff --git a/stdlib/toolchain/legacy_layouts/CMakeLists.txt b/stdlib/toolchain/legacy_layouts/CMakeLists.txt
+index ad18c6b1b32..96da3906821 100644
+--- a/stdlib/toolchain/legacy_layouts/CMakeLists.txt
++++ b/stdlib/toolchain/legacy_layouts/CMakeLists.txt
+@@ -55,7 +55,7 @@ foreach(sdk ${SWIFT_SDKS})
+   endforeach()
+ endforeach()
+ 
+-if(${BOOTSTRAPPING_MODE} MATCHES "BOOTSTRAPPING.*")
++if(BOOTSTRAPPING_MODE MATCHES "BOOTSTRAPPING.*")
+   # The resource dir for bootstrapping0 may be used explicitly
+   # to cross compile for other architectures, so we would need
+   # to have all the legacy layouts in there
+diff --git a/tools/SourceKit/CMakeLists.txt b/tools/SourceKit/CMakeLists.txt
+index f87720f9c80..6c0c0800bc4 100644
+--- a/tools/SourceKit/CMakeLists.txt
++++ b/tools/SourceKit/CMakeLists.txt
+@@ -82,7 +82,7 @@ if("${CMAKE_SYSTEM_NAME}" STREQUAL "Darwin")
+   # Add deployment target to C/C++ compiler and linker flags.
+   # FIXME: CMAKE_OSX_DEPLOYMENT_TARGET falls over when used for iOS versions.
+   if (XCODE)
+-    if (${SOURCEKIT_DEPLOYMENT_OS} MATCHES "^macosx")
++    if (SOURCEKIT_DEPLOYMENT_OS MATCHES "^macosx")
+       set(CMAKE_XCODE_ATTRIBUTE_MACOSX_DEPLOYMENT_TARGET ${SOURCEKIT_DEPLOYMENT_TARGET})
+     else()
+       set(CMAKE_XCODE_ATTRIBUTE_IPHONEOS_DEPLOYMENT_TARGET ${SOURCEKIT_DEPLOYMENT_TARGET})
+@@ -101,7 +101,7 @@ if(NOT "${CMAKE_SYSTEM_NAME}" STREQUAL "Darwin")
+ endif()
+ 
+ if(SWIFT_BUILD_HOST_DISPATCH)
+-  if(SWIFT_HOST_VARIANT_SDK STREQUAL WINDOWS)
++  if(SWIFT_HOST_VARIANT_SDK STREQUAL "WINDOWS")
+     set(SOURCEKIT_RUNTIME_DIR bin)
+   else()
+     set(SOURCEKIT_RUNTIME_DIR lib)
+@@ -114,7 +114,7 @@ if(SWIFT_BUILD_HOST_DISPATCH)
+       DESTINATION ${SOURCEKIT_RUNTIME_DIR}
+       COMPONENT sourcekit-inproc)
+   endif()
+-  if(SWIFT_HOST_VARIANT_SDK STREQUAL WINDOWS)
++  if(SWIFT_HOST_VARIANT_SDK STREQUAL "WINDOWS")
+     swift_install_in_component(FILES
+       $<TARGET_LINKER_FILE:dispatch>
+       $<TARGET_LINKER_FILE:BlocksRuntime>
+diff --git a/tools/SourceKit/cmake/modules/AddSwiftSourceKit.cmake b/tools/SourceKit/cmake/modules/AddSwiftSourceKit.cmake
+index 14d9a99a13a..bc26b263848 100644
+--- a/tools/SourceKit/cmake/modules/AddSwiftSourceKit.cmake
++++ b/tools/SourceKit/cmake/modules/AddSwiftSourceKit.cmake
+@@ -8,7 +8,7 @@ function(add_sourcekit_default_compiler_flags target)
+   _add_host_variant_link_flags(${target})
+ 
+   # Set compilation and link flags.
+-  if(${SWIFT_HOST_VARIANT_SDK} STREQUAL WINDOWS)
++  if(SWIFT_HOST_VARIANT_SDK STREQUAL "WINDOWS")
+     swift_windows_include_for_arch(${SWIFT_HOST_VARIANT_ARCH}
+       ${SWIFT_HOST_VARIANT_ARCH}_INCLUDE)
+     target_include_directories(${target} SYSTEM PRIVATE
+@@ -30,7 +30,7 @@ function(add_sourcekit_swift_runtime_link_flags target path HAS_SWIFT_MODULES)
+     endif()
+   endif()
+ 
+-  if(${SWIFT_HOST_VARIANT_SDK} IN_LIST SWIFT_DARWIN_PLATFORMS)
++  if(SWIFT_HOST_VARIANT_SDK IN_LIST SWIFT_DARWIN_PLATFORMS)
+ 
+     # Lists of rpaths that we are going to add to our executables.
+     #
+@@ -118,7 +118,7 @@ function(add_sourcekit_swift_runtime_link_flags target path HAS_SWIFT_MODULES)
+ 
+   elseif(SWIFT_HOST_VARIANT_SDK MATCHES "LINUX|ANDROID|OPENBSD" AND HAS_SWIFT_MODULES AND ASKD_BOOTSTRAPPING_MODE)
+     set(swiftrt "swiftImageRegistrationObject${SWIFT_SDK_${SWIFT_HOST_VARIANT_SDK}_OBJECT_FORMAT}-${SWIFT_SDK_${SWIFT_HOST_VARIANT_SDK}_LIB_SUBDIR}-${SWIFT_HOST_VARIANT_ARCH}")
+-    if(${ASKD_BOOTSTRAPPING_MODE} MATCHES "HOSTTOOLS|CROSSCOMPILE")
++    if(ASKD_BOOTSTRAPPING_MODE MATCHES "HOSTTOOLS|CROSSCOMPILE")
+       # At build time and run time, link against the swift libraries in the
+       # installed host toolchain.
+       get_filename_component(swift_bin_dir ${SWIFT_EXEC_FOR_SWIFT_MODULES} DIRECTORY)
+@@ -163,7 +163,7 @@ function(add_sourcekit_swift_runtime_link_flags target path HAS_SWIFT_MODULES)
+     # able to fall back to the SDK directory for libswiftCore et al.
+     if (BOOTSTRAPPING_MODE MATCHES "BOOTSTRAPPING.*")
+       if (NOT "${bootstrapping}" STREQUAL "1")
+-        if(${SWIFT_HOST_VARIANT_SDK} IN_LIST SWIFT_DARWIN_PLATFORMS)
++        if(SWIFT_HOST_VARIANT_SDK IN_LIST SWIFT_DARWIN_PLATFORMS)
+           target_link_directories(${target} PRIVATE "${sdk_dir}")
+ 
+           # Include the abi stable system stdlib in our rpath.
+diff --git a/tools/SourceKit/lib/Support/CMakeLists.txt b/tools/SourceKit/lib/Support/CMakeLists.txt
+index c4e2cbcd31e..a47b2347a12 100644
+--- a/tools/SourceKit/lib/Support/CMakeLists.txt
++++ b/tools/SourceKit/lib/Support/CMakeLists.txt
+@@ -9,7 +9,7 @@ target_link_libraries(SourceKitSupport PRIVATE
+   swiftBasic
+   clangBasic
+   clangRewrite)
+-if(NOT CMAKE_SYSTEM_NAME STREQUAL Darwin)
++if(NOT CMAKE_SYSTEM_NAME STREQUAL "Darwin")
+   target_link_libraries(SourceKitSupport INTERFACE
+     dispatch
+     BlocksRuntime)
+diff --git a/tools/SourceKit/tools/complete-test/CMakeLists.txt b/tools/SourceKit/tools/complete-test/CMakeLists.txt
+index ec3437650a0..d1b3fe3b36a 100644
+--- a/tools/SourceKit/tools/complete-test/CMakeLists.txt
++++ b/tools/SourceKit/tools/complete-test/CMakeLists.txt
+@@ -7,13 +7,13 @@ if(SWIFT_SOURCEKIT_USE_INPROC_LIBRARY)
+ else()
+   target_link_libraries(complete-test PRIVATE sourcekitd)
+ endif()
+-if(NOT CMAKE_SYSTEM_NAME STREQUAL Darwin)
++if(NOT CMAKE_SYSTEM_NAME STREQUAL "Darwin")
+   target_link_libraries(complete-test PRIVATE
+     dispatch
+     BlocksRuntime)
+ endif()
+ 
+-if(CMAKE_SYSTEM_NAME STREQUAL Darwin)
++if(CMAKE_SYSTEM_NAME STREQUAL "Darwin")
+   set_target_properties(complete-test PROPERTIES
+     INSTALL_RPATH "@executable_path/../lib")
+   target_link_options(complete-test PRIVATE
+diff --git a/tools/SourceKit/tools/sourcekitd-repl/CMakeLists.txt b/tools/SourceKit/tools/sourcekitd-repl/CMakeLists.txt
+index d4a3a77df2a..f537ad74544 100644
+--- a/tools/SourceKit/tools/sourcekitd-repl/CMakeLists.txt
++++ b/tools/SourceKit/tools/sourcekitd-repl/CMakeLists.txt
+@@ -7,7 +7,7 @@ if(SWIFT_SOURCEKIT_USE_INPROC_LIBRARY)
+ else()
+   target_link_libraries(sourcekitd-repl PRIVATE sourcekitd)
+ endif()
+-if(NOT CMAKE_SYSTEM_NAME STREQUAL Darwin)
++if(NOT CMAKE_SYSTEM_NAME STREQUAL "Darwin")
+   target_link_libraries(sourcekitd-repl PRIVATE
+     dispatch
+     BlocksRuntime)
+@@ -15,7 +15,7 @@ endif()
+ target_link_libraries(sourcekitd-repl PRIVATE
+   libedit)
+ 
+-if(CMAKE_SYSTEM_NAME STREQUAL Darwin)
++if(CMAKE_SYSTEM_NAME STREQUAL "Darwin")
+   set_target_properties(sourcekitd-repl PROPERTIES
+     INSTALL_RPATH "@executable_path/../lib")
+   target_link_options(sourcekitd-repl PRIVATE
+diff --git a/tools/SourceKit/tools/sourcekitd-test/CMakeLists.txt b/tools/SourceKit/tools/sourcekitd-test/CMakeLists.txt
+index 91c28f371c4..e5f7aa5c9fb 100644
+--- a/tools/SourceKit/tools/sourcekitd-test/CMakeLists.txt
++++ b/tools/SourceKit/tools/sourcekitd-test/CMakeLists.txt
+@@ -17,7 +17,7 @@ if(SWIFT_SOURCEKIT_USE_INPROC_LIBRARY)
+ else()
+   target_link_libraries(sourcekitd-test PRIVATE sourcekitd)
+ endif()
+-if(NOT CMAKE_SYSTEM_NAME STREQUAL Darwin)
++if(NOT CMAKE_SYSTEM_NAME STREQUAL "Darwin")
+   target_link_libraries(sourcekitd-test PRIVATE
+     dispatch
+     BlocksRuntime)
+@@ -25,7 +25,7 @@ endif()
+ 
+ add_dependencies(sourcekitd-test sourcekitdTestOptionsTableGen)
+ 
+-if(CMAKE_SYSTEM_NAME STREQUAL Darwin)
++if(CMAKE_SYSTEM_NAME STREQUAL "Darwin")
+   set_target_properties(sourcekitd-test PROPERTIES
+     INSTALL_RPATH "@executable_path/../lib")
+   target_link_options(sourcekitd-test PRIVATE
+diff --git a/tools/driver/CMakeLists.txt b/tools/driver/CMakeLists.txt
+index 4521356ffc6..ab6dad7b273 100644
+--- a/tools/driver/CMakeLists.txt
++++ b/tools/driver/CMakeLists.txt
+@@ -10,7 +10,7 @@ function(add_swift_parser_link_libraries target)
+   endif()
+ endfunction()
+ 
+-if(${BOOTSTRAPPING_MODE} MATCHES "BOOTSTRAPPING.*")
++if(BOOTSTRAPPING_MODE MATCHES "BOOTSTRAPPING.*")
+ 
+   # Bootstrapping - level 0
+   # For more information on how bootstrapping works, see docs/SwiftInTheCompiler.md
+diff --git a/tools/libSwiftScan/CMakeLists.txt b/tools/libSwiftScan/CMakeLists.txt
+index f11c2a99758..93beb4629b0 100644
+--- a/tools/libSwiftScan/CMakeLists.txt
++++ b/tools/libSwiftScan/CMakeLists.txt
+@@ -8,7 +8,7 @@ add_swift_host_library(libSwiftScan SHARED
+   libSwiftScan.cpp
+   c-include-check.c)
+ 
+-if(${SWIFT_HOST_VARIANT_SDK} IN_LIST SWIFT_DARWIN_PLATFORMS)
++if(SWIFT_HOST_VARIANT_SDK IN_LIST SWIFT_DARWIN_PLATFORMS)
+   # Workaround for a linker crash related to autolinking: rdar://77839981
+   set_property(TARGET libSwiftScan APPEND_STRING PROPERTY
+                LINK_FLAGS " -lobjc ")
+diff --git a/unittests/Basic/CMakeLists.txt b/unittests/Basic/CMakeLists.txt
+index 547751e6cac..10b413ce732 100644
+--- a/unittests/Basic/CMakeLists.txt
++++ b/unittests/Basic/CMakeLists.txt
+@@ -49,6 +49,6 @@ target_link_libraries(SwiftBasicTests
+   LLVMTestingSupport
+   )
+ 
+-if(SWIFT_HOST_VARIANT STREQUAL windows)
++if(SWIFT_HOST_VARIANT STREQUAL "windows")
+   target_link_libraries(SwiftBasicTests PRIVATE Synchronization)
+ endif()
+diff --git a/unittests/Threading/CMakeLists.txt b/unittests/Threading/CMakeLists.txt
+index 5e0f27c089d..239630d038c 100644
+--- a/unittests/Threading/CMakeLists.txt
++++ b/unittests/Threading/CMakeLists.txt
+@@ -14,7 +14,7 @@ if(("${SWIFT_HOST_VARIANT_SDK}" STREQUAL "${SWIFT_PRIMARY_VARIANT_SDK}") AND
+     swiftCore${SWIFT_PRIMARY_VARIANT_SUFFIX}
+     )
+ 
+-  if(SWIFT_HOST_VARIANT STREQUAL windows)
++  if(SWIFT_HOST_VARIANT STREQUAL "windows")
+     target_link_libraries(SwiftThreadingTests PRIVATE Synchronization)
+   endif()
+ endif()
+diff --git a/unittests/runtime/CMakeLists.txt b/unittests/runtime/CMakeLists.txt
+index 79df463c0ed..cef40263785 100644
+--- a/unittests/runtime/CMakeLists.txt
++++ b/unittests/runtime/CMakeLists.txt
+@@ -63,7 +63,7 @@ if(("${SWIFT_HOST_VARIANT_SDK}" STREQUAL "${SWIFT_PRIMARY_VARIANT_SDK}") AND
+     list(APPEND PLATFORM_TARGET_LINK_LIBRARIES
+       ${EXECINFO_LIBRARY}
+       )
+-  elseif(SWIFT_HOST_VARIANT STREQUAL windows)
++  elseif(SWIFT_HOST_VARIANT STREQUAL "windows")
+     list(APPEND PLATFORM_TARGET_LINK_LIBRARIES DbgHelp;Synchronization)
+   endif()
+ 
+diff --git a/unittests/runtime/LongTests/CMakeLists.txt b/unittests/runtime/LongTests/CMakeLists.txt
+index 592e532f8cf..37b5e00714e 100644
+--- a/unittests/runtime/LongTests/CMakeLists.txt
++++ b/unittests/runtime/LongTests/CMakeLists.txt
+@@ -30,7 +30,7 @@ if(("${SWIFT_HOST_VARIANT_SDK}" STREQUAL "${SWIFT_PRIMARY_VARIANT_SDK}") AND
+     list(APPEND PLATFORM_TARGET_LINK_LIBRARIES
+       ${EXECINFO_LIBRARY}
+       )
+-  elseif(SWIFT_HOST_VARIANT STREQUAL windows)
++  elseif(SWIFT_HOST_VARIANT STREQUAL "windows")
+     list(APPEND PLATFORM_TARGET_LINK_LIBRARIES DbgHelp;Synchronization)
+   endif()
+ 
+diff --git a/utils/api_checker/CMakeLists.txt b/utils/api_checker/CMakeLists.txt
+index e664a73ddd9..fea720f6095 100644
+--- a/utils/api_checker/CMakeLists.txt
++++ b/utils/api_checker/CMakeLists.txt
+@@ -16,7 +16,7 @@ set(SWIFTLIB_DIR "${CMAKE_BINARY_DIR}/${CMAKE_CFG_INTDIR}/lib/swift")
+ set(dest "${SWIFTLIB_DIR}/${framework}")
+ set(source "${CMAKE_CURRENT_SOURCE_DIR}/${framework}")
+ 
+-if(CMAKE_SYSTEM_NAME STREQUAL Windows)
++if(CMAKE_SYSTEM_NAME STREQUAL "Windows")
+     set(CMAKE_SYMLINK_COMMAND copy)
+ else()
+     set(CMAKE_SYMLINK_COMMAND create_symlink)

--- a/pkgs/development/compilers/swift/compiler/patches/swift-darwin-libcxx-flags.patch
+++ b/pkgs/development/compilers/swift/compiler/patches/swift-darwin-libcxx-flags.patch
@@ -1,0 +1,63 @@
+On Darwin, the SDK is a directory of stubs, and libc++ lives separately. We
+need to patch the CMake files in several places to make the build for C++
+interop succeed. The required flags can be read from cc-wrapper support files.
+
+--- a/SwiftCompilerSources/CMakeLists.txt
++++ b/SwiftCompilerSources/CMakeLists.txt
+@@ -105,18 +105,11 @@ function(add_swift_compiler_modules_library name)
+       get_filename_component(swift_exec_bin_dir ${ALS_SWIFT_EXEC} DIRECTORY)
+       set(sdk_option ${sdk_option} "-resource-dir" "${swift_exec_bin_dir}/../bootstrapping0/lib/swift")
+     endif()
+-    if(NOT EXISTS "${sdk_path}/usr/include/c++")
+-      # Darwin SDKs in Xcode 12 or older do not include libc++, which prevents clang from finding libc++ when invoked
+-      # from ClangImporter. This results in build errors. To workaround this, let's explicitly pass the path to libc++
+-      # to clang.
+-      message(WARNING "Building with an outdated Darwin SDK: libc++ missing from the ${SWIFT_HOST_VARIANT_SDK} SDK. Will use libc++ from the toolchain.")
+-      get_filename_component(absolute_libcxx_path "${CMAKE_C_COMPILER}/../../include/c++/v1" REALPATH)
+-      if (EXISTS "${absolute_libcxx_path}")
+-        set(sdk_option ${sdk_option} "-Xcc" "-isystem" "-Xcc" "${absolute_libcxx_path}")
+-      else()
+-        message(ERROR "libc++ not found in the toolchain.")
+-      endif()
+-    endif()
++    file(READ "$ENV{NIX_CC}/nix-support/libcxx-cxxflags" nix_libcxx_cxxflags)
++    separate_arguments(nix_libcxx_cxxflags)
++    foreach(nix_libcxx_cxxflag ${nix_libcxx_cxxflags})
++      set(sdk_option ${sdk_option} "-Xcc" "${nix_libcxx_cxxflag}")
++    endforeach()
+   elseif(BOOTSTRAPPING_MODE STREQUAL "CROSSCOMPILE")
+     set(sdk_option "-sdk" "${SWIFT_SDK_${SWIFT_HOST_VARIANT_SDK}_ARCH_${SWIFT_HOST_VARIANT_ARCH}_PATH}")
+     get_filename_component(swift_exec_bin_dir ${ALS_SWIFT_EXEC} DIRECTORY)
+--- a/cmake/modules/SwiftConfigureSDK.cmake
++++ b/cmake/modules/SwiftConfigureSDK.cmake
+@@ -270,6 +270,18 @@ macro(configure_sdk_darwin
+   # Add this to the list of known SDKs.
+   list(APPEND SWIFT_CONFIGURED_SDKS "${prefix}")
+ 
++  set(cxx_overlay_opt "")
++  if("${prefix}" STREQUAL "OSX")
++    file(READ "$ENV{NIX_CC}/nix-support/libcxx-cxxflags" nix_libcxx_cxxflags)
++    separate_arguments(nix_libcxx_cxxflags)
++    foreach(nix_libcxx_cxxflag ${nix_libcxx_cxxflags})
++      set(cxx_overlay_opt ${cxx_overlay_opt} "-Xcc" "${nix_libcxx_cxxflag}")
++    endforeach()
++  endif()
++  set(SWIFT_SDK_${prefix}_CXX_OVERLAY_SWIFT_COMPILE_FLAGS
++      ${cxx_overlay_opt}
++    CACHE STRING "Extra flags for compiling the C++ overlay")
++
+   _report_sdk("${prefix}")
+ endmacro()
+ 
+--- a/stdlib/public/Cxx/std/CMakeLists.txt
++++ b/stdlib/public/Cxx/std/CMakeLists.txt
+@@ -145,6 +145,9 @@ add_swift_target_library(swiftstd STATIC NO_LINK_NAME IS_STDLIB
+     SWIFT_COMPILE_FLAGS_LINUX
+     ${SWIFT_SDK_LINUX_CXX_OVERLAY_SWIFT_COMPILE_FLAGS}
+ 
++    SWIFT_COMPILE_FLAGS_OSX
++    ${SWIFT_SDK_OSX_CXX_OVERLAY_SWIFT_COMPILE_FLAGS}
++
+     LINK_FLAGS "${SWIFT_RUNTIME_SWIFT_LINK_FLAGS}"
+     TARGET_SDKS ALL_APPLE_PLATFORMS LINUX
+     INSTALL_IN_COMPONENT compiler

--- a/pkgs/development/compilers/swift/compiler/patches/swift-darwin-link-cxxabi.patch
+++ b/pkgs/development/compilers/swift/compiler/patches/swift-darwin-link-cxxabi.patch
@@ -1,0 +1,14 @@
+This patches the stdlib backdeploy static lib to have its users link c++abi.
+Without this, later steps that try to link this fail looking for global
+new/delete operators (__Znwm/__ZdlPv).
+
+--- a/stdlib/toolchain/Compatibility56/Overrides.cpp
++++ b/stdlib/toolchain/Compatibility56/Overrides.cpp
+@@ -23,6 +23,7 @@
+ using namespace swift;
+ 
+ __asm__ (".linker_option \"-lc++\"");
++__asm__ (".linker_option \"-lc++abi\"");
+ 
+ #define OVERRIDE(name, ret, attrs, ccAttrs, namespace, typedArgs, namedArgs) \
+   Override_ ## name name;

--- a/pkgs/development/compilers/swift/compiler/patches/swift-linux-fix-libc-paths.patch
+++ b/pkgs/development/compilers/swift/compiler/patches/swift-linux-fix-libc-paths.patch
@@ -1,0 +1,48 @@
+This code injects an LLVM modulemap for glibc and libstdc++ by overriding
+specific VFS paths. In order to do that, it needs to know the actual locations
+of glibc and libstdc++, but it only searches `-sysroot` and fails. Here we
+patch it to also consider `-idirafter` and `-isystem` as added by cc-wrapper.
+
+--- a/lib/ClangImporter/ClangIncludePaths.cpp
++++ b/lib/ClangImporter/ClangIncludePaths.cpp
+@@ -120,6 +120,7 @@ static clang::driver::Driver createClangDriver(const ASTContext &ctx) {
+ /// \return a path without dots (`../`, './').
+ static llvm::Optional<Path>
+ findFirstIncludeDir(const llvm::opt::InputArgList &args,
++                    const llvm::opt::ArgList &DriverArgs,
+                     const ArrayRef<const char *> expectedFileNames) {
+   // C++ stdlib paths are added as `-internal-isystem`.
+   std::vector<std::string> includeDirs =
+@@ -128,6 +129,14 @@ findFirstIncludeDir(const llvm::opt::InputArgList &args,
+   llvm::append_range(includeDirs,
+                      args.getAllArgValues(
+                          clang::driver::options::OPT_internal_externc_isystem));
++  // Nix adds the C stdlib include path using `-idirafter`.
++  llvm::append_range(includeDirs,
++                     DriverArgs.getAllArgValues(
++                         clang::driver::options::OPT_idirafter));
++  // Nix adds the C++ stdlib include path using `-isystem`.
++  llvm::append_range(includeDirs,
++                     DriverArgs.getAllArgValues(
++                         clang::driver::options::OPT_isystem));
+ 
+   for (const auto &includeDir : includeDirs) {
+     Path dir(includeDir);
+@@ -193,7 +202,7 @@ getGlibcFileMapping(ASTContext &ctx) {
+   // Ideally we would check that all of the headers referenced from the
+   // modulemap are present.
+   Path glibcDir;
+-  if (auto dir = findFirstIncludeDir(parsedIncludeArgs,
++  if (auto dir = findFirstIncludeDir(parsedIncludeArgs, clangDriverArgs,
+                                      {"inttypes.h", "unistd.h", "stdint.h"})) {
+     glibcDir = dir.value();
+   } else {
+@@ -251,7 +260,7 @@ getLibStdCxxFileMapping(ASTContext &ctx) {
+   auto parsedStdlibArgs = parseClangDriverArgs(clangDriver, stdlibArgStrings);
+ 
+   Path cxxStdlibDir;
+-  if (auto dir = findFirstIncludeDir(parsedStdlibArgs,
++  if (auto dir = findFirstIncludeDir(parsedStdlibArgs, clangDriverArgs,
+                                      {"cstdlib", "string", "vector"})) {
+     cxxStdlibDir = dir.value();
+   } else {

--- a/pkgs/development/compilers/swift/compiler/patches/swift-nix-resource-root.patch
+++ b/pkgs/development/compilers/swift/compiler/patches/swift-nix-resource-root.patch
@@ -7,15 +7,15 @@ second (ToolChains.cpp) happens when Swift is used to link the final product.
 
 --- a/lib/ClangImporter/ClangImporter.cpp
 +++ b/lib/ClangImporter/ClangImporter.cpp
-@@ -68,6 +68,7 @@
+@@ -73,6 +73,7 @@
  #include "llvm/Support/FileSystem.h"
  #include "llvm/Support/Memory.h"
  #include "llvm/Support/Path.h"
 +#include "llvm/Support/Process.h"
+ #include "llvm/Support/VirtualFileSystem.h"
  #include "llvm/Support/YAMLParser.h"
- #include "llvm/Support/YAMLTraits.h"
  #include <algorithm>
-@@ -809,6 +810,17 @@ importer::addCommonInvocationArguments(
+@@ -786,6 +787,17 @@ importer::addCommonInvocationArguments(
  
    const std::string &overrideResourceDir = importerOpts.OverrideResourceDir;
    if (overrideResourceDir.empty()) {
@@ -33,7 +33,7 @@ second (ToolChains.cpp) happens when Swift is used to link the final product.
      llvm::SmallString<128> resourceDir(searchPathOpts.RuntimeResourcePath);
  
      // Adjust the path to refer to our copy of the Clang resource directory
-@@ -824,6 +836,7 @@ importer::addCommonInvocationArguments(
+@@ -801,6 +813,7 @@ importer::addCommonInvocationArguments(
      // Set the Clang resource directory to the path we computed.
      invocationArgStrs.push_back("-resource-dir");
      invocationArgStrs.push_back(std::string(resourceDir.str()));
@@ -43,7 +43,7 @@ second (ToolChains.cpp) happens when Swift is used to link the final product.
      invocationArgStrs.push_back(overrideResourceDir);
 --- a/lib/Driver/ToolChains.cpp
 +++ b/lib/Driver/ToolChains.cpp
-@@ -1372,10 +1372,20 @@ void ToolChain::getClangLibraryPath(const ArgList &Args,
+@@ -1393,10 +1393,20 @@ void ToolChain::getClangLibraryPath(const ArgList &Args,
                                      SmallString<128> &LibPath) const {
    const llvm::Triple &T = getTriple();
  

--- a/pkgs/development/compilers/swift/default.nix
+++ b/pkgs/development/compilers/swift/default.nix
@@ -2,7 +2,7 @@
 , pkgs
 , newScope
 , darwin
-, llvmPackages_latest
+, llvmPackages_15
 , overrideCC
 }:
 
@@ -15,20 +15,21 @@ let
     # Re-export this so we can rely on the minimum Swift SDK elsewhere.
     apple_sdk = pkgs.darwin.apple_sdk_11_0;
 
-    # Our current Clang on Darwin is v11, but we need at least v12. The
-    # following applies the newer Clang with the same libc overrides as
-    # `apple_sdk.stdenv`.
+    # Swift builds its own Clang for internal use. We wrap that clang with a
+    # cc-wrapper derived from the clang configured below. Because cc-wrapper
+    # applies a specific resource-root, the two versions are best matched, or
+    # we'll often run into compilation errors.
     #
-    # If 'latest' becomes an issue, recommend replacing it with v14, which is
-    # currently closest to the official Swift builds.
+    # The following selects the correct Clang version, matching the version
+    # used in Swift, and applies the same libc overrides as `apple_sdk.stdenv`.
     clang = if pkgs.stdenv.isDarwin
       then
-        llvmPackages_latest.clang.override rec {
+        llvmPackages_15.clang.override rec {
           libc = apple_sdk.Libsystem;
           bintools = pkgs.bintools.override { inherit libc; };
         }
       else
-        llvmPackages_latest.clang;
+        llvmPackages_15.clang;
 
     # Overrides that create a useful environment for swift packages, allowing
     # packaging with `swiftPackages.callPackage`. These are similar to

--- a/pkgs/development/compilers/swift/sourcekit-lsp/default.nix
+++ b/pkgs/development/compilers/swift/sourcekit-lsp/default.nix
@@ -6,6 +6,7 @@
 , swiftpm2nix
 , Foundation
 , XCTest
+, pkg-config
 , sqlite
 , ncurses
 , CryptoKit
@@ -31,6 +32,7 @@ stdenv.mkDerivation {
   buildInputs = [
     Foundation
     XCTest
+    pkg-config
     sqlite
     ncursesInput
   ]

--- a/pkgs/development/compilers/swift/sourcekit-lsp/generated/default.nix
+++ b/pkgs/development/compilers/swift/sourcekit-lsp/generated/default.nix
@@ -2,15 +2,16 @@
 {
   workspaceStateFile = ./workspace-state.json;
   hashes = {
-    "indexstore-db" = "05d7l3fgcvbw8plaky3pgjm03x20a63z9r14njxg5qm2zcp5m6jx";
+    "indexstore-db" = "0lf96m82s8f6lv67wbcnm9ii01fgw4bsr4vn2xp07ydfj1iqy8il";
     "swift-argument-parser" = "1jph9w7lk9nr20fsv2c8p4hisx3dda817fh7pybd0r0j1jwa9nmw";
     "swift-collections" = "1k6sjx5rqmp3gklny77b480hyzy6gkhpi23r0s8ljfbrcwawgnan";
-    "swift-crypto" = "020b8q4ss2k7a65r5dgh59z40i6sn7ij1allxkh8c8a9d0jzn313";
-    "swift-driver" = "1lcb5wqragc74nd0fjnk47lyph9hs0i9cps1mplvp2i91yzjqk05";
-    "swift-llbuild" = "07zbp2dyfqd1bnyg7snpr9brn40jf22ivly5v10mql3hrg76a18h";
-    "swift-package-manager" = "0a3vahdkj35n0dkinwcgybgfb9dnq2lq1nknn874r38xbj3mhlff";
+    "swift-crypto" = "0kllp7j0hd8k67l9b9zr2c3ddc5bvshldchzivhcz3q31qvq9ag8";
+    "swift-driver" = "0cbvddj54k3sbw0vzlmzhccs7h43hi5kq6i3n2i0mysz3bf0c6zg";
+    "swift-llbuild" = "106vnssh6pgy5s9dnq1hi1c9v2wkfydqgncg5dy7c9n23iisjy3s";
+    "swift-package-manager" = "1d1ngh7da42dm0rwkw7jzxa63a1rpc88wimm85w2j59cm446pk9k";
+    "swift-syntax" = "05394mzznmcrw246lyzsjsn1fmilj98jgkjyyxr2ynhnbgzp2jl2";
     "swift-system" = "0402hkx2q2dv27gccnn8ma79ngvwiwzkhcv4zlcdldmy6cgi0px7";
-    "swift-tools-support-core" = "134f9x44jnzdy8cwi6hs372dwbyqvr4qmsjzjy25wzpyv6m9rhrz";
-    "Yams" = "1893y13sis2aimi1a5kgkczbf06z4yig054xb565yg2xm13srb45";
+    "swift-tools-support-core" = "1qvblyiazv58qwyxgyk2dh5ymbab3y70vm2q81qs6rmv43hs8ciz";
+    "Yams" = "0b4lprxl4f6yqq0djnp394mxgmsxm2pljr7fh4f6ihdhnpwfsfvl";
   };
 }

--- a/pkgs/development/compilers/swift/sourcekit-lsp/generated/workspace-state.json
+++ b/pkgs/development/compilers/swift/sourcekit-lsp/generated/workspace-state.json
@@ -12,8 +12,8 @@
         },
         "state": {
           "checkoutState": {
-            "branch": "release/5.7",
-            "revision": "9305648b0a8700434fa2e55eeacf7c7f4402a0d5"
+            "branch": "release/5.8",
+            "revision": "6caa12ab3bb6245eee4e09dce7677e64720c6545"
           },
           "name": "sourceControlCheckout"
         },
@@ -63,8 +63,8 @@
         },
         "state": {
           "checkoutState": {
-            "revision": "ddb07e896a2a8af79512543b1c7eb9797f8898a5",
-            "version": "1.1.7"
+            "revision": "75ec60b8b4cc0f085c3ac414f3dca5625fa3588e",
+            "version": "2.2.4"
           },
           "name": "sourceControlCheckout"
         },
@@ -80,8 +80,8 @@
         },
         "state": {
           "checkoutState": {
-            "branch": "release/5.7",
-            "revision": "82b274af66cfbb8f3131677676517b34d01e30fd"
+            "branch": "release/5.8",
+            "revision": "7cfe0c0b6e6297efe88a3ce34e6138ee7eda969e"
           },
           "name": "sourceControlCheckout"
         },
@@ -97,8 +97,8 @@
         },
         "state": {
           "checkoutState": {
-            "branch": "release/5.7",
-            "revision": "564424db5fdb62dcb5d863bdf7212500ef03a87b"
+            "branch": "release/5.8",
+            "revision": "dccfc2e127a34b89a849407594cf2d604b598ba9"
           },
           "name": "sourceControlCheckout"
         },
@@ -114,12 +114,29 @@
         },
         "state": {
           "checkoutState": {
-            "branch": "release/5.7",
-            "revision": "c6e40adbfc78acc60ca464ae482b56442f9f34f4"
+            "branch": "release/5.8",
+            "revision": "6651d98a4ce3c6faa82768256ca286412bf4a04d"
           },
           "name": "sourceControlCheckout"
         },
         "subpath": "swift-package-manager"
+      },
+      {
+        "basedOn": null,
+        "packageRef": {
+          "identity": "swift-syntax",
+          "kind": "remoteSourceControl",
+          "location": "https://github.com/apple/swift-syntax.git",
+          "name": "SwiftSyntax"
+        },
+        "state": {
+          "checkoutState": {
+            "branch": "release/5.8",
+            "revision": "cd793adf5680e138bf2bcbaacc292490175d0dcd"
+          },
+          "name": "sourceControlCheckout"
+        },
+        "subpath": "swift-syntax"
       },
       {
         "basedOn": null,
@@ -148,8 +165,8 @@
         },
         "state": {
           "checkoutState": {
-            "branch": "release/5.7",
-            "revision": "286b48b1d73388e1d49b2bb33aabf995838104e3"
+            "branch": "release/5.8",
+            "revision": "ac4871e01ef338cb95b5d28328cab0ec1dfae935"
           },
           "name": "sourceControlCheckout"
         },
@@ -165,8 +182,8 @@
         },
         "state": {
           "checkoutState": {
-            "revision": "9ff1cc9327586db4e0c8f46f064b6a82ec1566fa",
-            "version": "4.0.6"
+            "revision": "f47ba4838c30dbd59998a4e4c87ab620ff959e8a",
+            "version": "5.0.5"
           },
           "name": "sourceControlCheckout"
         },
@@ -174,5 +191,5 @@
       }
     ]
   },
-  "version": 5
+  "version": 6
 }

--- a/pkgs/development/compilers/swift/sources.nix
+++ b/pkgs/development/compilers/swift/sources.nix
@@ -5,20 +5,21 @@ let
   # These packages are all part of the Swift toolchain, and have a single
   # upstream version that should match. We also list the hashes here so a basic
   # version upgrade touches only this file.
-  version = "5.7.3";
+  version = "5.8";
   hashes = {
-    llvm-project = "sha256-IDtLPe0sXamnmovbFVKvmDMnci4u/A0urAPjWTYwJCo=";
-    sourcekit-lsp = "sha256-BT6+VCBSupKOg2mXo6HlkvNRc8pVZU772Mj3LKFamsU=";
-    swift = "sha256-essP2eIp1sLuROqk0OKGBPfJnvnyAW0moMk0cX1IVQQ=";
-    swift-cmark = "sha256-f0BoTs4HYdx/aJ9HIGCWMalhl8PvClWD6R4QK3qSgAw=";
-    swift-corelibs-foundation = "sha256-g78zKSq/b/pVFAD2k2SoMpzJQIpkxMvZOaSz5JPaQmA=";
-    swift-corelibs-libdispatch = "sha256-1qbXiC1k9+T+L6liqXKg6EZXqem6KEEx8OctuL4Kb2o=";
-    swift-corelibs-xctest = "sha256-qLUO9/3tkJWorDMEHgHd8VC3ovLLq/UWXJWMtb6CMN0=";
-    swift-docc = "sha256-WlXJMAnrlVPCM+iCIhG0Gyho76BsC2yVBEpX3m/WiIQ=";
-    swift-docc-render-artifact = "sha256-ttdurN/K7OX+I4577jG3YGeRs+GLUTc7BiiEZGmFD+s=";
-    swift-driver = "sha256-BUwsvw8pirvprUFfliLQMMHr6SHTSgeaJYc9lTEvi9E=";
-    swift-experimental-string-processing = "sha256-W0cQBkdR3A0hrV75Wwm0YULUDVg1bjT0O5w5VGBYDJs=";
-    swift-package-manager = "sha256-zlFYh1wdjUwOsnbagKnAtqXl3vKPcRtnA7YMORtUeyg=";
+    llvm-project = "sha256-0xwSAwwkzFgYO3mY1rHqV8TCeH2NpM7m3VUkCDqjcdE=";
+    sourcekit-lsp = "sha256-XDGq64LbpgBrRy3IvZNgsoLUePXECK5p10vQ8cUKeGE=";
+    swift = "sha256-EY2IImBCVLiUutvDQjNUiInwCNxZsCu1mZzYSjNd4+A=";
+    swift-cmark = "sha256-6xkO9kN6eXMAigjk+KyIgVhTyC50BxmkZmD4+9z6nz8=";
+    swift-corelibs-foundation = "sha256-yRjjxJRy1eTM9VG7/Fn60UMghPavsaoueH0V8cjaIyM=";
+    swift-corelibs-libdispatch = "sha256-XOAWuaGqWJtxhGIPXYT3PIvk5OK0rkY4g1IOybJUlm4=";
+    swift-corelibs-xctest = "sha256-uwxQhKUQ1xp5ao6kfkdlYOvMr6yAb5IaBIdOfoyf+n8=";
+    swift-docc = "sha256-k1ygYDZwF4Jo7iOkHxc/3NzfgN+8XNCks5aizxBgPjM=";
+    swift-docc-render-artifact = "sha256-vdSyICXOjlNSjZXzPRxa/5305pg6PG4xww9GYEV9m10=";
+    swift-driver = "sha256-7xsG3Bpf+wqisCMaPEuEg8CjGYO/0r8BX3pMUmRrezE=";
+    swift-experimental-string-processing = "sha256-ioXG6pQKjlAc2oF38Z7TGighyZN8w2ZAAtFUq83Ow6Q=";
+    swift-package-manager = "sha256-xd6ZpeXfMoHyVrJxz6XcDLPKBvc2nl1lgWXuLrJdq+E=";
+    swift-syntax = "sha256-gkpx/1sWWi9y917OJ1GSNFYXrJb6e2qI4JlV+38laRQ=";
   };
 
   # Create fetch derivations.

--- a/pkgs/development/compilers/swift/swift-docc/default.nix
+++ b/pkgs/development/compilers/swift/swift-docc/default.nix
@@ -28,6 +28,12 @@ stdenv.mkDerivation {
 
   configurePhase = generated.configure;
 
+  # We only install the docc binary, so don't need the other products.
+  # This works around a failure building generate-symbol-graph:
+  #  Sources/generate-symbol-graph/main.swift:13:18: error: module 'SwiftDocC' was not compiled for testing
+  # TODO: Figure out the cause. It doesn't seem to happen outside Nixpkgs.
+  swiftpmFlags = "--product docc";
+
   # TODO: Tests depend on indexstore-db being provided by an existing Swift
   # toolchain. (ie. looks for `../lib/libIndexStore.so` relative to swiftc.
   #doCheck = true;

--- a/pkgs/development/compilers/swift/swift-docc/generated/default.nix
+++ b/pkgs/development/compilers/swift/swift-docc/generated/default.nix
@@ -2,14 +2,13 @@
 {
   workspaceStateFile = ./workspace-state.json;
   hashes = {
-    "swift-argument-parser" = "070gip241dgn3d0nxgwxva4vp6kbnf11g01q5yaq6kmflcmz58f2";
-    "swift-cmark" = "0xfchdgls3070z16in8ks69y8fpiajmyk7lmp5h7ym7164isa6bb";
-    "swift-crypto" = "0h054rq14jyg94aiymmp37vqz60a13dlczp5g09pln724j4ypv92";
+    "swift-argument-parser" = "1jph9w7lk9nr20fsv2c8p4hisx3dda817fh7pybd0r0j1jwa9nmw";
+    "swift-cmark" = "1qswlh6j9mlfq8qj7xfqspla7w7rrzvplgcs4mgllgi012yfgwnp";
+    "swift-crypto" = "020b8q4ss2k7a65r5dgh59z40i6sn7ij1allxkh8c8a9d0jzn313";
     "swift-docc-plugin" = "11d6nhi139yzk1lxxrixsbgyj1bnvmh40wj30y725q83nqq49ljh";
-    "swift-docc-symbolkit" = "14hb2wc09hisf2r2yny17z28z0m58cf4lnqaczad2x2hk4s1iayi";
-    "swift-lmdb" = "1m5y6x2vs1wflcv2c57rx87gh12sy0hkwy5iy9inxmda2mcs8qcb";
-    "swift-markdown" = "09270bfrwlp904cma29hsbhr1p25v8kwgvhcfi7lg2av7aaknd97";
+    "swift-docc-symbolkit" = "14w37wzbx1mygfwm4iv0ypj120n1axhk627rg5a7v8j0ln511r7s";
+    "swift-lmdb" = "0azmc24mnxn4pbda8w8v7hy3h0gqqm4br43pnr7lc4sfj3dcv43m";
+    "swift-markdown" = "1l4ydc0xyv88gnyc33p61qavdh8cv98c548n1icphrfd6i78yygw";
     "swift-nio" = "04bvay94b34ynmlvgyl9a7f431l3cf8k2zr483spv8mvyh1hxiqn";
-    "swift-nio-ssl" = "1ak4aldilmz0pnfgbwq1x4alr38nfyvx2pz7p2vi2plf82da80g5";
   };
 }

--- a/pkgs/development/compilers/swift/swift-docc/generated/workspace-state.json
+++ b/pkgs/development/compilers/swift/swift-docc/generated/workspace-state.json
@@ -12,8 +12,8 @@
         },
         "state": {
           "checkoutState": {
-            "revision": "d2930e8fcf9c33162b9fcc1d522bc975e2d4179b",
-            "version": "1.0.1"
+            "revision": "e394bf350e38cb100b6bc4172834770ede1b7232",
+            "version": "1.0.3"
           },
           "name": "sourceControlCheckout"
         },
@@ -29,8 +29,8 @@
         },
         "state": {
           "checkoutState": {
-            "branch": "release/5.7-gfm",
-            "revision": "792c1c3326327515ce9bf64c44196b7f4daab9a6"
+            "branch": "gfm",
+            "revision": "eb9a6a357b6816c68f4b194eaa5b67f3cd1fa5c3"
           },
           "name": "sourceControlCheckout"
         },
@@ -46,8 +46,8 @@
         },
         "state": {
           "checkoutState": {
-            "revision": "9680b7251cd2be22caaed8f1468bd9e8915a62fb",
-            "version": "1.1.2"
+            "revision": "ddb07e896a2a8af79512543b1c7eb9797f8898a5",
+            "version": "1.1.7"
           },
           "name": "sourceControlCheckout"
         },
@@ -80,8 +80,8 @@
         },
         "state": {
           "checkoutState": {
-            "branch": "release/5.7",
-            "revision": "8682202025906dce29a8b04f9263f40ba87b89d8"
+            "branch": "main",
+            "revision": "b45d1f2ed151d057b54504d653e0da5552844e34"
           },
           "name": "sourceControlCheckout"
         },
@@ -97,8 +97,8 @@
         },
         "state": {
           "checkoutState": {
-            "branch": "release/5.7",
-            "revision": "6ea45a7ebf6d8f72bd299dfcc3299e284bbb92ee"
+            "branch": "main",
+            "revision": "584941b1236b15bad74d8163785d389c028b1ad8"
           },
           "name": "sourceControlCheckout"
         },
@@ -114,8 +114,8 @@
         },
         "state": {
           "checkoutState": {
-            "branch": "release/5.7",
-            "revision": "d6cd065a7e4b6c3fad615dcd39890e095a2f63a2"
+            "branch": "main",
+            "revision": "d491147940587dbadfb3472354f4d0c6e063e061"
           },
           "name": "sourceControlCheckout"
         },
@@ -137,25 +137,8 @@
           "name": "sourceControlCheckout"
         },
         "subpath": "swift-nio"
-      },
-      {
-        "basedOn": null,
-        "packageRef": {
-          "identity": "swift-nio-ssl",
-          "kind": "remoteSourceControl",
-          "location": "https://github.com/apple/swift-nio-ssl.git",
-          "name": "swift-nio-ssl"
-        },
-        "state": {
-          "checkoutState": {
-            "revision": "2e74773972bd6254c41ceeda827f229bccbf1c0f",
-            "version": "2.15.0"
-          },
-          "name": "sourceControlCheckout"
-        },
-        "subpath": "swift-nio-ssl"
       }
     ]
   },
-  "version": 5
+  "version": 6
 }

--- a/pkgs/development/compilers/swift/swift-driver/generated/default.nix
+++ b/pkgs/development/compilers/swift/swift-driver/generated/default.nix
@@ -2,10 +2,10 @@
 {
   workspaceStateFile = ./workspace-state.json;
   hashes = {
-    "swift-argument-parser" = "11did5snqj8chcbdbiyx84mpif940ls2pr1iikwivvfp63i248hm";
-    "swift-llbuild" = "07zbp2dyfqd1bnyg7snpr9brn40jf22ivly5v10mql3hrg76a18h";
+    "swift-argument-parser" = "1jph9w7lk9nr20fsv2c8p4hisx3dda817fh7pybd0r0j1jwa9nmw";
+    "swift-llbuild" = "106vnssh6pgy5s9dnq1hi1c9v2wkfydqgncg5dy7c9n23iisjy3s";
     "swift-system" = "0402hkx2q2dv27gccnn8ma79ngvwiwzkhcv4zlcdldmy6cgi0px7";
-    "swift-tools-support-core" = "134f9x44jnzdy8cwi6hs372dwbyqvr4qmsjzjy25wzpyv6m9rhrz";
-    "Yams" = "1893y13sis2aimi1a5kgkczbf06z4yig054xb565yg2xm13srb45";
+    "swift-tools-support-core" = "1qvblyiazv58qwyxgyk2dh5ymbab3y70vm2q81qs6rmv43hs8ciz";
+    "Yams" = "11abhcfkmqm3cmh7vp7rqzvxd1zj02j2866a2pp6v9m89456xb76";
   };
 }

--- a/pkgs/development/compilers/swift/swift-driver/generated/workspace-state.json
+++ b/pkgs/development/compilers/swift/swift-driver/generated/workspace-state.json
@@ -12,8 +12,8 @@
         },
         "state": {
           "checkoutState": {
-            "revision": "e1465042f195f374b94f915ba8ca49de24300a0d",
-            "version": "1.0.2"
+            "revision": "e394bf350e38cb100b6bc4172834770ede1b7232",
+            "version": "1.0.3"
           },
           "name": "sourceControlCheckout"
         },
@@ -29,8 +29,8 @@
         },
         "state": {
           "checkoutState": {
-            "branch": "release/5.7",
-            "revision": "564424db5fdb62dcb5d863bdf7212500ef03a87b"
+            "branch": "release/5.8",
+            "revision": "dccfc2e127a34b89a849407594cf2d604b598ba9"
           },
           "name": "sourceControlCheckout"
         },
@@ -63,8 +63,8 @@
         },
         "state": {
           "checkoutState": {
-            "branch": "release/5.7",
-            "revision": "286b48b1d73388e1d49b2bb33aabf995838104e3"
+            "branch": "release/5.8",
+            "revision": "ac4871e01ef338cb95b5d28328cab0ec1dfae935"
           },
           "name": "sourceControlCheckout"
         },
@@ -80,8 +80,8 @@
         },
         "state": {
           "checkoutState": {
-            "revision": "9ff1cc9327586db4e0c8f46f064b6a82ec1566fa",
-            "version": "4.0.6"
+            "revision": "01835dc202670b5bb90d07f3eae41867e9ed29f6",
+            "version": "5.0.1"
           },
           "name": "sourceControlCheckout"
         },
@@ -89,5 +89,5 @@
       }
     ]
   },
-  "version": 5
+  "version": 6
 }

--- a/pkgs/development/compilers/swift/swift-driver/patches/linux-fix-linking.patch
+++ b/pkgs/development/compilers/swift/swift-driver/patches/linux-fix-linking.patch
@@ -1,14 +1,14 @@
 --- a/Sources/SwiftDriver/Jobs/GenericUnixToolchain+LinkerSupport.swift
 +++ b/Sources/SwiftDriver/Jobs/GenericUnixToolchain+LinkerSupport.swift
-@@ -9,6 +9,7 @@
- // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+@@ -10,6 +10,7 @@
  //
  //===----------------------------------------------------------------------===//
+ 
 +import Foundation
- import TSCBasic
  import SwiftOptions
  
-@@ -116,7 +117,20 @@ extension GenericUnixToolchain {
+ import func TSCBasic.lookupExecutablePath
+@@ -120,7 +121,20 @@ extension GenericUnixToolchain {
        // just using `clang` and avoid a dependency on the C++ runtime.
        let clangTool: Tool =
          parsedOptions.hasArgument(.enableExperimentalCxxInterop) ? .clangxx : .clang
@@ -30,7 +30,7 @@
        if let toolsDirPath = parsedOptions.getLastArgument(.toolsDirectory) {
          // FIXME: What if this isn't an absolute path?
          let toolsDir = try AbsolutePath(validating: toolsDirPath.asSingle)
-@@ -132,6 +146,7 @@ extension GenericUnixToolchain {
+@@ -136,6 +150,7 @@ extension GenericUnixToolchain {
          commandLine.appendFlag("-B")
          commandLine.appendPath(toolsDir)
        }

--- a/pkgs/development/compilers/swift/swift-driver/patches/nix-resource-root.patch
+++ b/pkgs/development/compilers/swift/swift-driver/patches/nix-resource-root.patch
@@ -4,15 +4,15 @@ there, but we also here patch a check to try locate it via NIX_CC.
 
 --- a/Sources/SwiftDriver/Jobs/Toolchain+LinkerSupport.swift
 +++ b/Sources/SwiftDriver/Jobs/Toolchain+LinkerSupport.swift
-@@ -9,6 +9,7 @@
- // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+@@ -10,6 +10,7 @@
  //
  //===----------------------------------------------------------------------===//
+ 
 +import Foundation
- import TSCBasic
  import SwiftOptions
  
-@@ -24,6 +25,13 @@ extension Toolchain {
+ import protocol TSCBasic.FileSystem
+@@ -26,6 +27,13 @@ extension Toolchain {
      for targetInfo: FrontendTargetInfo,
      parsedOptions: inout ParsedOptions
    ) throws -> VirtualPath {

--- a/pkgs/development/compilers/swift/swiftpm/cmake-glue.nix
+++ b/pkgs/development/compilers/swift/swiftpm/cmake-glue.nix
@@ -57,9 +57,6 @@ in lib.mapAttrs mkInstallScript {
   '';
 
   Yams = ''
-    add_library(CYaml SHARED IMPORTED)
-    set_property(TARGET CYaml PROPERTY IMPORTED_LOCATION "@out@/lib/libCYaml@sharedLibExt@")
-
     add_library(Yams SHARED IMPORTED)
     set_property(TARGET Yams PROPERTY IMPORTED_LOCATION "@out@/lib/swift/@swiftOs@/libYams@sharedLibExt@")
   '';

--- a/pkgs/development/compilers/swift/swiftpm/generated/default.nix
+++ b/pkgs/development/compilers/swift/swiftpm/generated/default.nix
@@ -4,11 +4,11 @@
   hashes = {
     "swift-argument-parser" = "1jph9w7lk9nr20fsv2c8p4hisx3dda817fh7pybd0r0j1jwa9nmw";
     "swift-collections" = "1k6sjx5rqmp3gklny77b480hyzy6gkhpi23r0s8ljfbrcwawgnan";
-    "swift-crypto" = "020b8q4ss2k7a65r5dgh59z40i6sn7ij1allxkh8c8a9d0jzn313";
-    "swift-driver" = "1lcb5wqragc74nd0fjnk47lyph9hs0i9cps1mplvp2i91yzjqk05";
-    "swift-llbuild" = "07zbp2dyfqd1bnyg7snpr9brn40jf22ivly5v10mql3hrg76a18h";
+    "swift-crypto" = "0kllp7j0hd8k67l9b9zr2c3ddc5bvshldchzivhcz3q31qvq9ag8";
+    "swift-driver" = "0cbvddj54k3sbw0vzlmzhccs7h43hi5kq6i3n2i0mysz3bf0c6zg";
+    "swift-llbuild" = "106vnssh6pgy5s9dnq1hi1c9v2wkfydqgncg5dy7c9n23iisjy3s";
     "swift-system" = "0402hkx2q2dv27gccnn8ma79ngvwiwzkhcv4zlcdldmy6cgi0px7";
-    "swift-tools-support-core" = "134f9x44jnzdy8cwi6hs372dwbyqvr4qmsjzjy25wzpyv6m9rhrz";
-    "Yams" = "1893y13sis2aimi1a5kgkczbf06z4yig054xb565yg2xm13srb45";
+    "swift-tools-support-core" = "1qvblyiazv58qwyxgyk2dh5ymbab3y70vm2q81qs6rmv43hs8ciz";
+    "Yams" = "0b4lprxl4f6yqq0djnp394mxgmsxm2pljr7fh4f6ihdhnpwfsfvl";
   };
 }

--- a/pkgs/development/compilers/swift/swiftpm/generated/workspace-state.json
+++ b/pkgs/development/compilers/swift/swiftpm/generated/workspace-state.json
@@ -46,8 +46,8 @@
         },
         "state": {
           "checkoutState": {
-            "revision": "ddb07e896a2a8af79512543b1c7eb9797f8898a5",
-            "version": "1.1.7"
+            "revision": "75ec60b8b4cc0f085c3ac414f3dca5625fa3588e",
+            "version": "2.2.4"
           },
           "name": "sourceControlCheckout"
         },
@@ -63,8 +63,8 @@
         },
         "state": {
           "checkoutState": {
-            "branch": "release/5.7",
-            "revision": "82b274af66cfbb8f3131677676517b34d01e30fd"
+            "branch": "release/5.8",
+            "revision": "7cfe0c0b6e6297efe88a3ce34e6138ee7eda969e"
           },
           "name": "sourceControlCheckout"
         },
@@ -80,8 +80,8 @@
         },
         "state": {
           "checkoutState": {
-            "branch": "release/5.7",
-            "revision": "564424db5fdb62dcb5d863bdf7212500ef03a87b"
+            "branch": "release/5.8",
+            "revision": "dccfc2e127a34b89a849407594cf2d604b598ba9"
           },
           "name": "sourceControlCheckout"
         },
@@ -114,8 +114,8 @@
         },
         "state": {
           "checkoutState": {
-            "branch": "release/5.7",
-            "revision": "286b48b1d73388e1d49b2bb33aabf995838104e3"
+            "branch": "release/5.8",
+            "revision": "ac4871e01ef338cb95b5d28328cab0ec1dfae935"
           },
           "name": "sourceControlCheckout"
         },
@@ -131,8 +131,8 @@
         },
         "state": {
           "checkoutState": {
-            "revision": "9ff1cc9327586db4e0c8f46f064b6a82ec1566fa",
-            "version": "4.0.6"
+            "revision": "f47ba4838c30dbd59998a4e4c87ab620ff959e8a",
+            "version": "5.0.5"
           },
           "name": "sourceControlCheckout"
         },
@@ -140,5 +140,5 @@
       }
     ]
   },
-  "version": 5
+  "version": 6
 }

--- a/pkgs/development/compilers/swift/swiftpm/patches/cmake-fix-quoting.patch
+++ b/pkgs/development/compilers/swift/swiftpm/patches/cmake-fix-quoting.patch
@@ -1,0 +1,12 @@
+--- a/Sources/PackageCollectionsSigning/CMakeLists.txt
++++ b/Sources/PackageCollectionsSigning/CMakeLists.txt
+@@ -43,6 +43,7 @@ target_link_libraries(PackageCollectionsSigning PUBLIC
+   PackageCollectionsModel
+   TSCBasic)
+ target_link_libraries(PackageCollectionsSigning PRIVATE
+-  PackageCollectionsSigningLibc
+-  $<$<PLATFORM_ID:Darwin>:SHELL:-Xlinker -framework -Xlinker Security>)
++  PackageCollectionsSigningLibc)
++target_link_options(PackageCollectionsSigning PRIVATE
++  "$<$<PLATFORM_ID:Darwin>:SHELL:-Xlinker -framework -Xlinker Security>")
+ 

--- a/pkgs/development/compilers/swift/swiftpm/patches/disable-sandbox.patch
+++ b/pkgs/development/compilers/swift/swiftpm/patches/disable-sandbox.patch
@@ -2,13 +2,13 @@ Nix may already sandbox the build, in which case sandbox_apply will fail.
 
 --- a/Sources/Basics/Sandbox.swift
 +++ b/Sources/Basics/Sandbox.swift
-@@ -30,12 +30,14 @@ public enum Sandbox {
+@@ -33,12 +33,14 @@ public enum Sandbox {
          readOnlyDirectories: [AbsolutePath] = []
-     ) -> [String] {
+     ) throws -> [String] {
          #if os(macOS)
 +        let env = ProcessInfo.processInfo.environment
 +        if env["NIX_BUILD_TOP"] == nil || env["IN_NIX_SHELL"] != nil {
-         let profile = macOSSandboxProfile(strictness: strictness, writableDirectories: writableDirectories, readOnlyDirectories: readOnlyDirectories)
+         let profile = try macOSSandboxProfile(strictness: strictness, writableDirectories: writableDirectories, readOnlyDirectories: readOnlyDirectories)
          return ["/usr/bin/sandbox-exec", "-p", profile] + command
 -        #else
 +        }
@@ -17,5 +17,5 @@ Nix may already sandbox the build, in which case sandbox_apply will fail.
          return command
 -        #endif
      }
-
+ 
      /// Basic strictness level of a sandbox applied to a command line.

--- a/pkgs/development/compilers/swift/swiftpm/patches/disable-xctest.patch
+++ b/pkgs/development/compilers/swift/swiftpm/patches/disable-xctest.patch
@@ -1,21 +1,21 @@
 XCTest is not fully open-source, only the Swift library parts. We don't have a
 command-line runner available, so disable support.
 
---- a/Sources/Commands/TestingSupport.swift
-+++ b/Sources/Commands/TestingSupport.swift
-@@ -60,7 +60,7 @@ enum TestingSupport {
+--- a/Sources/Commands/Utilities/TestingSupport.swift
++++ b/Sources/Commands/Utilities/TestingSupport.swift
+@@ -72,7 +72,7 @@ enum TestingSupport {
      /// - Returns: Array of TestSuite
-     static func getTestSuites(fromTestAt path: AbsolutePath, swiftTool: SwiftTool, swiftOptions: SwiftToolOptions) throws -> [TestSuite] {
+     static func getTestSuites(fromTestAt path: AbsolutePath, swiftTool: SwiftTool, enableCodeCoverage: Bool, sanitizers: [Sanitizer]) throws -> [TestSuite] {
          // Run the correct tool.
 -        #if os(macOS)
 +        #if false
          let data: String = try withTemporaryFile { tempFile in
-             let args = [try TestingSupport.xctestHelperPath(swiftTool: swiftTool).pathString, path.pathString, tempFile.path.pathString]
-             var env = try TestingSupport.constructTestEnvironment(toolchain: try swiftTool.getToolchain(), options: swiftOptions, buildParameters: swiftTool.buildParametersForTest())
+             let args = [try Self.xctestHelperPath(swiftTool: swiftTool).pathString, path.pathString, tempFile.path.pathString]
+             var env = try Self.constructTestEnvironment(
 --- a/Sources/swiftpm-xctest-helper/main.swift
 +++ b/Sources/swiftpm-xctest-helper/main.swift
-@@ -9,8 +9,11 @@
- */
+@@ -11,8 +11,11 @@
+ //===----------------------------------------------------------------------===//
  
  #if os(macOS)
 -import XCTest
@@ -27,7 +27,7 @@ command-line runner available, so disable support.
  
  /// A helper tool to get list of tests from a XCTest Bundle on macOS.
  ///
-@@ -132,6 +135,7 @@ do {
+@@ -134,6 +137,7 @@ do {
      exit(1)
  }
  
@@ -35,14 +35,3 @@ command-line runner available, so disable support.
  #else
  
  #if os(Windows)
---- a/Sources/PackageModel/Destination.swift
-+++ b/Sources/PackageModel/Destination.swift
-@@ -174,7 +174,7 @@ public struct Destination: Encodable, Equatable {
-             arguments: ["/usr/bin/xcrun", "--sdk", "macosx", "--show-sdk-platform-path"],
-             environment: environment).spm_chomp()
-
--        if let platformPath = platformPath, !platformPath.isEmpty {
-+        if let platformPath = platformPath, !platformPath.isEmpty && !platformPath.starts(with: "@storeDir@") {
-             // For XCTest framework.
-             let fwk = AbsolutePath(platformPath).appending(
-                 components: "Developer", "Library", "Frameworks")

--- a/pkgs/development/compilers/swift/swiftpm/patches/fix-clang-cxx.patch
+++ b/pkgs/development/compilers/swift/swiftpm/patches/fix-clang-cxx.patch
@@ -2,9 +2,20 @@ Swiftpm may invoke clang, not clang++, to compile C++. Our cc-wrapper also
 doesn't pick up the arguments that enable C++ compilation in this case. Patch
 swiftpm to properly invoke clang++.
 
+--- a/Sources/Build/BuildPlan.swift
++++ b/Sources/Build/BuildPlan.swift
+@@ -2089,7 +2089,7 @@ public class BuildPlan: SPMBuildCore.BuildPlan {
+         for target in dependencies.staticTargets {
+             if case let target as ClangTarget = target.underlyingTarget, target.isCXX {
+                 if buildParameters.hostTriple.isDarwin() {
+-                    buildProduct.additionalFlags += ["-lc++"]
++                    buildProduct.additionalFlags += ["-lc++", "-lc++abi"]
+                 } else if buildParameters.hostTriple.isWindows() {
+                     // Don't link any C++ library.
+                 } else {
 --- a/Sources/Build/LLBuildManifestBuilder.swift
 +++ b/Sources/Build/LLBuildManifestBuilder.swift
-@@ -782,7 +782,7 @@ extension LLBuildManifestBuilder {
+@@ -786,7 +786,7 @@ extension LLBuildManifestBuilder {
  
              args += ["-c", path.source.pathString, "-o", path.object.pathString]
  
@@ -13,21 +24,10 @@ swiftpm to properly invoke clang++.
              args.insert(clangCompiler, at: 0)
  
              let objectFileNode: Node = .file(path.object)
---- a/Sources/PackageModel/Destination.swift
-+++ b/Sources/PackageModel/Destination.swift
-@@ -153,7 +153,7 @@ public struct Destination: Encodable, Equatable {
- 
-         var extraCPPFlags: [String] = []
- #if os(macOS)
--        extraCPPFlags += ["-lc++"]
-+        extraCPPFlags += ["-lc++", "-lc++abi"]
- #elseif os(Windows)
-         extraCPPFlags += []
- #else
 --- a/Sources/PackageModel/Toolchain.swift
 +++ b/Sources/PackageModel/Toolchain.swift
-@@ -20,7 +20,7 @@ public protocol Toolchain {
-     var macosSwiftStdlib: AbsolutePath { get }
+@@ -23,7 +23,7 @@ public protocol Toolchain {
+     var macosSwiftStdlib: AbsolutePath { get throws }
  
      /// Path of the `clang` compiler.
 -    func getClangCompiler() throws -> AbsolutePath
@@ -46,7 +46,7 @@ swiftpm to properly invoke clang++.
  
      private let environment: EnvironmentVariables
  
-@@ -150,29 +150,31 @@ public final class UserToolchain: Toolchain {
+@@ -196,29 +196,31 @@ public final class UserToolchain: Toolchain {
      }
  
      /// Returns the path to clang compiler tool.
@@ -70,7 +70,7 @@ swiftpm to properly invoke clang++.
          // Then, check the toolchain.
 +        let tool = isCXX ? "clang++" : "clang";
          do {
--            if let toolPath = try? UserToolchain.getTool("clang", binDir: self.destination.binDir) {
+-            if let toolPath = try? UserToolchain.getTool("clang", binDir: self.destination.toolchainBinDir) {
 -                self._clangCompiler = toolPath
 +            if let toolPath = try? UserToolchain.getTool(tool, binDir: self.destination.binDir) {
 +                self._clangCompiler[isCXX] = toolPath
@@ -88,18 +88,18 @@ swiftpm to properly invoke clang++.
  
 --- a/Sources/SPMBuildCore/BuildParameters.swift
 +++ b/Sources/SPMBuildCore/BuildParameters.swift
-@@ -342,7 +342,7 @@ private struct _Toolchain: Encodable {
+@@ -394,7 +394,7 @@ private struct _Toolchain: Encodable {
      public func encode(to encoder: Encoder) throws {
          var container = encoder.container(keyedBy: CodingKeys.self)
          try container.encode(toolchain.swiftCompilerPath, forKey: .swiftCompiler)
 -        try container.encode(toolchain.getClangCompiler(), forKey: .clangCompiler)
 +        try container.encode(toolchain.getClangCompiler(isCXX: false), forKey: .clangCompiler)
  
-         try container.encode(toolchain.extraCCFlags, forKey: .extraCCFlags)
-         try container.encode(toolchain.extraCPPFlags, forKey: .extraCPPFlags)
+         try container.encode(toolchain.extraFlags.cCompilerFlags, forKey: .extraCCFlags)
+         // Maintaining `extraCPPFlags` key for compatibility with older encoding.
 --- a/Sources/XCBuildSupport/XcodeBuildSystem.swift
 +++ b/Sources/XCBuildSupport/XcodeBuildSystem.swift
-@@ -172,7 +172,7 @@ public final class XcodeBuildSystem: SPMBuildCore.BuildSystem {
+@@ -182,7 +182,7 @@ public final class XcodeBuildSystem: SPMBuildCore.BuildSystem {
          // Generate a table of any overriding build settings.
          var settings: [String: String] = [:]
          // An error with determining the override should not be fatal here.
@@ -107,15 +107,15 @@ swiftpm to properly invoke clang++.
 +        settings["CC"] = try? buildParameters.toolchain.getClangCompiler(isCXX: false).pathString
          // Always specify the path of the effective Swift compiler, which was determined in the same way as for the native build system.
          settings["SWIFT_EXEC"] = buildParameters.toolchain.swiftCompilerPath.pathString
-         settings["LIBRARY_SEARCH_PATHS"] = "$(inherited) \(buildParameters.toolchain.toolchainLibDir.pathString)"
+         settings["LIBRARY_SEARCH_PATHS"] = "$(inherited) \(try buildParameters.toolchain.toolchainLibDir.pathString)"
 --- a/Tests/BuildTests/MockBuildTestHelper.swift
 +++ b/Tests/BuildTests/MockBuildTestHelper.swift
-@@ -15,7 +15,7 @@ struct MockToolchain: PackageModel.Toolchain {
+@@ -23,7 +23,7 @@ struct MockToolchain: PackageModel.Toolchain {
      #else
-     let extraCPPFlags: [String] = ["-lstdc++"]
+     let extraFlags = BuildFlags(cxxCompilerFlags: ["-lstdc++"])
      #endif
 -    func getClangCompiler() throws -> AbsolutePath {
 +    func getClangCompiler(isCXX: Bool) throws -> AbsolutePath {
-         return AbsolutePath("/fake/path/to/clang")
+         return AbsolutePath(path: "/fake/path/to/clang")
      }
  

--- a/pkgs/development/compilers/swift/swiftpm/patches/fix-stdlib-path.patch
+++ b/pkgs/development/compilers/swift/swiftpm/patches/fix-stdlib-path.patch
@@ -4,20 +4,22 @@ necessary for back-deployment of some features.
 
 --- a/Sources/PackageModel/Toolchain.swift
 +++ b/Sources/PackageModel/Toolchain.swift
-@@ -43,10 +43,16 @@ extension Toolchain {
-     }
+@@ -53,12 +53,18 @@ extension Toolchain {
  
-     public var macosSwiftStdlib: AbsolutePath { 
-+        if swiftCompilerPath.pathString.starts(with: "@storeDir@") {
-+            return AbsolutePath("@swiftLib@/lib/swift/macosx")
-+        }
-         return AbsolutePath("../../lib/swift/macosx", relativeTo: resolveSymlinks(swiftCompilerPath))
+     public var macosSwiftStdlib: AbsolutePath {
+         get throws {
++            if swiftCompilerPath.pathString.starts(with: "@storeDir@") {
++                return AbsolutePath("@swiftLib@/lib/swift/macosx")
++            }
+             return try AbsolutePath(validating: "../../lib/swift/macosx", relativeTo: resolveSymlinks(swiftCompilerPath))
+         }
      }
  
      public var toolchainLibDir: AbsolutePath {
-+        if swiftCompilerPath.pathString.starts(with: "@storeDir@") {
-+            return AbsolutePath("@swiftLib@/lib")
-+        }
-         // FIXME: Not sure if it's better to base this off of Swift compiler or our own binary.
-         return AbsolutePath("../../lib", relativeTo: resolveSymlinks(swiftCompilerPath))
-     }
+         get throws {
++            if swiftCompilerPath.pathString.starts(with: "@storeDir@") {
++                return AbsolutePath("@swiftLib@/lib")
++            }
+             // FIXME: Not sure if it's better to base this off of Swift compiler or our own binary.
+             return try AbsolutePath(validating: "../../lib", relativeTo: resolveSymlinks(swiftCompilerPath))
+         }

--- a/pkgs/development/compilers/swift/swiftpm/patches/nix-pkgconfig-vars.patch
+++ b/pkgs/development/compilers/swift/swiftpm/patches/nix-pkgconfig-vars.patch
@@ -1,0 +1,28 @@
+Swift parses .pc files manually, but this means it bypasses our pkg-config
+wrapper. That wrapper normally takes care of introducing the correct
+PKG_CONFIG_PATH for cross compiling.
+
+--- a/Sources/PackageLoading/PkgConfig.swift
++++ b/Sources/PackageLoading/PkgConfig.swift
+@@ -123,14 +123,17 @@ public struct PkgConfig {
+ 
+     private static var envSearchPaths: [AbsolutePath] {
+         get throws {
+-            if let configPath = ProcessEnv.vars["PKG_CONFIG_PATH"] {
++            var result: [AbsolutePath] = []
++            for envVar in ["PKG_CONFIG_PATH", "PKG_CONFIG_PATH_FOR_TARGET"] {
++            if let configPath = ProcessEnv.vars[envVar] {
+                 #if os(Windows)
+-                return try configPath.split(separator: ";").map({ try AbsolutePath(validating: String($0)) })
++                result += try configPath.split(separator: ";").map({ try AbsolutePath(validating: String($0)) })
+                 #else
+-                return try configPath.split(separator: ":").map({ try AbsolutePath(validating: String($0)) })
++                result += try configPath.split(separator: ":").map({ try AbsolutePath(validating: String($0)) })
+                 #endif
+             }
+-            return []
++            }
++            return result
+         }
+     }
+ }

--- a/pkgs/development/compilers/swift/wrapper/wrapper.sh
+++ b/pkgs/development/compilers/swift/wrapper/wrapper.sh
@@ -105,7 +105,7 @@ dontLink=$isFrontend
 
 for p in "${params[@]}"; do
     case "$p" in
-        -enable-cxx-interop)
+        -enable-cxx-interop | -enable-experimental-cxx-interop)
             isCxx=1 ;;
     esac
 done

--- a/pkgs/development/tools/swiftpm2nix/support.nix
+++ b/pkgs/development/tools/swiftpm2nix/support.nix
@@ -6,7 +6,7 @@ in rec {
 
   # Derive a pin file from workspace state.
   mkPinFile = workspaceState:
-    assert workspaceState.version == 5;
+    assert workspaceState.version >= 5 && workspaceState.version <= 6;
     json.generate "Package.resolved" {
       version = 1;
       object.pins = map (dep: {

--- a/pkgs/development/tools/swiftpm2nix/swiftpm2nix.sh
+++ b/pkgs/development/tools/swiftpm2nix/swiftpm2nix.sh
@@ -12,7 +12,8 @@ if [[ ! -f "$stateFile" ]]; then
   exit 1
 fi
 
-if [[ "$(jq .version $stateFile)" != "5" ]]; then
+stateVersion="$(jq .version $stateFile)"
+if [[ $stateVersion -lt 5 || $stateVersion -gt 6 ]]; then
   echo >&2 "Unsupported $stateFile version"
   exit 1
 fi


### PR DESCRIPTION
###### Description of changes

This also fixes the Linux build.

Result of `nixpkgs-review` run on aarch64-darwin [1](https://github.com/Mic92/nixpkgs-review)
<details>
  <summary>6 packages failed to build:</summary>
  <ul>
    <li>clipboard-jh</li>
    <li>hydrus</li>
    <li>hydrus.doc</li>
    <li>kakoune-cr</li>
    <li>mpc-qt</li>
    <li>scry</li>
  </ul>
</details>
<details>
  <summary>69 packages built:</summary>
  <ul>
    <li>ameba</li>
    <li>amqpcat</li>
    <li>ani-cli</li>
    <li>anki</li>
    <li>anki.dist</li>
    <li>anki.doc</li>
    <li>anki.man</li>
    <li>clang-tools_15</li>
    <li>clang_15</li>
    <li>cplay-ng</li>
    <li>cplay-ng.dist</li>
    <li>crystal (crystal_1_8)</li>
    <li>crystal.bin (crystal_1_8.bin)</li>
    <li>crystal.lib (crystal_1_8.lib)</li>
    <li>crystal2nix</li>
    <li>curseradio</li>
    <li>curseradio.dist</li>
    <li>dmlive</li>
    <li>ff2mpv</li>
    <li>icr</li>
    <li>invidious</li>
    <li>llvmPackages_15.clangNoLibc</li>
    <li>llvmPackages_15.clangNoLibcxx</li>
    <li>llvmPackages_15.clangUseLLVM</li>
    <li>llvmPackages_15.compiler-rt (llvmPackages_15.compiler-rt-libc)</li>
    <li>llvmPackages_15.compiler-rt.dev (llvmPackages_15.compiler-rt-libc.dev)</li>
    <li>llvmPackages_15.libcxx</li>
    <li>llvmPackages_15.libcxx.dev</li>
<li>llvmPackages_15.stdenv (llvmPackages_15.libcxxStdenv)</li>
    <li>llvmPackages_15.libstdcxxClang</li>
    <li>llvmPackages_15.libunwind</li>
    <li>llvmPackages_15.libunwind.dev</li>
    <li>lucky-cli</li>
    <li>mnemosyne</li>
    <li>mnemosyne.dist</li>
    <li>mpv</li>
    <li>mpv-unwrapped</li>
    <li>mpv-unwrapped.dev</li>
    <li>mpv-unwrapped.man</li>
    <li>oq</li>
    <li>plex-media-player</li>
    <li>python310Packages.mpv</li>
    <li>python310Packages.mpv.dist</li>
    <li>python311Packages.mpv</li>
    <li>python311Packages.mpv.dist</li>
    <li>shards (shards_0_17)</li>
    <li>somafm-cli</li>
    <li>sourcekit-lsp</li>
    <li>subtitleedit</li>
    <li>swift</li>
    <li>swift.man</li>
    <li>swiftPackages.XCTest</li>
    <li>swiftPackages.clang</li>
    <li>swiftPackages.stdenv</li>
    <li>swiftPackages.swift-docc</li>
    <li>swiftPackages.swift-driver</li>
    <li>swiftPackages.swift-unwrapped</li>
    <li>swiftPackages.swift-unwrapped.dev</li>
    <li>swiftPackages.swift-unwrapped.doc</li>
    <li>swiftPackages.swift-unwrapped.lib</li>
    <li>swiftPackages.swift-unwrapped.man</li>
    <li>swiftPackages.swiftNoSwiftDriver</li>
    <li>swiftPackages.swiftNoSwiftDriver.man</li>
    <li>swiftPackages.swiftpm</li>
    <li>swiftPackages.xcbuild</li>
    <li>swiftpm2nix</li>
    <li>thicket</li>
    <li>wtwitch</li>
    <li>ytfzf</li>
  </ul>
</details>

The rebuild on Darwin is a little larger primarily because of the compiler-rt fix, but it should be benign.

On x86_64-darwin, I didn't run a full build of all dependents, but `swift`, `sourcekit-lsp` and `mpv` build successfully. (The compiler-rt change only affects ARM.)

Similarly on x86_64-linux, I only built `swift` and `sourcekit-lsp`. (The compiler-rt change doesn't affect Linux.)

Regarding the failures above:

 - clipboard-jh: No previous Hydra build for Darwin. (Broken?) Failure seems unrelated.
 - hydrus: Strange intermittent dyld assertion failure in install tests. A rebuild _did_ succeed.
 - kakoune-cr: Also broken on master for Darwin.
 - mpc-qt: No previous Hydra build for Darwin. (Broken?) Failure seems unrelated.
 - scry: Also broken on master for Darwin.

So it looks like there are no new failures.

Fixes https://github.com/NixOS/nixpkgs/issues/229280

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).