### PR TITLE
tree-sitter-grammars: add nu

### DIFF
--- a/pkgs/development/tools/parsing/tree-sitter/grammars/default.nix
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/default.nix
@@ -57,6 +57,7 @@
   tree-sitter-nickel = lib.importJSON ./tree-sitter-nickel.json;
   tree-sitter-nix = lib.importJSON ./tree-sitter-nix.json;
   tree-sitter-norg = lib.importJSON ./tree-sitter-norg.json;
+  tree-sitter-nu = lib.importJSON ./tree-sitter-nu.json;
   tree-sitter-ocaml = lib.importJSON ./tree-sitter-ocaml.json;
   tree-sitter-org-nvim = lib.importJSON ./tree-sitter-org-nvim.json;
   tree-sitter-perl = lib.importJSON ./tree-sitter-perl.json;

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-nu.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-nu.json
@@ -1,0 +1,11 @@
+{
+  "url": "https://github.com/LhKipp/tree-sitter-nu",
+  "rev": "3133b2f391be10698c4fd6bc3d16f94cf2cb39b2",
+  "date": "2023-02-18T19:56:18+01:00",
+  "path": "/nix/store/x4yfa2dvs7gzi62qqs084jx38mhla0ym-tree-sitter-nu",
+  "sha256": "096jz9bb0dihi1civ8x1milyhdmx5chzwyrg84wj1jv94fkfmjk0",
+  "fetchLFS": false,
+  "fetchSubmodules": false,
+  "deepClone": false,
+  "leaveDotGit": false
+}

--- a/pkgs/development/tools/parsing/tree-sitter/update.nix
+++ b/pkgs/development/tools/parsing/tree-sitter/update.nix
@@ -362,6 +362,10 @@ let
       orga = "JoranHonig";
       repo = "tree-sitter-solidity";
     };
+    "tree-sitter-nu" = {
+      orga = "LhKipp";
+      repo = "tree-sitter-nu";
+    };
   };
 
   allGrammars =


### PR DESCRIPTION
###### Description of changes

Add tree sitter grammar for nushell. Homepage is [here][1]. There's also another tree-sitter grammar with the same name on github [here][2], but that one has not been updated since 2022. The version that I added here is used by [`nvim-nu`], which is more-or-less the canonical nvim plugin for nushell.

[1]: https://github.com/LhKipp/tree-sitter-nu
[2]: https://github.com/fdncred/tree-sitter-nu
[3]: https://github.com/LhKipp/nvim-nu

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
