### PR TITLE
dosbox-staging: pull upstream fixes for SDL2_net and SDL2_image headers

### DIFF
--- a/pkgs/applications/emulators/dosbox-staging/default.nix
+++ b/pkgs/applications/emulators/dosbox-staging/default.nix
@@ -1,6 +1,7 @@
 { lib
 , stdenv
 , fetchFromGitHub
+, fetchpatch
 , SDL2
 , SDL2_image
 , SDL2_net
@@ -39,6 +40,25 @@ stdenv.mkDerivation (self: {
     hash = "sha256-I90poBeLSq1c8PXyjrx7/UcbfqFNnnNiXfJdWhLPGMc=";
   };
 
+  patches = [
+    # Pull missind SDL2_net dependency:
+    #   https://github.com/dosbox-staging/dosbox-staging/pull/2358
+    (fetchpatch {
+      name = "sdl2-net.patch";
+      url = "https://github.com/dosbox-staging/dosbox-staging/commit/1b02f187a39263f4b0285323dcfe184bccd749c2.patch";
+      hash = "sha256-Ev97xApInu6r5wvI9Q7FhkSXqtMW/rwJj48fExvqnT0=";
+    })
+
+    # Pull missing SDL2_image dependency:
+    #   https://github.com/dosbox-staging/dosbox-staging/pull/2239
+    (fetchpatch {
+      name = "sdl2-image.patch";
+      url = "https://github.com/dosbox-staging/dosbox-staging/commit/ca8b7a906d29a3f8ce956c4af7dc829a6ac3e229.patch";
+      hash = "sha256-WtTVSWWSlfXrdPVsnlDe4P5K/Fnj4QsOzx3Wo/Kusmg=";
+      includes = [ "src/gui/meson.build" ];
+    })
+  ];
+
   nativeBuildInputs = [
     copyDesktopItems
     gtest
@@ -67,11 +87,6 @@ stdenv.mkDerivation (self: {
     SDL2_image
     SDL2_net
     speexdsp
-  ];
-
-  env.NIX_CFLAGS_COMPILE = toString [
-    "-I${SDL2_image}/include/SDL2"
-    "-I${SDL2_net}/include/SDL2"
   ];
 
   desktopItems = [


### PR DESCRIPTION
Without the change `dosbox-staging` fails to build as:

    FAILED: src/dos/libdos.a.p/program_serial.cpp.o
    g++ -Isrc/dos/libdos.a.p -Isrc/dos -I../src/dos -I../include -I. -I.. -Isrc/libs/ghc -I../src/libs/ghc -Isrc/libs/loguru -I../src/libs/loguru -I/nix/store/58cdrn1birpig59wqygva9cmsnxh7wwa-SDL2-2.26.4-dev/include -I/nix/store/58cdrn1birpig59wqygva9cmsnxh7wwa-SDL2-2.26.4-dev/include/SDL2 -I/nix/store/y8ab9wi9sldj6y7md833xkbppgimrs>
    In file included from ../src/dos/../hardware/serialport/softmodem.h:30,
                     from ../src/dos/program_serial.cpp:27:
    ../src/dos/../hardware/serialport/misc_util.h:59:10: fatal error: SDL_net.h: No such file or directory
       59 | #include <SDL_net.h>
          |          ^~~~~~~~~~~

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
