### PR TITLE
ocamlPackages.alcotest: 1.6.0 → 1.7.0

### DIFF
--- a/pkgs/development/ocaml-modules/alcotest/default.nix
+++ b/pkgs/development/ocaml-modules/alcotest/default.nix
@@ -4,11 +4,13 @@
 
 buildDunePackage rec {
   pname = "alcotest";
-  version = "1.6.0";
+  version = "1.7.0";
+
+  duneVersion = "3";
 
   src = fetchurl {
     url = "https://github.com/mirage/alcotest/releases/download/${version}/alcotest-${version}.tbz";
-    sha256 = "sha256-/QD5ZoOVh0/zsdfvVm0U78Avp900Ej6yXVk1W+lLIyk=";
+    hash = "sha256-gSus2zS0XoiZXgfXMGvasvckee8ZlmN/HV0fQWZ5At8=";
   };
 
   nativeBuildInputs = [ ocaml-syntax-shims ];

--- a/pkgs/development/ocaml-modules/alcotest/lwt.nix
+++ b/pkgs/development/ocaml-modules/alcotest/lwt.nix
@@ -7,6 +7,8 @@ buildDunePackage {
 
   inherit (alcotest) version src;
 
+  duneVersion = "3";
+
   propagatedBuildInputs = [ alcotest logs lwt fmt ];
 
   doCheck = true;

--- a/pkgs/development/ocaml-modules/angstrom-async/default.nix
+++ b/pkgs/development/ocaml-modules/angstrom-async/default.nix
@@ -3,9 +3,10 @@
 buildDunePackage rec {
   pname = "angstrom-async";
 
-  inherit (angstrom) version useDune2 src;
+  inherit (angstrom) version src;
 
-  minimumOCamlVersion = "4.04.1";
+  duneVersion = "3";
+  minimalOCamlVersion = "4.04.1";
 
   propagatedBuildInputs = [ angstrom async ];
 

--- a/pkgs/development/ocaml-modules/angstrom-lwt-unix/default.nix
+++ b/pkgs/development/ocaml-modules/angstrom-lwt-unix/default.nix
@@ -1,13 +1,13 @@
-{ lib, fetchFromGitHub, buildDunePackage, angstrom, ocaml_lwt }:
+{ lib, fetchFromGitHub, buildDunePackage, angstrom, lwt }:
 
 buildDunePackage rec {
   pname = "angstrom-lwt-unix";
 
-  inherit (angstrom) version useDune2 src;
+  inherit (angstrom) version src;
 
-  minimumOCamlVersion = "4.03";
+  duneVersion = "3";
 
-  propagatedBuildInputs = [ angstrom ocaml_lwt ];
+  propagatedBuildInputs = [ angstrom lwt ];
 
   doCheck = true;
 

--- a/pkgs/development/ocaml-modules/angstrom-unix/default.nix
+++ b/pkgs/development/ocaml-modules/angstrom-unix/default.nix
@@ -3,9 +3,9 @@
 buildDunePackage rec {
   pname = "angstrom-unix";
 
-  inherit (angstrom) version useDune2 src;
+  inherit (angstrom) version src;
 
-  minimumOCamlVersion = "4.03";
+  duneVersion = "3";
 
   propagatedBuildInputs = [ angstrom ];
 

--- a/pkgs/development/ocaml-modules/angstrom/default.nix
+++ b/pkgs/development/ocaml-modules/angstrom/default.nix
@@ -3,9 +3,9 @@
 buildDunePackage rec {
   pname = "angstrom";
   version = "0.15.0";
-  useDune2 = true;
+  duneVersion = "3";
 
-  minimumOCamlVersion = "4.04";
+  minimalOCamlVersion = "4.04";
 
   src = fetchFromGitHub {
     owner  = "inhabitedtype";

--- a/pkgs/development/ocaml-modules/bigstringaf/default.nix
+++ b/pkgs/development/ocaml-modules/bigstringaf/default.nix
@@ -5,12 +5,13 @@ buildDunePackage rec {
   version = "0.9.0";
 
   minimalOCamlVersion = "4.08";
+  duneVersion = "3";
 
   src = fetchFromGitHub {
     owner = "inhabitedtype";
     repo = pname;
     rev = version;
-    sha256 = "sha256-HXPjnE56auy2MI6HV2XuBX/VeqsO50HFzTul17lKEqE=";
+    hash = "sha256-HXPjnE56auy2MI6HV2XuBX/VeqsO50HFzTul17lKEqE=";
   };
 
   nativeBuildInputs = [ pkg-config ];

--- a/pkgs/development/ocaml-modules/dispatch/default.nix
+++ b/pkgs/development/ocaml-modules/dispatch/default.nix
@@ -4,7 +4,7 @@ buildDunePackage rec {
   pname = "dispatch";
   version = "0.5.0";
 
-  useDune2 = true;
+  duneVersion = "3";
 
   src = fetchFromGitHub {
     owner = "inhabitedtype";

--- a/pkgs/development/ocaml-modules/domain-name/default.nix
+++ b/pkgs/development/ocaml-modules/domain-name/default.nix
@@ -12,6 +12,7 @@ buildDunePackage rec {
   };
 
   minimalOCamlVersion = "4.04";
+  duneVersion = "3";
 
   checkInputs = [ alcotest ];
 

--- a/pkgs/development/ocaml-modules/duff/default.nix
+++ b/pkgs/development/ocaml-modules/duff/default.nix
@@ -1,7 +1,6 @@
 { lib
 , fetchurl
 , buildDunePackage
-, ocaml
 , fmt
 , alcotest
 , hxd
@@ -13,6 +12,9 @@ buildDunePackage rec {
   pname = "duff";
   version = "0.5";
 
+  minimalOCamlVersion = "4.08";
+  duneVersion = "3";
+
   src = fetchurl {
     url = "https://github.com/mirage/duff/releases/download/v${version}/duff-${version}.tbz";
     sha256 = "sha256-0eqpfPWNOHYjkcjXRnZUTUFF0/L9E+TNoOqKCETN5hI=";
@@ -20,7 +22,7 @@ buildDunePackage rec {
 
   propagatedBuildInputs = [ fmt ];
 
-  doCheck = lib.versionAtLeast ocaml.version "4.08";
+  doCheck = true;
   checkInputs = [
     alcotest
     crowbar

--- a/pkgs/development/ocaml-modules/encore/default.nix
+++ b/pkgs/development/ocaml-modules/encore/default.nix
@@ -1,7 +1,6 @@
 { lib
 , buildDunePackage
 , fetchurl
-, ocaml
 , fmt
 , bigstringaf
 , angstrom
@@ -12,14 +11,14 @@ buildDunePackage rec {
   pname = "encore";
   version = "0.8";
 
-  minimumOCamlVersion = "4.07";
+  minimalOCamlVersion = "4.08";
 
   src = fetchurl {
     url = "https://github.com/mirage/encore/releases/download/v${version}/encore-v${version}.tbz";
     sha256 = "a406bc9863b04bb424692045939d6c170a2bb65a98521ae5608d25b0559344f6";
   };
 
-  useDune2 = true;
+  duneVersion = "3";
 
   propagatedBuildInputs = [ angstrom fmt bigstringaf ];
   checkInputs = [ alcotest ];

--- a/pkgs/development/ocaml-modules/faraday/async.nix
+++ b/pkgs/development/ocaml-modules/faraday/async.nix
@@ -5,6 +5,7 @@ buildDunePackage rec {
   inherit (faraday) version src;
 
   minimalOCamlVersion = "4.08";
+  duneVersion = "3";
 
   propagatedBuildInputs = [ faraday core_unix async ];
 

--- a/pkgs/development/ocaml-modules/faraday/default.nix
+++ b/pkgs/development/ocaml-modules/faraday/default.nix
@@ -5,6 +5,7 @@ buildDunePackage rec {
   version = "0.8.2";
 
   minimalOCamlVersion = "4.08";
+  duneVersion = "3";
 
   src = fetchFromGitHub {
     owner = "inhabitedtype";

--- a/pkgs/development/ocaml-modules/faraday/lwt-unix.nix
+++ b/pkgs/development/ocaml-modules/faraday/lwt-unix.nix
@@ -3,6 +3,7 @@
 buildDunePackage rec {
   pname = "faraday-lwt-unix";
   inherit (faraday) version src;
+  duneVersion = "3";
 
   propagatedBuildInputs = [ lwt faraday-lwt ];
 

--- a/pkgs/development/ocaml-modules/faraday/lwt.nix
+++ b/pkgs/development/ocaml-modules/faraday/lwt.nix
@@ -5,6 +5,7 @@ buildDunePackage rec {
   inherit (faraday) version src;
 
   propagatedBuildInputs = [ faraday lwt ];
+  duneVersion = "3";
 
   meta = faraday.meta // {
     description = "Lwt support for Faraday";

--- a/pkgs/development/ocaml-modules/ff/default.nix
+++ b/pkgs/development/ocaml-modules/ff/default.nix
@@ -3,6 +3,7 @@
 buildDunePackage rec {
   pname = "ff";
   inherit (ff-sig) version src;
+  duneVersion = "3";
 
   propagatedBuildInputs = [
     ff-sig

--- a/pkgs/development/ocaml-modules/ff/pbt.nix
+++ b/pkgs/development/ocaml-modules/ff/pbt.nix
@@ -5,6 +5,7 @@ buildDunePackage {
   inherit (ff-sig) version src;
 
   minimalOCamlVersion = "4.08";
+  duneVersion = "3";
 
   checkInputs = [
     alcotest

--- a/pkgs/development/ocaml-modules/ff/sig.nix
+++ b/pkgs/development/ocaml-modules/ff/sig.nix
@@ -10,6 +10,8 @@ buildDunePackage rec {
     sha256 = "sha256-IoUH4awMOa1pm/t8E5io87R0TZsAxJjGWaXhXjn/w+Y=";
   };
 
+  duneVersion = "3";
+
   propagatedBuildInputs = [
     zarith
   ];

--- a/pkgs/development/ocaml-modules/gmap/default.nix
+++ b/pkgs/development/ocaml-modules/gmap/default.nix
@@ -4,14 +4,14 @@ buildDunePackage rec {
   pname = "gmap";
   version = "0.3.0";
 
-  useDune2 = true;
+  duneVersion = "3";
 
   src = fetchurl {
     url = "https://github.com/hannesm/gmap/releases/download/${version}/gmap-${version}.tbz";
     sha256 = "073wa0lrb0jj706j87cwzf1a8d1ff14100mnrjs8z3xc4ri9xp84";
   };
 
-  minimumOCamlVersion = "4.03";
+  minimalOCamlVersion = "4.03";
 
   checkInputs = [ alcotest fmt ];
 

--- a/pkgs/development/ocaml-modules/janestreet/0.14.nix
+++ b/pkgs/development/ocaml-modules/janestreet/0.14.nix
@@ -871,6 +871,7 @@ with self;
 
   vcaml = janePackage {
     pname = "vcaml";
+    duneVersion = "3";
     hash = "0ykwrn8bvwx26ad4wb36jw9xnlwsdpnnx88396laxvcfimrp13qs";
     meta.description = "OCaml bindings for the Neovim API";
     propagatedBuildInputs = [ angstrom-async async_extra faraday ];

--- a/pkgs/development/ocaml-modules/janestreet/0.15.nix
+++ b/pkgs/development/ocaml-modules/janestreet/0.15.nix
@@ -898,6 +898,7 @@ with self;
 
   sexp = janePackage {
     pname = "sexp";
+    duneVersion = "3";
     hash = "00xlsymm1mpgs8cqkb6c36vh5hfw0saghvwiqh7jry65qc5nvv9z";
     propagatedBuildInputs = [
       async

--- a/pkgs/development/ocaml-modules/janestreet/0.15.nix
+++ b/pkgs/development/ocaml-modules/janestreet/0.15.nix
@@ -1063,6 +1063,7 @@ with self;
   };
 
   vcaml = janePackage {
+    duneVersion = "3";
     pname = "vcaml";
     hash = "12fd29x9dgf4f14xrx7z4y1bm1wbfynrs3jismjbiqnckfpbqrib";
     meta.description = "OCaml bindings for the Neovim API";

--- a/pkgs/development/ocaml-modules/janestreet/0.15.nix
+++ b/pkgs/development/ocaml-modules/janestreet/0.15.nix
@@ -451,6 +451,7 @@ with self;
 
   jsonaf = janePackage {
     pname = "jsonaf";
+    duneVersion = "3";
     hash = "1j9rn8vsvfpgmdpmdqb5qhvss5171j8n3ii1bcgnavqinchbvqa6";
     meta.description = "A library for parsing, manipulating, and serializing data structured as JSON";
     propagatedBuildInputs = [ base ppx_jane angstrom faraday ];
@@ -690,6 +691,7 @@ with self;
 
   ppx_jsonaf_conv = janePackage {
     pname = "ppx_jsonaf_conv";
+    duneVersion = "3";
     version = "0.15.1";
     hash = "0wprs7qmscklyskj4famhaqqisi6jypy414aqba14qdyi43w0cv3";
     minimumOCamlVersion = "4.08";

--- a/pkgs/development/ocaml-modules/junit/alcotest.nix
+++ b/pkgs/development/ocaml-modules/junit/alcotest.nix
@@ -3,7 +3,8 @@
 buildDunePackage ({
   pname = "junit_alcotest";
 
-  inherit (junit) src version meta useDune2;
+  inherit (junit) src version meta;
+  duneVersion = "3";
 
   propagatedBuildInputs = [
     junit

--- a/pkgs/development/ocaml-modules/junit/default.nix
+++ b/pkgs/development/ocaml-modules/junit/default.nix
@@ -14,7 +14,7 @@ buildDunePackage (rec {
     tyxml
   ];
 
-  useDune2 = true;
+  duneVersion = "3";
   doCheck = true;
 
   meta = with lib; {

--- a/pkgs/development/ocaml-modules/junit/ounit.nix
+++ b/pkgs/development/ocaml-modules/junit/ounit.nix
@@ -3,7 +3,8 @@
 buildDunePackage ({
   pname = "junit_ounit";
 
-  inherit (junit) src version meta useDune2;
+  inherit (junit) src version meta;
+  duneVersion = "3";
 
   propagatedBuildInputs = [
     junit

--- a/pkgs/development/ocaml-modules/ke/default.nix
+++ b/pkgs/development/ocaml-modules/ke/default.nix
@@ -18,6 +18,7 @@ buildDunePackage rec {
   doCheck = true;
 
   minimalOCamlVersion = "4.08";
+  duneVersion = "3";
 
   meta = {
     description = "Fast implementation of queue in OCaml";

--- a/pkgs/development/ocaml-modules/pecu/default.nix
+++ b/pkgs/development/ocaml-modules/pecu/default.nix
@@ -4,9 +4,9 @@ buildDunePackage rec {
   pname = "pecu";
   version = "0.6";
 
-  useDune2 = true;
+  duneVersion = "3";
 
-  minimumOCamlVersion = "4.03";
+  minimalOCamlVersion = "4.03";
 
   src = fetchurl {
     url = "https://github.com/mirage/pecu/releases/download/v${version}/pecu-v${version}.tbz";

--- a/pkgs/development/ocaml-modules/ppx_blob/default.nix
+++ b/pkgs/development/ocaml-modules/ppx_blob/default.nix
@@ -4,7 +4,7 @@ buildDunePackage rec {
   pname = "ppx_blob";
   version = "0.7.2";
 
-  useDune2 = true;
+  duneVersion = "3";
 
   src = fetchurl {
     url = "https://github.com/johnwhitington/${pname}/releases/download/${version}/ppx_blob-${version}.tbz";

--- a/pkgs/development/ocaml-modules/ppx_deriving_cmdliner/default.nix
+++ b/pkgs/development/ocaml-modules/ppx_deriving_cmdliner/default.nix
@@ -14,6 +14,7 @@ buildDunePackage rec {
   version = "0.6.1";
 
   minimalOCamlVersion = "4.11";
+  duneVersion = "3";
 
   src = fetchFromGitHub {
     owner = "hammerlab";

--- a/pkgs/development/ocaml-modules/terminal/default.nix
+++ b/pkgs/development/ocaml-modules/terminal/default.nix
@@ -8,11 +8,11 @@ buildDunePackage rec {
   version = "0.2.1";
 
   minimalOCamlVersion = "4.03";
-  useDune2 = true;
+  duneVersion = "3";
 
   src = fetchurl {
     url = "https://github.com/CraigFe/progress/releases/download/${version}/terminal-${version}.tbz";
-    sha256 = "sha256:0vjqkvmpyi8kvmb4vrx3f0994rph8i9pvlrz1dyi126vlb2zbrvs";
+    hash = "sha256:0vjqkvmpyi8kvmb4vrx3f0994rph8i9pvlrz1dyi126vlb2zbrvs";
   };
 
   propagatedBuildInputs = [ stdlib-shims uutf uucp ];

--- a/pkgs/development/ocaml-modules/unstrctrd/default.nix
+++ b/pkgs/development/ocaml-modules/unstrctrd/default.nix
@@ -21,7 +21,7 @@ buildDunePackage rec {
     sha256 = "0mjm4v7kk75iwwsfnpmxc3bsl8aisz53y7z21sykdp60f4rxnah7";
   };
 
-  useDune2 = true;
+  duneVersion = "3";
 
   propagatedBuildInputs = [
     angstrom

--- a/pkgs/development/ocaml-modules/yuscii/default.nix
+++ b/pkgs/development/ocaml-modules/yuscii/default.nix
@@ -13,6 +13,7 @@ buildDunePackage rec {
   version = "0.3.0";
 
   minimalOCamlVersion = "4.03";
+  duneVersion = "3";
 
   src = fetchzip {
     url = "https://github.com/mirage/yuscii/releases/download/v${version}/yuscii-v${version}.tbz";


### PR DESCRIPTION
###### Description of changes

https://github.com/mirage/alcotest/blob/1.7.0/CHANGES.md

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
