### PR TITLE
kitty: 0.27.1 -> 0.28.0

### DIFF
--- a/pkgs/applications/terminal-emulators/kitty/default.nix
+++ b/pkgs/applications/terminal-emulators/kitty/default.nix
@@ -28,16 +28,16 @@
 with python3Packages;
 buildPythonApplication rec {
   pname = "kitty";
-  version = "0.27.1";
+  version = "0.28.0";
   format = "other";
 
   src = fetchFromGitHub {
     owner = "kovidgoyal";
     repo = "kitty";
     rev = "refs/tags/v${version}";
-    hash = "sha256-/K/5T15kULTQP1FCLnyrKfhlQjIStayutaxLjmHjHes=";
+    hash = "sha256-XailVHvXY9hteyTkNwmg+b2fUZPo8YPksljMa4lAk4Q=";
   };
-  vendorHash = "sha256-JLPPNOsoq+ErLhELsX3z3YehYfgp7OGXEXlP3IVcM5k=";
+  vendorHash = "sha256-2fbFSFDK80uTp+3Y8zp0UrB1EsFYdaVLOskvQ2481m4=";
 
   buildInputs = [
     harfbuzz
@@ -215,18 +215,6 @@ buildPythonApplication rec {
 
     runHook postInstall
   '';
-
-  # Patch shebangs that Nix can't automatically patch
-  preFixup =
-    let
-      pathComponent = if stdenv.isDarwin then "Applications/kitty.app/Contents/Resources" else "lib";
-    in
-    ''
-      substituteInPlace $out/${pathComponent}/kitty/shell-integration/ssh/askpass.py \
-        --replace '/usr/bin/env -S ' $out/bin/
-      substituteInPlace $shell_integration/ssh/askpass.py \
-        --replace '/usr/bin/env -S ' $out/bin/
-    '';
 
   passthru.tests.test = nixosTests.terminal-emulators.kitty;
 


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
