### PR TITLE
publii: init at 0.42.0

### DIFF
--- a/pkgs/development/web/publii/default.nix
+++ b/pkgs/development/web/publii/default.nix
@@ -1,0 +1,102 @@
+{ stdenv
+, lib
+, fetchurl
+, autoPatchelfHook
+, makeShellWrapper
+, wrapGAppsHook
+, alsa-lib
+, at-spi2-atk
+, at-spi2-core
+, atk
+, cairo
+, cups
+, dbus
+, expat
+, glib
+, gtk3
+, libsecret
+, mesa
+, nss
+, pango
+, udev
+, xdg-utils
+, xorg
+}:
+
+stdenv.mkDerivation rec {
+  pname = "publii";
+  version = "0.42.1";
+
+  src = fetchurl {
+    url = "https://getpublii.com/download/Publii-${version}.deb";
+    hash = "sha256-GHGXu/z2L4aJG1O1THPIxnRBdPJOIVuQsZP0zhjTZlo=";
+  };
+
+  dontConfigure = true;
+  dontBuild = true;
+  dontWrapGApps = true;
+
+  nativeBuildInputs = [
+    autoPatchelfHook
+    makeShellWrapper
+    wrapGAppsHook
+  ];
+
+  buildInputs = [
+    alsa-lib
+    at-spi2-atk
+    at-spi2-core
+    atk
+    cairo
+    cups
+    dbus
+    expat
+    glib
+    gtk3
+    libsecret
+    mesa
+    nss
+    pango
+    xorg.libX11
+    xorg.libxcb
+  ];
+
+  unpackPhase = ''
+    ar p $src data.tar.xz | tar xJ
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/bin
+
+    mv usr/share $out
+    substituteInPlace $out/share/applications/Publii.desktop \
+      --replace 'Exec=/opt/Publii/Publii' 'Exec=Publii'
+
+    mv opt $out
+
+    runHook postInstall
+  '';
+
+  preFixup = ''
+    makeWrapper $out/opt/Publii/Publii $out/bin/Publii \
+      "''${gappsWrapperArgs[@]}" \
+      --suffix PATH : ${lib.makeBinPath [ xdg-utils ]} \
+      --prefix LD_LIBRARY_PATH : ${lib.makeLibraryPath [ udev ]}
+  '';
+
+  meta = with lib; {
+    description = "Static Site CMS with GUI to build privacy-focused SEO-friendly website.";
+    longDescription = ''
+      Creating a website doesn't have to be complicated or expensive. With Publii, the most
+      intuitive static site CMS, you can create a beautiful, safe, and privacy-friendly website
+      quickly and easily; perfect for anyone who wants a fast, secure website in a flash.
+    '';
+    homepage = "https://getpublii.com";
+    changelog = "https://github.com/getpublii/publii/releases/tag/v${version}";
+    license = licenses.gpl3Only;
+    maintainers = with lib.maintainers; [ urandom sebtm ];
+    platforms = [ "x86_64-linux" ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -17330,6 +17330,8 @@ with pkgs;
 
   protege-distribution = callPackage ../development/web/protege-distribution { };
 
+  publii = callPackage ../development/web/publii {};
+
   umr = callPackage ../development/misc/umr {
     llvmPackages = llvmPackages_latest;
   };


### PR DESCRIPTION
###### Description of changes

Init Publii at 0.42.0 - still some errors when launched from CLI (sway/wayland) but overall useable created a test-project and published (after import) existing site to gitlab without issues. Preview/Opening browser works as well - partial based on https://github.com/urandom2/nixpkgs/commit/6ea789fcc8ea1cda05c1545ba3227e2dc240f99a but figured out the error by adding udev in wrapper.

Solves #193461

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
