### PR TITLE
grafana-agent: 0.30.2 -> 0.32.1, remove obsolete test fix; nixos/grafana-agent: use `lib.getExe`

### DIFF
--- a/nixos/modules/services/monitoring/grafana-agent.nix
+++ b/nixos/modules/services/monitoring/grafana-agent.nix
@@ -140,7 +140,7 @@ in
         # We can't use Environment=HOSTNAME=%H, as it doesn't include the domain part.
         export HOSTNAME=$(< /proc/sys/kernel/hostname)
 
-        exec ${cfg.package}/bin/agent -config.expand-env -config.file ${configFile}
+        exec ${lib.getExe cfg.package} -config.expand-env -config.file ${configFile}
       '';
       serviceConfig = {
         Restart = "always";

--- a/pkgs/servers/monitoring/grafana-agent/default.nix
+++ b/pkgs/servers/monitoring/grafana-agent/default.nix
@@ -41,11 +41,6 @@ buildGoModule rec {
   # https://github.com/coreos/go-systemd/issues/351
   env.NIX_CFLAGS_COMPILE = toString (lib.optionals stdenv.isLinux [ "-I${lib.getDev systemd}/include" ]);
 
-  # tries to access /sys: https://github.com/grafana/agent/issues/333
-  preBuild = ''
-    rm pkg/integrations/node_exporter/node_exporter_test.go
-  '';
-
   # go-systemd uses libsystemd under the hood, which does dlopen(libsystemd) at
   # runtime.
   # Add to RUNPATH so it can be found.

--- a/pkgs/servers/monitoring/grafana-agent/default.nix
+++ b/pkgs/servers/monitoring/grafana-agent/default.nix
@@ -56,6 +56,6 @@ buildGoModule rec {
     description = "A lightweight subset of Prometheus and more, optimized for Grafana Cloud";
     license = licenses.asl20;
     homepage = "https://grafana.com/products/cloud";
-    maintainers = with maintainers; [ flokli ];
+    maintainers = with maintainers; [ flokli indeednotjames ];
   };
 }

--- a/pkgs/servers/monitoring/grafana-agent/default.nix
+++ b/pkgs/servers/monitoring/grafana-agent/default.nix
@@ -2,16 +2,17 @@
 
 buildGoModule rec {
   pname = "grafana-agent";
-  version = "0.30.2";
+  version = "0.32.1";
 
   src = fetchFromGitHub {
     rev = "v${version}";
     owner = "grafana";
     repo = "agent";
-    sha256 = "sha256-yexCK4GBA997CShtuQQTs1GBsXoknUnWWO0Uotb9EG8=";
+    sha256 = "sha256-t5rQSNLpX0ktK4mKgX6OhNLkANQ1LbFEjmQo/r7UHOM=";
   };
 
-  vendorHash = "sha256-Cl3oygH1RPF+ZdJvkDmr7eyU5daxaZwNE8pQOHK/qP4=";
+  vendorHash = "sha256-5beHG1mZkNcDhccleqTlMA+uiV5d6SSh2QWiL4g3O28=";
+  proxyVendor = true; # darwin/linux hash mismatch
 
   ldflags = let
     prefix = "github.com/grafana/agent/pkg/build";
@@ -32,8 +33,8 @@ buildGoModule rec {
   ];
 
   subPackages = [
-    "cmd/agent"
-    "cmd/agentctl"
+    "cmd/grafana-agent"
+    "cmd/grafana-agentctl"
   ];
 
   # uses go-systemd, which uses libsystemd headers
@@ -50,8 +51,8 @@ buildGoModule rec {
   # Add to RUNPATH so it can be found.
   postFixup = lib.optionalString stdenv.isLinux ''
     patchelf \
-      --set-rpath "${lib.makeLibraryPath [ (lib.getLib systemd) ]}:$(patchelf --print-rpath $out/bin/agent)" \
-      $out/bin/agent
+      --set-rpath "${lib.makeLibraryPath [ (lib.getLib systemd) ]}:$(patchelf --print-rpath $out/bin/grafana-agent)" \
+      $out/bin/grafana-agent
   '';
 
   passthru.tests.grafana-agent = nixosTests.grafana-agent;


### PR DESCRIPTION
###### Description of changes

breaking: 0.31.0 renamed the binaries from `agent` and `agentctl` to `grafana-agent` and `grafana-agentctl`

https://github.com/grafana/agent/releases/tag/v0.32.1
https://github.com/grafana/agent/releases/tag/v0.32.0
https://github.com/grafana/agent/releases/tag/v0.31.3
https://github.com/grafana/agent/releases/tag/v0.31.2
https://github.com/grafana/agent/releases/tag/v0.31.1
https://github.com/grafana/agent/releases/tag/v0.31.0
diff: https://github.com/grafana/agent/compare/v0.30.2...v0.32.1

This version bump will break `services.grafana-agent.package` on 22.11 when `cfg.package` is coming from unstable!

Also removed the obsolete test fix in the `preBuild` hook, as `node_exporter_test.go` does no longer need access to `/sys`.


`services.grafana-agent` has been switched to use `lib.getExe` instead of the hardcoded `/bin/agent` paths (because those paths had to be fixed anyway).

A subset of this pull request could be backported to 22.11 to use `lib.getExe` as well, together with `pkgs.grafana-agent.meta.mainProgram = "agent"` for v0.30.2, so a user setting `cfg.package` to the version from unstable won't break their setup (while keeping the default `cfg.package` compatible as well).
Let me know if I should do that.
I just expect such errors are expected when mixing 22.11 with unstable :woman_shrugging: 

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).