### PR TITLE
adguardhome: 0.107.27 -> 0.107.28

### DIFF
--- a/pkgs/servers/adguardhome/bins.nix
+++ b/pkgs/servers/adguardhome/bins.nix
@@ -1,31 +1,31 @@
 { fetchurl, fetchzip }:
 {
 x86_64-darwin = fetchzip {
-  sha256 = "sha256-R4Id8neiQypnj2hYYWEYSY10eJ7yId5k95aMnphvqEs=";
-  url = "https://github.com/AdguardTeam/AdGuardHome/releases/download/v0.107.27/AdGuardHome_darwin_amd64.zip";
+  sha256 = "sha256-amKwWr+0Q9Ci0CxLEjtxTiu/T9wJL77DPL/QiWqsMoc=";
+  url = "https://github.com/AdguardTeam/AdGuardHome/releases/download/v0.107.28/AdGuardHome_darwin_amd64.zip";
 };
 aarch64-darwin = fetchzip {
-  sha256 = "sha256-EWQ02mIWYQfYEc8A9+U6N14v0h4kux8Cg7x4Xfj5uL0=";
-  url = "https://github.com/AdguardTeam/AdGuardHome/releases/download/v0.107.27/AdGuardHome_darwin_arm64.zip";
+  sha256 = "sha256-dJHFGTIv+inVU6djuQkFcOF2nTALd+1dS888ooHXt/w=";
+  url = "https://github.com/AdguardTeam/AdGuardHome/releases/download/v0.107.28/AdGuardHome_darwin_arm64.zip";
 };
 i686-linux = fetchurl {
-  sha256 = "sha256-Hmy3A2KuWk+Myqha/Typd6sY4rHI7kTAGLnz9XH1KRA=";
-  url = "https://github.com/AdguardTeam/AdGuardHome/releases/download/v0.107.27/AdGuardHome_linux_386.tar.gz";
+  sha256 = "sha256-ijcR3z0aUN0euC9oygULlMtaNnffelv45ku4zmcZkUA=";
+  url = "https://github.com/AdguardTeam/AdGuardHome/releases/download/v0.107.28/AdGuardHome_linux_386.tar.gz";
 };
 x86_64-linux = fetchurl {
-  sha256 = "sha256-mNBv8F4BJHXJ86vnSM+0sfEkS3jB8TcMhM+6RJ5zgYM=";
-  url = "https://github.com/AdguardTeam/AdGuardHome/releases/download/v0.107.27/AdGuardHome_linux_amd64.tar.gz";
+  sha256 = "sha256-aXmDer5/bq0L6SoPhqyJ8IY2FzH+TYNHDvQTZgrrrj0=";
+  url = "https://github.com/AdguardTeam/AdGuardHome/releases/download/v0.107.28/AdGuardHome_linux_amd64.tar.gz";
 };
 aarch64-linux = fetchurl {
-  sha256 = "sha256-2J06RvoKZJj3qRj6fg4l+S6soR+5gpCCupcJ75ggvD8=";
-  url = "https://github.com/AdguardTeam/AdGuardHome/releases/download/v0.107.27/AdGuardHome_linux_arm64.tar.gz";
+  sha256 = "sha256-E2QBwA0prJ4B8a6tEj9lBkAnrYUTlsweOJBpQsLBo9M=";
+  url = "https://github.com/AdguardTeam/AdGuardHome/releases/download/v0.107.28/AdGuardHome_linux_arm64.tar.gz";
 };
 armv6l-linux = fetchurl {
-  sha256 = "sha256-U3np5JP2/otbEkn+S5xtNO+RuUt6CkWMK4iftoTT460=";
-  url = "https://github.com/AdguardTeam/AdGuardHome/releases/download/v0.107.27/AdGuardHome_linux_armv6.tar.gz";
+  sha256 = "sha256-NARiVRdT7U0E6BUlehJbEeHQ9tF6vmCh/d59osVy/S0=";
+  url = "https://github.com/AdguardTeam/AdGuardHome/releases/download/v0.107.28/AdGuardHome_linux_armv6.tar.gz";
 };
 armv7l-linux = fetchurl {
-  sha256 = "sha256-y5/svgOJS3KbUJLbgjy9VOpog9W7xGyyx96JtdVyzjk=";
-  url = "https://github.com/AdguardTeam/AdGuardHome/releases/download/v0.107.27/AdGuardHome_linux_armv7.tar.gz";
+  sha256 = "sha256-HU6uUSfdr3UkPX+oyjGlMHJkcfpGBRphBNLtBG3oLzY=";
+  url = "https://github.com/AdguardTeam/AdGuardHome/releases/download/v0.107.28/AdGuardHome_linux_armv7.tar.gz";
 };
 }

--- a/pkgs/servers/adguardhome/default.nix
+++ b/pkgs/servers/adguardhome/default.nix
@@ -7,7 +7,7 @@ in
 
 stdenv.mkDerivation rec {
   pname = "adguardhome";
-  version = "0.107.27";
+  version = "0.107.28";
   src = sources.${system} or (throw "Source for ${pname} is not available for ${system}");
 
   installPhase = ''
@@ -16,7 +16,7 @@ stdenv.mkDerivation rec {
 
   passthru = {
     updateScript = ./update.sh;
-    schema_version = 17;
+    schema_version = 20;
     tests.adguardhome = nixosTests.adguardhome;
   };
 


### PR DESCRIPTION
###### Things done

- Built on platform(s)
  - [X] x86_64-linux
  - [X] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [X] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
