### PR TITLE
laurel: init at 0.5.2

### DIFF
--- a/pkgs/servers/monitoring/laurel/default.nix
+++ b/pkgs/servers/monitoring/laurel/default.nix
@@ -1,0 +1,31 @@
+{ acl
+, fetchFromGitHub
+, lib
+, rustPlatform
+}:
+
+rustPlatform.buildRustPackage rec {
+  pname = "laurel";
+  version = "0.5.2";
+
+  src = fetchFromGitHub {
+    owner = "threathunters-io";
+    repo = pname;
+    rev = "v${version}";
+    hash = "sha256-MT3Zcuztb2QUwWR3HFViJQtygI0oIUE3TlMu+vWzbMI=";
+  };
+
+  cargoHash = "sha256-hX2nSBgXctAHGqvP/ZmMjGJf7C/wPJ/gL+gV7uI8gco=";
+
+  nativeBuildInputs = [ rustPlatform.bindgenHook ];
+  buildInputs = [ acl ];
+
+  meta = with lib; {
+    description = "Transform Linux Audit logs for SIEM usage";
+    homepage = "https://github.com/threathunters-io/laurel";
+    changelog = "https://github.com/threathunters-io/laurel/releases/tag/v${version}";
+    license = licenses.gpl3Plus;
+    maintainers = with maintainers; [ indeednotjames ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -20942,6 +20942,8 @@ with pkgs;
   LASzip = callPackage ../development/libraries/LASzip { };
   LASzip2 = callPackage ../development/libraries/LASzip/LASzip2.nix { };
 
+  laurel = callPackage ../servers/monitoring/laurel/default.nix { };
+
   lcm = callPackage ../development/libraries/lcm { };
 
   lcms = lcms2;


### PR DESCRIPTION
###### Description of changes

https://github.com/threathunters-io/laurel

From the README:

> LAUREL is an event post-processing plugin for auditd(8) that generates useful, enriched JSON-based audit logs suitable for modern security monitoring setups.

This PR is marked as draft, as I don't intent on adding a pre-release :^)

I just picked [`v0.5.2-pre1`](https://github.com/threathunters-io/laurel/releases/tag/v0.5.2-pre1) specifically, because it added a `Cargo.lock`.
diff: https://github.com/threathunters-io/laurel/compare/v0.5.1...v0.5.2-pre1

I do however intend to add a nixos module (and VM tests) for it.
Would be cool if we could get #222197 merged first :)

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
