### PR TITLE
lib/generators: add toLua/mkLuaInline

### DIFF
--- a/lib/generators.nix
+++ b/lib/generators.nix
@@ -428,26 +428,37 @@ ${expr "" v}
       builtins.toJSON v;
 
   /*
-   * Translate a simple Nix expression to Lua representation with occasional
-   * Lua-inlines that can be construted by mkLuaInline function.
-   *
-   * generators.toLua {} {
-   *   cmd = [ "typescript-language-server" "--stdio" ];
-   *   settings.workspace.library = mkLuaInline ''vim.api.nvim_get_runtime_file("", true)'';
-   * }
-   *
-   *> {
-   *>   ["cmd"] = {
-   *>     "typescript-language-server",
-   *>     "--stdio"
-   *>   },
-   *>   ["settings"] = {
-   *>     ["workspace"] = {
-   *>       ["library"] = (vim.api.nvim_get_runtime_file("", true))
-   *>     }
-   *>   }
-   *> }
-   */
+   Translate a simple Nix expression to Lua representation with occasional
+   Lua-inlines that can be construted by mkLuaInline function.
+
+   Configuration:
+     * indent - initial indent.
+
+   Attention:
+     Regardless of multiline parameter there is no trailing newline.
+
+   Example:
+     generators.toLua {}
+       {
+         cmd = [ "typescript-language-server" "--stdio" ];
+         settings.workspace.library = mkLuaInline ''vim.api.nvim_get_runtime_file("", true)'';
+       }
+     ->
+      {
+        ["cmd"] = {
+          "typescript-language-server",
+          "--stdio"
+        },
+        ["settings"] = {
+          ["workspace"] = {
+            ["library"] = (vim.api.nvim_get_runtime_file("", true))
+          }
+        }
+      }
+
+   Type:
+     toLua :: AttrSet -> Any -> String
+  */
   toLua = { indent ? "" }@args: v:
     with builtins;
     let
@@ -478,7 +489,10 @@ ${expr "" v}
       abort "generators.toLua: type ${typeOf v} is unsupported";
 
   /*
-   * Mark string as Lua expression to be inlined when processed by toLua.
-   */
+   Mark string as Lua expression to be inlined when processed by toLua.
+
+   Type:
+     mkLuaInline :: String -> AttrSet
+  */
   mkLuaInline = expr: { _type = "lua-inline"; inherit expr; };
 }

--- a/lib/tests/misc.nix
+++ b/lib/tests/misc.nix
@@ -950,11 +950,16 @@ runTests {
   };
 
   testToLuaAttrsetWithSpaceInKey = {
-    expr = generators.toLua {} { "some space and double-quote (\")" = generators.mkLuaInline ''"abc" .. "def"''; };
+    expr = generators.toLua {} { "some space and double-quote (\")" = 42; };
     expected = ''
       {
-        ["some space and double-quote (\")"] = ("abc" .. "def")
+        ["some space and double-quote (\")"] = 42
       }'';
+  };
+
+  testToLuaWithoutMultiline = {
+    expr = generators.toLua { multiline = false; } [ 41 43 ];
+    expected = ''{ 41, 43 }'';
   };
 
   testToLuaBasicExample = {

--- a/lib/tests/misc.nix
+++ b/lib/tests/misc.nix
@@ -915,6 +915,67 @@ runTests {
   };
 
 
+  testToLuaEmptyAttrSet = {
+    expr = generators.toLua {} {};
+    expected = ''{}'';
+  };
+
+  testToLuaEmptyList = {
+    expr = generators.toLua {} [];
+    expected = ''{}'';
+  };
+
+  testToLuaListOfVariousTypes = {
+    expr = generators.toLua {} [ null 43 3.14159 true ];
+    expected = ''
+      {
+        nil,
+        43,
+        3.14159,
+        true
+      }'';
+  };
+
+  testToLuaString = {
+    expr = generators.toLua {} ''double-quote (") and single quotes (')'';
+    expected = ''"double-quote (\") and single quotes (')"'';
+  };
+
+  testToLuaAttrsetWithLuaInline = {
+    expr = generators.toLua {} { x = generators.mkLuaInline ''"abc" .. "def"''; };
+    expected = ''
+      {
+        ["x"] = ("abc" .. "def")
+      }'';
+  };
+
+  testToLuaAttrsetWithSpaceInKey = {
+    expr = generators.toLua {} { "some space and double-quote (\")" = generators.mkLuaInline ''"abc" .. "def"''; };
+    expected = ''
+      {
+        ["some space and double-quote (\")"] = ("abc" .. "def")
+      }'';
+  };
+
+  testToLuaBasicExample = {
+    expr = generators.toLua {} {
+      cmd = [ "typescript-language-server" "--stdio" ];
+      settings.workspace.library = generators.mkLuaInline ''vim.api.nvim_get_runtime_file("", true)'';
+    };
+    expected = ''
+      {
+        ["cmd"] = {
+          "typescript-language-server",
+          "--stdio"
+        },
+        ["settings"] = {
+          ["workspace"] = {
+            ["library"] = (vim.api.nvim_get_runtime_file("", true))
+          }
+        }
+      }'';
+  };
+
 # CLI
 
   testToGNUCommandLine = {


### PR DESCRIPTION
###### Description of changes

Add a generator for translating Nix values to Lua values. Not yet used within this repository, but useful for writing Neovim Lua configs that can benefit from settings merges.

`mkLuaInline` - is there for lifting string as a plain Lua code that requires no escapes. E.g. call vim Lua functions.

Main use-case is to write config module for `neovim-lspconfig` and benefit from settings being merged.

Example:
```nix
toLua {} {
  cmd = [
    "${pkgs.nodePackages.typescript-language-server}/bin/typescript-language-server" "--stdio"
    "--tsserver-path" "${pkgs.nodePackages.typescript}/lib/node_modules/typescript/lib/"
  ];
  settings.workspace.library = mkLuaInline ''vim.api.nvim_get_runtime_file("", true)'';
}
```
```lua
{
  cmd = {
    "/nix/store/gyan9yc62dlqd63vb03ydd4ahnzjamnp-typescript-language-server-2.1.0/bin/typescript-language-server",
    "--stdio",
    "--tsserver-path",
    "/nix/store/dsjnz3gk4imdpby5s7g71schw1jyf207-typescript-4.8.4/lib/node_modules/typescript/lib/"
  },
  settings = {
    workspace = {
      library = (vim.api.nvim_get_runtime_file("", true))
    }
  }
}
```


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

P.S. Inspired by `toDhall` 1cd48efa96bc677bfbf7111bd116d092521c3914