### PR TITLE
rocmPackages.clr: Add OpenCL test

### DIFF
--- a/pkgs/development/rocm-modules/5/clr/default.nix
+++ b/pkgs/development/rocm-modules/5/clr/default.nix
@@ -147,8 +147,11 @@ in stdenv.mkDerivation (finalAttrs: {
     };
 
     impureTests = {
-      clr-icd = callPackage ./test.nix {
+      rocm-smi = callPackage ./test-rocm-smi.nix {
         inherit rocm-smi;
+        clr = finalAttrs.finalPackage;
+      };
+      opencl-example = callPackage ./test-opencl-example.nix {
         clr = finalAttrs.finalPackage;
       };
     };

--- a/pkgs/development/rocm-modules/5/clr/test-opencl-example.nix
+++ b/pkgs/development/rocm-modules/5/clr/test-opencl-example.nix
@@ -1,0 +1,75 @@
+{ lib
+, stdenv
+, makeImpureTest
+, fetchFromGitHub
+, clr
+, cmake
+, pkg-config
+, glew
+, freeglut
+, opencl-headers
+, ocl-icd
+}:
+
+let
+
+  examples = stdenv.mkDerivation {
+    pname = "amd-app-samples";
+    version = "2018-06-10";
+
+    src = fetchFromGitHub {
+      owner = "OpenCL";
+      repo = "AMD_APP_samples";
+      rev = "54da6ca465634e78fc51fc25edf5840467ee2411";
+      hash = "sha256-qARQpUiYsamHbko/I1gPZE9pUGJ+3396Vk2n7ERSftA=";
+    };
+
+    nativeBuildInputs = [ cmake pkg-config ];
+
+    buildInputs = [ glew freeglut opencl-headers ocl-icd ];
+
+    installPhase = ''
+      runHook preInstall
+
+      mkdir -p $out/bin
+      # Example path is bin/x86_64/Release/cl/Reduction/Reduction
+      cp -r bin/*/*/*/*/* $out/bin/
+
+      runHook postInstall
+    '';
+
+    cmakeFlags = [ "-DBUILD_CPP_CL=OFF" ];
+
+    meta = with lib; {
+      description = "Samples from the AMD APP SDK (with OpenCRun support) ";
+      homepage    = "https://github.com/OpenCL/AMD_APP_samples";
+      license     = licenses.bsd2;
+      platforms   = platforms.linux;
+      maintainers = lib.teams.rocm.members;
+    };
+  };
+
+in
+makeImpureTest {
+  name = "opencl-example";
+  testedPackage = "rocmPackages_5.clr";
+
+  sandboxPaths = [ "/sys" "/dev/dri" "/dev/kfd" ];
+
+  nativeBuildInputs = [ examples ];
+
+  OCL_ICD_VENDORS = "${clr.icd}/etc/OpenCL/vendors";
+
+  testScript = ''
+    # Examples load resources from current directory
+    cd ${examples}/bin
+    echo OCL_ICD_VENDORS=$OCL_ICD_VENDORS
+    pwd
+
+    HelloWorld | grep HelloWorld
+  '';
+
+  meta = with lib; {
+    maintainers = teams.rocm.members;
+  };
+}

--- a/pkgs/development/rocm-modules/5/clr/test-rocm-smi.nix
+++ b/pkgs/development/rocm-modules/5/clr/test-rocm-smi.nix
@@ -6,8 +6,8 @@
 }:
 
 makeImpureTest {
-  name = "clr-icd";
-  testedPackage = "rocmPackages.clr";
+  name = "rocm-smi";
+  testedPackage = "rocmPackages_5.clr";
   nativeBuildInputs = [ clinfo rocm-smi ];
   OCL_ICD_VENDORS = "${clr.icd}/etc/OpenCL/vendors";
 


### PR DESCRIPTION
###### Description of changes

Add a test that runs a simple OpenCL example on the GPU.
Run with `eval $(nix-build -A rocmPackages.impureTests.opencl-example)`.

###### Original description

ROCm support on gfx8 can now be enabled by setting `ROC_ENABLE_PRE_VEGA=1`
at runtime. See https://github.com/rocm-arch/rocm-arch/pull/853 for the
arch counterpart.

Tested on my gfx8 card.

Also add a test that runs a simple OpenCL example on the GPU.
Run with `eval $(nix-build -A rocm-opencl-icd.impureTests.opencl-example)`.
(Re-run with `eval $(nix-build -A rocm-opencl-icd.impureTests.opencl-example) --check`)

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
