### PR TITLE
ocamlPackages.class_group_vdf: Bump MACOSX_DEPLOYMENT_TARGET to fix build

### DIFF
--- a/pkgs/development/ocaml-modules/class_group_vdf/default.nix
+++ b/pkgs/development/ocaml-modules/class_group_vdf/default.nix
@@ -4,7 +4,7 @@
 , alcotest, bisect_ppx
 }:
 
-buildDunePackage rec {
+buildDunePackage (rec {
   pname = "class_group_vdf";
   version = "0.0.4";
   duneVersion = "3";
@@ -43,8 +43,13 @@ buildDunePackage rec {
   meta = {
     description = "Verifiable Delay Functions bindings to Chia's VDF";
     homepage = "https://gitlab.com/nomadic-labs/tezos";
-    broken = stdenv.isDarwin && stdenv.isx86_64;
     license = lib.licenses.mit;
     maintainers = [ lib.maintainers.ulrikstrid ];
   };
 }
+# Darwin sdk on intel target 10.12 (2016) at the time of writing. It is likely that host will be at least 10.14 (2018). This fix allow it to build and run on 10.14 and build on 10.12 (but don't run).
+// lib.optionalAttrs (lib.versionOlder stdenv.hostPlatform.darwinMinVersion "10.14" && stdenv.hostPlatform.isMacOS && stdenv.hostPlatform.isx86_64) {
+  preHook = ''
+    export MACOSX_DEPLOYMENT_TARGET=10.14
+  '';
+})


### PR DESCRIPTION
Found while testing https://github.com/NixOS/nixpkgs/pull/225044

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux (aren't affected)
  - [ ] aarch64-linux (aren't affected)
  - [x] x86_64-darwin
  - [ ] aarch64-darwin (shouldn't change)
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

If someone with aarch64-darwin could test. From other usage I see in nixpkgs it should still build.