### PR TITLE
doc: Fix the function locations always pointing to master

### DIFF
--- a/doc/doc-support/lib-function-locations.nix
+++ b/doc/doc-support/lib-function-locations.nix
@@ -1,6 +1,6 @@
 { pkgs, nixpkgs ? { }, libsets }:
 let
-  revision = pkgs.lib.trivial.revisionWithDefault (nixpkgs.revision or "master");
+  revision = pkgs.lib.trivial.revisionWithDefault (nixpkgs.rev or "master");
 
   libDefPos = prefix: set:
     builtins.concatMap


### PR DESCRIPTION
Instead of revisions as they should. This is (most-likely) caused by a simple typo, because Hydra is where the revision should come from, but it doesn't set `.revision` as the attribute, but rather `.rev`! This comes from https://github.com/NixOS/hydra/blob/082495e34e094cae1eb49dbfc5648938e23c6355/src/script/hydra-eval-jobset#L300-L301

Fixes https://github.com/NixOS/nixpkgs/issues/223404

I can't actually verify this, but everything points to this being the problem, we'll have to check whether this worked when Hydra completes the next manual build.

This work is sponsored by [Antithesis](https://antithesis.com/) :sparkles:
