### PR TITLE
lzwolf: fix build on SDL2_net-2.2

### DIFF
--- a/pkgs/games/lzwolf/default.nix
+++ b/pkgs/games/lzwolf/default.nix
@@ -1,21 +1,38 @@
-{ stdenv, lib, fetchFromBitbucket, p7zip, cmake
-, SDL2, bzip2, zlib, libjpeg
-, libsndfile, mpg123
-, SDL2_net, SDL2_mixer }:
+{ stdenv
+, lib
+, fetchFromBitbucket
+, p7zip
+, cmake
+, SDL2
+, bzip2
+, zlib
+, libjpeg
+, libsndfile
+, mpg123
+, pkg-config
+, SDL2_net
+, SDL2_mixer
+}:
 
 stdenv.mkDerivation rec {
   pname = "lzwolf";
   # Fix-Me: Remember to remove SDL2_mixer pin (at top-level) on next lzwolf upgrade.
-  version = "unstable-2022-01-04";
+  version = "unstable-2022-12-26";
 
   src = fetchFromBitbucket {
     owner = "linuxwolf6";
     repo = "lzwolf";
-    rev = "6e470316382b87378966f441e233760ce0ff478c";
-    sha256 = "sha256-IbZleY2FPyW3ORIGO2YFXQyAf1l9nDthpJjEKTTsilM=";
+    rev = "a24190604296e16941c601b57afe4350462fc659";
+    sha256 = "sha256-CtBdvk6LXb/ll92Fxig/M4t4QNj8dNFJYd8F99b47kQ=";
   };
 
-  nativeBuildInputs = [ p7zip cmake ];
+  postPatch = ''
+    # SDL2_net-2.2.0 changed CMake component name slightly.
+    substituteInPlace src/CMakeLists.txt \
+      --replace 'SDL2::SDL2_net' 'SDL2_net::SDL2_net'
+  '';
+
+  nativeBuildInputs = [ p7zip pkg-config cmake ];
   buildInputs = [
     SDL2 bzip2 zlib libjpeg SDL2_mixer SDL2_net libsndfile mpg123
   ];


### PR DESCRIPTION
Without the change build fails as:

    /build/source/src/wl_net.h:38:10: fatal error: SDL_net.h: No such file or directory
       38 | #include <SDL_net.h>
          |          ^~~~~~~~~~~
    compilation terminated.

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
