### PR TITLE
doc/python: Adds workarounds for building extensions on Darwin

### DIFF
--- a/doc/languages-frameworks/python.section.md
+++ b/doc/languages-frameworks/python.section.md
@@ -273,6 +273,55 @@ This is particularly useful for numpy and scipy users who want to gain speed wit
 Note that using `scipy = super.scipy.override { blas = super.pkgs.mkl; };` will likely result in
 compilation issues, because scipy dependencies need to use the same blas implementation as well.
 
+##### Building packages with extensions on Darwin {#python-building-cxx-extensions-on-darwin}
+
+Building Python packages with extensions on Darwin (macOS) may fail because of
+missing C++ or OS framework libraries. The former case is because Python uses
+`clang` instead of `clang++` to compile C++ extensions (see [unixcompiler.py][
+cpython_cxx_unix_compiler]), but Nix doesn't include C++ standard libraries in
+the `clang` wrapper on Darwin. The latter case is because a package may require
+OS framework libraries. To fix either issue include C++ libraries in the
+derivation like so:
+
+```nix
+{ lib, stdenv, buildPythonPackage, darwin }:
+
+buildPythonPackage {
+  # ...
+  buildInputs = [
+    # ...
+  ] ++ lib.optionals stdenv.isDarwin [
+    # Add any Apple framework libraries your package needs, e.g.
+    darwin.apple_sdk.frameworks.IOKit
+  ];
+  # Include C++ standard library
+  env.NIX_CFLAGS_COMPILE = lib.optionalString stdenv.isDarwin "-I${lib.getDev libcxx}/include/c++/v1";
+  # ...
+}
+```
+
+This technique also works when installing packages in a virtual environment
+inside of a `nix-shell`:
+
+```nix
+{ pkgs ? import <nixpkgs> {}}:
+
+with pkgs; mkShell {
+  # ...
+  buildInputs = [
+    # ...
+  ] ++ lib.optionals stdenv.isDarwin [
+    # Add any Apple framework libraries your package needs, e.g.
+    darwin.apple_sdk.frameworks.IOKit
+  ];
+  # Include C++ standard library
+  env.NIX_CFLAGS_COMPILE = lib.optionalString stdenv.isDarwin "-I${lib.getDev libcxx}/include/c++/v1";
+  # ...
+}
+```
+
+[cpython_cxx_unix_compiler]: https://github.com/python/cpython/blob/71cf7c3dddd9c49ec70c1a95547f2fcd5daa7034/Tools/c-analyzer/distutils/unixccompiler.py#L51
+
 #### `buildPythonApplication` function {#buildpythonapplication-function}
 
 The [`buildPythonApplication`](#buildpythonapplication-function) function is practically the same as


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
Adds documentation on how work around issues building Python packages with extensions on Darwin as a follow-up to [this post on discourse](https://discourse.nixos.org/t/nix-shells-and-python-packages-with-c-extensions/26326).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
