### PR TITLE
sapling: teach gen-deps.py script to update Cargo.lock

### DIFF
--- a/pkgs/applications/version-management/sapling/gen-deps.py
+++ b/pkgs/applications/version-management/sapling/gen-deps.py
@@ -1,18 +1,47 @@
 #!/usr/bin/env nix-shell
-#!nix-shell -i python3 -p "python3.withPackages (ps: with ps; [ requests ])"
+#!nix-shell -i python3 -p cargo -p "python3.withPackages (ps: with ps; [ requests ])"
 import json
+import pathlib
 import re
+import tempfile
+import os
+import shutil
 from hashlib import sha1
 from struct import unpack
 from subprocess import run
+import subprocess
 
 from requests import get
 
 # Fetch the latest stable release metadata from GitHub
-latestTag = get("https://api.github.com/repos/facebook/sapling/releases/latest").json()[
-    "tag_name"
-]
+releaseMetadata = get("https://api.github.com/repos/facebook/sapling/releases/latest").json()
+latestTag = releaseMetadata["tag_name"]
+latestTarballURL = releaseMetadata["tarball_url"]
 
+[_tarballHash, sourceDirectory] = run(
+    ["nix-prefetch-url", "--print-path", "--unpack", latestTarballURL],
+    check=True,
+    text=True,
+    stdout=subprocess.PIPE,
+).stdout.rstrip().splitlines()
+
+def updateCargoLock():
+    with tempfile.TemporaryDirectory() as tempDir:
+        tempDir = pathlib.Path(tempDir)
+
+        # NOTE(strager): We cannot use shutil.tree because it copies the
+        # read-only permissions.
+        for dirpath, dirnames, filenames in os.walk(sourceDirectory):
+            relativeDirpath = os.path.relpath(dirpath, sourceDirectory)
+            for filename in filenames:
+                shutil.copy(os.path.join(dirpath, filename), tempDir / relativeDirpath / filename)
+            for dirname in dirnames:
+                os.mkdir(tempDir / relativeDirpath / dirname)
+
+        run(["cargo", "fetch"], check=True, cwd=tempDir / "eden" / "scm")
+        shutil.copy(tempDir / "eden" / "scm" / "Cargo.lock", "Cargo.lock")
+
+updateCargoLock()
 
 def nixPrefetchUrl(url):
     return run(
@@ -25,9 +54,7 @@ def nixPrefetchUrl(url):
 
 # Fetch the `setup.py` source and look for instances of assets being downloaded
 # from files.pythonhosted.org.
-setupPy = get(
-    f"https://github.com/facebook/sapling/raw/{latestTag}/eden/scm/setup.py"
-).text
+setupPy = (pathlib.Path(sourceDirectory) / "eden/scm/setup.py").read_text()
 foundUrls = re.findall(r'(https://files\.pythonhosted\.org/packages/[^\s]+)"', setupPy)
 
 dataDeps = {


### PR DESCRIPTION
###### Description of changes

Upstream Sapling does not maintain a Cargo.lock file, so Nixpkgs has its own. Teach the gen-deps.py script to update Nixpkgs' Cargo.lock whenever the Cargo.toml files change.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
