### PR TITLE
jool-cli: fix build

### DIFF
--- a/pkgs/os-specific/linux/jool/cli.nix
+++ b/pkgs/os-specific/linux/jool/cli.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchFromGitHub, autoreconfHook, pkg-config, libnl, iptables }:
+{ lib, stdenv, fetchFromGitHub, fetchpatch, autoreconfHook, pkg-config, libnl, iptables }:
 
 let
   sourceAttrs = (import ./source.nix) { inherit fetchFromGitHub; };
@@ -9,6 +9,11 @@ stdenv.mkDerivation {
   version = sourceAttrs.version;
 
   src = sourceAttrs.src;
+
+  patches = [ (fetchpatch {
+    url = "https://github.com/NICMx/Jool/commit/490ddb0933061cab3c2a7952dffc61789deed565.patch";
+    hash = "sha256-1dpMth0ocPHujlk+96St1a63RipcWiL/CdmSz4O87Lg=";
+  }) ];
 
   outputs = [
     "out"


### PR DESCRIPTION
prior to this, building with iptables-1.8.9 failed with

> make[2]: Entering directory '/tmp/nix-shell.okX50g/tmp.O3HX8QruLZ/source/src/usr/iptables'
> gcc -Wall -pedantic -std=gnu11 -O2 -I../.. -I/nix/store/h6saqb0001ps7mwi1c40m90f53af1hpj-iptables-1.8.9-dev/include   -D_INIT=libxt_JOOL_SIIT_init -fPIC -c -o libxt_JOOL_SIIT.o libxt_JOOL_SIIT.c;
> gcc -shared -fPIC  -o libxt_JOOL_SIIT.so libxt_JOOL_SIIT.o;
> /nix/store/f4qnwzv6y0nq8lix33jr5ykkyybs6fxf-binutils-2.40/bin/ld: libxt_JOOL_SIIT.o: in function `_init':
> libxt_JOOL_SIIT.c:(.text+0x150): multiple definition of `_init'; /nix/store/1n2l5law9g3b77hcfyp50vrhhssbrj5g-glibc-2.37-8/lib/crti.o:(.init+0x0): first defined here
> collect2: error: ld returned 1 exit status
> make[2]: *** [Makefile:37: libxt_JOOL_SIIT.so] Error 1

This adds the upstream fix from https://github.com/NICMx/Jool/commit/490ddb0933061cab3c2a7952dffc61789deed565

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
