### PR TITLE
qt6: general cleanup to ease future reworking of packaging

### DIFF
--- a/pkgs/development/libraries/qt-6/default.nix
+++ b/pkgs/development/libraries/qt-6/default.nix
@@ -2,22 +2,11 @@
 , lib
 , stdenv
 , fetchurl
-, fetchgit
 , fetchpatch
-, fetchFromGitHub
 , makeSetupHook
 , makeWrapper
-, bison
-, cups
-, harfbuzz
-, libGL
-, perl
 , cmake
-, ninja
-, writeText
 , gst_all_1
-, gtk3
-, dconf
 , libglvnd
 , darwin
 , buildPackages
@@ -54,7 +43,7 @@ let
       qtbase = callPackage ./modules/qtbase.nix {
         withGtk3 = true;
         inherit (srcs.qtbase) src version;
-        inherit bison cups harfbuzz libGL dconf gtk3 developerBuild;
+        inherit developerBuild;
         inherit (darwin.apple_sdk_11_0.frameworks) AGL AVFoundation AppKit GSS MetalKit;
         patches = [
           ./patches/qtbase-qmake-mkspecs-mac.patch

--- a/pkgs/development/libraries/qt-6/default.nix
+++ b/pkgs/development/libraries/qt-6/default.nix
@@ -38,7 +38,7 @@ let
 
       inherit callPackage srcs;
 
-      qtModule = callPackage ./qtModule.nix { inherit self; };
+      qtModule = callPackage ./qtModule.nix { };
 
       qtbase = callPackage ./modules/qtbase.nix {
         withGtk3 = true;

--- a/pkgs/development/libraries/qt-6/default.nix
+++ b/pkgs/development/libraries/qt-6/default.nix
@@ -35,7 +35,15 @@ let
 
   addPackages = self: with self;
     let
-      callPackage = self.newScope ({ inherit qtModule stdenv srcs cmake; });
+      callPackage = self.newScope ({
+        inherit qtModule srcs;
+        stdenv = if stdenv.isDarwin then darwin.apple_sdk_11_0.stdenv else stdenv;
+        cmake = cmake.overrideAttrs (attrs: {
+          patches = attrs.patches ++ [
+            ./patches/cmake.patch
+          ];
+        });
+      });
     in
     {
 
@@ -46,7 +54,7 @@ let
       qtbase = callPackage ./modules/qtbase.nix {
         withGtk3 = true;
         inherit (srcs.qtbase) src version;
-        inherit bison cups harfbuzz libGL dconf gtk3 developerBuild cmake;
+        inherit bison cups harfbuzz libGL dconf gtk3 developerBuild;
         inherit (darwin.apple_sdk_11_0.frameworks) AGL AVFoundation AppKit GSS MetalKit;
         patches = [
           ./patches/qtbase-qmake-mkspecs-mac.patch

--- a/pkgs/development/libraries/qt-6/default.nix
+++ b/pkgs/development/libraries/qt-6/default.nix
@@ -33,18 +33,15 @@ let
     mirror = "mirror://qt";
   };
 
-  qtModule =
-    import ./qtModule.nix
-      { inherit stdenv lib perl cmake ninja writeText; }
-      { inherit self srcs; };
-
   addPackages = self: with self;
     let
-      callPackage = self.newScope ({ inherit qtModule stdenv srcs; });
+      callPackage = self.newScope ({ inherit qtModule stdenv srcs cmake; });
     in
     {
 
-      inherit callPackage qtModule srcs;
+      inherit callPackage srcs;
+
+      qtModule = callPackage ./qtModule.nix { inherit self; };
 
       qtbase = callPackage ./modules/qtbase.nix {
         withGtk3 = true;

--- a/pkgs/development/libraries/qt-6/default.nix
+++ b/pkgs/development/libraries/qt-6/default.nix
@@ -58,7 +58,7 @@ let
           })
         ];
       };
-      env = callPackage ./qt-env.nix {};
+      env = callPackage ./qt-env.nix { };
       full = env "qt-full-${qtbase.version}" ([
         qt3d
         qt5compat
@@ -130,19 +130,21 @@ let
         inherit (darwin.apple_sdk_11_0.frameworks) WebKit;
       };
 
-      wrapQtAppsHook = makeSetupHook {
-        name = "wrap-qt6-apps-hook";
-        propagatedBuildInputs = [ buildPackages.makeWrapper ];
+      wrapQtAppsHook = makeSetupHook
+        {
+          name = "wrap-qt6-apps-hook";
+          propagatedBuildInputs = [ buildPackages.makeWrapper ];
         } ./hooks/wrap-qt-apps-hook.sh;
 
-      qmake = makeSetupHook {
-        name = "qmake6-hook";
-        propagatedBuildInputs = [ self.qtbase.dev ];
-        substitutions = {
-          inherit debug;
-          fix_qmake_libtool = ./hooks/fix-qmake-libtool.sh;
-        };
-      } ./hooks/qmake-hook.sh;
+      qmake = makeSetupHook
+        {
+          name = "qmake6-hook";
+          propagatedBuildInputs = [ self.qtbase.dev ];
+          substitutions = {
+            inherit debug;
+            fix_qmake_libtool = ./hooks/fix-qmake-libtool.sh;
+          };
+        } ./hooks/qmake-hook.sh;
     };
 
   # TODO(@Artturin): convert to makeScopeWithSplicing

--- a/pkgs/development/libraries/qt-6/default.nix
+++ b/pkgs/development/libraries/qt-6/default.nix
@@ -15,11 +15,7 @@
 , cmake
 , ninja
 , writeText
-, gstreamer
-, gst-plugins-base
-, gst-plugins-good
-, gst-libav
-, gst-vaapi
+, gst_all_1
 , gtk3
 , dconf
 , libglvnd
@@ -111,7 +107,7 @@ let
       qtlanguageserver = callPackage ./modules/qtlanguageserver.nix { };
       qtlottie = callPackage ./modules/qtlottie.nix { };
       qtmultimedia = callPackage ./modules/qtmultimedia.nix {
-        inherit gstreamer gst-plugins-base gst-plugins-good gst-libav gst-vaapi;
+        inherit (gst_all_1) gstreamer gst-plugins-base gst-plugins-good gst-libav gst-vaapi;
         inherit (darwin.apple_sdk_11_0.frameworks) VideoToolbox;
       };
       qtnetworkauth = callPackage ./modules/qtnetworkauth.nix { };

--- a/pkgs/development/libraries/qt-6/qtModule.nix
+++ b/pkgs/development/libraries/qt-6/qtModule.nix
@@ -1,4 +1,4 @@
-{ stdenv, lib, perl, cmake, ninja, writeText, self, srcs, patches ? [ ] }:
+{ stdenv, lib, perl, cmake, ninja, writeText, qtbase, qmake, srcs, patches ? [ ] }:
 
 args:
 
@@ -16,7 +16,7 @@ stdenv.mkDerivation (args // {
     perl
     cmake
     ninja
-    self.qmake
+    qmake
   ];
   propagatedBuildInputs = args.qtInputs ++ (args.propagatedBuildInputs or [ ]);
 
@@ -59,7 +59,7 @@ stdenv.mkDerivation (args // {
       if [[ -z "$dontSyncQt" && -f sync.profile ]]; then
         # FIXME: this probably breaks crosscompiling as it's not from nativeBuildInputs
         # I don't know how to get /libexec from nativeBuildInputs to work, it's not under /bin
-        ${lib.getDev self.qtbase}/libexec/syncqt.pl -version "''${version%%-*}"
+        ${lib.getDev qtbase}/libexec/syncqt.pl -version "''${version%%-*}"
       fi
     '';
 

--- a/pkgs/development/libraries/qt-6/qtModule.nix
+++ b/pkgs/development/libraries/qt-6/qtModule.nix
@@ -1,6 +1,4 @@
-{ stdenv, lib, perl, cmake, ninja, writeText }:
-
-{ self, srcs, patches ? [ ] }:
+{ stdenv, lib, perl, cmake, ninja, writeText, self, srcs, patches ? [ ] }:
 
 args:
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -23216,15 +23216,7 @@ with pkgs;
   qtEnv = qt5.env;
   qt5Full = qt5.full;
 
-  qt6 = recurseIntoAttrs
-    (callPackage ../development/libraries/qt-6 {
-      stdenv = if stdenv.isDarwin then darwin.apple_sdk_11_0.stdenv else stdenv;
-      cmake = cmake.overrideAttrs (attrs: {
-        patches = attrs.patches ++ [
-          ../development/libraries/qt-6/patches/cmake.patch
-        ];
-      });
-    });
+  qt6 = recurseIntoAttrs (callPackage ../development/libraries/qt-6 { });
 
   qt6Packages = recurseIntoAttrs (import ./qt6-packages.nix {
     inherit lib pkgs qt6;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -23216,13 +23216,8 @@ with pkgs;
   qtEnv = qt5.env;
   qt5Full = qt5.full;
 
-  qt6 = recurseIntoAttrs (makeOverridable
-    (import ../development/libraries/qt-6) {
-      inherit newScope;
-      inherit lib fetchurl fetchpatch fetchgit fetchFromGitHub makeSetupHook makeWrapper writeText;
-      inherit bison cups dconf harfbuzz libGL perl gtk3 ninja;
-      inherit (gst_all_1) gstreamer gst-plugins-base gst-plugins-good gst-libav gst-vaapi;
-      inherit darwin buildPackages libglvnd;
+  qt6 = recurseIntoAttrs
+    (callPackage ../development/libraries/qt-6 {
       stdenv = if stdenv.isDarwin then darwin.apple_sdk_11_0.stdenv else stdenv;
       cmake = cmake.overrideAttrs (attrs: {
         patches = attrs.patches ++ [


### PR DESCRIPTION
###### Description of changes
In https://github.com/NixOS/nixpkgs/pull/224469, we noticed strange issues with cmake, likely introduced by our non standard qt packaging. And I'd like to take this as a chance to rework qt6 packaging to follow more closely with the upstream build system. To reduce the burden in the process, here lies some preparatory cleanups.
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
