### PR TITLE
crystal: 1.7 -> 1.8

### DIFF
--- a/pkgs/development/compilers/crystal/default.nix
+++ b/pkgs/development/compilers/crystal/default.nix
@@ -274,5 +274,11 @@ rec {
     binary = binaryCrystal_1_2;
   };
 
-  crystal = crystal_1_7;
+  crystal_1_8 = generic {
+    version = "1.8.0";
+    sha256 = "sha256-oTvBKrfDkrpJg4gaOVrrKWfsqZC+Z9Lp/jt4ye+Iw/M=";
+    binary = binaryCrystal_1_2;
+  };
+
+  crystal = crystal_1_8;
 }

--- a/pkgs/development/compilers/crystal/default.nix
+++ b/pkgs/development/compilers/crystal/default.nix
@@ -74,6 +74,7 @@ let
 
   commonBuildInputs = extraBuildInputs: [
     boehmgc
+    pcre
     pcre2
     libevent
     libyaml
@@ -266,14 +267,13 @@ rec {
     version = "1.2.2";
     sha256 = "sha256-nyOXhsutVBRdtJlJHe2dALl//BUXD1JeeQPgHU4SwiU=";
     binary = binaryCrystal_1_2;
-    extraBuildInputs = [ libatomic_ops pcre ];
+    extraBuildInputs = [ libatomic_ops ];
   };
 
   crystal_1_7 = generic {
     version = "1.7.3";
     sha256 = "sha256-ULhLGHRIZbsKhaMvNhc+W74BwNgfEjHcMnVNApWY+EE=";
     binary = binaryCrystal_1_2;
-    extraBuildInputs = [ pcre ];
   };
 
   crystal_1_8 = generic {

--- a/pkgs/development/compilers/crystal/default.nix
+++ b/pkgs/development/compilers/crystal/default.nix
@@ -20,6 +20,7 @@
 , llvmPackages
 , makeWrapper
 , openssl
+, pcre2
 , pcre
 , pkg-config
 , readline
@@ -73,7 +74,7 @@ let
 
   commonBuildInputs = extraBuildInputs: [
     boehmgc
-    pcre
+    pcre2
     libevent
     libyaml
     zlib
@@ -265,13 +266,14 @@ rec {
     version = "1.2.2";
     sha256 = "sha256-nyOXhsutVBRdtJlJHe2dALl//BUXD1JeeQPgHU4SwiU=";
     binary = binaryCrystal_1_2;
-    extraBuildInputs = [ libatomic_ops ];
+    extraBuildInputs = [ libatomic_ops pcre ];
   };
 
   crystal_1_7 = generic {
     version = "1.7.3";
     sha256 = "sha256-ULhLGHRIZbsKhaMvNhc+W74BwNgfEjHcMnVNApWY+EE=";
     binary = binaryCrystal_1_2;
+    extraBuildInputs = [ pcre ];
   };
 
   crystal_1_8 = generic {

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -14543,7 +14543,6 @@ with pkgs;
 
   inherit (callPackages ../development/compilers/crystal {
     llvmPackages = llvmPackages_15;
-    pcre = pcre2;
     stdenv = if stdenv.isDarwin then darwin.apple_sdk_11_0.stdenv else stdenv;
   })
     crystal_1_8

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -14539,7 +14539,14 @@ with pkgs;
     stdenv = if stdenv.isDarwin then darwin.apple_sdk_11_0.stdenv else stdenv;
   })
     crystal_1_2
-    crystal_1_7
+    crystal_1_7;
+
+  inherit (callPackages ../development/compilers/crystal {
+    llvmPackages = llvmPackages_15;
+    pcre = pcre2;
+    stdenv = if stdenv.isDarwin then darwin.apple_sdk_11_0.stdenv else stdenv;
+  })
+    crystal_1_8
     crystal;
 
   crystal2nix = callPackage ../development/compilers/crystal2nix { };


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

[Changelog](https://github.com/crystal-lang/crystal/blob/14bfa992ebd9cfa8946a151065dff7eebf829333/CHANGELOG.md?plain=1#L1-L242)

The key changes package-wise are the use of llvm15 and pcre2. I'm not sure if the approach I took is the best one but considering the size of the nix file, I'm leaning towards it than maintaining multiple copies of it for each version.

**Why LLVM 15?**

Crystal 1.8 is the first version with LLVM 15 support which includes opaque pointers. It has performance improvements including an up to 34% speed-up for release builds. You can read more on this great write-up from HertzDevil: https://crystal-lang.org/2023/03/23/llvm-opaque-pointers/

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [X] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
