### PR TITLE
c0: init at unstable-2022-10-25

### DIFF
--- a/pkgs/development/compilers/c0/default.nix
+++ b/pkgs/development/compilers/c0/default.nix
@@ -1,0 +1,80 @@
+{ lib
+, stdenv
+, fetchFromBitbucket
+, mlton
+, pkg-config
+, getopt
+, boehmgc
+, darwin
+, libbacktrace
+, libpng
+, ncurses
+, readline
+}:
+
+stdenv.mkDerivation rec {
+  pname = "c0";
+  version = "unstable-2022-10-25";
+
+  src = fetchFromBitbucket {
+    owner = "c0-lang";
+    repo = "c0";
+    rev = "7ef3bc9ca232ec41936e93ec8957051e48cacfba";
+    sha256 = "sha256-uahF8fOp2ZJE8EhZke46sbPmN0MNHzsLkU4EXkV710U=";
+  };
+
+  patches = [
+    ./use-system-libraries.patch
+  ];
+
+  postPatch = ''
+    substituteInPlace cc0/Makefile \
+      --replace '$(shell ./get_version.sh)' '${version}'
+    substituteInPlace cc0/compiler/bin/buildid \
+      --replace '`../get_version.sh`' '${version}' \
+      --replace '`date`' '1970-01-01T00:00:00Z' \
+      --replace '`hostname`' 'nixpkgs'
+  '' + lib.optionalString stdenv.isDarwin ''
+    for f in cc0/compiler/bin/coin-o0-support cc0/compiler/bin/cc0-o0-support; do
+      substituteInPlace $f --replace '$(brew --prefix gnu-getopt)' '${getopt}'
+    done
+  '';
+
+  preConfigure = ''
+    cd cc0/
+  '';
+
+  nativeBuildInputs = [
+    getopt
+    mlton
+    pkg-config
+  ] ++ lib.optionals stdenv.isDarwin [ darwin.sigtool ];
+
+  buildInputs = [
+    boehmgc
+    libbacktrace
+    libpng
+    ncurses
+    readline
+  ];
+
+  strictDeps = true;
+
+  installFlags = [ "PREFIX=$(out)" ];
+
+  postInstall = ''
+    mkdir -p $out/share/emacs/site-lisp
+    mv $out/c0-mode/ $out/share/emacs/site-lisp/
+  '';
+
+  meta = with lib; {
+    description = "A small safe subset of the C programming language, augmented with contracts";
+    homepage = "https://c0.cs.cmu.edu/";
+    license = licenses.mit;
+    maintainers = [ maintainers.marsam ];
+    platforms = platforms.unix;
+    # line 1: ../../bin/wrappergen: cannot execute: required file not found
+    # make[2]: *** [../../lib.mk:83:
+    broken = stdenv.isLinux;
+  };
+}

--- a/pkgs/development/compilers/c0/use-system-libraries.patch
+++ b/pkgs/development/compilers/c0/use-system-libraries.patch
@@ -1,0 +1,53 @@
+Use system libraries
+
+--- a/cc0/Makefile
++++ b/cc0/Makefile
+@@ -22,12 +22,12 @@ MLTON_BASIC = mlton $(MLTON_FLAGS) -verbose $(MLTON_VERB)  -output
+ MLTON_NATIVE := mlton -default-ann "redundantMatch error" -default-ann "sequenceNonUnit error"
+ MLTON_NATIVE += -link-opt "-lpthread -ldl -rdynamic" -cc-opt "-Iinclude" -default-ann "allowFFI true"
+ MLTON_NATIVE += -cc-opt "-I../externals/"
+-MLTON_NATIVE += -link-opt "../externals/readline/libreadline.a ../externals/readline/libhistory.a"
++MLTON_NATIVE += -link-opt "$(shell pkg-config readline --libs)"
+ MLTON_NATIVE += -link-opt "$(shell pkg-config libpng --libs)"
+ 
+ # libreadline dependencies
+ ifeq ($(PLATFORM),osx)
+-MLTON_NATIVE += -link-opt "-ltermcap"
++MLTON_NATIVE += -link-opt "-lncurses"
+ else
+ # (Assuming Linux)
+ MLTON_NATIVE += -link-opt "-ltinfo"
+@@ -122,9 +122,9 @@ endef
+ 
+ $(foreach rt,$(RUNTIMES),$(eval $(call runtime_template,$(rt))))
+ 
+-c0rt/$(call dllname,c0rt): gc libbacktrace
++c0rt/$(call dllname,c0rt):
+ 
+-unsafe/$(call dllname,unsafe): gc
++unsafe/$(call dllname,unsafe):
+ 
+ 
+ ### cc0 - the C0 compiler
+@@ -222,7 +222,6 @@ NATIVE_COIN    = $(NATIVE_CYMBOL) $(NATIVE_CALLING)
+ NATIVE_COIN += coin/c0readline.c
+ 
+ COIN_DEPS = $(CC0_DEPS) $(NATIVE_COIN) cymbol/cymbol*.cm cymbol/*.sml cymbol/*.mlb coin/coin*.cm coin/*.sml coin/*.sml
+-COIN_DEPS += readline
+ 
+ .PHONY: coin
+ coin: bin/coin
+--- a/cc0/lib.mk
++++ b/cc0/lib.mk
+@@ -15,9 +15,9 @@ TARGET = $(call dllname,$(LIBNAME))
+ endif
+ 
+ # These libs are handled specially by this file
+-NATIVELIBS = gc ncurses backtrace
++NATIVELIBS =
+ C0LIBS = $(filter-out $(NATIVELIBS),$(REQUIRES))
+-LIBS = -L$(abspath $(DEPTH)/lib) $(patsubst %,$(DEPTH)/lib/$(call dllname,%),$(C0LIBS))
++LIBS = -L$(abspath $(DEPTH)/lib)
+ LDFLAGS = 
+ 
+ # -fPIC is not supported on Windows and is not necessary there because we link statically

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -18984,6 +18984,10 @@ with pkgs;
 
   c2ffi = callPackage ../development/tools/misc/c2ffi { };
 
+  c0 = callPackage ../development/compilers/c0 {
+    stdenv = if stdenv.isDarwin then gccStdenv else stdenv;
+  };
+
   c3c = callPackage ../development/compilers/c3c { };
 
   swfmill = callPackage ../tools/video/swfmill { stdenv = gcc10StdenvCompat; };


### PR DESCRIPTION
###### Description of changes
Add https://c0.cs.cmu.edu/
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->