### PR TITLE
qnotero: fix desktop file

### DIFF
--- a/pkgs/applications/office/qnotero/default.nix
+++ b/pkgs/applications/office/qnotero/default.nix
@@ -26,6 +26,18 @@ python3Packages.buildPythonPackage rec {
     wrapQtApp "$out"/bin/qnotero
   '';
 
+  postInstall = ''
+    mkdir $out/share
+    mv $out/usr/share/applications $out/share/applications
+
+    substituteInPlace $out/share/applications/qnotero.desktop \
+      --replace "Icon=/usr/share/qnotero/resources/light/qnotero.png" "Icon=qnotero"
+
+    mkdir -p $out/share/icons/hicolor/64x64/apps
+    ln -s $out/usr/share/qnotero/resources/light/qnotero.png \
+      $out/share/icons/hicolor/64x64/apps/qnotero.png
+  '';
+
   # no tests executed
   doCheck = false;
 


### PR DESCRIPTION
###### Description of changes

- Moved `qnotero.desktop` from `$out/usr/share/applications/` to `$out/share/applications` so that the desktop file is symlinked automatically 

- Fixed `Icon=` path of `.desktop` file

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).