### PR TITLE
[22.11] cmark-gfm: 0.29.0.gfm.8 -> 0.29.0.gfm.10

### DIFF
--- a/pkgs/development/libraries/cmark-gfm/default.nix
+++ b/pkgs/development/libraries/cmark-gfm/default.nix
@@ -1,13 +1,13 @@
 { lib, stdenv, fetchFromGitHub, cmake }:
 stdenv.mkDerivation rec {
   pname = "cmark-gfm";
-  version = "0.29.0.gfm.8";
+  version = "0.29.0.gfm.9";
 
   src = fetchFromGitHub {
     owner = "github";
     repo = "cmark-gfm";
     rev = version;
-    sha256 = "sha256-i+y1VORza6pn8a/AfbBKpov/n0ChR9++RC7E8P9p3MY=";
+    sha256 = "sha256-goQtLaiLCyEqVItPfH3e/pFroQWZuVT5oxLs1/GwdoU=";
   };
 
   nativeBuildInputs = [ cmake ];

--- a/pkgs/development/libraries/cmark-gfm/default.nix
+++ b/pkgs/development/libraries/cmark-gfm/default.nix
@@ -1,13 +1,13 @@
 { lib, stdenv, fetchFromGitHub, cmake }:
 stdenv.mkDerivation rec {
   pname = "cmark-gfm";
-  version = "0.29.0.gfm.9";
+  version = "0.29.0.gfm.10";
 
   src = fetchFromGitHub {
     owner = "github";
     repo = "cmark-gfm";
     rev = version;
-    sha256 = "sha256-goQtLaiLCyEqVItPfH3e/pFroQWZuVT5oxLs1/GwdoU=";
+    sha256 = "sha256-8TGwxZB/sT+VmQ0eIwK8rHJrCZXvpG69t+HA3aFz5h8=";
   };
 
   nativeBuildInputs = [ cmake ];

--- a/pkgs/development/libraries/cmark-gfm/default.nix
+++ b/pkgs/development/libraries/cmark-gfm/default.nix
@@ -1,13 +1,13 @@
 { lib, stdenv, fetchFromGitHub, cmake }:
 stdenv.mkDerivation rec {
   pname = "cmark-gfm";
-  version = "0.29.0.gfm.10";
+  version = "0.29.0.gfm.11";
 
   src = fetchFromGitHub {
     owner = "github";
     repo = "cmark-gfm";
     rev = version;
-    sha256 = "sha256-8TGwxZB/sT+VmQ0eIwK8rHJrCZXvpG69t+HA3aFz5h8=";
+    sha256 = "sha256-2jkMJcfcOH5qYP13qS5Hutbyhhzq9WlqlkthmQoJoCM=";
   };
 
   nativeBuildInputs = [ cmake ];

--- a/pkgs/development/libraries/cmark-gfm/default.nix
+++ b/pkgs/development/libraries/cmark-gfm/default.nix
@@ -14,12 +14,6 @@ stdenv.mkDerivation rec {
 
   doCheck = true;
 
-  # remove when https://github.com/github/cmark-gfm/pull/248 merged and released
-  postInstall = ''
-    substituteInPlace $out/include/cmark-gfm-core-extensions.h \
-    --replace '#include "config.h"' '#include <stdbool.h>'
-  '';
-
   meta = with lib; {
     description = "GitHub's fork of cmark, a CommonMark parsing and rendering library and program in C";
     homepage = "https://github.com/github/cmark-gfm";


### PR DESCRIPTION
###### Description of changes

Fixes CVE-2023-26485 / GHSA-r8vr-c48j-fcc5 and CVE-2023-24824 / GHSA-66g8-4hjf-77xh.

Changelogs:
https://github.com/github/cmark-gfm/releases/tag/0.29.0.gfm.9
https://github.com/github/cmark-gfm/releases/tag/0.29.0.gfm.10
https://github.com/github/cmark-gfm/releases/tag/0.29.0.gfm.11

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
Result of `nixpkgs-review pr 225801` run on x86_64-linux [1](https://github.com/Mic92/nixpkgs-review)
<details>
  <summary>3 packages built:</summary>
  <ul>
    <li>cmark-gfm</li>
    <li>mindforger</li>
    <li>mmdoc</li>
  </ul>
</details>