### PR TITLE
gnatboot: rename to gnat-bootstrap

### DIFF
--- a/pkgs/build-support/bintools-wrapper/default.nix
+++ b/pkgs/build-support/bintools-wrapper/default.nix
@@ -166,7 +166,7 @@ stdenv.mkDerivation {
 
     # If we are asked to wrap `gas` and this bintools has it,
     # then symlink it (`as` will be symlinked next).
-    # This is mainly for the wrapped gnatboot on x86-64 Darwin,
+    # This is mainly for the wrapped gnat-bootstrap on x86-64 Darwin,
     # as it must have both the GNU assembler from cctools (installed as `gas`)
     # and the Clang integrated assembler (installed as `as`).
     # See pkgs/os-specific/darwin/binutils/default.nix for details.

--- a/pkgs/development/compilers/gcc/10/default.nix
+++ b/pkgs/development/compilers/gcc/10/default.nix
@@ -16,7 +16,7 @@
 , gmp, mpfr, libmpc, gettext, which, patchelf, binutils
 , isl ? null # optional, for the Graphite optimization framework.
 , zlib ? null
-, gnatboot ? null
+, gnat-bootstrap ? null
 , enableMultilib ? false
 , enablePlugin ? stdenv.hostPlatform == stdenv.buildPlatform # Whether to support user-supplied plug-ins
 , name ? "gcc"
@@ -34,7 +34,7 @@ assert stdenv.buildPlatform.isDarwin -> gnused != null;
 
 # The go frontend is written in c++
 assert langGo -> langCC;
-assert langAda -> gnatboot != null;
+assert langAda -> gnat-bootstrap != null;
 
 # threadsCross is just for MinGW
 assert threadsCross != {} -> stdenv.targetPlatform.isWindows;
@@ -111,7 +111,7 @@ let majorVersion = "10";
         fetchurl
         gettext
         gmp
-        gnatboot
+        gnat-bootstrap
         gnused
         isl
         langAda

--- a/pkgs/development/compilers/gcc/11/default.nix
+++ b/pkgs/development/compilers/gcc/11/default.nix
@@ -16,7 +16,7 @@
 , gmp, mpfr, libmpc, gettext, which, patchelf, binutils
 , isl ? null # optional, for the Graphite optimization framework.
 , zlib ? null
-, gnatboot ? null
+, gnat-bootstrap ? null
 , enableMultilib ? false
 , enablePlugin ? stdenv.hostPlatform == stdenv.buildPlatform # Whether to support user-supplied plug-ins
 , name ? "gcc"
@@ -37,7 +37,7 @@ assert stdenv.buildPlatform.isDarwin -> gnused != null;
 
 # The go frontend is written in c++
 assert langGo -> langCC;
-assert langAda -> gnatboot != null;
+assert langAda -> gnat-bootstrap != null;
 
 # threadsCross is just for MinGW
 assert threadsCross != {} -> stdenv.targetPlatform.isWindows;
@@ -126,7 +126,7 @@ let majorVersion = "11";
         fetchurl
         gettext
         gmp
-        gnatboot
+        gnat-bootstrap
         gnused
         isl
         langAda

--- a/pkgs/development/compilers/gcc/12/default.nix
+++ b/pkgs/development/compilers/gcc/12/default.nix
@@ -17,7 +17,7 @@
 , isl ? null # optional, for the Graphite optimization framework.
 , zlib ? null
 , libucontext ? null
-, gnatboot ? null
+, gnat-bootstrap ? null
 , enableMultilib ? false
 , enablePlugin ? stdenv.hostPlatform == stdenv.buildPlatform # Whether to support user-supplied plug-ins
 , name ? "gcc"
@@ -39,7 +39,7 @@ assert stdenv.buildPlatform.isDarwin -> gnused != null;
 
 # The go frontend is written in c++
 assert langGo -> langCC;
-assert langAda -> gnatboot != null;
+assert langAda -> gnat-bootstrap != null;
 
 # TODO: fixup D bootstapping, probably by using gdc11 (and maybe other changes).
 #   error: GDC is required to build d
@@ -159,7 +159,7 @@ let majorVersion = "12";
         fetchurl
         gettext
         gmp
-        gnatboot
+        gnat-bootstrap
         gnused
         isl
         langAda

--- a/pkgs/development/compilers/gcc/6/default.nix
+++ b/pkgs/development/compilers/gcc/6/default.nix
@@ -17,7 +17,7 @@
 , gmp, mpfr, libmpc, gettext, which, patchelf, binutils
 , isl ? null # optional, for the Graphite optimization framework.
 , zlib ? null, boehmgc ? null
-, gnatboot ? null
+, gnat-bootstrap ? null
 , zip ? null, unzip ? null, pkg-config ? null
 , gtk2 ? null, libart_lgpl ? null
 , libX11 ? null, libXt ? null, libSM ? null, libICE ? null, libXtst ? null
@@ -45,7 +45,7 @@ assert stdenv.buildPlatform.isDarwin -> gnused != null;
 # The go frontend is written in c++
 assert langGo -> langCC;
 
-assert langAda -> gnatboot != null;
+assert langAda -> gnat-bootstrap != null;
 
 # threadsCross is just for MinGW
 assert threadsCross != {} -> stdenv.targetPlatform.isWindows;
@@ -151,7 +151,7 @@ let majorVersion = "6";
         flex
         gettext
         gmp
-        gnatboot
+        gnat-bootstrap
         gnused
         gtk2
         isl

--- a/pkgs/development/compilers/gcc/9/default.nix
+++ b/pkgs/development/compilers/gcc/9/default.nix
@@ -16,7 +16,7 @@
 , gmp, mpfr, libmpc, gettext, which, patchelf, binutils
 , isl ? null # optional, for the Graphite optimization framework.
 , zlib ? null
-, gnatboot ? null
+, gnat-bootstrap ? null
 , enableMultilib ? false
 , enablePlugin ? stdenv.hostPlatform == stdenv.buildPlatform # Whether to support user-supplied plug-ins
 , name ? "gcc"
@@ -38,7 +38,7 @@ assert stdenv.buildPlatform.isDarwin -> gnused != null;
 
 # The go frontend is written in c++
 assert langGo -> langCC;
-assert langAda -> gnatboot != null;
+assert langAda -> gnat-bootstrap != null;
 
 # threadsCross is just for MinGW
 assert threadsCross != {} -> stdenv.targetPlatform.isWindows;
@@ -112,7 +112,7 @@ let majorVersion = "9";
         fetchurl
         gettext
         gmp
-        gnatboot
+        gnat-bootstrap
         gnused
         isl
         langAda

--- a/pkgs/development/compilers/gcc/common/dependencies.nix
+++ b/pkgs/development/compilers/gcc/common/dependencies.nix
@@ -17,7 +17,7 @@
 , cloog ? null
 , isl ? null
 , zlib ? null
-, gnatboot ? null
+, gnat-bootstrap ? null
 , flex ? null
 , boehmgc ? null
 , zip ? null
@@ -51,7 +51,7 @@ in
   ++ optionals (perl != null) [ perl ]
   ++ optionals javaAwtGtk [ pkg-config ]
   ++ optionals (with stdenv.targetPlatform; isVc4 || isRedox && flex != null) [ flex ]
-  ++ optionals langAda [ gnatboot ]
+  ++ optionals langAda [ gnat-bootstrap ]
   # The builder relies on GNU sed (for instance, Darwin's `sed' fails with
   # "-i may not be used with stdin"), and `stdenvNative' doesn't provide it.
   ++ optionals buildPlatform.isDarwin [ gnused ]

--- a/pkgs/development/compilers/gcc/common/pre-configure.nix
+++ b/pkgs/development/compilers/gcc/common/pre-configure.nix
@@ -1,5 +1,5 @@
 { lib, version, buildPlatform, hostPlatform, targetPlatform
-, gnatboot ? null
+, gnat-bootstrap ? null
 , langAda ? false
 , langJava ? false
 , langJit ? false
@@ -9,7 +9,7 @@
 }:
 
 assert langJava -> lib.versionOlder version "7";
-assert langAda -> gnatboot != null; let
+assert langAda -> gnat-bootstrap != null; let
   needsLib
     =  (lib.versionOlder version "7" && (langJava || langGo))
     || (lib.versions.major version == "4" && lib.versions.minor version == "9" && targetPlatform.isDarwin);
@@ -21,13 +21,13 @@ in lib.optionalString (hostPlatform.isSunOS && hostPlatform.is64bit) ''
 '' + lib.optionalString needsLib ''
   export lib=$out;
 '' + lib.optionalString langAda ''
-  export PATH=${gnatboot}/bin:$PATH
+  export PATH=${gnat-bootstrap}/bin:$PATH
 ''
 
-# On x86_64-darwin, the gnatboot bootstrap compiler that we need to build a
+# On x86_64-darwin, the gnat-bootstrap bootstrap compiler that we need to build a
 # native GCC with Ada support emits assembly that is accepted by the Clang
 # integrated assembler, but not by the GNU assembler in cctools-port that Nix
-# usually in the x86_64-darwin stdenv.  In particular, x86_64-darwin gnatboot
+# usually in the x86_64-darwin stdenv.  In particular, x86_64-darwin gnat-bootstrap
 # emits MOVQ as the mnemonic for quadword interunit moves, such as between XMM
 # and general registers (e.g "movq %xmm0, %rbp"); the cctools-port assembler,
 # however, only recognises MOVD for such moves.
@@ -35,7 +35,7 @@ in lib.optionalString (hostPlatform.isSunOS && hostPlatform.is64bit) ''
 # Therefore, for native x86_64-darwin builds that support Ada, we have to use
 # the Clang integrated assembler to build (at least stage 1 of) GCC, but have to
 # target GCC at the cctools-port GNU assembler.  In the wrapped x86_64-darwin
-# gnatboot, the former is provided as `as`, while the latter is provided as
+# gnat-bootstrap, the former is provided as `as`, while the latter is provided as
 # `gas`.
 #
 + lib.optionalString (
@@ -45,8 +45,8 @@ in lib.optionalString (hostPlatform.isSunOS && hostPlatform.is64bit) ''
     && targetPlatform.isx86_64
     && targetPlatform.isDarwin
   ) ''
-  export AS_FOR_BUILD=${gnatboot}/bin/as
-  export AS_FOR_TARGET=${gnatboot}/bin/gas
+  export AS_FOR_BUILD=${gnat-bootstrap}/bin/as
+  export AS_FOR_TARGET=${gnat-bootstrap}/bin/gas
 ''
 
 # NOTE 2020/3/18: This environment variable prevents configure scripts from

--- a/pkgs/development/compilers/gnat-bootstrap/default.nix
+++ b/pkgs/development/compilers/gnat-bootstrap/default.nix
@@ -38,7 +38,7 @@ let
 in with versionMap.${majorVersion};
 
 stdenv.mkDerivation rec {
-  pname = "gnatboot";
+  pname = "gnat-bootstrap";
   inherit gccVersion alireRevision;
 
   version = "${gccVersion}-${alireRevision}";
@@ -86,7 +86,7 @@ stdenv.mkDerivation rec {
     cp -ar * $out/
   ''
 
-  # So far with the Darwin gnatboot binary packages, there have been two
+  # So far with the Darwin gnat-bootstrap binary packages, there have been two
   # types of dylib path references to other dylibs that need fixups:
   #
   # 1.  Dylibs in $out/lib with paths starting with

--- a/pkgs/os-specific/darwin/binutils/default.nix
+++ b/pkgs/os-specific/darwin/binutils/default.nix
@@ -60,7 +60,7 @@ stdenv.mkDerivation {
     makeWrapper "${clang-unwrapped}/bin/clang" "$out/bin/${targetPrefix}as" \
       --add-flags "-x assembler -integrated-as -c"
   ''
-  # x86-64 Darwin gnatboot emits assembly
+  # x86-64 Darwin gnat-bootstrap emits assembly
   # with MOVQ as the mnemonic for quadword interunit moves
   # such as `movq %rbp, %xmm0`.
   # The clang integrated assembler recognises this as valid,

--- a/pkgs/top-level/aliases.nix
+++ b/pkgs/top-level/aliases.nix
@@ -566,6 +566,9 @@ mapAliases ({
   gmic-qt-krita = throw "gmic-qt-krita was removed as it's no longer supported upstream."; # Converted to throw 2023-02-02
   gmvault = throw "gmvault has been removed because it is unmaintained, mostly broken, and insecure"; # Added 2021-03-08
   gnash = throw "gnash has been removed; broken and abandoned upstream"; # added 2022-02-06
+  gnatboot11 = gnat-bootstrap11;
+  gnatboot12 = gnat-bootstrap12;
+  gnatboot = gnat-bootstrap;
   gnome-breeze = throw "gnome-breeze has been removed, use libsForQt5.breeze-gtk instead"; # Added 2022-04-22
   gnome-firmware-updater = gnome-firmware; # added 2022-04-14
   gnome-passwordsafe = gnome-secrets; # added 2022-01-30

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -14995,10 +14995,10 @@ with pkgs;
     # As per upstream instructions building a cross compiler
     # should be done with a (native) compiler of the same version.
     # If we are cross-compiling GNAT, we may as well do the same.
-    gnatboot =
+    gnat-bootstrap =
       if stdenv.hostPlatform == stdenv.targetPlatform
          && stdenv.buildPlatform == stdenv.hostPlatform
-      then buildPackages.gnatboot11
+      then buildPackages.gnat-bootstrap11
       else buildPackages.gnat11;
   });
 
@@ -15011,24 +15011,24 @@ with pkgs;
     # As per upstream instructions building a cross compiler
     # should be done with a (native) compiler of the same version.
     # If we are cross-compiling GNAT, we may as well do the same.
-    gnatboot =
+    gnat-bootstrap =
       if stdenv.hostPlatform == stdenv.targetPlatform
          && stdenv.buildPlatform == stdenv.hostPlatform
-      then buildPackages.gnatboot12
+      then buildPackages.gnat-bootstrap12
       else buildPackages.gnat12;
     stdenv =
       if stdenv.hostPlatform == stdenv.targetPlatform
          && stdenv.buildPlatform == stdenv.hostPlatform
          && stdenv.buildPlatform.isDarwin
          && stdenv.buildPlatform.isx86_64
-      then overrideCC stdenv gnatboot12
+      then overrideCC stdenv gnat-bootstrap12
       else stdenv;
   });
 
-  gnatboot = gnatboot12;
-  gnatboot11 = wrapCC (callPackage ../development/compilers/gnatboot { majorVersion = "11"; });
-  gnatboot12 = wrapCCWith ({
-    cc = callPackage ../development/compilers/gnatboot { majorVersion = "12"; };
+  gnat-bootstrap = gnat-bootstrap12;
+  gnat-bootstrap11 = wrapCC (callPackage ../development/compilers/gnat-bootstrap { majorVersion = "11"; });
+  gnat-bootstrap12 = wrapCCWith ({
+    cc = callPackage ../development/compilers/gnat-bootstrap { majorVersion = "12"; };
   } // lib.optionalAttrs (stdenv.hostPlatform.isDarwin) {
     bintools = bintoolsDualAs;
   });


### PR DESCRIPTION
###### Description of changes

Renames gnatboot to gnat-bootstrap to match the pattern used by other bootstrap compiler derivations. Split this out from https://github.com/NixOS/nixpkgs/pull/225191.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).