### PR TITLE
ec2instanceconnectcli: 1.0.2 -> 1.0.3

### DIFF
--- a/pkgs/tools/virtualization/ec2instanceconnectcli/default.nix
+++ b/pkgs/tools/virtualization/ec2instanceconnectcli/default.nix
@@ -2,11 +2,11 @@
 
 buildPythonPackage rec {
   pname = "ec2instanceconnectcli";
-  version = "1.0.2";
+  version = "1.0.3";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "sha256-VaCyCnEhSx1I3bNo57p0IXf92+tO1tT7KSUXzO1IyIU=";
+    sha256 = "sha256-/U59a6od0JI27VHX+Bvue/7tQy+iwU+g8yt9/GgdoH4=";
   };
 
   propagatedBuildInputs = [ boto3 cryptography ];


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [X] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->


---


<details>
<summary>output of <code>nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"
</code></summary>

```
; nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"
$ git -c fetch.prune=false fetch --no-tags --force https://github.com/NixOS/nixpkgs master:refs/nixpkgs-review/0


$ git worktree add /home/bheesham/.cache/nixpkgs-review/rev-2cd14d77467a64cd0985e4d2a74df0c9a0eeccd8-2/nixpkgs 200c9183806b888894265b7ae47d84a61361232a
Preparing worktree (detached HEAD 200c9183806)
Updating files: 100% (34397/34397), done.
HEAD is now at 200c9183806 Merge pull request #224534 from developer-guy/feature/bom-upgrade
$ nix-env --option system x86_64-linux -f /home/bheesham/.cache/nixpkgs-review/rev-2cd14d77467a64cd0985e4d2a74df0c9a0eeccd8-2/nixpkgs -qaP --xml --out-path --show-trace --no-allow-import-from-derivation
$ git merge --no-commit --no-ff 2cd14d77467a64cd0985e4d2a74df0c9a0eeccd8
Automatic merge went well; stopped before committing as requested
$ nix-env --option system x86_64-linux -f /home/bheesham/.cache/nixpkgs-review/rev-2cd14d77467a64cd0985e4d2a74df0c9a0eeccd8-2/nixpkgs -qaP --xml --out-path --show-trace --no-allow-import-from-derivation --meta
2 packages updated:
python310Packages.ec2instanceconnectcli (1.0.2 → 1.0.3) python311Packages.ec2instanceconnectcli (1.0.2 → 1.0.3)

$ nix --experimental-features nix-command build --no-link --keep-going --no-allow-import-from-derivation --option build-use-sandbox relaxed -f /home/bheesham/.cache/nixpkgs-review/rev-2cd14d77467a64cd0985e4d2a74df0c9a0eeccd8-2/build.nix
2 packages built:
python310Packages.ec2instanceconnectcli python311Packages.ec2instanceconnectcli

error: build log of '/nix/store/inq4zj8k288wy01xz9krvp3m881ian63-python3.10-ec2instanceconnectcli-1.0.3.drv!*' is not available
$ /nix/store/nnznavnhyli08264apz6lanbjza48si1-nix-2.13.2/bin/nix-shell /home/bheesham/.cache/nixpkgs-review/rev-2cd14d77467a64cd0985e4d2a74df0c9a0eeccd8-2/shell.nix

[nix-shell:~/.cache/nixpkgs-review/rev-2cd14d77467a64cd0985e4d2a74df0c9a0eeccd8-2]$ 

[nix-shell:~/.cache/nixpkgs-review/rev-2cd14d77467a64cd0985e4d2a74df0c9a0eeccd8-2]$ 

[nix-shell:~/.cache/nixpkgs-review/rev-2cd14d77467a64cd0985e4d2a74df0c9a0eeccd8-2]$ 
```

</details>