### PR TITLE
chayang: init at 0.1.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -11674,6 +11674,12 @@
     githubId = 38578268;
     name = "Morgan Wolfe";
   };
+  mxkrsv = {
+    email = "mxkrsv@disroot.org";
+    github = "mxkrsv";
+    githubId = 59313755;
+    name = "Maxim Karasev";
+  };
   myaats = {
     email = "mats@mats.sh";
     github = "Myaats";

--- a/pkgs/tools/wayland/chayang/default.nix
+++ b/pkgs/tools/wayland/chayang/default.nix
@@ -1,0 +1,52 @@
+{ lib
+, stdenv
+, fetchFromSourcehut
+, meson
+, ninja
+, pkg-config
+, wayland-scanner
+, wayland-protocols
+, wayland
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "chayang";
+  version = "0.1.0";
+
+  src = fetchFromSourcehut {
+    owner = "~emersion";
+    repo = "chayang";
+    rev = "v${finalAttrs.version}";
+    hash = "sha256-3Vu9/Bu2WQe2Yx/2BK25pEpuPNwX6g3qoFUMznCFHeI=";
+  };
+
+  strictDeps = true;
+
+  pkgsBuildBuild = [
+    pkg-config
+  ];
+
+  nativeBuildInputs = [
+    meson
+    ninja
+    pkg-config
+    wayland-scanner
+  ];
+
+  buildInputs = [
+    wayland-protocols
+    wayland
+  ];
+
+  meta = with lib; {
+    description = "Gradually dim the screen on Wayland";
+    homepage = "https://git.sr.ht/~emersion/chayang/";
+    license = licenses.mit;
+    longDescription = ''
+      Gradually dim the screen on Wayland.
+      Can be used to implement a grace period before locking the session.
+    '';
+    maintainers = with maintainers; [ mxkrsv ];
+    platforms = platforms.linux;
+  };
+})

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4584,6 +4584,8 @@ with pkgs;
     inherit (darwin.apple_sdk.frameworks) Foundation;
   };
 
+  chayang = callPackage ../tools/wayland/chayang { };
+
   cherrytree = callPackage ../applications/misc/cherrytree { };
 
   chntpw = callPackage ../tools/security/chntpw { };


### PR DESCRIPTION
###### Description of changes

A simple program for Wayland compositors written in C that gradually dims the screen.

Very useful for screen locking scripts to give user some time to abort entering the locked state.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
