### PR TITLE
abcl: follow up fixes for #223317

### DIFF
--- a/pkgs/development/compilers/abcl/default.nix
+++ b/pkgs/development/compilers/abcl/default.nix
@@ -29,9 +29,11 @@ stdenv.mkDerivation rec {
     runHook postConfigure
   '';
 
-  buildInputs = [ jre ant jdk jre ];
+  buildInputs = [ jre ];
 
-  nativeBuildInputs = [ makeWrapper ];
+  # note for the future:
+  # if you use makeBinaryWrapper, you will trade bash for glibc, the closure will be slightly larger
+  nativeBuildInputs = [ makeWrapper ant jdk ];
 
   buildPhase = ''
     runHook preBuild

--- a/pkgs/development/compilers/abcl/update.sh
+++ b/pkgs/development/compilers/abcl/update.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env nix-shell
-#!nix-shell -i bash -p nix-update curl
+#!nix-shell -i bash -p nix-update subversion
 
-new_version=$(curl https://armedbear.common-lisp.dev/ | grep abcl-src | sed 's;[^>]*>abcl-src-\(.*\).tar[^$]*;\1;' | head -n 1)
+new_version=$(svn ls https://abcl.org/svn/tags | tail -1 | tr -d /)
 nix-update abcl --version "$new_version"


### PR DESCRIPTION
###### Description of changes

Some follow up fixes suggested in #223317 after it was merged

Basically changed the update script to use svn and moved some packages from buildInputs to nativeBuildInputs.

The closure size is the same.

```shell
lucasew@riverwood ~/WORKSPACE/nixpkgs 0$ nix build nixpkgs#abcl --json
[{"drvPath":"/nix/store/c6qxm67897mnv9m1giqwcpgb6m789gim-abcl-1.9.1.drv","outputs":{"out":"/nix/store/dsd3ipq642yw48b9fihwvxxq1hjasslj-abcl-1.9.1"},"startTime":0,"stopTime":0}]
lucasew@riverwood ~/WORKSPACE/nixpkgs 0$ nix build .#abcl --json
warning: Git tree '/home/lucasew/WORKSPACE/nixpkgs' is dirty
[{"drvPath":"/nix/store/czz1jl150dj3ih25d403vi5fv5f3h2ij-abcl-1.9.1.drv","outputs":{"out":"/nix/store/46bgm94r5120v8423msjkksyrm1j3hd6-abcl-1.9.1"},"startTime":0,"stopTime":0}]
lucasew@riverwood ~/WORKSPACE/nixpkgs 0$ nix store diff-closures /nix/store/c6qxm67897mnv9m1giqwcpgb6m789gim-abcl-1.9.1.drv /nix/store/czz1jl150dj3ih25d403vi5fv5f3h2ij-abcl-1.9.1.drv
lucasew@riverwood ~/WORKSPACE/nixpkgs 0$ nix store diff-closures /nix/store/dsd3ipq642yw48b9fihwvxxq1hjasslj-abcl-1.9.1 /nix/store/46bgm94r5120v8423msjkksyrm1j3hd6-abcl-1.9.1
```

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
