### PR TITLE
swaylock-fprintd: init at unstable-20230130

### DIFF
--- a/pkgs/applications/window-managers/sway/lock-fprintd.nix
+++ b/pkgs/applications/window-managers/sway/lock-fprintd.nix
@@ -1,0 +1,80 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, meson
+, ninja
+, pkg-config
+, scdoc
+, wayland-scanner
+, wayland
+, wayland-protocols
+, libxkbcommon
+, cairo
+, gdk-pixbuf
+, pam
+, glib
+, dbus
+, fprintd
+, unstableGitUpdater
+}:
+
+stdenv.mkDerivation rec {
+  pname = "swaylock-fprintd";
+  version = "unstable-20230130";
+
+  src = fetchFromGitHub {
+    owner = "SL-RU";
+    repo = "swaylock-fprintd";
+    rev = "ffd639a785df0b9f39e9a4d77b7c0d7ba0b8ef79";
+    hash = "sha256-2VklrbolUV00djPt+ngUyU+YMnJLAHhD+CLZD1wH4ww=";
+  };
+
+  postPatch = ''
+    substituteInPlace fingerprint/meson.build --replace \
+      '/usr/share/dbus-1/interfaces/net.reactivated.Fprint' \
+      '${fprintd}/share/dbus-1/interfaces/net.reactivated.Fprint'
+  '';
+
+  strictDeps = true;
+  depsBuildBuild = [ pkg-config ];
+  nativeBuildInputs = [
+    pkg-config
+    glib
+    meson
+    ninja
+    pkg-config
+    scdoc
+    wayland-scanner
+  ];
+  buildInputs = [
+    wayland
+    wayland-protocols
+    libxkbcommon
+    cairo
+    gdk-pixbuf
+    pam
+    dbus
+  ];
+
+  mesonFlags = [
+    "-Dpam=enabled" "-Dgdk-pixbuf=enabled" "-Dman-pages=enabled"
+  ];
+
+  passthru.updateScript = unstableGitUpdater {};
+
+  meta = with lib; {
+    description = "Screen locker for Wayland with fingerprint support via fprintd";
+    longDescription = ''
+      swaylock-fprintd is a fork of swaylock, a screen locking utility for Wayland compositors,
+      with fingerprint support via fprintd. It is compatible with any Wayland compositor which
+      implements the ext-session-lock-v1 Wayland protocol.
+      Important note: If you don't use the Sway module (programs.sway.enable)
+      you need to set "security.pam.services.swaylock = {};" manually.
+    '';
+    inherit (src.meta) homepage;
+    license = licenses.mit;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ lilyinstarlight sebtm ];
+    mainProgram = "swaylock";
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -31265,6 +31265,7 @@ with pkgs;
   swayidle = callPackage ../applications/window-managers/sway/idle.nix { };
   swaylock = callPackage ../applications/window-managers/sway/lock.nix { };
   swayosd = callPackage ../applications/window-managers/sway/osd.nix { };
+  swaylock-fprintd = callPackage ../applications/window-managers/sway/lock-fprintd.nix { };
   swayws = callPackage ../applications/window-managers/sway/ws.nix { };
   swaywsr = callPackage ../applications/window-managers/sway/wsr.nix { };
   sway-contrib = recurseIntoAttrs (callPackages ../applications/window-managers/sway/contrib.nix { });


### PR DESCRIPTION
###### Description of changes

For now init the fork with proper fprintd-dbus support but I haven't fully given up for a potential merge: https://github.com/swaywm/swaylock/pull/283#issuecomment-1510372328

I could also make it more generic and combine it with swaylock but I was unsure about this bigger refactoring so feel free to discuss ✌🏻 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
