### PR TITLE
tenacity: unstable-2022-06-30 -> 1.3-beta2

### DIFF
--- a/pkgs/applications/audio/tenacity/default.nix
+++ b/pkgs/applications/audio/tenacity/default.nix
@@ -1,6 +1,6 @@
 { stdenv
 , lib
-, fetchFromGitHub
+, fetchFromGitea
 , fetchpatch
 , cmake
 , wxGTK32
@@ -30,7 +30,7 @@
 , expat
 , libid3tag
 , libopus
-, ffmpeg_4
+, ffmpeg_5
 , soundtouch
 , pcre
 , portaudio
@@ -49,32 +49,27 @@
 
 stdenv.mkDerivation rec {
   pname = "tenacity";
-  version = "unstable-2022-06-30";
+  version = "1.3-beta2";
 
-  src = fetchFromGitHub {
+  src = fetchFromGitea {
+    domain = "codeberg.org";
     owner = "tenacityteam";
     repo = pname;
-    rev = "91f8b4340b159af551fff94a284c6b0f704a7932";
-    sha256 = "sha256-4VWckXzqo2xspw9eUloDvjxQYbsHn6ghEDw+hYqJcCE=";
+    rev = "v${version}";
+    sha256 = "sha256-9gWoqFa87neIvRnezWI3RyCAOU4wKEHPn/Hgj3/fol0=";
   };
 
-  patches = [
-    (fetchpatch {
-      url = "https://aur.archlinux.org/cgit/aur.git/plain/wxwidgets-gtk3-3.1.6-plus.patch?h=tenacity-wxgtk3-git&id=c2503538fa7d7001181905988179952d09f69659";
-      postFetch = "echo >> $out";
-      sha256 = "sha256-xRY1tizBJ9CBY6e9oZVz4CWx7DWPGD9A9Ysol4prBww=";
-    })
-  ];
-
   postPatch = ''
-    touch src/RevisionIdent.h
+    mkdir -p build/src/private
+    touch build/src/private/RevisionIdent.h
 
-    substituteInPlace src/FileNames.cpp \
-      --replace /usr/include/linux/magic.h ${linuxHeaders}/include/linux/magic.h
+    substituteInPlace libraries/lib-files/FileNames.cpp \
+         --replace /usr/include/linux/magic.h \
+                   ${linuxHeaders}/include/linux/magic.h
   '';
 
   postFixup = ''
-    rm $out/tenacity
+    rm $out/audacity
     wrapProgram "$out/bin/tenacity" \
       --suffix AUDACITY_PATH : "$out/share/tenacity" \
       --suffix AUDACITY_MODULES_PATH : "$out/lib/tenacity/modules" \
@@ -90,7 +85,6 @@ stdenv.mkDerivation rec {
     "-lavdevice"
     "-lavfilter"
     "-lavformat"
-    "-lavresample"
     "-lavutil"
     "-lpostproc"
     "-lswresample"
@@ -110,7 +104,7 @@ stdenv.mkDerivation rec {
   buildInputs = [
     alsa-lib
     expat
-    ffmpeg_4
+    ffmpeg_5
     file
     flac
     glib


### PR DESCRIPTION
###### Description of changes

The upstream maintainers have requested an update, as per https://github.com/NixOS/nixpkgs/issues/225176

The changelog is on the upstream gitea: https://codeberg.org/tenacityteam/tenacity/releases

This release also includes a change in upstream maintainership and hosting. I have dug into the details and can attest that yes, it's the same project (the history is interesting but beyond the scope of this PR).

###### Things done

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [X] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).