### PR TITLE
python3.pkgs.w1thermsensor: init at 2.0.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -12506,6 +12506,15 @@
     githubId = 1024891;
     name = "Jens Nolte";
   };
+  quentin = {
+    email = "quentin@mit.edu";
+    github = "quentinmit";
+    githubId = 115761;
+    name = "Quentin Smith";
+    keys = [{
+      fingerprint = "1C71 A066 5400 AACD 142E  B1A0 04EE 05A8 FCEF B697";
+    }];
+  };
   quentini = {
     email = "quentini@airmail.cc";
     github = "QuentinI";

--- a/pkgs/development/python-modules/w1thermsensor/default.nix
+++ b/pkgs/development/python-modules/w1thermsensor/default.nix
@@ -1,0 +1,70 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, pkgs
+, setuptools
+, aiofiles
+, click
+, coverage
+, tomli
+, pytest
+, pytest-mock
+, pytest-asyncio
+, pytestCheckHook
+, pythonOlder
+}:
+buildPythonPackage rec {
+  pname = "w1thermsensor";
+  version = "2.0.0";
+  format = "pyproject";
+
+  src = fetchPypi {
+    inherit pname version;
+    hash = "sha256-EcaEr4B8icbwZu2Ty3z8AAgglf74iZ5BLpLnSOZC2cE=";
+  };
+
+  postPatch = ''
+    sed -i 's/3\.5\.\*/3.5/' setup.py
+  '';
+
+  nativeBuildInputs = [
+    setuptools
+  ];
+
+  propagatedBuildInputs = [
+    aiofiles
+    click
+  ];
+
+  # Don't try to load the kernel module in tests.
+  env.W1THERMSENSOR_NO_KERNEL_MODULE = 1;
+
+  nativeCheckInputs = [
+    pytest-mock
+    pytest-asyncio
+    pytestCheckHook
+  ] ++ lib.optionals (pythonOlder "3.11") [
+    tomli
+  ];
+
+  # Tests for 2.0.0 currently fail on python3.11
+  # https://github.com/timofurrer/w1thermsensor/issues/116
+  doCheck = pythonOlder "3.11";
+
+  pythonImportsCheck = [
+    "w1thermsensor"
+  ];
+
+  meta = with lib; {
+    description = "Python interface to 1-Wire temperature sensors";
+    longDescription = ''
+      A Python package and CLI tool to work with w1 temperature sensors like
+      DS1822, DS18S20 & DS18B20 on the Raspberry Pi, Beagle Bone and other
+      devices.
+    '';
+    homepage = "https://github.com/timofurrer/w1thermsensor";
+    license = licenses.mit;
+    maintainers = with maintainers; [ quentin ];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -12459,6 +12459,8 @@ self: super: with self; {
 
   vyper = callPackage ../development/compilers/vyper { };
 
+  w1thermsensor = callPackage ../development/python-modules/w1thermsensor { };
+
   w3lib = callPackage ../development/python-modules/w3lib { };
 
   wadllib = callPackage ../development/python-modules/wadllib { };


### PR DESCRIPTION
###### Description of changes

This is a package for accessing 1-Wire temperature sensors.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
```
[root@bedroom-pi:~/nixpkgs]# w1thermsensor all
Got temperatures of 4 sensors:
  Sensor 1 (000002b1bcc5) measured temperature: 19.88 celsius
  Sensor 2 (0120541bbaa7) measured temperature: 9.5 celsius
  Sensor 3 (00000284c7a7) measured temperature: 20.81 celsius
  Sensor 4 (000002849de2) measured temperature: 27.19 celsius
```
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
