### PR TITLE
python38Packages.meson: fix build with libxcrypt

### DIFF
--- a/pkgs/development/tools/build-managers/meson/default.nix
+++ b/pkgs/development/tools/build-managers/meson/default.nix
@@ -12,6 +12,7 @@
 , OpenGL
 , AppKit
 , Cocoa
+, libxcrypt
 }:
 
 python3.pkgs.buildPythonApplication rec {
@@ -119,6 +120,10 @@ python3.pkgs.buildPythonApplication rec {
     substituteInPlace "$out/share/bash-completion/completions/meson" \
       --replace "python3 -c " "${python3.interpreter} -c "
   '';
+
+  buildInputs = lib.optionals (python3.pythonOlder "3.9") [
+    libxcrypt
+  ];
 
   nativeBuildInputs = [ installShellFiles ];
 


### PR DESCRIPTION
###### Description of changes

This fixes the build of `python38Packages.meson`:

```
Found ninja-1.11.1 at /nix/store/msnllnk5qn0nmwlwdz1kd2zc91w8b2da-ninja-1.11.1/bin/ninja
[1/2] Compiling C object ext/tachyon.cpython-38-x86_64-linux-gnu.so.p/tachyon_module.c.o
FAILED: ext/tachyon.cpython-38-x86_64-linux-gnu.so.p/tachyon_module.c.o
gcc -Iext/tachyon.cpython-38-x86_64-linux-gnu.so.p -Iext '-I../test cases/python/8 different python versions/ext' -I/nix/store/vpm9l2pqd7wkrlr6mzhakfqm93rx70j6-python3-3.8.16/include/python3.8 -fdiagnostics-color=always -D_FILE_OFFSET_BITS=64 -Wall -Winvalid-pch -O3 -fPIC -MD -MQ ext/tachyon.cpython-38-x86_64-linux-gnu.so.p/tachyon_module.c.o -MF ext/tachyon.cpython-38-x86_64-linux-gnu.so.p/tachyon_module.c.o.d -o ext/tachyon.cpython-38-x86_64-linux-gnu.so.p/tachyon_module.c.o -c '../test cases/python/8 different python versions/ext/tachyon_module.c'
In file included from ../test cases/python/8 different python versions/ext/tachyon_module.c:19:
/nix/store/vpm9l2pqd7wkrlr6mzhakfqm93rx70j6-python3-3.8.16/include/python3.8/Python.h:44:10: fatal error: crypt.h: No such file or directory
   44 | #include <crypt.h>
      |          ^~~~~~~~~
compilation terminated.
ninja: build stopped: subcommand failed.
```

`python38Packages.meson` is used by something in `grab-site`'s dependencies (grab-site is stuck on Python 3.8 at the moment).

Similar to https://github.com/NixOS/nixpkgs/pull/198045

cc @mweinelt

cc maintainers @jtojnar @brandonedens @AndersonTorres 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
