### PR TITLE
qt6ct: init at 0.8

### DIFF
--- a/pkgs/tools/misc/qt6ct/default.nix
+++ b/pkgs/tools/misc/qt6ct/default.nix
@@ -1,0 +1,32 @@
+{ stdenv, lib, fetchFromGitHub, qtbase, qtsvg, qttools, qmake, wrapQtAppsHook }:
+
+stdenv.mkDerivation rec {
+  pname = "qt6ct";
+  version = "0.8";
+
+  src = fetchFromGitHub {
+    owner = "trialuser02";
+    repo = pname;
+    rev = version;
+    hash = "sha256-BFE5aUgn3uFJWTgd4sUwP2L9RZwwwr5jVtAapA9vYbA=";
+  };
+
+  nativeBuildInputs = [ qmake qttools wrapQtAppsHook ];
+
+  buildInputs = [ qtbase qtsvg ];
+
+  qmakeFlags = [
+    "LRELEASE_EXECUTABLE=${lib.getDev qttools}/bin/lrelease"
+    "PLUGINDIR=${placeholder "out"}/${qtbase.qtPluginPrefix}"
+    "LIBDIR=${placeholder "out"}/lib"
+  ];
+
+  meta = with lib; {
+    description = "Qt6 Configuration Tool";
+    homepage = "https://github.com/trialuser02/qt6ct";
+    changelog = "https://github.com/trialuser02/qt6ct/releases/tag/${version}";
+    platforms = platforms.linux;
+    license = licenses.bsd2;
+    maintainers = with maintainers; [ Flakebi ];
+  };
+}

--- a/pkgs/top-level/qt6-packages.nix
+++ b/pkgs/top-level/qt6-packages.nix
@@ -42,4 +42,6 @@ in
     qt6Support = true;
     suffix = "qt6";
   };
+
+  qt6ct = callPackage ../tools/misc/qt6ct { };
 })))


### PR DESCRIPTION
###### Description of changes

A fork of qt5ct with Qt6 support: https://github.com/trialuser02/qt6ct

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
