### PR TITLE
ocamlPackages.bisect_ppx: 2.8.1 → 2.8.2

### DIFF
--- a/pkgs/development/ocaml-modules/bisect_ppx/default.nix
+++ b/pkgs/development/ocaml-modules/bisect_ppx/default.nix
@@ -2,23 +2,18 @@
 
 buildDunePackage rec {
   pname = "bisect_ppx";
-  version = "2.8.1";
+  version = "2.8.2";
 
   src = fetchFromGitHub {
     owner = "aantron";
     repo = "bisect_ppx";
     rev = version;
-    sha256 = "sha256-pOeeSxzUF1jXQjA71atSZALdgQ2NB9qpKo5iaDnPwhQ=";
+    hash = "sha256-Uc5ZYL6tORcCCvCe9UmOnBF68FqWpQ4bc48fTQwnfis=";
   };
 
-  patches = lib.optionals (lib.versionAtLeast ppxlib.version "0.26.0") [
-    # Ppxlib >= 0.26.0 compatibility
+  patches = [
+    # Ppxlib >= 0.28.0 compatibility
     # remove when a new version is released
-    (fetchpatch {
-      name = "${pname}-${version}-ppxlib-0.26-compatibility.patch";
-      url = "https://patch-diff.githubusercontent.com/raw/aantron/bisect_ppx/pull/400.patch";
-      sha256 = "sha256-WAn6+d6pMUr79LVugOENuh9s0gbVEcTg0rxXMz1P3ak=";
-    })
     (fetchpatch {
       name = "${pname}-${version}-ppxlib-0.28-compatibility.patch";
       url = "https://github.com/anmonteiro/bisect_ppx/commit/cc442a08e3a2e0e18deb48f3a696076ac0986728.patch";
@@ -26,7 +21,8 @@ buildDunePackage rec {
     })
   ];
 
-  minimalOCamlVersion = "4.08";
+  minimalOCamlVersion = "4.11";
+  duneVersion = "3";
 
   buildInputs = [
     cmdliner


### PR DESCRIPTION
###### Description of changes

https://github.com/aantron/bisect_ppx/blob/2.8.2/doc/CHANGES

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
