### PR TITLE
aarch64-support for NVIDIA closed and open source drivers

### DIFF
--- a/pkgs/os-specific/linux/nvidia-x11/default.nix
+++ b/pkgs/os-specific/linux/nvidia-x11/default.nix
@@ -27,6 +27,7 @@ rec {
   production = generic {
     version = "525.105.17";
     sha256_64bit = "sha256-xjWiGigsm1NIXxnrtkoPS1NqlouU1Nl2KeC8VHpYFCo=";
+    sha256_aarch64 = "sha256-FUbmupHNVab3sM/ShDXPM7pK+5GC2/ri1YW20Hx3vbE=";
     openSha256 = "sha256-O3XB8tNLmNkzrYoVyJVEE0IcE772lOdr8qn4rQHIupE=";
     settingsSha256 = "sha256-KUw31Am9Zfwk5QTs6th8+J3C4oUBacNgb7ZUNeV68W4=";
     persistencedSha256 = "sha256-jhBtsf9MXrkU/SsBndR1ESGUHhgUWiSH7R75swk3m40=";
@@ -37,6 +38,7 @@ rec {
   latest = selectHighestVersion production (generic {
     version = "530.41.03";
     sha256_64bit = "sha256-riehapaMhVA/XRYd2jQ8FgJhKwJfSu4V+S4uoKy3hLE=";
+    sha256_aarch64 = "sha256-uM5zMEO/AO32VmqUOzmc05FFm/lz76jPSSaQmeZUlFo=";
     openSha256 = "sha256-etbtw6LMRUcFoZC9EDDRrTDekV8JFRYmkp3idLaMk5g=";
     settingsSha256 = "sha256-8KB6T9f+gWl8Ni+uOyrJKiiH5mNx9eyfCcW/RjPTQQA=";
     persistencedSha256 = "sha256-zrstlt/0YVGnsPGUuBbR9ULutywi2wNDVxh7OhJM7tM=";
@@ -45,6 +47,7 @@ rec {
   beta = selectHighestVersion latest (generic {
     version = "530.30.02";
     sha256_64bit = "sha256-R/3bvXoiumYZI9vObn9R7sVN9oBQxAbMBJDDv77eeWM=";
+    sha256_aarch64 = "sha256-/b5Jdow+O7ExXjtXTzDX38qgmBDUYDUl+5zxXvbi1ts=";
     openSha256 = "sha256-LCtTyuJ8s8isTBt9HetItLqSjL1GOn0tPUarjuxHpMk=";
     settingsSha256 = "sha256-6mynLNSaWeiB52HdwZ0EQNyPg+tuat0oEqpZGSb2yQo=";
     persistencedSha256 = "sha256-h6iq0iD9F41a7s6jWKPTI+oVzgDRIr1Kk97LNH9rg7E=";
@@ -71,6 +74,7 @@ rec {
   legacy_470 = generic {
     version = "470.161.03";
     sha256_64bit = "sha256-Xagqf4x254Hn1/C+e3mNtNNE8mvU+s+avPPHHHH+dkA=";
+    sha256_aarch64 = "sha256-Ak+j3CkQNCsclv0X23gP1fx3XPOSEyRkjyK5+GDxhn4=";
     settingsSha256 = "sha256-ryUSiI8PsY3knkJLg0k1EmyYW5OWkhuZma/hmXNuojw=";
     persistencedSha256 = "sha256-/2h90Gq9NQd9Q+9eLVE6vrxXmINXxlLcSNOHxKToOEE=";
 

--- a/pkgs/os-specific/linux/nvidia-x11/generic.nix
+++ b/pkgs/os-specific/linux/nvidia-x11/generic.nix
@@ -2,6 +2,7 @@
 , url ? null
 , sha256_32bit ? null
 , sha256_64bit
+, sha256_aarch64 ? null
 , openSha256 ? null
 , settingsSha256
 , settingsVersion ? version
@@ -28,7 +29,7 @@
   libsOnly ? false
 , # don't include the bundled 32-bit libraries on 64-bit platforms,
   # even if it’s in downloaded binary
-  disable32Bit ? false
+  disable32Bit ? stdenv.hostPlatform.system == "aarch64-linux"
   # 32 bit libs only version of this package
 , lib32 ? null
   # Whether to extract the GSP firmware
@@ -59,13 +60,27 @@ let
     src =
       if stdenv.hostPlatform.system == "x86_64-linux" then
         fetchurl {
-          url = args.url or "https://us.download.nvidia.com/XFree86/Linux-x86_64/${version}/NVIDIA-Linux-x86_64-${version}${pkgSuffix}.run";
+          urls = if args ? url then [ args.url ] else [
+            "https://us.download.nvidia.com/XFree86/Linux-x86_64/${version}/NVIDIA-Linux-x86_64-${version}${pkgSuffix}.run"
+            "https://download.nvidia.com/XFree86/Linux-x86_64/${version}/NVIDIA-Linux-x86_64-${version}${pkgSuffix}.run"
+          ];
           sha256 = sha256_64bit;
         }
       else if stdenv.hostPlatform.system == "i686-linux" then
         fetchurl {
-          url = args.url or "https://download.nvidia.com/XFree86/Linux-x86/${version}/NVIDIA-Linux-x86-${version}${pkgSuffix}.run";
+          urls = if args ? url then [ args.url ] else [
+            "https://us.download.nvidia.com/XFree86/Linux-x86/${version}/NVIDIA-Linux-x86-${version}${pkgSuffix}.run"
+            "https://download.nvidia.com/XFree86/Linux-x86/${version}/NVIDIA-Linux-x86-${version}${pkgSuffix}.run"
+          ];
           sha256 = sha256_32bit;
+        }
+      else if stdenv.hostPlatform.system == "aarch64-linux" && sha256_aarch64 != null then
+        fetchurl {
+          urls = if args ? url then [ args.url ] else [
+            "https://us.download.nvidia.com/XFree86/aarch64/${version}/NVIDIA-Linux-aarch64-${version}${pkgSuffix}.run"
+            "https://download.nvidia.com/XFree86/Linux-aarch64/${version}/NVIDIA-Linux-aarch64-${version}${pkgSuffix}.run"
+          ];
+          sha256 = sha256_aarch64;
         }
       else throw "nvidia-x11 does not support platform ${stdenv.hostPlatform.system}";
 
@@ -126,7 +141,9 @@ let
       homepage = "https://www.nvidia.com/object/unix.html";
       description = "X.org driver and kernel module for NVIDIA graphics cards";
       license = licenses.unfreeRedistributable;
-      platforms = [ "x86_64-linux" ] ++ optionals (!i686bundled) [ "i686-linux" ];
+      platforms = [ "x86_64-linux" ]
+        ++ optionals (sha256_32bit != null) [ "i686-linux" ]
+        ++ optionals (sha256_aarch64 != null) [ "aarch64-linux" ];
       maintainers = with maintainers; [ jonringer kiskae ];
       priority = 4; # resolves collision with xorg-server's "lib/xorg/modules/extensions/libglx.so"
       inherit broken;

--- a/pkgs/os-specific/linux/nvidia-x11/open.nix
+++ b/pkgs/os-specific/linux/nvidia-x11/open.nix
@@ -7,7 +7,7 @@
 , broken ? false
 }:
 
-stdenv.mkDerivation {
+stdenv.mkDerivation ({
   pname = "nvidia-open";
   version = "${kernel.version}-${nvidia_x11.version}";
 
@@ -24,6 +24,10 @@ stdenv.mkDerivation {
     "SYSSRC=${kernel.dev}/lib/modules/${kernel.modDirVersion}/source"
     "SYSOUT=${kernel.dev}/lib/modules/${kernel.modDirVersion}/build"
     "MODLIB=$(out)/lib/modules/${kernel.modDirVersion}"
+    {
+      aarch64-linux = "TARGET_ARCH=aarch64";
+      x86_64-linux = "TARGET_ARCH=x86_64";
+    }.${stdenv.hostPlatform.system}
   ];
 
   installTargets = [ "modules_install" ];
@@ -33,8 +37,10 @@ stdenv.mkDerivation {
     description = "NVIDIA Linux Open GPU Kernel Module";
     homepage = "https://github.com/NVIDIA/open-gpu-kernel-modules";
     license = with licenses; [ gpl2Plus mit ];
-    platforms = [ "x86_64-linux" ];
+    platforms = [ "x86_64-linux" "aarch64-linux" ];
     maintainers = with maintainers; [ nickcao ];
     inherit broken;
   };
-}
+} // lib.optionalAttrs stdenv.hostPlatform.isAarch64 {
+  env.NIX_CFLAGS_COMPILE = "-fno-stack-protector";
+})


### PR DESCRIPTION
###### Description of changes

NVIDIA seems to have provided closed source (and the new open source) aarch64-linux drivers for some time, alongside the x86_64 package. Adding it

###### Things done

I used NVIDIA Jetson AGX Orin developer kit as a test platform. It had (already quite outdated) NVIDIA Quadro P1000 GPU connected to the PCI Express slot. Tested X11 with i3, and Wayland with Weston. Basic 3D acceleration at least seems to be working

- Built on platform(s)
  - [X] x86_64-linux
  - [X] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
