### PR TITLE
Make VirtualBox with Alsa Audio Driver working

### DIFF
--- a/pkgs/applications/virtualization/virtualbox/fix-audio-driver-loading.patch
+++ b/pkgs/applications/virtualization/virtualbox/fix-audio-driver-loading.patch
@@ -7,7 +7,7 @@ index cfcb0abbf..2ce564f6f 100644
  
      RTLDRMOD hMod = NIL_RTLDRMOD;
 -    int rc = RTLdrLoadSystemEx(VBOX_ALSA_LIB, RTLDRLOAD_FLAGS_NO_UNLOAD, &hMod);
-+    int rc = RTLdrLoad(VBOX_ALSA_LIB, &hMod);
++    int rc = RTLdrLoadEx(VBOX_ALSA_LIB, &hMod, RTLDRLOAD_FLAGS_NO_UNLOAD, nullptr);
      if (RT_SUCCESS(rc))
      {
          for (uintptr_t i = 0; i < RT_ELEMENTS(SharedFuncs); i++)
@@ -20,7 +20,7 @@ index a17fc93f9..148f5c39a 100644
  
      RTLDRMOD hMod = NIL_RTLDRMOD;
 -    int rc = RTLdrLoadSystemEx(VBOX_PULSE_LIB, RTLDRLOAD_FLAGS_NO_UNLOAD, &hMod);
-+    int rc = RTLdrLoad(VBOX_PULSE_LIB, &hMod);
++    int rc = RTLdrLoadEx(VBOX_PULSE_LIB, &hMod, RTLDRLOAD_FLAGS_NO_UNLOAD, nullptr);
      if (RT_SUCCESS(rc))
      {
          for (unsigned i = 0; i < RT_ELEMENTS(g_aImportedFunctions); i++)


### PR DESCRIPTION
###### Description of changes

Currently,  VirtualBox causes a segmentation fault, if a VirtualBox VM is started with  Alsa as  audio backend.

This PR makes Alsa operable, by passing the correct flags to the shared Library loading mechanism in VirtualBox

The patch is necessary, to allow the correct Nix Store Path for the Alsa lib.

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

