### PR TITLE
python3Packages.asyncua: 1.0.1 -> 1.0.2

### DIFF
--- a/pkgs/development/python-modules/asyncua/default.nix
+++ b/pkgs/development/python-modules/asyncua/default.nix
@@ -16,7 +16,7 @@
 
 buildPythonPackage rec {
   pname = "asyncua";
-  version = "1.0.1";
+  version = "1.0.2";
   format = "setuptools";
 
   disabled = pythonOlder "3.8";
@@ -25,7 +25,8 @@ buildPythonPackage rec {
     owner = "FreeOpcUa";
     repo = "opcua-asyncio";
     rev = "refs/tags/v${version}";
-    hash = "sha256-6A4z+tiQ2oUlB9t44wlW64j5sjWFMAgqT3Xt0FdJCBs=";
+    hash = "sha256-DnBxR4nD3dBBhiElDuRgljHaoBPiakdjY/VFn3VsKEQ=";
+    fetchSubmodules = true;
   };
 
   postPatch = ''

--- a/pkgs/development/python-modules/asyncua/default.nix
+++ b/pkgs/development/python-modules/asyncua/default.nix
@@ -33,6 +33,11 @@ buildPythonPackage rec {
     # https://github.com/FreeOpcUa/opcua-asyncio/issues/1263
     substituteInPlace setup.py \
       --replace ", 'asynctest'" ""
+
+    # Workaround hardcoded paths in test
+    # "test_cli_tools_which_require_sigint"
+    substituteInPlace tests/test_tools.py \
+      --replace "tools/" "$out/bin/"
   '';
 
   propagatedBuildInputs = [
@@ -53,11 +58,6 @@ buildPythonPackage rec {
 
   pythonImportsCheck = [
     "asyncua"
-  ];
-
-  disabledTests = [
-    # Hard coded path only works from root of src
-    "test_cli_tools_which_require_sigint"
   ];
 
   meta = with lib; {


### PR DESCRIPTION
###### Description of changes

There is no good changelog, just "[many bug fixes. See commits for details](https://github.com/FreeOpcUa/opcua-asyncio/releases/tag/v1.0.2)".
Commits: https://github.com/FreeOpcUa/opcua-asyncio/compare/v1.0.1...v1.0.2

I reenabled the CLI tools test with a workaround. If you don't like it and prefer it disabled, I can remove the commit. If the commit should be squashed with the update, I can also do that.

Maintainer(s): @harvidsen

###### Things done

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [X] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

Result of `nixpkgs-review` run on x86_64-linux [1](https://github.com/Mic92/nixpkgs-review)
<details>
  <summary>4 packages built:</summary>
  <ul>
    <li>python310Packages.asyncua</li>
    <li>python310Packages.asyncua.dist</li>
    <li>python311Packages.asyncua</li>
    <li>python311Packages.asyncua.dist</li>
  </ul>
</details>