### PR TITLE
ocamlPackages.hack_parallel: disable for OCaml < 4.08 (broken)

### DIFF
--- a/pkgs/development/ocaml-modules/hack_parallel/default.nix
+++ b/pkgs/development/ocaml-modules/hack_parallel/default.nix
@@ -3,8 +3,8 @@
 buildDunePackage rec {
   pname = "hack_parallel";
   version = "1.0.1";
-  useDune2 = true;
-  minimumOcamlVersion = "4.04.1";
+  duneVersion = "3";
+  minimalOCamlVersion = "4.08";
 
   src = fetchFromGitHub {
     owner = "rvantonder";

--- a/pkgs/development/ocaml-modules/ocaml-migrate-parsetree/1.8.x.nix
+++ b/pkgs/development/ocaml-modules/ocaml-migrate-parsetree/1.8.x.nix
@@ -8,7 +8,7 @@ buildDunePackage rec {
    pname = "ocaml-migrate-parsetree";
    version = "1.8.0";
 
-   useDune2 = lib.versionAtLeast ocaml.version "4.08";
+   duneVersion = if lib.versionAtLeast ocaml.version "4.08" then "3" else "1";
 
    src = fetchFromGitHub {
      owner = "ocaml-ppx";

--- a/pkgs/development/ocaml-modules/ppx_tools_versioned/default.nix
+++ b/pkgs/development/ocaml-modules/ppx_tools_versioned/default.nix
@@ -4,7 +4,7 @@ buildDunePackage rec {
   pname = "ppx_tools_versioned";
   version = "5.4.0";
 
-  useDune2 = true;
+  duneVersion = "3";
 
   src = fetchFromGitHub {
     owner = "ocaml-ppx";


### PR DESCRIPTION
###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
