### PR TITLE
ocamlPackages.morbig: init at 0.11.0

### DIFF
--- a/pkgs/development/ocaml-modules/morbig/default.nix
+++ b/pkgs/development/ocaml-modules/morbig/default.nix
@@ -1,0 +1,33 @@
+{ lib, buildDunePackage, fetchFromGitHub, ocamlPackages }:
+
+buildDunePackage rec {
+  pname = "morbig";
+  version = "0.11.0";
+
+  src = fetchFromGitHub {
+    owner = "colis-anr";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "sha256-fOBaJHHP/Imi9UDLflI52OdKDcmMxpl+NH3pfofmv/o=";
+  };
+
+  duneVersion = "3";
+
+  nativeBuildInputs = with ocamlPackages; [
+    menhir
+  ];
+
+  propagatedBuildInputs = with ocamlPackages; [
+    menhirLib
+    ppx_deriving_yojson
+    visitors
+    yojson
+  ];
+
+  meta = with lib; {
+    homepage = "https://github.com/colis-anr/${pname}";
+    description = "A static parser for POSIX Shell";
+    license = licenses.gpl3Plus;
+    maintainers = with maintainers; [ niols ];
+  };
+}

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -1042,6 +1042,8 @@ let
 
     mmap =  callPackage ../development/ocaml-modules/mmap { };
 
+    morbig = callPackage ../development/ocaml-modules/morbig { };
+
     mparser =  callPackage ../development/ocaml-modules/mparser { };
 
     mparser-pcre =  callPackage ../development/ocaml-modules/mparser/pcre.nix { };


### PR DESCRIPTION
###### Description of changes

[Morbig](https://github.com/colis-anr/morbig/) is a trustworthy static parser for shell scripts written in the POSIX shell script language. It parses the scripts statically, that is without executing them, and constructs a concrete syntax tree for each of them. The concrete syntax trees are built using constructors according to the shell grammar of the POSIX standard.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [X] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
