### PR TITLE
86Box: init at 3.11

### DIFF
--- a/pkgs/applications/emulators/86Box/default.nix
+++ b/pkgs/applications/emulators/86Box/default.nix
@@ -1,0 +1,73 @@
+{ stdenv
+, lib
+, fetchzip
+, SDL2
+, alsa-lib
+, cmake
+, coreutils
+, extra-cmake-modules
+, faudio
+, freetype
+, hicolor-icon-theme
+, jack2
+, libevdev
+, libpng
+, openal
+, pkg-config
+, qt5
+, rtmidi
+, soundfont-fluid
+, vulkan-tools
+, wayland
+, withALSA ? true }:
+
+stdenv.mkDerivation rec {
+  pname = "86Box";
+  version = "3.11";
+
+  src = fetchzip {
+    url = "https://github.com/86Box/86Box/archive/refs/tags/v${version}.tar.gz";
+    stripRoot = false;
+    sha256 = "HwL1A5y63wJvCf+8dq84dGC+y6417DnbsGUldI9AMJk=";
+  };
+
+  nativeBuildInputs = [ cmake extra-cmake-modules pkg-config qt5.wrapQtAppsHook];
+  qtWrapperArgs = [ ''--prefix PATH : "${runtimeLibs}"'' ];
+
+  buildInputs = [ coreutils SDL2 openal freetype rtmidi qt5.qtbase qt5.qttools qt5.qtwayland libevdev wayland jack2 vulkan-tools faudio libpng ]
+    ++ lib.optional withALSA alsa-lib;
+
+  dontUseCmakeConfigure = true;
+
+  runtimeLibs = lib.makeLibraryPath [ qt5.qtwayland hicolor-icon-theme soundfont-fluid];
+
+  preConfigure = ''
+    cmake -B /build/source/86Box-${version}/build -S /build/source/86Box-${version} -D CMAKE_TOOLCHAIN_FILE=/build/source/86Box-${version}/cmake/flags-gcc-x86_64.cmake
+    cd /build/source/86Box-${version}/build
+  '';
+
+  installPhase = ''
+    runHook preInstall;
+    for i in 48x48 64x64 72x72 96x96 128x128 192x192 256x256 512x512; do
+      install -Dm644 "/build/source/86Box-${version}/src/unix/assets/$i/net.86box.86Box.png" -t "$out/share/icons/hicolor/$i/apps"
+    done
+    install -Dm644 /build/source/86Box-${version}/src/unix/assets/net.86box.86Box.desktop -t $out/share/applications/
+    install -Dm755 /build/source/86Box-${version}/build/src/86Box -t $out/bin/
+    runHook postInstall;
+  '';
+
+  preFixup = ''
+    gappsWrapperArgs+=(--prefix LD_LIBRARY_PATH : "${runtimeLibs}" )
+    substituteInPlace $out/share/applications/net.86box.86Box.desktop \
+      --replace "Exec=86Box" "Exec=$out/bin/86Box"
+  '';
+
+  meta = with lib; {
+    description = "Emulator of x86-based machines based on PCem";
+    homepage = "https://86box.net";
+    license = licenses.gpl2Only;
+    maintainers = [ maintainers.dansbandit ];
+    platforms = platforms.linux ++ platforms.windows;
+  };
+}
+

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2120,6 +2120,8 @@ with pkgs;
 
   ### APPLICATIONS/EMULATORS
 
+  _86Box = callPackage ../applications/emulators/86Box { };
+
   atari800 = callPackage ../applications/emulators/atari800 { };
 
   ataripp = callPackage ../applications/emulators/atari++ { };


### PR DESCRIPTION
###### Description of changes

Emulator of x86-based machines based on PCem.
https://86box.net

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
