### PR TITLE
maintainers/haskell/merge-and-open-pr: only push haskell-updates

### DIFF
--- a/maintainers/scripts/haskell/merge-and-open-pr.sh
+++ b/maintainers/scripts/haskell/merge-and-open-pr.sh
@@ -53,6 +53,10 @@ if ! gh auth status 2>/dev/null ; then
   die "You must setup the \`gh\` command.  Run \`gh auth login\`."
 fi
 
+# Make sure this is configured before we start doing anything
+push_remote="$(git config branch.haskell-updates.pushRemote \
+  || die 'Can'\''t determine pushRemote for haskell-updates. Please set using `git config branch.haskell-updates.pushremote <remote name>`.')"
+
 # Fetch nixpkgs to get an up-to-date origin/haskell-updates branch.
 echo "Fetching origin..."
 git fetch origin >/dev/null
@@ -89,8 +93,8 @@ echo "Regenerating Hackage packages..."
 ./maintainers/scripts/haskell/regenerate-hackage-packages.sh --fast --do-commit
 
 # Push these new commits to the haskell-updates branch
-echo "Pushing commits just created to the remote haskell-updates branch..."
-git push
+echo "Pushing commits just created to the remote $push_remote/haskell-updates branch..."
+git push "$push_remote" haskell-updates
 
 # Open new PR
 new_pr_body=$(cat <<EOF


### PR DESCRIPTION
If we want to push only one branch, we'll have to specify branch and remote explicitly. Pushing to origin doesn't work for everyone, since some of us have a origin remote that can't be pushed to. Using plain `git push` has the problem that it'll try pushing all checked out branchs which fails e.g. if some branches (staging, staging-next, …) are behind their remote counterparts.

The solution is to require everyone to configure a per branch pushRemote for haskell-updates which will then be used by merge-and-open-pr.sh.

(Untested so far). cc @expipiplus1 @cdepillabout @maralorn 

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
