### PR TITLE
ungoogled-chromium,chromium+llvm: use versionhistory.googleapis.com over omahaproxy.appspot.com, fix various update script issues

### DIFF
--- a/pkgs/applications/networking/browsers/chromium/README.md
+++ b/pkgs/applications/networking/browsers/chromium/README.md
@@ -29,7 +29,7 @@
 - Release updates: https://chromereleases.googleblog.com/
   - Available as Atom or RSS feed (filter for
     "Stable Channel Update for Desktop")
-  - Channel overview: https://omahaproxy.appspot.com/
+  - Release API: https://developer.chrome.com/docs/versionhistory/guide/
   - Release schedule: https://chromiumdash.appspot.com/schedule
 
 # Updating Chromium
@@ -38,6 +38,16 @@ Simply run `./pkgs/applications/networking/browsers/chromium/update.py` to
 update `upstream-info.json`. After updates it is important to test at least
 `nixosTests.chromium` (or basic manual testing) and `google-chrome` (which
 reuses `upstream-info.json`).
+
+Note: Due to the script downloading many large tarballs it might be
+necessary to adjust the available tmpfs size (it defaults to 10% of the
+systems memory)
+
+```nix
+services.logind.extraConfig = ''
+  RuntimeDirectorySize=4G
+'';
+```
 
 Note: The source tarball is often only available a few hours after the release
 was announced. The CI/CD status can be tracked here:

--- a/pkgs/applications/networking/browsers/chromium/browser.nix
+++ b/pkgs/applications/networking/browsers/chromium/browser.nix
@@ -82,7 +82,7 @@ mkChromiumDerivation (base: rec {
       of source code for Google Chrome (which has some additional features).
     '';
     homepage = if ungoogled
-      then "https://github.com/Eloston/ungoogled-chromium"
+      then "https://github.com/ungoogled-software/ungoogled-chromium"
       else "https://www.chromium.org/";
     maintainers = with lib.maintainers; if ungoogled
       then [ squalus primeos michaeladler ]

--- a/pkgs/applications/networking/browsers/chromium/ungoogled.nix
+++ b/pkgs/applications/networking/browsers/chromium/ungoogled.nix
@@ -15,7 +15,7 @@ stdenv.mkDerivation rec {
   version = rev;
 
   src = fetchFromGitHub {
-    owner = "Eloston";
+    owner = "ungoogled-software";
     repo = "ungoogled-chromium";
     inherit rev sha256;
   };

--- a/pkgs/applications/networking/browsers/chromium/update.py
+++ b/pkgs/applications/networking/browsers/chromium/update.py
@@ -92,7 +92,7 @@ def get_channel_dependencies(version):
 
 def get_latest_ungoogled_chromium_tag():
     """Returns the latest ungoogled-chromium tag using the GitHub API."""
-    api_tag_url = 'https://api.github.com/repos/Eloston/ungoogled-chromium/tags?per_page=1'
+    api_tag_url = 'https://api.github.com/repos/ungoogled-software/ungoogled-chromium/tags'
     with urlopen(api_tag_url) as http_response:
         tag_data = json.load(http_response)
         return tag_data[0]['name']
@@ -111,7 +111,7 @@ def get_latest_ungoogled_chromium_build():
 
 def get_ungoogled_chromium_gn_flags(revision):
     """Returns ungoogled-chromium's GN build flags for the given revision."""
-    gn_flags_url = f'https://raw.githubusercontent.com/Eloston/ungoogled-chromium/{revision}/flags.gn'
+    gn_flags_url = f'https://raw.githubusercontent.com/ungoogled-software/ungoogled-chromium/{revision}/flags.gn'
     return urlopen(gn_flags_url).read().decode()
 
 
@@ -209,7 +209,7 @@ with urlopen(RELEASES_URL) as resp:
         if channel_name == 'stable':
             channel['chromedriver'] = get_matching_chromedriver(channel['version'])
         elif channel_name == 'ungoogled-chromium':
-            ungoogled_repo_url = 'https://github.com/Eloston/ungoogled-chromium.git'
+            ungoogled_repo_url = 'https://github.com/ungoogled-software/ungoogled-chromium.git'
             channel['deps']['ungoogled-patches'] = {
                 'rev': release['ungoogled_tag'],
                 'sha256': nix_prefetch_git(ungoogled_repo_url, release['ungoogled_tag'])['sha256']

--- a/pkgs/development/compilers/llvm/update-git.py
+++ b/pkgs/development/compilers/llvm/update-git.py
@@ -18,14 +18,10 @@ DEFAULT_NIX = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'git/defa
 
 
 def get_latest_chromium_build():
-    HISTORY_URL = 'https://omahaproxy.appspot.com/history?os=linux'
-    print(f'GET {HISTORY_URL}')
-    with urlopen(HISTORY_URL) as resp:
-        builds = csv.DictReader(iterdecode(resp, 'utf-8'))
-        for build in builds:
-            if build['channel'] != 'dev':
-                continue
-            return build
+    RELEASES_URL = 'https://versionhistory.googleapis.com/v1/chrome/platforms/linux/channels/dev/versions/all/releases?filter=endtime=none&order_by=version%20desc'
+    print(f'GET {RELEASES_URL}')
+    with urlopen(RELEASES_URL) as resp:
+        return json.load(resp)['releases'][0]
 
 
 def get_file_revision(revision, file_path):


### PR DESCRIPTION
###### Description of changes

This pull request updates chromium's update.py and llvms update-git.py script to use the versionhistory.googleapis.com api as a replacement for the now deprecated omahaproxy.appspot.com.

See https://groups.google.com/a/chromium.org/g/chromium-dev/c/uH-nFrOLWtE/m/PhUj_inyAQAJ for the deprecation notice and https://github.com/ungoogled-software/ungoogled-chromium/pull/2260 for a discussion about the query parameters used.

Additionally, it fixes some issues related to the ungoogled-chromium packaging, namely that the update.py script would update to Windows only releases. The script will now only update to ungoogled-chromium releases matching the Linux stable channel.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
