### PR TITLE
gnomeExtensions.gsconnect: 54 -> 55

### DIFF
--- a/pkgs/desktops/gnome/extensions/gsconnect/default.nix
+++ b/pkgs/desktops/gnome/extensions/gsconnect/default.nix
@@ -23,7 +23,7 @@
 
 stdenv.mkDerivation rec {
   pname = "gnome-shell-extension-gsconnect";
-  version = "54";
+  version = "55";
 
   outputs = [ "out" "installedTests" ];
 
@@ -31,7 +31,7 @@ stdenv.mkDerivation rec {
     owner = "GSConnect";
     repo = "gnome-shell-extension-gsconnect";
     rev = "v${version}";
-    hash = "sha256-Dt5T5luuKpSkoOs6MjOBg/yMm52hRfymKBeRklPWy+M=";
+    hash = "sha256-n6NbNgl+2FOhly/BeR7I6BvPOYe7leAdeAegaqhcGJU=";
   };
 
   patches = [

--- a/pkgs/desktops/gnome/extensions/gsconnect/fix-paths.patch
+++ b/pkgs/desktops/gnome/extensions/gsconnect/fix-paths.patch
@@ -1,8 +1,8 @@
 diff --git a/data/org.gnome.Shell.Extensions.GSConnect.desktop.in b/data/org.gnome.Shell.Extensions.GSConnect.desktop.in
-index ffb23342..b405c73b 100644
+index 3fb887c3..e8cbe1bd 100644
 --- a/data/org.gnome.Shell.Extensions.GSConnect.desktop.in
 +++ b/data/org.gnome.Shell.Extensions.GSConnect.desktop.in
-@@ -1,7 +1,7 @@
+@@ -5,7 +5,7 @@
  [Desktop Entry]
  Type=Application
  Name=GSConnect
@@ -12,10 +12,11 @@ index ffb23342..b405c73b 100644
  NoDisplay=true
  Icon=org.gnome.Shell.Extensions.GSConnect
 diff --git a/src/extension.js b/src/extension.js
-index e7fd971a..8474bb3b 100644
+index 3fae443a..7aa19842 100644
 --- a/src/extension.js
 +++ b/src/extension.js
-@@ -1,5 +1,7 @@
+@@ -4,6 +4,8 @@
+ 
  'use strict';
  
 +'@typelibPath@'.split(':').forEach(path => imports.gi.GIRepository.Repository.prepend_search_path(path));
@@ -24,10 +25,11 @@ index e7fd971a..8474bb3b 100644
  const GObject = imports.gi.GObject;
  const Gtk = imports.gi.Gtk;
 diff --git a/src/prefs.js b/src/prefs.js
-index 922ea60c..2cd62eb5 100644
+index b8860c82..d6292606 100644
 --- a/src/prefs.js
 +++ b/src/prefs.js
-@@ -1,5 +1,7 @@
+@@ -4,6 +4,8 @@
+ 
  'use strict';
  
 +'@typelibPath@'.split(':').forEach(path => imports.gi.GIRepository.Repository.prepend_search_path(path));

--- a/pkgs/desktops/gnome/extensions/gsconnect/installed-tests-path.patch
+++ b/pkgs/desktops/gnome/extensions/gsconnect/installed-tests-path.patch
@@ -1,8 +1,11 @@
 diff --git a/installed-tests/meson.build b/installed-tests/meson.build
-index c7eff2fb..ef4f6052 100644
+index 5bc38bfd..02404c3a 100644
 --- a/installed-tests/meson.build
 +++ b/installed-tests/meson.build
-@@ -1,5 +1,5 @@
+@@ -2,8 +2,8 @@
+ #
+ # SPDX-License-Identifier: GPL-2.0-or-later
+ 
 -installed_tests_execdir = join_paths(libexecdir, 'installed-tests', meson.project_name())
 -installed_tests_metadir = join_paths(datadir, 'installed-tests', meson.project_name())
 +installed_tests_execdir = join_paths(get_option('installed_test_prefix'), 'libexec', 'installed-tests', meson.project_name())
@@ -11,10 +14,10 @@ index c7eff2fb..ef4f6052 100644
  installed_tests_srcdir = meson.current_source_dir()
  installed_tests_builddir = meson.current_build_dir()
 diff --git a/meson_options.txt b/meson_options.txt
-index 8912e052..ca6ee5eb 100644
+index 745c541c..b4b602ca 100644
 --- a/meson_options.txt
 +++ b/meson_options.txt
-@@ -116,6 +116,13 @@ option(
+@@ -104,6 +104,13 @@ option(
    description: 'Native Messaging Host directory for Mozilla'
  )
  


### PR DESCRIPTION
###### Description of changes
gnomeExtensions.gsconnect: 54 -> 55

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
