### PR TITLE
hackneyed: backport ImageMagick 7 support

### DIFF
--- a/pkgs/data/icons/hackneyed/default.nix
+++ b/pkgs/data/icons/hackneyed/default.nix
@@ -1,4 +1,4 @@
-{ lib, fetchzip, stdenvNoCC, fetchFromGitLab, xcursorgen, imagemagick6, inkscape }:
+{ lib, stdenvNoCC, fetchFromGitLab, fetchpatch, imagemagick, inkscape, xcursorgen }:
 
 stdenvNoCC.mkDerivation rec {
   pname = "hackneyed";
@@ -8,10 +8,13 @@ stdenvNoCC.mkDerivation rec {
     owner = "Enthymeme";
     repo = "hackneyed-x11-cursors";
     rev = version;
-    sha256 = "sha256-Wtrw/EzxCj4cAyfdBp0OJE4+c6FouW7+b6nFTLxdXNY=";
+    hash = "sha256-Wtrw/EzxCj4cAyfdBp0OJE4+c6FouW7+b6nFTLxdXNY=";
   };
 
-  buildInputs = [ imagemagick6 inkscape xcursorgen ];
+  # Backport ImageMagick 7 support; remove on the next release
+  patches = [ ./imagemagick-7.patch ];
+
+  buildInputs = [ imagemagick inkscape xcursorgen ];
 
   postPatch = ''
     patchShebangs *.sh

--- a/pkgs/data/icons/hackneyed/imagemagick-7.patch
+++ b/pkgs/data/icons/hackneyed/imagemagick-7.patch
@@ -1,0 +1,45 @@
+From 91168872fb65c35b1273f294475552a954147ebb Mon Sep 17 00:00:00 2001
+From: Richard Ferreira <richardleoferreira@outlook.com>
+Date: Fri, 24 Mar 2023 17:54:21 -0300
+Subject: [PATCH] quick-and-dirty ImageMagick 7 port
+
+---
+ Makefile  | 4 +++-
+ png2cur.c | 6 +++++-
+ 2 files changed, 8 insertions(+), 2 deletions(-)
+
+diff --git a/Makefile b/Makefile
+index 047428f..2b74dcb 100644
+--- a/Makefile
++++ b/Makefile
+@@ -432,7 +432,9 @@ all.large.left: $(LCURSORS_LARGE) $(COMMON_LARGE) $(LCURSORS_ANIMATED_LARGE) $(C
+ 	$(XCURSORGEN) $< $@
+ 
+ png2cur: png2cur.c
+-	$(CC) -std=c99 -Wall -Werror -pedantic -g -o png2cur png2cur.c -lm `pkg-config --cflags --libs libpng MagickWand`
++	$(CC) -std=c99 -Wall -Werror -pedantic -g -o png2cur png2cur.c \
++		-lm `pkg-config --cflags --libs libpng MagickWand` \
++		-DWAND_VERSION="`pkg-config --modversion MagickWand|tr -d .`"
+ 
+ animaker: animaker.c
+ 	$(CC) -std=c99 -Wall -Werror -pedantic -g -o animaker animaker.c
+diff --git a/png2cur.c b/png2cur.c
+index 99e99f1..71b416f 100644
+--- a/png2cur.c
++++ b/png2cur.c
+@@ -47,7 +47,11 @@
+ #include <png.h>
+ #include <sys/stat.h>
+ #include <math.h>
+-#include <wand/magick_wand.h>
++#if WAND_VERSION >= 700
++# include <MagickWand/MagickWand.h>
++#else
++# include <wand/magick_wand.h>
++#endif
+ 
+ #define ICONMAX			1024
+ #define PNG_BYTES		8
+-- 
+GitLab
+


### PR DESCRIPTION
###### Description of changes

Without this, building `hackneyed` requires allowing usage of `imagemagick-6.9.12-68`,
which is marked insecure.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
