### PR TITLE
serial-studio: init at 1.1.7

### DIFF
--- a/pkgs/applications/misc/serial-studio/default.nix
+++ b/pkgs/applications/misc/serial-studio/default.nix
@@ -1,0 +1,26 @@
+{ lib, stdenv, fetchFromGitHub, qmake, qtquickcontrols2, qtserialport, qtsvg, wrapQtAppsHook }:
+
+stdenv.mkDerivation rec {
+  pname = "serial-studio";
+  version = "1.1.7";
+
+  src = fetchFromGitHub {
+    owner = "Serial-Studio";
+    repo = "Serial-Studio";
+    rev = "v${version}";
+    hash = "sha256-Tsd1PGB7cO8h3HDifOtB8jsnj+fS4a/o5nfLoohVLM4=";
+    fetchSubmodules = true;
+  };
+
+  nativeBuildInputs = [ qmake wrapQtAppsHook ];
+
+  buildInputs = [ qtquickcontrols2 qtserialport qtsvg ];
+
+  meta = with lib; {
+    description = "Multi-purpose serial data visualization & processing program";
+    homepage = "https://serial-studio.github.io/";
+    license = licenses.mit;
+    maintainers = with maintainers; [ sikmir ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -39760,6 +39760,8 @@ with pkgs;
 
   sequelpro = callPackage ../applications/misc/sequelpro { };
 
+  serial-studio = libsForQt5.callPackage ../applications/misc/serial-studio { };
+
   snowsql = callPackage ../applications/misc/snowsql { };
 
   snowmachine = python3Packages.callPackage ../applications/misc/snowmachine { };


### PR DESCRIPTION
###### Description of changes

https://serial-studio.github.io:
> Serial Studio allows you to easily display, process & export data from your embedded projects. The application is able to interact with serial ports, network sockets & MQTT brokers.

###### Things done
- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
