### PR TITLE
tektoncd-cli: 0.28.0 -> 0.30.1

### DIFF
--- a/pkgs/applications/networking/cluster/tektoncd-cli/default.nix
+++ b/pkgs/applications/networking/cluster/tektoncd-cli/default.nix
@@ -2,13 +2,13 @@
 
 buildGoModule rec {
   pname = "tektoncd-cli";
-  version = "0.28.0";
+  version = "0.30.1";
 
   src = fetchFromGitHub {
     owner = "tektoncd";
     repo = "cli";
     rev = "v${version}";
-    sha256 = "sha256-8OW0n6aS7bDDbzbrMfJLL8Yvq3vJg47qHQB4zY0xxAw=";
+    sha256 = "sha256-tn7nK5YTdEYJf9UBajOZEc8fQ0cx3qM0X/7UYnDklj8=";
   };
 
   vendorSha256 = null;


### PR DESCRIPTION
- [Compare changes on GitHub](https://github.com/tektoncd/cli/compare/v0.28.0...v0.30.1)

cc @06kellyjac @mstrangfeld @vdemeester for [testing](https://github.com/ryantm/nixpkgs-update/blob/master/doc/nixpkgs-maintainer-faq.md#r-ryantm-opened-a-pr-for-my-package-what-do-i-do).

Signed-off-by: Vincent Demeester <vincent@sbr.pm>
