### PR TITLE
wch-isp: init at 0.2.4

### DIFF
--- a/pkgs/development/embedded/wch-isp/default.nix
+++ b/pkgs/development/embedded/wch-isp/default.nix
@@ -1,0 +1,27 @@
+{ lib, stdenv, fetchFromGitHub, pkg-config, libusb1 }:
+
+stdenv.mkDerivation rec {
+  pname = "wch-isp";
+  version = "0.2.4";
+
+  src = fetchFromGitHub {
+    owner = "jmaselbas";
+    repo = pname;
+    rev = "v${version}";
+    hash = "sha256-YjxzfDSZRMa7B+hNqtj87nRlRuQyr51VidZqHLddgwI=";
+  };
+
+  nativeBuildInputs = [ pkg-config ];
+  buildInputs = [ libusb1 ];
+
+  installFlags = [ "DESTDIR=$(out)" "PREFIX=" ];
+  installTargets = [ "install" "install-rules" ];
+
+  meta = {
+    description = "Firmware programmer for WCH microcontrollers over USB";
+    license = lib.licenses.gpl2Only;
+    homepage = "https://github.com/jmaselbas/wch-isp";
+    maintainers = with lib.maintainers; [ lesuisse ];
+    platforms = lib.platforms.unix;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -19086,6 +19086,8 @@ with pkgs;
 
   uisp = callPackage ../development/embedded/uisp { };
 
+  wch-isp = callPackage ../development/embedded/wch-isp { };
+
   uncrustify = callPackage ../development/tools/misc/uncrustify { };
 
   universal-ctags = callPackage ../development/tools/misc/universal-ctags { };


### PR DESCRIPTION
###### Description of changes

https://github.com/jmaselbas/wch-isp

NixOS users can load the udev rule with `services.udev.packages = [ wch-isp ];`
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
