### PR TITLE
buildNimPackage: add Security framework to all nim packages on darwin

### DIFF
--- a/pkgs/development/compilers/nim/default.nix
+++ b/pkgs/development/compilers/nim/default.nix
@@ -203,6 +203,10 @@ in {
 
       nativeBuildInputs = [ makeWrapper ];
 
+      # Needed for any nim package that uses the standard library's
+      # 'std/sysrand' module.
+      depsTargetTargetPropagated = lib.optional stdenv.isDarwin Security;
+
       patches = [
         ./nim.cfg.patch
         # Remove configurations that clash with ours


### PR DESCRIPTION
###### Description of changes

Many nim packages regressed on darwin after 31254120db53fe07d9f1f05fa8ff41af8feaac03, which upgrade nim to 1.6.12. The cause of the breakage is that the nim standard library was changed to link against the Security framework when using the system rng on darwin. Notably not *all* nim packages were broken by this, since packages that don't use this part of the standard library don't need the framework to build.

This commit adds the Security framework to the buildInputs for all nim packages, since the standard library isn't fully functional without it.

Previous discussion about this issue:
 - https://github.com/NixOS/nixpkgs/pull/224854#issuecomment-1498214785
 - https://github.com/NixOS/nixpkgs/pull/222243
 - https://github.com/NixOS/nixpkgs/pull/223373
 - https://github.com/NixOS/nixpkgs/pull/224504

###### Things done

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

For the `nixpkgs-review` run, my build for `nimPackages.npeg` was hanging on the check phase both before and after this change. I disabled checks for it in my local copy in order to test the build for it and it's dependents. With this change, the following packages are still failing:

 - `nimPackages.bumpy`
 - `nimPackages.eris`
 - `nimPackages.eris.bin`
 - `nimPackages.pixie`
 - `nimPackages.vmath`
 - `nrpl`

I tested all the these against the 2887b03d635fce105ebc33543e8b2a60d2c5d733 (the commit before the large batch the darwin regressions), and they were all failing with the same errors. I think it's safe to say that these failures are unrelated, and need to be fixed separately.