### PR TITLE
stdenv: delete the NIX_COREFOUNDATION_RPATH sledgehammer

### DIFF
--- a/pkgs/build-support/bintools-wrapper/ld-wrapper.sh
+++ b/pkgs/build-support/bintools-wrapper/ld-wrapper.sh
@@ -224,12 +224,6 @@ if [[ "$NIX_DONT_SET_RPATH_@suffixSalt@" != 1 && "$linkType" != static-pie ]]; t
 
 fi
 
-# This is outside the DONT_SET_RPATH branch because it's more targeted and we
-# usually want it (on Darwin) even if DONT_SET_RPATH is set.
-if [ -n "${NIX_COREFOUNDATION_RPATH:-}" ]; then
-  extraAfter+=(-rpath $NIX_COREFOUNDATION_RPATH)
-fi
-
 # Only add --build-id if this is a final link. FIXME: should build gcc
 # with --enable-linker-build-id instead?
 #

--- a/pkgs/development/libraries/glibc/default.nix
+++ b/pkgs/development/libraries/glibc/default.nix
@@ -40,9 +40,6 @@ in
 
       # Apparently --bindir is not respected.
       makeFlagsArray+=("bindir=$bin/bin" "sbindir=$bin/sbin" "rootsbindir=$bin/sbin")
-    '' + lib.optionalString stdenv.buildPlatform.isDarwin ''
-      # ld-wrapper will otherwise attempt to inject CoreFoundation into ld-linux's RUNPATH
-      export NIX_COREFOUNDATION_RPATH=
     '';
 
     # The pie, stackprotector and fortify hardening flags are autodetected by

--- a/pkgs/os-specific/darwin/apple-sdk/framework-setup-hook.sh
+++ b/pkgs/os-specific/darwin/apple-sdk/framework-setup-hook.sh
@@ -29,14 +29,3 @@ fixDarwinFrameworksIn() {
     local dir="$1"
     fixDarwinFrameworks $(find "$dir" -name "*.dylib")
 }
-
-
-# This configures the stdenv to use /System/Library/Frameworks/CoreFoundation.framework
-# instead of the nix version by including the system frameworks path
-# as an rpath entry when creating binaries.
-
-useSystemCoreFoundationFramework () {
-  export NIX_COREFOUNDATION_RPATH=/System/Library/Frameworks
-}
-
-addEnvHooks "$hostOffset" useSystemCoreFoundationFramework

--- a/pkgs/stdenv/darwin/default.nix
+++ b/pkgs/stdenv/darwin/default.nix
@@ -681,7 +681,6 @@ rec {
       targetPlatform = localSystem;
 
       preHook = commonPreHook + ''
-        export NIX_COREFOUNDATION_RPATH=${pkgs.darwin.CF}/Library/Frameworks
         export PATH_LOCALE=${pkgs.darwin.locale}/share/locale
       '';
 


### PR DESCRIPTION
Similar to PR #223861 and the issue #221350, NIX_COREFOUNDATION_RPATH is set unconditionally in the darwin stdenv. This is wrong for cross-compiles and results in `rpaths` depending on the builder platform.

This change makes another bold move and deletes the NIX_COREFOUNDATION_RPATH facility completely, in the hope it is no longer needed, or that any breakage is manageable.

As an added bonus we can delete a darwin specific hack in glibc.

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
