### PR TITLE
python3.pkgs.django-two-factor-auth: init at 1.15.1

### DIFF
--- a/pkgs/development/python-modules/django-two-factor-auth/default.nix
+++ b/pkgs/development/python-modules/django-two-factor-auth/default.nix
@@ -5,6 +5,7 @@
 , django-otp
 , django-phonenumber-field
 , fetchFromGitHub
+, phonenumbers
 , pydantic
 , pythonOlder
 , pythonRelaxDepsHook
@@ -41,18 +42,38 @@ buildPythonPackage rec {
     django
     django-formtools
     django-otp
-    # django-otp-yubikey #Addtional Pkgs not in nixpkgs yet
     django-phonenumber-field
-    pydantic
     qrcode
-    twilio
-    webauthn
   ];
 
-  # require internet connection
+  passthru.optional-dependencies = {
+    call = [
+      twilio
+    ];
+    sms = [
+      twilio
+    ];
+    webauthn = [
+      pydantic
+      webauthn
+    ];
+    # yubikey = [
+    #   django-otp-yubikey
+    # ];
+    phonenumbers = [
+      phonenumbers
+    ];
+    # phonenumberslite = [
+    #   phonenumberslite
+    # ];
+  };
+
+  # Tests require internet connection
   doCheck = false;
 
-  pythonImportsCheck = [ "two_factor" ];
+  pythonImportsCheck = [
+    "two_factor"
+  ];
 
   meta = with lib; {
     description = "Complete Two-Factor Authentication for Django";

--- a/pkgs/development/python-modules/django-two-factor-auth/default.nix
+++ b/pkgs/development/python-modules/django-two-factor-auth/default.nix
@@ -1,0 +1,64 @@
+{ lib
+, buildPythonPackage
+, django
+, django-formtools
+, django-otp
+, django-phonenumber-field
+, fetchFromGitHub
+, pydantic
+, pythonOlder
+, pythonRelaxDepsHook
+, qrcode
+, setuptools-scm
+, twilio
+, webauthn
+}:
+
+buildPythonPackage rec {
+  pname = "django-two-factor-auth";
+  version = "1.15.1";
+  format = "setuptools";
+
+  disabled = pythonOlder "3.7";
+
+  src = fetchFromGitHub {
+    owner = "jazzband";
+    repo = "django-two-factor-auth";
+    rev = "refs/tags/${version}";
+    hash = "sha256-+E6kSD00ChPiRLT2i43dNlVkbvuR1vKkbSZfD1Bf3qc=";
+  };
+
+  nativeBuildInputs = [
+    pythonRelaxDepsHook
+    setuptools-scm
+  ];
+
+  pythonRelaxDeps = [
+    "django-phonenumber-field"
+  ];
+
+  propagatedBuildInputs = [
+    django
+    django-formtools
+    django-otp
+    # django-otp-yubikey #Addtional Pkgs not in nixpkgs yet
+    django-phonenumber-field
+    pydantic
+    qrcode
+    twilio
+    webauthn
+  ];
+
+  # require internet connection
+  doCheck = false;
+
+  pythonImportsCheck = [ "two_factor" ];
+
+  meta = with lib; {
+    description = "Complete Two-Factor Authentication for Django";
+    homepage = "https://github.com/jazzband/django-two-factor-auth";
+    changelog = "https://github.com/jazzband/django-two-factor-auth/releases/tag/${version}";
+    license = licenses.mit;
+    maintainers = with maintainers; [ derdennisop ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2767,6 +2767,8 @@ self: super: with self; {
 
   django_treebeard = callPackage ../development/python-modules/django_treebeard { };
 
+  django-two-factor-auth = callPackage ../development/python-modules/django-two-factor-auth { };
+
   django-versatileimagefield = callPackage ../development/python-modules/django-versatileimagefield { };
 
   django-vite = callPackage ../development/python-modules/django-vite { };


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
