### PR TITLE
cudaPackages: append $ORIGIN to Runpaths

### DIFF
--- a/pkgs/build-support/setup-hooks/auto-patchelf.py
+++ b/pkgs/build-support/setup-hooks/auto-patchelf.py
@@ -167,7 +167,7 @@ class Dependency:
     found: bool = False     # Whether it was found somewhere
 
 
-def auto_patchelf_file(path: Path, runtime_deps: list[Path]) -> list[Dependency]:
+def auto_patchelf_file(path: Path, runtime_deps: list[Path], append_rpaths: List[Path] = []) -> list[Dependency]:
     try:
         with open_elf(path) as elf:
 
@@ -235,6 +235,8 @@ def auto_patchelf_file(path: Path, runtime_deps: list[Path]) -> list[Dependency]
             dependencies.append(Dependency(path, dep, False))
             print(f"    {dep} -> not found!")
 
+    rpath.extend(append_rpaths)
+
     # Dedup the rpath
     rpath_str = ":".join(dict.fromkeys(map(Path.as_posix, rpath)))
 
@@ -251,8 +253,9 @@ def auto_patchelf(
         paths_to_patch: List[Path],
         lib_dirs: List[Path],
         runtime_deps: List[Path],
-        recursive: bool =True,
-        ignore_missing: List[str] = []) -> None:
+        recursive: bool = True,
+        ignore_missing: List[str] = [],
+        append_rpaths: List[Path] = []) -> None:
 
     if not paths_to_patch:
         sys.exit("No paths to patch, stopping.")
@@ -265,7 +268,7 @@ def auto_patchelf(
     dependencies = []
     for path in chain.from_iterable(glob(p, '*', recursive) for p in paths_to_patch):
         if not path.is_symlink() and path.is_file():
-            dependencies += auto_patchelf_file(path, runtime_deps)
+            dependencies += auto_patchelf_file(path, runtime_deps, append_rpaths)
 
     missing = [dep for dep in dependencies if not dep.found]
 
@@ -312,6 +315,12 @@ def main() -> None:
     parser.add_argument(
         "--runtime-dependencies", nargs="*", type=Path,
         help="Paths to prepend to the runtime path of executable binaries.")
+    parser.add_argument(
+        "--append-rpaths",
+        nargs="*",
+        type=Path,
+        help="Paths to append to all runtime paths unconditionally",
+    )
 
     print("automatically fixing dependencies for ELF files")
     args = parser.parse_args()
@@ -322,7 +331,8 @@ def main() -> None:
         args.libs,
         args.runtime_dependencies,
         args.recursive,
-        args.ignore_missing)
+        args.ignore_missing,
+        append_rpaths=args.append_rpaths)
 
 
 interpreter_path: Path  = None # type: ignore

--- a/pkgs/build-support/setup-hooks/auto-patchelf.sh
+++ b/pkgs/build-support/setup-hooks/auto-patchelf.sh
@@ -61,6 +61,7 @@ autoPatchelf() {
         ignoreMissingDepsArray=( "*" )
     fi
 
+    local appendRunpathsArray=($appendRunpaths)
     local runtimeDependenciesArray=($runtimeDependencies)
     @pythonInterpreter@ @autoPatchelfScript@                            \
         ${norecurse:+--no-recurse}                                      \
@@ -68,7 +69,8 @@ autoPatchelf() {
         --paths "$@"                                                    \
         --libs "${autoPatchelfLibs[@]}"                                 \
                "${extraAutoPatchelfLibs[@]}"                            \
-        --runtime-dependencies "${runtimeDependenciesArray[@]/%//lib}"
+        --runtime-dependencies "${runtimeDependenciesArray[@]/%//lib}"  \
+        --append-rpaths "${appendRunpathsArray[@]}"
 }
 
 # XXX: This should ultimately use fixupOutputHooks but we currently don't have

--- a/pkgs/development/compilers/cudatoolkit/redist/build-cuda-redist-package.nix
+++ b/pkgs/development/compilers/cudatoolkit/redist/build-cuda-redist-package.nix
@@ -38,6 +38,12 @@ backendStdenv.mkDerivation {
     stdenv.cc.cc.lib
   ];
 
+  # Picked up by autoPatchelf
+  # Needed e.g. for libnvrtc to locate (dlopen) libnvrtc-builtins
+  appendRunpaths = [
+    "$ORIGIN"
+  ];
+
   dontBuild = true;
 
   # TODO: choose whether to install static/dynamic libs


### PR DESCRIPTION
###### Description of changes

Re-opening https://github.com/NixOS/nixpkgs/pull/225955 to target staging because modifying autopatchelf triggers rebuilds for some measly 21k packages...

@NixOS/cuda-maintainers 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
