### PR TITLE
OVMF: support RiscV64

### DIFF
--- a/pkgs/applications/virtualization/OVMF/0001-RiscVVirt-support-split-code-and-vars-binaries.patch
+++ b/pkgs/applications/virtualization/OVMF/0001-RiscVVirt-support-split-code-and-vars-binaries.patch
@@ -1,0 +1,115 @@
+From 6b73457af11c89ec097c1d589831db8c9175d901 Mon Sep 17 00:00:00 2001
+From: Raito Bezarius <masterancpp@gmail.com>
+Date: Sun, 16 Apr 2023 16:14:57 +0200
+Subject: [PATCH] RiscVVirt: support split code and vars binaries
+
+---
+ OvmfPkg/RiscVVirt/RiscVVirtQemu.fdf | 92 +++++++++++++++++++++++++++++
+ 1 file changed, 92 insertions(+)
+
+diff --git a/OvmfPkg/RiscVVirt/RiscVVirtQemu.fdf b/OvmfPkg/RiscVVirt/RiscVVirtQemu.fdf
+index 354c9271d1..4ab01fc5ca 100644
+--- a/OvmfPkg/RiscVVirt/RiscVVirtQemu.fdf
++++ b/OvmfPkg/RiscVVirt/RiscVVirtQemu.fdf
+@@ -24,6 +24,98 @@ gUefiOvmfPkgTokenSpaceGuid.PcdOvmfDxeMemFvBase|gUefiOvmfPkgTokenSpaceGuid.PcdOvm
+ FV = FVMAIN_COMPACT
+ 
+ !include VarStore.fdf.inc
++
++#
++# Build the variable store and the firmware code as separate flash device
++# images.
++#
++[FD.QEMU_EFI]
++BaseAddress   = $(CODE_BASE_ADDRESS)
++Size          = $(CODE_SIZE)
++ErasePolarity = 1
++BlockSize     = $(BLOCK_SIZE)
++NumBlocks     = $(CODE_BLOCKS)
++
++0x00000000|$(CODE_SIZE)
++gUefiOvmfPkgTokenSpaceGuid.PcdOvmfDxeMemFvBase|gUefiOvmfPkgTokenSpaceGuid.PcdOvmfDxeMemFvSize
++FV = FVMAIN_COMPACT
++
++[FD.QEMU_VARS]
++BaseAddress   = $(FW_BASE_ADDRESS)
++# Size          = $(VARS_SIZE)
++Size          = 0xc0000
++ErasePolarity = 1
++BlockSize     = 0x40000
++NumBlocks     = 3
++
++0x00000000|$(VARS_LIVE_SIZE)
++gEfiMdeModulePkgTokenSpaceGuid.PcdFlashNvStorageVariableBase|gEfiMdeModulePkgTokenSpaceGuid.PcdFlashNvStorageVariableSize
++#
++# NV_VARIABLE_STORE
++#
++DATA = {
++  ## This is the EFI_FIRMWARE_VOLUME_HEADER
++  # ZeroVector []
++  0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
++  0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
++  # FileSystemGuid: gEfiSystemNvDataFvGuid         =
++  #   { 0xFFF12B8D, 0x7696, 0x4C8B,
++  #     { 0xA9, 0x85, 0x27, 0x47, 0x07, 0x5B, 0x4F, 0x50 }}
++  0x8D, 0x2B, 0xF1, 0xFF, 0x96, 0x76, 0x8B, 0x4C,
++  0xA9, 0x85, 0x27, 0x47, 0x07, 0x5B, 0x4F, 0x50,
++  # FvLength: 0x20000
++  0x00, 0x00, 0x02, 0x00, 0x00, 0x00, 0x00, 0x00,
++  # Signature "_FVH"       # Attributes
++  0x5f, 0x46, 0x56, 0x48, 0xff, 0xfe, 0x04, 0x00,
++  # HeaderLength # CheckSum # ExtHeaderOffset #Reserved #Revision
++  0x48, 0x00, 0x39, 0xF1, 0x00, 0x00, 0x00, 0x02,
++  # Blockmap[0]: 0x20 Blocks * 0x1000 Bytes / Block
++  0x00, 0x08, 0x00, 0x00, 0x00, 0x10, 0x00, 0x00,
++  # Blockmap[1]: End
++  0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
++  ## This is the VARIABLE_STORE_HEADER
++!if $(SECURE_BOOT_ENABLE) == TRUE
++  # Signature: gEfiAuthenticatedVariableGuid =
++  #   { 0xaaf32c78, 0x947b, 0x439a,
++  #     { 0xa1, 0x80, 0x2e, 0x14, 0x4e, 0xc3, 0x77, 0x92 }}
++  0x78, 0x2c, 0xf3, 0xaa, 0x7b, 0x94, 0x9a, 0x43,
++  0xa1, 0x80, 0x2e, 0x14, 0x4e, 0xc3, 0x77, 0x92,
++!else
++  # Signature: gEfiVariableGuid =
++  #   { 0xddcf3616, 0x3275, 0x4164,
++  #     { 0x98, 0xb6, 0xfe, 0x85, 0x70, 0x7f, 0xfe, 0x7d }}
++  0x16, 0x36, 0xcf, 0xdd, 0x75, 0x32, 0x64, 0x41,
++  0x98, 0xb6, 0xfe, 0x85, 0x70, 0x7f, 0xfe, 0x7d,
++!endif
++  # Size: 0x40000 (gEfiMdeModulePkgTokenSpaceGuid.PcdFlashNvStorageVariableSize) -
++  #         0x48 (size of EFI_FIRMWARE_VOLUME_HEADER) = 0x3FFB8
++  # This can speed up the Variable Dispatch a bit.
++  0xB8, 0xFF, 0x03, 0x00,
++  # FORMATTED: 0x5A #HEALTHY: 0xFE #Reserved: UINT16 #Reserved1: UINT32
++  0x5A, 0xFE, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00
++}
++
++0x00040000|$(VARS_FTW_WORKING_SIZE)
++gEfiMdeModulePkgTokenSpaceGuid.PcdFlashNvStorageFtwWorkingBase|gEfiMdeModulePkgTokenSpaceGuid.PcdFlashNvStorageFtwWorkingSize
++#
++#NV_FTW_WROK
++#
++DATA = {
++  # EFI_FAULT_TOLERANT_WORKING_BLOCK_HEADER->Signature = gEdkiiWorkingBlockSignatureGuid         =
++  #  { 0x9e58292b, 0x7c68, 0x497d, { 0xa0, 0xce, 0x65,  0x0, 0xfd, 0x9f, 0x1b, 0x95 }}
++  0x2b, 0x29, 0x58, 0x9e, 0x68, 0x7c, 0x7d, 0x49,
++  0xa0, 0xce, 0x65,  0x0, 0xfd, 0x9f, 0x1b, 0x95,
++  # Crc:UINT32            #WorkingBlockValid:1, WorkingBlockInvalid:1, Reserved
++  0x2c, 0xaf, 0x2c, 0x64, 0xFE, 0xFF, 0xFF, 0xFF,
++  # WriteQueueSize: UINT64
++  0xE0, 0x0F, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00
++}
++
++0x00080000|$(VARS_FTW_SPARE_SIZE)
++gEfiMdeModulePkgTokenSpaceGuid.PcdFlashNvStorageFtwSpareBase|gEfiMdeModulePkgTokenSpaceGuid.PcdFlashNvStorageFtwSpareSize
++#
++#NV_FTW_SPARE
++
+ ################################################################################
+ 
+ [FV.DXEFV]
+-- 
+2.39.2
+

--- a/pkgs/development/compilers/edk2/default.nix
+++ b/pkgs/development/compilers/edk2/default.nix
@@ -36,7 +36,7 @@ buildType = if stdenv.isDarwin then
 
 edk2 = buildStdenv.mkDerivation {
   pname = "edk2";
-  version = "202211";
+  version = "202302";
 
   patches = [
     # pass targetPrefix as an env var
@@ -52,7 +52,7 @@ edk2 = buildStdenv.mkDerivation {
     repo = "edk2";
     rev = "edk2-stable${edk2.version}";
     fetchSubmodules = true;
-    sha256 = "sha256-0jE73xPyenAcgJ1mS35oTc5cYw7jJvVYxhPdhTWpKA0=";
+    hash = "sha256-KZ5bTdaStO2M1hLPx9LsUSMl9NEiZeYMmFiShxCJqJM=";
   };
 
   nativeBuildInputs = [ pythonEnv ];

--- a/pkgs/development/compilers/edk2/default.nix
+++ b/pkgs/development/compilers/edk2/default.nix
@@ -86,6 +86,7 @@ edk2 = buildStdenv.mkDerivation {
     homepage = "https://github.com/tianocore/tianocore.github.io/wiki/EDK-II/";
     license = licenses.bsd2;
     platforms = with platforms; aarch64 ++ arm ++ i686 ++ x86_64;
+    maintainers = [ maintainers.raitobezarius ];
   };
 
   passthru = {

--- a/pkgs/development/compilers/edk2/default.nix
+++ b/pkgs/development/compilers/edk2/default.nix
@@ -8,6 +8,7 @@
 , llvmPackages_9
 , lib
 , buildPackages
+, hostPlatform
 }:
 
 let
@@ -21,6 +22,8 @@ else if stdenv.isAarch32 then
   "ARM"
 else if stdenv.isAarch64 then
   "AARCH64"
+else if hostPlatform.isRiscV64 then
+  "RISCV64"
 else
   throw "Unsupported architecture";
 
@@ -85,7 +88,7 @@ edk2 = buildStdenv.mkDerivation {
     description = "Intel EFI development kit";
     homepage = "https://github.com/tianocore/tianocore.github.io/wiki/EDK-II/";
     license = licenses.bsd2;
-    platforms = with platforms; aarch64 ++ arm ++ i686 ++ x86_64;
+    platforms = with platforms; aarch64 ++ arm ++ i686 ++ x86_64 ++ riscv64;
     maintainers = [ maintainers.raitobezarius ];
   };
 


### PR DESCRIPTION
###### Description of changes

This brings the RISCV64 support to OVMF/EDK2.
Needs **cleanup** and I should dispatch some commits in other PRs to minimize this one.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
