### PR TITLE
alice-tools*: 0.12.1 -> 0.13.0

### DIFF
--- a/pkgs/tools/games/alice-tools/default.nix
+++ b/pkgs/tools/games/alice-tools/default.nix
@@ -33,8 +33,12 @@ stdenv.mkDerivation (finalAttrs: {
   };
 
   postPatch = lib.optionalString (withGUI && lib.versionAtLeast qtbase.version "6.0") ''
+    # Use Meson's Qt6 module
     substituteInPlace src/meson.build \
       --replace qt5 qt6
+
+    # For some reason Meson uses QMake instead of pkg-config detection method for Qt6 on Darwin, which gives wrong search paths for tools
+    export PATH=${qtbase.dev}/libexec:$PATH
   '';
 
   mesonFlags = lib.optionals (withGUI && lib.versionAtLeast qtbase.version "6.0") [

--- a/pkgs/tools/games/alice-tools/default.nix
+++ b/pkgs/tools/games/alice-tools/default.nix
@@ -2,7 +2,6 @@
 , lib
 , gitUpdater
 , fetchFromGitHub
-, fetchpatch
 , meson
 , ninja
 , pkg-config
@@ -21,32 +20,16 @@
 assert withGUI -> qtbase != null && wrapQtAppsHook != null;
 
 stdenv.mkDerivation rec {
-  pname = "alice-tools";
-  version = "0.12.1";
+  pname = "alice-tools" + lib.optionalString withGUI "-qt${lib.versions.major qtbase.version}";
+  version = "0.13.0";
 
   src = fetchFromGitHub {
     owner = "nunuhara";
     repo = "alice-tools";
     rev = version;
     fetchSubmodules = true;
-    hash = "sha256-uXiNNneAOTDupgc+ZvaeRNbEQFJBv4ppdEc3kZeUsg8=";
+    hash = "sha256-DazWnBeI5XShkIx41GFZLP3BbE0O8T9uflvKIZUXCHo=";
   };
-
-  patches = [
-    # These two patches (one to alice-tools, one to a subproject) improve DCF & PCF parsing
-    # Remove them when version > 0.12.1
-    (fetchpatch {
-      url = "https://github.com/nunuhara/alice-tools/commit/c800e85b37998d7a47060f5da4b1782d7201a042.patch";
-      excludes = [ "subprojects/libsys4" ];
-      hash = "sha256-R5ckFHqUWHdAPkFa53UbVeLgxJg/8qGLTQWwj5YRJc4=";
-    })
-    (fetchpatch {
-      url = "https://github.com/nunuhara/libsys4/commit/cff2b826d1618fb17616cdd288ab0c50f35e8032.patch";
-      stripLen = 1;
-      extraPrefix = "subprojects/libsys4/";
-      hash = "sha256-CmetiVP2kGL+MwuE9OoEDrDFxzwWvv1TtZuq1li1uIw=";
-    })
-  ];
 
   postPatch = lib.optionalString (withGUI && lib.versionAtLeast qtbase.version "6.0") ''
     substituteInPlace src/meson.build \


### PR DESCRIPTION
###### Description of changes

- bump, dropping the fetching of now-merged patches in the process
- reflect Qt version in `pname` so it's easier to tell apart which path belongs to which variant
- add version tests to all variants

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
