### PR TITLE
nixos/oomd: monitor some slices by default

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2305.section.md
+++ b/nixos/doc/manual/release-notes/rl-2305.section.md
@@ -557,6 +557,8 @@ In addition to numerous new and upgraded packages, this release has the followin
 
 - `make-disk-image` handles `contents` arguments that are directories better, fixing a bug where it used to put them in a subdirectory of the intended `target`.
 
+- Following Fedora's behaviour, `systemd-oomd` now monitors the system slice by default, using the memory pressure policy. This can be reverted by setting `systemd-oomd.enableSystemSlice` to `false`, or disabling the daemon completely with `systemd-oomd.enable`. Monitoring of all user slices can also be enabled by setting `systemd-oomd.enableUserSlices` to `true`, but as `systemd-oomd` acts on a per-cgroup level, applications will need to spawn processes into separate cgroups (e.g. with `systemd-run`) or use a desktop environment (e.g. GNOME, KDE) that does this for them.
+
 ## Detailed migration information {#sec-release-23.05-migration}
 
 ### Pipewire configuration overrides {#sec-release-23.05-migration-pipewire}


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Following the new behaviour of Fedora 38, this makes systemd-oomd:
- monitor the system slice by default
- use the memory pressure policy instead of the swap policy
- make use of its new support for monitoring user-owned services

https://src.fedoraproject.org/rpms/systemd/c/7665e1796f915dedbf8e014f0a78f4f576d609bb 
https://src.fedoraproject.org/rpms/systemd/c/1320fc300948e7c12d16ea8dd4e0fae3fd821d54
https://src.fedoraproject.org/rpms/systemd/c/806c95e1c70af18f81d499b24cd7acfa4c36ffd6

For context, see discussion at https://github.com/NixOS/nixpkgs/pull/169613#issuecomment-1493826723

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
