### PR TITLE
clippy: use the right rustc when cross compiling

### DIFF
--- a/pkgs/development/compilers/rust/clippy.nix
+++ b/pkgs/development/compilers/rust/clippy.nix
@@ -1,7 +1,8 @@
-{ stdenv, lib, rustPlatform, rustc, Security, patchelf }:
+{ stdenv, lib, rustPlatform, Security, patchelf }:
+
 rustPlatform.buildRustPackage {
   pname = "clippy";
-  inherit (rustc) version src;
+  inherit (rustPlatform.rust.rustc) version src;
 
   # the rust source tarball already has all the dependencies vendored, no need to fetch them again
   cargoVendorDir = "vendor";
@@ -10,7 +11,8 @@ rustPlatform.buildRustPackage {
   # changes hash of vendor directory otherwise
   dontUpdateAutotoolsGnuConfigScripts = true;
 
-  buildInputs = [ rustc.llvm ] ++ lib.optionals stdenv.isDarwin [ Security ];
+  buildInputs = [ rustPlatform.rust.rustc.llvm ]
+    ++ lib.optionals stdenv.isDarwin [ Security ];
 
   # fixes: error: the option `Z` is only accepted on the nightly compiler
   RUSTC_BOOTSTRAP = 1;
@@ -27,8 +29,8 @@ rustPlatform.buildRustPackage {
   # [0]: https://github.com/rust-lang/rust/blob/f77f4d55bdf9d8955d3292f709bd9830c2fdeca5/src/bootstrap/builder.rs#L1543
   # [1]: https://github.com/rust-lang/rust/blob/f77f4d55bdf9d8955d3292f709bd9830c2fdeca5/compiler/rustc_codegen_ssa/src/back/linker.rs#L323-L331
   preFixup = lib.optionalString stdenv.isDarwin ''
-    install_name_tool -add_rpath "${rustc}/lib" "$out/bin/clippy-driver"
-    install_name_tool -add_rpath "${rustc}/lib" "$out/bin/cargo-clippy"
+    install_name_tool -add_rpath "${rustPlatform.rust.rustc}/lib" "$out/bin/clippy-driver"
+    install_name_tool -add_rpath "${rustPlatform.rust.rustc}/lib" "$out/bin/cargo-clippy"
   '';
 
   meta = with lib; {

--- a/pkgs/development/compilers/rust/default.nix
+++ b/pkgs/development/compilers/rust/default.nix
@@ -83,7 +83,13 @@ in
       };
       cargo-auditable = self.callPackage ./cargo-auditable.nix { };
       cargo-auditable-cargo-wrapper = self.callPackage ./cargo-auditable-cargo-wrapper.nix { };
-      clippy = self.callPackage ./clippy.nix { inherit Security; };
+      clippy = callPackage ./clippy.nix {
+        # We want to use self, not buildRustPackages, so that
+        # buildPackages.clippy uses the cross compiler and supports
+        # linting for the target platform.
+        rustPlatform = makeRustPlatform self;
+        inherit Security;
+      };
     });
   };
 }


### PR DESCRIPTION
###### Description of changes

When cross compiling, buildPackages.cargo uses a rustc that can build for both the build and host platforms.  This was not true of buildPackages.clippy, so it was not possible to use clippy for a cross target.  Now it is.

I've modified clippy.nix to use rustc from rustPlatform, so we only have to add a single override in default.nix.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
