### PR TITLE
arianna: init at 1.0.0

### DIFF
--- a/pkgs/applications/office/arianna/default.nix
+++ b/pkgs/applications/office/arianna/default.nix
@@ -1,0 +1,70 @@
+{ lib
+, mkDerivation
+, fetchurl
+
+, cmake
+, extra-cmake-modules
+, reuse
+, wrapGAppsHook
+
+, baloo
+, karchive
+, kconfig
+, kcoreaddons
+, kdbusaddons
+, kfilemetadata
+, ki18n
+, kirigami2
+, kirigami-addons
+, kquickcharts
+, kwindowsystem
+, qqc2-desktop-style
+, qtbase
+, qtquickcontrols2
+, qtwebengine
+, qtwebsockets
+}:
+
+mkDerivation rec {
+  pname = "arianna";
+  version = "1.0.0";
+
+  src = fetchurl {
+    url = "mirror://kde/stable/arianna/arianna-${version}.tar.xz";
+    hash = "sha256-UZnetRo0ozBMCOoIz56qExv92uZ8dyaW5cgI835vARs=";
+  };
+
+  nativeBuildInputs = [
+    extra-cmake-modules
+    cmake
+    reuse
+    wrapGAppsHook
+  ];
+
+  buildInputs = [
+    baloo
+    kconfig
+    kcoreaddons
+    kdbusaddons
+    kfilemetadata
+    ki18n
+    kirigami2
+    kirigami-addons
+    kquickcharts
+    kwindowsystem
+    qqc2-desktop-style
+    qtbase
+    qtquickcontrols2
+    qtwebengine
+    qtwebsockets
+  ];
+
+  doCheck = true;
+
+  meta = with lib; {
+    description = "EPub Reader for mobile devices";
+    homepage = "https://invent.kde.org/graphics/arianna";
+    license = licenses.gpl3Only;
+    maintainers = with maintainers; [ apfelkuchen6 ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -28854,6 +28854,8 @@ with pkgs;
 
   argo-rollouts = callPackage ../applications/networking/cluster/argo-rollouts { };
 
+  arianna = libsForQt5.callPackage ../applications/office/arianna { };
+
   ario = callPackage ../applications/audio/ario { };
 
   arion = callPackage ../applications/virtualization/arion { };


### PR DESCRIPTION
###### Description of changes

Adds an ebook reader for KDE. 
Project url: https://invent.kde.org/graphics/arianna

Requires kirigami-addons 0.8.0 (#226156) for the settings-panel to work.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
