### PR TITLE
kvmtool: unstable-2022-06-09 -> unstable-2023-04-06

### DIFF
--- a/pkgs/applications/virtualization/kvmtool/default.nix
+++ b/pkgs/applications/virtualization/kvmtool/default.nix
@@ -1,23 +1,31 @@
-{ stdenv, fetchgit, lib }:
+{ stdenv, fetchgit, lib, dtc }:
 
 stdenv.mkDerivation {
   pname = "kvmtool";
-  version = "unstable-2022-06-09";
+  version = "unstable-2023-04-06";
+
+  buildInputs = lib.optionals stdenv.hostPlatform.isAarch64 [ dtc ];
 
   src = fetchgit {
     url = "https://git.kernel.org/pub/scm/linux/kernel/git/will/kvmtool.git";
-    rev = "f44af23e3a62e46158341807b0d2d132249b96a8";
-    sha256 = "sha256-M83dCCXU/fkh21x10vx6BLg9Wja1714qW7yxl5zY6z0=";
+    rev = "77b108c6a6f1c66fb7f60a80d17596bb80bda8ad";
+    sha256 = "sha256-wPhqjVpc6I9UOdb6lmzGh797sdvJ5q4dap2ssg8OY5E=";
   };
 
   enableParallelBuilding = true;
-  makeFlags = [ "prefix=${placeholder "out"}" ];
+  makeFlags = [ "prefix=${placeholder "out"}"
+    ] ++ lib.optionals stdenv.hostPlatform.isAarch64 [
+      "LIBFDT_DIR=${dtc}/lib"
+    ] ++ lib.optionals ((stdenv.buildPlatform != stdenv.hostPlatform) && stdenv.hostPlatform.isAarch64) [
+      "CROSS_COMPILE=aarch64-unknown-linux-gnu-"
+      "ARCH=arm64"
+    ];
 
   meta = with lib; {
     description = "A lightweight tool for hosting KVM guests";
     homepage = "https://git.kernel.org/pub/scm/linux/kernel/git/will/kvmtool.git/tree/README";
     license = licenses.gpl2Only;
     maintainers = with maintainers; [ astro ];
-    platforms = [ "x86_64-linux" ];
+    platforms = [ "x86_64-linux" "aarch64-linux" ];
   };
 }


### PR DESCRIPTION
###### Description of changes

Updated package version, there has many fixes regarding arm-support since last update. Added aarch64-linux support, it needs libfdt from dtc (for device trees). Also added support for cross-compilation

###### Things done

Tested on both x86_64-linux and aarch64-linux that virtual machine actually starts and it is possible to connect to it using SSH

- Built on platform(s)
  - [X] x86_64-linux
  - [X] aarch64-linux
  - [X] x86_64-linux.pkgsCross.aarch64-multiplatform
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
