### PR TITLE
ocamlPackages.headache: init at 1.06

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -11015,6 +11015,12 @@
     githubId = 47835714;
     name = "Nintron";
   };
+  niols = {
+    email = "niols@niols.fr";
+    github = "niols";
+    githubId = 5920602;
+    name = "Nicolas Jeannerod";
+  };
   nioncode = {
     email = "nioncode+github@gmail.com";
     github = "nioncode";

--- a/pkgs/development/ocaml-modules/headache/default.nix
+++ b/pkgs/development/ocaml-modules/headache/default.nix
@@ -1,0 +1,24 @@
+{ lib, buildDunePackage, fetchFromGitHub, camomile }:
+
+buildDunePackage rec {
+  pname = "headache";
+  version = "1.06";
+
+  src = fetchFromGitHub {
+    owner = "frama-c";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "sha256-BA7u09MKYMyspFX8AcAkDVA6UUG5DKAdbIDdt+b3Fc4=";
+  };
+
+  duneVersion = "3";
+
+  propagatedBuildInputs = [ camomile ];
+
+  meta = with lib; {
+    homepage = "https://github.com/frama-c/${pname}";
+    description = "Lightweight tool for managing headers in source code files";
+    license = licenses.lgpl2Plus;
+    maintainers = with maintainers; [ niols ];
+  };
+}

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -609,6 +609,8 @@ let
 
     hashcons = callPackage ../development/ocaml-modules/hashcons { };
 
+    headache = callPackage ../development/ocaml-modules/headache { };
+
     hex = callPackage ../development/ocaml-modules/hex { };
 
     hidapi = callPackage ../development/ocaml-modules/hidapi { };


### PR DESCRIPTION
###### Description of changes

[Headache](https://github.com/Frama-C/headache) is a “lightweight tool for managing headers in source code files” from the OCaml ecosystem. This PR adds an OCaml module `ocamlPackages.headache` providing headache. In particular, one can run headache with `nix run nixpkgs#ocamlPackages.headache` and all is well.

I know some utliities, despite existing in a specific ecosystem's packages, are aliased at top-level, eg. `nixpkgs#headache` would alias `nixpkgs#ocamlPackages.headache` but I don't know what the policy is for such packages so I just didn't do it.

Finally, I add myself as a maintainer in nixpkgs and as maintainer of this package.

###### Things done

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [X] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).