### PR TITLE
albert: 0.17.6 -> 0.20.13

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2305.section.md
+++ b/nixos/doc/manual/release-notes/rl-2305.section.md
@@ -172,6 +172,8 @@ In addition to numerous new and upgraded packages, this release has the followin
 
 - `fail2ban` has been updated to 1.0.2, which has a few breaking changes compared to 0.11.2 ([changelog for 1.0.1](https://github.com/fail2ban/fail2ban/blob/1.0.1/ChangeLog), [changelog for 1.0.2](https://github.com/fail2ban/fail2ban/blob/1.0.2/ChangeLog))
 
+- `albert` has been updated from 0.17.6 to 0.20.13, and 0.18.0 changed the config format and many plugins ([changelog for 0.18.0](https://github.com/albertlauncher/albert/blob/v0.18.0/CHANGELOG.md))
+
 - Calling `makeSetupHook` without passing a `name` argument is deprecated.
 
 - `lib.systems.examples.ghcjs` and consequently `pkgsCross.ghcjs` now use the target triplet `javascript-unknown-ghcjs` instead of `js-unknown-ghcjs`. This has been done to match an [upstream decision](https://gitlab.haskell.org/ghc/ghc/-/commit/6636b670233522f01d002c9b97827d00289dbf5c) to follow Cabal's platform naming more closely. Nixpkgs will also reject `js` as an architecture name.

--- a/pkgs/applications/misc/albert/default.nix
+++ b/pkgs/applications/misc/albert/default.nix
@@ -2,27 +2,25 @@
 , stdenv
 , fetchFromGitHub
 , cmake
+, libqalculate
 , muparser
-, python3
+, python3Packages
 , qtbase
-, qtcharts
-, qtdeclarative
-, qtgraphicaleffects
+, qtscxml
 , qtsvg
-, qtx11extras
 , wrapQtAppsHook
 , nix-update-script
 }:
 
 stdenv.mkDerivation rec {
   pname = "albert";
-  version = "0.17.6";
+  version = "0.20.13";
 
   src = fetchFromGitHub {
     owner = "albertlauncher";
     repo = "albert";
     rev = "v${version}";
-    sha256 = "sha256-nbnywrsKvFG8AkayjnylOKSnn7rRWgNv5zE9DDeOmLw=";
+    sha256 = "sha256-zG6XlFOzSpUSswG4kvKf2lgwUSZkzEVslgQBjzVTLYQ=";
     fetchSubmodules = true;
   };
 
@@ -32,20 +30,17 @@ stdenv.mkDerivation rec {
   ];
 
   buildInputs = [
+    libqalculate
     muparser
-    python3
     qtbase
-    qtcharts
-    qtdeclarative
-    qtgraphicaleffects
+    qtscxml
     qtsvg
-    qtx11extras
-  ];
+  ] ++ (with python3Packages; [ python pybind11 ]);
 
   postPatch = ''
     find -type f -name CMakeLists.txt -exec sed -i {} -e '/INSTALL_RPATH/d' \;
 
-    sed -i src/app/main.cpp \
+    sed -i src/nativepluginprovider.cpp \
       -e "/QStringList dirs = {/a    QFileInfo(\"$out/lib\").canonicalFilePath(),"
   '';
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1425,7 +1425,7 @@ with pkgs;
 
   akku = callPackage ../tools/package-management/akku { };
 
-  albert = libsForQt5.callPackage ../applications/misc/albert { };
+  albert = qt6Packages.callPackage ../applications/misc/albert { };
 
   alice-tools = callPackage ../tools/games/alice-tools {
     withGUI = false;


### PR DESCRIPTION
###### Description of changes

As added to the release notes, the biggest changes are in [0.18.0](https://github.com/albertlauncher/albert/blob/v0.18.0/CHANGELOG.md). The config and plugin format changed and they updated to QT 6.

I tested it on sway.

Diff: https://github.com/albertlauncher/albert/compare/v0.17.6...v0.20.13

Changelog: https://github.com/albertlauncher/albert/blob/v0.20.13/CHANGELOG.md


<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [x] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
