### PR TITLE
python310Packages.bitsandbytes: init at 0.38.0

### DIFF
--- a/pkgs/development/python-modules/bitsandbytes/default.nix
+++ b/pkgs/development/python-modules/bitsandbytes/default.nix
@@ -1,0 +1,98 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, python
+, pythonOlder
+, pytestCheckHook
+, setuptools
+, torch
+, einops
+, lion-pytorch
+, scipy
+, symlinkJoin
+}:
+
+let
+  pname = "bitsandbytes";
+  version = "0.38.0";
+
+  inherit (torch) cudaCapabilities cudaPackages cudaSupport;
+  inherit (cudaPackages) backendStdenv cudaVersion;
+
+  # NOTE: torchvision doesn't use cudnn; torch does!
+  #   For this reason it is not included.
+  cuda-common-redist = with cudaPackages; [
+    cuda_cccl # <thrust/*>
+    libcublas # cublas_v2.h
+    libcurand
+    libcusolver # cusolverDn.h
+    libcusparse # cusparse.h
+  ];
+
+  cuda-native-redist = symlinkJoin {
+    name = "cuda-native-redist-${cudaVersion}";
+    paths = with cudaPackages; [
+      cuda_cudart # cuda_runtime.h cuda_runtime_api.h
+      cuda_nvcc
+    ] ++ cuda-common-redist;
+  };
+
+  cuda-redist = symlinkJoin {
+    name = "cuda-redist-${cudaVersion}";
+    paths = cuda-common-redist;
+  };
+
+in
+buildPythonPackage {
+  inherit pname version;
+  format = "pyproject";
+
+  disabled = pythonOlder "3.7";
+
+  src = fetchFromGitHub {
+    owner = "TimDettmers";
+    repo = pname;
+    rev = "refs/tags/${version}";
+    hash = "sha256-gGlbzTDvZNo4MhcYzLvWuB2ec7q+Qt5/LtTbJ0Rc+Kk=";
+  };
+
+  postPatch = ''
+    substituteInPlace Makefile --replace "/usr/bin/g++" "g++" --replace "lib64" "lib"
+    substituteInPlace bitsandbytes/cuda_setup/main.py  \
+      --replace "binary_path = package_dir / binary_name"  \
+                "binary_path = Path('$out/${python.sitePackages}/${pname}')/binary_name"
+  '' + lib.optionalString torch.cudaSupport ''
+    substituteInPlace bitsandbytes/cuda_setup/main.py  \
+      --replace "/usr/local/cuda/lib64" "${cuda-native-redist}/lib"
+  '';
+
+  CUDA_HOME = "${cuda-native-redist}";
+
+  preBuild = if torch.cudaSupport then
+    with torch.cudaPackages;
+    let cudaVersion = lib.concatStrings (lib.splitVersion torch.cudaPackages.cudaMajorMinorVersion); in
+    ''make CUDA_VERSION=${cudaVersion} cuda${cudaMajorVersion}x''
+  else
+    ''make CUDA_VERSION=CPU cpuonly'';
+
+  nativeBuildInputs = [ setuptools ] ++ lib.optionals torch.cudaSupport [ cuda-native-redist ];
+  buildInputs = lib.optionals torch.cudaSupport [ cuda-redist ];
+
+  propagatedBuildInputs = [
+    torch
+  ];
+
+  doCheck = false;  # tests require CUDA and also GPU access
+  nativeCheckInputs = [ pytestCheckHook einops lion-pytorch scipy ];
+
+  pythonImportsCheck = [
+    "bitsandbytes"
+  ];
+
+  meta = with lib; {
+    homepage = "https://github.com/TimDettmers/bitsandbytes";
+    description = "8-bit CUDA functions for PyTorch";
+    license = licenses.mit;
+    maintainers = with maintainers; [ bcdarwin ];
+  };
+}

--- a/pkgs/development/python-modules/lion-pytorch/default.nix
+++ b/pkgs/development/python-modules/lion-pytorch/default.nix
@@ -1,0 +1,32 @@
+{ lib
+, buildPythonPackage
+, pythonOlder
+, fetchFromGitHub
+, torch
+}:
+
+buildPythonPackage rec {
+  pname = "lion-pytorch";
+  version = "0.0.7";
+  format = "setuptools";
+  disabled = pythonOlder "3.6";
+
+  src = fetchFromGitHub {
+    owner = "lucidrains";
+    repo = "lion-pytorch";
+    rev = "refs/tags/${version}";
+    hash = "sha256-CSb0s3DKv/KpEmCkCR+Y8iwrLdCL9w9Pl6W46cPB420";
+  };
+
+  propagatedBuildInputs = [ torch ];
+
+  pythonImportsCheck = [ "lion_pytorch" ];
+  doCheck = false;  # no tests currently
+
+  meta = with lib; {
+    description = "Optimizer tuned by Google Brain using genetic algorithms";
+    homepage = "https://github.com/lucidrains/lion-pytorch";
+    license = licenses.mit;
+    maintainers = with maintainers; [ bcdarwin ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5627,6 +5627,8 @@ self: super: with self; {
 
   linuxfd = callPackage ../development/python-modules/linuxfd { };
 
+  lion-pytorch = callPackage ../development/python-modules/lion-pytorch { };
+
   liquidctl = callPackage ../development/python-modules/liquidctl { };
 
   lirc = toPythonModule (pkgs.lirc.override {

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1312,6 +1312,8 @@ self: super: with self; {
 
   bitmath = callPackage ../development/python-modules/bitmath { };
 
+  bitsandbytes = callPackage ../development/python-modules/bitsandbytes { };
+
   bitstring = callPackage ../development/python-modules/bitstring { };
 
   bitstruct = callPackage ../development/python-modules/bitstruct { };


### PR DESCRIPTION
python310Packages.lion-pytorch: init at 0.0.7

###### Description of changes

Add package `bitsandbytes` for 8-bit integer quantization of models and its dependency `lion-pytorch`.

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).