### PR TITLE
deepin.deepin-terminal: 5.9.40 -> 6.0.5

### DIFF
--- a/pkgs/desktops/deepin/apps/deepin-terminal/default.nix
+++ b/pkgs/desktops/deepin/apps/deepin-terminal/default.nix
@@ -17,27 +17,18 @@
 , libsecret
 , chrpath
 , lxqt
-, gtest
 }:
 
 stdenv.mkDerivation rec {
   pname = "deepin-terminal";
-  version = "5.9.40";
+  version = "6.0.5";
 
   src = fetchFromGitHub {
     owner = "linuxdeepin";
     repo = pname;
     rev = version;
-    sha256 = "sha256-GtrbR59IUYNAOmioW5NYhDsPKBmK4uybyDjHsbelkE4=";
+    sha256 = "sha256-pRTdvR3hyiJVpi38Ex58X74ns+rSWuytsOXemvdW1Rk=";
   };
-
-  patches = [
-    (fetchpatch {
-      name = "chore-use-GNUInstallDirs-in-CmakeLists.patch";
-      url = "https://github.com/linuxdeepin/deepin-terminal/commit/b18a2ca8411f09f5573aa2a8403a484b693ec975.patch";
-      sha256 = "sha256-Qy8Jg+7BfZr8tQEsCAzhMEwf6rU96gkgup5f9bMMELY=";
-    })
-  ];
 
   cmakeFlags = [ "-DVERSION=${version}" ];
 
@@ -50,17 +41,16 @@ stdenv.mkDerivation rec {
   ];
 
   buildInputs = [
+    qt5integration
+    qt5platform-plugins
     qtbase
     qtsvg
     dtkwidget
-    qt5integration
-    qt5platform-plugins
     dde-qt-dbus-factory
     qtx11extras
     at-spi2-core
     libsecret
     chrpath
-    gtest
   ];
 
   strictDeps = true;


### PR DESCRIPTION
###### Description of changes

Don't need gtest now,  only when CMAKE_BUILD_TYPE=Debug will enable unit testing

https://github.com/linuxdeepin/deepin-terminal/blob/master/CMakeLists.txt#L284-L286

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
