### PR TITLE
valgrind: Support NIX_DEBUG_INFO_DIRS

### DIFF
--- a/pkgs/development/tools/analysis/valgrind/Support-NIX_DEBUG_INFO_DIRS.patch
+++ b/pkgs/development/tools/analysis/valgrind/Support-NIX_DEBUG_INFO_DIRS.patch
@@ -1,0 +1,45 @@
+diff --git a/coregrind/m_debuginfo/readelf.c b/coregrind/m_debuginfo/readelf.c
+index ce7b7998d..a8f9273df 100644
+--- a/coregrind/m_debuginfo/readelf.c
++++ b/coregrind/m_debuginfo/readelf.c
+@@ -1514,17 +1514,30 @@ DiImage* find_debug_file( struct _DebugInfo* di,
+    DiImage* dimg      = NULL; /* the img that we found */
+    HChar*   debugpath = NULL; /* where we found it */
+ 
+-   if (buildid != NULL) {
+-      debugpath = ML_(dinfo_zalloc)("di.fdf.1",
+-                                    VG_(strlen)(buildid) + 33);
+-
+-      VG_(sprintf)(debugpath, "/usr/lib/debug/.build-id/%c%c/%s.debug",
+-                   buildid[0], buildid[1], buildid + 2);
++   HChar* debug_dirs_env = VG_(getenv)("NIX_DEBUG_INFO_DIRS");
++   const HChar* debug_dirs_path = debug_dirs_env == NULL ? "/usr/lib/debug" : debug_dirs_env;
++   HChar debug_dirs_path_mut[VG_(strlen)(debug_dirs_path) + 1]; /* copy for strtok_r */
++   VG_(strcpy) (debug_dirs_path_mut, debug_dirs_path);
++   HChar *ssaveptr;
++   HChar *debug_dir;
+ 
+-      dimg = open_debug_file(debugpath, buildid, 0, rel_ok, NULL);
+-      if (!dimg) {
+-         ML_(dinfo_free)(debugpath);
+-         debugpath = NULL;
++   if (buildid != NULL) {
++      for (debug_dir = VG_(strtok_r) (debug_dirs_path_mut, " ", &ssaveptr);
++           debug_dir != NULL;
++           debug_dir = VG_(strtok_r) (NULL, " ", &ssaveptr)) {
++         debugpath = ML_(dinfo_zalloc)("di.fdf.1",
++                                       VG_(strlen)(debug_dir) + VG_(strlen)(buildid) + 19);
++
++         VG_(sprintf)(debugpath, "%s/.build-id/%c%c/%s.debug",
++                      debug_dir, buildid[0], buildid[1], buildid + 2);
++
++         dimg = open_debug_file(debugpath, buildid, 0, rel_ok, NULL);
++         if (!dimg) {
++            ML_(dinfo_free)(debugpath);
++            debugpath = NULL;
++         } else {
++            break;
++         }
+       }
+    }
+ 

--- a/pkgs/development/tools/analysis/valgrind/default.nix
+++ b/pkgs/development/tools/analysis/valgrind/default.nix
@@ -40,6 +40,9 @@ stdenv.mkDerivation rec {
       url = "https://bugsfiles.kde.org/attachment.cgi?id=149174";
       sha256 = "sha256-f1YIFIhWhXYVw3/UNEWewDak2mvbAd3aGzK4B+wTlys=";
     })
+
+    # Support NIX_DEBUG_INFO_DIRS environment variable.
+    ./Support-NIX_DEBUG_INFO_DIRS.patch
   ];
 
   outputs = [ "out" "dev" "man" "doc" ];


### PR DESCRIPTION
###### Description of changes

This will allow valgrind to obtain line numbers from debug symbols installed using NixOS debug-info module and dwarffs.

Before:

```
==22== Invalid free() / delete / delete[] / realloc()
==22==    at 0x4844F6C: free (in /nix/store/p50fqa6fr8qs85qli3ba41bd4vnjmnnl-valgrind-3.20.0/libexec/valgrind/vgpreload_memcheck-amd64-linux.so)
==22==    by 0x40116A: main (4iv0pwvqkfa866n9vv9xxjbvwwfbhjg0-test.c:7)
==22==  Address 0x5018680 is 0 bytes inside a block of size 5 free'd
==22==    at 0x4844F6C: free (in /nix/store/p50fqa6fr8qs85qli3ba41bd4vnjmnnl-valgrind-3.20.0/libexec/valgrind/vgpreload_memcheck-amd64-linux.so)
==22==    by 0x40115E: main (4iv0pwvqkfa866n9vv9xxjbvwwfbhjg0-test.c:6)
==22==  Block was alloc'd at
==22==    at 0x484279B: malloc (in /nix/store/p50fqa6fr8qs85qli3ba41bd4vnjmnnl-valgrind-3.20.0/libexec/valgrind/vgpreload_memcheck-amd64-linux.so)
==22==    by 0x4B038B8: g_malloc (in /nix/store/pdg7ljsallvykhjwdh8193i2s4p3a4k4-glib-2.76.1/lib/libglib-2.0.so.0.7600.1)
==22==    by 0x40114E: main (4iv0pwvqkfa866n9vv9xxjbvwwfbhjg0-test.c:5)
```

After:

```
==22== Invalid free() / delete / delete[] / realloc()
==22==    at 0x4844F6C: free (in /nix/store/cpdihnwgb0bx7mh9q0h11m2xrl6mzcp1-valgrind-3.20.0/libexec/valgrind/vgpreload_memcheck-amd64-linux.so)
==22==    by 0x40116A: main (4iv0pwvqkfa866n9vv9xxjbvwwfbhjg0-test.c:7)
==22==  Address 0x5018680 is 0 bytes inside a block of size 5 free'd
==22==    at 0x4844F6C: free (in /nix/store/cpdihnwgb0bx7mh9q0h11m2xrl6mzcp1-valgrind-3.20.0/libexec/valgrind/vgpreload_memcheck-amd64-linux.so)
==22==    by 0x40115E: main (4iv0pwvqkfa866n9vv9xxjbvwwfbhjg0-test.c:6)
==22==  Block was alloc'd at
==22==    at 0x484279B: malloc (in /nix/store/cpdihnwgb0bx7mh9q0h11m2xrl6mzcp1-valgrind-3.20.0/libexec/valgrind/vgpreload_memcheck-amd64-linux.so)
==22==    by 0x4B038B8: g_malloc (gmem.c:130)
==22==    by 0x40114E: main (4iv0pwvqkfa866n9vv9xxjbvwwfbhjg0-test.c:5)
```

<details><summary>Example repro</summary>

```nix
with import <nixpkgs> { };
with pkgs;

let
  testSrc = writeText "test.c" ''
    #include <glib.h>

    int main(int argc, char const *argv[]) {
        char* foo = g_malloc(5);
        g_free(foo);
        g_free(foo);

        return 0;
    }
  '';
in
runCommand "gdk-pixbuf-loading-test" {
  nativeBuildInputs = [
    pkg-config
    gcc
    valgrind
  ];

  buildInputs = [
    glib
  ];

  env.NIX_DEBUG_INFO_DIRS = pkgs.lib.makeSearchPathOutput "debug" "lib/debug" (with pkgs; [
    glib
  ]);
} ''
  cc -ggdb \
    $(pkg-config --cflags glib-2.0) \
    $(pkg-config --libs glib-2.0) \
    ${testSrc} -o test

  mkdir -p $out
  mv test $out/test

  valgrind --leak-check=full --error-exitcode=1 $out/test
''
```
</details>

Previously done for libbacktrace: https://github.com/NixOS/nixpkgs/pull/207611

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
