### PR TITLE
deno: fix CVE-2023-28446

### DIFF
--- a/pkgs/development/web/deno/CVE-2023-28446_escape_control_chars_backport.patch
+++ b/pkgs/development/web/deno/CVE-2023-28446_escape_control_chars_backport.patch
@@ -1,0 +1,140 @@
+diff --git a/Cargo.lock b/Cargo.lock
+index c9b2f0bf6..ac412caeb 100644
+--- a/Cargo.lock
++++ b/Cargo.lock
+@@ -513,6 +513,16 @@ dependencies = [
+  "winapi 0.3.9",
+ ]
+ 
++[[package]]
++name = "console_static_text"
++version = "0.7.1"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++checksum = "953d2c3cf53213a4eccdbe8f2e0b49b5d0f77e87a2a9060117bbf9346f92b64e"
++dependencies = [
++ "unicode-width",
++ "vte",
++]
++
+ [[package]]
+ name = "const-oid"
+ version = "0.9.0"
+@@ -778,6 +788,7 @@ dependencies = [
+  "clap",
+  "clap_complete",
+  "clap_complete_fig",
++ "console_static_text",
+  "data-url",
+  "deno_ast",
+  "deno_bench_util",
+@@ -1177,6 +1188,7 @@ name = "deno_runtime"
+ version = "0.88.0"
+ dependencies = [
+  "atty",
++ "console_static_text",
+  "deno_broadcast_channel",
+  "deno_cache",
+  "deno_console",
+@@ -5416,6 +5428,27 @@ version = "1.0.2"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+ checksum = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"
+ 
++[[package]]
++name = "vte"
++version = "0.11.0"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++checksum = "1aae21c12ad2ec2d168c236f369c38ff332bc1134f7246350dca641437365045"
++dependencies = [
++ "arrayvec",
++ "utf8parse",
++ "vte_generate_state_changes",
++]
++
++[[package]]
++name = "vte_generate_state_changes"
++version = "0.1.1"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++checksum = "d257817081c7dffcdbab24b9e62d2def62e2ff7d00b1c20062551e6cccc145ff"
++dependencies = [
++ "proc-macro2 1.0.43",
++ "quote 1.0.21",
++]
++
+ [[package]]
+ name = "walkdir"
+ version = "2.3.2"
+diff --git a/Cargo.toml b/Cargo.toml
+index 256623504..0db382997 100644
+--- a/Cargo.toml
++++ b/Cargo.toml
+@@ -78,6 +78,7 @@ base64 = "=0.13.1"
+ bencher = "0.1"
+ bytes = "=1.2.1"
+ cache_control = "=0.2.0"
++console_static_text = "=0.7.1"
+ data-url = "=0.2.0"
+ dlopen = "0.1.8"
+ encoding_rs = "=0.8.31"
+diff --git a/cli/Cargo.toml b/cli/Cargo.toml
+index a72ddc822..263234b70 100644
+--- a/cli/Cargo.toml
++++ b/cli/Cargo.toml
+@@ -59,6 +59,7 @@ chrono = { version = "=0.4.22", default-features = false, features = ["clock"] }
+ clap = "=3.1.12"
+ clap_complete = "=3.1.2"
+ clap_complete_fig = "=3.1.5"
++console_static_text.workspace = true
+ data-url.workspace = true
+ dissimilar = "=1.0.4"
+ dprint-plugin-json = "=0.16.0"
+diff --git a/runtime/Cargo.toml b/runtime/Cargo.toml
+index a62259a1a..be94ce420 100644
+--- a/runtime/Cargo.toml
++++ b/runtime/Cargo.toml
+@@ -72,6 +72,7 @@ deno_websocket.workspace = true
+ deno_webstorage.workspace = true
+ 
+ atty.workspace = true
++console_static_text.workspace = true
+ dlopen.workspace = true
+ encoding_rs.workspace = true
+ filetime = "0.2.16"
+diff --git a/runtime/permissions.rs b/runtime/permissions.rs
+index 95f95b512..d5c28ecdf 100644
+--- a/runtime/permissions.rs
++++ b/runtime/permissions.rs
+@@ -29,6 +29,14 @@ use std::sync::atomic::AtomicBool;
+ #[cfg(test)]
+ use std::sync::atomic::Ordering;
+ 
++/// Helper function to strip ansi codes and ASCII control characters.
++fn strip_ansi_codes_and_ascii_control(s: &str) -> std::borrow::Cow<str> {
++  console_static_text::strip_ansi_codes(s)
++    .chars()
++    .filter(|c| !c.is_ascii_control())
++    .collect()
++}
++
+ const PERMISSION_EMOJI: &str = "⚠️";
+ 
+ static DEBUG_LOG_ENABLED: Lazy<bool> =
+@@ -2389,13 +2397,17 @@ fn permission_prompt(
+     return false; // don't grant permission if this fails
+   }
+ 
++  let message = strip_ansi_codes_and_ascii_control(message);
++  let name = strip_ansi_codes_and_ascii_control(name);
++  let api_name = api_name.map(strip_ansi_codes_and_ascii_control);
++
+   // print to stderr so that if stdout is piped this is still displayed.
+   const OPTS: &str = "[y/n] (y = yes, allow; n = no, deny)";
+   eprint!("{}  ┌ ", PERMISSION_EMOJI);
+   eprint!("{}", colors::bold("Deno requests "));
+-  eprint!("{}", colors::bold(message));
++  eprint!("{}", colors::bold(message.clone()));
+   eprintln!("{}", colors::bold("."));
+-  if let Some(api_name) = api_name {
++  if let Some(api_name) = api_name.clone() {
+     eprintln!("   ├ Requested by `{}` API", api_name);
+   }
+   let msg = format!(

--- a/pkgs/development/web/deno/default.nix
+++ b/pkgs/development/web/deno/default.nix
@@ -25,7 +25,12 @@ rustPlatform.buildRustPackage rec {
     rev = "v${version}";
     sha256 = "sha256-Rkzr5Y50Z2A+TeWCrrC6GUvu8/x6IgDxvd8D6mKbIGE=";
   };
-  cargoSha256 = "sha256-n2K0CghobLri69oMrs8nCNSwq/5eH3YlzLtC9JRriQ8=";
+  cargoSha256 = "sha256-D6YjBMUBlfSkPcNDSAln0coADFFCMf8ukO7kAbuZp+g=";
+
+  cargoPatches = [
+    # resolved in 1.31.2
+    ./CVE-2023-28446_escape_control_chars_backport.patch
+  ];
 
   postPatch = ''
     # upstream uses lld on aarch64-darwin for faster builds


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Fix https://github.com/denoland/deno/security/advisories/GHSA-vq67-rp93-65qf on release channel
Similar to #224804

Can't just pull latest fixed because it would also require pulling in a new copy of rust. That could be an option to pull as a single attribute but that copy of rust only just made it to master.
This fix needed to be adapted from https://github.com/denoland/deno/commit/78d430103a8f6931154ddbbe19d36f3b8630286d.patch to work for the older copy of deno.

Need to adapt the POC (see GH sec advisory) to work for this copy of deno to ensure the issue is fixed.
Sadly no one from deno discord has responded to my request for adapting the POC


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
