### PR TITLE
haskell.compiler: allow overriding source with hadrian

### DIFF
--- a/pkgs/development/compilers/ghc/common-hadrian.nix
+++ b/pkgs/development/compilers/ghc/common-hadrian.nix
@@ -143,6 +143,20 @@
         return $ verbosity >= Verbose
   ''
 
+, ghcSrc ? (if rev != null then fetchgit else fetchurl) ({
+    inherit url sha256;
+  } // lib.optionalAttrs (rev != null) {
+    inherit rev;
+  })
+
+  # GHC's build system hadrian built from the GHC-to-build's source tree
+  # using our bootstrap GHC.
+, hadrian ? bootPkgs.callPackage ../../tools/haskell/hadrian {
+    ghcSrc = ghcSrc;
+    ghcVersion = version;
+    userSettings = hadrianUserSettings;
+  }
+
 , #  Whether to build sphinx documentation.
   enableDocs ? (
     # Docs disabled for musl and cross because it's a large task to keep
@@ -161,12 +175,6 @@
 assert !enableNativeBignum -> gmp != null;
 
 let
-  src = (if rev != null then fetchgit else fetchurl) ({
-    inherit url sha256;
-  } // lib.optionalAttrs (rev != null) {
-    inherit rev;
-  });
-
   inherit (stdenv) buildPlatform hostPlatform targetPlatform;
 
   inherit (bootPkgs) ghc;
@@ -187,14 +195,6 @@ let
     ++ lib.optionals targetPlatform.useAndroidPrebuilt [
       "*.*.ghc.c.opts += -optc-std=gnu99"
     ];
-
-  # GHC's build system hadrian built from the GHC-to-build's source tree
-  # using our bootstrap GHC.
-  hadrian = bootPkgs.callPackage ../../tools/haskell/hadrian {
-    ghcSrc = src;
-    ghcVersion = version;
-    userSettings = hadrianUserSettings;
-  };
 
   # Splicer will pull out correct variations
   libDeps = platform: lib.optional enableTerminfo ncurses
@@ -258,7 +258,7 @@ stdenv.mkDerivation ({
   pname = "${targetPrefix}ghc${variantSuffix}";
   inherit version;
 
-  inherit src;
+  src = ghcSrc;
 
   enableParallelBuilding = true;
 


### PR DESCRIPTION
Hadrian (the GHC build tool) is built separately from GHC. This means that if `haskell.compiler.ghc961` is overridden to add patches, those patches will _only_ be applied to the GHC portion of the build, and not the Hadrian build. For example, backporting this patch to GHC 9.6.1 failed because the changes to `hadrian/` files were not reflected in the Nix build:

[Enable response files for linker if supported](https://gitlab.haskell.org/ghc/ghc/-/commit/5ed77deb1b49bff7bae9660487ee4a40a496476d)

By lifting `src` and `hadrian` from variables defined in the function body to parameters with default values, the `hadrian/` files can be overridden using the `haskell.compiler.ghc961.override` function. For example:

```nix
self.haskell.compiler.ghc961.override {
  # The GHC 9.6 builder in nixpkgs first builds hadrian with the
  # source tree provided here and then uses the built hadrian to
  # build the rest of GHC. We need to make sure our patches get
  # included in this `src`, then, rather than modifying the tree in
  # the `patchPhase` or `postPatch` of the outer builder.
  src = self.applyPatches {
    src = let
      version = "9.6.1";
    in
      self.fetchurl {
        url = "https://downloads.haskell.org/ghc/${version}/ghc-${version}-src.tar.xz";
        sha256 = "fe5ac909cb8bb087e235de97fa63aff47a8ae650efaa37a2140f4780e21f34cb";
      };

    patches = [
      # Enable response files for linker if supported
      (self.fetchpatch {
        url = "https://gitlab.haskell.org/ghc/ghc/-/commit/5ed77deb1b49bff7bae9660487ee4a40a496476d.patch";
        hash = "sha256-dvenK+EPTZJYXnyfKPdkvLp+zeUmsY9YrWpcGCzYStM=";
      })
    ];
  };
}
```

Note that we do have to re-declare the `src` we want, but I'm not sure of a good way to avoid this while also sharing one set of patches between the GHC and Hadrian builds.