### PR TITLE
timer: unstable-2023-02-01 -> v1.3.0

### DIFF
--- a/pkgs/tools/misc/timer/default.nix
+++ b/pkgs/tools/misc/timer/default.nix
@@ -2,22 +2,20 @@
 
 buildGoModule rec {
   pname = "timer";
-  version = "unstable-2023-02-01";
+  version = "1.3.0";
 
   src = fetchFromGitHub {
     owner = "caarlos0";
     repo = "timer";
-    rev = "1f437baceb1ca76b341fdc229fe45938b282f2aa";
-    hash = "sha256-u+naemEiKufKYROuJB55u8QgiIgg4nLsB+FerUImtXs=";
+    rev = "v${version}";
+    hash = "sha256-9p/L3Hj3VqlNiyY3lfUAhCjwTl1iSTegWxaVEGB4qHM=";
   };
 
-  vendorHash = "sha256-n4AjaojcDAYbgOIuaAJ4faVJqV+/0uby5OHRMsyL9Dg=";
+  vendorHash = "sha256-j7Xik0te6GdjfhXHT7DRf+MwM+aKjfgTGvroxnlD3MM=";
 
   ldflags = [ "-s" "-w" "-X main.version=${version}" ];
 
-  passthru.tests.version = testers.testVersion {
-    package = timer;
-  };
+  passthru.tests.version = testers.testVersion { package = timer; };
 
   meta = with lib; {
     description = "A `sleep` with progress";


### PR DESCRIPTION
###### Description of changes

update to last tag

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
