### PR TITLE
libmicrohttpd*: add patch for CVE-2023-27371

### DIFF
--- a/pkgs/development/libraries/libmicrohttpd/0.9.69.nix
+++ b/pkgs/development/libraries/libmicrohttpd/0.9.69.nix
@@ -1,4 +1,4 @@
-{ callPackage, fetchurl }:
+{ callPackage, fetchurl, fetchpatch }:
 
 callPackage ./generic.nix ( rec {
   version = "0.9.69";
@@ -7,4 +7,8 @@ callPackage ./generic.nix ( rec {
     url = "mirror://gnu/libmicrohttpd/libmicrohttpd-${version}.tar.gz";
     sha256 = "sha256-+5trFIt4dJPmN9MINYhxHmXLy3JvoCzuLNVDxd4n434=";
   };
+
+  patches = [
+    ((import ./CVE-2023-27371.nix) fetchpatch)
+  ];
 })

--- a/pkgs/development/libraries/libmicrohttpd/0.9.71.nix
+++ b/pkgs/development/libraries/libmicrohttpd/0.9.71.nix
@@ -1,4 +1,4 @@
-{ callPackage, fetchurl }:
+{ callPackage, fetchurl, fetchpatch }:
 
 callPackage ./generic.nix ( rec {
   version = "0.9.71";
@@ -7,4 +7,8 @@ callPackage ./generic.nix ( rec {
     url = "mirror://gnu/libmicrohttpd/libmicrohttpd-${version}.tar.gz";
     sha256 = "10mii4mifmfs3v7kgciqml7f0fj7ljp0sngrx64pnwmgbzl4bx78";
   };
+
+  patches = [
+    ((import ./CVE-2023-27371.nix) fetchpatch)
+  ];
 })

--- a/pkgs/development/libraries/libmicrohttpd/0.9.72.nix
+++ b/pkgs/development/libraries/libmicrohttpd/0.9.72.nix
@@ -1,4 +1,4 @@
-{ callPackage, fetchurl }:
+{ callPackage, fetchurl, fetchpatch }:
 
 callPackage ./generic.nix ( rec {
   version = "0.9.72";
@@ -7,4 +7,8 @@ callPackage ./generic.nix ( rec {
     url = "mirror://gnu/libmicrohttpd/libmicrohttpd-${version}.tar.gz";
     sha256 = "sha256-Cugl+ODX9BIB/USg3xz0VMHLC8UP6dWcJlUiYCZML/g=";
   };
+
+  patches = [
+    ((import ./CVE-2023-27371.nix) fetchpatch)
+  ];
 })

--- a/pkgs/development/libraries/libmicrohttpd/0.9.76.nix
+++ b/pkgs/development/libraries/libmicrohttpd/0.9.76.nix
@@ -1,0 +1,10 @@
+{ callPackage, fetchurl }:
+
+callPackage ./generic.nix ( rec {
+  version = "0.9.76";
+
+  src = fetchurl {
+    url = "mirror://gnu/libmicrohttpd/libmicrohttpd-${version}.tar.gz";
+    sha256 = "sha256-8LFUe1pCpsD3JOjhwctc6cTDX7SV59eAuZMNNQEc60w=";
+  };
+})

--- a/pkgs/development/libraries/libmicrohttpd/CVE-2023-27371.nix
+++ b/pkgs/development/libraries/libmicrohttpd/CVE-2023-27371.nix
@@ -1,0 +1,6 @@
+fetchpatch: fetchpatch {
+  name = "CVE-2023-27371.patch";
+  url = "https://git.gnunet.org/libmicrohttpd.git/patch/?id=6d6846e20bfdf4b3eb1b592c97520a532f724238";
+  excludes = [ "ChangeLog" ];
+  sha256 = "sha256-t40ivMYhh6m4lXRf4ttQ7iZRz/9xkF5td2UmO/c0Zgc=";
+}

--- a/pkgs/development/libraries/libmicrohttpd/generic.nix
+++ b/pkgs/development/libraries/libmicrohttpd/generic.nix
@@ -1,4 +1,16 @@
-{ lib, stdenv, libgcrypt, curl, gnutls, pkg-config, libiconv, libintl, version, src, meta ? {} }:
+{ lib
+, stdenv
+, libgcrypt
+, curl
+, gnutls
+, pkg-config
+, libiconv
+, libintl
+, version
+, src
+, meta ? {}
+, patches ? []
+}:
 
 let
   meta_ = meta;
@@ -6,7 +18,7 @@ in
 
 stdenv.mkDerivation rec {
   pname = "libmicrohttpd";
-  inherit version src;
+  inherit version src patches;
 
   outputs = [ "out" "dev" "devdoc" "info" ];
   nativeBuildInputs = [ pkg-config ];

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -21806,6 +21806,7 @@ with pkgs;
   libmicrohttpd_0_9_69 = callPackage ../development/libraries/libmicrohttpd/0.9.69.nix { };
   libmicrohttpd_0_9_71 = callPackage ../development/libraries/libmicrohttpd/0.9.71.nix { };
   libmicrohttpd_0_9_72 = callPackage ../development/libraries/libmicrohttpd/0.9.72.nix { };
+  libmicrohttpd_0_9_76 = callPackage ../development/libraries/libmicrohttpd/0.9.76.nix { };
   libmicrohttpd = libmicrohttpd_0_9_71;
 
   libmikmod = callPackage ../development/libraries/libmikmod {


### PR DESCRIPTION
###### Description of changes

https://nvd.nist.gov/vuln/detail/CVE-2023-27371

Added 0.9.76, not sure what the value is as projects seem to have enough trouble moving to 0.9.72 that we still alias `libmicrohttpd` to 0.9.71

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
