### PR TITLE
datalad: 0.16.5 -> 0.18.3; unbreak

### DIFF
--- a/pkgs/applications/version-management/datalad/default.nix
+++ b/pkgs/applications/version-management/datalad/default.nix
@@ -1,14 +1,14 @@
-{ lib, stdenv, fetchFromGitHub, installShellFiles, python3, git }:
+{ lib, stdenv, fetchFromGitHub, installShellFiles, python3, git, git-annex }:
 
 python3.pkgs.buildPythonApplication rec {
   pname = "datalad";
-  version = "0.16.5";
+  version = "0.18.3";
 
   src = fetchFromGitHub {
     owner = "datalad";
     repo = pname;
     rev = version;
-    hash = "sha256-F5UFW0/XqntrHclpj3TqoAwuHJbiiv5a7/4MnFoJ1dE=";
+    hash = "sha256-vqO37o5NxQk+gHfvhM1I2ea9/q9ZaLWkDEyPYJKEPcs";
   };
 
   nativeBuildInputs = [ installShellFiles git ];
@@ -24,6 +24,9 @@ python3.pkgs.buildPythonApplication rec {
     patool
     tqdm
     annexremote
+    looseversion
+    setuptools
+    git-annex
 
     # downloaders-extra
     # requests-ftp # not in nixpkgs yet
@@ -66,10 +69,13 @@ python3.pkgs.buildPythonApplication rec {
     installShellCompletion --cmd datalad \
          --bash <($out/bin/datalad shell-completion) \
          --zsh  <($out/bin/datalad shell-completion)
+    wrapProgram $out/bin/datalad --prefix PYTHONPATH : "$PYTHONPATH"
   '';
 
   # no tests
   doCheck = false;
+
+  pythonImportsCheck = [ "datalad" ];
 
   meta = with lib; {
     description = "Keep code, data, containers under control with git and git-annex";


### PR DESCRIPTION
###### Description of changes

Update and unbreak the package ~by adding missing dependency `python310Packages.looseversion`~.

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).


