### PR TITLE
ifcfg: init at 0.23

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -10411,6 +10411,13 @@
     githubId = 20026143;
     name = "Katona László";
   };
+  movefasta = {
+    email = "movefasta@dezcom.org";
+    matrix = "@movefasta:matrix.org";
+    github = "movefasta";
+    githubId = 5147021;
+    name = "Igor Brylyov";
+  };
   MP2E = {
     email = "MP2E@archlinux.us";
     github = "MP2E";

--- a/pkgs/development/python-modules/ifcfg/default.nix
+++ b/pkgs/development/python-modules/ifcfg/default.nix
@@ -1,0 +1,36 @@
+{ lib
+, fetchFromGitHub
+, buildPythonPackage
+, iproute2
+, mock
+, nose
+}:
+
+buildPythonPackage rec{
+  pname = "ifcfg";
+  version = "0.23";
+  format = "setuptools";
+
+  src = fetchFromGitHub {
+    owner = "ftao";
+    repo = "python-ifcfg";
+    rev = "releases/${version}";
+    hash = "sha256-j621Yx/LjLaHPZ1N95cUSGxl0qESISS+HeQJRETLeoo=";
+  };
+
+  propagatedBuildInputs = [ iproute2 ];
+
+  nativeCheckInputs = [ iproute2 ];
+
+  checkInputs = [ nose mock ];
+
+  pythonImportsCheck = [ "ifcfg" ];
+
+  meta = with lib; {
+    description = "A library for parsing ifconfig and ipconfig output";
+    homepage = "https://github.com/ftao/python-ifcfg";
+    license = licenses.bsd3;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ movefasta ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -4658,6 +4658,8 @@ self: super: with self; {
 
   ifconfig-parser = callPackage ../development/python-modules/ifconfig-parser { };
 
+  ifcfg = callPackage ../development/python-modules/ifcfg { };
+
   ifcopenshell = callPackage ../development/python-modules/ifcopenshell { };
 
   ignite = callPackage ../development/python-modules/ignite { };


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Adds https://github.com/ftao/python-ifcfg. It is useful for pulling information such as IP, Netmask, MAC Address, Hostname, etc.

This is a re-creation of https://github.com/NixOS/nixpkgs/pull/164515 that's author is not active right now.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
