### PR TITLE
sequoia: 0.27.0 -> 0.28.0

### DIFF
--- a/pkgs/tools/security/sequoia/default.nix
+++ b/pkgs/tools/security/sequoia/default.nix
@@ -5,6 +5,7 @@
 , darwin
 , git
 , nettle
+, nix-update-script
 # Use the same llvmPackages version as Rust
 , llvmPackages_12
 , cargo
@@ -26,23 +27,22 @@ rustPlatform.buildRustPackage rec {
   pname = "sequoia";
   # Upstream has separate version numbering for the library and the CLI frontend.
   # This derivation provides the CLI frontend, and thus uses its version number.
-  version = "0.27.0";
+  version = "0.28.0";
 
   src = fetchFromGitLab {
     owner = "sequoia-pgp";
     repo = "sequoia";
     rev = "sq/v${version}";
-    sha256 = "sha256-KhJAXpj47Tvds5SLYwnsNeIlPf9QEopoCzsvvHgCwaI=";
+    hash = "sha256-T7WOYMqyBeVHs+4w8El99t0NTUKqMW1QeAkNGKcaWr0=";
   };
 
-  cargoSha256 = "sha256-Y7iiZVIT9Vbe4YmTfGTU8p3H3odQKms2FBnnWgvF7mI=";
+  cargoHash = "sha256-zaAAEFBumfHU4hGzAOmLvBu3X4J7LAlmexqixHtVPr8=";
 
   patches = [
-    (fetchpatch
-      { url = "https://gitlab.com/sequoia-pgp/sequoia/-/commit/7916f90421ecb9a75e32f0284459bcc9a3fd02b0.patch";
-        sha256 = "sha256-KBBn6XaGzIT0iVzoCYsS0N+OkZzGuWmUmIF2hl49FEI=";
-      }
-    )
+    (fetchpatch {
+      url = "https://gitlab.com/sequoia-pgp/sequoia/-/commit/4dc6e624c2394936dc447f18aedb4a4810bb2ddb.patch";
+      hash = "sha256-T6hh7U1gvKvyn/OCuJBvLM7TG1VFnpvpAiWS72m3P6I=";
+    })
   ];
 
   nativeBuildInputs = [
@@ -102,6 +102,8 @@ rustPlatform.buildRustPackage rec {
   doCheck = true;
   checkPhase = null;
   installPhase = null;
+
+  passthru.updateScript = nix-update-script { };
 
   meta = with lib; {
     description = "A cool new OpenPGP implementation";


### PR DESCRIPTION
upstream changelog:
<https://gitlab.com/sequoia-pgp/sequoia/-/compare/sq%2Fv0.27.0...sq%2Fv0.28.0>

changes to the nix package:
- removes the cherry-picked 7916f90421 patch that made it into 0.28.0
- cherry-picks upstream commit 4dc6e624c2 which adds support for newer rust versions but didn't make the 0.28.0 release. see <https://github.com/NixOS/nixpkgs/pull/224806>
- adds an update script. future routine updates can be automated with `nix-shell maintainers/scripts/update.nix --argstr package sequoia`

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
