### PR TITLE
checkmake: 0.2.1 -> 0.2.2

### DIFF
--- a/pkgs/development/tools/checkmake/default.nix
+++ b/pkgs/development/tools/checkmake/default.nix
@@ -2,13 +2,13 @@
 
 buildGoModule rec {
   pname = "checkmake";
-  version = "0.2.1";
+  version = "0.2.2";
 
   src = fetchFromGitHub {
     owner = "mrtazz";
     repo = pname;
     rev = version;
-    sha256 = "sha256-Zkrr1BrP8ktRGf6EYhDpz3oTnX6msrSpfFqkqi9pmlc=";
+    sha256 = "sha256-Ql8XSQA/w7wT9GbmYOM2vG15GVqj9LxOGIu8Wqp9Wao=";
   };
 
   vendorSha256 = null;
@@ -41,7 +41,6 @@ buildGoModule rec {
     homepage = "https://github.com/mrtazz/checkmake";
     license = licenses.mit;
     maintainers = with maintainers; [ vidbina ];
-    platforms = platforms.linux;
     longDescription = ''
       checkmake is an experimental tool for linting and checking
       Makefiles. It may not do what you want it to.


### PR DESCRIPTION
###### Description of changes

From [the description of the release](https://github.com/mrtazz/checkmake/releases/tag/0.2.2):

> - https://github.com/mrtazz/checkmake/pull/75
> - https://github.com/mrtazz/checkmake/pull/70
> - https://github.com/mrtazz/checkmake/pull/76
> - https://github.com/mrtazz/checkmake/pull/69
> - https://github.com/mrtazz/checkmake/pull/77
> - https://github.com/mrtazz/checkmake/pull/93


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [X] aarch64-linux
  - [X] x86_64-darwin
  - [X] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
