### PR TITLE
figma-agent: init at 0.2.7

### DIFF
--- a/pkgs/applications/graphics/figma-agent/default.nix
+++ b/pkgs/applications/graphics/figma-agent/default.nix
@@ -1,0 +1,45 @@
+{ lib
+, fetchFromGitHub
+, rustPlatform
+, pkg-config
+, fontconfig
+, freetype
+, libclang
+}:
+let
+  inherit (rustPlatform) buildRustPackage bindgenHook;
+
+  version = "0.2.7";
+in
+buildRustPackage {
+  pname = "figma-agent";
+  inherit version;
+
+  src = fetchFromGitHub {
+    owner = "neetly";
+    repo = "figma-agent-linux";
+    rev = version;
+    sha256 = "sha256-Cq1hWNwJLBY9Bb41WFJxnr9fcygFZ8eNsn5cPXmGTyw=";
+  };
+
+  cargoSha256 = "sha256-Gc94Uk/Ikxjnb541flQL7AeblgU/yS6zQ/187ZGRYco=";
+
+  nativeBuildInputs = [ pkg-config ];
+
+  buildInputs = [
+    fontconfig
+    freetype
+    bindgenHook
+  ];
+
+  LIBCLANG_PATH = "${libclang.lib}/lib";
+
+  doCheck = true;
+
+  meta = with lib; {
+    homepage = "https://github.com/neetly/figma-agent-linux";
+    description = "Figma Agent for Linux (a.k.a. Font Helper)";
+    license = licenses.mit;
+    maintainers = with maintainers; [ ercao ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -542,6 +542,8 @@ with pkgs;
 
   expressvpn = callPackage ../applications/networking/expressvpn { };
 
+  figma-agent = callPackage ../applications/graphics/figma-agent { };
+
   figma-linux = callPackage ../applications/graphics/figma-linux { };
 
   firefly-desktop = callPackage ../applications/misc/firefly-desktop { };


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

[figma agent for linux](https://github.com/neetly/figma-agent-linux)


`nixpkgs-review` result: 
```shell
$ git -c fetch.prune=false fetch --no-tags --force https://github.com/NixOS/nixpkgs master:refs/nixpkgs-review/0
remote: Enumerating objects: 40, done.
remote: Counting objects: 100% (33/33), done.
remote: Compressing objects: 100% (24/24), done.
remote: Total 40 (delta 22), reused 10 (delta 9), pack-reused 7
Unpacking objects: 100% (40/40), 425.19 KiB | 974.00 KiB/s, done.
From https://github.com/NixOS/nixpkgs
   a3d8b7f691c..8c7ae65c39a  master     -> refs/nixpkgs-review/0
$ git worktree add /home/ercao/.cache/nixpkgs-review/rev-421684ab3ed929050423b1352c530a731cdd5043/nixpkgs 8c7ae65c39a4660529c1c0e4269aece58e4c44b4
Preparing worktree (detached HEAD 8c7ae65c39a)
Updating files: 100% (34428/34428), done.
HEAD is now at 8c7ae65c39a Merge pull request #225373 from fortuneteller2k/ncspot
$ nix-env --extra-experimental-features no-url-literals --option system x86_64-linux -f /home/ercao/.cache/nixpkgs-review/rev-421684ab3ed929050423b1352c530a731cdd5043/nixpkgs -qaP --xml --out-path --show-trace --no-allow-import-from-derivation
$ git merge --no-commit --no-ff 421684ab3ed929050423b1352c530a731cdd5043
Auto-merging pkgs/top-level/all-packages.nix
Automatic merge went well; stopped before committing as requested
$ nix-env --extra-experimental-features no-url-literals --option system x86_64-linux -f /home/ercao/.cache/nixpkgs-review/rev-421684ab3ed929050423b1352c530a731cdd5043/nixpkgs -qaP --xml --out-path --show-trace --no-allow-import-from-derivation --meta
1 package added:
figma-agent (init at 0.2.7)

$ nix build --extra-experimental-features nix-command no-url-literals --no-link --keep-going --no-allow-import-from-derivation --option build-use-sandbox relaxed -f /home/ercao/.cache/nixpkgs-review/rev-421684ab3ed929050423b1352c530a731cdd5043/build.nix
1 package built:
figma-agent
```

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
