### PR TITLE
emacsPackages.wat-mode: init at unstable-2022-07-13

### DIFF
--- a/pkgs/applications/editors/emacs/elisp-packages/manual-packages.nix
+++ b/pkgs/applications/editors/emacs/elisp-packages/manual-packages.nix
@@ -81,6 +81,8 @@ in
 
   voicemacs = callPackage ./manual-packages/voicemacs { };
 
+  wat-mode = callPackage ./manual-packages/wat-mode { };
+
   yes-no = callPackage ./manual-packages/yes-no { };
 
   youtube-dl = callPackage ./manual-packages/youtube-dl { };

--- a/pkgs/applications/editors/emacs/elisp-packages/manual-packages/wat-mode/default.nix
+++ b/pkgs/applications/editors/emacs/elisp-packages/manual-packages/wat-mode/default.nix
@@ -1,0 +1,23 @@
+# Manually packaged until it is upstreamed to melpa
+# See https://github.com/devonsparks/wat-mode/issues/1
+{ lib, trivialBuild, fetchFromGitHub, fetchpatch, emacs }:
+
+trivialBuild rec {
+  pname = "wat-mode";
+  version = "unstable-2022-07-13";
+
+  src = fetchFromGitHub {
+    owner = "devonsparks";
+    repo = pname;
+    rev = "46b4df83e92c585295d659d049560dbf190fe501";
+    hash = "sha256-jV5V3TRY+D3cPSz3yFwVWn9yInhGOYIaUTPEhsOBxto=";
+  };
+
+  meta = with lib; {
+    homepage = "https://github.com/devonsparks/wat-mode";
+    description = "An Emacs major mode for WebAssembly's text format";
+    license = licenses.gpl3Only;
+    maintainers = with maintainers; [ nagy ];
+    inherit (emacs.meta) platforms;
+  };
+}


### PR DESCRIPTION
###### Description of changes

Manually packaged until it is upstreamed to melpa. 
 * https://github.com/devonsparks/wat-mode/issues/1

###### Things done



- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
