### PR TITLE
vscode-extensions.ms-dotnettools.csharp: 1.25.0 -> 1.25.4

### DIFF
--- a/pkgs/applications/editors/vscode/extensions/ms-dotnettools.csharp/default.nix
+++ b/pkgs/applications/editors/vscode/extensions/ms-dotnettools.csharp/default.nix
@@ -5,12 +5,12 @@
 , icu
 , stdenv
 , openssl
+, coreutils
 }:
 let
   inherit (stdenv.hostPlatform) system;
 
-  version = "1.25.0";
-
+  version = "1.25.4";
 
   vsixInfo =
     let
@@ -27,7 +27,7 @@ let
         ".debugger/arm64/vsdbg"
       ];
       omniSharpBins = [
-        ".omnisharp/1.39.0-net6.0/OmniSharp"
+        ".omnisharp/1.39.4-net6.0/OmniSharp"
       ];
       razorBins = [
         ".razor/createdump"
@@ -37,22 +37,22 @@ let
       {
         x86_64-linux = {
           url = "https://github.com/OmniSharp/omnisharp-vscode/releases/download/v${version}/csharp-${version}-linux-x64.vsix";
-          sha256 = "1cqqjg8q6v56b19aabs9w1kxly457mpm0akbn5mis9nd1mrdmydl";
+          sha256 = "08k0wxyj8wz8npw1yqrkdpbvwbnrdnsngdkrd2p5ayn3v608ifc2";
           binaries = linuxDebuggerBins ++ omniSharpBins ++ razorBins;
         };
         aarch64-linux = {
           url = "https://github.com/OmniSharp/omnisharp-vscode/releases/download/v${version}/csharp-${version}-linux-arm64.vsix";
-          sha256 = "0nsjgrb7y4w71w1gnrf50ifwbmjidi4vrw2fyfmch7lgjl8ilnhd";
-          binaries = linuxDebuggerBins ++ omniSharpBins; # Linux aarch64 version has no Razor Language Server
+          sha256 = "09r2d463dk35905f2c3msqzxa7ylcf0ynhbp3n6d12y3x1200pr2";
+          binaries = linuxDebuggerBins ++ omniSharpBins ++ razorBins;
         };
         x86_64-darwin = {
           url = "https://github.com/OmniSharp/omnisharp-vscode/releases/download/v${version}/csharp-${version}-darwin-x64.vsix";
-          sha256 = "01qn398vmjfi9imzlmzm0qi7y2h214wx6a8la088lfkhyj3gfjh8";
+          sha256 = "0mp550kq33zwmlvrhymwnixl4has62imw3ia5z7a01q7mp0w9wpn";
           binaries = darwinX86DebuggerBins ++ omniSharpBins ++ razorBins;
         };
         aarch64-darwin = {
           url = "https://github.com/OmniSharp/omnisharp-vscode/releases/download/v${version}/csharp-${version}-darwin-arm64.vsix";
-          sha256 = "020j451innh7jzarbv1ij57rfmqnlngdxaw6wdgp8sjkgbylr634";
+          sha256 = "08406xz2raal8f10bmnkz1mwdfprsbkjxzc01v0i4sax1hr2a2yl";
           binaries = darwinAarch64DebuggerBins ++ darwinX86DebuggerBins ++ omniSharpBins ++ razorBins;
         };
       }.${system} or (throw "Unsupported system: ${system}");
@@ -87,6 +87,11 @@ vscode-utils.buildVscodeMarketplaceExtension rec {
     # However, this really would better be fixed upstream.
     sed -i \
       -E -e 's/(this\._pipePath=[a-zA-Z0-9_]+\.join\()([a-zA-Z0-9_]+\.getExtensionPath\(\)[^,]*,)/\1require("os").tmpdir(), "'"$ext_unique_id"'"\+/g' \
+      "$PWD/dist/extension.js"
+
+    # Fix reference to uname
+    sed -i \
+      -E -e 's_uname -m_${coreutils}/bin/uname -m_g' \
       "$PWD/dist/extension.js"
 
     patchelf_add_icu_as_needed() {


### PR DESCRIPTION
###### Description of changes

Changelogs:
- [v1.25.1](https://github.com/OmniSharp/omnisharp-vscode/releases/tag/v1.25.1)
- [v1.25.2](https://github.com/OmniSharp/omnisharp-vscode/releases/tag/v1.25.2)
- [v1.25.3](https://github.com/OmniSharp/omnisharp-vscode/releases/tag/v1.25.3)
- [v1.25.4](https://github.com/OmniSharp/omnisharp-vscode/releases/tag/v1.25.4)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
