### PR TITLE
docker-compose-language-service: init at 0.1.3

### DIFF
--- a/pkgs/development/tools/language-servers/docker-compose-language-service/default.nix
+++ b/pkgs/development/tools/language-servers/docker-compose-language-service/default.nix
@@ -1,0 +1,30 @@
+{ lib
+, buildNpmPackage
+, nodejs-16_x
+, fetchFromGitHub
+}:
+let
+  buildNpmPackage' = buildNpmPackage.override { nodejs = nodejs-16_x; };
+in
+buildNpmPackage' rec {
+  pname = "docker-compose-language-service";
+  version = "0.1.3";
+
+  src = fetchFromGitHub {
+    owner = "microsoft";
+    repo = "compose-language-service";
+    rev = "v${version}";
+    hash = "sha256-faQvUHzqtCipceGnamVQIlAWCDpo7oX01/zGz9RLjMY=";
+  };
+
+  npmDepsHash = "sha256-gWaZMsI1HVIXKZInfgzfH8syzOwU2C6kcKvB2M6KLX4=";
+
+  meta = with lib; {
+    description = "Language service for Docker Compose documents";
+    homepage = "https://github.com/microsoft/compose-language-service";
+    changelog = "https://github.com/microsoft/compose-language-service/releases/tag/v${version}";
+    license = licenses.mit;
+    maintainers = with maintainers; [ natsukium ];
+    mainProgram = "docker-compose-langserver";
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -17315,6 +17315,8 @@ with pkgs;
     llvmPackages = llvmPackages_latest;
   };
 
+  docker-compose-language-service = callPackage ../development/tools/language-servers/docker-compose-language-service { };
+
   dot-language-server = callPackage ../development/tools/language-servers/dot-language-server { };
 
   fortls = python3.pkgs.callPackage ../development/tools/language-servers/fortls { };


### PR DESCRIPTION
###### Description of changes

Language service for Docker Compose documents
https://github.com/microsoft/compose-language-service

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
