### PR TITLE
pulsar: 1.103.0 -> 1.104.0

### DIFF
--- a/pkgs/applications/editors/pulsar/update.mjs
+++ b/pkgs/applications/editors/pulsar/update.mjs
@@ -4,15 +4,13 @@
 */
 
 import { promises as fs } from 'node:fs';
-import { promisify } from 'node:util';
-import { exec as _exec } from 'node:child_process';
-const exec = promisify(_exec);
 
 const constants = {
     githubUrl: "https://api.github.com/repos/pulsar-edit/pulsar/releases",
     sha256FileURL: (newVersion) => `https://github.com/pulsar-edit/pulsar/releases/download/v${newVersion}/SHA256SUMS.txt`,
     x86_64FileName: (newVersion) => `Linux.pulsar-${newVersion}.tar.gz`,
     aarch64FileName: (newVersion) => `ARM.Linux.pulsar-${newVersion}-arm64.tar.gz`,
+    targetFile: new URL("default.nix", import.meta.url).pathname,
 };
 
 async function getLatestVersion() {
@@ -69,10 +67,10 @@ async function updateFile(newVersion, sha256Sums, currentFile) {
     newFile = newFile.replace(/x86_64-linux\.hash = "(.*)";/, `x86_64-linux.hash = "${sha256Sums.x86_64}";`);
     newFile = newFile.replace(/aarch64-linux\.hash = "(.*)";/, `aarch64-linux.hash = "${sha256Sums.aarch64}";`);
 
-    await fs.writeFile('default.nix', newFile);
+    await fs.writeFile(constants.targetFile, newFile);
 };
 
-let currentFile = await fs.readFile('default.nix', 'utf8');
+let currentFile = await fs.readFile(constants.targetFile, 'utf8');
 let currentVersion = currentFile.match(/version = "(.*)";/)[1];
 const newVersion = await getLatestVersion();
 if (currentVersion === newVersion) {


### PR DESCRIPTION
List of changes in the build:
- Updates to release [1.104.0](https://github.com/pulsar-edit/pulsar/releases/tag/v1.104.0)
- Set the `pname` to small caps (fixes #225755)
- Unpacks/repacks the app.asar bundle to patch binaries for the missing libstdc++.so.6
  - Fixes non-starting Pulsar encountered on non NixOS devices
  - This requires adding asar (and Python3) as dependencies
- Removes the unused imports in the update script
- Made the update script CWD-independant

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
