### PR TITLE
hybrid-bar: init at 0.4.9 (based on #200208)

### DIFF
--- a/pkgs/applications/misc/hybrid-bar/default.nix
+++ b/pkgs/applications/misc/hybrid-bar/default.nix
@@ -1,0 +1,43 @@
+{ lib
+, rustPlatform
+, fetchFromGitHub
+, stdenv
+, pkg-config
+, atk
+, gtk3
+, pango
+, gdk-pixbuf
+, gtk-layer-shell
+}:
+
+rustPlatform.buildRustPackage rec {
+  pname = "hybrid-bar";
+  version = "0.4.9";
+
+  src = fetchFromGitHub {
+    owner = "vars1ty";
+    repo = "HybridBar";
+    rev = version;
+    hash = "sha256-e9QVDDN8AtCZYuYqef1rzLJ0mklaKXzxgj+ZqGrSYEY=";
+  };
+
+  cargoHash = "sha256-9vHoa7t9XA7zuN7MLG8Q5pDae6dznYrGMKp6H8/+Iu0=";
+
+  buildInputs = [
+    gtk3
+    pango
+    gdk-pixbuf
+    atk
+    gtk-layer-shell
+  ];
+
+  nativeBuildInputs = [ pkg-config ];
+
+  meta = with lib; {
+    description = "A status bar focused on wlroots Wayland compositors";
+    homepage = "https://github.com/vars1ty/HybridBar";
+    license = licenses.mit;
+    platforms = platforms.unix;
+    maintainers = with maintainers; [ ocfox ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8469,6 +8469,8 @@ with pkgs;
 
   hw-probe = perlPackages.callPackage ../tools/system/hw-probe { };
 
+  hybrid-bar = callPackage ../applications/misc/hybrid-bar { };
+
   hybridreverb2 = callPackage ../applications/audio/hybridreverb2 {
     stdenv = gcc8Stdenv;
   };


### PR DESCRIPTION
###### Description of changes

Init hybrid-bar at latest release for personal testing would close my PR as I'm not planning in maintaining it but there was a request in the PR so I wanted to share it until OP responds. (#200208)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
