### PR TITLE
crunchy-cli: init at 3.0.0-dev.10

### DIFF
--- a/pkgs/applications/video/crunchy-cli/default.nix
+++ b/pkgs/applications/video/crunchy-cli/default.nix
@@ -1,0 +1,44 @@
+{ lib
+, stdenv
+, clangStdenv
+, darwin
+, xcbuild
+, openssl
+, pkg-config
+, rustPlatform
+, fetchFromGitHub
+}:
+
+rustPlatform.buildRustPackage.override { stdenv = clangStdenv; } rec {
+  pname = "crunchy-cli";
+  version = "3.0.0-dev.10";
+
+  src = fetchFromGitHub {
+    owner = "crunchy-labs";
+    repo = pname;
+    rev = "v${version}";
+    hash = "sha256-uc19SmVfa5BZYDidlEgV6GNvcm9Dj0mSjdwHP5S+O4A=";
+  };
+
+  cargoHash = "sha256-H3D55qMUAF6t45mRbGZl+DORAl1H1a7AOe+lQP0WUUQ=";
+
+  nativeBuildInputs = [
+    pkg-config
+  ] ++ lib.optionals stdenv.isDarwin [
+    xcbuild
+  ];
+
+  buildInputs = [
+    openssl
+  ] ++ lib.optionals stdenv.isDarwin [
+    darwin.apple_sdk.frameworks.Security
+  ];
+
+  meta = with lib; {
+    description = "A pure Rust written Crunchyroll cli client and downloader";
+    homepage = "https://github.com/crunchy-labs/crunchy-cli";
+    license = with licenses; [ gpl3 ];
+    maintainers = with maintainers; [ stepbrobd ];
+  };
+}
+

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4358,6 +4358,8 @@ with pkgs;
 
   crunch = callPackage ../tools/security/crunch { };
 
+  crunchy-cli = callPackage ../applications/video/crunchy-cli { };
+
   crudini = callPackage ../tools/misc/crudini { };
 
   csv2odf = callPackage ../applications/office/csv2odf { };


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Added [`crunchy-cli`](https://github.com/crunchy-labs/crunchy-cli), the authors of this repo is in the process of rewriting `crunchy-cli` from Go to Rust, it's still not compete yet but most features are already in there. I'll switch the pre-release to stable release once the authors releases a stable version written in Rust (current stable release is still in Go).

Result of `nix run nixpkgs#nixpkgs-review -- pr 225502`:

```shell
# on aarch64-darwin
$ nix run nixpkgs#nixpkgs-review -- pr 225502
...
1 package added:
crunchy-cli (init at 3.0.0-dev.10)
...
1 package built:
crunchy-cli
...
```

```shell
# on x86_64-linux (Debian)
$ nix run nixpkgs#nixpkgs-review -- pr 225502
...
1 package added:
crunchy-cli (init at 3.0.0-dev.10)
...
1 package built:
crunchy-cli
...
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
