### PR TITLE
lisp-modules: add polyclot & fix mcclim

### DIFF
--- a/pkgs/development/lisp-modules/imported.nix
+++ b/pkgs/development/lisp-modules/imported.nix
@@ -48177,7 +48177,6 @@ in lib.makeScope pkgs.newScope (self: {
     systems = [ "mcclim-bezier" ];
     lispLibs = [ (getAttr "clim" self) (getAttr "clim-pdf" self) (getAttr "clim-postscript" self) (getAttr "flexichain" self) (getAttr "mcclim-clx" self) (getAttr "mcclim-null" self) (getAttr "mcclim-render" self) ];
     meta = {
-      broken = true;
       hydraPlatforms = [  ];
     };
   });

--- a/pkgs/development/lisp-modules/packages.nix
+++ b/pkgs/development/lisp-modules/packages.nix
@@ -579,6 +579,18 @@ let
     ];
   };
 
+  polyclot = build-asdf-system {
+    pname = "polyclot";
+    version = "trunk";
+    src = pkgs.fetchfossil {
+      url = "https://fossil.turtleware.eu/polyclot";
+      rev = "e678b3c3e002f53b446780406c9ed13f8451309d22a1dc50ced4dbeedf08a1ec";
+      sha256 = "sha256-J08bU9HSVbzEivYtQsyIYPZJTrugj+jJSa4LglS0Olg=";
+    };
+    systems = [ "eu.turtleware.polyclot" "eu.turtleware.polyclot/demo" ];
+    lispLibs = with super; [ clim mcclim mcclim-layouts ];
+  };
+
   });
 
 in packages

--- a/pkgs/development/lisp-modules/ql.nix
+++ b/pkgs/development/lisp-modules/ql.nix
@@ -203,6 +203,21 @@ let
       patches = [ ./patches/math-no-compile-time-directory.patch ];
       nativeLibs = [ pkgs.fontconfig ];
     });
+    mcclim-fonts = super.mcclim-fonts.overrideLispAttrs (o: {
+      lispLibs = o.lispLibs ++ [
+        super.cl-dejavu
+        super.zpb-ttf
+        super.cl-vectors
+        super.cl-paths-ttf
+        super.flexi-streams
+      ];
+      systems = [ "mcclim-fonts" "mcclim-fonts/truetype" ];
+    });
+    mcclim-render = super.mcclim-render.overrideLispAttrs (o: {
+      lispLibs = o.lispLibs ++ [
+        self.mcclim-fonts
+      ];
+    });
   });
 
   qlpkgs =

--- a/pkgs/development/lisp-modules/ql.nix
+++ b/pkgs/development/lisp-modules/ql.nix
@@ -218,6 +218,12 @@ let
         self.mcclim-fonts
       ];
     });
+    mcclim-layouts = super.mcclim-layouts.overrideLispAttrs (o: {
+      systems = [ "mcclim-layouts" "mcclim-layouts/tab" ];
+      lispLibs = o.lispLibs ++ [
+        self.mcclim
+      ];
+});
   });
 
   qlpkgs =


### PR DESCRIPTION
###### Description of changes

Package the [Polyclot](https://www.reddit.com/r/lisp/comments/bdlcyh/a_new_clim_chart_library/) Lisp grammar-of-graphics plotting library.

Include two necessary fixes to the [McCLIM](https://github.com/McCLIM/McCLIM) package (a dependency.)