### PR TITLE
gnomeExtensions.system-monitor: 2022-04-25 → 2023-01-21

### DIFF
--- a/pkgs/desktops/gnome/extensions/system-monitor/default.nix
+++ b/pkgs/desktops/gnome/extensions/system-monitor/default.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation rec {
   pname = "gnome-shell-extension-system-monitor";
-  version = "unstable-2022-04-25";
+  version = "unstable-2023-01-21";
 
   src = fetchFromGitHub {
     owner = "paradoxxxzero";
     repo = "gnome-shell-system-monitor-applet";
-    rev = "b359d888fd3fcccf1252f5f1dc390299e701493e";
-    hash = "sha256-FHErXetGN4n0TbrLQ5cN7V2IgO96ekHxiHLd0diRFAY=";
+    rev = "21d7b4e7a03ec8145b0b90c4f0b15c27d6f53788";
+    hash = "sha256-XDqWxTyaFEWPdXMTklcNQxqql73ESXAIF6TjMFHaj7g=";
   };
 
   nativeBuildInputs = [
@@ -17,14 +17,10 @@ stdenv.mkDerivation rec {
   ];
 
   patches = [
-    # GNOME 43 compatibility
+    # GNOME 44 compatibility
     (fetchpatch {
-      url = "https://github.com/paradoxxxzero/gnome-shell-system-monitor-applet/pull/754/commits/3b3a617f78c5e9bbce0aa2864b3989335edb37b7.patch";
-      hash = "sha256-BAD0ExQYmTg6i02Gg7jcF0vf1zp232vXRjGCn+rBYXE=";
-    })
-    (fetchpatch {
-      url = "https://github.com/paradoxxxzero/gnome-shell-system-monitor-applet/pull/754/commits/0815ed9da5056542730838fbf6c600506cf7a76f.patch";
-      hash = "sha256-pavjlPV9BxXoqb0YrlP2bXT7tkNQaBkTy1pMrI9MLnk=";
+      url = "https://github.com/paradoxxxzero/gnome-shell-system-monitor-applet/pull/788/commits/e69349942791140807c01d472dfe5e0ddf5c73c0.patch";
+      hash = "sha256-g5Ocpvp7eO/pBkDBZsxgXH7e8rdPBUUxDSwK2hJHKbY=";
     })
     (substituteAll {
       src = ./paths_and_nonexisting_dirs.patch;


### PR DESCRIPTION
###### Description of changes

Upgrade the system-monitor GNOME extension to add GNOME 44 support.

https://github.com/paradoxxxzero/gnome-shell-system-monitor-applet/compare/b359d888fd3fcccf1252f5f1dc390299e701493e...21d7b4e7a03ec8145b0b90c4f0b15c27d6f53788
https://github.com/paradoxxxzero/gnome-shell-system-monitor-applet/pull/788

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
