### PR TITLE
nixos/kubo: improve API access

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2305.section.md
+++ b/nixos/doc/manual/release-notes/rl-2305.section.md
@@ -137,6 +137,8 @@ In addition to numerous new and upgraded packages, this release has the followin
 
 - The [services.kubo.settings](#opt-services.kubo.settings) option is now no longer stateful. If you changed any of the options in [services.kubo.settings](#opt-services.kubo.settings) in the past and then removed them from your NixOS configuration again, those changes are still in your Kubo configuration file but will now be reset to the default. If you're unsure, you may want to make a backup of your configuration file (probably /var/lib/ipfs/config) and compare after the update.
 
+- The Kubo HTTP API will no longer listen on localhost and will instead only listen on a Unix domain socket by default. Read the [services.kubo.settings.Addresses.API](#opt-services.kubo.settings.Addresses.API) option description for more information.
+
 - The EC2 image module no longer fetches instance metadata in stage-1. This results in a significantly smaller initramfs, since network drivers no longer need to be included, and faster boots, since metadata fetching can happen in parallel with startup of other services.
   This breaks services which rely on metadata being present by the time stage-2 is entered. Anything which reads EC2 metadata from `/etc/ec2-metadata` should now have an `after` dependency on `fetch-ec2-metadata.service`
 

--- a/nixos/doc/manual/release-notes/rl-2305.section.md
+++ b/nixos/doc/manual/release-notes/rl-2305.section.md
@@ -135,7 +135,7 @@ In addition to numerous new and upgraded packages, this release has the followin
 
 - `keepassx` and `keepassx2` have been removed, due to upstream [stopping development](https://www.keepassx.org/index.html%3Fp=636.html). Consider [KeePassXC](https://keepassxc.org) as a maintained alternative.
 
-- The `services.kubo.settings` option is now no longer stateful. If you changed any of the options in `services.kubo.settings` in the past and then removed them from your NixOS configuration again, those changes are still in your Kubo configuration file but will now be reset to the default. If you're unsure, you may want to make a backup of your configuration file (probably /var/lib/ipfs/config) and compare after the update.
+- The [services.kubo.settings](#opt-services.kubo.settings) option is now no longer stateful. If you changed any of the options in [services.kubo.settings](#opt-services.kubo.settings) in the past and then removed them from your NixOS configuration again, those changes are still in your Kubo configuration file but will now be reset to the default. If you're unsure, you may want to make a backup of your configuration file (probably /var/lib/ipfs/config) and compare after the update.
 
 - The EC2 image module no longer fetches instance metadata in stage-1. This results in a significantly smaller initramfs, since network drivers no longer need to be included, and faster boots, since metadata fetching can happen in parallel with startup of other services.
   This breaks services which rely on metadata being present by the time stage-2 is entered. Anything which reads EC2 metadata from `/etc/ec2-metadata` should now have an `after` dependency on `fetch-ec2-metadata.service`
@@ -338,7 +338,7 @@ In addition to numerous new and upgraded packages, this release has the followin
     [headscale's example configuration](https://github.com/juanfont/headscale/blob/main/config-example.yaml)
     can be directly written as attribute-set in Nix within this option.
 
-- `services.kubo` now unmounts `ipfsMountDir` and `ipnsMountDir` even if it is killed unexpectedly when 'autoMount` is enabled.
+- `services.kubo` now unmounts `ipfsMountDir` and `ipnsMountDir` even if it is killed unexpectedly when `autoMount` is enabled.
 
 - `nixos/lib/make-disk-image.nix` can now mutate EFI variables, run user-provided EFI firmware or variable templates. This is now extensively documented in the NixOS manual.
 

--- a/nixos/modules/services/network-filesystems/kubo.nix
+++ b/nixos/modules/services/network-filesystems/kubo.nix
@@ -22,6 +22,18 @@ let
 
   configFile = settingsFormat.generate "kubo-config.json" customizedConfig;
 
+  # Create a fake repo containing only the file "api".
+  # $IPFS_PATH will point to this directory instead of the real one.
+  # For some reason the Kubo CLI tools insist on reading the
+  # config file when it exists. But the Kubo daemon sets the file
+  # permissions such that only the ipfs user is allowed to read
+  # this file. This prevents normal users from talking to the daemon.
+  # To work around this terrible design, create a fake repo with no
+  # config file, only an api file and everything should work as expected.
+  fakeKuboRepo = pkgs.writeTextDir "api" ''
+    /unix/run/ipfs.sock
+  '';
+
   kuboFlags = utils.escapeSystemdExecArgs (
     optional cfg.autoMount "--mount" ++
     optional cfg.enableGC "--enable-gc" ++
@@ -248,7 +260,7 @@ in
     ];
 
     environment.systemPackages = [ cfg.package ];
-    environment.variables.IPFS_PATH = cfg.dataDir;
+    environment.variables.IPFS_PATH = fakeKuboRepo;
 
     # https://github.com/lucas-clemente/quic-go/wiki/UDP-Receive-Buffer-Size
     boot.kernel.sysctl."net.core.rmem_max" = mkDefault 2500000;

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -359,7 +359,7 @@ in {
   ksm = handleTest ./ksm.nix {};
   kthxbye = handleTest ./kthxbye.nix {};
   kubernetes = handleTestOn ["x86_64-linux"] ./kubernetes {};
-  kubo = handleTest ./kubo.nix {};
+  kubo = runTest ./kubo.nix;
   ladybird = handleTest ./ladybird.nix {};
   languagetool = handleTest ./languagetool.nix {};
   latestKernel.login = handleTest ./login.nix { latestKernel = true; };

--- a/nixos/tests/kubo.nix
+++ b/nixos/tests/kubo.nix
@@ -1,7 +1,7 @@
 import ./make-test-python.nix ({ pkgs, ...} : {
   name = "kubo";
   meta = with pkgs.lib.maintainers; {
-    maintainers = [ mguentner ];
+    maintainers = [ mguentner Luflosi ];
   };
 
   nodes.machine = { ... }: {

--- a/nixos/tests/kubo.nix
+++ b/nixos/tests/kubo.nix
@@ -25,42 +25,42 @@
   testScript = ''
     start_all()
 
-    # IPv4 socket activation
-    machine.succeed("ipfs --api /ip4/127.0.0.1/tcp/2324 id")
-    ipfs_hash = machine.succeed(
-        "echo fnord | ipfs --api /ip4/127.0.0.1/tcp/2324 add --quieter"
-    )
-    machine.succeed(f"ipfs cat /ipfs/{ipfs_hash.strip()} | grep fnord")
+    with subtest("IPv4 socket activation"):
+        machine.succeed("ipfs --api /ip4/127.0.0.1/tcp/2324 id")
+        ipfs_hash = machine.succeed(
+            "echo fnord | ipfs --api /ip4/127.0.0.1/tcp/2324 add --quieter"
+        )
+        machine.succeed(f"ipfs cat /ipfs/{ipfs_hash.strip()} | grep fnord")
 
     machine.stop_job("ipfs")
 
-    # Unix domain socket activation
-    ipfs_hash = machine.succeed(
-        "echo fnord2 | ipfs --api /unix/run/ipfs.sock add --quieter"
-    )
-    machine.succeed(
-        f"ipfs --api /unix/run/ipfs.sock cat /ipfs/{ipfs_hash.strip()} | grep fnord2"
-    )
+    with subtest("Unix domain socket activation"):
+        ipfs_hash = machine.succeed(
+            "echo fnord2 | ipfs --api /unix/run/ipfs.sock add --quieter"
+        )
+        machine.succeed(
+            f"ipfs --api /unix/run/ipfs.sock cat /ipfs/{ipfs_hash.strip()} | grep fnord2"
+        )
 
-    # Test if setting dataDir works properly with the hardened systemd unit
-    machine.succeed("test -e /mnt/ipfs/config")
-    machine.succeed("test ! -e /var/lib/ipfs/")
+    with subtest("Setting dataDir works properly with the hardened systemd unit"):
+        machine.succeed("test -e /mnt/ipfs/config")
+        machine.succeed("test ! -e /var/lib/ipfs/")
 
-    # Test FUSE mountpoint
-    # The FUSE mount functionality is broken as of v0.13.0 and v0.17.0.
-    # See https://github.com/ipfs/kubo/issues/9044.
-    # Workaround: using CID Version 1 avoids that.
-    ipfs_hash = fuse.succeed(
-        "echo fnord3 | ipfs --api /ip4/127.0.0.1/tcp/2324 add --quieter --cid-version=1"
-    ).strip()
+    with subtest("FUSE mountpoint"):
+        # The FUSE mount functionality is broken as of v0.13.0 and v0.17.0.
+        # See https://github.com/ipfs/kubo/issues/9044.
+        # Workaround: using CID Version 1 avoids that.
+        ipfs_hash = fuse.succeed(
+            "echo fnord3 | ipfs --api /ip4/127.0.0.1/tcp/2324 add --quieter --cid-version=1"
+        ).strip()
 
-    fuse.succeed(f"cat /ipfs/{ipfs_hash} | grep fnord3")
+        fuse.succeed(f"cat /ipfs/{ipfs_hash} | grep fnord3")
 
-    # Force Kubo to crash and wait for it to restart
-    # Tests the unmounting of /ipns and /ipfs
-    fuse.systemctl("kill --signal=SIGKILL ipfs.service")
-    fuse.wait_for_unit("ipfs.service", timeout = 30)
+    with subtest("Unmounting of /ipns and /ipfs"):
+        # Force Kubo to crash and wait for it to restart
+        fuse.systemctl("kill --signal=SIGKILL ipfs.service")
+        fuse.wait_for_unit("ipfs.service", timeout = 30)
 
-    fuse.succeed(f"cat /ipfs/{ipfs_hash} | grep fnord3")
+        fuse.succeed(f"cat /ipfs/{ipfs_hash} | grep fnord3")
   '';
 }

--- a/nixos/tests/kubo.nix
+++ b/nixos/tests/kubo.nix
@@ -20,7 +20,8 @@
   nodes.fuse = { ... }: {
     services.kubo = {
       enable = true;
-      settings.Addresses.API = "/ip4/127.0.0.1/tcp/2324";
+      # Only allow API access through the Unix domain socket
+      settings.Addresses.API = [ ];
       autoMount = true;
     };
   };

--- a/nixos/tests/kubo.nix
+++ b/nixos/tests/kubo.nix
@@ -1,6 +1,6 @@
-import ./make-test-python.nix ({ pkgs, ...} : {
+{ lib, ...} : {
   name = "kubo";
-  meta = with pkgs.lib.maintainers; {
+  meta = with lib.maintainers; {
     maintainers = [ mguentner Luflosi ];
   };
 
@@ -25,21 +25,18 @@ import ./make-test-python.nix ({ pkgs, ...} : {
   testScript = ''
     start_all()
 
-    # IPv4 activation
-
+    # IPv4 socket activation
     machine.succeed("ipfs --api /ip4/127.0.0.1/tcp/2324 id")
     ipfs_hash = machine.succeed(
-        "echo fnord | ipfs --api /ip4/127.0.0.1/tcp/2324 add | awk '{ print $2 }'"
+        "echo fnord | ipfs --api /ip4/127.0.0.1/tcp/2324 add --quieter"
     )
-
     machine.succeed(f"ipfs cat /ipfs/{ipfs_hash.strip()} | grep fnord")
-
-    # Unix domain socket activation
 
     machine.stop_job("ipfs")
 
+    # Unix domain socket activation
     ipfs_hash = machine.succeed(
-        "echo fnord2 | ipfs --api /unix/run/ipfs.sock add | awk '{ print $2 }'"
+        "echo fnord2 | ipfs --api /unix/run/ipfs.sock add --quieter"
     )
     machine.succeed(
         f"ipfs --api /unix/run/ipfs.sock cat /ipfs/{ipfs_hash.strip()} | grep fnord2"
@@ -66,4 +63,4 @@ import ./make-test-python.nix ({ pkgs, ...} : {
 
     fuse.succeed(f"cat /ipfs/{ipfs_hash} | grep fnord3")
   '';
-})
+}


### PR DESCRIPTION
###### Description of changes
Fixes https://github.com/NixOS/nixpkgs/issues/223289.

This allows the ipfs CLI tools to communicate with the daemon when the user is in the ipfs group. Before, the user had to be root or do some annoying and error-prone manual setup to allow this.
I also locked down the security a bit. Before this PR, all users on the system could access the API of the Kubo daemon with some manual setup but with this PR, only users in the ipfs group can talk to the daemon by default.

I feel like the wording in some commit messages, comments and changelog documentation could be improved. Please suggest improvements.

###### Things done

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).