### PR TITLE
obs-studio-plugins.obs-vkcapture: 1.3.1 -> 1.3.2

### DIFF
--- a/pkgs/applications/video/obs-studio/plugins/obs-vkcapture.nix
+++ b/pkgs/applications/video/obs-studio/plugins/obs-vkcapture.nix
@@ -7,7 +7,10 @@
 , wayland
 , wayland-scanner
 , obs-studio
+, libffi
 , libX11
+, libXau
+, libXdmcp
 , libxcb
 , vulkan-headers
 , vulkan-loader
@@ -17,13 +20,13 @@
 
 stdenv.mkDerivation rec {
   pname = "obs-vkcapture";
-  version = "1.3.1";
+  version = "1.3.2";
 
   src = fetchFromGitHub {
     owner = "nowrep";
     repo = pname;
     rev = "v${version}";
-    hash = "sha256-4rEUA8V5WgAVyBeUT0ALVmj14HaAgeASYd2YiBn8MC0=";
+    hash = "sha256-UQQ8oBEnOxmSN4ZyW4LdPZYvd5eB9EmdR0UvE1wgMZw=";
   };
 
   cmakeFlags = lib.optionals stdenv.isi686 [
@@ -35,7 +38,10 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ cmake extra-cmake-modules ninja wayland-scanner ];
   buildInputs = [
     libGL
+    libffi
     libX11
+    libXau
+    libXdmcp
     libxcb
     vulkan-headers
     vulkan-loader


### PR DESCRIPTION
###### Description of changes

- Changelog: https://github.com/nowrep/obs-vkcapture/releases/tag/v1.3.2
- Diff: https://github.com/nowrep/obs-vkcapture/compare/v1.3.1...v1.3.2

There were three propagated dependencies generating noise during build: libffi, libXau, and libXdmcp. (I packed them in, but I'm not sure `builtInputs` is the right place, since they seem totally optional)

###### Things done

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

