### PR TITLE
owncloud-client: 2.11.0.8354 -> 3.2.1

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -6118,6 +6118,12 @@
     githubId = 2405974;
     name = "Sébastian Méric de Bellefon";
   };
+  hellwolf = {
+    email = "zhicheng.miao@gmail.com";
+    github = "hellwolf";
+    githubId = 186660;
+    name = "Miao, ZhiCheng";
+  };
   henkery = {
     email = "jim@reupload.nl";
     github = "henkery";

--- a/pkgs/applications/networking/owncloud-client/default.nix
+++ b/pkgs/applications/networking/owncloud-client/default.nix
@@ -1,16 +1,32 @@
-{ lib, fetchurl, mkDerivation, cmake, extra-cmake-modules, pkg-config, qtbase, qtkeychain, sqlite, libsecret }:
+{ lib
+, fetchFromGitHub
+, mkDerivation
+, pkg-config
+, cmake
+, extra-cmake-modules
+, callPackage
+, qtbase
+, qtkeychain
+, qttools
+, sqlite
+, libsecret
+}:
 
 mkDerivation rec {
   pname = "owncloud-client";
-  version = "2.11.0.8354";
+  version = "3.2.1";
 
-  src = fetchurl {
-    url = "https://download.owncloud.com/desktop/ownCloud/stable/${version}/source/ownCloud-${version}.tar.xz";
-    sha256 = "sha256-YraWvGgeF5b1+3i5Jlk+bwvAULr7KFOSX8y0ZoPpljI=";
+  libregraph = callPackage ./libre-graph-api-cpp-qt-client.nix { };
+
+  src = fetchFromGitHub {
+    owner = "owncloud";
+    repo = "client";
+    rev = "refs/tags/v${version}";
+    hash = "sha256-39tpvzlTy3KRxg8DzCQW2VnsaLqJ+dNQRur2TqRZytE=";
   };
 
   nativeBuildInputs = [ pkg-config cmake extra-cmake-modules ];
-  buildInputs = [ qtbase qtkeychain sqlite libsecret ];
+  buildInputs = [ qtbase qttools qtkeychain sqlite libsecret libregraph ];
 
   qtWrapperArgs = [
     "--prefix LD_LIBRARY_PATH : ${lib.makeLibraryPath [ libsecret ]}"
@@ -19,13 +35,17 @@ mkDerivation rec {
   cmakeFlags = [
     "-UCMAKE_INSTALL_LIBDIR"
     "-DNO_SHIBBOLETH=1"
+    # https://github.com/owncloud/client/issues/10537#issuecomment-1447965096
+    # NB! From 4.0 it may be turned off by default
+    "-DWITH_AUTO_UPDATER=OFF"
   ];
 
   meta = with lib; {
     description = "Synchronise your ownCloud with your computer using this desktop client";
     homepage = "https://owncloud.org";
-    maintainers = [ maintainers.qknight ];
+    maintainers = with maintainers; [ qknight hellwolf ];
     platforms = platforms.unix;
     license = licenses.gpl2Plus;
+    changelog = "https://github.com/owncloud/client/releases/tag/v${version}";
   };
 }

--- a/pkgs/applications/networking/owncloud-client/libre-graph-api-cpp-qt-client.nix
+++ b/pkgs/applications/networking/owncloud-client/libre-graph-api-cpp-qt-client.nix
@@ -1,0 +1,34 @@
+{ lib
+, fetchFromGitHub
+, mkDerivation
+, cmake
+, qtbase
+}:
+
+mkDerivation rec {
+  pname = "libre-graph-api-cpp-qt-client";
+  version = "0.13.2";
+
+  src = fetchFromGitHub {
+    owner = "owncloud";
+    repo = pname;
+    rev = "refs/tags/v${version}";
+    hash = "sha256-gbrA8P+ukQAiF2czC2szw3fJv1qoPJyMQ72t7PqB5/s=";
+  };
+
+  sourceRoot = "source/client";
+
+  nativeBuildInputs = [ cmake ];
+  buildInputs = [ qtbase ];
+
+  cmakeFlags = [  ];
+
+  meta = with lib; {
+    description = "C++ Qt API for Libre Graph, a free API for cloud collaboration inspired by the MS Graph API";
+    homepage = "https://owncloud.org";
+    maintainers = with maintainers; [ qknight hellwolf ];
+    platforms = platforms.unix;
+    license = licenses.asl20;
+    changelog = "https://github.com/owncloud/libre-graph-api-cpp-qt-client/releases/tag/v${version}";
+  };
+}


### PR DESCRIPTION
###### Description of changes

Uprade owncloud-client to 3.2.1.10355.

###### Things done

- Include a `libre-graph-api-cpp-qt-client` library package required for the upgrade.
- Uprade owncloud-client to 3.2.1.10355.

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
