### PR TITLE
teams-for-linux: 1.0.59 -> 1.0.65

### DIFF
--- a/pkgs/applications/networking/instant-messengers/teams-for-linux/default.nix
+++ b/pkgs/applications/networking/instant-messengers/teams-for-linux/default.nix
@@ -30,6 +30,11 @@ stdenv.mkDerivation rec {
     sha256 = "sha256-3zjmVIPQ+F2jPQ2xkAv5hQUjr8k5jIHTsa73J+IMayw=";
   };
 
+  patches = [
+    # Can be removed once Electron upstream resolves https://github.com/electron/electron/issues/36660
+    ./screensharing-wayland-hack-fix.patch
+  ];
+
   nativeBuildInputs = [ yarn fixup_yarn_lock nodejs copyDesktopItems makeWrapper ];
 
   configurePhase = ''

--- a/pkgs/applications/networking/instant-messengers/teams-for-linux/default.nix
+++ b/pkgs/applications/networking/instant-messengers/teams-for-linux/default.nix
@@ -16,13 +16,13 @@
 
 stdenv.mkDerivation rec {
   pname = "teams-for-linux";
-  version = "1.0.59";
+  version = "1.0.65";
 
   src = fetchFromGitHub {
     owner = "IsmaelMartinez";
     repo = pname;
     rev = "v${version}";
-    sha256 = "sha256-82uRZEktKHMQhozG5Zpa2DFu1VZOEDBWpsbfgMzoXY8=";
+    sha256 = "sha256-Rj6A1h5R4w8zacoTV0WKTbTD67qwsw4zHP+KQ6h7/gs=";
   };
 
   offlineCache = fetchYarnDeps {

--- a/pkgs/applications/networking/instant-messengers/teams-for-linux/screensharing-wayland-hack-fix.patch
+++ b/pkgs/applications/networking/instant-messengers/teams-for-linux/screensharing-wayland-hack-fix.patch
@@ -1,0 +1,28 @@
+diff --git a/app/index.js b/app/index.js
+index 20ccf43..b251f62 100644
+--- a/app/index.js
++++ b/app/index.js
+@@ -1,4 +1,4 @@
+-const { app, ipcMain, desktopCapturer, systemPreferences, powerMonitor } = require('electron');
++const { app, ipcMain, desktopCapturer, nativeImage, systemPreferences, powerMonitor } = require('electron');
+ const path = require('path');
+ const { LucidLog } = require('lucid-log');
+ const isDev = require('electron-is-dev');
+@@ -93,7 +93,16 @@ if (!gotTheLock) {
+ 	ipcMain.handle('getSystemIdleState', handleGetSystemIdleState);
+ 	ipcMain.handle('getZoomLevel', handleGetZoomLevel);
+ 	ipcMain.handle('saveZoomLevel', handleSaveZoomLevel);
+-	ipcMain.handle('desktopCapturerGetSources', (event, opts) => desktopCapturer.getSources(opts));
++	ipcMain.handle('desktopCapturerGetSources', (event, opts) => process.env.XDG_SESSION_TYPE == 'wayland' ?
++		// Port wayland electron 22+ screenshare "fix" from webcord
++		Promise.resolve([{
++			id: "screen:1:0",
++			appIcon: nativeImage.createEmpty(),
++			display_id: "",
++			name: "Entire Screen",
++			thumbnail: nativeImage.createEmpty()
++		}])
++		: desktopCapturer.getSources(opts));
+ 	ipcMain.on('play-notification-sound', playNotificationSound);
+ }
+ 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -33935,9 +33935,7 @@ with pkgs;
 
   teams = callPackage ../applications/networking/instant-messengers/teams { };
 
-  teams-for-linux = callPackage ../applications/networking/instant-messengers/teams-for-linux {
-    electron = electron_21;
-  };
+  teams-for-linux = callPackage ../applications/networking/instant-messengers/teams-for-linux { };
 
   teamspeak_client = libsForQt5.callPackage ../applications/networking/instant-messengers/teamspeak/client.nix { };
   teamspeak5_client = callPackage ../applications/networking/instant-messengers/teamspeak/client5.nix { };


### PR DESCRIPTION
###### Description of changes

Another minor bump with release notes at https://github.com/ismaelmartinez/teams-for-linux/releases. It's mostly just small features like better screen lock inhibitor, presence, and spellcheck language option from text box context menu

This also upgrades back to `electron` (currently v24) instead of `electron_21` (which is now marked insecure). To get around the screensharing issue with newer versions of Electron (upstream issue: https://github.com/electron/electron/issues/36660), I've ported a hacky patch from WebCord (https://github.com/SpacingBat3/WebCord/commit/f26e95bf17281d82a25bee82a4805136bd3f042b) to teams-for-linux

The screensharing patch does work, but wow do I hate this patch so much 🙃

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).