### PR TITLE
[WIP] SuperSlicer 2.4.58.5 and SuperSlicer 2.5.59.2

### DIFF
--- a/pkgs/applications/misc/prusa-slicer/default.nix
+++ b/pkgs/applications/misc/prusa-slicer/default.nix
@@ -18,7 +18,6 @@
 , glew
 , glib
 , gmp
-, gtest
 , gtk3
 , hicolor-icon-theme
 , ilmbase
@@ -105,10 +104,9 @@ stdenv.mkDerivation (finalAttrs: {
     xorg.libX11
   ] ++ lib.optionals withSystemd [
     systemd
-  ] ++ finalAttrs.nativeCheckInputs;
+  ];
 
   doCheck = true;
-  nativeCheckInputs = [ gtest ];
 
   separateDebugInfo = true;
 

--- a/pkgs/applications/misc/prusa-slicer/default.nix
+++ b/pkgs/applications/misc/prusa-slicer/default.nix
@@ -197,7 +197,7 @@ stdenv.mkDerivation (finalAttrs: {
     description = "G-code generator for 3D printer";
     homepage = "https://github.com/prusa3d/PrusaSlicer";
     license = licenses.agpl3;
-    maintainers = with maintainers; [ moredread tweber ];
+    maintainers = with maintainers; [ moredread tweber tmarkus ];
   } // lib.optionalAttrs (stdenv.isDarwin) {
     mainProgram = "PrusaSlicer";
   };

--- a/pkgs/applications/misc/prusa-slicer/default.nix
+++ b/pkgs/applications/misc/prusa-slicer/default.nix
@@ -106,8 +106,6 @@ stdenv.mkDerivation (finalAttrs: {
     systemd
   ];
 
-  doCheck = true;
-
   separateDebugInfo = true;
 
   # The build system uses custom logic - defined in
@@ -148,9 +146,6 @@ stdenv.mkDerivation (finalAttrs: {
     # Fix resources folder location on macOS
     substituteInPlace src/PrusaSlicer.cpp \
       --replace "#ifdef __APPLE__" "#if 0"
-  '' + lib.optionalString (stdenv.isDarwin && stdenv.isx86_64) ''
-    # Disable segfault tests
-    sed -i '/libslic3r/d' tests/CMakeLists.txt
   '';
 
   patches = [
@@ -189,6 +184,18 @@ stdenv.mkDerivation (finalAttrs: {
     gappsWrapperArgs+=(
       --prefix LD_LIBRARY_PATH : "$out/lib"
     )
+  '';
+
+  doCheck = true;
+
+  checkPhase = ''
+    runHook preCheck
+
+    ctest \
+      --force-new-ctest-process \
+      -E 'libslic3r_tests|sla_print_tests'
+
+    runHook postCheck
   '';
 
   meta = with lib; {

--- a/pkgs/applications/misc/prusa-slicer/default.nix
+++ b/pkgs/applications/misc/prusa-slicer/default.nix
@@ -114,11 +114,6 @@ stdenv.mkDerivation (finalAttrs: {
   # additionally need to set the path via the NLOPT environment variable.
   NLOPT = nlopt;
 
-  # Disable compiler warnings that clutter the build log.
-  # It seems to be a known issue for Eigen:
-  # http://eigen.tuxfamily.org/bz/show_bug.cgi?id=1221
-  env.NIX_CFLAGS_COMPILE = "-Wno-ignored-attributes";
-
   # prusa-slicer uses dlopen on `libudev.so` at runtime
   NIX_LDFLAGS = lib.optionalString withSystemd "-ludev";
 

--- a/pkgs/applications/misc/prusa-slicer/super-slicer.nix
+++ b/pkgs/applications/misc/prusa-slicer/super-slicer.nix
@@ -47,10 +47,15 @@ let
       fetchSubmodules = true;
     };
 
-    # wxScintilla is not used on macOS
+    # - wxScintilla is not used on macOS
+    # - Partially applied upstream changes cause a bug when trying to link against a nonexistent libexpat
     prePatch = super.prePatch + ''
       substituteInPlace src/CMakeLists.txt \
-        --replace "scintilla" ""
+        --replace "scintilla" "" \
+        --replace "list(APPEND wxWidgets_LIBRARIES libexpat)" "list(APPEND wxWidgets_LIBRARIES EXPAT::EXPAT)"
+
+      substituteInPlace src/libslic3r/CMakeLists.txt \
+        --replace "libexpat" "EXPAT::EXPAT"
     '';
 
     # We don't need PS overrides anymore, and gcode-viewer is embedded in the binary.

--- a/pkgs/applications/misc/prusa-slicer/super-slicer.nix
+++ b/pkgs/applications/misc/prusa-slicer/super-slicer.nix
@@ -63,11 +63,6 @@ let
     postInstall = null;
     separateDebugInfo = true;
 
-    # See https://github.com/supermerill/SuperSlicer/issues/432
-    cmakeFlags = super.cmakeFlags ++ [
-      "-DSLIC3R_BUILD_TESTS=0"
-    ];
-
     buildInputs = super.buildInputs ++ [
       libspnav
     ];

--- a/pkgs/applications/misc/prusa-slicer/super-slicer.nix
+++ b/pkgs/applications/misc/prusa-slicer/super-slicer.nix
@@ -1,4 +1,4 @@
-{ lib, fetchFromGitHub, fetchpatch, makeDesktopItem, wxGTK31, prusa-slicer }:
+{ lib, fetchFromGitHub, fetchpatch, makeDesktopItem, wxGTK31, prusa-slicer, libspnav }:
 let
   appname = "SuperSlicer";
   pname = "super-slicer";
@@ -11,8 +11,8 @@ let
       patches = null;
     };
     latest = {
-      version = "2.4.58.3";
-      sha256 = "sha256-pEZcBEvK4Mq8nytiXLJvta7Bk6qZRJfTNrYz7N/aUAE=";
+      version = "2.4.58.5";
+      sha256 = "sha256-UywxEGedXaBUTKojEkbkuejI6SdPSkPxTJMwUDNW6W0=";
       patches = [
         # Fix detection of TBB, see https://github.com/prusa3d/PrusaSlicer/issues/6355
         (fetchpatch {
@@ -58,6 +58,10 @@ let
     # See https://github.com/supermerill/SuperSlicer/issues/432
     cmakeFlags = super.cmakeFlags ++ [
       "-DSLIC3R_BUILD_TESTS=0"
+    ];
+
+    buildInputs = super.buildInputs ++ [
+      libspnav
     ];
 
     desktopItems = [

--- a/pkgs/applications/misc/prusa-slicer/super-slicer.nix
+++ b/pkgs/applications/misc/prusa-slicer/super-slicer.nix
@@ -5,12 +5,6 @@ let
   description = "PrusaSlicer fork with more features and faster development cycle";
 
   patches = [
-    # Fix detection of TBB, see https://github.com/prusa3d/PrusaSlicer/issues/6355
-    (fetchpatch {
-      url = "https://github.com/prusa3d/PrusaSlicer/commit/76f4d6fa98bda633694b30a6e16d58665a634680.patch";
-      sha256 = "1r806ycp704ckwzgrw1940hh1l6fpz0k1ww3p37jdk6mygv53nv6";
-    })
-
     # Fix compile error with boost 1.79. See https://github.com/supermerill/SuperSlicer/issues/2823
     (fetchpatch {
       url = "https://raw.githubusercontent.com/gentoo/gentoo/81e3ca3b7c131e8345aede89e3bbcd700e1ad567/media-gfx/superslicer/files/superslicer-2.4.58.3-boost-1.79-port-v2.patch";

--- a/pkgs/applications/misc/prusa-slicer/super-slicer.nix
+++ b/pkgs/applications/misc/prusa-slicer/super-slicer.nix
@@ -4,6 +4,26 @@ let
   pname = "super-slicer";
   description = "PrusaSlicer fork with more features and faster development cycle";
 
+  patches = [
+    # Fix detection of TBB, see https://github.com/prusa3d/PrusaSlicer/issues/6355
+    (fetchpatch {
+      url = "https://github.com/prusa3d/PrusaSlicer/commit/76f4d6fa98bda633694b30a6e16d58665a634680.patch";
+      sha256 = "1r806ycp704ckwzgrw1940hh1l6fpz0k1ww3p37jdk6mygv53nv6";
+    })
+
+    # Fix compile error with boost 1.79. See https://github.com/supermerill/SuperSlicer/issues/2823
+    (fetchpatch {
+      url = "https://raw.githubusercontent.com/gentoo/gentoo/81e3ca3b7c131e8345aede89e3bbcd700e1ad567/media-gfx/superslicer/files/superslicer-2.4.58.3-boost-1.79-port-v2.patch";
+      # Excludes Linux-only patches
+      excludes = [
+        "src/slic3r/GUI/FreeCADDialog.cpp"
+        "src/slic3r/GUI/Tab.cpp"
+        "src/slic3r/Utils/Http.cpp"
+      ];
+      sha256 = "sha256-v0q2MhySayij7+qBTE5q01IOq/DyUcWnjpbzB/AV34c=";
+    })
+  ];
+
   versions = {
     stable = {
       version = "2.3.57.12";
@@ -13,24 +33,12 @@ let
     latest = {
       version = "2.4.58.5";
       sha256 = "sha256-UywxEGedXaBUTKojEkbkuejI6SdPSkPxTJMwUDNW6W0=";
-      patches = [
-        # Fix detection of TBB, see https://github.com/prusa3d/PrusaSlicer/issues/6355
-        (fetchpatch {
-          url = "https://github.com/prusa3d/PrusaSlicer/commit/76f4d6fa98bda633694b30a6e16d58665a634680.patch";
-          sha256 = "1r806ycp704ckwzgrw1940hh1l6fpz0k1ww3p37jdk6mygv53nv6";
-        })
-        # Fix compile error with boost 1.79. See https://github.com/supermerill/SuperSlicer/issues/2823
-        (fetchpatch {
-          url = "https://raw.githubusercontent.com/gentoo/gentoo/81e3ca3b7c131e8345aede89e3bbcd700e1ad567/media-gfx/superslicer/files/superslicer-2.4.58.3-boost-1.79-port-v2.patch";
-          # Excludes Linux-only patches
-          excludes = [
-            "src/slic3r/GUI/FreeCADDialog.cpp"
-            "src/slic3r/GUI/Tab.cpp"
-            "src/slic3r/Utils/Http.cpp"
-          ];
-          sha256 = "sha256-v0q2MhySayij7+qBTE5q01IOq/DyUcWnjpbzB/AV34c=";
-        })
-      ];
+      inherit patches;
+    };
+    beta = {
+      version = "2.5.59.2";
+      sha256 = "sha256-IgE+NWy2DUrPR2ROfK1F67e8B3eoM9yRVQ0GZTxJ42I=";
+      inherit patches;
     };
   };
 

--- a/pkgs/applications/misc/prusa-slicer/super-slicer.nix
+++ b/pkgs/applications/misc/prusa-slicer/super-slicer.nix
@@ -83,7 +83,7 @@ let
       inherit description;
       homepage = "https://github.com/supermerill/SuperSlicer";
       license = licenses.agpl3;
-      maintainers = with maintainers; [ cab404 moredread ];
+      maintainers = with maintainers; [ cab404 moredread tmarkus ];
       mainProgram = "superslicer";
     };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -35454,6 +35454,8 @@ with pkgs;
 
   super-slicer = darwin.apple_sdk_11_0.callPackage ../applications/misc/prusa-slicer/super-slicer.nix { };
 
+  super-slicer-beta = super-slicer.beta;
+
   super-slicer-latest = super-slicer.latest;
 
   snapmaker-luban = callPackage ../applications/misc/snapmaker-luban { };


### PR DESCRIPTION
###### Description of changes

* Updates `super-slicer-latest` to 2.4.58.5 (based on #195185): https://github.com/supermerill/SuperSlicer/releases/tag/2.4.58.5
* Adds `super-slicer-beta` for release 2.5.59.2: https://github.com/supermerill/SuperSlicer/releases/tag/2.5.59.2
* Remove workaround for https://github.com/supermerill/SuperSlicer/issues/432 which shouldn't be necessary anymore
* Use `tbb_2021_8` because `super-slicer-beta` requires a newer TBB version. ~~Also add an override for `openvdb` since it requires TBB itself and the TBB versions should match (there's a warning otherwise, not sure if it's harmful, but better safe than sorry)~~ It turns out the `openvdb` override is more complicated than I thought (causes a number of build issues), so I removed it again.
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Closes #222788

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
