### PR TITLE
python310Packages.galois: fix broken dep constraints

### DIFF
--- a/pkgs/development/python-modules/galois/default.nix
+++ b/pkgs/development/python-modules/galois/default.nix
@@ -2,6 +2,7 @@
 , buildPythonPackage
 , setuptools-scm
 , pythonOlder
+, pythonRelaxDepsHook
 , fetchFromGitHub
 , pytestCheckHook
 , pytest-xdist
@@ -28,6 +29,7 @@ buildPythonPackage rec {
 
   nativeBuildInputs = [
     setuptools-scm
+    pythonRelaxDepsHook
   ];
 
   propagatedBuildInputs = [
@@ -41,11 +43,7 @@ buildPythonPackage rec {
     pytest-xdist
   ];
 
-  postPatch = ''
-     substituteInPlace pyproject.toml \
-       --replace "numpy >= 1.18.4, < 1.24" "numpy >= 1.18.4" \
-       --replace "numba >= 0.53, < 0.57" "numba >= 0.53" \
-    '';
+  pythonRelaxDeps = [ "numpy" "numba" ];
 
   pythonImportsCheck = [ "galois" ];
 

--- a/pkgs/development/python-modules/galois/default.nix
+++ b/pkgs/development/python-modules/galois/default.nix
@@ -47,11 +47,11 @@ buildPythonPackage rec {
 
   pythonImportsCheck = [ "galois" ];
 
-  meta = {
-    description = "A Python 3 package that extends NumPy arrays to operate over finite fields";
+  meta = with lib; {
+    description = "Python package that extends NumPy arrays to operate over finite fields";
     homepage = "https://github.com/mhostetter/galois";
-    downloadPage = "https://github.com/mhostetter/galois/releases";
-    license = lib.licenses.mit;
-    maintainers = with lib.maintainers; [ chrispattison ];
+    downloadPage = "https://github.com/mhostetter/galois/releases/tag/v${version}";
+    license = licenses.mit;
+    maintainers = with maintainers; [ chrispattison ];
   };
 }


### PR DESCRIPTION
###### Description of changes

A previous automated update of this package caused the version constraint to no longer match, so the package broke after a numpy update. This PR refactors to use `pythonRelaxDepsHook`, so the package works again

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
