### PR TITLE
ethq: init at 0.6.2

### DIFF
--- a/pkgs/os-specific/linux/ethq/default.nix
+++ b/pkgs/os-specific/linux/ethq/default.nix
@@ -1,0 +1,32 @@
+{ stdenv, lib, fetchFromGitHub, ncurses }:
+
+stdenv.mkDerivation rec {
+  pname = "ethq";
+  version = "0.6.2";
+
+  src = fetchFromGitHub {
+    owner = "isc-projects";
+    repo = "ethq";
+    rev = "refs/tags/v${builtins.replaceStrings ["."] ["_"] version}";
+    hash = "sha256-luvvNdH4kERAMy242kLCqlnGmfPjSjvoHa6J2J7BFi4=";
+  };
+
+  buildInputs = [ ncurses ];
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/bin
+    install -m0755 ethq $out/bin/ethq
+
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    description = "Ethernet NIC Queue stats viewer";
+    homepage = "https://github.com/isc-projects/ethq";
+    license = licenses.mpl20;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ delroth ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1503,6 +1503,8 @@ with pkgs;
 
   elkhound = callPackage ../development/tools/elkhound { };
 
+  ethq = callPackage ../os-specific/linux/ethq { };
+
   weidu = callPackage ../tools/games/weidu { };
 
   weylus = callPackage ../applications/graphics/weylus  {


### PR DESCRIPTION
###### Description of changes

ethq is a tool published by the ISC to monitor NIC queues usage: https://www.isc.org/blogs/ethq-linux-nic-monitoring-tool/

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
