### PR TITLE
openai-whisper: 20230124 -> 20230314

### DIFF
--- a/pkgs/development/python-modules/openai-whisper/default.nix
+++ b/pkgs/development/python-modules/openai-whisper/default.nix
@@ -92,6 +92,6 @@ buildPythonPackage rec {
     description = "General-purpose speech recognition model";
     homepage = "https://github.com/openai/whisper";
     license = licenses.mit;
-    maintainers = with maintainers; [ hexa ];
+    maintainers = with maintainers; [ hexa MayNiklas ];
   };
 }

--- a/pkgs/development/python-modules/openai-whisper/default.nix
+++ b/pkgs/development/python-modules/openai-whisper/default.nix
@@ -2,6 +2,7 @@
 , fetchFromGitHub
 , buildPythonPackage
 , substituteAll
+, cudaSupport ? false
 
 # runtime
 , ffmpeg
@@ -9,10 +10,15 @@
 # propagates
 , numpy
 , torch
+, torchWithCuda
 , tqdm
 , more-itertools
 , transformers
 , ffmpeg-python
+, numba
+, openai-triton
+, scipy
+, tiktoken
 
 # tests
 , pytestCheckHook
@@ -20,14 +26,14 @@
 
 buildPythonPackage rec {
   pname = "whisper";
-  version = "20230124";
+  version = "20230314";
   format = "setuptools";
 
   src = fetchFromGitHub {
     owner = "openai";
     repo = pname;
     rev = "refs/tags/v${version}";
-    hash = "sha256-+3fs/EXK5NGlISuMTk7r2ZZ4tNFKbNFNkVS2LmHBvwk=";
+    hash = "sha256-qQCELjRFeRCT1k1CBc3netRtFvt+an/EbkrgnmiX/mc=";
   };
 
   patches = [
@@ -39,12 +45,30 @@ buildPythonPackage rec {
 
   propagatedBuildInputs = [
     numpy
-    torch
     tqdm
     more-itertools
     transformers
     ffmpeg-python
+    numba
+    scipy
+    tiktoken
+  ] ++ lib.optionals (!cudaSupport) [
+    torch
+  ] ++ lib.optionals (cudaSupport) [
+    openai-triton
+    torchWithCuda
   ];
+
+  postPatch = ''
+    substituteInPlace requirements.txt \
+      --replace "tiktoken==0.3.1" "tiktoken>=0.3.1"
+  ''
+  # openai-triton is only needed for CUDA support.
+  # triton needs CUDA to be build.
+  # -> by making it optional, we can build whisper without unfree packages enabled
+  + lib.optionalString (!cudaSupport) ''
+    sed -i '/if sys.platform.startswith("linux") and platform.machine() == "x86_64":/{N;d}' setup.py
+  '';
 
   preCheck = ''
     export HOME=$TMPDIR
@@ -56,14 +80,18 @@ buildPythonPackage rec {
 
   disabledTests = [
     # requires network access to download models
+    "test_tokenizer"
     "test_transcribe"
+    # requires NVIDIA drivers
+    "test_dtw_cuda_equivalence"
+    "test_median_filter_equivalence"
   ];
 
   meta = with lib; {
+    changelog = "https://github.com/openai/whisper/blob/v$[version}/CHANGELOG.md";
     description = "General-purpose speech recognition model";
     homepage = "https://github.com/openai/whisper";
     license = licenses.mit;
     maintainers = with maintainers; [ hexa ];
   };
 }
-

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -6813,7 +6813,9 @@ self: super: with self; {
 
   openai-triton = callPackage ../development/python-modules/openai-triton { llvmPackages = pkgs.llvmPackages_rocm; };
 
-  openai-whisper = callPackage ../development/python-modules/openai-whisper { };
+  openai-whisper = callPackage ../development/python-modules/openai-whisper {
+    cudaSupport = pkgs.config.cudaSupport or false;
+  };
 
   openant = callPackage ../development/python-modules/openant { };
 


### PR DESCRIPTION
###### Description of changes

This week, two PR's got merged making this update possible:
We now have Tiktoken & Triton in NixPkgs!

This is a simple version bump, needing additional dependencies.

OpenAI introduced additional tests - some of them we can't run:
- they require network access
- they require access to the NVIDIA driver

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
