### PR TITLE
libxisf: init at 0.2.3

### DIFF
--- a/pkgs/development/libraries/science/astronomy/libxisf/default.nix
+++ b/pkgs/development/libraries/science/astronomy/libxisf/default.nix
@@ -1,0 +1,47 @@
+{ lib
+, stdenv
+, fetchFromGitea
+, cmake
+, pkg-config
+, lz4
+, pugixml
+, zlib
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "libxisf";
+  version = "0.2.3";
+
+  src = fetchFromGitea {
+    domain = "gitea.nouspiro.space";
+    owner = "nou";
+    repo = "libXISF";
+    rev = "v${finalAttrs.version}";
+    hash = "sha256-u5EYnRO2rUV8ofLL9qfACeVvVbWXEXpkqh2Q4OOxpaQ=";
+  };
+
+  nativeBuildInputs = [
+    cmake
+    pkg-config
+  ];
+
+  cmakeFlags = [
+    "-DUSE_BUNDLED_LIBS=OFF"
+  ] ++ lib.optional stdenv.hostPlatform.isStatic "-DBUILD_SHARED_LIBS=OFF";
+
+  buildInputs = [
+    lz4
+    pugixml
+    zlib
+  ];
+
+  doCheck = true;
+
+  meta = with lib; {
+    description = "Library to load and write XISF format from PixInsight";
+    homepage = "https://gitea.nouspiro.space/nou/libXISF";
+    license = licenses.gpl3Plus;
+    maintainers = with maintainers; [ panicgh ];
+    platforms = platforms.linux;
+  };
+})

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -22342,6 +22342,8 @@ with pkgs;
 
   libxdg_basedir = callPackage ../development/libraries/libxdg-basedir { };
 
+  libxisf = callPackage ../development/libraries/science/astronomy/libxisf { };
+
   libxkbcommon = libxkbcommon_8;
   libxkbcommon_8 = callPackage ../development/libraries/libxkbcommon { };
   libxkbcommon_7 = callPackage ../development/libraries/libxkbcommon/libxkbcommon_7.nix { };


### PR DESCRIPTION
###### Description of changes

https://gitea.nouspiro.space/nou/libXISF

LibXISF is C++ library that can read and write XISF files produced by [PixInsight](https://pixinsight.com/). It implement [XISF 1.0 specification](https://pixinsight.com/doc/docs/XISF-1.0-spec/XISF-1.0-spec.html). It is licensed under GPLv3 or later.

XISF is an alternative to the FITS format popular in astronomy, see https://pixinsight.com/xisf/.

It can be used e.g. in the `indilib` package.

###### Things done

- Built on platform(s)
  - [X] x86_64-linux
  - [X] x86_64-linux static (`pkgsStatic.libxisf`)
  - [X] i686-linux (`pkgsi686Linux.libxisf`)
  - [X] aarch64-linux (`pkgsCross.aarch64-multiplatform.libxisf`)
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
