### PR TITLE
ps2eps: init at 1.70

### DIFF
--- a/pkgs/tools/typesetting/ps2eps/default.nix
+++ b/pkgs/tools/typesetting/ps2eps/default.nix
@@ -1,0 +1,68 @@
+{ lib
+, fetchFromGitHub
+, perlPackages
+, substituteAll
+, ghostscript
+, installShellFiles
+}:
+
+
+perlPackages.buildPerlPackage rec {
+  pname = "ps2eps";
+  version = "1.70";
+
+  src = fetchFromGitHub {
+    owner = "roland-bless";
+    repo = pname;
+    rev = "v${version}";
+    hash = "sha256-SPLwsGKLVhANoqSQ/GJ938cYjbjMbUOXkNn9so3aJTA=";
+  };
+  patches = [
+    (substituteAll {
+      src = ./hardcode-deps.patch;
+      gs = "${ghostscript}/bin/gs";
+      # bbox cannot be substituted here because substituteAll doesn't know what
+      # will be the $out path of the main derivation
+    })
+  ];
+
+  nativeBuildInputs = [
+    installShellFiles
+  ];
+
+  configurePhase = "true";
+
+  buildPhase = ''
+    runHook preBuild
+
+    make -C src/C bbox
+    patchShebangs src/perl/ps2eps
+    substituteInPlace src/perl/ps2eps \
+      --replace @bbox@ $out/bin/bbox
+
+    runHook postBuild
+  '';
+
+  # Override buildPerlPackage's outputs setting
+  outputs = ["out" "man"];
+  installPhase = ''
+    runHook preInstall
+
+    installManPage \
+      doc/ps2eps.1 \
+      doc/bbox.1
+
+    install -D src/perl/ps2eps $out/bin/ps2eps
+    install -D src/C/bbox $out/bin/bbox
+
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    inherit (src.meta) homepage;
+    description = "Calculate correct bounding boxes for PostScript and PDF files";
+    license = licenses.gpl2Plus;
+    platforms = platforms.unix;
+    maintainers = [ maintainers.doronbehar ];
+  };
+}

--- a/pkgs/tools/typesetting/ps2eps/hardcode-deps.patch
+++ b/pkgs/tools/typesetting/ps2eps/hardcode-deps.patch
@@ -1,0 +1,26 @@
+diff --git i/src/perl/ps2eps w/src/perl/ps2eps
+index 1122a81..31d6a9a 100755
+--- i/src/perl/ps2eps
++++ w/src/perl/ps2eps
+@@ -43,19 +43,13 @@ Getopt::Long::Configure("no_ignore_case");
+ 
+ $prgname= "ps2eps";
+ 
+-if (! -d "/usr/bin")
+-{ # we assume that we are running under native windows
+-  $ghostscriptname = "gswin32c";
+-  $NULLDEV = "nul";
+-} 
+-else 
+ { # Unix or cygwin
+-  $ghostscriptname = "gs";
++  $ghostscriptname = "@gs@";
+   $NULLDEV = "/dev/null 2>&1";
+ }
+ 
+ $bboxver=`bbox >$NULLDEV -V`;
+-$bboxname= ($?== -1) ? "" : "bbox";
++$bboxname= ($?== -1) ? "" : "@bbox@";
+ $version= '$Id: ps2eps,v 1.70 2018-01-09 18:00:00 bless Exp $'; #'
+ $insertPScode= 1;     # Insert surrounding Postscript code
+ $infhandle = STDIN;   # Standard input is the default input file

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -33080,6 +33080,8 @@ with pkgs;
 
   ps2client = callPackage ../applications/networking/ps2client { };
 
+  ps2eps = callPackage ../tools/typesetting/ps2eps { };
+
   psi = libsForQt5.callPackage ../applications/networking/instant-messengers/psi { };
 
   psi-plus = libsForQt5.callPackage ../applications/networking/instant-messengers/psi-plus { };


### PR DESCRIPTION
###### Motivation for this change


###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
