### PR TITLE
deepin.startdde: init at 5.10.1

### DIFF
--- a/pkgs/desktops/deepin/default.nix
+++ b/pkgs/desktops/deepin/default.nix
@@ -69,6 +69,7 @@ let
     dde-daemon = callPackage ./go-package/dde-daemon { };
     deepin-pw-check = callPackage ./go-package/deepin-pw-check { };
     deepin-desktop-schemas = callPackage ./go-package/deepin-desktop-schemas { };
+    startdde = callPackage ./go-package/startdde { };
 
     #### TOOLS
     dde-device-formatter = callPackage ./tools/dde-device-formatter { };

--- a/pkgs/desktops/deepin/go-package/startdde/0001-avoid-use-hardcode-path.patch
+++ b/pkgs/desktops/deepin/go-package/startdde/0001-avoid-use-hardcode-path.patch
@@ -1,0 +1,153 @@
+From 47a700c64329f76ab91ac01d83a93f43bebe638b Mon Sep 17 00:00:00 2001
+From: rewine <lhongxu@outlook.com>
+Date: Sun, 9 Apr 2023 17:14:00 +0800
+Subject: [PATCH] avoid use hardcode path
+
+---
+ display/wayland.go            |  4 ++--
+ main.go                       | 10 +++++-----
+ misc/auto_launch/chinese.json |  4 ++--
+ session.go                    | 15 +++++++++------
+ 4 files changed, 18 insertions(+), 15 deletions(-)
+
+diff --git a/display/wayland.go b/display/wayland.go
+index b980425..e44342a 100644
+--- a/display/wayland.go
++++ b/display/wayland.go
+@@ -556,7 +556,7 @@ func (mm *kMonitorManager) applyByWLOutput(monitorMap map[uint32]*Monitor) error
+ 	
+ 	if len(args_enable) > 0 {
+ 		ctx, cancel := context.WithTimeout(context.Background(), time.Second*5)
+-		cmdline := exec.CommandContext(ctx, "/usr/bin/dde_wloutput", "set")
++		cmdline := exec.CommandContext(ctx, "dde_wloutput", "set")
+ 		cmdline.Args = append(cmdline.Args, args_enable...)
+ 		logger.Info("cmd line args_enable:", cmdline.Args)
+ 
+@@ -572,7 +572,7 @@ func (mm *kMonitorManager) applyByWLOutput(monitorMap map[uint32]*Monitor) error
+ 	}
+ 	if len(args_disable) > 0 {
+ 		ctx, cancel := context.WithTimeout(context.Background(), time.Second*5)
+-		cmdline := exec.CommandContext(ctx, "/usr/bin/dde_wloutput", "set")
++		cmdline := exec.CommandContext(ctx, "dde_wloutput", "set")
+ 		cmdline.Args = append(cmdline.Args, args_disable...)
+ 		logger.Info("cmd line args_disable:", cmdline.Args)
+ 
+diff --git a/main.go b/main.go
+index 77b4e78..30aa3fd 100644
+--- a/main.go
++++ b/main.go
+@@ -96,17 +96,17 @@ func shouldUseDDEKWin() bool {
+ 	}
+ 
+ end:
+-	_, err = os.Stat("/usr/bin/kwin_no_scale")
++        _, err = exec.LookPath("kwin_no_scale")
+ 	return err == nil
+ }
+ 
+ const (
+-	cmdKWin                = "/usr/bin/kwin_no_scale"
++	cmdKWin                = "kwin_no_scale"
+ 	cmdDdeSessionDaemon    = "/usr/lib/deepin-daemon/dde-session-daemon"
+-	cmdDdeDock             = "/usr/bin/dde-dock"
+-	cmdDdeDesktop          = "/usr/bin/dde-desktop"
++	cmdDdeDock             = "dde-dock"
++	cmdDdeDesktop          = "dde-desktop"
+ 	cmdLoginReminderHelper = "/usr/libexec/deepin/login-reminder-helper"
+-	cmdDdeHintsDialog      = "/usr/bin/dde-hints-dialog"
++	cmdDdeHintsDialog      = "dde-hints-dialog"
+ 
+ 	loginReminderTimeout    = 5 * time.Second
+ 	loginReminderTimeFormat = "2006-01-02 15:04:05"
+diff --git a/misc/auto_launch/chinese.json b/misc/auto_launch/chinese.json
+index 079a521..1856ab1 100644
+--- a/misc/auto_launch/chinese.json
++++ b/misc/auto_launch/chinese.json
+@@ -13,7 +13,7 @@
+     "Priority": 9,
+     "Group": [
+       {
+-        "Command": "/usr/bin/dde-file-manager",
++        "Command": "dde-file-manager",
+         "Wait": false,
+         "Args": [
+           "-d"
+@@ -39,7 +39,7 @@
+     "Priority": 7,
+     "Group": [
+       {
+-        "Command": "/usr/bin/dde-shutdown",
++        "Command": "dde-shutdown",
+         "Wait": false,
+         "Args": [
+           "-d"
+diff --git a/session.go b/session.go
+index 26f89ef..f412ca4 100644
+--- a/session.go
++++ b/session.go
+@@ -18,6 +18,7 @@ import (
+ 	"syscall"
+ 	"time"
+ 
++	"github.com/adrg/xdg"
+ 	"github.com/godbus/dbus"
+ 	"github.com/linuxdeepin/dde-api/soundutils"
+ 	daemon "github.com/linuxdeepin/go-dbus-factory/com.deepin.daemon.daemon"
+@@ -53,8 +54,10 @@ const (
+ 
+ 	xsKeyQtFontName     = "Qt/FontName"
+ 	xsKeyQtMonoFontName = "Qt/MonoFontName"
++)
+ 
+-	ddeLockDesktopFile = "/usr/share/applications/dde-lock.desktop"
++var (
++	ddeLockDesktopFile, _ = xdg.SearchDataFile("applications/dde-lock.desktop");
+ )
+ 
+ type SessionManager struct {
+@@ -90,7 +93,7 @@ type SessionManager struct {
+ }
+ 
+ const (
+-	cmdShutdown      = "/usr/bin/dde-shutdown"
++	cmdShutdown      = "dde-shutdown"
+ 	lockFrontDest    = "com.deepin.dde.lockFront"
+ 	lockFrontIfc     = lockFrontDest
+ 	lockFrontObjPath = "/com/deepin/dde/lockFront"
+@@ -471,7 +474,7 @@ func (m *SessionManager) SetLocked(sender dbus.Sender, value bool) *dbus.Error {
+ 		return dbusutil.ToError(err)
+ 	}
+ 
+-	if exe == "/usr/bin/dde-lock" {
++	if strings.Contains(exe, "dde-lock") {
+ 		m.setLocked(value)
+ 		return nil
+ 	}
+@@ -491,7 +494,7 @@ func (m *SessionManager) SetLocked(sender dbus.Sender, value bool) *dbus.Error {
+ 		return dbusutil.ToError(fmt.Errorf("desktop file %q is invalid", desktopFile))
+ 	}
+ 	exe = info.GetExecutable()
+-	if exe != "/usr/bin/dde-lock" {
++	if strings.Contains(exe, "dde-lock") {
+ 		return dbusutil.ToError(fmt.Errorf("exe %q of desktop file %q is invalid", exe, desktopFile))
+ 	}
+ 
+@@ -798,7 +801,7 @@ func setupEnvironments2() {
+ 	// man gnome-keyring-daemon:
+ 	// The daemon will print out various environment variables which should be set
+ 	// in the user's environment, in order to interact with the daemon.
+-	gnomeKeyringOutput, err := exec.Command("/usr/bin/gnome-keyring-daemon", "--start",
++	gnomeKeyringOutput, err := exec.Command("gnome-keyring-daemon", "--start",
+ 		"--components=secrets,pkcs11,ssh").Output()
+ 	if err == nil {
+ 		lines := bytes.Split(gnomeKeyringOutput, []byte{'\n'})
+@@ -1389,4 +1392,4 @@ func initXEventMonitor() {
+ 			setDPMSMode(true)
+ 		}
+ 	})
+-}
+\ No newline at end of file
++}
+-- 
+2.39.2
+

--- a/pkgs/desktops/deepin/go-package/startdde/default.nix
+++ b/pkgs/desktops/deepin/go-package/startdde/default.nix
@@ -1,0 +1,102 @@
+{ stdenv
+, lib
+, fetchFromGitHub
+, buildGoPackage
+, pkg-config
+, go-dbus-factory
+, go-gir-generator
+, go-lib
+, gettext
+, dde-api
+, libgnome-keyring
+, gtk3
+, alsa-lib
+, libpulseaudio
+, libgudev
+, libsecret
+, jq
+, wrapGAppsHook
+, runtimeShell
+, dde-polkit-agent
+}:
+
+buildGoPackage rec {
+  pname = "startdde";
+  version = "5.10.1";
+
+  goPackagePath = "github.com/linuxdeepin/startdde";
+
+  src = fetchFromGitHub {
+    owner = "linuxdeepin";
+    repo = pname;
+    rev = version;
+    sha256 = "sha256-dbTcYS7dEvT0eP45jKE8WiG9Pm4LU6jvR8hjMQv/yxU=";
+  };
+
+  patches = [
+    ./0001-avoid-use-hardcode-path.patch
+  ];
+
+  postPatch = ''
+    substituteInPlace display/manager.go session.go \
+      --replace "/bin/bash" "${runtimeShell}"
+    substituteInPlace display/manager.go main.go utils.go session.go \
+      --replace "/usr/lib/deepin-daemon" "/run/current-system/sw/lib/deepin-daemon"
+    substituteInPlace misc/xsessions/deepin.desktop.in --subst-var-by PREFIX $out
+    substituteInPlace watchdog/dde_polkit_agent.go misc/auto_launch/{default.json,chinese.json} \
+      --replace "/usr/lib/polkit-1-dde/dde-polkit-agent" "${dde-polkit-agent}/lib/polkit-1-dde/dde-polkit-agent"
+    substituteInPlace startmanager.go launch_group.go memchecker/config.go \
+      --replace "/usr/share/startdde" "$out/share/startdde"
+    substituteInPlace misc/lightdm.conf --replace "/usr" "$out"
+  '';
+
+  goDeps = ./deps.nix;
+
+  nativeBuildInputs = [
+    gettext
+    pkg-config
+    jq
+    wrapGAppsHook
+  ];
+
+  buildInputs = [
+    go-dbus-factory
+    go-gir-generator
+    go-lib
+    dde-api
+    libgnome-keyring
+    gtk3
+    alsa-lib
+    libpulseaudio
+    libgudev
+    libsecret
+  ];
+
+  buildPhase = ''
+    runHook preBuild
+    addToSearchPath GOPATH "${go-dbus-factory}/share/gocode"
+    addToSearchPath GOPATH "${go-gir-generator}/share/gocode"
+    addToSearchPath GOPATH "${go-lib}/share/gocode"
+    addToSearchPath GOPATH "${dde-api}/share/gocode"
+    make -C go/src/${goPackagePath}
+    runHook postBuild
+  '';
+
+  installPhase = ''
+    make install DESTDIR="$out" PREFIX="/" -C go/src/${goPackagePath}
+  '';
+
+  passthru.providedSessions = [ "deepin" ];
+
+  meta = with lib; {
+    description = "Starter of deepin desktop environment";
+    longDescription = ''
+      Startdde is used for launching DDE components and invoking user's
+      custom applications which compliant with xdg autostart specification
+    '';
+    homepage = "https://github.com/linuxdeepin/startdde";
+    license = licenses.gpl3Plus;
+    platforms = platforms.linux;
+    maintainers = teams.deepin.members;
+  };
+}

--- a/pkgs/desktops/deepin/go-package/startdde/deps.nix
+++ b/pkgs/desktops/deepin/go-package/startdde/deps.nix
@@ -1,0 +1,236 @@
+[
+  {
+    goPackagePath = "github.com/cryptix/wav";
+    fetch = {
+      type = "git";
+      url = "https://github.com/cryptix/wav";
+      rev = "8bdace674401f0bd3b63c65479b6a6ff1f9d5e44";
+      sha256 = "18nyqv0ic35fs9fny8sj84c00vbxs8mnric6vr6yl42624fh5id6";
+    };
+  }
+  {
+    goPackagePath = "github.com/davecgh/go-spew";
+    fetch = {
+      type = "git";
+      url = "https://github.com/davecgh/go-spew";
+      rev = "v1.1.1";
+      sha256 = "sha256-nhzSUrE1fCkN0+RL04N4h8jWmRFPPPWbCuDc7Ss0akI=";
+    };
+  }
+  {
+    goPackagePath = "github.com/linuxdeepin/go-x11-client";
+    fetch = {
+      type = "git";
+      url = "https://github.com/linuxdeepin/go-x11-client";
+      rev = "0.6.9";
+      sha256 = "sha256-xXNaXpFFHJN1fCFLoVrQFCXQ4ya+Kga55QWcJL/InkA=";
+    };
+  }
+  {
+    goPackagePath = "golang.org/x/xerrors";
+    fetch = {
+      type = "git";
+      url = "https://github.com/golang/xerrors";
+      rev = "2f41105eb62f341cfe208d06de4ee3bdd3a083da";
+      sha256 = "sha256-yZNeG+jcarcw/aOFhrhxWWE20r0P+/VJF4i/0JQfv1c=";
+    };
+  }
+  {
+    goPackagePath = "github.com/fsnotify/fsnotify";
+    fetch = {
+      type = "git";
+      url = "https://github.com/fsnotify/fsnotify";
+      rev = "v1.5.1";
+      sha256 = "sha256-B8kZ8yiWgallT7R2j1kSRJcJkSGFVf9ise+TpXa+7XY=";
+    };
+  }
+  {
+    goPackagePath = "github.com/godbus/dbus";
+    fetch = {
+      type = "git";
+      url = "https://github.com/godbus/dbus";
+      rev = "v5.1.0";
+      sha256 = "sha256-JSPtmkGEStBEVrKGszeLCb7P38SzQKgMiDC3eDppXs0=";
+    };
+  }
+  {
+    goPackagePath = "github.com/stretchr/testify";
+    fetch = {
+      type = "git";
+      url = "https://github.com/stretchr/testify";
+      rev = "v1.7.1";
+      sha256 = "sha256-disUVIHiIDSj/go3APtJH8awSl8QwKRRFLKI7LRnl0w=";
+    };
+  }
+  {
+    goPackagePath = "golang.org/x/sys";
+    fetch = {
+      type = "git";
+      url = "https://github.com/golang/sys";
+      rev = "289d7a0edf712062d9f1484b07bdf2383f48802f";
+      sha256 = "sha256-AzS/J3OocI7mA0xsIfQzyskNKVija7F2yvuts+EFJBs=";
+    };
+  }
+  {
+    goPackagePath = "gopkg.in/yaml.v3";
+    fetch = {
+      type = "git";
+      url = "https://github.com/go-yaml/yaml";
+      rev = "496545a6307b2a7d7a710fd516e5e16e8ab62dbc";
+      sha256 = "sha256-j8yDji+vqsitpRZirpb4w/Em8nstgf28wpwkcrOlxBk=";
+    };
+  }
+  {
+    goPackagePath = "github.com/stretchr/objx";
+    fetch = {
+      type = "git";
+      url = "https://github.com/stretchr/objx";
+      rev = "v0.3.0";
+      sha256 = "sha256-T753/EiD5Cpk6H2JFhd+s1gFvpNptG2XlEHxZF6dQaw=";
+    };
+  }
+  {
+    goPackagePath = "github.com/pmezard/go-difflib";
+    fetch = {
+      type = "git";
+      url = "https://github.com/pmezard/go-difflib";
+      rev = "5d4384ee4fb2527b0a1256a821ebfc92f91efefc";
+      sha256 = "sha256-XA4Oj1gdmdV/F/+8kMI+DBxKPthZ768hbKsO3d9Gx90=";
+    };
+  }
+  {
+    goPackagePath = "github.com/axgle/mahonia";
+    fetch = {
+      type = "git";
+      url = "https://github.com/axgle/mahonia";
+      rev = "3358181d7394e26beccfae0ffde05193ef3be33a";
+      sha256 = "0b8wsrxmv8a0cqbnsg55lpf29pxy2zw8azvgh3ck664lqpcfybhq";
+    };
+  }
+  {
+    goPackagePath = "golang.org/x/text";
+    fetch = {
+      type = "git";
+      url = "https://github.com/golang/text";
+      rev = "v0.3.7";
+      sha256 = "sha256-XpIbgE6MxWwDQQcPXr2NIsE2cev2+CIabi566TYGfHY=";
+    };
+  }
+  {
+    goPackagePath = "golang.org/x/image";
+    fetch = {
+      type = "git";
+      url = "https://github.com/golang/image";
+      rev = "70e8d0d3baa9a699c3865c753cbfa8ae65bd86ce";
+      sha256 = "sha256-oMbDIke/qQ6cp7JLNsMusf7EIUfuj0WavFVfI0lxTDs=";
+    };
+  }
+  {
+    goPackagePath = "github.com/nfnt/resize";
+    fetch = {
+      type = "git";
+      url = "https://github.com/nfnt/resize";
+      rev = "83c6a9932646f83e3267f353373d47347b6036b2";
+      sha256 = "005cpiwq28krbjf0zjwpfh63rp4s4is58700idn24fs3g7wdbwya";
+    };
+  }
+  {
+    goPackagePath = "github.com/Lofanmi/pinyin-golang";
+    fetch = {
+      type = "git";
+      url = "https://github.com/Lofanmi/pinyin-golang";
+      rev = "1db892057f20c56a3286cc1517e0642dacbff54c";
+      sha256 = "sha256-nhO6AYZ3vc7nwgmmfTlE6m33caY9gGZoKiSYvFLqHQc=";
+    };
+  }
+  {
+    goPackagePath = "github.com/mozillazg/go-pinyin";
+    fetch = {
+      type = "git";
+      url = "https://github.com/mozillazg/go-pinyin";
+      rev = "8930bc1fcb5693689dc35d98ad2a4153662e34b1";
+      sha256 = "sha256-kuMNiWpPeqsIsFgYIOsffxUfwcLPaMZWdZRBJAMDVvA=";
+    };
+  }
+  {
+    goPackagePath = "github.com/kelvins/sunrisesunset";
+    fetch = {
+      type = "git";
+      url = "https://github.com/kelvins/sunrisesunset";
+      rev = "39fa1bd816d52927b4cfcab0a1535b17eafe0a3d";
+      sha256 = "sha256-awklKAW1YM3sWM21irbyu2sUMIo3kCOj12lzyVzDefw=";
+    };
+  }
+  {
+    goPackagePath = "github.com/rickb777/date";
+    fetch = {
+      type = "git";
+      url = "https://github.com/rickb777/date";
+      rev = "v1.18";
+      sha256 = "sha256-8r8eFOF5dKtowE3dnjpSMIXJ/yX2IjiR7nZ/EApUZbA=";
+    };
+  }
+  {
+    goPackagePath = "github.com/rickb777/plural";
+    fetch = {
+      type = "git";
+      url = "https://github.com/rickb777/plural";
+      rev = "v1.4.1";
+      sha256 = "sha256-nhN+ApdfUie45L+M2OZAPtSoiIZ1pZ2UpDX/DePS6Yw=";
+    };
+  }
+  {
+    goPackagePath = "github.com/gosexy/gettext";
+    fetch = {
+      type = "git";
+      url = "https://github.com/gosexy/gettext";
+      rev = "v0.9";
+      sha256 = "0asphx8nd7zmp88wk6aakk5292np7yw73akvfdvlvs9q5r5ahkgi";
+    };
+  }
+  {
+    goPackagePath = "github.com/msteinert/pam";
+    fetch = {
+      type = "git";
+      url = "https://github.com/msteinert/pam";
+      rev = "v1.0.0";
+      sha256 = "sha256-Ji13ckPyZUBAovhK2hRHgf2LB1ieglX/XrIJBxVcsXc=";
+    };
+  }
+  {
+    goPackagePath = "github.com/youpy/go-wav";
+    fetch = {
+      type = "git";
+      url = "https://github.com/youpy/go-wav";
+      rev = "v0.3.2";
+      sha256 = "sha256-jNqXW3F3fcgjT47+d2MVXauWkA7+1KfYVu3ZZpRCTkM=";
+    };
+  }
+  {
+    goPackagePath = "github.com/zaf/g711";
+    fetch = {
+      type = "git";
+      url = "https://github.com/zaf/g711";
+      rev = "v1.2";
+      sha256 = "sha256-G+0cgGw/fcOUFVn32AeqUE0YjyOS82Z5MTcn6IANhCY=";
+    };
+  }
+  {
+    goPackagePath = "github.com/youpy/go-riff";
+    fetch = {
+      type = "git";
+      url = "https://github.com/youpy/go-riff";
+      rev = "v0.1.0";
+      sha256 = "sha256-d/3rkxDeRTPveZblArKc61gB4LJVV08n7g0THieuhx8=";
+    };
+  }
+  {
+    goPackagePath = "github.com/adrg/xdg";
+    fetch = {
+      type = "git";
+      url = "https://github.com/adrg/xdg";
+      rev = "v0.4.0";
+      sha256 = "sha256-zGjkdUQmrVqD6rMO9oDY+TeJCpuqnHyvkPCaXDlac/U=";
+    };
+  }
+]


### PR DESCRIPTION
###### Description of changes

This is the last go language application for DDE


We can use `buildGoModule` in future  https://github.com/linuxdeepin/dde-nixos/pull/10 ,  before that though, there are a lot of hardcoded path that need to be resolved for upstream




https://github.com/linuxdeepin/dde-nixos/issues/9
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
