### PR TITLE
gfxreconstruct: 0.9.18 -> 0.9.19

### DIFF
--- a/pkgs/tools/graphics/gfxreconstruct/default.nix
+++ b/pkgs/tools/graphics/gfxreconstruct/default.nix
@@ -17,13 +17,13 @@
 
 stdenv.mkDerivation rec {
   pname = "gfxreconstruct";
-  version = "0.9.18";
+  version = "0.9.19";
 
   src = fetchFromGitHub {
     owner = "LunarG";
     repo = "gfxreconstruct";
     rev = "v${version}";
-    hash = "sha256-9MDmeHid/faHeBjBfPgpRMjMMXZeHKP0VZZJtEQgBhs=";
+    hash = "sha256-a1eMfVhBpnNoh0JTElHsPBfITlxeCbQKbDCGbj1ub1o=";
     fetchSubmodules = true;
   };
 
@@ -50,10 +50,17 @@ stdenv.mkDerivation rec {
       --replace "scriptdir, '..', cmd" 'scriptdir'
   '';
 
-  # Fix the path to the layer library
+  # Fix the paths to load the layer.
+  # Also remove the .py suffix on files so that gfxrecon
+  # does not try to start the wrapper bash scripts with python.
   postInstall = ''
     substituteInPlace $out/share/vulkan/explicit_layer.d/VkLayer_gfxreconstruct.json \
       --replace 'libVkLayer_gfxreconstruct.so' "$out/lib/libVkLayer_gfxreconstruct.so"
+    for f in $out/bin/*.py; do
+      mv -- "$f" "''${f%%.py}"
+    done
+    wrapProgram $out/bin/gfxrecon-capture-vulkan \
+      --prefix VK_ADD_LAYER_PATH : "$out/share/vulkan/explicit_layer.d"
     wrapProgram $out/bin/gfxrecon-replay \
       --prefix LD_LIBRARY_PATH : ${lib.makeLibraryPath [ vulkan-loader ]}
   '';
@@ -61,6 +68,7 @@ stdenv.mkDerivation rec {
   meta = with lib; {
     description = "Graphics API Capture and Replay Tools";
     homepage = "https://github.com/LunarG/gfxreconstruct/";
+    changelog = "https://github.com/LunarG/gfxreconstruct/releases/tag/v${version}";
     license = licenses.mit;
     maintainers = with maintainers; [ Flakebi ];
   };


### PR DESCRIPTION
###### Description of changes

Wrap the capture app so that it works from nix-shell, without installing gfxreconstruct (the layer needs to be available to Vulkan).

Diff: https://github.com/LunarG/gfxreconstruct/compare/v0.9.18...v0.9.19

Changelog: https://github.com/LunarG/gfxreconstruct/releases/tag/v0.9.19


<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
