### PR TITLE
maintainers/haskell/upload-package-list: support 3.10 config dir

### DIFF
--- a/maintainers/scripts/haskell/upload-nixos-package-list-to-hackage.sh
+++ b/maintainers/scripts/haskell/upload-nixos-package-list-to-hackage.sh
@@ -15,8 +15,29 @@
 #      password-command: pass hackage.haskell.org (this can be any command, but not an arbitrary shell expression. Like cabal we only read the first output line and ignore the rest.)
 # Those fields are specified under `upload` on the `cabal` man page.
 
+if test -z "$CABAL_DIR"; then
+  dirs=(
+    "$HOME/.cabal"
+    "${XDG_CONFIG_HOME:-$HOME/.config}/cabal"
+  )
+  missing=true
+
+  for dir in "${dirs[@]}"; do
+    if test -d "$dir"; then
+      export CABAL_DIR="$dir"
+      missing=false
+      break
+    fi
+  done
+
+  if $missing; then
+    echo "Could not find the cabal configuration directory in any of: ${dirs[@]}" >&2
+    exit 101
+  fi
+fi
+
 package_list="$(nix-build -A haskell.package-list)/nixos-hackage-packages.csv"
-username=$(grep "^username:" ~/.cabal/config | sed "s/^username: //")
-password_command=$(grep "^password-command:" ~/.cabal/config | sed "s/^password-command: //")
+username=$(grep "^username:" "$CABAL_DIR/config" | sed "s/^username: //")
+password_command=$(grep "^password-command:" "$CABAL_DIR/config" | sed "s/^password-command: //")
 curl -u "$username:$($password_command | head -n1)" --digest -H "Content-type: text/csv" -T "$package_list" http://hackage.haskell.org/distro/NixOS/packages.csv
 echo


### PR DESCRIPTION
cabal-install 3.10 has some quirky new logic for config, cache, … directory discovery. We reimplement this in this simple bash script, additionally respecting the CABAL_DIR environment variable.

Since I've just *had* to move my cabal dir around, I am now the walking edge case.

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
