### PR TITLE
dpkg: add setup-hook for unpacking .deb files

### DIFF
--- a/pkgs/servers/jibri/default.nix
+++ b/pkgs/servers/jibri/default.nix
@@ -21,7 +21,6 @@ stdenv.mkDerivation rec {
 
   dontBuild = true;
   nativeBuildInputs = [ dpkg makeWrapper ];
-  unpackCmd = "dpkg-deb -x $src debcontents";
 
   installPhase = ''
     runHook preInstall

--- a/pkgs/tools/package-management/dpkg/default.nix
+++ b/pkgs/tools/package-management/dpkg/default.nix
@@ -71,6 +71,8 @@ stdenv.mkDerivation rec {
       cp -r scripts/t/origins $out/etc/dpkg
     '';
 
+  setupHook = ./setup-hook.sh;
+
   meta = with lib; {
     description = "The Debian package manager";
     homepage = "https://wiki.debian.org/Teams/Dpkg";

--- a/pkgs/tools/package-management/dpkg/setup-hook.sh
+++ b/pkgs/tools/package-management/dpkg/setup-hook.sh
@@ -1,0 +1,12 @@
+unpackCmdHooks+=(_tryDpkgDeb)
+_tryDpkgDeb() {
+    if ! [[ "$curSrc" =~ \.deb$ ]]; then return 1; fi
+    # Don't use dpkg-deb -x as that will error if the archive contains a file
+    # or directory with a setuid bit in its permissions. This is because dpkg
+    # calls tar internally with the -p flag, preserving file permissions.
+    #
+    # We instead only use dpkg-deb to extract the tarfile containing the files
+    # we want from the .deb, then finish extracting with tar directly.
+    mkdir root
+    dpkg-deb --fsys-tarfile "$curSrc" | tar --extract --directory=root
+}


### PR DESCRIPTION
###### Description of changes
Implementation for #219937. Adds a setup hook for `dpkg` that adds a hook for unpacking `.deb` files to `unpackCmdHook`.

###### TODO
- [ ] Convert existing packages that manually set `unpackCmd` or `unpackPhase` to use the built-in hook.
  - Should we also convert `fetchurl` to `fetchzip`?
- [ ] Add documentation on this, specifically for packaging binary packages in a `.deb` format.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
