### PR TITLE
ocamlPackages.morbig: take OCaml dependencies individually

### DIFF
--- a/pkgs/development/ocaml-modules/morbig/default.nix
+++ b/pkgs/development/ocaml-modules/morbig/default.nix
@@ -1,4 +1,6 @@
-{ lib, buildDunePackage, fetchFromGitHub, ocamlPackages }:
+{ lib, buildDunePackage, fetchFromGitHub
+, menhir, menhirLib, ppx_deriving_yojson, visitors, yojson
+}:
 
 buildDunePackage rec {
   pname = "morbig";
@@ -13,11 +15,11 @@ buildDunePackage rec {
 
   duneVersion = "3";
 
-  nativeBuildInputs = with ocamlPackages; [
+  nativeBuildInputs = [
     menhir
   ];
 
-  propagatedBuildInputs = with ocamlPackages; [
+  propagatedBuildInputs = [
     menhirLib
     ppx_deriving_yojson
     visitors


### PR DESCRIPTION
###### Description of changes

After discussion in https://github.com/NixOS/nixpkgs/pull/226101#discussion_r1166595187, I come back to fix the `ocamlPackages.morbig` package so that it takes input OCaml packages individually instead of just taking `ocamlPackages`.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
