### PR TITLE
sile: 0.14.8 → 0.14.9

### DIFF
--- a/pkgs/tools/typesetting/sile/default.nix
+++ b/pkgs/tools/typesetting/sile/default.nix
@@ -45,11 +45,11 @@ in
 
 stdenv.mkDerivation rec {
   pname = "sile";
-  version = "0.14.8";
+  version = "0.14.9";
 
   src = fetchurl {
     url = "https://github.com/sile-typesetter/sile/releases/download/v${version}/${pname}-${version}.tar.xz";
-    sha256 = "0r00s7c8ycc9haqf7p141gj5jn3k0kxpjdzb538f1jpwkgi6mjh9";
+    sha256 = "0528835iir2ws14fwb7w4dqs3wlzzcv5arjxs8v13drb194rlwcs";
   };
 
   configureFlags = [


### PR DESCRIPTION
Upstream release is a rollup of small features and bugfixes has no build changes relevant to Nix. See [upstream release notes](https://github.com/sile-typesetter/sile/releases/tag/v0.14.9)