### PR TITLE
swapspace: patch paths to binaries and install systemd unit file

### DIFF
--- a/pkgs/tools/admin/swapspace/default.nix
+++ b/pkgs/tools/admin/swapspace/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchFromGitHub, autoreconfHook, installShellFiles }:
+{ lib, stdenv, fetchFromGitHub, autoreconfHook, installShellFiles, util-linux }:
 
 stdenv.mkDerivation rec {
   pname = "swapspace";
@@ -16,8 +16,23 @@ stdenv.mkDerivation rec {
     installShellFiles
   ];
 
+  postPatch = ''
+    substituteInPlace 'swapspace.service' \
+      --replace '/usr/local/sbin/' "$out/bin/"
+    substituteInPlace 'src/support.c' \
+      --replace '/sbin/swapon' '${lib.getBin util-linux}/bin/swapon' \
+      --replace '/sbin/swapoff' '${lib.getBin util-linux}/bin/swapoff'
+    substituteInPlace 'src/swaps.c' \
+      --replace 'mkswap' '${lib.getBin util-linux}/bin/mkswap'
+
+    # Don't create empty directory $out/var/lib/swapspace
+    substituteInPlace 'Makefile.am' \
+      --replace 'install-data-local:' 'do-not-execute:'
+  '';
+
   postInstall = ''
     installManPage doc/swapspace.8
+    install --mode=444 -D 'swapspace.service' "$out/etc/systemd/system/swapspace.service"
   '';
 
   meta = with lib; {

--- a/pkgs/tools/admin/swapspace/default.nix
+++ b/pkgs/tools/admin/swapspace/default.nix
@@ -25,6 +25,6 @@ stdenv.mkDerivation rec {
     homepage = "https://github.com/Tookmund/Swapspace";
     license = licenses.gpl2Only;
     platforms = platforms.linux;
-    maintainers = with maintainers; [ misuzu ];
+    maintainers = with maintainers; [ misuzu Luflosi ];
   };
 }


### PR DESCRIPTION
###### Description of changes
This will be useful when creating a NixOS module for this program.
Also add myself as a maintainer.

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).