### PR TITLE
checkmake: fix version information and date of the man page, refactor

### DIFF
--- a/pkgs/development/tools/checkmake/default.nix
+++ b/pkgs/development/tools/checkmake/default.nix
@@ -1,4 +1,10 @@
-{ buildGoModule, fetchFromGitHub, pandoc, lib }:
+{ lib
+, buildGoModule
+, fetchFromGitHub
+, installShellFiles
+, pandoc
+, go
+}:
 
 buildGoModule rec {
   pname = "checkmake";
@@ -8,37 +14,42 @@ buildGoModule rec {
     owner = "mrtazz";
     repo = pname;
     rev = version;
-    sha256 = "sha256-Ql8XSQA/w7wT9GbmYOM2vG15GVqj9LxOGIu8Wqp9Wao=";
+    hash = "sha256-Ql8XSQA/w7wT9GbmYOM2vG15GVqj9LxOGIu8Wqp9Wao=";
   };
 
-  vendorSha256 = null;
+  vendorHash = null;
 
-  nativeBuildInputs = [ pandoc ];
+  nativeBuildInputs = [
+    installShellFiles
+    pandoc
+  ];
 
-  preBuild =
-    let
-      buildVars = {
-        version = version;
-        buildTime = "N/A";
-        builder = "nix";
-        goversion = "$(go version | egrep -o 'go[0-9]+[.][^ ]*')";
-      };
-      buildVarsFlags = lib.concatStringsSep " " (lib.mapAttrsToList (k: v: "-X main.${k}=${v}") buildVars);
-    in
-    ''
-      buildFlagsArray+=("-ldflags=${buildVarsFlags}")
-    '';
+  ldflags = [
+    "-s"
+    "-w"
+    "-X=main.version=${version}"
+    "-X=main.buildTime=1970-01-01T00:00:00Z"
+    "-X=main.builder=nixpkgs"
+    "-X=main.goversion=go${go.version}"
+  ];
 
-  ldflags = [ "-s" "-w" ];
+  postPatch = ''
+    substituteInPlace man/man1/checkmake.1.md \
+      --replace REPLACE_DATE 1970-01-01T00:00:00Z
+  '';
+
+  postBuild = ''
+    pandoc man/man1/checkmake.1.md -st man -o man/man1/checkmake.1
+  '';
 
   postInstall = ''
-    mkdir -p $out/share/man/man1
-    pandoc -s -t man -o $out/share/man/man1/checkmake.1 man/man1/checkmake.1.md
+    installManPage man/man1/checkmake.1
   '';
 
   meta = with lib; {
     description = "Experimental tool for linting and checking Makefiles";
     homepage = "https://github.com/mrtazz/checkmake";
+    changelog = "https://github.com/mrtazz/checkmake/releases/tag/${src.rev}";
     license = licenses.mit;
     maintainers = with maintainers; [ vidbina ];
     longDescription = ''


### PR DESCRIPTION
###### Description of changes

before

```console
checkmake  built at  by  with 
```

after

```console
checkmake 0.2.2 built at 1970-01-01T00:00:00Z by nixpkgs with go1.20.2
```
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
