### PR TITLE
[22.11] libtiff: add patches for many related CVEs

### DIFF
--- a/pkgs/development/libraries/libtiff/4.4.0-CVE-2023-0795.CVE-2023-0796.CVE-2023-0797.CVE-2023-0798.CVE-2023-0799.patch
+++ b/pkgs/development/libraries/libtiff/4.4.0-CVE-2023-0795.CVE-2023-0796.CVE-2023-0797.CVE-2023-0798.CVE-2023-0799.patch
@@ -1,0 +1,140 @@
+Based on upstream 33aee1275d9d1384791d2206776eb8152d397f00, adjusted for
+formatting differences in 4.4.0
+
+diff --git a/tools/tiffcrop.c b/tools/tiffcrop.c
+index 3ad044a4..2016422d 100644
+--- a/tools/tiffcrop.c
++++ b/tools/tiffcrop.c
+@@ -271,7 +271,6 @@ struct  region {
+   uint32_t width;     /* width in pixels */
+   uint32_t length;    /* length in pixels */
+   uint32_t buffsize;  /* size of buffer needed to hold the cropped region */
+-  unsigned char *buffptr; /* address of start of the region */
+ };
+ 
+ /* Cropping parameters from command line and image data 
+@@ -526,7 +525,7 @@ static int rotateContigSamples24bits(uint16_t, uint16_t, uint16_t, uint32_t,
+ static int rotateContigSamples32bits(uint16_t, uint16_t, uint16_t, uint32_t,
+                                      uint32_t, uint32_t, uint8_t *, uint8_t *);
+ static int rotateImage(uint16_t, struct image_data *, uint32_t *, uint32_t *,
+-                       unsigned char **, size_t *);
++                       unsigned char **, size_t *, int);
+ static int mirrorImage(uint16_t, uint16_t, uint16_t, uint32_t, uint32_t,
+                        unsigned char *);
+ static int invertImage(uint16_t, uint16_t, uint16_t, uint32_t, uint32_t,
+@@ -5227,7 +5226,6 @@ initCropMasks (struct crop_mask *cps)
+      cps->regionlist[i].width = 0;
+      cps->regionlist[i].length = 0;
+      cps->regionlist[i].buffsize = 0;
+-     cps->regionlist[i].buffptr = NULL;
+      cps->zonelist[i].position = 0;
+      cps->zonelist[i].total = 0;
+      }
+@@ -6553,9 +6551,13 @@ static int  correct_orientation(struct image_data *image, unsigned char **work_b
+                  (uint16_t) (image->adjustments & ROTATE_ANY));
+       return (-1);
+       }
+- 
+-        if (rotateImage(rotation, image, &image->width, &image->length,
+-                        work_buff_ptr, NULL))
++        /* Dummy variable in order not to switch two times the
++         * image->width,->length within rotateImage(),
++         * but switch xres, yres there. */
++        uint32_t width = image->width;
++        uint32_t length = image->length;
++        if (rotateImage(rotation, image, &width, &length, work_buff_ptr, NULL,
++                        TRUE))
+       {
+       TIFFError ("correct_orientation", "Unable to rotate image");
+       return (-1);
+@@ -6663,7 +6665,6 @@ extractCompositeRegions(struct image_data *image,  struct crop_mask *crop,
+     /* These should not be needed for composite images */
+     crop->regionlist[i].width = crop_width;
+     crop->regionlist[i].length = crop_length;
+-    crop->regionlist[i].buffptr = crop_buff;
+ 
+     src_rowsize = ((img_width * bps * spp) + 7) / 8;
+     dst_rowsize = (((crop_width * bps * count) + 7) / 8);
+@@ -6902,7 +6903,6 @@ extractSeparateRegion(struct image_data *image,  struct crop_mask *crop,
+ 
+   crop->regionlist[region].width = crop_width;
+   crop->regionlist[region].length = crop_length;
+-  crop->regionlist[region].buffptr = crop_buff;
+ 
+   src = read_buff;
+   dst = crop_buff;
+@@ -7784,7 +7784,8 @@ processCropSelections(struct image_data *image, struct crop_mask *crop,
+              * accordingly. */
+             size_t rot_buf_size = 0;
+       if (rotateImage(crop->rotation, image, &crop->combined_width, 
+-                            &crop->combined_length, &crop_buff, &rot_buf_size))
++                            &crop->combined_length, &crop_buff, &rot_buf_size,
++                            FALSE))
+         {
+         TIFFError("processCropSelections", 
+                   "Failed to rotate composite regions by %"PRIu32" degrees", crop->rotation);
+@@ -7897,9 +7898,10 @@ processCropSelections(struct image_data *image, struct crop_mask *crop,
+                  * its size individually. Therefore, seg_buffs size  needs to be
+                  * updated accordingly. */
+                 size_t rot_buf_size = 0;
+-                if (rotateImage(
+-                        crop->rotation, image, &crop->regionlist[i].width,
+-                        &crop->regionlist[i].length, &crop_buff, &rot_buf_size))
++                if (rotateImage(crop->rotation, image,
++                                &crop->regionlist[i].width,
++                                &crop->regionlist[i].length, &crop_buff,
++                                &rot_buf_size, FALSE))
+           {
+           TIFFError("processCropSelections", 
+                     "Failed to rotate crop region by %"PRIu16" degrees", crop->rotation);
+@@ -8030,7 +8032,7 @@ createCroppedImage(struct image_data *image, struct crop_mask *crop,
+   if (crop->crop_mode & CROP_ROTATE) /* rotate should be last as it can reallocate the buffer */
+     {
+     if (rotateImage(crop->rotation, image, &crop->combined_width, 
+-                        &crop->combined_length, crop_buff_ptr, NULL))
++                        &crop->combined_length, crop_buff_ptr, NULL, TRUE))
+       {
+       TIFFError("createCroppedImage", 
+                 "Failed to rotate image or cropped selection by %"PRIu16" degrees", crop->rotation);
+@@ -8693,7 +8695,8 @@ rotateContigSamples32bits(uint16_t rotation, uint16_t spp, uint16_t bps, uint32_
+ /* Rotate an image by a multiple of 90 degrees clockwise */
+ static int rotateImage(uint16_t rotation, struct image_data *image,
+                        uint32_t *img_width, uint32_t *img_length,
+-                       unsigned char **ibuff_ptr, size_t *rot_buf_size)
++                       unsigned char **ibuff_ptr, size_t *rot_buf_size,
++                       int rot_image_params)
+ {
+   int      shift_width;
+   uint32_t   bytes_per_pixel, bytes_per_sample;
+@@ -8886,11 +8889,15 @@ static int rotateImage(uint16_t rotation, struct image_data *image,
+ 
+               *img_width = length;
+               *img_length = width;
++            /* Only toggle image parameters if whole input image is rotated. */
++            if (rot_image_params)
++            {
+               image->width = length;
+               image->length = width;
+               res_temp = image->xres;
+               image->xres = image->yres;
+               image->yres = res_temp;
++            }
+ 	      break;
+ 
+     case 270: if ((bps % 8) == 0) /* byte aligned data */
+@@ -8963,11 +8970,15 @@ static int rotateImage(uint16_t rotation, struct image_data *image,
+ 
+               *img_width = length;
+               *img_length = width;
++            /* Only toggle image parameters if whole input image is rotated. */
++            if (rot_image_params)
++            {
+               image->width = length;
+               image->length = width;
+               res_temp = image->xres;
+               image->xres = image->yres;
+               image->yres = res_temp;
++            }
+               break;
+     default:
+               break;

--- a/pkgs/development/libraries/libtiff/4.4.0-CVE-2023-0795.CVE-2023-0796.CVE-2023-0797.CVE-2023-0798.CVE-2023-0799.prerequisite-0.patch
+++ b/pkgs/development/libraries/libtiff/4.4.0-CVE-2023-0795.CVE-2023-0796.CVE-2023-0797.CVE-2023-0798.CVE-2023-0799.prerequisite-0.patch
@@ -1,0 +1,115 @@
+Based on upstream 9c22495e5eeeae9e00a1596720c969656bb8d678, adjusted for
+formatting differences in 4.4.0
+
+diff --git a/tools/tiffcrop.c b/tools/tiffcrop.c
+index 00309b8d..0d61a95e 100644
+--- a/tools/tiffcrop.c
++++ b/tools/tiffcrop.c
+@@ -526,7 +526,7 @@ static int rotateContigSamples24bits(uint16_t, uint16_t, uint16_t, uint32_t,
+ static int rotateContigSamples32bits(uint16_t, uint16_t, uint16_t, uint32_t,
+                                      uint32_t, uint32_t, uint8_t *, uint8_t *);
+ static int rotateImage(uint16_t, struct image_data *, uint32_t *, uint32_t *,
+-                       unsigned char **);
++                       unsigned char **, size_t *);
+ static int mirrorImage(uint16_t, uint16_t, uint16_t, uint32_t, uint32_t,
+                        unsigned char *);
+ static int invertImage(uint16_t, uint16_t, uint16_t, uint32_t, uint32_t,
+@@ -6551,7 +6551,8 @@ static int  correct_orientation(struct image_data *image, unsigned char **work_b
+       return (-1);
+       }
+  
+-    if (rotateImage(rotation, image, &image->width, &image->length, work_buff_ptr))
++        if (rotateImage(rotation, image, &image->width, &image->length,
++                        work_buff_ptr, NULL))
+       {
+       TIFFError ("correct_orientation", "Unable to rotate image");
+       return (-1);
+@@ -7775,16 +7776,19 @@ processCropSelections(struct image_data *image, struct crop_mask *crop,
+ 
+     if (crop->crop_mode & CROP_ROTATE) /* rotate should be last as it can reallocate the buffer */
+       {
++            /* rotateImage() set up a new buffer and calculates its size
++             * individually. Therefore, seg_buffs size  needs to be updated
++             * accordingly. */
++            size_t rot_buf_size = 0;
+       if (rotateImage(crop->rotation, image, &crop->combined_width, 
+-                      &crop->combined_length, &crop_buff))
++                            &crop->combined_length, &crop_buff, &rot_buf_size))
+         {
+         TIFFError("processCropSelections", 
+                   "Failed to rotate composite regions by %"PRIu32" degrees", crop->rotation);
+         return (-1);
+         }
+       seg_buffs[0].buffer = crop_buff;
+-      seg_buffs[0].size = (((crop->combined_width * image->bps + 7 ) / 8)
+-                            * image->spp) * crop->combined_length; 
++            seg_buffs[0].size = rot_buf_size;
+       }
+     }
+   else  /* Separated Images */
+@@ -7882,11 +7886,17 @@ processCropSelections(struct image_data *image, struct crop_mask *crop,
+ 
+       if (crop->crop_mode & CROP_ROTATE) /* rotate should be last as it can reallocate the buffer */
+         {
+-          /* rotateImage() changes image->width, ->length, ->xres and ->yres, what it schouldn't do here, when more than one section is processed. 
+-           * ToDo: Therefore rotateImage() and its usage has to be reworked (e.g. like mirrorImage()) !!
+-           */
+-	if (rotateImage(crop->rotation, image, &crop->regionlist[i].width, 
+-			&crop->regionlist[i].length, &crop_buff))
++                /* rotateImage() changes image->width, ->length, ->xres and
++                 * ->yres, what it schouldn't do here, when more than one
++                 * section is processed. ToDo: Therefore rotateImage() and its
++                 * usage has to be reworked (e.g. like mirrorImage()) !!
++                 * Furthermore, rotateImage() set up a new buffer and calculates
++                 * its size individually. Therefore, seg_buffs size  needs to be
++                 * updated accordingly. */
++                size_t rot_buf_size = 0;
++                if (rotateImage(
++                        crop->rotation, image, &crop->regionlist[i].width,
++                        &crop->regionlist[i].length, &crop_buff, &rot_buf_size))
+           {
+           TIFFError("processCropSelections", 
+                     "Failed to rotate crop region by %"PRIu16" degrees", crop->rotation);
+@@ -7897,8 +7907,7 @@ processCropSelections(struct image_data *image, struct crop_mask *crop,
+         crop->combined_width = total_width;
+         crop->combined_length = total_length;
+         seg_buffs[i].buffer = crop_buff;
+-        seg_buffs[i].size = (((crop->regionlist[i].width * image->bps + 7 ) / 8)
+-                               * image->spp) * crop->regionlist[i].length; 
++                seg_buffs[i].size = rot_buf_size;
+         }
+       }  /* for crop->selections loop */
+     }  /* Separated Images (else case) */
+@@ -8018,7 +8027,7 @@ createCroppedImage(struct image_data *image, struct crop_mask *crop,
+   if (crop->crop_mode & CROP_ROTATE) /* rotate should be last as it can reallocate the buffer */
+     {
+     if (rotateImage(crop->rotation, image, &crop->combined_width, 
+-                    &crop->combined_length, crop_buff_ptr))
++                        &crop->combined_length, crop_buff_ptr, NULL))
+       {
+       TIFFError("createCroppedImage", 
+                 "Failed to rotate image or cropped selection by %"PRIu16" degrees", crop->rotation);
+@@ -8679,10 +8688,10 @@ rotateContigSamples32bits(uint16_t rotation, uint16_t spp, uint16_t bps, uint32_
+ 
+ 
+ /* Rotate an image by a multiple of 90 degrees clockwise */
+-static int
+-rotateImage(uint16_t rotation, struct image_data *image, uint32_t *img_width,
+-            uint32_t *img_length, unsigned char **ibuff_ptr)
+-  {
++static int rotateImage(uint16_t rotation, struct image_data *image,
++                       uint32_t *img_width, uint32_t *img_length,
++                       unsigned char **ibuff_ptr, size_t *rot_buf_size)
++{
+   int      shift_width;
+   uint32_t   bytes_per_pixel, bytes_per_sample;
+   uint32_t   row, rowsize, src_offset, dst_offset;
+@@ -8732,6 +8741,8 @@ rotateImage(uint16_t rotation, struct image_data *image, uint32_t *img_width,
+     return (-1);
+     }
+   _TIFFmemset(rbuff, '\0', buffsize + NUM_BUFF_OVERSIZE_BYTES);
++    if (rot_buf_size != NULL)
++        *rot_buf_size = buffsize;
+ 
+   ibuff = *ibuff_ptr;
+   switch (rotation)

--- a/pkgs/development/libraries/libtiff/4.4.0-CVE-2023-0795.CVE-2023-0796.CVE-2023-0797.CVE-2023-0798.CVE-2023-0799.prerequisite-1.patch
+++ b/pkgs/development/libraries/libtiff/4.4.0-CVE-2023-0795.CVE-2023-0796.CVE-2023-0797.CVE-2023-0798.CVE-2023-0799.prerequisite-1.patch
@@ -1,0 +1,38 @@
+Based on upstream d63de61b1ec3385f6383ef9a1f453e4b8b11d536, adjusted for
+formatting differences in 4.4.0
+
+diff --git a/libtiff/tif_close.c b/libtiff/tif_close.c
+index 04977bc7..b6c9c97a 100644
+--- a/libtiff/tif_close.c
++++ b/libtiff/tif_close.c
+@@ -125,11 +125,14 @@ TIFFCleanup(TIFF* tif)
+ void
+ TIFFClose(TIFF* tif)
+ {
++    if (tif != NULL)
++    {
+ 	TIFFCloseProc closeproc = tif->tif_closeproc;
+ 	thandle_t fd = tif->tif_clientdata;
+ 
+ 	TIFFCleanup(tif);
+-	(void) (*closeproc)(fd);
++        (void)(*closeproc)(fd);
++    }
+ }
+ 
+ /* vim: set ts=8 sts=8 sw=8 noet: */
+diff --git a/tools/tiffcrop.c b/tools/tiffcrop.c
+index 0d61a95e..3ad044a4 100644
+--- a/tools/tiffcrop.c
++++ b/tools/tiffcrop.c
+@@ -2554,7 +2554,10 @@ main(int argc, char* argv[])
+       }
+     }
+ 
++    if (out != NULL)
++    {
+   TIFFClose(out);
++    }
+ 
+   return (0);
+   } /* end main */

--- a/pkgs/development/libraries/libtiff/4.4.0-CVE-2023-0800.CVE-2023-0801.CVE-2023-0802.CVE-2023-0803.CVE-2023-0804.patch
+++ b/pkgs/development/libraries/libtiff/4.4.0-CVE-2023-0800.CVE-2023-0801.CVE-2023-0802.CVE-2023-0803.CVE-2023-0804.patch
@@ -1,0 +1,115 @@
+Based on upstream afaabc3e50d4e5d80a94143f7e3c997e7e410f68, adjusted for
+formatting differences in 4.4.0
+
+diff --git a/tools/tiffcrop.c b/tools/tiffcrop.c
+index 698fb1cb..00309b8d 100644
+--- a/tools/tiffcrop.c
++++ b/tools/tiffcrop.c
+@@ -5364,18 +5364,40 @@ computeInputPixelOffsets(struct crop_mask *crop, struct image_data *image,
+ 
+       crop->regionlist[i].buffsize = buffsize;
+       crop->bufftotal += buffsize;
++
++            /* For composite images with more than one region, the
++             * combined_length or combined_width always needs to be equal,
++             * respectively.
++             * Otherwise, even the first section/region copy
++             * action might cause buffer overrun. */
+       if (crop->img_mode == COMPOSITE_IMAGES)
+         {
+         switch (crop->edge_ref)
+           {
+           case EDGE_LEFT:
+           case EDGE_RIGHT:
++                        if (i > 0 && zlength != crop->combined_length)
++                        {
++                            TIFFError(
++                                "computeInputPixelOffsets",
++                                "Only equal length regions can be combined for "
++                                "-E left or right");
++                            return (-1);
++                        }
+                crop->combined_length = zlength;
+                crop->combined_width += zwidth;
+                break;
+           case EDGE_BOTTOM:
+           case EDGE_TOP:  /* width from left, length from top */
+           default:
++                        if (i > 0 && zwidth != crop->combined_width)
++                        {
++                            TIFFError("computeInputPixelOffsets",
++                                      "Only equal width regions can be "
++                                      "combined for -E "
++                                      "top or bottom");
++                            return (-1);
++                        }
+                crop->combined_width = zwidth;
+                crop->combined_length += zlength;
+ 	       break;
+@@ -6583,6 +6605,46 @@ extractCompositeRegions(struct image_data *image,  struct crop_mask *crop,
+   crop->combined_width = 0;
+   crop->combined_length = 0;
+ 
++    /* If there is more than one region, check beforehand whether all the width
++     * and length values of the regions are the same, respectively. */
++    switch (crop->edge_ref)
++    {
++        default:
++        case EDGE_TOP:
++        case EDGE_BOTTOM:
++            for (i = 1; i < crop->selections; i++)
++            {
++                uint32_t crop_width0 =
++                    crop->regionlist[i - 1].x2 - crop->regionlist[i - 1].x1 + 1;
++                uint32_t crop_width1 =
++                    crop->regionlist[i].x2 - crop->regionlist[i].x1 + 1;
++                if (crop_width0 != crop_width1)
++                {
++                    TIFFError("extractCompositeRegions",
++                              "Only equal width regions can be combined for -E "
++                              "top or bottom");
++                    return (1);
++                }
++            }
++            break;
++        case EDGE_LEFT:
++        case EDGE_RIGHT:
++            for (i = 1; i < crop->selections; i++)
++            {
++                uint32_t crop_length0 =
++                    crop->regionlist[i - 1].y2 - crop->regionlist[i - 1].y1 + 1;
++                uint32_t crop_length1 =
++                    crop->regionlist[i].y2 - crop->regionlist[i].y1 + 1;
++                if (crop_length0 != crop_length1)
++                {
++                    TIFFError("extractCompositeRegions",
++                              "Only equal length regions can be combined for "
++                              "-E left or right");
++                    return (1);
++                }
++            }
++    }
++
+   for (i = 0; i < crop->selections; i++)
+     {
+     /* rows, columns, width, length are expressed in pixels */
+@@ -6607,7 +6669,8 @@ extractCompositeRegions(struct image_data *image,  struct crop_mask *crop,
+       default:
+       case EDGE_TOP:
+       case EDGE_BOTTOM:
+-	   if ((i > 0) && (crop_width != crop->regionlist[i - 1].width))
++                if ((crop->selections > i + 1) &&
++                    (crop_width != crop->regionlist[i + 1].width))
+              {
+ 	     TIFFError ("extractCompositeRegions", 
+                           "Only equal width regions can be combined for -E top or bottom");
+@@ -6688,7 +6751,8 @@ extractCompositeRegions(struct image_data *image,  struct crop_mask *crop,
+ 	   break;
+       case EDGE_LEFT:  /* splice the pieces of each row together, side by side */
+       case EDGE_RIGHT:
+-	   if ((i > 0) && (crop_length != crop->regionlist[i - 1].length))
++                if ((crop->selections > i + 1) &&
++                    (crop_length != crop->regionlist[i + 1].length))
+              {
+ 	     TIFFError ("extractCompositeRegions", 
+                           "Only equal length regions can be combined for -E left or right");

--- a/pkgs/development/libraries/libtiff/default.nix
+++ b/pkgs/development/libraries/libtiff/default.nix
@@ -63,6 +63,15 @@ stdenv.mkDerivation rec {
       sha256 = "sha256-pgItgS+UhMjoSjkDJH5y7iGFZ+yxWKqlL7BdT2mFcH0=";
     })
     ./4.4.0-CVE-2022-48281.patch
+    ./4.4.0-CVE-2023-0800.CVE-2023-0801.CVE-2023-0802.CVE-2023-0803.CVE-2023-0804.patch
+    ./4.4.0-CVE-2023-0795.CVE-2023-0796.CVE-2023-0797.CVE-2023-0798.CVE-2023-0799.prerequisite-0.patch
+    ./4.4.0-CVE-2023-0795.CVE-2023-0796.CVE-2023-0797.CVE-2023-0798.CVE-2023-0799.prerequisite-1.patch
+    ./4.4.0-CVE-2023-0795.CVE-2023-0796.CVE-2023-0797.CVE-2023-0798.CVE-2023-0799.patch
+    (fetchpatch {
+      name = "CVE-2022-4645.patch";
+      url = "https://gitlab.com/libtiff/libtiff/-/commit/f00484b9519df933723deb38fff943dc291a793d.patch";
+      sha256 = "sha256-sFVi5BY/L8WisrtTThkux1Gw2x0UrurnSlv4KkEvw3w=";
+    })
   ];
 
   postPatch = ''


### PR DESCRIPTION
###### Description of changes
Backport of #217557 (although all patches needed adjustment in the end due to formatting changes, hence brought in-repo) + patch for CVE-2022-4645 (which is already addressed in 4.5.0 so not needed for master)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
