### PR TITLE
radianWrapper: Explicitly set R_HOME and always have R in buildInputs

### DIFF
--- a/pkgs/development/r-modules/wrapper-radian.nix
+++ b/pkgs/development/r-modules/wrapper-radian.nix
@@ -12,8 +12,7 @@ runCommand (radian.name + "-wrapper") {
   preferLocalBuild = true;
   allowSubstitutes = false;
 
-  buildInputs = [ radian ] ++ recommendedPackages ++ packages
-    ++ lib.optional wrapR R;
+  buildInputs = [ R radian ] ++ recommendedPackages ++ packages;
 
   nativeBuildInputs = [ makeWrapper ];
 
@@ -27,7 +26,8 @@ runCommand (radian.name + "-wrapper") {
   };
 } (''
   makeWrapper "${radian}/bin/radian" "$out/bin/radian" \
-    --prefix "R_LIBS_SITE" ":" "$R_LIBS_SITE"
+    --prefix "R_LIBS_SITE" ":" "$R_LIBS_SITE" \
+    --set "R_HOME" "${R}/lib/R"
 '' + lib.optionalString wrapR ''
   cd ${R}/bin
   for exe in *; do


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
Before this commit, `wrapR = false` (the default) would lead to situations where the `RHOME` variable would not be found. Adding `--set R_HOME ${R}/lib/R` so that the wrapper explicitly exports `R_HOME` fixes this issue. In addition, R is also made part of `buildInputs` by default so that package loading works correctly.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
