### PR TITLE
router: init at 1.14.0

### DIFF
--- a/pkgs/servers/http/router/default.nix
+++ b/pkgs/servers/http/router/default.nix
@@ -1,0 +1,46 @@
+{ lib
+, callPackage
+, fetchFromGitHub
+, rustPlatform
+, pkg-config
+, protobuf
+, elfutils
+}:
+
+rustPlatform.buildRustPackage rec {
+  pname = "router";
+  version = "1.15.0";
+
+  src = fetchFromGitHub {
+    owner = "apollographql";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "sha256-TA0HE5zbSSPTq5Z/NP6/s1yqXyCicDmSAgqulmKbQeM=";
+  };
+
+  cargoSha256 = "sha256-binpEhtq5tQhSDD2mRKYMdwg9VZlBQZR3xZpOeZNYyY=";
+
+  nativeBuildInputs = [
+    pkg-config
+    protobuf
+  ];
+
+  buildInputs = [
+    elfutils
+  ];
+
+  # The v8 package will try to download a `librusty_v8.a` release at build time to our read-only filesystem
+  # To avoid this we pre-download the file and export it via RUSTY_V8_ARCHIVE
+  RUSTY_V8_ARCHIVE = callPackage ./librusty_v8.nix { };
+
+  cargoTestFlags = [
+    "-- --skip=uplink::test::stream_from_uplink_error_no_retry"
+  ];
+
+  meta = with lib; {
+    description = "A configurable, high-performance routing runtime for Apollo Federation";
+    homepage = "https://www.apollographql.com/docs/router/";
+    license = licenses.elastic;
+    maintainers = [ maintainers.bbigras ];
+  };
+}

--- a/pkgs/servers/http/router/librusty_v8.nix
+++ b/pkgs/servers/http/router/librusty_v8.nix
@@ -1,0 +1,20 @@
+{ rust, stdenv, fetchurl }:
+
+let
+  arch = rust.toRustTarget stdenv.hostPlatform;
+  fetch_librusty_v8 = args: fetchurl {
+    name = "librusty_v8-${args.version}";
+    url = "https://github.com/denoland/rusty_v8/releases/download/v${args.version}/librusty_v8_release_${arch}.a";
+    sha256 = args.shas.${stdenv.hostPlatform.system};
+    meta = { inherit (args) version; };
+  };
+in
+fetch_librusty_v8 {
+  version = "0.60.1";
+  shas = {
+    x86_64-linux = "sha256-P8H+XJqrt9jdKM885L1epMldp+stwmEw+0Gtd2x3r4g=";
+    aarch64-linux = "sha256-frHpBP2pL3o4efFLHP2r3zsWJrNT93yYu2Qkxv+7m8Y=";
+    x86_64-darwin = "sha256-taewoYBkyikqWueLSD9dW1EDjzkV68Xplid1UaLZgRM=";
+    aarch64-darwin = "sha256-s2YEVbuYpiT/qrmE37aXk13MetrnJo6l+s1Q2y6b5kU=";
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -23430,6 +23430,8 @@ with pkgs;
 
   ronn = callPackage ../development/tools/ronn { };
 
+  router = callPackage ../servers/http/router { };
+
   rover = callPackage ../development/tools/rover { };
 
   rqlite = callPackage ../servers/sql/rqlite { };


### PR DESCRIPTION
###### Description of changes

https://github.com/apollographql/router

I stole the 'librusty_v8' part from pkgs/development/web/deno

Is `licenses.elastic` right for Elastic License 2?

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
