### PR TITLE
batman-adv: 2022.3 -> 2023.0

### DIFF
--- a/pkgs/os-specific/linux/batman-adv/version.nix
+++ b/pkgs/os-specific/linux/batman-adv/version.nix
@@ -1,9 +1,9 @@
 {
-  version = "2022.3";
+  version = "2023.0";
 
   sha256 = {
-    batman-adv = "sha256-IY/7U0/q0cm1sNkOwbL7poggnN8A6GG+zhy/Rp/mmVM=";
-    alfred = "sha256-wD8XY7hV4yzCOE7KlWDpYJyW2bAe9TdfKHZc7hgAURI=";
-    batctl = "sha256-xYs3F3HXy5qHhtc5SDTx/41F1BVjemTpB26qCVOx8tc=";
+    batman-adv = "sha256-LOTsBAYyUue/7DorP6KmGztCx7BNaYumATK/qx1gpc0=";
+    alfred = "sha256-xeytzlDoIoqRK0iUVnrUXW/x0ro5kcl4RW5L75t9utE=";
+    batctl = "sha256-EQcewCth4B4F74Awt72o/xXlxwspSmQgRZLFtssx7SI=";
   };
 }


### PR DESCRIPTION
###### Description of changes

Update.

###### Things done

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [X] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

Result of `nixpkgs-review` run on x86_64-linux [1](https://github.com/Mic92/nixpkgs-review)
<details>
  <summary>1 package failed to build:</summary>
  <ul>
    <li>linuxKernel.packages.linux_5_4_hardened.batman_adv</li>
  </ul>
</details>
<details>
  <summary>21 packages built:</summary>
  <ul>
    <li>alfred</li>
    <li>batctl</li>
    <li>linuxKernel.packages.linux_4_14.batman_adv</li>
    <li>linuxKernel.packages.linux_4_14_hardened.batman_adv</li>
    <li>linuxKernel.packages.linux_4_19.batman_adv</li>
    <li>linuxKernel.packages.linux_4_19_hardened.batman_adv</li>
    <li>linuxKernel.packages.linux_5_10.batman_adv</li>
    <li>linuxKernel.packages.linux_5_10_hardened.batman_adv</li>
    <li>linuxKernel.packages.linux_5_15.batman_adv</li>
    <li>linuxKernel.packages.linux_5_15_hardened.batman_adv</li>
    <li>linuxKernel.packages.linux_5_4.batman_adv</li>
    <li>linuxKernel.packages.linux_6_1.batman_adv</li>
    <li>linuxKernel.packages.linux_hardened.batman_adv (linuxKernel.packages.linux_6_1_hardened.batman_adv)</li>
    <li>linuxKernel.packages.linux_6_2.batman_adv</li>
    <li>linuxKernel.packages.linux_latest_libre.batman_adv</li>
    <li>linuxKernel.packages.linux_libre.batman_adv</li>
    <li>linuxKernel.packages.linux_lqx.batman_adv</li>
    <li>linuxKernel.packages.linux_testing_bcachefs.batman_adv</li>
    <li>linuxKernel.packages.linux_xanmod.batman_adv</li>
    <li>linuxKernel.packages.linux_xanmod_latest.batman_adv (linuxKernel.packages.linux_xanmod_stable.batman_adv)</li>
    <li>linuxKernel.packages.linux_zen.batman_adv</li>
  </ul>
</details>