### PR TITLE
nodejs: explicitly disable __contentAddressed

### DIFF
--- a/pkgs/development/web/nodejs/nodejs.nix
+++ b/pkgs/development/web/nodejs/nodejs.nix
@@ -96,6 +96,14 @@ let
 
     enableParallelBuilding = true;
 
+    # Don't allow enabling content addressed conversion as `nodejs`
+    # checksums it's image before conversion happens and image loading
+    # breaks:
+    #   $ nix build -f. nodejs --arg config '{ contentAddressedByDefault = true; }'
+    #   $ ./result/bin/node
+    #   Check failed: VerifyChecksum(blob).
+    __contentAddressed = false;
+
     passthru.interpreterName = "nodejs";
 
     passthru.pkgs = callPackage ../../node-packages/default.nix {


### PR DESCRIPTION
Without the change attempt to enable content addressing on nodejs breaks the `nodejs` binary:

    $ nix build -f. nodejs --arg config '{ contentAddressedByDefault = true; }'
    $ LANG=C ./result/bin/node
    #
    # Fatal error in , line 0
    # Check failed: VerifyChecksum(blob).
    #
    #
    #
    #FailureMessage Object: 0x7ffce2820790
     1: 0xb2a2c5  [./result/bin/node]
     2: 0x1866d9a V8_Fatal(char const*, ...) [./result/bin/node]
     3: 0x12d7473 v8::internal::Snapshot::Initialize(v8::internal::Isolate*) [./result/bin/node]
     4: 0xce85e6 v8::Isolate::Initialize(v8::Isolate*, v8::Isolate::CreateParams const&) [./result/bin/node]
     5: 0x9e0614 node::NewIsolate(v8::Isolate::CreateParams*, uv_loop_s*, node::MultiIsolatePlatform*, bool) [./result/bin/node]
     6: 0xafdcb2 node::NodeMainInstance::NodeMainInstance(node::SnapshotData const*, uv_loop_s*, node::MultiIsolatePlatform*, std::vector<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::allocator<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > > const&, std::vector<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::allocator<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > > const&) [./result/bin/node]
     7: 0xa670a3 node::LoadSnapshotDataAndRun(node::SnapshotData const**, node::InitializationResult const*) [./result/bin/node]
     8: 0xa6ac9c node::Start(int, char**) [./result/bin/node]
     9: 0x7f2b7002924e  [/nix/store/h9w6fix9k2lrbc05p4a6inw2r9sywlb1-glibc-2.35-224/lib/libc.so.6]
    10: 0x7f2b70029309 __libc_start_main [/nix/store/h9w6fix9k2lrbc05p4a6inw2r9sywlb1-glibc-2.35-224/lib/libc.so.6]
    11: 0x9da7f5 _start [./result/bin/node]
    Trace/breakpoint trap (core dumped)

Let's override the default by always disable content addressing.

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
