### PR TITLE
libde265: add patches for CVE-2023-27102 & CVE-2023-27103 

### DIFF
--- a/pkgs/development/libraries/libde265/default.nix
+++ b/pkgs/development/libraries/libde265/default.nix
@@ -1,6 +1,7 @@
 { lib
 , stdenv
 , fetchFromGitHub
+, fetchpatch
 , autoreconfHook
 , pkg-config
 
@@ -21,6 +22,19 @@ stdenv.mkDerivation rec {
     rev = "v${version}";
     sha256 = "sha256-0aRUh5h49fnjBjy42A5fWYHnhnQ4CFoeSIXZilZewW8=";
   };
+
+  patches = [
+    (fetchpatch {
+      name = "CVE-2023-27102.patch";
+      url = "https://github.com/strukturag/libde265/commit/0b1752abff97cb542941d317a0d18aa50cb199b1.patch";
+      sha256 = "sha256-q0NKuk2r5RQT9MJpRO3CTPj6VqYRBnffs9yZ+GM+lNc=";
+    })
+    (fetchpatch {
+      name = "CVE-2023-27103.patch";
+      url = "https://github.com/strukturag/libde265/commit/d6bf73e765b7a23627bfd7a8645c143fd9097995.patch";
+      sha256 = "sha256-vxciVzSuVCVDpdz+TKg2tMWp2ArubYji5GLaR9VP4F0=";
+    })
+  ];
 
   nativeBuildInputs = [ autoreconfHook pkg-config ];
 

--- a/pkgs/development/libraries/libde265/default.nix
+++ b/pkgs/development/libraries/libde265/default.nix
@@ -5,6 +5,8 @@
 , autoreconfHook
 , pkg-config
 
+, callPackage
+
 # for passthru.tests
 , imagemagick
 , libheif
@@ -12,7 +14,7 @@
 , gst_all_1
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: rec {
   version = "1.0.11";
   pname = "libde265";
 
@@ -43,6 +45,10 @@ stdenv.mkDerivation rec {
   passthru.tests = {
     inherit imagemagick libheif imlib2Full;
     inherit (gst_all_1) gst-plugins-bad;
+
+    test-corpus-decode = callPackage ./test-corpus-decode.nix {
+      libde265 = finalAttrs.finalPackage;
+    };
   };
 
   meta = {
@@ -52,4 +58,4 @@ stdenv.mkDerivation rec {
     platforms = lib.platforms.unix;
     maintainers = with lib.maintainers; [ gebner ];
   };
-}
+})

--- a/pkgs/development/libraries/libde265/test-corpus-decode.nix
+++ b/pkgs/development/libraries/libde265/test-corpus-decode.nix
@@ -1,0 +1,48 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, libde265
+}:
+
+stdenv.mkDerivation {
+  pname = "libde265-test-corpus-decode";
+  version = "unstable-2020-02-19";
+
+  src = fetchFromGitHub {
+    owner = "strukturag";
+    repo = "libde265-data";
+    rev = "bdfdfdbe682f514c5185c270c74eac42731a7fa8";
+    sha256 = "sha256-fOgu7vMoyH30Zzbkfm4a6JVDZtYLO/0R2syC2Wux+Z8=";
+  };
+
+  dontConfigure = true;
+  dontBuild = true;
+
+  doCheck = true;
+  nativeCheckInputs = [ libde265 ];
+  # based on invocations in https://github.com/strukturag/libde265/blob/0b1752abff97cb542941d317a0d18aa50cb199b1/scripts/ci-run.sh
+  checkPhase = ''
+    echo "Single-threaded:"
+    find . -name '*.bin' | while read f; do
+      echo "Decoding $f"
+      dec265 -q -c $f
+      dec265 -0 -q -c $f
+      dec265 -q --disable-deblocking --disable-sao $f
+    done
+    echo "Multi-threaded:"
+    find RandomAccess/ -name '*.bin' | while read f; do
+      echo "Decoding $f"
+      dec265 -t 4 -q -c $f
+      dec265 -t 4 -0 -q -c $f
+      dec265 -t 4 -q --disable-deblocking --disable-sao $f
+    done
+  '';
+  # a larger corpus of files can be found
+  # as an ubuntu package libde265-teststreams @
+  # https://launchpad.net/~strukturag/+archive/ubuntu/libde265/+packages
+  # but it is *much* larger
+
+  installPhase = ''
+    touch $out
+  '';
+}


### PR DESCRIPTION
###### Description of changes

https://nvd.nist.gov/vuln/detail/CVE-2023-27102
https://nvd.nist.gov/vuln/detail/CVE-2023-27103

Also add a passthru test decoding the test corpus, which is what upstream appear to do in lieu of having a proper test suite.

Built `passthru.tests` on indicated platforms (cherry-picked to master for testing).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
