### PR TITLE
kodiPackages.certifi: add support for system-wide cacert

### DIFF
--- a/pkgs/applications/video/kodi/addons/certifi/default.nix
+++ b/pkgs/applications/video/kodi/addons/certifi/default.nix
@@ -1,4 +1,4 @@
-{ lib, buildKodiAddon, fetchzip, addonUpdateScript }:
+{ lib, buildKodiAddon, fetchzip, addonUpdateScript, cacert }:
 buildKodiAddon rec {
   pname = "certifi";
   namespace = "script.module.certifi";
@@ -8,6 +8,21 @@ buildKodiAddon rec {
     url = "https://mirrors.kodi.tv/addons/nexus/${namespace}/${namespace}-${version}.zip";
     sha256 = "sha256-kIPGEjmnHlgVb11W2RKBlrMy3/+kUOcQZiLCcnHCcno=";
   };
+
+  patches = [
+    # Add support for NIX_SSL_CERT_FILE
+    ./env.patch
+  ];
+
+  postPatch = ''
+    # Use our system-wide ca-bundle instead of the bundled one
+    ln -snvf "${cacert}/etc/ssl/certs/ca-bundle.crt" "lib/certifi/cacert.pem"
+  '';
+
+  propagatedNativeBuildInputs = [
+    # propagate cacerts setup-hook to set up `NIX_SSL_CERT_FILE`
+    cacert
+  ];
 
   passthru = {
     pythonPath = "lib";

--- a/pkgs/applications/video/kodi/addons/certifi/env.patch
+++ b/pkgs/applications/video/kodi/addons/certifi/env.patch
@@ -1,0 +1,86 @@
+diff --git a/lib/certifi/core.py b/lib/certifi/core.py
+index de02898..c033d20 100644
+--- a/lib/certifi/core.py
++++ b/lib/certifi/core.py
+@@ -4,15 +4,25 @@ certifi.py
+ 
+ This module returns the installation location of cacert.pem or its contents.
+ """
++import os
+ import sys
+ 
+ 
++def get_cacert_path_from_environ():
++    path = os.environ.get("NIX_SSL_CERT_FILE", None)
++
++    if path == "/no-cert-file.crt":
++        return None
++
++    return path
++
++
+ if sys.version_info >= (3, 11):
+ 
+     from importlib.resources import as_file, files
+ 
+     _CACERT_CTX = None
+-    _CACERT_PATH = None
++    _CACERT_PATH = get_cacert_path_from_environ()
+ 
+     def where() -> str:
+         # This is slightly terrible, but we want to delay extracting the file
+@@ -39,14 +49,16 @@ if sys.version_info >= (3, 11):
+         return _CACERT_PATH
+ 
+     def contents() -> str:
+-        return files("certifi").joinpath("cacert.pem").read_text(encoding="ascii")
++        if _CACERT_PATH is not None:
++            return open(_CACERT_PATH, encoding="utf-8").read()
++        return files("certifi").joinpath("cacert.pem").read_text(encoding="utf-8")
+ 
+ elif sys.version_info >= (3, 7):
+ 
+     from importlib.resources import path as get_path, read_text
+ 
+     _CACERT_CTX = None
+-    _CACERT_PATH = None
++    _CACERT_PATH = get_cacert_path_from_environ()
+ 
+     def where() -> str:
+         # This is slightly terrible, but we want to delay extracting the
+@@ -74,7 +86,9 @@ elif sys.version_info >= (3, 7):
+         return _CACERT_PATH
+ 
+     def contents() -> str:
+-        return read_text("certifi", "cacert.pem", encoding="ascii")
++        if _CACERT_PATH is not None:
++            return open(_CACERT_PATH, encoding="utf-8").read()
++        return read_text("certifi", "cacert.pem", encoding="utf-8")
+ 
+ else:
+     import os
+@@ -84,6 +98,8 @@ else:
+     Package = Union[types.ModuleType, str]
+     Resource = Union[str, "os.PathLike"]
+ 
++    _CACERT_PATH = get_cacert_path_from_environ()
++
+     # This fallback will work for Python versions prior to 3.7 that lack the
+     # importlib.resources module but relies on the existing `where` function
+     # so won't address issues with environments like PyOxidizer that don't set
+@@ -102,7 +118,14 @@ else:
+     def where() -> str:
+         f = os.path.dirname(__file__)
+ 
++        if _CACERT_PATH is not None:
++            return _CACERT_PATH
++
+         return os.path.join(f, "cacert.pem")
+ 
+     def contents() -> str:
+-        return read_text("certifi", "cacert.pem", encoding="ascii")
++        if _CACERT_PATH is not None:
++            with open(_CACERT_PATH, encoding="utf-8") as data:
++                return data.read()
++
++        return read_text("certifi", "cacert.pem", encoding="utf-8")


### PR DESCRIPTION
###### Description of changes

Add support for system-wide cacert

analog to 8d7cc9cac9ecdf95f554c5ea7ca15118baa06c39

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
