### PR TITLE
nixos/dokuwiki: Finally remove extraConfig

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2305.section.md
+++ b/nixos/doc/manual/release-notes/rl-2305.section.md
@@ -279,9 +279,10 @@ In addition to numerous new and upgraded packages, this release has the followin
   `services.dnsmasq.extraConfig` will be deprecated when NixOS 22.11 reaches
   end of life.
 
-- The `dokuwiki` service now takes configuration via the `services.dokuwiki.sites.<name>.settings` attribute set, `extraConfig` is deprecated and will be removed.
-  The `{aclUse,superUser,disableActions}` attributes have been renamed, `pluginsConfig` now also accepts an attribute set of booleans, passing plain PHP is deprecated.
-  Same applies to `acl` which now also accepts structured settings.
+- The `dokuwiki` service is now configured via `services.dokuwiki.sites.<name>.settings` attribute set; `extraConfig` has been removed.
+  The `{aclUse,superUser,disableActions}` attributes have been renamed accordingly. `pluginsConfig` now only accepts an attribute set of booleans.
+  Passing plain PHP is no longer possible.
+  Same applies to `acl` which now also only accepts structured `settings`.
 
 - The `zsh` package changes the way to set environment variables on NixOS systems where `programs.zsh.enable` equals `false`.  It now sources `/etc/set-environment` when reading the system-level `zshenv` file.  Before, it sourced `/etc/profile` when reading the system-level `zprofile` file.
 

--- a/nixos/modules/services/web-apps/dokuwiki.nix
+++ b/nixos/modules/services/web-apps/dokuwiki.nix
@@ -91,13 +91,13 @@ let
 
       page = mkOption {
         type = types.str;
-        description = "Page or namespace to restrict";
+        description = lib.mdDoc "Page or namespace to restrict";
         example = "start";
       };
 
       actor = mkOption {
         type = types.str;
-        description = "User or group to restrict";
+        description = lib.mdDoc "User or group to restrict";
         example = "@external";
       };
 
@@ -113,7 +113,7 @@ let
       in mkOption {
         type = types.enum ((attrValues available) ++ (attrNames available));
         apply = x: if isInt x then x else available.${x};
-        description = ''
+        description = lib.mdDoc ''
           Permission level to restrict the actor(s) to.
           See <https://www.dokuwiki.org/acl#background_info> for explanation
         '';

--- a/nixos/modules/services/web-apps/dokuwiki.nix
+++ b/nixos/modules/services/web-apps/dokuwiki.nix
@@ -3,6 +3,8 @@
 with lib;
 
 let
+  inherit (lib.options) showOption showFiles;
+
   cfg = config.services.dokuwiki;
   eachSite = cfg.sites;
   user = "dokuwiki";
@@ -63,7 +65,6 @@ let
     conf_gen = c: map (v: "$conf${v}") (mkPhpAttrVals c);
   in writePhpFile "local-${hostName}.php" ''
     ${concatStringsSep "\n" (conf_gen cfg.mergedConfig)}
-    ${toString cfg.extraConfig}
   '';
 
   dokuwikiPluginsLocalConfig = hostName: cfg: let
@@ -118,32 +119,63 @@ let
         '';
         example = "read";
       };
-
     };
   };
 
-  siteOpts = { config, lib, name, ... }:
+  # The current implementations of `doRename`,  `mkRenamedOptionModule` do not provide the full options path when used with submodules.
+  # They would only show `settings.useacl' instead of `services.dokuwiki.sites."site1.local".settings.useacl'
+  # The partial re-implementation of these functions is done to help users in debugging by showing the full path.
+  mkRenamed = from: to: { config, options, name, ... }: let
+    pathPrefix = [ "services" "dokuwiki" "sites" name ];
+    fromPath = pathPrefix  ++ from;
+    fromOpt = getAttrFromPath from options;
+    toOp = getAttrsFromPath to config;
+    toPath = pathPrefix ++ to;
+  in {
+    options = setAttrByPath from (mkOption {
+      visible = false;
+      description = lib.mdDoc "Alias of {option}${showOption toPath}";
+      apply = x: builtins.trace "Obsolete option `${showOption fromPath}' is used. It was renamed to ${showOption toPath}" toOp;
+    });
+    config = mkMerge [
+      {
+        warnings = optional fromOpt.isDefined
+          "The option `${showOption fromPath}' defined in ${showFiles fromOpt.files} has been renamed to `${showOption toPath}'.";
+      }
+      (lib.modules.mkAliasAndWrapDefsWithPriority (setAttrByPath to) fromOpt)
+    ];
+  };
+
+  siteOpts = { options, config, lib, name, ... }:
     {
       imports = [
-        # NOTE: These will sadly not print the absolute argument path but only the name. Related to #96006
-        (mkRenamedOptionModule [ "aclUse" ] [ "settings" "useacl" ] )
-        (mkRenamedOptionModule [ "superUser" ] [ "settings" "superuser" ] )
-        (mkRenamedOptionModule [ "disableActions" ] [ "settings" "disableactions" ] )
-        ({ config, options, name, ...}: {
-          config.warnings =
-            (optional (isString config.pluginsConfig) ''
-              Passing plain strings to services.dokuwiki.sites.${name}.pluginsConfig has been deprecated and will not be continue to be supported in the future.
-              Please pass structured settings instead.
-            '')
-            ++ (optional (isString config.acl) ''
-              Passing a plain string to services.dokuwiki.sites.${name}.acl has been deprecated and will not continue to be supported in the future.
-              Please pass structured settings instead.
-            '')
-            ++ (optional (config.extraConfig != null) ''
-              services.dokuwiki.sites.${name}.extraConfig is deprecated and will be removed in the future.
-              Please pass structured settings to services.dokuwiki.sites.${name}.settings instead.
-            '')
-          ;
+        (mkRenamed [ "aclUse" ] [ "settings" "useacl" ])
+        (mkRenamed [ "superUser" ] [ "settings" "superuser" ])
+        (mkRenamed [ "disableActions" ] [ "settings"  "disableactions" ])
+        ({ config, options, ... }: let
+          showPath = suffix: lib.options.showOption ([ "services" "dokuwiki" "sites" name ] ++ suffix);
+          replaceExtraConfig = "Please use `${showPath ["settings"]}' to pass structured settings instead.";
+          ecOpt = options.extraConfig;
+          ecPath = showPath [ "extraConfig" ];
+        in {
+          options.extraConfig = mkOption {
+            visible = false;
+            apply = x: throw "The option ${ecPath} can no longer be used since it's been removed.\n${replaceExtraConfig}";
+          };
+          config.assertions = [
+            {
+              assertion = !ecOpt.isDefined;
+              message = "The option definition `${ecPath}' in ${showFiles ecOpt.files} no longer has any effect; please remove it.\n${replaceExtraConfig}";
+            }
+            {
+              assertion = config.mergedConfig.useacl -> (config.acl != null || config.aclFile != null);
+              message = "Either ${showPath [ "acl" ]} or ${showPath [ "aclFile" ]} is mandatory if ${showPath [ "settings" "useacl" ]} is true";
+            }
+            {
+              assertion = config.usersFile != null -> config.mergedConfig.useacl != false;
+              message = "${showPath [ "settings" "useacl" ]} is required when ${showPath [ "usersFile" ]} is set (Currently defiend as `${config.usersFile}' in ${showFiles options.usersFile.files}).";
+            }
+          ];
         })
       ];
 
@@ -164,7 +196,7 @@ let
         };
 
         acl = mkOption {
-          type = with types; nullOr (oneOf [ lines (listOf (submodule aclOpts)) ]);
+          type = with types; nullOr (listOf (submodule aclOpts));
           default = null;
           example = literalExpression ''
             [
@@ -203,7 +235,7 @@ let
         };
 
         pluginsConfig = mkOption {
-          type = with types; oneOf [lines (attrsOf bool)];
+          type = with types; attrsOf bool;
           default = {
             authad = false;
             authldap = false;
@@ -370,36 +402,21 @@ let
           '';
         };
 
-        extraConfig = mkOption {
-          # This Option is deprecated and only kept until sometime before 23.05 for compatibility reasons
-          # FIXME (@e1mo): Actually remember removing this before 23.05.
-          visible = false;
-          type = types.nullOr types.lines;
-          default = null;
-          example = ''
-            $conf['title'] = 'My Wiki';
-            $conf['userewrite'] = 1;
-          '';
-          description = lib.mdDoc ''
-            DokuWiki configuration. Refer to
-            <https://www.dokuwiki.org/config>
-            for details on supported values.
-
-            **Note**: Please pass Structured settings via
-            `services.dokuwiki.sites.${name}.settings` instead.
-          '';
-        };
-
       # Required for the mkRenamedOptionModule
       # TODO: Remove me once https://github.com/NixOS/nixpkgs/issues/96006 is fixed
-      # or the aclUse, ... options are removed.
+      # or we don't have any more notes about the removal of extraConfig, ...
       warnings = mkOption {
         type = types.listOf types.unspecified;
         default = [ ];
         visible = false;
         internal = true;
       };
-
+      assertions = mkOption {
+        type = types.listOf types.unspecified;
+        default = [ ];
+        visible = false;
+        internal = true;
+      };
     };
   };
 in
@@ -435,16 +452,7 @@ in
 
     warnings = flatten (mapAttrsToList (_: cfg: cfg.warnings) eachSite);
 
-    assertions = flatten (mapAttrsToList (hostName: cfg:
-    [{
-      assertion = cfg.mergedConfig.useacl -> (cfg.acl != null || cfg.aclFile != null);
-      message = "Either services.dokuwiki.sites.${hostName}.acl or services.dokuwiki.sites.${hostName}.aclFile is mandatory if settings.useacl is true";
-    }
-    {
-      assertion = cfg.usersFile != null -> cfg.mergedConfig.useacl != false;
-      message = "services.dokuwiki.sites.${hostName}.settings.useacl must must be true if usersFile is not null";
-    }
-    ]) eachSite);
+    assertions = flatten (mapAttrsToList (_: cfg: cfg.assertions) eachSite);
 
     services.phpfpm.pools = mapAttrs' (hostName: cfg: (
       nameValuePair "dokuwiki-${hostName}" {


### PR DESCRIPTION
###### Description of changes

After the introduction of structured settings in #208299 the old string-style options  / types which were kept for compatibility are now removed in preparation for the 23.05 release.

I went to the extra effort for both the renamed and removed options to show the full option paths to offer users upgrading from 22.11 to 23.05 actually useful warnings that make migrating as effortless as possible.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [x] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->