### PR TITLE
nixos/maddy: Add option ensureCredentials

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2305.section.md
+++ b/nixos/doc/manual/release-notes/rl-2305.section.md
@@ -274,6 +274,8 @@ In addition to numerous new and upgraded packages, this release has the followin
   replacement. It stores backups as volume dump files and thus better integrates
   into contemporary backup solutions.
 
+- `services.maddy` now allows to configure users and their credentials using `services.maddy.ensureCredentials`.
+
 - The `dnsmasq` service now takes configuration via the
   `services.dnsmasq.settings` attribute set. The option
   `services.dnsmasq.extraConfig` will be deprecated when NixOS 22.11 reaches

--- a/nixos/tests/maddy.nix
+++ b/nixos/tests/maddy.nix
@@ -10,6 +10,11 @@ import ./make-test-python.nix ({ pkgs, ... }: {
         primaryDomain = "server";
         openFirewall = true;
         ensureAccounts = [ "postmaster@server" ];
+        ensureCredentials = {
+          # Do not use this in production. This will make passwords world-readable
+          # in the Nix store
+          "postmaster@server".passwordFile = "${pkgs.writeText "postmaster" "test"}";
+        };
       };
     };
 
@@ -49,9 +54,6 @@ import ./make-test-python.nix ({ pkgs, ... }: {
     server.wait_for_unit("maddy.service")
     server.wait_for_open_port(143)
     server.wait_for_open_port(587)
-
-    server.succeed("maddyctl creds create --password test postmaster@server")
-
     client.succeed("send-testmail")
     client.succeed("test-imap")
   '';


### PR DESCRIPTION
###### Description of changes

Add option `ensureCredentials` for maddy mail server

```
services.maddy = {
  enable = true;
  hostname = "localhost";
  ensureAccounts = [
    "admin@localhost"
    "user1@localhost"
    "user2@localhost"
  ];
  ensureCredentials = {
    "admin@localhost".passwordFile = /secrets/admin-localhost;
    "user1@localhost".passwordFile = /secrets/user1-localhost;
    "user2@localhost".passwordFile = /secrets/user2-localhost;
  };
};
```
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [x] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
