### PR TITLE
octavePackages.control: update 3.5.1 -> 3.5.2

### DIFF
--- a/pkgs/development/octave-modules/control/default.nix
+++ b/pkgs/development/octave-modules/control/default.nix
@@ -1,21 +1,37 @@
 { buildOctavePackage
 , lib
-, fetchurl
+, fetchFromGitHub
 , gfortran
 , lapack, blas
+, autoreconfHook
 }:
 
 buildOctavePackage rec {
   pname = "control";
-  version = "3.5.1";
+  version = "3.5.2";
 
-  src = fetchurl {
-    url = "mirror://sourceforge/octave/${pname}-${version}.tar.gz";
-    sha256 = "sha256-U/o0RQoHdDhPP3xuiR9gCFb60CKrA30bpc/dH/ozDpg=";
+  src = fetchFromGitHub {
+    owner = "gnu-octave";
+    repo = "pkg-control";
+    rev = "${pname}-${version}";
+    sha256 = "sha256-isUHovpknIFclspHjAtUxGLkrdxitdWSnQMED9n+R3s=";
   };
+
+  # Running autoreconfHook inside the src directory fixes a compile issue about
+  # the config.h header for control missing.
+  # This is supposed to be handled by control's top-level Makefile, but does not
+  # appear to be working. This manually forces it instead.
+  preAutoreconf = ''
+    pushd src
+  '';
+
+  postAutoreconf = ''
+    popd
+  '';
 
   nativeBuildInputs = [
     gfortran
+    autoreconfHook
   ];
 
   buildInputs = [
@@ -23,7 +39,7 @@ buildOctavePackage rec {
   ];
 
   meta = with lib; {
-    homepage = "https://octave.sourceforge.io/control/index.html";
+    homepage = "https://gnu-octave.github.io/packages/control/";
     license = licenses.gpl3Plus;
     maintainers = with maintainers; [ KarlJoad ];
     description = "Computer-Aided Control System Design (CACSD) Tools for GNU Octave, based on the proven SLICOT Library";


### PR DESCRIPTION
Also update to use the GitHub version of control, as development has moved there from SourceForge and 3.5.1 is no longer obtainable from SourceForge.

Add autoreconfHook so that config.h header is generated for control by control.
This seems to be a regression, as 3.5.1 and earlier should have been building fine without it?

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

Closes Issue #226014