### PR TITLE
[Backport 22.11] gitlab: 15.10.1 -> 15.10.2

### DIFF
--- a/pkgs/applications/version-management/gitlab/data.json
+++ b/pkgs/applications/version-management/gitlab/data.json
@@ -1,14 +1,14 @@
 {
-  "version": "15.10.1",
-  "repo_hash": "sha256-BETTehy2GxZDGWLgdao1I0cqm4cNaL9lhXe+JmCNi10=",
+  "version": "15.10.2",
+  "repo_hash": "sha256-XjL1D2DschFn64D2KcTQP6pppecIN26LrWMJPUfYvgI=",
   "yarn_hash": "1il8dnjb7591ss6w14zibdihg3bylw866jjjclv1qm8cihp8k3y8",
   "owner": "gitlab-org",
   "repo": "gitlab",
-  "rev": "v15.10.1-ee",
+  "rev": "v15.10.2-ee",
   "passthru": {
-    "GITALY_SERVER_VERSION": "15.10.1",
-    "GITLAB_PAGES_VERSION": "15.10.1",
+    "GITALY_SERVER_VERSION": "15.10.2",
+    "GITLAB_PAGES_VERSION": "15.10.2",
     "GITLAB_SHELL_VERSION": "14.18.0",
-    "GITLAB_WORKHORSE_VERSION": "15.10.1"
+    "GITLAB_WORKHORSE_VERSION": "15.10.2"
   }
 }

--- a/pkgs/applications/version-management/gitlab/gitaly/default.nix
+++ b/pkgs/applications/version-management/gitlab/gitaly/default.nix
@@ -11,7 +11,7 @@ let
     gemdir = ./.;
   };
 
-  version = "15.10.1";
+  version = "15.10.2";
   package_version = "v${lib.versions.major version}";
   gitaly_package = "gitlab.com/gitlab-org/gitaly/${package_version}";
 
@@ -22,7 +22,7 @@ let
       owner = "gitlab-org";
       repo = "gitaly";
       rev = "v${version}";
-      sha256 = "sha256-iGYmBMRno2qCvdklyztGTV48m0UMeozuyX7ZZdS7K/c=";
+      sha256 = "sha256-18BmECQqzwwxl7nY5+Bi4oyA2EPd5HqzJdgVPV8J1OM=";
     };
 
     vendorSha256 = "sha256-knuUyJGz5JvYyKeDQ66cMQQSh2YKkkDB54iCir1QpEY=";

--- a/pkgs/applications/version-management/gitlab/gitlab-workhorse/default.nix
+++ b/pkgs/applications/version-management/gitlab/gitlab-workhorse/default.nix
@@ -5,7 +5,7 @@ in
 buildGoModule rec {
   pname = "gitlab-workhorse";
 
-  version = "15.10.1";
+  version = "15.10.2";
 
   src = fetchFromGitLab {
     owner = data.owner;

--- a/pkgs/applications/version-management/gitlab/rubyEnv/Gemfile
+++ b/pkgs/applications/version-management/gitlab/rubyEnv/Gemfile
@@ -546,7 +546,7 @@ gem 'lru_redux'
 # Locked as long as quoted-printable encoding issues are not resolved
 # Monkey-patched in `config/initializers/mail_encoding_patch.rb`
 # See https://gitlab.com/gitlab-org/gitlab/issues/197386
-gem 'mail', '= 2.7.1'
+gem 'mail', '= 2.8.1'
 gem 'mail-smtp_pool', '~> 0.1.0', path: 'vendor/gems/mail-smtp_pool', require: false
 
 gem 'microsoft_graph_mailer', '~> 0.1.0', path: 'vendor/gems/microsoft_graph_mailer'
@@ -593,12 +593,8 @@ gem 'app_store_connect'
 # For phone verification
 gem 'telesignenterprise', '~> 2.2'
 
-# Ruby 3 extracts net-protocol into a separate gem, while Ruby 2 has it built-in
-# This condition installs the gem only for Ruby 3 to avoid warnings on Ruby 2
-# Can be removed when support for Ruby 2 is dropped
-install_if -> { Gem::Version.new(RUBY_VERSION) >= Gem::Version.new("3.0.0") } do
-  # BufferedIO patch
-  gem 'net-protocol', '~> 0.1.3'
-end
+# BufferedIO patch
+# Updating this version will require updating scripts/allowed_warnings.txt
+gem 'net-protocol', '~> 0.1.3'
 
 gem 'duo_api', '~> 1.3'

--- a/pkgs/applications/version-management/gitlab/rubyEnv/Gemfile.lock
+++ b/pkgs/applications/version-management/gitlab/rubyEnv/Gemfile.lock
@@ -344,6 +344,7 @@ GEM
       danger
       gitlab (~> 4.2, >= 4.2.0)
     database_cleaner (1.7.0)
+    date (3.3.3)
     dead_end (3.1.1)
     debug_inspector (1.1.0)
     deckar01-task_list (2.3.2)
@@ -927,8 +928,11 @@ GEM
       zeitwerk (~> 2.5)
     lru_redux (1.1.0)
     lumberjack (1.2.7)
-    mail (2.7.1)
+    mail (2.8.1)
       mini_mime (>= 0.1.1)
+      net-imap
+      net-pop
+      net-smtp
     marcel (1.0.2)
     marginalia (1.11.1)
       actionpack (>= 5.2)
@@ -972,12 +976,19 @@ GEM
     nenv (0.3.0)
     net-http-persistent (4.0.1)
       connection_pool (~> 2.2)
+    net-imap (0.3.4)
+      date
+      net-protocol
     net-ldap (0.17.1)
     net-ntp (2.1.3)
+    net-pop (0.1.2)
+      net-protocol
     net-protocol (0.1.3)
       timeout
     net-scp (3.0.0)
       net-ssh (>= 2.6.5, < 7.0.0)
+    net-smtp (0.3.3)
+      net-protocol
     net-ssh (6.0.0)
     netrc (0.11.0)
     nio4r (2.5.8)
@@ -1790,7 +1801,7 @@ DEPENDENCIES
   loofah (~> 2.19.1)
   lookbook (~> 1.5, >= 1.5.3)
   lru_redux
-  mail (= 2.7.1)
+  mail (= 2.8.1)
   mail-smtp_pool (~> 0.1.0)!
   marginalia (~> 1.11.1)
   memory_profiler (~> 1.0)

--- a/pkgs/applications/version-management/gitlab/rubyEnv/gemset.nix
+++ b/pkgs/applications/version-management/gitlab/rubyEnv/gemset.nix
@@ -1064,6 +1064,16 @@ src:
     };
     version = "1.7.0";
   };
+  date = {
+    groups = ["default" "development" "test"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "03skfikihpx37rc27vr3hwrb057gxnmdzxhmzd4bf4jpkl0r55w1";
+      type = "gem";
+    };
+    version = "3.3.3";
+  };
   dead_end = {
     groups = ["default" "test"];
     platforms = [];
@@ -3416,15 +3426,15 @@ src:
     version = "1.2.7";
   };
   mail = {
-    dependencies = ["mini_mime"];
+    dependencies = ["mini_mime" "net-imap" "net-pop" "net-smtp"];
     groups = ["default" "development" "test"];
     platforms = [];
     source = {
       remotes = ["https://rubygems.org"];
-      sha256 = "00wwz6ys0502dpk8xprwcqfwyf3hmnx6lgxaiq6vj43mkx43sapc";
+      sha256 = "1bf9pysw1jfgynv692hhaycfxa8ckay1gjw5hz3madrbrynryfzc";
       type = "gem";
     };
-    version = "2.7.1";
+    version = "2.8.1";
   };
   mail-smtp_pool = {
     dependencies = ["connection_pool" "mail"];
@@ -3739,6 +3749,17 @@ src:
     };
     version = "4.0.1";
   };
+  net-imap = {
+    dependencies = ["date" "net-protocol"];
+    groups = ["default" "development" "test"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "1d996zf3g8xz244791b0qsl9vr7zg4lqnnmf9k2kshr9lki5jam8";
+      type = "gem";
+    };
+    version = "0.3.4";
+  };
   net-ldap = {
     groups = ["default"];
     platforms = [];
@@ -3758,6 +3779,17 @@ src:
       type = "gem";
     };
     version = "2.1.3";
+  };
+  net-pop = {
+    dependencies = ["net-protocol"];
+    groups = ["default" "development" "test"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "1wyz41jd4zpjn0v1xsf9j778qx1vfrl24yc20cpmph8k42c4x2w4";
+      type = "gem";
+    };
+    version = "0.1.2";
   };
   net-protocol = {
     dependencies = ["timeout"];
@@ -3780,6 +3812,17 @@ src:
       type = "gem";
     };
     version = "3.0.0";
+  };
+  net-smtp = {
+    dependencies = ["net-protocol"];
+    groups = ["default" "development" "test"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "1c6md06hm5bf6rv53sk54dl2vg038pg8kglwv3rayx0vk2mdql9x";
+      type = "gem";
+    };
+    version = "0.3.3";
   };
   net-ssh = {
     groups = ["default"];


### PR DESCRIPTION
###### Description of changes

Manual backport for https://github.com/NixOS/nixpkgs/pull/225716

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).