### PR TITLE
lib/systems: add UEFI systems for i686, aarch64, x86_64 as examples

### DIFF
--- a/lib/systems/default.nix
+++ b/lib/systems/default.nix
@@ -50,7 +50,7 @@ rec {
         else if final.isFreeBSD             then "fblibc"
         else if final.isNetBSD              then "nblibc"
         else if final.isAvr                 then "avrlibc"
-        else if final.isNone                then "newlib"
+        else if final.isUefi                then "none" # TODO: execute can actually be QEMU?
         # TODO(@Ericson2314) think more about other operating systems
         else                                     "native/impure";
       # Choose what linker we wish to use by default. Someday we might also

--- a/lib/systems/examples.nix
+++ b/lib/systems/examples.nix
@@ -191,8 +191,6 @@ rec {
     };
   };
 
-
-
   aarch64-embedded = {
     config = "aarch64-none-elf";
     libc = "newlib";

--- a/lib/systems/examples.nix
+++ b/lib/systems/examples.nix
@@ -191,6 +191,8 @@ rec {
     };
   };
 
+
+
   aarch64-embedded = {
     config = "aarch64-none-elf";
     libc = "newlib";
@@ -219,6 +221,35 @@ rec {
   x86_64-embedded = {
     config = "x86_64-elf";
     libc = "newlib";
+  };
+
+  #
+  # UEFI
+  #
+
+  # See: https://github.com/rust-lang/rust/pull/56769/files#r241916113
+  i686-uefi = {
+    # config = "i686-unknown-windows-gnu";
+    config = "i686-pc-win32-coff";
+    rust.config = "i686-unknown-uefi";
+    useLLVM = true;
+    libc = null;
+  };
+
+  x86_64-uefi = {
+    # config = "x86_64-unknown-windows-msvc";
+    config = "x86_64-pc-win32-coff";
+    rust.config = "x86_64-unknown-uefi";
+    useLLVM = true;
+    libc = null;
+  };
+
+  aarch64-uefi = {
+    # config = "aarch64-unknown-windows-msvc";
+    config = "aarch64-pc-win32-coff";
+    rust.config = "aarch64-unknown-uefi";
+    useLLVM = true;
+    libc = null;
   };
 
   #

--- a/lib/systems/inspect.nix
+++ b/lib/systems/inspect.nix
@@ -6,8 +6,6 @@ with lib.lists;
 let abis_ = abis; in
 let abis = lib.mapAttrs (_: abi: builtins.removeAttrs abi [ "assertions" ]) abis_; in
 
-# TODO: isUefi
-
 rec {
   # these patterns are to be matched against {host,build,target}Platform.parsed
   patterns = rec {

--- a/lib/systems/inspect.nix
+++ b/lib/systems/inspect.nix
@@ -86,7 +86,8 @@ rec {
 
     isUefi         = { /* kernel = kernels.windows; replace with none? */ abi = abis.coff; vendor = vendors.pc; }; # this may not be restrictive enough? TODO
 
-    isEfi = [
+    # Those are platforms for known UEFI firmwares
+    hasUefi = [
       { cpu = { family = "arm"; version = "6"; }; }
       { cpu = { family = "arm"; version = "7"; }; }
       { cpu = { family = "arm"; version = "8"; }; }

--- a/lib/systems/inspect.nix
+++ b/lib/systems/inspect.nix
@@ -6,6 +6,8 @@ with lib.lists;
 let abis_ = abis; in
 let abis = lib.mapAttrs (_: abi: builtins.removeAttrs abi [ "assertions" ]) abis_; in
 
+# TODO: isUefi
+
 rec {
   # these patterns are to be matched against {host,build,target}Platform.parsed
   patterns = rec {
@@ -81,6 +83,8 @@ rec {
     isGnu          = with abis; map (a: { abi = a; }) [ gnuabi64 gnu gnueabi gnueabihf gnuabielfv1 gnuabielfv2 ];
     isMusl         = with abis; map (a: { abi = a; }) [ musl musleabi musleabihf muslabin32 muslabi64 ];
     isUClibc       = with abis; map (a: { abi = a; }) [ uclibc uclibceabi uclibceabihf ];
+
+    isUefi         = { /* kernel = kernels.windows; replace with none? */ abi = abis.coff; vendor = vendors.pc; }; # this may not be restrictive enough? TODO
 
     isEfi = [
       { cpu = { family = "arm"; version = "6"; }; }

--- a/lib/systems/parse.nix
+++ b/lib/systems/parse.nix
@@ -377,6 +377,9 @@ rec {
     uclibceabihf = { float = "hard"; };
     uclibc       = {};
 
+    # object format, not an abi...
+    coff         = {}; # TODO: probably assert win32?
+
     unknown = {};
   };
 

--- a/lib/systems/parse.nix
+++ b/lib/systems/parse.nix
@@ -329,6 +329,16 @@ rec {
 
     # Other architectures should use ELF in embedded situations.
     elf          = {};
+    # Not really an ABI, rather an object format.
+    coff         = {
+      assertions = [
+        { assertion = platform: platform.isWindows || platform.isUefi;
+          message = ''
+            The "COFF" object file format is for Windows or UEFI targets.
+          '';
+        }
+      ];
+    };
 
     androideabi  = {};
     android      = {
@@ -377,11 +387,9 @@ rec {
     uclibceabihf = { float = "hard"; };
     uclibc       = {};
 
-    # object format, not an abi...
-    coff         = {}; # TODO: probably assert win32?
-
     unknown = {};
   };
+
 
   ################################################################################
 

--- a/pkgs/build-support/cc-wrapper/default.nix
+++ b/pkgs/build-support/cc-wrapper/default.nix
@@ -474,7 +474,7 @@ stdenv.mkDerivation {
     ## Hardening support
     ##
     + ''
-      export hardening_unsupported_flags="${builtins.concatStringsSep " " (cc.hardeningUnsupportedFlags or [])}"
+      export hardening_unsupported_flags="${builtins.concatStringsSep " " ((cc.hardeningUnsupportedFlags or []) ++ lib.optional targetPlatform.isUefi "pic") /* TODO: where should this go? */}"
     ''
 
     # Machine flags. These are necessary to support

--- a/pkgs/build-support/rust/build-rust-package/default.nix
+++ b/pkgs/build-support/rust/build-rust-package/default.nix
@@ -134,7 +134,7 @@ stdenv.mkDerivation ((removeAttrs args [ "depsExtraArgs" "cargoUpdateHook" "carg
 
   buildInputs = buildInputs
     ++ lib.optionals stdenv.hostPlatform.isDarwin [ libiconv ]
-    ++ lib.optionals (stdenv.hostPlatform.isMinGW && stdenv.hostPlatform.libc != null) [ windows.pthreads ]; # TODO: gate for UEFI correctly
+    ++ lib.optionals (stdenv.hostPlatform.isMinGW && !stdenv.hostPlatform.isUefi) [ windows.pthreads ];
 
   patches = cargoPatches ++ patches;
 

--- a/pkgs/build-support/rust/build-rust-package/default.nix
+++ b/pkgs/build-support/rust/build-rust-package/default.nix
@@ -134,7 +134,7 @@ stdenv.mkDerivation ((removeAttrs args [ "depsExtraArgs" "cargoUpdateHook" "carg
 
   buildInputs = buildInputs
     ++ lib.optionals stdenv.hostPlatform.isDarwin [ libiconv ]
-    ++ lib.optionals stdenv.hostPlatform.isMinGW [ windows.pthreads ];
+    ++ lib.optionals (stdenv.hostPlatform.isMinGW && stdenv.hostPlatform.libc != null) [ windows.pthreads ]; # TODO: gate for UEFI correctly
 
   patches = cargoPatches ++ patches;
 

--- a/pkgs/development/compilers/llvm/15/compiler-rt/default.nix
+++ b/pkgs/development/compilers/llvm/15/compiler-rt/default.nix
@@ -7,7 +7,7 @@
 let
 
   useLLVM = stdenv.hostPlatform.useLLVM or false;
-  bareMetal = stdenv.hostPlatform.parsed.kernel.name == "none";
+  bareMetal = (stdenv.hostPlatform.parsed.kernel.name == "none") || stdenv.hostPlatform.isUefi; # TODO: shouldn't need to special case UEFI here... can we actually drop win32 from our triple?
   haveLibc = stdenv.cc.libc != null;
   inherit (stdenv.hostPlatform) isMusl isGnu;
 
@@ -31,9 +31,11 @@ stdenv.mkDerivation {
     ++ lib.optional stdenv.isDarwin xcbuild.xcrun;
   buildInputs = lib.optional stdenv.hostPlatform.isDarwin libcxxabi;
 
-  env.NIX_CFLAGS_COMPILE = toString [
+  env.NIX_CFLAGS_COMPILE = toString ([
     "-DSCUDO_DEFAULT_OPTIONS=DeleteSizeMismatch=0:DeallocationTypeMismatch=0"
-  ];
+  ] ++ lib.optional stdenv.hostPlatform.isUefi [
+    "-U_MSC_VER"
+  ]);
 
   cmakeFlags = [
     "-DCOMPILER_RT_DEFAULT_TARGET_ONLY=ON"

--- a/pkgs/development/compilers/llvm/15/default.nix
+++ b/pkgs/development/compilers/llvm/15/default.nix
@@ -210,7 +210,7 @@ in let
 
     clangUseLLVM =
     if stdenv.targetPlatform.libc == null then
-      builtins.trace "yo" tools.clangNoLibc # TODO: gate correctly...
+      tools.clangNoLibc
     else wrapCCWith rec {
       cc = tools.clang-unwrapped;
       libcxx = targetLlvmLibraries.libcxx;
@@ -218,7 +218,7 @@ in let
       extraPackages = [
         libcxx.cxxabi
         targetLlvmLibraries.compiler-rt
-      ] ++ lib.optionals (!stdenv.targetPlatform.isWasm && stdenv.targetPlatform.libc != null) [ # TODO: gate on uefi correctly
+      ] ++ lib.optionals (!stdenv.targetPlatform.isWasm && !stdenv.targetPlatform.isUefi) [
         targetLlvmLibraries.libunwind
       ];
       extraBuildCommands = mkExtraBuildCommands cc;
@@ -227,7 +227,7 @@ in let
           "-Wno-unused-command-line-argument"
           "-B${targetLlvmLibraries.compiler-rt}/lib"
         ]
-        ++ lib.optional (!stdenv.targetPlatform.isWasm && stdenv.targetPlatform.libc != null) "--unwindlib=libunwind" # TODO: gate on UEFI correctly
+        ++ lib.optional (!stdenv.targetPlatform.isWasm && !stdenv.targetPlatform.isUefi) "--unwindlib=libunwind"
         ++ lib.optional
           (!stdenv.targetPlatform.isWasm && stdenv.targetPlatform.useLLVM or false)
           "-lunwind"

--- a/pkgs/development/compilers/llvm/15/default.nix
+++ b/pkgs/development/compilers/llvm/15/default.nix
@@ -232,6 +232,7 @@ in let
           (!stdenv.targetPlatform.isWasm && stdenv.targetPlatform.useLLVM or false)
           "-lunwind"
         ++ lib.optional stdenv.targetPlatform.isWasm "-fno-exceptions";
+      dontWrap = stdenv.targetPlatform.isUefi;
     };
 
     clangNoLibcxx = wrapCCWith rec {
@@ -261,6 +262,7 @@ in let
         "-rtlib=compiler-rt"
         "-B${targetLlvmLibraries.compiler-rt}/lib"
       ];
+      dontWrap = stdenv.targetPlatform.isUefi;
     };
 
     clangNoCompilerRt = wrapCCWith rec {

--- a/pkgs/development/compilers/llvm/15/libcxxabi/default.nix
+++ b/pkgs/development/compilers/llvm/15/libcxxabi/default.nix
@@ -53,7 +53,7 @@ stdenv.mkDerivation rec {
   '';
 
   nativeBuildInputs = [ cmake ninja python3 ];
-  buildInputs = lib.optional (!stdenv.isDarwin && !stdenv.hostPlatform.isWasm && stdenv.hostPlatform.libc != null) libunwind;
+  buildInputs = lib.optional (!stdenv.isDarwin && !stdenv.hostPlatform.isWasm && !stdenv.hostPlatform.isUefi) libunwind;
 
   cmakeFlags = [
     "-DLLVM_ENABLE_RUNTIMES=libcxxabi"

--- a/pkgs/development/compilers/llvm/15/libcxxabi/default.nix
+++ b/pkgs/development/compilers/llvm/15/libcxxabi/default.nix
@@ -53,7 +53,7 @@ stdenv.mkDerivation rec {
   '';
 
   nativeBuildInputs = [ cmake ninja python3 ];
-  buildInputs = lib.optional (!stdenv.isDarwin && !stdenv.hostPlatform.isWasm) libunwind;
+  buildInputs = lib.optional (!stdenv.isDarwin && !stdenv.hostPlatform.isWasm && stdenv.hostPlatform.libc != null) libunwind;
 
   cmakeFlags = [
     "-DLLVM_ENABLE_RUNTIMES=libcxxabi"

--- a/pkgs/development/compilers/llvm/15/llvm/default.nix
+++ b/pkgs/development/compilers/llvm/15/llvm/default.nix
@@ -9,7 +9,7 @@
 , python3
 , python3Packages
 , libffi
-, enableGoldPlugin ? libbfd.hasPluginAPI
+, enableGoldPlugin ? pkgsBuildBuild.libbfd.hasPluginAPI
 , libbfd
 , libpfm
 , libxml2
@@ -329,7 +329,7 @@ in stdenv.mkDerivation (rec {
     "-DSPHINX_OUTPUT_HTML=OFF"
     "-DSPHINX_WARNINGS_AS_ERRORS=OFF"
   ] ++ optionals (enableGoldPlugin) [
-    "-DLLVM_BINUTILS_INCDIR=${libbfd.dev}/include"
+    "-DLLVM_BINUTILS_INCDIR=${pkgsBuildBuild.libbfd.dev}/include"
   ] ++ optionals isDarwin [
     "-DLLVM_ENABLE_LIBCXX=ON"
     "-DCAN_TARGET_i386=false"

--- a/pkgs/development/compilers/rust/default.nix
+++ b/pkgs/development/compilers/rust/default.nix
@@ -82,7 +82,9 @@ in
         inherit CoreFoundation Security;
       };
       cargo-auditable = self.callPackage ./cargo-auditable.nix { };
-      cargo-auditable-cargo-wrapper = self.callPackage ./cargo-auditable-cargo-wrapper.nix { };
+      cargo-auditable-cargo-wrapper = self.callPackage ./cargo-auditable-cargo-wrapper.nix {
+        writeShellScriptBin = pkgsBuildBuild.writeShellScriptBin; # TODO: fix
+      };
       clippy = self.callPackage ./clippy.nix { inherit Security; };
     });
   };

--- a/pkgs/os-specific/linux/systemd/default.nix
+++ b/pkgs/os-specific/linux/systemd/default.nix
@@ -90,7 +90,7 @@
 , withCoredump ? true
 , withCryptsetup ? true
 , withDocumentation ? true
-, withEfi ? stdenv.hostPlatform.isEfi
+, withUefi ? stdenv.hostPlatform.hasUefi
 , withFido2 ? true
 , withHomed ? !stdenv.hostPlatform.isMusl
 , withHostnamed ? true
@@ -402,7 +402,7 @@ stdenv.mkDerivation (finalAttrs: {
     ++ lib.optionals withCompression [ bzip2 lz4 xz zstd ]
     ++ lib.optional withCoredump elfutils
     ++ lib.optional withCryptsetup (lib.getDev cryptsetup.dev)
-    ++ lib.optional withEfi gnu-efi
+    ++ lib.optional withUefi gnu-efi
     ++ lib.optional withKexectools kexec-tools
     ++ lib.optional withKmod kmod
     ++ lib.optional withLibidn2 libidn2
@@ -513,11 +513,11 @@ stdenv.mkDerivation (finalAttrs: {
     # more frequent development builds
     "-Dman=true"
 
-    "-Defi=${lib.boolToString withEfi}"
-    "-Dgnu-efi=${lib.boolToString withEfi}"
+    "-Defi=${lib.boolToString withUefi}"
+    "-Dgnu-efi=${lib.boolToString withUefi}"
 
     "-Dukify=${lib.boolToString withUkify}"
-  ] ++ lib.optionals withEfi [
+  ] ++ lib.optionals withUefi [
     "-Defi-libdir=${toString gnu-efi}/lib"
     "-Defi-includedir=${toString gnu-efi}/include/efi"
   ] ++ lib.optionals (withShellCompletions == false) [
@@ -705,7 +705,7 @@ stdenv.mkDerivation (finalAttrs: {
   #   https://github.com/NixOS/nixpkgs/issues/169693
   # The hack is to move EFI file out of lib/ before doStrip
   # run and return it after doStrip run.
-  preFixup = lib.optionalString withEfi ''
+  preFixup = lib.optionalString withUefi ''
     mv $out/lib/systemd/boot/efi $out/dont-strip-me
   '';
 
@@ -715,7 +715,7 @@ stdenv.mkDerivation (finalAttrs: {
       # This needs to be in LD_LIBRARY_PATH because rpath on a binary is not propagated to libraries using dlopen, in this case `libcryptsetup.so`
       wrapProgram $out/$f --prefix LD_LIBRARY_PATH : ${placeholder "out"}/lib/cryptsetup
     done
-  '' + lib.optionalString withEfi ''
+  '' + lib.optionalString withUefi ''
     mv $out/dont-strip-me $out/lib/systemd/boot/efi
   '';
 

--- a/pkgs/tools/misc/lanzaboote/default.nix
+++ b/pkgs/tools/misc/lanzaboote/default.nix
@@ -1,31 +1,20 @@
-{ rustPlatform, stdenv, fetchFromGitHub, lib, breakpointHook }: rustPlatform.buildRustPackage {
+{ rustPlatform, stdenv, fetchFromGitHub, lib }:
+rustPlatform.buildRustPackage {
   pname = "lanzaboote-stub";
-  version = "0.3.0";
+  version = "0.4.0";
   src = fetchFromGitHub {
     owner = "nix-community";
     repo = "lanzaboote";
-    rev = "83a357eb7c261c82e2fa6412216b3c4f8f0d1d18";
-    hash = "sha256-jWmTTUejSCa5qO0D/FJMbgXKdFEllRdvA+jG0KX+MfY=";
+    rev = "b21c4007afaf461834da091afe7ba8b37331de65";
+    hash = "sha256-WmuqqaHfDEXoNDcZ7jT4XdOxJqVbbVFZa89BtmLMENQ=";
   };
   sourceRoot = "source/rust/stub";
 
-  cargoHash = "sha256-FlnheCgowYsEHcFMn6k8ESxDuggbO4tNdQlOjUIj7oE=";
+  cargoHash = lib.fakeHash;
+
+  # `cc-wrapper`/our clang doesn't understand MSVC link opts (hack):
+  # RUSTFLAGS = "-Clinker=${stdenv.cc.targetPrefix}ld.lld -Clinker-flavor=lld-link";
 
   # TODO: limit supported platforms to UEFI
   meta.platforms = lib.platforms.all;
-
-  # `cc-wrapper`/our clang doesn't understand MSVC link opts (hack):
-  RUSTFLAGS = "-Clinker=${stdenv.cc.targetPrefix}ld.lld -Clinker-flavor=lld-link";
-
-  # `/`-style parameters are confused for bad paths.
-  NIX_ENFORCE_PURITY = 0;
-  hardeningDisable = [ "all" ];
-  auditable = false;
-
-  # nativeBuildInputs = [ breakpointHook ];
-
-  # Note: broken on i686-uefi: `flush_instruction_cache` is called but not
-  # defined
-  #
-  # TODO(@raitobezarius)
 }

--- a/pkgs/tools/misc/lanzaboote/default.nix
+++ b/pkgs/tools/misc/lanzaboote/default.nix
@@ -1,25 +1,28 @@
-{ rustPlatform, stdenv, fetchFromGitHub, lib }: rustPlatform.buildRustPackage rec {
+{ rustPlatform, stdenv, fetchFromGitHub, lib, breakpointHook }: rustPlatform.buildRustPackage {
   pname = "lanzaboote-stub";
-  version = "0.2.0";
+  version = "0.3.0";
   src = fetchFromGitHub {
     owner = "nix-community";
     repo = "lanzaboote";
-    rev = "v${version}";
-    hash = "sha256-PHnTsEOF5AzGJyc5E80L2aik3MsZ9G6EjZZg2dkh3vI=";
+    rev = "83a357eb7c261c82e2fa6412216b3c4f8f0d1d18";
+    hash = "sha256-jWmTTUejSCa5qO0D/FJMbgXKdFEllRdvA+jG0KX+MfY=";
   };
   sourceRoot = "source/rust/stub";
 
-  cargoHash = "sha256-84KwSNnnW167KiyCgHDk7bDEUlYuS+TGtFKh3sMQOKo=";
+  cargoHash = "sha256-FlnheCgowYsEHcFMn6k8ESxDuggbO4tNdQlOjUIj7oE=";
 
-
-  # Needs unstable (TODO: remove this hack):
-  RUSTC_BOOTSTRAP = 1;
   # TODO: limit supported platforms to UEFI
   meta.platforms = lib.platforms.all;
 
-
   # `cc-wrapper`/our clang doesn't understand MSVC link opts (hack):
-  RUSTFLAGS = "-C linker=${stdenv.cc.targetPrefix}ld.lld -C linker-flavor=ld.lld";
+  RUSTFLAGS = "-Clinker=${stdenv.cc.targetPrefix}ld.lld -Clinker-flavor=lld-link";
+
+  # `/`-style parameters are confused for bad paths.
+  NIX_ENFORCE_PURITY = 0;
+  hardeningDisable = [ "all" ];
+  auditable = false;
+
+  # nativeBuildInputs = [ breakpointHook ];
 
   # Note: broken on i686-uefi: `flush_instruction_cache` is called but not
   # defined

--- a/pkgs/tools/misc/lanzaboote/default.nix
+++ b/pkgs/tools/misc/lanzaboote/default.nix
@@ -1,0 +1,28 @@
+{ rustPlatform, stdenv, fetchFromGitHub, lib }: rustPlatform.buildRustPackage rec {
+  pname = "lanzaboote-stub";
+  version = "0.2.0";
+  src = fetchFromGitHub {
+    owner = "nix-community";
+    repo = "lanzaboote";
+    rev = "v${version}";
+    hash = "sha256-PHnTsEOF5AzGJyc5E80L2aik3MsZ9G6EjZZg2dkh3vI=";
+  };
+  sourceRoot = "source/rust/stub";
+
+  cargoHash = "sha256-84KwSNnnW167KiyCgHDk7bDEUlYuS+TGtFKh3sMQOKo=";
+
+
+  # Needs unstable (TODO: remove this hack):
+  RUSTC_BOOTSTRAP = 1;
+  # TODO: limit supported platforms to UEFI
+  meta.platforms = lib.platforms.all;
+
+
+  # `cc-wrapper`/our clang doesn't understand MSVC link opts (hack):
+  RUSTFLAGS = "-C linker=${stdenv.cc.targetPrefix}ld.lld -C linker-flavor=ld.lld";
+
+  # Note: broken on i686-uefi: `flush_instruction_cache` is called but not
+  # defined
+  #
+  # TODO(@raitobezarius)
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5181,6 +5181,8 @@ with pkgs;
     inherit (darwin.apple_sdk.frameworks) Security;
   };
 
+  lanzaboote = callPackage ../tools/misc/lanzaboote { };
+
   lapce = callPackage ../applications/editors/lapce {
     inherit (darwin) libobjc;
     inherit (darwin.apple_sdk.frameworks) Security CoreServices ApplicationServices Carbon AppKit;
@@ -15469,7 +15471,7 @@ with pkgs;
       else if platform.isAndroid then 12
       else if platform.isLinux then 11
       else if platform.isWasm then 12
-      else latest_version;
+      else 15;
     # We take the "max of the mins". Why? Since those are lower bounds of the
     # supported version set, this is like intersecting those sets and then
     # taking the min bound of that.
@@ -20307,6 +20309,7 @@ with pkgs;
     else if name == "wasilibc" then targetPackages.wasilibc or wasilibc
     else if name == "relibc" then targetPackages.relibc or relibc
     else if stdenv.targetPlatform.isGhcjs then null
+    else if name == null then null # TODO: have a `isUefi` check like ghcJs above
     else throw "Unknown libc ${name}";
 
   libcCross = assert stdenv.targetPlatform != stdenv.buildPlatform; libcCrossChooser stdenv.targetPlatform.libc;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -20455,7 +20455,7 @@ with pkgs;
 
   gnu-config = callPackage ../development/libraries/gnu-config { };
 
-  gnu-efi = if stdenv.hostPlatform.isEfi
+  gnu-efi = if stdenv.hostPlatform.hasUefi
               then callPackage ../development/libraries/gnu-efi { }
             else null;
 


### PR DESCRIPTION
# Latest attempt at #228374

###### Description of changes

It also adds the metadata for Rust.

So @alyssais suggested me the next step should be to create a UEFI stdenv.
I'm not very knowledgeable on adding such stdenvs in nixpkgs, should this be part of `pkgs/stdenv` ? or `pkgs/build-support/uefi` ?

It's uncertain to me.

Thanks to @rrbutani help, we were able to get Lanzaboote's stub to build!

Steps to make it acceptable:

- [ ] Acceptable hack for UEFI systems
- [ ] Acceptable solution for NIX_ENFORCE_PURITY
- [ ] Acceptable solution for cc-wrapper at linkage time
- [ ] Acceptable solution to order `-z relro -z ...` properly and re-enable hardening
- [ ] Acceptable solution for cargo-auditable
- [ ] Acceptable solution for unsupported hardening flags

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
