### PR TITLE
clipmon: init at unstable-2022-08-28

### DIFF
--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -1135,6 +1135,7 @@
   ./services/video/unifi-video.nix
   ./services/video/v4l2-relayd.nix
   ./services/wayland/cage.nix
+  ./services/wayland/clipmon.nix
   ./services/web-apps/akkoma.nix
   ./services/web-apps/alps.nix
   ./services/web-apps/atlassian/confluence.nix

--- a/nixos/modules/services/wayland/clipmon.nix
+++ b/nixos/modules/services/wayland/clipmon.nix
@@ -1,0 +1,27 @@
+{ lib, pkgs, config, ... }:
+
+with lib;
+
+let
+  cfg = config.services.clipmon;
+in {
+  options.services.clipmon = {
+    enable = mkEnableOption (mdDoc "clipmon");
+  };
+
+  config = mkIf cfg.enable {
+    systemd.user.services.clipmon = {
+      description = "Clipboard monitor for Wayland";
+      documentation = [ "https://sr.ht/~whynothugo/clipmon" ];
+      after = [ "graphical-session.target" ];
+      partOf = [ "graphical-session.target" ];
+      wantedBy = [ "graphical-session.target" ];
+      serviceConfig = {
+        Restart = "on-failure";
+        ExecStart = "${pkgs.clipmon}/bin/clipmon";
+      };
+    };
+  };
+
+  meta.maintainers = with maintainers; [ ma27 ];
+}

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -135,6 +135,7 @@ in {
   cinnamon = handleTest ./cinnamon.nix {};
   cjdns = handleTest ./cjdns.nix {};
   clickhouse = handleTest ./clickhouse.nix {};
+  clipmon = handleTest ./clipmon.nix {};
   cloud-init = handleTest ./cloud-init.nix {};
   cloud-init-hostname = handleTest ./cloud-init-hostname.nix {};
   cloudlog = handleTest ./cloudlog.nix {};

--- a/nixos/tests/clipmon.nix
+++ b/nixos/tests/clipmon.nix
@@ -1,0 +1,66 @@
+import ./make-test-python.nix ({ lib, ... }: {
+  name = "clipmon";
+  meta.maintainers = with lib.maintainers; [ ma27 ];
+  enableOCR = true;
+
+  nodes.machine = { pkgs, ... }: {
+    imports = [ ./common/user-account.nix ];
+    services.clipmon.enable = true;
+    services.getty.autologinUser = "alice";
+    programs.sway.enable = true;
+    environment.systemPackages = with pkgs; [ wl-clipboard procps ];
+    # see tests.sway
+    environment.variables.WLR_RENDERER = "pixman";
+    virtualisation.qemu.options = [ "-vga none -device virtio-gpu-pci" ];
+    programs.bash.loginShellInit = ''
+      if [ "$(tty)" = "/dev/tty1" ]; then
+        mkdir -p ~/.config/sway
+        sed s/Mod4/Mod1/ /etc/sway/config > ~/.config/sway/config
+        echo "exec systemctl --user start graphical-session.target" >> ~/.config/sway/config
+        exec sway
+      fi
+    '';
+    environment.etc."xdg/foot/foot.ini".text = lib.generators.toINI { } {
+      main = {
+        font = "inconsolata:size=14";
+      };
+      colors = rec {
+        foreground = "000000";
+        background = "ffffff";
+        regular2 = foreground;
+      };
+    };
+    fonts.fonts = [ pkgs.inconsolata ];
+  };
+
+  testScript = ''
+    start_all()
+
+    machine.wait_for_unit("multi-user.target")
+    machine.wait_for_file("/run/user/1000/wayland-1")
+    machine.wait_until_succeeds("pgrep sway")
+
+    machine.send_key("alt-ret")
+    machine.wait_for_text("alice@machine")
+
+    machine.send_chars("echo foo | wl-copy -f\n")
+
+    machine.send_key("alt-ret")
+    machine.wait_until_succeeds("test $(pgrep foot | wc -l) = 2")
+    machine.send_chars('echo "clipboard: $(wl-paste)"' + "\n")
+    machine.wait_for_text("clipboard: foo")
+
+    machine.send_key("alt-shift-q")
+    machine.send_key("alt-shift-q")
+
+    machine.wait_until_fails("pgrep foot")
+
+    machine.send_key("alt-ret")
+    machine.wait_for_text("alice@machine")
+    machine.send_chars('echo "clipboard: $(wl-paste)"' + "\n")
+    machine.wait_for_text("clipboard: foo")
+    machine.screenshot("result")
+
+    machine.shutdown()
+  '';
+})

--- a/pkgs/tools/wayland/clipmon/default.nix
+++ b/pkgs/tools/wayland/clipmon/default.nix
@@ -1,0 +1,32 @@
+{ rustPlatform, fetchFromSourcehut, lib, wayland, makeWrapper, nixosTests }:
+
+rustPlatform.buildRustPackage rec {
+  pname = "clipmon";
+  version = "unstable-2022-08-28";
+
+  src = fetchFromSourcehut {
+    owner = "~whynothugo";
+    repo = pname;
+    rev = "2e338fdc2841c3b2de9271d90fcceceda9e45d29";
+    hash = "sha256-bEMgJYz3e2xwMO084bmCT1oZImcmO3xH6rIsjvAxnTA=";
+  };
+
+  nativeBuildInputs = [ makeWrapper ];
+
+  cargoHash = "sha256-TI7KVj9SOG+RovkzwMBX3lQ0QFKu1AS5nIHzvHXg/SU=";
+
+  passthru.tests = { inherit (nixosTests) clipmon; };
+
+  postInstall = ''
+    wrapProgram $out/bin/clipmon \
+      --prefix LD_LIBRARY_PATH : "${lib.makeLibraryPath [ wayland ]}"
+  '';
+
+  meta = with lib; {
+    homepage = "https://git.sr.ht/~whynothugo/clipmon/";
+    description = "Clipboard monitor for Wayland";
+    license = licenses.mit;
+    maintainers = with maintainers; [ ma27 ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4220,6 +4220,8 @@ with pkgs;
 
   clipman = callPackage ../tools/wayland/clipman { };
 
+  clipmon = callPackage ../tools/wayland/clipmon { };
+
   kabeljau = callPackage ../games/kabeljau { };
 
   kanshi = callPackage ../tools/wayland/kanshi { };


### PR DESCRIPTION

###### Description of changes
Under Wayland, an application itself is responsible for "serving" the current clipboard contents. As soon as that happens, `clipmon` claims the clipboard and copies the contents from the application[1].

As a result, clipboard contents are still available after closing the application where something was copied from.

Additionally, I implemented a small VM test to check the behavior when using Sway like this:

* Open a terminal and write something to the clipboard using `wl-copy -f`. That way the clipboard is held by a sub-process of the terminal (which simulates a Ctrl-Shift-C in `foot`, not using `-f` would cause `wl-copy` to fork itself to keep the contents after closing the terminal which wouldn't happen when copying by e.g. mouse).
* Ensure in a second terminal that the clipboard contents can be accessed.
* Close both terminals. Without `clipmon`, the selection would be lost now.
* Open another terminal and run `wl-paste` to ensure that the selection still exists (because of `clipmon`).

[1] https://git.sr.ht/~whynothugo/clipmon#design

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
