### PR TITLE
apple-framework-System: fix System.tbd dangling symbolic link

### DIFF
--- a/pkgs/os-specific/darwin/apple-sdk-11.0/apple_sdk.nix
+++ b/pkgs/os-specific/darwin/apple-sdk-11.0/apple_sdk.nix
@@ -233,6 +233,19 @@ in rec {
             $out/Library/Frameworks/CoreVideo.framework/Headers/CVBase.h
         '';
       });
+
+      System = lib.overrideDerivation super.System (drv: {
+        installPhase = drv.installPhase + ''
+          # Contrarily to the other frameworks, System framework's TBD file
+          # is a symlink pointing to ${MacOSX-SDK}/usr/lib/libSystem.B.tbd.
+          # This produces an error when installing the framework as:
+          #   1. The original file is not copied into the output directory
+          #   2. Even if it was copied, the relative path wouldn't match
+          # Thus, it is easier to replace the file than to fix the symlink.
+          cp --remove-destination ${MacOSX-SDK}/usr/lib/libSystem.B.tbd \
+            $out/Library/Frameworks/System.framework/Versions/B/System.tbd
+        '';
+      });
     };
 
     # Merge extraDeps into generatedDeps.


### PR DESCRIPTION
###### Description of changes

Contrarily to the other frameworks, System framework's TBD file is a symlink pointing to `${MacOSX-SDK}/usr/lib/libSystem.B.tbd`.

This produces an error when using the framework, as:

  1. The original file is not copied into the output directory
  2. Even if it was copied, the relative path wouldn't match

Resulting in the symlink being broken and the linker failing when trying to link against `-framework System`.

The fix applied consists in replacing the symbolic link with the real file, as this is easier than fixing the link and doesn't seem to produce any side effects.

Doesn't seem like I broke anything, but I'm not yet too familiar with Nix neither the apple sdk building process, so take this change with a grain of salt :)

Related to the issue #163215 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [X] aarch64-darwin
- [X] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [X] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
