### PR TITLE
androidStudioPackages.stable: 2022.1.1.20 -> 2022.2.1.18

### DIFF
--- a/pkgs/applications/editors/android-studio/default.nix
+++ b/pkgs/applications/editors/android-studio/default.nix
@@ -14,8 +14,8 @@ let
     sha256Hash = "sha256-zdhSxEmbX3QC30Tfxp6MpBj/yaaEyqs0BHR2/SyyTvw=";
   };
   betaVersion = {
-    version = "2022.3.1.11"; # "Android Studio Giraffe (2022.3.1) Canary 11"
-    sha256Hash = "sha256-hQ0t7EbM22Ah8zL6jllzj1HY/9nktk4xliTyGOqqgS4=";
+    version = "2022.3.1.12"; # "Android Studio Giraffe (2022.3.1) Beta 1"
+    sha256Hash = "sha256-Wy5iifscL1Ko7ZInx/uAvyJyM4cS6LfTYWxdJbZk6po=";
   };
   latestVersion = betaVersion;
 in {

--- a/pkgs/applications/editors/android-studio/default.nix
+++ b/pkgs/applications/editors/android-studio/default.nix
@@ -10,17 +10,14 @@ let
     inherit tiling_wm;
   };
   stableVersion = {
-    version = "2022.1.1.20"; # "Android Studio Electric Eel (2022.1.1) Patch 1"
-    sha256Hash = "sha256-UX7aOpTM23S7NBPNAz/fKEyK/dqWpok0NnpX9wck6p4=";
+    version = "2022.2.1.18"; # "Android Studio Flamingo (2022.2.1)"
+    sha256Hash = "sha256-zdhSxEmbX3QC30Tfxp6MpBj/yaaEyqs0BHR2/SyyTvw=";
   };
   betaVersion = {
-    version = "2022.2.1.12"; # "Android Studio Flamingo (2022.2.1) Beta 1"
-    sha256Hash = "tIgmX9KiRInIupgIXWgg4dMf8bTwkVopOxAO5O1PUAc=";
+    version = "2022.3.1.11"; # "Android Studio Giraffe (2022.3.1) Canary 11"
+    sha256Hash = "sha256-hQ0t7EbM22Ah8zL6jllzj1HY/9nktk4xliTyGOqqgS4=";
   };
-  latestVersion = { # canary & dev
-    version = "2022.3.1.1"; # "Android Studio Girrafe (2022.3.1) Canary 1"
-    sha256Hash = "I7Zc4DDByUB6XOnk7v+91ccpNI7eX/T4d3vH60ih8ec=";
-  };
+  latestVersion = betaVersion;
 in {
   # Attributes are named by their corresponding release channels
 


### PR DESCRIPTION
###### Description of changes

Android Studio 2022.2.1 Flamingo is now in the stable channel. This means Giraffe moves from the Canary to the Beta channel (see https://developer.android.com/studio/preview/features), and that the Canary channel is temporarily "empty", reflected in the fact that this commit changes latestVersion to equal betaVersion. This pull request also updates the Giraffe build to 11.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

