### PR TITLE
memreserver: init and add module

### DIFF
--- a/nixos/modules/hardware/memreserver.nix
+++ b/nixos/modules/hardware/memreserver.nix
@@ -15,7 +15,7 @@ with lib;
     };
   };
 
-  config = mkIf hardware.memreserver.enable {
+  config = mkIf config.hardware.memreserver.enable {
     systemd.services.memreserver = {
       description = "Sleep hook which frees up RAM needed to evacuate GPU VRAM into";
       before = [ "sleep.target" ];

--- a/nixos/modules/hardware/memreserver.nix
+++ b/nixos/modules/hardware/memreserver.nix
@@ -1,0 +1,30 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+{
+  options = {
+    hardware.memreserver = {
+      enable = mkOption {
+        default = false;
+        type = types.bool;
+        description = lib.mdDoc ''
+          Enable memreserver sleep hook.
+          Makes sure that GPUs with dedicated VRAM can suspend correctly.
+        '';
+      };
+    };
+  };
+
+  config = mkIf hardware.memreserver.enable {
+    systemd.services.memreserver = {
+      description = "Sleep hook which frees up RAM needed to evacuate GPU VRAM into";
+      before = [ "sleep.target" ];
+      wantedBy =  [ "sleep.target" ];
+      serviceConfig = {
+        Type = "oneshot";
+        ExecStart = "${pkgs.memreserver}/bin/memreserver";
+      };
+    };
+  };
+}
+

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -67,6 +67,7 @@
   ./hardware/ledger.nix
   ./hardware/logitech.nix
   ./hardware/mcelog.nix
+  ./hardware/memreserver.nix
   ./hardware/network/ath-user-regd.nix
   ./hardware/network/b43.nix
   ./hardware/network/intel-2200bg.nix

--- a/pkgs/misc/memreserver/default.nix
+++ b/pkgs/misc/memreserver/default.nix
@@ -1,0 +1,32 @@
+{ lib
+, stdenv
+, fetchFromGitLab
+, meson
+, ninja
+, pkg-config
+, libdrm
+}:
+
+stdenv.mkDerivation rec {
+  pname = "memreserver";
+  version = "unstable-2023-04-01";
+
+  src = fetchFromGitLab {
+    domain = "git.dolansoft.org";
+    owner = "lorenz";
+    repo = pname;
+    rev = "480253e565dab935df1d1c4e615ebc8a8dc81ba4";
+    hash = "sha256-HjcrH98hH2zKdsHolYCFugL39sT1VjroVhRf8a8dpIA=";
+  };
+
+  nativeBuildInputs = [ meson ninja pkg-config ];
+  buildInputs = [ libdrm ];
+
+  meta = with lib; {
+    homepage = "https://git.dolansoft.org/lorenz/memreserver";
+    description = "Sleep hook which frees up RAM needed to evacuate GPU VRAM into";
+    license = licenses.mit;
+    maintainers = with maintainers; [ lorenz ];
+  };
+}
+

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -26808,6 +26808,8 @@ with pkgs;
 
   impl = callPackage ../development/tools/impl { };
 
+  memreserver = callPackage ../misc/memreserver { };
+
   moq = callPackage ../development/tools/moq { };
 
   quicktemplate = callPackage ../development/tools/quicktemplate { };


### PR DESCRIPTION
###### Description of changes

This adds memreserver (I don't like the name, please leave a comment if you have a better one), a small utility which implements a workaround for the inability to reliably enter deep sleep states on systems with dedicated GPUs (i.e. those containing their own VRAM).

Linux's current PM system which is responsible for putting hardware to sleep in an orderly fashion currently has only hierarchical relationships and no phases, thus when the GPU is getting suspended the kernel might have already suspended the disks. The process of suspending a GPU with VRAM needs significant amounts of memory as all contents from the GPU VRAM need to be moved to system RAM as GPU VRAM will be fully powered down and thus lose its contents when entering deep sleep. But if the disks are already suspended the kernel can no longer swap out additional memory nor release all types of disk caches, thus even with plenty of nominally free memory the suspend can fail due the kernel running out of a specific allocation type. On anything but the newest kernels (6.1+) at least on AMD this cascades into a full resume failure which can only be fixed by a reboot.

memreserver works around this by forcing the kernel to free enough real system memory to fit all of the GPU VRAM before allowing the system to proceed to suspending devices. During this phase the kernel can still flush caches and swap out data to a swap device, thus unless the system is completely out of system memory as well as swap this will succeed. Afterwards when the kernel suspends the GPU it now always has enough free system memory to evacuate the entire GPU VRAM into.

It works by listing all known GPUs, checking if they have VRAM which needs to be evacuated, summing the amount of used VRAM and then allocating this amount as locked memory (forcing the kernel to move everything else out of it) and immediately freeing it, thus allowing the kernel to use it later. It currently only works for AMD GPUs, but can be extended if we have testers for Intel dGPUs and/or nouveau.

## TODO
- [x] More testing (especially the more efficient mode that's now in there which looks at VRAM usage, not just VRAM present)
- [ ] Maybe enable this via udev when the relevant kernel modules are loaded so that this works OOTB? If the GPU(s) aren't affected, it just does nothing.
- [ ] Find a better name
- [ ] Write release notes (kind of want to wait for a better name for this)

@davidak Can you help testing this?

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [x] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
