### PR TITLE
gst_all_1: 1.20.3 -> 1.22.2

### DIFF
--- a/pkgs/development/libraries/gstreamer/bad/default.nix
+++ b/pkgs/development/libraries/gstreamer/bad/default.nix
@@ -11,6 +11,7 @@
 , orc
 , gstreamer
 , gobject-introspection
+, hotdoc
 , enableZbar ? false
 , faacSupport ? false
 , faac
@@ -57,7 +58,7 @@
 , neon
 , openal
 , opencv4
-, openexr
+, openexr_3
 , openh264
 , libopenmpt
 , pango
@@ -80,6 +81,7 @@
 , libGLU
 , libGL
 , addOpenGLRunpath
+, gtk3
 , libintl
 , game-music-emu
 , openssl
@@ -103,13 +105,13 @@
 
 stdenv.mkDerivation rec {
   pname = "gst-plugins-bad";
-  version = "1.20.3";
+  version = "1.22.2";
 
   outputs = [ "out" "dev" ];
 
   src = fetchurl {
     url = "https://gstreamer.freedesktop.org/src/${pname}/${pname}-${version}.tar.xz";
-    sha256 = "sha256-ehHBO1XdHSOG3ZAiGeQcv83ajh4Ko+c4GGyVB0s12k8=";
+    hash = "sha256-PY+vHONALIU1zjqMThpslg5LVlXb2mtVlD25rHkCLQ8=";
   };
 
   patches = [
@@ -129,6 +131,9 @@ stdenv.mkDerivation rec {
     gettext
     gstreamer # for gst-tester-1.0
     gobject-introspection
+
+    # documentation
+    hotdoc
   ] ++ lib.optionals stdenv.isLinux [
     wayland # for wayland-scanner
   ];
@@ -165,7 +170,7 @@ stdenv.mkDerivation rec {
     neon
     openal
     opencv4
-    openexr
+    openexr_3
     openh264
     rtmpdump
     pango
@@ -178,6 +183,7 @@ stdenv.mkDerivation rec {
     gnutls
     libGL
     libGLU
+    gtk3
     game-music-emu
     openssl
     libxml2
@@ -243,10 +249,11 @@ stdenv.mkDerivation rec {
 
   mesonFlags = [
     "-Dexamples=disabled" # requires many dependencies and probably not useful for our users
-    "-Ddoc=disabled" # `hotdoc` not packaged in nixpkgs as of writing
     "-Dglib-asserts=disabled" # asserts should be disabled on stable releases
 
+    "-Damfcodec=disabled" # Windows-only
     "-Davtp=disabled"
+    "-Ddirectshow=disabled" # Windows-only
     "-Ddts=disabled" # required `libdca` library not packaged in nixpkgs as of writing, and marked as "BIG FAT WARNING: libdca is still in early development"
     "-Dzbar=${if enableZbar then "enabled" else "disabled"}"
     "-Dfaac=${if faacSupport then "enabled" else "disabled"}"
@@ -282,6 +289,8 @@ stdenv.mkDerivation rec {
     "-Dbluez=${if bluezSupport then "enabled" else "disabled"}"
   ]
   ++ lib.optionals (!stdenv.isLinux) [
+    "-Ddoc=disabled" # needs gstcuda to be enabled which is Linux-only
+    "-Dnvcodec=disabled" # Linux-only
     "-Dva=disabled" # see comment on `libva` in `buildInputs`
   ]
   ++ lib.optionals stdenv.isDarwin [
@@ -299,9 +308,12 @@ stdenv.mkDerivation rec {
     "-Dladspa=disabled" # requires lrdf
     "-Dwebrtc=disabled" # requires libnice, which as of writing doesn't work on Darwin in nixpkgs
     "-Dwildmidi=disabled" # see dependencies above
+  ] ++ lib.optionals (!stdenv.isLinux || !stdenv.isx86_64) [
+    "-Dqsv=disabled" # Linux (and Windows) x86 only
   ] ++ lib.optionals (!gst-plugins-base.glEnabled) [
     "-Dgl=disabled"
   ] ++ lib.optionals (!gst-plugins-base.waylandEnabled) [
+    "-Dgtk3=disabled" # Wayland-based GTK sink
     "-Dwayland=disabled"
   ] ++ lib.optionals (!gst-plugins-base.glEnabled) [
     # `applemedia/videotexturecache.h` requires `gst/gl/gl.h`,
@@ -325,11 +337,6 @@ stdenv.mkDerivation rec {
   postPatch = ''
     patchShebangs \
       scripts/extract-release-date-from-doap-file.py
-
-    # upstream bumps this version check one minor version at a time
-    # https://gitlab.freedesktop.org/gstreamer/gstreamer/-/blob/main/subprojects/gst-plugins-bad/ext/opencv/meson.build#L74
-    substituteInPlace ext/opencv/meson.build \
-      --replace '< 4.7.0' '< 5.0.0'
   '';
 
   # This package has some `_("string literal")` string formats

--- a/pkgs/development/libraries/gstreamer/bad/fix-paths.patch
+++ b/pkgs/development/libraries/gstreamer/bad/fix-paths.patch
@@ -1,21 +1,21 @@
-diff --git a/sys/nvcodec/gstcudaloader.c b/sys/nvcodec/gstcudaloader.c
-index 4223ba1fbd..ca8bb5ceb1 100644
---- a/sys/nvcodec/gstcudaloader.c
-+++ b/sys/nvcodec/gstcudaloader.c
-@@ -135,6 +135,11 @@ gst_cuda_load_library (void)
+diff --git a/gst-libs/gst/cuda/gstcudaloader.c b/gst-libs/gst/cuda/gstcudaloader.c
+index fffcbefd2b..6f738d3af3 100644
+--- a/gst-libs/gst/cuda/gstcudaloader.c
++++ b/gst-libs/gst/cuda/gstcudaloader.c
+@@ -165,6 +165,11 @@ gst_cuda_load_library (void)
      return TRUE;
  
    module = g_module_open (filename, G_MODULE_BIND_LAZY);
 +
 +  if (module == NULL) {
-+    module = g_module_open("@driverLink@/lib/" CUDA_LIBNAME, G_MODULE_BIND_LAZY);
++    module = g_module_open ("@driverLink@/lib/" CUDA_LIBNAME, G_MODULE_BIND_LAZY);
 +  }
 +
    if (module == NULL) {
      GST_WARNING ("Could not open library %s, %s", filename, g_module_error ());
      return FALSE;
 diff --git a/sys/nvcodec/gstcuvidloader.c b/sys/nvcodec/gstcuvidloader.c
-index 3c7505ca36..eeb376fa80 100644
+index e957e062e0..004ec2dcd5 100644
 --- a/sys/nvcodec/gstcuvidloader.c
 +++ b/sys/nvcodec/gstcuvidloader.c
 @@ -85,6 +85,11 @@ gst_cuvid_load_library (guint api_major_ver, guint api_minor_ver)
@@ -31,10 +31,10 @@ index 3c7505ca36..eeb376fa80 100644
      GST_WARNING ("Could not open library %s, %s", filename, g_module_error ());
      return FALSE;
 diff --git a/sys/nvcodec/gstnvenc.c b/sys/nvcodec/gstnvenc.c
-index 19637671ad..39858ccdee 100644
+index 106857a954..3bab9989f0 100644
 --- a/sys/nvcodec/gstnvenc.c
 +++ b/sys/nvcodec/gstnvenc.c
-@@ -874,6 +874,11 @@ gst_nvenc_load_library (guint * api_major_ver, guint * api_minor_ver)
+@@ -907,6 +907,11 @@ gst_nvenc_load_library (guint * api_major_ver, guint * api_minor_ver)
    };
  
    module = g_module_open (NVENC_LIBRARY_NAME, G_MODULE_BIND_LAZY);

--- a/pkgs/development/libraries/gstreamer/base/default.nix
+++ b/pkgs/development/libraries/gstreamer/base/default.nix
@@ -20,9 +20,11 @@
 , tremor # provides 'virbisidec'
 , libGL
 , gobject-introspection
+, hotdoc
 , enableX11 ? stdenv.isLinux
-, libXv
 , libXext
+, libXi
+, libXv
 , enableWayland ? stdenv.isLinux
 , wayland
 , wayland-protocols
@@ -41,7 +43,7 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "gst-plugins-base";
-  version = "1.20.3";
+  version = "1.22.2";
 
   outputs = [ "out" "dev" ];
 
@@ -49,7 +51,7 @@ stdenv.mkDerivation (finalAttrs: {
     inherit (finalAttrs) pname version;
   in fetchurl {
     url = "https://gstreamer.freedesktop.org/src/${pname}/${pname}-${version}.tar.xz";
-    sha256 = "sha256-fjCz3YGnA4D/dVT5mEcdaZb/drvm/FRHCW+FHiRHPJ8=";
+    hash = "sha256-62USDE7nm3oVPDwZctXAFYwhUYd8xR7Hclu6V0lnnUk=";
   };
 
   strictDeps = true;
@@ -65,9 +67,10 @@ stdenv.mkDerivation (finalAttrs: {
     orc
     glib
     gstreamer
-    # docs
-    # TODO add hotdoc here
     gobject-introspection
+
+    # documentation
+    hotdoc
   ] ++ lib.optional enableWayland wayland;
 
   buildInputs = [
@@ -91,6 +94,7 @@ stdenv.mkDerivation (finalAttrs: {
     alsa-lib
   ] ++ lib.optionals enableX11 [
     libXext
+    libXi
     libXv
   ] ++ lib.optionals enableWayland [
     wayland
@@ -104,7 +108,6 @@ stdenv.mkDerivation (finalAttrs: {
 
   mesonFlags = [
     "-Dexamples=disabled" # requires many dependencies and probably not useful for our users
-    "-Ddoc=disabled" # `hotdoc` not packaged in nixpkgs as of writing
     # See https://github.com/GStreamer/gst-plugins-base/blob/d64a4b7a69c3462851ff4dcfa97cc6f94cd64aef/meson_options.txt#L15 for a list of choices
     "-Dgl_winsys=${lib.concatStringsSep "," (lib.optional enableX11 "x11" ++ lib.optional enableWayland "wayland" ++ lib.optional enableCocoa "cocoa")}"
   ] ++ lib.optionals (stdenv.buildPlatform != stdenv.hostPlatform) [

--- a/pkgs/development/libraries/gstreamer/core/default.nix
+++ b/pkgs/development/libraries/gstreamer/core/default.nix
@@ -8,13 +8,14 @@
 , flex
 , python3
 , glib
+, hotdoc
 , makeWrapper
 , libcap
 , libunwind
-, darwin
 , elfutils # for libdw
 , bash-completion
 , lib
+, Cocoa
 , CoreServices
 , gobject-introspection
 , testers
@@ -22,22 +23,19 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "gstreamer";
-  version = "1.20.3";
+  version = "1.22.2";
 
   outputs = [
     "bin"
     "out"
     "dev"
-    # "devdoc" # disabled until `hotdoc` is packaged in nixpkgs, see:
-    # - https://github.com/NixOS/nixpkgs/pull/98767
-    # - https://github.com/NixOS/nixpkgs/issues/98769#issuecomment-702296551
   ];
 
   src = let
     inherit (finalAttrs) pname version;
   in fetchurl {
     url = "https://gstreamer.freedesktop.org/src/${pname}/${pname}-${version}.tar.xz";
-    sha256 = "sha256-YH2vZLu9X7GK+dF+IcDSLE1wL//oOyPLItGxryyiOio=";
+    hash = "sha256-sq/nNgOSHGCLpIlp27fXQ3dnRL/l2AWeziQRN7f4jiE=";
   };
 
   depsBuildBuild = [
@@ -59,7 +57,7 @@ stdenv.mkDerivation (finalAttrs: {
     gobject-introspection
 
     # documentation
-    # TODO add hotdoc here
+    hotdoc
   ] ++ lib.optionals stdenv.isLinux [
     libcap # for setcap binary
   ];
@@ -72,6 +70,7 @@ stdenv.mkDerivation (finalAttrs: {
     libunwind
     elfutils
   ] ++ lib.optionals stdenv.isDarwin [
+    Cocoa
     CoreServices
   ];
 
@@ -82,7 +81,6 @@ stdenv.mkDerivation (finalAttrs: {
   mesonFlags = [
     "-Ddbghelp=disabled" # not needed as we already provide libunwind and libdw, and dbghelp is a fallback to those
     "-Dexamples=disabled" # requires many dependencies and probably not useful for our users
-    "-Ddoc=disabled" # `hotdoc` not packaged in nixpkgs as of writing
   ] ++ lib.optionals stdenv.isDarwin [
     # darwin.libunwind doesn't have pkg-config definitions so meson doesn't detect it.
     "-Dlibunwind=disabled"

--- a/pkgs/development/libraries/gstreamer/default.nix
+++ b/pkgs/development/libraries/gstreamer/default.nix
@@ -16,7 +16,7 @@
 }:
 
 {
-  gstreamer = callPackage ./core { inherit CoreServices; };
+  gstreamer = callPackage ./core { inherit Cocoa CoreServices; };
 
   gstreamermm = callPackage ./gstreamermm { };
 

--- a/pkgs/development/libraries/gstreamer/devtools/default.nix
+++ b/pkgs/development/libraries/gstreamer/devtools/default.nix
@@ -10,22 +10,22 @@
 , gst-rtsp-server
 , python3
 , gobject-introspection
+, hotdoc
 , json-glib
 }:
 
 stdenv.mkDerivation rec {
   pname = "gst-devtools";
-  version = "1.20.3";
+  version = "1.22.2";
 
   src = fetchurl {
     url = "https://gstreamer.freedesktop.org/src/${pname}/${pname}-${version}.tar.xz";
-    sha256 = "sha256-u71F6tcDNn6o9L6bPAgte2K+9HskCjkIPyeETih1jEc=";
+    hash = "sha256-62JybT4nqHgjaaJP1jZKiIXtJGKzu9qwkd/8gTnuBtg=";
   };
 
   outputs = [
     "out"
     "dev"
-    # "devdoc" # disabled until `hotdoc` is packaged in nixpkgs
   ];
 
   depsBuildBuild = [
@@ -39,7 +39,7 @@ stdenv.mkDerivation rec {
     gobject-introspection
 
     # documentation
-    # TODO add hotdoc here
+    hotdoc
   ];
 
   buildInputs = [
@@ -54,10 +54,6 @@ stdenv.mkDerivation rec {
     gst-plugins-base
     gst-plugins-bad
     gst-rtsp-server
-  ];
-
-  mesonFlags = [
-    "-Ddoc=disabled" # `hotdoc` not packaged in nixpkgs as of writing
   ];
 
   meta = with lib; {

--- a/pkgs/development/libraries/gstreamer/ges/default.nix
+++ b/pkgs/development/libraries/gstreamer/ges/default.nix
@@ -10,23 +10,23 @@
 , gst-devtools
 , libxml2
 , flex
+, hotdoc
 , gettext
 , gobject-introspection
 }:
 
 stdenv.mkDerivation rec {
   pname = "gst-editing-services";
-  version = "1.20.3";
+  version = "1.22.2";
 
   outputs = [
     "out"
     "dev"
-    # "devdoc" # disabled until `hotdoc` is packaged in nixpkgs
   ];
 
   src = fetchurl {
     url = "https://gstreamer.freedesktop.org/src/${pname}/${pname}-${version}.tar.xz";
-    sha256 = "sha256-X9iW3mn74kQh62sP+NL4tMPLo/MCXOrNMCFy85qKuqI=";
+    hash = "sha256-RTsUZPw4V94mmnyw69lmr+Ahcdl772cqC4oKbUPgzr8=";
   };
 
   nativeBuildInputs = [
@@ -39,7 +39,7 @@ stdenv.mkDerivation rec {
     flex
 
     # documentation
-    # TODO add hotdoc here
+    hotdoc
   ];
 
   buildInputs = [
@@ -53,10 +53,6 @@ stdenv.mkDerivation rec {
   propagatedBuildInputs = [
     gst-plugins-base
     gst-plugins-bad
-  ];
-
-  mesonFlags = [
-    "-Ddoc=disabled" # `hotdoc` not packaged in nixpkgs as of writing
   ];
 
   postPatch = ''

--- a/pkgs/development/libraries/gstreamer/good/default.nix
+++ b/pkgs/development/libraries/gstreamer/good/default.nix
@@ -31,6 +31,7 @@
 , twolame
 , gtkSupport ? false, gtk3
 , qt5Support ? false, qt5
+, qt6Support ? false, qt6
 , raspiCameraSupport ? false, libraspberrypi
 , enableJack ? true, libjack2
 , libXdamage
@@ -43,19 +44,20 @@
 , libgudev
 , wavpack
 , glib
+, hotdoc
 }:
 
 assert raspiCameraSupport -> (stdenv.isLinux && stdenv.isAarch64);
 
 stdenv.mkDerivation rec {
   pname = "gst-plugins-good";
-  version = "1.20.3";
+  version = "1.22.2";
 
   outputs = [ "out" "dev" ];
 
   src = fetchurl {
     url = "https://gstreamer.freedesktop.org/src/${pname}/${pname}-${version}.tar.xz";
-    sha256 = "sha256-+PPCBr9c2rwAlTkgtHs1da8O8V6fhxwLaWb20KpYaLc=";
+    hash = "sha256-fIzFlCXysjL2DKfRPlbt1hXaT3Eec90Bp8/6Rua8DN0=";
   };
 
   strictDeps = true;
@@ -72,8 +74,14 @@ stdenv.mkDerivation rec {
     orc
     libshout
     glib
+
+    # documentation
+    hotdoc
   ] ++ lib.optionals qt5Support (with qt5; [
     qtbase
+  ]) ++ lib.optionals qt6Support (with qt6; [
+    qtbase
+    qttools
   ]) ++ lib.optionals stdenv.isLinux [
     wayland-protocols
   ];
@@ -114,6 +122,10 @@ stdenv.mkDerivation rec {
     qtdeclarative
     qtwayland
     qtx11extras
+  ]) ++ lib.optionals qt6Support (with qt6; [
+    qtbase
+    qtdeclarative
+    qtwayland
   ]) ++ lib.optionals stdenv.isDarwin [
     Cocoa
   ] ++ lib.optionals stdenv.isLinux [
@@ -129,10 +141,11 @@ stdenv.mkDerivation rec {
 
   mesonFlags = [
     "-Dexamples=disabled" # requires many dependencies and probably not useful for our users
-    "-Ddoc=disabled" # `hotdoc` not packaged in nixpkgs as of writing
     "-Dglib-asserts=disabled" # asserts should be disabled on stable releases
   ] ++ lib.optionals (!qt5Support) [
     "-Dqt5=disabled"
+  ] ++ lib.optionals (!qt6Support) [
+    "-Dqt6=disabled"
   ] ++ lib.optionals (!gtkSupport) [
     "-Dgtk3=disabled"
   ] ++ lib.optionals (!enableJack) [

--- a/pkgs/development/libraries/gstreamer/libav/default.nix
+++ b/pkgs/development/libraries/gstreamer/libav/default.nix
@@ -5,6 +5,7 @@
 , ninja
 , pkg-config
 , python3
+, hotdoc
 , gstreamer
 , gst-plugins-base
 , gettext
@@ -16,11 +17,11 @@
 
 stdenv.mkDerivation rec {
   pname = "gst-libav";
-  version = "1.20.3";
+  version = "1.22.2";
 
   src = fetchurl {
     url = "https://gstreamer.freedesktop.org/src/${pname}/${pname}-${version}.tar.xz";
-    sha256 = "sha256-P+3RBWD836obZGLL95o4xOe1fX85A1k5P8DO9tvyff4=";
+    hash = "sha256-/Kr5h4/o87yCMX7xOhVYgky2jfH4loxnl/VWxeM7z/0=";
   };
 
   outputs = [ "out" "dev" ];
@@ -31,16 +32,15 @@ stdenv.mkDerivation rec {
     gettext
     pkg-config
     python3
+
+    # documentation
+    hotdoc
   ];
 
   buildInputs = [
     gstreamer
     gst-plugins-base
     libav
-  ];
-
-  mesonFlags = [
-    "-Ddoc=disabled" # `hotdoc` not packaged in nixpkgs as of writing
   ];
 
   postPatch = ''

--- a/pkgs/development/libraries/gstreamer/rtsp-server/default.nix
+++ b/pkgs/development/libraries/gstreamer/rtsp-server/default.nix
@@ -5,6 +5,7 @@
 , ninja
 , pkg-config
 , python3
+, hotdoc
 , gettext
 , gobject-introspection
 , gst-plugins-base
@@ -13,17 +14,16 @@
 
 stdenv.mkDerivation rec {
   pname = "gst-rtsp-server";
-  version = "1.20.3";
+  version = "1.22.2";
 
   src = fetchurl {
     url = "https://gstreamer.freedesktop.org/src/${pname}/${pname}-${version}.tar.xz";
-    sha256 = "sha256-7kAnGL6bEn8OXmbKTBtPQuSSbsk7owe3zMpdxsyXlMo=";
+    hash = "sha256-K+Suz7iHEBAOpxFe0CFkA+gJQ0Tr8UYJQnG41Nc4KL8=";
   };
 
   outputs = [
     "out"
     "dev"
-    # "devdoc" # disabled until `hotdoc` is packaged in nixpkgs
   ];
 
   nativeBuildInputs = [
@@ -35,7 +35,7 @@ stdenv.mkDerivation rec {
     python3
 
     # documentation
-    # TODO add hotdoc here
+    hotdoc
   ];
 
   buildInputs = [
@@ -46,7 +46,6 @@ stdenv.mkDerivation rec {
 
   mesonFlags = [
     "-Dexamples=disabled" # requires many dependencies and probably not useful for our users
-    "-Ddoc=disabled" # `hotdoc` not packaged in nixpkgs as of writing
   ];
 
   postPatch = ''

--- a/pkgs/development/libraries/gstreamer/ugly/default.nix
+++ b/pkgs/development/libraries/gstreamer/ugly/default.nix
@@ -4,6 +4,7 @@
 , ninja
 , pkg-config
 , python3
+, hotdoc
 , gst-plugins-base
 , orc
 , gettext
@@ -24,13 +25,13 @@
 
 stdenv.mkDerivation rec {
   pname = "gst-plugins-ugly";
-  version = "1.20.3";
+  version = "1.22.2";
 
   outputs = [ "out" "dev" ];
 
   src = fetchurl {
     url = "https://gstreamer.freedesktop.org/src/${pname}/${pname}-${version}.tar.xz";
-    sha256 = "sha256-jKogeJoJwwS0nPVj0zzKlCGxh1uE/MGH5KOF+gHWrv0=";
+    hash = "sha256-jzD0TbC9BjcJv2++VROOOpivCry2HDYPNVgrvhDoBpE=";
   };
 
   nativeBuildInputs = [
@@ -39,6 +40,9 @@ stdenv.mkDerivation rec {
     gettext
     pkg-config
     python3
+
+    # documentation
+    hotdoc
   ];
 
   buildInputs = [
@@ -60,7 +64,6 @@ stdenv.mkDerivation rec {
   ];
 
   mesonFlags = [
-    "-Ddoc=disabled" # `hotdoc` not packaged in nixpkgs as of writing
     "-Dsidplay=disabled" # sidplay / sidplay/player.h isn't packaged in nixpkgs as of writing
   ] ++ (if enableGplPlugins then [
     "-Dgpl=enabled"

--- a/pkgs/development/libraries/gstreamer/vaapi/default.nix
+++ b/pkgs/development/libraries/gstreamer/vaapi/default.nix
@@ -5,8 +5,10 @@
 , pkg-config
 , gst-plugins-base
 , bzip2
+, hotdoc
 , libva
 , wayland
+, wayland-protocols
 , libdrm
 , udev
 , xorg
@@ -21,17 +23,16 @@
 
 stdenv.mkDerivation rec {
   pname = "gstreamer-vaapi";
-  version = "1.20.3";
+  version = "1.22.2";
 
   src = fetchurl {
     url = "https://gstreamer.freedesktop.org/src/${pname}/${pname}-${version}.tar.xz";
-    sha256 = "sha256-bumesxar3emtNwApFb2MOGeRj2/cdLfPKsTBrg1pC0U=";
+    hash = "sha256-0uZC+XRfl9n3On9Qhedlmpox/iCbd05uRdrgQbQ13wY=";
   };
 
   outputs = [
     "out"
     "dev"
-    # "devdoc" # disabled until `hotdoc` is packaged in nixpkgs
   ];
 
   nativeBuildInputs = [
@@ -40,9 +41,10 @@ stdenv.mkDerivation rec {
     pkg-config
     python3
     bzip2
+    wayland
 
     # documentation
-    # TODO add hotdoc here
+    hotdoc
   ];
 
   buildInputs = [
@@ -51,6 +53,7 @@ stdenv.mkDerivation rec {
     gst-plugins-bad
     libva
     wayland
+    wayland-protocols
     libdrm
     udev
     xorg.libX11
@@ -65,9 +68,10 @@ stdenv.mkDerivation rec {
     libvpx
   ];
 
+  strictDeps = true;
+
   mesonFlags = [
     "-Dexamples=disabled" # requires many dependencies and probably not useful for our users
-    "-Ddoc=disabled" # `hotdoc` not packaged in nixpkgs as of writing
   ];
 
   postPatch = ''

--- a/pkgs/development/libraries/libnice/default.nix
+++ b/pkgs/development/libraries/libnice/default.nix
@@ -18,14 +18,14 @@
 
 stdenv.mkDerivation rec {
   pname = "libnice";
-  version = "0.1.18";
+  version = "0.1.21";
 
   outputs = [ "bin" "out" "dev" ]
     ++ lib.optionals (stdenv.buildPlatform == stdenv.hostPlatform) [ "devdoc" ];
 
   src = fetchurl {
     url = "https://libnice.freedesktop.org/releases/${pname}-${version}.tar.gz";
-    sha256 = "1x3kj9b3dy9m2h6j96wgywfamas1j8k2ca43k5v82kmml9dx5asy";
+    hash = "sha256-cuc6Ks8g9ZCT4h1WAWBuQFhzUD6zXzRvpiHeI+mbOzk=";
   };
 
   patches = [

--- a/pkgs/development/python-modules/dbus-deviation/default.nix
+++ b/pkgs/development/python-modules/dbus-deviation/default.nix
@@ -1,0 +1,35 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, lxml
+, setuptools-git
+, sphinx
+}:
+
+buildPythonPackage rec {
+  pname = "dbus-deviation";
+  version = "0.6.1";
+
+  src = fetchPypi {
+    inherit pname version;
+    hash = "sha256-4GuI7+IjiF0nJd9Rz3ybe0Y9HG8E6knUaQh0MY0Ot6M=";
+  };
+
+  nativeBuildInputs = [
+    setuptools-git
+    sphinx
+  ];
+
+  propagatedBuildInputs = [
+    lxml
+  ];
+
+  pythonImportsCheck = [ "dbusdeviation" ];
+
+  meta = with lib; {
+    homepage = "https://tecnocode.co.uk/dbus-deviation/";
+    description = "A project for parsing D-Bus introspection XML and processing it in various ways";
+    license = licenses.lgpl21Plus;
+    maintainers = with maintainers; [ lilyinstarlight ];
+  };
+}

--- a/pkgs/development/python-modules/gst-python/default.nix
+++ b/pkgs/development/python-modules/gst-python/default.nix
@@ -14,7 +14,7 @@
 
 buildPythonPackage rec {
   pname = "gst-python";
-  version = "1.20.0";
+  version = "1.22.2";
 
   format = "other";
 
@@ -22,7 +22,7 @@ buildPythonPackage rec {
 
   src = fetchurl {
     url = "${meta.homepage}/src/gst-python/${pname}-${version}.tar.xz";
-    sha256 = "j2e9xWBrozYGxryJbonefc2M9PykWfcTibG2/gdbXlQ=";
+    hash = "sha256-vvKz2Czkvka3dbG7VjBcEAPuAbU1pTqC+f6JJJchU60=";
   };
 
   # Python 2.x is not supported.

--- a/pkgs/development/python-modules/wheezy-template/default.nix
+++ b/pkgs/development/python-modules/wheezy-template/default.nix
@@ -1,0 +1,23 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+}:
+
+buildPythonPackage rec {
+  pname = "wheezy.template";
+  version = "3.1.0";
+
+  src = fetchPypi {
+    inherit pname version;
+    hash = "sha256-4RAHysczaNzhKZjjS2bEdgFrtGFHH/weTVboQALslg8=";
+  };
+
+  pythonImportsCheck = [ "wheezy.template" ];
+
+  meta = with lib; {
+    homepage = "https://wheezytemplate.readthedocs.io/en/latest/";
+    description = "A lightweight template library";
+    license = licenses.mit;
+    maintainers = with maintainers; [ lilyinstarlight ];
+  };
+}

--- a/pkgs/development/tools/hotdoc/default.nix
+++ b/pkgs/development/tools/hotdoc/default.nix
@@ -1,0 +1,112 @@
+{ lib
+, buildPythonApplication
+, fetchPypi
+, pytestCheckHook
+, pkg-config
+, cmake
+, flex
+, glib
+, json-glib
+, libxml2
+, appdirs
+, dbus-deviation
+, faust-cchardet
+, feedgen
+, lxml
+, networkx
+, pkgconfig
+, pyyaml
+, schema
+, setuptools
+, toposort
+, wheezy-template
+, libclang
+, gst_all_1
+}:
+
+buildPythonApplication rec {
+  pname = "hotdoc";
+  version = "0.13.7";
+
+  src = fetchPypi {
+    inherit pname version;
+    hash = "sha256-ESOmWeLJSXLDKBPsMBGR0zPbJHEqg/fj0G3VjUfPAJg=";
+  };
+
+  nativeBuildInputs = [
+    pkg-config
+    cmake
+    flex
+  ];
+
+  buildInputs = [
+    glib
+    json-glib
+    libxml2.dev
+  ];
+
+  propagatedBuildInputs = [
+    appdirs
+    dbus-deviation
+    faust-cchardet
+    feedgen
+    lxml
+    networkx
+    pkgconfig
+    pyyaml
+    schema
+    setuptools  # for pkg_resources
+    toposort
+    wheezy-template
+  ];
+
+  nativeCheckInputs = [
+    pytestCheckHook
+  ];
+
+  # CMake is used to build CMARK, but the build system is still python
+  dontUseCmakeConfigure = true;
+
+  # Ensure C+GI+GST extensions are built and can be imported
+  pythonImportsCheck = [
+    "hotdoc.extensions.c.c_extension"
+    "hotdoc.extensions.gi.gi_extension"
+    "hotdoc.extensions.gst.gst_extension"
+  ];
+
+  # Run the tests by package instead of current dir
+  pytestFlagsArray = [ "--pyargs" "hotdoc" ];
+
+  disabledTests = [
+    # Test does not correctly handle path normalization for test comparison
+    "test_cli_overrides"
+  ];
+
+  # Hardcode libclang paths
+  postPatch = ''
+    substituteInPlace hotdoc/extensions/c/c_extension.py \
+      --replace "shutil.which('llvm-config')" 'True' \
+      --replace "subprocess.check_output(['llvm-config', '--version']).strip().decode()" '"${libclang.version}"' \
+      --replace "subprocess.check_output(['llvm-config', '--prefix']).strip().decode()" '"${libclang.lib}"' \
+      --replace "subprocess.check_output(['llvm-config', '--libdir']).strip().decode()" '"${libclang.lib}/lib"'
+  '';
+
+  # Make pytest run from a temp dir to have it pick up installed package for cmark
+  preCheck = ''
+    pushd $TMPDIR
+  '';
+  postCheck = ''
+    popd
+  '';
+
+  passthru.tests = {
+    inherit (gst_all_1) gstreamer gst-plugins-base;
+  };
+
+  meta = with lib; {
+    description = "The tastiest API documentation system";
+    homepage = "https://hotdoc.github.io/";
+    license = [ licenses.lgpl21Plus ];
+    maintainers = with maintainers; [ lilyinstarlight ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8416,6 +8416,8 @@ with pkgs;
 
   hostname-debian = callPackage ../tools/networking/hostname-debian { };
 
+  hotdoc = python3Packages.callPackage ../development/tools/hotdoc { };
+
   hotpatch = callPackage ../development/libraries/hotpatch { };
 
   hotspot = libsForQt5.callPackage ../development/tools/analysis/hotspot { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -12636,6 +12636,8 @@ self: super: with self; {
 
   wheel-inspect = callPackage ../development/python-modules/wheel-inspect { };
 
+  wheezy-template = callPackage ../development/python-modules/wheezy-template { };
+
   whichcraft = callPackage ../development/python-modules/whichcraft { };
 
   whirlpool-sixth-sense = callPackage ../development/python-modules/whirlpool-sixth-sense { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2320,6 +2320,8 @@ self: super: with self; {
 
   dbus-client-gen = callPackage ../development/python-modules/dbus-client-gen { };
 
+  dbus-deviation = callPackage ../development/python-modules/dbus-deviation { };
+
   dbus-fast = callPackage ../development/python-modules/dbus-fast { };
 
   dbus-next = callPackage ../development/python-modules/dbus-next { };


### PR DESCRIPTION
###### Description of changes

I was hoping this could make it into 23.05 so that we aren't stuck on stable with an old GStreamer release that won't receive any more fixes. I couldn't find a document describing GStreamer's support model, but they seem to generally make one final bug fix release after a new stable is available and this already occured in late February

If GStreamer 1.22 (which supposedly 1.x releases should be backwards-compatible according to the project, but I did not empirically test this) is not acceptable for 23.05, then I will submit another PR for 1.20.3 -> 1.20.6 and this PR can be marked draft and wait until after branch-off

@RaitoBezarius and @mweinelt, is this acceptable for 23.05?

Release notes: https://gstreamer.freedesktop.org/releases/1.22/

I additionally packaged hotdoc, but currently the generated .json files aren't actually copied to a devdoc output (and to turn those json files into usable documentation, we'd need to package gst-doc and provide those json files to it anyway). Adding it does mean that some helper libexecs for generating documentation are now included in the output, though, which can be helpful

Also if these packages are in need of more maintainers, I'm happy to add myself and ensure they stay relatively up-to-date and functional. Many plugins that do work now are still disabled (which I plan to re-evaluate soon) and there have been several bug fix bumps since the version we have packaged (which was released mid-last-year). Also I'm going to be maintaining gst_all_1.gst-plugins-rs already from #225143

###### Things done

- Built on platform(s)
  - [x] x86_64-linux (post-rebase on staging)
  - [x] aarch64-linux (pre-rebase on staging)
  - [x] x86_64-darwin (pre-rebase on staging)
  - [x] aarch64-darwin (pre-rebase on staging)
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).