### PR TITLE
openjdk{8,11,17,19}: version bump for darwin

### DIFF
--- a/pkgs/applications/editors/vscode/extensions/default.nix
+++ b/pkgs/applications/editors/vscode/extensions/default.nix
@@ -3201,6 +3201,9 @@ let
     };
 
   aliases = super: {
+    _1Password = super."1Password";
+    _2gua = super."2gua";
+    _4ops = super."4ops";
     Arjun.swagger-viewer = super.arjun.swagger-viewer;
     jakebecker.elixir-ls = super.elixir-lsp.vscode-elixir-ls;
     jpoissonnier.vscode-styled-components = super.styled-components.vscode-styled-components;
@@ -3209,9 +3212,6 @@ let
     ms-vscode.PowerShell = super.ms-vscode.powershell;
     rioj7.commandOnAllFiles = super.rioj7.commandonallfiles;
     WakaTime.vscode-wakatime = super.wakatime.vscode-wakatime;
-    _1Password = throw ''_1Password has been replaced with "1Password"'';
-    _2gua = throw ''_2gua has been replaced with "2gua"'';
-    _4ops = throw ''_4ops has been replaced with "4ops"'';
   };
 
   # TODO: add overrides overlay, so that we can have a generated.nix

--- a/pkgs/development/compilers/openjdk/darwin/11.nix
+++ b/pkgs/development/compilers/openjdk/darwin/11.nix
@@ -11,20 +11,20 @@ let
   dist = {
     x86_64-darwin = {
       arch = "x64";
-      zuluVersion = "11.48.21";
-      jdkVersion = "11.0.11";
+      zuluVersion = "11.62.17";
+      jdkVersion = "11.0.18";
       sha256 =
-        if enableJavaFX then "18bd9cd66d6abc6f8c627bc70278dc8fd4860e138e1dc9e170eddb89727ccc7b"
-        else "0v0n7h7i04pvna41wpdq2k9qiy70sbbqzqzvazfdvgm3gb22asw6";
+        if enableJavaFX then "0s4ylx650kcd6kc03dmkrn7swmknwrlha21givr6yhbwasvynd32"
+        else "1qqlg3q5fkmhki48ylf6gh0lwwgqaj0bh9ph6v8x8r3h31j1c5xx";
     };
 
     aarch64-darwin = {
       arch = "aarch64";
-      zuluVersion = "11.48.21";
-      jdkVersion = "11.0.11";
+      zuluVersion = "11.62.17";
+      jdkVersion = "11.0.18";
       sha256 =
-        if enableJavaFX then "ef0de2705c6c2d586812f7f3736b70e22b069545b38034816016f9f264ad43f9"
-        else "066whglrxx81c95grv2kxdbvyh32728ixhml2v44ildh549n4lhc";
+        if enableJavaFX then "0mda5s5ydyjxglfknzjydjgs2zyv9gwbh5pi02rhy6y3vwmvkky1"
+        else "011pfxnyh1xnpp9qxhf7fy5ddfrb54d7fvjxrvgq1lgrhfpmcgra";
     };
   }."${stdenv.hostPlatform.system}";
 

--- a/pkgs/development/compilers/openjdk/darwin/17.nix
+++ b/pkgs/development/compilers/openjdk/darwin/17.nix
@@ -5,16 +5,16 @@ let
   dist = {
     x86_64-darwin = {
       arch = "x64";
-      zuluVersion = "17.34.19";
-      jdkVersion = "17.0.3";
-      sha256 = "sha256-qImyxVC2y2QhxuVZwamKPyo46+n+7ytIFXpYI0e6w2c=";
+      zuluVersion = "17.40.19";
+      jdkVersion = "17.0.6";
+      sha256 = "sha256-FxDIsvU9eHYMT0RuKRGaMvQK+wo4MPaMAtw3sReZq28=";
     };
 
     aarch64-darwin = {
       arch = "aarch64";
-      zuluVersion = "17.34.19";
-      jdkVersion = "17.0.3";
-      sha256 = "sha256-eaRX8Qa/Mqr9JhpHSEcf0Q9c4qmqLMgWqRhkEEwAjf8=";
+      zuluVersion = "17.40.19";
+      jdkVersion = "17.0.6";
+      sha256 = "sha256-917j+8F0TmYbphBYxMDDchf2/7JHEJh7ovvN+AGqRi4=";
     };
   }."${stdenv.hostPlatform.system}";
 

--- a/pkgs/development/compilers/openjdk/darwin/19.nix
+++ b/pkgs/development/compilers/openjdk/darwin/19.nix
@@ -5,16 +5,16 @@ let
   dist = {
     x86_64-darwin = {
       arch = "x64";
-      zuluVersion = "19.30.11";
-      jdkVersion = "19.0.1";
-      sha256 = "1h0qj0xgpxjy506ikbgdn74pi4860lsnh5n3q3bayfmn0pxc5ksn";
+      zuluVersion = "19.32.13";
+      jdkVersion = "19.0.2";
+      sha256 = "1h9ayv4zrqhqinljh6b75ng0yazm1dhmf3limaff6qxcx5d5f118";
     };
 
     aarch64-darwin = {
       arch = "aarch64";
-      zuluVersion = "19.30.11";
-      jdkVersion = "19.0.1";
-      sha256 = "0g8i371h5fv686xhiff0431sgvdk80lbp2lkz86jpfdv9lgg0qnk";
+      zuluVersion = "19.32.13";
+      jdkVersion = "19.0.2";
+      sha256 = "14b3zfr7i7hklgqh8419rrv66vy1rlcfpv7mbxxbwbwbjs6haz8p";
     };
   }."${stdenv.hostPlatform.system}";
 

--- a/pkgs/development/compilers/openjdk/darwin/8.nix
+++ b/pkgs/development/compilers/openjdk/darwin/8.nix
@@ -11,20 +11,20 @@ let
   dist = {
     x86_64-darwin = {
       arch = "x64";
-      zuluVersion = "8.54.0.21";
-      jdkVersion = "8.0.292";
+      zuluVersion = "8.68.0.21";
+      jdkVersion = "8.0.362";
       sha256 =
-        if enableJavaFX then "e671f8990229b1ca2a76faabb21ba2f1a9e1f7211392e0f657225559be9b05c8"
-        else "1pgl0bir4r5v349gkxk54k6v62w241q7vw4gjxhv2g6pfq6hv7in";
+        if enableJavaFX then "0kscvpkimxn3x8nq3vzwfni1g0dz0hr7n8s54d15vh7ajhfrizz6"
+        else "06gnpa9b909aafkhmra1bjw8sa4qsw3934px9nrkrwfbfsbhy84v";
     };
 
     aarch64-darwin = {
       arch = "aarch64";
-      zuluVersion = "8.54.0.21";
-      jdkVersion = "8.0.292";
+      zuluVersion = "8.68.0.21";
+      jdkVersion = "8.0.362";
       sha256 =
-        if enableJavaFX then "8e901075cde2c31f531a34e8321ea4201970936abf54240a232e9389952afe84"
-        else "05w89wfjlfbpqfjnv6wisxmaf13qb28b2223f9264jyx30qszw1c";
+        if enableJavaFX then "0y7hnfk1db2z8pxvrr6dakiy2w1g7dlknssk3zk4fp7lay6vdl3y"
+        else "0m1lflgv12sslafsn0vvjqdnx7d1gi9pgkxx26k4z9zvjiqklsgl";
     };
   }."${stdenv.hostPlatform.system}";
 

--- a/pkgs/development/python-modules/html5-parser/default.nix
+++ b/pkgs/development/python-modules/html5-parser/default.nix
@@ -1,28 +1,59 @@
-{ lib, buildPythonPackage, fetchPypi, pkgs, pkg-config, chardet, lxml, beautifulsoup4 }:
+{ lib
+, beautifulsoup4
+, buildPythonPackage
+, chardet
+, fetchFromGitHub
+, lxml
+, pkg-config
+, pkgs
+, pytestCheckHook
+, pythonOlder
+}:
 
 buildPythonPackage rec {
   pname = "html5-parser";
   version = "0.4.11";
-
   format = "setuptools";
 
-  src = fetchPypi {
-    inherit pname version;
-    sha256 = "sha256-hbsW+qPN88bGhC4Mss4CgHy678bjuw87jhjavlEHB2M=";
+  disabled = pythonOlder "3.7";
+
+  src = fetchFromGitHub {
+    owner = "kovidgoyal";
+    repo = pname;
+    rev = "refs/tags/v${version}";
+    hash = "sha256-l7cCt+zX+qOujS6noc1/p7mELqrHae3eiKQNXBxLm7o=";
   };
 
-  nativeBuildInputs = [ pkg-config ];
-  propagatedBuildInputs = [ chardet lxml pkgs.libxml2 ];
+  nativeBuildInputs = [
+    pkg-config
+  ];
 
-  nativeCheckInputs = [ beautifulsoup4 ];
+  buildInputs = [
+    pkgs.libxml2
+  ];
+
+  propagatedBuildInputs = [
+    chardet
+    lxml
+  ];
+
+  nativeCheckInputs = [
+    beautifulsoup4
+    pytestCheckHook
+  ];
 
   pythonImportsCheck = [
     "html5_parser"
+  ];
+
+  pytestFlagsArray = [
+    "test/*.py"
   ];
 
   meta = with lib; {
     description = "Fast C based HTML 5 parsing for python";
     homepage = "https://html5-parser.readthedocs.io";
     license = licenses.asl20;
+    maintainers = with maintainers; [ ];
   };
 }

--- a/pkgs/development/python-modules/html5-parser/default.nix
+++ b/pkgs/development/python-modules/html5-parser/default.nix
@@ -1,18 +1,24 @@
-{ lib, buildPythonPackage, fetchPypi, pkgs, pkg-config, chardet, lxml }:
+{ lib, buildPythonPackage, fetchPypi, pkgs, pkg-config, chardet, lxml, beautifulsoup4 }:
 
 buildPythonPackage rec {
   pname = "html5-parser";
-  version = "0.4.10";
+  version = "0.4.11";
+
+  format = "setuptools";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "f9294418c0da95c2d5facc19d3dc32941093a6b8e3b3e4b36cc7b5a1697fbca4";
+    sha256 = "sha256-hbsW+qPN88bGhC4Mss4CgHy678bjuw87jhjavlEHB2M=";
   };
 
   nativeBuildInputs = [ pkg-config ];
   propagatedBuildInputs = [ chardet lxml pkgs.libxml2 ];
 
-  doCheck = false; # No such file or directory: 'run_tests.py'
+  nativeCheckInputs = [ beautifulsoup4 ];
+
+  pythonImportsCheck = [
+    "html5_parser"
+  ];
 
   meta = with lib; {
     description = "Fast C based HTML 5 parsing for python";

--- a/pkgs/servers/openvscode-server/default.nix
+++ b/pkgs/servers/openvscode-server/default.nix
@@ -40,13 +40,13 @@ let
 
 in stdenv.mkDerivation rec {
   pname = "openvscode-server";
-  version = "1.76.2";
+  version = "1.77.1";
 
   src = fetchFromGitHub {
     owner = "gitpod-io";
     repo = "openvscode-server";
     rev = "openvscode-server-v${version}";
-    sha256 = "IZyuMcu3f0jOflJsor/gMDoONgyOGU8Py+wRbRV38RU=";
+    sha256 = "i1AexC4EmVi7xSjdCfYmMIUU+CgKT48o03n39XQ0nVY=";
   };
 
   yarnCache = stdenv.mkDerivation {
@@ -69,7 +69,7 @@ in stdenv.mkDerivation rec {
 
     outputHashMode = "recursive";
     outputHashAlgo = "sha256";
-    outputHash = "sha256-zcT74h1bEPPwHCXPB2VoVDVelQlDW6FBO/b6SP1x8b4=";
+    outputHash = "sha256-Ca2qd9Q88BNUIT9avq1KiMwKcKkMX/NkU2q8DjGYQjg=";
   };
 
   nativeBuildInputs = [


### PR DESCRIPTION
###### Description of changes

https://openjdk.org/groups/vulnerability/advisories/2023-01-17

Same version bump for linux was made in #214285, this PR bumps darwin packages.

###### Things done

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
