### PR TITLE
nixos/sslh: fix default config

### DIFF
--- a/nixos/modules/services/networking/sslh.nix
+++ b/nixos/modules/services/networking/sslh.nix
@@ -6,12 +6,12 @@ let
   cfg = config.services.sslh;
   user = "sslh";
   configFile = pkgs.writeText "sslh.conf" ''
-    verbose: ${boolToString cfg.verbose};
+    ${lib.optionalString cfg.verbose "verbose: 1"}
     foreground: true;
     inetd: false;
     numeric: false;
     transparent: ${boolToString cfg.transparent};
-    timeout: "${toString cfg.timeout}";
+    timeout: ${toString cfg.timeout};
 
     listen:
     (
@@ -27,12 +27,12 @@ let
   defaultAppendConfig = ''
     protocols:
     (
-      { name: "ssh"; service: "ssh"; host: "localhost"; port: "22"; probe: "builtin"; },
-      { name: "openvpn"; host: "localhost"; port: "1194"; probe: "builtin"; },
-      { name: "xmpp"; host: "localhost"; port: "5222"; probe: "builtin"; },
-      { name: "http"; host: "localhost"; port: "80"; probe: "builtin"; },
-      { name: "tls"; host: "localhost"; port: "443"; probe: "builtin"; },
-      { name: "anyprot"; host: "localhost"; port: "443"; probe: "builtin"; }
+      { name: "ssh"; service: "ssh"; host: "localhost"; port: "22"; },
+      { name: "openvpn"; host: "localhost"; port: "1194"; },
+      { name: "xmpp"; host: "localhost"; port: "5222"; },
+      { name: "http"; host: "localhost"; port: "80"; },
+      { name: "tls"; host: "localhost"; port: "443"; },
+      { name: "anyprot"; host: "localhost"; port: "443"; }
     );
   '';
 in

--- a/nixos/tests/sslh.nix
+++ b/nixos/tests/sslh.nix
@@ -21,8 +21,8 @@ import ./make-test-python.nix {
         appendConfig = ''
           protocols:
           (
-            { name: "ssh"; service: "ssh"; host: "localhost"; port: "22"; probe: "builtin"; },
-            { name: "http"; host: "localhost"; port: "80"; probe: "builtin"; },
+            { name: "ssh"; service: "ssh"; host: "localhost"; port: "22"; },
+            { name: "http"; host: "localhost"; port: "80"; },
           );
         '';
       };


### PR DESCRIPTION
sslh only warns when a config parameter does not exist or has the wrong type so such mistakes can easily go unnoticed

Fixes https://github.com/NixOS/nixpkgs/issues/225454

@VAWVAW please test

@GrahamcOfBorg  test sslh

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
