### PR TITLE
playwright: fix build on darwin

### DIFF
--- a/pkgs/development/python-modules/playwright/default.nix
+++ b/pkgs/development/python-modules/playwright/default.nix
@@ -87,7 +87,7 @@ let
       outputHashMode = "recursive";
       outputHashAlgo = "sha256";
       outputHash = {
-        x86_64-darwin = "0z2kww4iby1izkwn6z2ai94y87bkjvwak8awdmjm8sgg00pa9l1a";
+        x86_64-darwin = "08qnb07d93h0rvp72ywan8isl9n0c2027viaymp807aavr3nnfjg";
       }.${system} or throwSystem;
     } ''
       export PLAYWRIGHT_BROWSERS_PATH=$out


### PR DESCRIPTION
###### Description of changes

Fixes
```
error: hash mismatch in fixed-output derivation '/nix/store/ap67n1ygkw141jq0qsq17wzq2vfg1g9a-playwright-browsers-base.drv':
         specified: sha256-KtCkLgDvaVRlbVyhqfiWcx3kSYpKfGP5/DH4FQnnU3w=
            got:    sha256-TzprR95KHYBu9SruI4BgwCaqI7KKe3HuzgCO1A5YFiM=
error: 1 dependencies of derivation '/nix/store/9qx2rh97hm05brfkmy62m0sgdyrwbinv-playwright-browsers-1.27.1.drv' failed to build
error: 1 dependencies of derivation '/nix/store/qzl0n1n9byjv154y85lh1hnw47jay45j-nix-shell-env.drv' failed to build
```

###### Things done

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
