### PR TITLE
g810-led: init at 0.4.3

### DIFF
--- a/pkgs/misc/g810-led/default.nix
+++ b/pkgs/misc/g810-led/default.nix
@@ -1,0 +1,51 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, hidapi
+, profile ? "/etc/g810-led/profile"
+}:
+
+stdenv.mkDerivation rec {
+  pname = "g810-led";
+  version = "0.4.3";
+
+  src = fetchFromGitHub {
+    owner = "MatMoul";
+    repo = pname;
+    rev = "refs/tags/v${version}";
+    hash = "sha256-GKHtQ7DinqfhclDdPO94KtTLQhhonAoWS4VOvs6CMhY=";
+  };
+
+  postPatch = ''
+    substituteInPlace udev/g810-led.rules \
+      --replace "/usr" $out \
+      --replace "/etc/g810-led/profile" "${profile}"
+  '';
+
+  buildInputs = [
+    hidapi
+  ];
+
+  installPhase = ''
+    runHook preInstall
+
+    install -D bin/g810-led $out/bin/g810-led
+
+    # See https://github.com/MatMoul/g810-led#compatible-keyboards-
+    for keyboard in {g213,g410,g413,g512,g513,g610,g815,g910,gpro}; do
+      ln -s \./g810-led $out/bin/$keyboard-led
+    done
+
+    install -D udev/g810-led.rules $out/etc/udev/rules.d/90-g810-led.rules
+
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    description = "Linux LED controller for some Logitech G Keyboards";
+    homepage = "https://github.com/MatMoul/g810-led";
+    license = licenses.gpl3Only;
+    maintainers = with maintainers; [ fab ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2199,6 +2199,8 @@ with pkgs;
     inherit (darwin.apple_sdk.frameworks) Security;
   };
 
+  g810-led = callPackage ../misc/g810-led { };
+
   gcdemu = callPackage ../applications/emulators/cdemu/gui.nix { };
 
   gensgs = pkgsi686Linux.callPackage ../applications/emulators/gens-gs { };


### PR DESCRIPTION
###### Description of changes
Linux LED controller for some Logitech G Keyboards

https://github.com/MatMoul/g810-led

Successor of #92119 and the work done by @samuelgrf. 

Patching upstream's `makefile as proposed in [this comment](https://github.com/NixOS/nixpkgs/pull/92119/files#r544937801) would require a rewrite of a large portion of the file as the phases also deal with systemd unit file and systemd itself.

Fixes #117951
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
