### PR TITLE
gcc: remove aligned_alloc hack on Darwin

### DIFF
--- a/pkgs/development/compilers/gcc/common/pre-configure.nix
+++ b/pkgs/development/compilers/gcc/common/pre-configure.nix
@@ -49,38 +49,6 @@ in lib.optionalString (hostPlatform.isSunOS && hostPlatform.is64bit) ''
   export AS_FOR_TARGET=${gnatboot}/bin/gas
 ''
 
-# NOTE 2020/3/18: This environment variable prevents configure scripts from
-# detecting the presence of aligned_alloc on Darwin.  There are many facts that
-# collectively make this fix necessary:
-#  - Nix uses a fixed set of standard library headers on all MacOS systems,
-#    regardless of their actual version.  (Nix uses version 10.12 headers.)
-#  - Nix uses the native standard library binaries for the build system.  That
-#    means the standard library binaries may not exactly match the standard
-#    library headers.
-#  - The aligned_alloc procedure is present in MacOS 10.15 (Catalina), but not
-#    in earlier versions.  Therefore on Catalina systems, aligned_alloc is
-#    linkable (i.e. present in the binary libraries) but not present in the
-#    headers.
-#  - Configure scripts detect a procedure's existence by checking whether it is
-#    linkable.  They do not check whether it is present in the headers.
-#  - GCC throws an error during compilation because aligned_alloc is not
-#    defined in the headers---even though the linker can see it.
-#
-# This fix would not be necessary if ANY of the above were false:
-#  - If Nix used native headers for each different MacOS version, aligned_alloc
-#    would be in the headers on Catalina.
-#  - If Nix used the same libary binaries for each MacOS version, aligned_alloc
-#    would not be in the library binaries.
-#  - If Catalina did not include aligned_alloc, this wouldn't be a problem.
-#  - If the configure scripts looked for header presence as well as
-#    linkability, they would see that aligned_alloc is missing.
-#  - If GCC allowed implicit declaration of symbols, it would not fail during
-#    compilation even if the configure scripts did not check header presence.
-#
-+ lib.optionalString (hostPlatform.isDarwin) ''
-  export ac_cv_func_aligned_alloc=no
-''
-
 # In order to properly install libgccjit on macOS Catalina, strip(1)
 # upon installation must not remove external symbols, otherwise the
 # install step errors with "symbols referenced by indirect symbol


### PR DESCRIPTION
In a similar vein as PR #226048 this hack doesn't seem necessary anymore and introduces build differences for cross-compilation depending on build platform.

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
