### PR TITLE
nixos/make-disk-image: fix contents dir paths

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2305.section.md
+++ b/nixos/doc/manual/release-notes/rl-2305.section.md
@@ -415,6 +415,8 @@ In addition to numerous new and upgraded packages, this release has the followin
 
 - The `bind` module now allows the per-zone `allow-query` setting to be configured (previously it was hard-coded to `any`; it still defaults to `any` to retain compatibility).
 
+- `make-disk-image` handles `contents` arguments that are directories better, fixing a bug where it used to put them in a subdirectory of the intended `target`.
+
 ## Detailed migration information {#sec-release-23.05-migration}
 
 ### Pipewire configuration overrides {#sec-release-23.05-migration-pipewire}

--- a/nixos/lib/make-disk-image.nix
+++ b/nixos/lib/make-disk-image.nix
@@ -402,11 +402,16 @@ let format' = format; in let
         done
       else
         mkdir -p $root/$(dirname $target)
-        if ! [ -e $root/$target ]; then
-          rsync $rsync_flags $source $root/$target
-        else
+        if [ -e $root/$target ]; then
           echo "duplicate entry $target -> $source"
           exit 1
+        elif [ -d $source ]; then
+          # Append a slash to the end of source to get rsync to copy the
+          # directory _to_ the target instead of _inside_ the target.
+          # (See `man rsync`'s note on a trailing slash.)
+          rsync $rsync_flags $source/ $root/$target
+        else
+          rsync $rsync_flags $source $root/$target
         fi
       fi
     done

--- a/nixos/tests/common/ec2.nix
+++ b/nixos/tests/common/ec2.nix
@@ -17,6 +17,7 @@ with pkgs.lib;
           ln -s ${pkgs.writeText "sshPublicKey" sshPublicKey} $out/1.0/meta-data/public-keys/0/openssh-key
         '';
       };
+      indentLines = str: concatLines (map (s: "  " + s) (splitString "\n" str));
     in makeTest {
       name = "ec2-" + name;
       nodes = {};
@@ -35,6 +36,8 @@ with pkgs.lib;
                 "qemu-img",
                 "create",
                 "-f",
+                "qcow2",
+                "-F",
                 "qcow2",
                 "-o",
                 "backing_file=${image}",
@@ -59,7 +62,11 @@ with pkgs.lib;
         )
 
         machine = create_machine({"startCommand": start_command})
-      '' + script;
+        try:
+      '' + indentLines script + ''
+        finally:
+          machine.shutdown()
+      '';
 
       inherit meta;
     };


### PR DESCRIPTION
###### Description of changes
`make-disk-image` is a tool for creating VM images. It takes an argument `contents` that allows one to specify files and directories that should be copied into the VM image. However, directories do not end up at the specified target, but instead at a subdirectory of the target, with a nix-store-like path, e.g. `/target/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx-source`. See issue https://github.com/NixOS/nixpkgs/issues/226203 .

This change adds a test for make-disk-image's contents directory handling and adds a fix (appending `/` to rsync input directory names).

This closes issue https://github.com/NixOS/nixpkgs/issues/226203 .

###### Things done
I added some checks in `nixosTests.image-contents` and ran it on an x86_64 machine. I also ran `nixosTests.qemu-vm-restrictnetwork`.

I did not run these relevant-looking tests, however, because they had issues on master:
* `nixosTests.ec2-config` (not run because it logged about something broken on master)
* `nixosTests.ec2-nixops` (not run because it failed on master)
* `nixosTests.sourcehut` (not tested because it did not complete in 10 minutes on master)
* `nixosTests.systemd-repart` (not tested because it failed on master)

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [X] Tested, as applicable:
  - [X] [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests)), see specific tests listed above
  - [ ] and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - [ ] or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - [ ] made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [X] Added a release notes entry for this library function fix. (I'm not sure if this is useful.)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

