### PR TITLE
libfprint-2-tod1-goodix-550a: init at 0.0.9

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -15909,6 +15909,12 @@
     githubId = 15697697;
     name = "Kasper Gałkowski";
   };
+  utkarshgupta137 = {
+    email = "utkarshgupta137@gmail.com";
+    github = "utkarshgupta137";
+    githubId = 5155100;
+    name = "Utkarsh Gupta";
+  };
   uvnikita = {
     email = "uv.nikita@gmail.com";
     github = "uvNikita";

--- a/pkgs/development/libraries/libfprint-2-tod1-goodix-550a/default.nix
+++ b/pkgs/development/libraries/libfprint-2-tod1-goodix-550a/default.nix
@@ -1,0 +1,45 @@
+{ stdenv, lib, fetchzip, unzip, libfprint-tod }:
+
+stdenv.mkDerivation {
+  pname = "libfprint-2-tod1-goodix-550a";
+  version = "0.0.9";
+
+  src = fetchzip {
+    url = "https://download.lenovo.com/pccbbs/mobiles/r1slg01w.zip";
+    sha256 = "sha256-6tp8Unu6rs27oB5VAqfRqHmv5D9N3njl5qv6We0b/Ec=";
+  };
+
+  nativeBuildInputs = [ unzip ];
+
+  unpackPhase = ''
+    unzip $src/libfprint-tod-goodix-550a-0.0.9.zip
+    cd libfprint-tod-goodix-550a-0.0.9
+    ar x libfprint-2-tod-goodix_amd64.deb
+    tar xf data.tar.xz
+  '';
+
+  buildPhase = ''
+    patchelf \
+      --set-rpath ${lib.makeLibraryPath [ libfprint-tod ]} \
+      usr/lib/x86_64-linux-gnu/libfprint-2/tod-1/libfprint-tod-goodix-550a-$version.so
+  '';
+
+  installPhase = ''
+    mkdir -p "$out/lib/libfprint-2/tod-1/"
+    mkdir -p "$out/lib/udev/rules.d/"
+
+    cp usr/lib/x86_64-linux-gnu/libfprint-2/tod-1/libfprint-tod-goodix-550a-$version.so "$out/lib/libfprint-2/tod-1/"
+    cp lib/udev/rules.d/60-libfprint-2-tod1-goodix.rules "$out/lib/udev/rules.d/"
+  '';
+
+  passthru.driverPath = "/lib/libfprint-2/tod-1";
+
+  meta = with lib; {
+    description = "Goodix 550a driver module for libfprint-2-tod Touch OEM Driver (from Lenovo)";
+    homepage = "https://support.lenovo.com/us/en/downloads/ds560884-goodix-fingerprint-driver-for-linux-thinkpad-e14-gen-4-e15-gen-4";
+    sourceProvenance = with sourceTypes; [ binaryNativeCode ];
+    license = licenses.unfree;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ utkarshgupta137 ];
+  };
+}

--- a/pkgs/development/libraries/libfprint-2-tod1-goodix/default.nix
+++ b/pkgs/development/libraries/libfprint-2-tod1-goodix/default.nix
@@ -1,4 +1,5 @@
 { stdenv, lib, fetchgit, libfprint-tod }:
+
 stdenv.mkDerivation {
   pname = "libfprint-2-tod1-goodix";
   version = "0.0.6";
@@ -12,9 +13,7 @@ stdenv.mkDerivation {
   buildPhase = ''
     patchelf \
       --set-rpath ${lib.makeLibraryPath [ libfprint-tod ]} \
-      usr/lib/x86_64-linux-gnu/libfprint-2/tod-1/libfprint-tod-goodix-53xc-0.0.6.so
-
-    ldd usr/lib/x86_64-linux-gnu/libfprint-2/tod-1/libfprint-tod-goodix-53xc-0.0.6.so
+      usr/lib/x86_64-linux-gnu/libfprint-2/tod-1/libfprint-tod-goodix-53xc-$version.so
   '';
 
   installPhase = ''

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -21377,6 +21377,8 @@ with pkgs;
 
   libfprint-2-tod1-goodix = callPackage ../development/libraries/libfprint-2-tod1-goodix { };
 
+  libfprint-2-tod1-goodix-550a = callPackage ../development/libraries/libfprint-2-tod1-goodix-550a { };
+
   libfprint-2-tod1-vfs0090 = callPackage ../development/libraries/libfprint-2-tod1-vfs0090 { };
 
   libfpx = callPackage ../development/libraries/libfpx { };


### PR DESCRIPTION
###### Description of changes

Added the driver for Goodix 27c6::550a fingerprint reader, provided by Lenovo.
Even though the driver is provided "only" for Thinkpad laptops, it is working perfectly fine on my Lenovo Legion (16ARHA7).

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).