### PR TITLE
nixos/trackpoint: make activateScript recursive

### DIFF
--- a/nixos/modules/tasks/trackpoint.nix
+++ b/nixos/modules/tasks/trackpoint.nix
@@ -82,7 +82,7 @@ with lib;
 
       system.activationScripts.trackpoint =
         ''
-          ${config.systemd.package}/bin/udevadm trigger --attr-match=name="${cfg.device}"
+          ${config.systemd.package}/bin/udevadm trigger "$(${config.systemd.package}/bin/udevadm trigger -vn --attr-match=name="${cfg.device}")"
         '';
     })
 


### PR DESCRIPTION
###### Description of changes

When I changed trackpoint sensitivity and speed. I noticed that after `nixos-rebuild switch` the new settings were not applied, moreover, it reset them to the defaults.

The reason for this behavior is that the old script only triggers devices that match the name attr.

```fish
> udevadm trigger -vn --attr-match="name=TPPS/2 IBM TrackPoint"
/sys/devices/pci0000:00/0000:00:1f.3/i2c-9/9-002c/rmi4-00/rmi4-00.fn03/serio2/input/input18
```

But there are 2 more devices inside the matched device for my Thinkpad T440s.

```fish
> udevadm trigger -vn (udevadm trigger -vn --attr-match="name=TPPS/2 IBM TrackPoint")
/sys/devices/pci0000:00/0000:00:1f.3/i2c-9/9-002c/rmi4-00/rmi4-00.fn03/serio2/input/input18
/sys/devices/pci0000:00/0000:00:1f.3/i2c-9/9-002c/rmi4-00/rmi4-00.fn03/serio2/input/input18/event16
/sys/devices/pci0000:00/0000:00:1f.3/i2c-9/9-002c/rmi4-00/rmi4-00.fn03/serio2/input/input18/mouse1
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
