### PR TITLE
python3Packages.fastparquet: remove unnecessary numba dependency

### DIFF
--- a/pkgs/development/python-modules/fastparquet/default.nix
+++ b/pkgs/development/python-modules/fastparquet/default.nix
@@ -5,7 +5,6 @@
 , cython
 , setuptools
 , substituteAll
-, numba
 , numpy
 , pandas
 , cramjam
@@ -14,6 +13,7 @@
 , python-lzo
 , pytestCheckHook
 , pythonOlder
+, packaging
 }:
 
 buildPythonPackage rec {
@@ -53,10 +53,10 @@ buildPythonPackage rec {
   propagatedBuildInputs = [
     cramjam
     fsspec
-    numba
     numpy
     pandas
     thrift
+    packaging
   ];
 
   passthru.optional-dependencies = {


### PR DESCRIPTION
###### Description of changes

Since version 0.6, fastparquet no longer depends on numba. Since numba doesn't build for Python 3.11 yet, this is unnecessarily preventing fastparquet from being used under Python 3.11.

###### Things done

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

7 packages failed to build:

- python310Packages.dask-awkward
- python310Packages.glymur 
- python310Packages.runway-python 
- python311Packages.glymur 
- python311Packages.intake 
- python311Packages.pyvista 
- python311Packages.runway-python

The other 47 packages did build. None of the packages that failed, failed because they were looking for numba. In fact, most appear to be hoping for certain things in numpy that aren't there, so perhaps the dependencies are improperly specified on these dependent packages.