### PR TITLE
qt6: rework packaging of qt modules (part 1)

### DIFF
--- a/pkgs/development/libraries/qt-6/hooks/qtbase-setup-hook.sh
+++ b/pkgs/development/libraries/qt-6/hooks/qtbase-setup-hook.sh
@@ -58,7 +58,9 @@ else # Only set up Qt once.
         local doc="${!outputDoc}"
         local lib="${!outputLib}"
 
-        moveToOutput "mkspecs" "$dev"
+        moveToOutput "mkspecs"   "$dev"
+        moveToOutput "modules"   "$dev"
+        moveToOutput "lib/*.prl" "$dev"
 
         if [ -d "$dev/mkspecs/modules" ]; then
             fixQtModulePaths "$dev/mkspecs/modules"
@@ -68,8 +70,8 @@ else # Only set up Qt once.
             fixQtBuiltinPaths "$dev/mkspecs" '*.pr?'
         fi
 
-        if [ -d "$lib" ]; then
-            fixQtBuiltinPaths "$lib" '*.pr?'
+        if [ -d "$dev/lib" ]; then
+            fixQtBuiltinPaths "$dev/lib" '*.pr?'
         fi
     }
     if [ -z "${dontPatchMkspecs-}" ]; then

--- a/pkgs/development/libraries/qt-6/modules/qtbase.nix
+++ b/pkgs/development/libraries/qt-6/modules/qtbase.nix
@@ -233,10 +233,6 @@ stdenv.mkDerivation rec {
 
   outputs = [ "out" "dev" ];
 
-  postInstall = ''
-    moveToOutput "mkspecs" "$dev"
-  '';
-
   devTools = [
     "libexec/moc"
     "libexec/rcc"
@@ -264,10 +260,12 @@ stdenv.mkDerivation rec {
   ];
 
   postFixup = ''
-    # Don't retain build-time dependencies like gdb.
-    sed '/QMAKE_DEFAULT_.*DIRS/ d' -i $dev/mkspecs/qconfig.pri
-    fixQtModulePaths "''${!outputDev}/mkspecs/modules"
-    fixQtBuiltinPaths "''${!outputDev}" '*.pr?'
+    moveToOutput "mkspecs"   "$dev"
+    moveToOutput "modules"   "$dev"
+    moveToOutput "lib/*.prl" "$dev"
+
+    fixQtModulePaths  "$dev/mkspecs/modules"
+    fixQtBuiltinPaths "$dev" '*.pr?'
 
     # Move development tools to $dev
     moveQtDevTools

--- a/pkgs/development/libraries/qt-6/modules/qtwebengine.nix
+++ b/pkgs/development/libraries/qt-6/modules/qtwebengine.nix
@@ -226,9 +226,9 @@ qtModule {
     export NINJAFLAGS="-j$NIX_BUILD_CORES"
   '';
 
-  postInstall = ''
+  postFixup = ''
     # This is required at runtime
-    mkdir $out/libexec
+    mkdir -p $out/libexec
     mv $dev/libexec/QtWebEngineProcess $out/libexec
   '';
 

--- a/pkgs/development/libraries/qt-6/qtModule.nix
+++ b/pkgs/development/libraries/qt-6/qtModule.nix
@@ -1,4 +1,11 @@
-{ stdenv, lib, perl, cmake, ninja, writeText, qtbase, qmake, srcs, patches ? [ ] }:
+{ lib
+, stdenv
+, cmake
+, ninja
+, perl
+, srcs
+, patches ? [ ]
+}:
 
 args:
 
@@ -11,68 +18,20 @@ stdenv.mkDerivation (args // {
   inherit pname version src;
   patches = args.patches or patches.${pname} or [ ];
 
-  buildInputs = args.buildInputs or [ ];
-  nativeBuildInputs = (args.nativeBuildInputs or [ ]) ++ [
-    perl
-    cmake
-    ninja
-    qmake
-  ];
-  propagatedBuildInputs = args.qtInputs ++ (args.propagatedBuildInputs or [ ]);
-
   preHook = ''
     . ${./hooks/move-qt-dev-tools.sh}
-    . ${./hooks/fix-qt-builtin-paths.sh}
   '';
+
+  buildInputs = args.buildInputs or [ ];
+  nativeBuildInputs = (args.nativeBuildInputs or [ ]) ++ [ cmake ninja perl ];
+  propagatedBuildInputs = args.qtInputs ++ (args.propagatedBuildInputs or [ ]);
 
   outputs = args.outputs or [ "out" "dev" ];
 
   dontWrapQtApps = args.dontWrapQtApps or true;
-  postInstall = ''
-    if [ ! -z "$dev" ]; then
-      mkdir "$dev"
-      for dir in libexec mkspecs
-      do
-        moveToOutput "$dir" "$dev"
-      done
-    fi
-    fixQtBuiltinPaths $out/lib "*.pr?"
-    ${args.postInstall or ""}
-  '';
-
-  preConfigure = args.preConfigure or "" + ''
-    fixQtBuiltinPaths . '*.pr?'
-  '' + lib.optionalString (builtins.compareVersions "5.15.0" version <= 0)
-    # Note: We use ${version%%-*} to remove any tag from the end of the version
-    # string. Version tags are added by Nixpkgs maintainers and not reflected in
-    # the source version.
-    ''
-      if [[ -z "$dontCheckQtModuleVersion" ]] \
-          && grep -q '^MODULE_VERSION' .qmake.conf 2>/dev/null \
-          && ! grep -q -F "''${version%%-*}" .qmake.conf 2>/dev/null
-      then
-        echo >&2 "error: could not find version ''${version%%-*} in .qmake.conf"
-        echo >&2 "hint: check .qmake.conf and update the package version in Nixpkgs"
-        exit 1
-      fi
-
-      if [[ -z "$dontSyncQt" && -f sync.profile ]]; then
-        # FIXME: this probably breaks crosscompiling as it's not from nativeBuildInputs
-        # I don't know how to get /libexec from nativeBuildInputs to work, it's not under /bin
-        ${lib.getDev qtbase}/libexec/syncqt.pl -version "''${version%%-*}"
-      fi
-    '';
 
   postFixup = ''
-    if [ -d "''${!outputDev}/lib/pkgconfig" ]; then
-      find "''${!outputDev}/lib/pkgconfig" -name '*.pc' | while read pc; do
-        sed -i "$pc" \
-          -e "/^prefix=/ c prefix=''${!outputLib}" \
-          -e "/^exec_prefix=/ c exec_prefix=''${!outputBin}" \
-          -e "/^includedir=/ c includedir=''${!outputDev}/include"
-      done
-    fi
-
+    moveToOutput "libexec" "''${!outputDev}"
     moveQtDevTools
   '' + args.postFixup or "";
 


### PR DESCRIPTION
###### Description of changes
In stead of moving as much files as possible to the `$dev` output, we now keep most of them (tools, headers, pkg-config files, cmake files) in the `$out` output. While this bloats the closure size by a little bit, it greatly simplifies our packaging and future maintenance.

This is part one of the changes, cleanup the qtModule function of redundant fixup handlings. 

Reference: https://github.com/NixOS/nixpkgs/pull/225555 https://github.com/NixOS/nixpkgs/pull/224469
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
