### PR TITLE
python310Packages.safetensors: init at 0.3.0

### DIFF
--- a/pkgs/development/python-modules/safetensors/default.nix
+++ b/pkgs/development/python-modules/safetensors/default.nix
@@ -1,0 +1,79 @@
+{ stdenv
+, lib
+, buildPythonPackage
+, fetchFromGitHub
+, fetchpatch
+, h5py
+, numpy
+, pythonOlder
+, pytestCheckHook
+, rustPlatform
+, setuptools-rust
+, torch
+, libiconv
+}:
+
+buildPythonPackage rec {
+  pname = "safetensors";
+  version = "0.3.0";
+  format = "pyproject";
+
+  disabled = pythonOlder "3.7";
+
+  src = fetchFromGitHub {
+    owner = "huggingface";
+    repo = pname;
+    rev = "refs/tags/v${version}";
+    hash = "sha256-Qpb5lTw1WEME9tWEGfxC8l8dK9mGMH2rz+O+xGCrUxw";
+  };
+
+  patches = [
+    # remove after next release
+    (fetchpatch {
+      name = "commit-cargo-lockfile";
+      relative = "bindings/python";
+      url = "https://github.com/huggingface/safetensors/commit/a7061b4235b59312010b2dd6f9597381428ee9a2.patch";
+      hash = "sha256-iH4vQOL2LU93kd0dSS8/JJxKGb+kDstqnExjYSSwi78";
+    })
+  ];
+
+  cargoDeps = rustPlatform.fetchCargoTarball {
+    inherit src patches;
+    sourceRoot = "source/bindings/python";
+    hash = "sha256-tC0XawmKWNGCaByHQfJEfmHM3m/qgTuIpcRaEFJC6dM";
+  };
+
+  sourceRoot = "source/bindings/python";
+
+  nativeBuildInputs = with rustPlatform; [
+    setuptools-rust
+    rust.cargo
+    rust.rustc
+    cargoSetupHook
+  ];
+
+  buildInputs = lib.optionals stdenv.isDarwin [ libiconv ];
+
+  nativeCheckInputs = [
+    h5py numpy pytestCheckHook torch
+  ];
+  pytestFlagsArray = [ "tests" ];
+  # don't require PaddlePaddle (not in Nixpkgs), Flax, or Tensorflow (onerous) to run tests:
+  disabledTestPaths = [
+    "tests/test_flax_comparison.py"
+    "tests/test_paddle_comparison.py"
+    "tests/test_tf_comparison.py"
+  ];
+
+  pythonImportsCheck = [
+    "safetensors"
+  ];
+
+  meta = with lib; {
+    homepage = "https://github.com/huggingface/safetensors";
+    description = "Fast (zero-copy) and safe (unlike pickle) format for storing tensors";
+    changelog = "https://github.com/huggingface/safetensors/releases/tag/v${version}";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ bcdarwin ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -10499,6 +10499,8 @@ self: super: with self; {
 
   safeio = callPackage ../development/python-modules/safeio { };
 
+  safetensors = callPackage ../development/python-modules/safetensors { };
+
   safety = callPackage ../development/python-modules/safety { };
 
   sagemaker = callPackage ../development/python-modules/sagemaker { };


### PR DESCRIPTION
###### Description of changes

Add a package.

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).