### PR TITLE
gnomeExtensions.vitals: Patch it to find libgtop

### DIFF
--- a/pkgs/desktops/gnome/extensions/extensionOverrides.nix
+++ b/pkgs/desktops/gnome/extensions/extensionOverrides.nix
@@ -122,6 +122,15 @@ super: lib.trivial.pipe super [
     ];
   }))
 
+  (patchExtension "Vitals@CoreCoding.com" (old: {
+    patches = [
+      (substituteAll {
+        src = ./extensionOverridesPatches/vitals_at_corecoding.com.patch;
+        gtop_path = "${libgtop}/lib/girepository-1.0";
+      })
+    ];
+  }))
+
   (patchExtension "unite@hardpixel.eu" (old: {
     buildInputs = [ xprop ];
 

--- a/pkgs/desktops/gnome/extensions/extensionOverridesPatches/vitals_at_corecoding.com.patch
+++ b/pkgs/desktops/gnome/extensions/extensionOverridesPatches/vitals_at_corecoding.com.patch
@@ -1,0 +1,14 @@
+diff --git i/sensors.js w/sensors.js
+index 5ab7068..00cfa19 100644
+--- i/sensors.js
++++ w/sensors.js
+@@ -29,6 +29,9 @@ const Me = imports.misc.extensionUtils.getCurrentExtension();
+ const FileModule = Me.imports.helpers.file;
+ const Gettext = imports.gettext.domain(Me.metadata['gettext-domain']);
+ const _ = Gettext.gettext;
++
++imports.gi.GIRepository.Repository.prepend_search_path('@gtop_path@');
++
+ const NM = imports.gi.NM;
+ 
+ let GTop, hasGTop = true;


### PR DESCRIPTION
###### Motivation for this change

Make Storage sensor work.

###### Things done

Tested for full functionality on Gnome 43.3 .

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
