### PR TITLE
Revert "maintainers/scripts/update.nix: Remove unicode from message"

### DIFF
--- a/maintainers/scripts/update.py
+++ b/maintainers/scripts/update.py
@@ -100,7 +100,7 @@ async def commit_changes(name: str, merge_lock: asyncio.Lock, worktree: str, bra
         # Git can only handle a single index operation at a time
         async with merge_lock:
             await check_subprocess('git', 'add', *change['files'], cwd=worktree)
-            commit_message = '{attrPath}: {oldVersion} -> {newVersion}'.format(**change)
+            commit_message = '{attrPath}: {oldVersion} → {newVersion}'.format(**change)
             if 'commitMessage' in change:
                 commit_message = change['commitMessage']
             elif 'commitBody' in change:


### PR DESCRIPTION
The change broke updates in third party repos that do not want ugly arrows, while using Unicode arrows is [arguably fine](https://github.com/NixOS/nixpkgs/pull/224746#issuecomment-1497313628) in Nixpkgs.

Reverts NixOS/nixpkgs#224746