### PR TITLE
nixos/keter: 2.0 -> 2.1

### DIFF
--- a/nixos/modules/services/web-servers/keter/default.nix
+++ b/nixos/modules/services/web-servers/keter/default.nix
@@ -1,7 +1,7 @@
 { config, pkgs, lib, ... }:
 let
   cfg = config.services.keter;
-  yaml = pkgs.formats.yaml {};
+  yaml = pkgs.formats.yaml { };
 in
 {
   meta = {
@@ -52,7 +52,7 @@ Keep an old app running and swap the ports when the new one is booted.
                 };
                 port = lib.mkOption {
                   type = lib.types.int;
-                  description =  lib.mdDoc "port";
+                  description = lib.mdDoc "port";
                 };
               };
             });

--- a/nixos/modules/services/web-servers/keter/default.nix
+++ b/nixos/modules/services/web-servers/keter/default.nix
@@ -1,11 +1,17 @@
 { config, pkgs, lib, ... }:
 let
   cfg = config.services.keter;
+  yaml = pkgs.formats.yaml {};
 in
 {
   meta = {
     maintainers = with lib.maintainers; [ jappie ];
   };
+
+  imports = [
+    (lib.mkRenamedOptionModule [ "services" "keter" "keterRoot" ] [ "services" "keter" "root" ])
+    (lib.mkRenamedOptionModule [ "services" "keter" "keterPackage" ] [ "services" "keter" "package" ])
+  ];
 
   options.services.keter = {
     enable = lib.mkEnableOption (lib.mdDoc ''keter, a web app deployment manager.
@@ -13,41 +19,64 @@ Note that this module only support loading of webapps:
 Keep an old app running and swap the ports when the new one is booted.
 '');
 
-    keterRoot = lib.mkOption {
+    root = lib.mkOption {
       type = lib.types.str;
       default = "/var/lib/keter";
       description = lib.mdDoc "Mutable state folder for keter";
     };
 
-    keterPackage = lib.mkOption {
+    package = lib.mkOption {
       type = lib.types.package;
       default = pkgs.haskellPackages.keter;
       defaultText = lib.literalExpression "pkgs.haskellPackages.keter";
       description = lib.mdDoc "The keter package to be used";
     };
 
+
     globalKeterConfig = lib.mkOption {
-      type = lib.types.attrs;
-      default = {
-        ip-from-header = true;
-        listeners = [{
-          host = "*4";
-          port = 6981;
-        }];
+      type = lib.types.submodule {
+        freeformType = yaml.type;
+        options = {
+          ip-from-header = lib.mkOption {
+            default = true;
+            type = lib.types.bool;
+            description = lib.mdDoc "You want that ip-from-header in the nginx setup case. It allows nginx setting the original ip address rather then it being localhost (due to reverse proxying)";
+          };
+          listeners = lib.mkOption {
+            default = [{ host = "*"; port = 6981; }];
+            type = lib.types.listOf (lib.types.submodule {
+              options = {
+                host = lib.mkOption {
+                  type = lib.types.str;
+                  description = lib.mdDoc "host";
+                };
+                port = lib.mkOption {
+                  type = lib.types.int;
+                  description =  lib.mdDoc "port";
+                };
+              };
+            });
+            description = lib.mdDoc ''
+              You want that ip-from-header in
+              the nginx setup case.
+              It allows nginx setting the original ip address rather
+              then it being localhost (due to reverse proxying).
+              However if you configure keter to accept connections
+              directly you may want to set this to false.'';
+          };
+          rotate-logs = lib.mkOption {
+            default = false;
+            type = lib.types.bool;
+            description = lib.mdDoc ''
+              emits keter logs and it's applications to stderr.
+              which allows journald to capture them.
+              Set to true to let keter put the logs in files
+              (useful on non systemd systems, this is the old approach
+              where keter handled log management)'';
+          };
+        };
       };
-      # You want that ip-from-header in the nginx setup case
-      # so it's not set to 127.0.0.1.
-      # using a port above 1024 allows you to avoid needing CAP_NET_BIND_SERVICE
-      defaultText = lib.literalExpression ''
-        {
-          ip-from-header = true;
-          listeners = [{
-            host = "*4";
-            port = 6981;
-          }];
-        }
-      '';
-      description = lib.mdDoc "Global config for keter";
+      description = lib.mdDoc "Global config for keter, see <https://github.com/snoyberg/keter/blob/master/etc/keter-config.yaml> for reference";
     };
 
     bundle = {
@@ -90,12 +119,12 @@ Keep an old app running and swap the ports when the new one is booted.
 
   config = lib.mkIf cfg.enable (
     let
-      incoming = "${cfg.keterRoot}/incoming";
+      incoming = "${cfg.root}/incoming";
 
 
       globalKeterConfigFile = pkgs.writeTextFile {
         name = "keter-config.yml";
-        text = (lib.generators.toYAML { } (cfg.globalKeterConfig // { root = cfg.keterRoot; }));
+        text = (lib.generators.toYAML { } (cfg.globalKeterConfig // { root = cfg.root; }));
       };
 
       # If things are expected to change often, put it in the bundle!
@@ -122,7 +151,7 @@ Keep an old app running and swap the ports when the new one is booted.
         script = ''
           set -xe
           mkdir -p ${incoming}
-          { tail -F ${cfg.keterRoot}/log/keter/current.log -n 0 & ${cfg.keterPackage}/bin/keter ${globalKeterConfigFile}; }
+          ${lib.getExe cfg.package} ${globalKeterConfigFile};
         '';
         wantedBy = [ "multi-user.target" "nginx.service" ];
 

--- a/nixos/modules/services/web-servers/keter/default.nix
+++ b/nixos/modules/services/web-servers/keter/default.nix
@@ -51,7 +51,7 @@ Keep an old app running and swap the ports when the new one is booted.
                   description = lib.mdDoc "host";
                 };
                 port = lib.mkOption {
-                  type = lib.types.int;
+                  type = lib.types.port;
                   description = lib.mdDoc "port";
                 };
               };

--- a/nixos/tests/keter.nix
+++ b/nixos/tests/keter.nix
@@ -1,42 +1,43 @@
 import ./make-test-python.nix ({ pkgs, ... }:
-let
-  port = 81;
-in
-{
-  name = "keter";
-  meta = with pkgs.lib.maintainers; {
-    maintainers = [ jappie ];
-  };
+  let
+    port = 81;
+  in
+  {
+    name = "keter";
+    meta = with pkgs.lib.maintainers; {
+      maintainers = [ jappie ];
+    };
 
 
-  nodes.machine = { config, pkgs, ... }: {
-    services.keter = {
-      enable = true;
+    nodes.machine = { config, pkgs, ... }: {
+      services.keter = {
+        enable = true;
 
-      globalKeterConfig = {
-        listeners = [{
-          host = "*4";
-          inherit port;
-        }];
-      };
-      bundle = {
-        appName = "test-bundle";
-        domain = "localhost";
-        executable = pkgs.writeShellScript "run" ''
-          ${pkgs.python3}/bin/python -m http.server $PORT
-        '';
+        globalKeterConfig = {
+          cli-port = 123; # just adding this to test the freeform
+          listeners = [{
+            host = "*4";
+            inherit port;
+          }];
+        };
+        bundle = {
+          appName = "test-bundle";
+          domain = "localhost";
+          executable = pkgs.writeShellScript "run" ''
+            ${pkgs.python3}/bin/python -m http.server $PORT
+          '';
+        };
       };
     };
-  };
 
-  testScript =
-    ''
-      machine.wait_for_unit("keter.service")
+    testScript =
+      ''
+        machine.wait_for_unit("keter.service")
 
-      machine.wait_for_open_port(${toString port})
-      machine.wait_for_console_text("Activating app test-bundle with hosts: localhost")
+        machine.wait_for_open_port(${toString port})
+        machine.wait_for_console_text("Activating app test-bundle with hosts: localhost")
 
 
-      machine.succeed("curl --fail http://localhost:${toString port}/")
-    '';
-})
+        machine.succeed("curl --fail http://localhost:${toString port}/")
+      '';
+  })


### PR DESCRIPTION
keter 2.1 now can log to stderr instead of file rotation.
Which is faster and more reliable.
These changes support that.

Announcement:
https://discourse.haskell.org/t/keter-2-1-0-released/6134

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant **TODO**, this should pass
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
