### PR TITLE
nvme-cli & libnvme: 2.2.1 -> 2.4 and 1.2 -> 1.4

### DIFF
--- a/pkgs/os-specific/linux/libnvme/default.nix
+++ b/pkgs/os-specific/linux/libnvme/default.nix
@@ -1,5 +1,6 @@
 { fetchFromGitHub
 , json_c
+, keyutils
 , lib
 , meson
 , ninja
@@ -8,12 +9,13 @@
 , pkg-config
 , python3
 , stdenv
+, swig
 , systemd
 }:
 
 stdenv.mkDerivation rec {
   pname = "libnvme";
-  version = "1.2";
+  version = "1.4";
 
   outputs = [ "out" "man" ];
 
@@ -21,7 +23,7 @@ stdenv.mkDerivation rec {
     owner = "linux-nvme";
     repo = "libnvme";
     rev = "v${version}";
-    sha256 = "sha256-U9Fj3OcBe32C0PKhI05eF/6jikHAvdyvXH16IY0rWxI=";
+    sha256 = "sha256-8DlEQ4LH6UhIHr0znJGqkuCosLHqA6hkJjmiCawNE1k=";
   };
 
   postPatch = ''
@@ -36,9 +38,11 @@ stdenv.mkDerivation rec {
     perl # for kernel-doc
     pkg-config
     python3
+    swig
   ];
 
   buildInputs = [
+    keyutils
     json_c
     openssl
     systemd

--- a/pkgs/os-specific/linux/nvme-cli/default.nix
+++ b/pkgs/os-specific/linux/nvme-cli/default.nix
@@ -9,13 +9,13 @@
 
 stdenv.mkDerivation rec {
   pname = "nvme-cli";
-  version = "2.2.1";
+  version = "2.4";
 
   src = fetchFromGitHub {
     owner = "linux-nvme";
     repo = "nvme-cli";
     rev = "v${version}";
-    hash = "sha256-okYtGiKUPNO31ntD9j5iAgdcnS5OQ/g1QAY+svhga4c=";
+    hash = "sha256-vnhvVVfEDnmEIdIkfTRoiLB7dZ1rJV3U4PmUUoaxTUs=";
   };
 
   mesonFlags = [


### PR DESCRIPTION
###### Description of changes

Release changelog for nvme-cli: https://github.com/linux-nvme/nvme-cli/releases/tag/v2.4
Changes since last nvme-cli version in nixpkgs: https://github.com/linux-nvme/nvme-cli/compare/v2.2.1...v2.4

Release changelog for libnvme: Changelog: https://github.com/linux-nvme/libnvme/releases/tag/v1.4
Changes since last libnvme version in nixpkgs: https://github.com/linux-nvme/libnvme/compare/v1.2...v1.4

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
