### PR TITLE
kicad: 7.0.1 -> 7.0.2

### DIFF
--- a/pkgs/applications/science/electronics/kicad/base.nix
+++ b/pkgs/applications/science/electronics/kicad/base.nix
@@ -94,9 +94,6 @@ stdenv.mkDerivation rec {
     # should be resolved in the next release
     "-DCMAKE_CTEST_ARGUMENTS='--exclude-regex;qa_eeschema'"
   ]
-  ++ optionals (!stable) [ # workaround for https://gitlab.com/kicad/code/kicad/-/issues/14346
-    "-DPYTHON_SITE_PACKAGE_PATH=${placeholder "out"}/${python.sitePackages}/"
-  ]
   ++ optional (stable && !withNgspice) "-DKICAD_SPICE=OFF"
   ++ optionals (!withScripting) [
     "-DKICAD_SCRIPTING_WXPYTHON=OFF"

--- a/pkgs/applications/science/electronics/kicad/versions.nix
+++ b/pkgs/applications/science/electronics/kicad/versions.nix
@@ -3,23 +3,23 @@
 {
   "kicad" = {
     kicadVersion = {
-      version =			"7.0.1";
+      version =			"7.0.2";
       src = {
-        rev =			"3b83917a115be1ce2f33a73039f59f8784b5c2e7";
-        sha256 =		"021safxvyq9qzs08jy3jvpazmhvix4kyl05s9y9hwmyzdmdl2smn";
+        rev =			"6a45011f421d65a241e1df4a2dc720819922f343";
+        sha256 =		"0san7pjgvd8niwrki722qb6y46r71rlyspqp43pmkiz55dmz52zx";
       };
     };
     libVersion = {
-      version =			"7.0.1";
+      version =			"7.0.2";
       libSources = {
-        symbols.rev =		"adfe3c06b5750d81580ed44e669b578f49c205eb";
-        symbols.sha256 =	"14c5gci13m30xv0cmic5jxsmfx9lq3fnd8hyq3mmgkrw7443zy30";
-        templates.rev =		"66d76556d9e81f8a5be74457686d211c666ed200";
-        templates.sha256 =	"02i279269mhq7wjhb1yqk90820ncssxl9n7b20qr2r4fmm7jpvxv";
-        footprints.rev =	"1cf5a1d979cffebd62464c1bb0d7b09c5ee3b8c3";
-        footprints.sha256 =	"0k0z40wmaq665hjxb6kp1yl3v7clxz49r6ki0chyphsxv1cnixmy";
-        packages3d.rev =	"e54b5b6368d03f396098448bcce37f2e432dac33";
-        packages3d.sha256 =	"0nzi7ijfb3rjm98kaa9va2mkh0nfzpq4vfhxkq8j18qhx24h5c8v";
+        symbols.rev =		"22ed11504c140fded542eeb104cdb02e0a65672e";
+        symbols.sha256 =	"0aah92rb8yx00z0xwx9z7xn5rrw4cc3z35gr7c0bnb49hiak01jc";
+        templates.rev =		"331068741c80fee8195646d3dee40f3b840495e7";
+        templates.sha256 =	"1qi20mrsfn4fxmr1fyphmil2i9p2nzmwk5rlfchc5aq2194nj3lq";
+        footprints.rev =	"e187e2dfa9bd04d91cad0d875049ab56780b6e32";
+        footprints.sha256 =	"1qrdznfd4a6kzwd4aaijkpyjy0xnrmi66isq9z52652a8s6ja48v";
+        packages3d.rev =	"6374ae3db8b43a4d779185b7017fcfe0e1f32590";
+        packages3d.sha256 =	"1nkk4325jh89vh52ykfnf9pz1k3jk5017gz6r2cia2v4b3jadi31";
       };
     };
   };

--- a/pkgs/applications/science/electronics/kicad/versions.nix
+++ b/pkgs/applications/science/electronics/kicad/versions.nix
@@ -25,23 +25,23 @@
   };
   "kicad-unstable" = {
     kicadVersion = {
-      version =			"2023-03-29";
+      version =			"2023-04-14";
       src = {
-        rev =			"d5bc223ff2cd1fbf4e923e23b5bb442bb54faa95";
-        sha256 =		"0pbzmv9vh4bzhsxj46gjkgh7kk6a0v8gijvkmb56fy5i8xv2ixkn";
+        rev =			"4a3f77cd9dac9dc5921eb9beaa63d0d3c9c051e5";
+        sha256 =		"06dsiyvr7zn3cp13w0y63d1qmjlhzsqlvajkximg3pw5mmiljxrr";
       };
     };
     libVersion = {
-      version =			"2023-03-29";
+      version =			"2023-04-14";
       libSources = {
-        symbols.rev =		"36fc1c88921bf32ebf667e027dfe63cca649fd95";
-        symbols.sha256 =	"177mqvjf3knldnl7pf1abv4pmlgi5cg02ggfwbc655jq4x6x8fkz";
+        symbols.rev =		"38d4e7e1ab6a9b5d9eee85f687e60467753b2135";
+        symbols.sha256 =	"0df6fx9b19v6sxrfyggbisw72y66kiwqi05k8mldsgiw6q55gbkc";
         templates.rev =		"867eef383a0f61015cb69677d5c632d78a2ea01a";
         templates.sha256 =	"1qi20mrsfn4fxmr1fyphmil2i9p2nzmwk5rlfchc5aq2194nj3lq";
-        footprints.rev =	"dc4574eb65136d95a7775d09412d5159f8d7832c";
-        footprints.sha256 =	"1iz4wyiysdii378c3pjgkgwh1cssxbh5jkbhvj7rmi2vmgngl6nc";
-        packages3d.rev =	"e54b5b6368d03f396098448bcce37f2e432dac33";
-        packages3d.sha256 =	"0nzi7ijfb3rjm98kaa9va2mkh0nfzpq4vfhxkq8j18qhx24h5c8v";
+        footprints.rev =	"4da055a2d572ff87e7ecea97cf358ed8c1d46dfc";
+        footprints.sha256 =	"1xb84284dmcb7mbvzlrxb4v4km3ih7gq856h8cglf9jn8wzlnvrk";
+        packages3d.rev =	"0f43a0962437feb53bd2083e9f39efffb5a5dd90";
+        packages3d.sha256 =	"1nkk4325jh89vh52ykfnf9pz1k3jk5017gz6r2cia2v4b3jadi31";
       };
     };
   };


### PR DESCRIPTION
###### Description of changes

latest point release, and latest master commit

release blog post expected [here](https://www.kicad.org/blog/2023/04/KiCad-7.0.2-Release/) soon

###### Things done

bumped `kicad` and `kicad-unstable` to latest
remove workaround for a now resolved issue in `kicad-unstable`

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [x] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).