### PR TITLE
gst_all_1.gst-plugins-bad: remove gstmicrodns

### DIFF
--- a/pkgs/development/libraries/gstreamer/bad/default.nix
+++ b/pkgs/development/libraries/gstreamer/bad/default.nix
@@ -100,6 +100,8 @@
 , MediaToolbox
 , enableGplPlugins ? true
 , bluezSupport ? stdenv.isLinux
+# Causes every application using GstDeviceMonitor to send mDNS queries every 2 seconds
+, microdnsSupport ? false
 # Checks meson.is_cross_build(), so even canExecute isn't enough.
 , enableDocumentation ? stdenv.hostPlatform == stdenv.buildPlatform, hotdoc
 }:
@@ -151,7 +153,6 @@ stdenv.mkDerivation rec {
     #webrtc-audio-processing_1 # required by isac
     libbs2b
     libmodplug
-    libmicrodns
     openjpeg
     libopenmpt
     libopus
@@ -203,6 +204,8 @@ stdenv.mkDerivation rec {
     x265
   ] ++ lib.optionals bluezSupport [
     bluez
+  ] ++ lib.optionals microdnsSupport [
+    libmicrodns
   ] ++ lib.optionals stdenv.isLinux [
     libva # vaapi requires libva -> libdrm -> libpciaccess, which is Linux-only in nixpkgs
     wayland
@@ -286,6 +289,7 @@ stdenv.mkDerivation rec {
     "-Dgs=disabled" # depends on `google-cloud-cpp`
     "-Donnx=disabled" # depends on `libonnxruntime` not packaged in nixpkgs as of writing
     "-Dopenaptx=enabled" # since gstreamer-1.20.1 `libfreeaptx` is supported for circumventing the dubious license conflict with `libopenaptx`
+    "-Dmicrodns=${if microdnsSupport then "enabled" else "disabled"}"
     "-Dbluez=${if bluezSupport then "enabled" else "disabled"}"
     (lib.mesonEnable "doc" enableDocumentation)
   ]


### PR DESCRIPTION
###### Description of changes

This plugin causes every application which uses GstDeviceMonitor to emit an mDNS query for _rtsp._tcp.local every two seconds. The application can filter devices to exclude any devices found, but there does not seem to be a way for applications to opt out of sending these messages. See [1] and [2].

This plugin was apparently introduced by its author to be able to access local and networked cameras through a single API [3], I'm pretty sure that nixpkgs has no applications making use of it.

Remove it at least until it does not emit mDNS requests by default anymore.

[1] https://gitlab.freedesktop.org/gstreamer/gst-plugins-bad/-/merge_requests/721#note_253085
[2] https://gitlab.freedesktop.org/gstreamer/gst-plugins-bad/-/issues/1090
[3] https://gitlab.freedesktop.org/gstreamer/gst-plugins-bad/-/merge_requests/721#note_253104

Tested with Dino 0.4.2

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
