### PR TITLE
python310Packages.espeak-phonemizer: 1.1.0 -> 1.2.0

### DIFF
--- a/pkgs/development/python-modules/espeak-phonemizer/cdll.patch
+++ b/pkgs/development/python-modules/espeak-phonemizer/cdll.patch
@@ -1,14 +1,10 @@
 diff --git a/espeak_phonemizer/__init__.py b/espeak_phonemizer/__init__.py
-index a09472e..730a7f9 100644
+index 44cd943..adeaeba 100644
 --- a/espeak_phonemizer/__init__.py
 +++ b/espeak_phonemizer/__init__.py
-@@ -163,14 +163,10 @@ class Phonemizer:
+@@ -150,11 +150,7 @@ class Phonemizer:
              # Already initialized
              return
- 
--        self.libc = ctypes.cdll.LoadLibrary("libc.so.6")
-+        self.libc = ctypes.cdll.LoadLibrary("@libc@")
-         self.libc.open_memstream.restype = ctypes.POINTER(ctypes.c_char)
  
 -        try:
 -            self.lib_espeak = ctypes.cdll.LoadLibrary("libespeak-ng.so")

--- a/pkgs/development/python-modules/espeak-phonemizer/default.nix
+++ b/pkgs/development/python-modules/espeak-phonemizer/default.nix
@@ -2,27 +2,25 @@
 , buildPythonPackage
 , fetchFromGitHub
 , substituteAll
-, glibc
 , espeak-ng
 , pytestCheckHook
 }:
 
 buildPythonPackage rec {
   pname = "espeak-phonemizer";
-  version = "1.1.0";
+  version = "1.2.0";
   format = "setuptools";
 
   src = fetchFromGitHub {
     owner = "rhasspy";
     repo = "espeak-phonemizer";
     rev = "refs/tags/v${version}";
-    hash = "sha256-qnJtS5iIARdg+umolzLHT3/nLon9syjxfTnMWHOmYPU=";
+    hash = "sha256-FiajWpxSDRxTiCj8xGHea4e0voqOvaX6oQYB72FkVbw=";
   };
 
   patches = [
     (substituteAll {
       src = ./cdll.patch;
-      libc = "${lib.getLib glibc}/lib/libc.so.6";
       libespeak_ng = "${lib.getLib espeak-ng}/lib/libespeak-ng.so";
     })
   ];


### PR DESCRIPTION
https://github.com/rhasspy/espeak-phonemizer/releases/tag/v1.2.0

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
