### PR TITLE
Support building `syncthingtray` on Darwin

### DIFF
--- a/pkgs/applications/misc/syncthingtray/default.nix
+++ b/pkgs/applications/misc/syncthingtray/default.nix
@@ -1,5 +1,6 @@
 { mkDerivation
 , lib
+, stdenv
 , fetchFromGitHub
 , substituteAll
 , qtbase
@@ -14,11 +15,12 @@
 , kio
 , plasma-framework
 , qttools
+, iconv
 , webviewSupport ? true
 , jsSupport ? true
-, kioPluginSupport ? true
-, plasmoidSupport  ? true
-, systemdSupport ? true
+, kioPluginSupport ? stdenv.isLinux
+, plasmoidSupport  ? stdenv.isLinux
+, systemdSupport ? stdenv.isLinux
 /* It is possible to set via this option an absolute exec path that will be
 written to the `~/.config/autostart/syncthingtray.desktop` file generated
 during runtime. Alternatively, one can edit the desktop file themselves after
@@ -44,7 +46,7 @@ mkDerivation rec {
     qtutilities
     boost
     qtforkawesome
-  ]
+  ] ++ lib.optionals stdenv.isDarwin [ iconv ]
     ++ lib.optionals webviewSupport [ qtwebengine ]
     ++ lib.optionals jsSupport [ qtdeclarative ]
     ++ lib.optionals kioPluginSupport [ kio ]
@@ -59,7 +61,8 @@ mkDerivation rec {
   ;
 
   # No tests are available by upstream, but we test --help anyway
-  doInstallCheck = true;
+  # Don't test on Darwin because output is .app
+  doInstallCheck = !stdenv.isDarwin;
   installCheckPhase = ''
     $out/bin/syncthingtray --help | grep ${version}
   '';
@@ -79,6 +82,6 @@ mkDerivation rec {
     description = "Tray application and Dolphin/Plasma integration for Syncthing";
     license = licenses.gpl2Plus;
     maintainers = with maintainers; [ doronbehar ];
-    platforms = platforms.linux;
+    platforms = platforms.linux ++ platforms.darwin;
   };
 }

--- a/pkgs/development/libraries/cpp-utilities/default.nix
+++ b/pkgs/development/libraries/cpp-utilities/default.nix
@@ -3,6 +3,7 @@
 , fetchFromGitHub
 , cmake
 , cppunit
+, iconv
 }:
 
 stdenv.mkDerivation rec {
@@ -18,19 +19,23 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ cmake ];
   nativeCheckInputs = [ cppunit ];
+  buildInputs = lib.optionals stdenv.isDarwin [
+    iconv # needed on Darwin, see https://github.com/Martchus/cpp-utilities/issues/4
+  ];
   # Otherwise, tests fail since the resulting shared object libc++utilities.so is only available in PWD of the make files
   preCheck = ''
     checkFlagsArray+=(
       "LD_LIBRARY_PATH=$PWD"
     )
   '';
-  doCheck = true;
+  # tests fail on Darwin
+  doCheck = !stdenv.isDarwin;
 
   meta = with lib; {
     homepage = "https://github.com/Martchus/cpp-utilities";
     description = "Common C++ classes and routines used by @Martchus' applications featuring argument parser, IO and conversion utilities";
     license = licenses.gpl2Plus;
     maintainers = with maintainers; [ doronbehar ];
-    platforms = platforms.linux;
+    platforms = platforms.linux ++ platforms.darwin;
   };
 }

--- a/pkgs/development/libraries/qtforkawesome/default.nix
+++ b/pkgs/development/libraries/qtforkawesome/default.nix
@@ -53,7 +53,7 @@ in stdenv.mkDerivation rec {
     description = "Library that bundles ForkAwesome for use within Qt applications";
     license = licenses.gpl2Plus;
     maintainers = with maintainers; [ doronbehar ];
-    platforms   = platforms.linux;
+    platforms   = platforms.linux ++ platforms.darwin;
   };
 }
 

--- a/pkgs/development/libraries/qtutilities/default.nix
+++ b/pkgs/development/libraries/qtutilities/default.nix
@@ -28,6 +28,6 @@ stdenv.mkDerivation rec {
     description = "Common Qt related C++ classes and routines used by @Martchus' applications such as dialogs, widgets and models Topics";
     license = licenses.gpl2Plus;
     maintainers = with maintainers; [ doronbehar ];
-    platforms   = platforms.linux;
+    platforms   = platforms.linux ++ platforms.darwin;
   };
 }


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Add support for building on darwin platforms.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [X] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [X] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

Application was tested by using open. 
```sh
open ./result/bin/syncthingtray.app
```
Runs in tray and connects with syncthing successfully. Seems to be working normally. 
