### PR TITLE
lsd2dsl: 0.5.4 -> 0.5.6

### DIFF
--- a/pkgs/applications/misc/lsd2dsl/default.nix
+++ b/pkgs/applications/misc/lsd2dsl/default.nix
@@ -1,21 +1,45 @@
-{ lib, stdenv, mkDerivation, fetchFromGitHub
-, makeDesktopItem, copyDesktopItems, cmake
-, boost, libvorbis, libsndfile, minizip, gtest, qtwebkit }:
+{ lib
+, stdenv
+, fetchFromGitHub
+, cmake
+, copyDesktopItems
+, boost
+, gtest
+, libvorbis
+, libsndfile
+, minizip
+, withGUI ? true
+, qtwebengine ? null
+, wrapQtAppsHook ? null
+, makeDesktopItem
+}:
 
-mkDerivation rec {
+assert withGUI -> qtwebengine != null && wrapQtAppsHook != null;
+
+stdenv.mkDerivation rec {
   pname = "lsd2dsl";
-  version = "0.5.4";
+  version = "0.5.6";
 
   src = fetchFromGitHub {
     owner = "nongeneric";
     repo = pname;
     rev = "v${version}";
-    sha256 = "sha256-PLgfsVVrNBTxI4J0ukEOFRoBkbmB55/sLNn5KyiHeAc=";
+    hash = "sha256-lzw4WwCguPVStdf2gbphPVqBABfALSCrv/RasbKHhkI=";
   };
 
-  nativeBuildInputs = [ cmake ] ++ lib.optional stdenv.isLinux copyDesktopItems;
+  nativeBuildInputs = [ cmake ]
+    ++ lib.optional stdenv.isLinux copyDesktopItems
+    ++ lib.optional withGUI wrapQtAppsHook;
 
-  buildInputs = [ boost libvorbis libsndfile minizip gtest qtwebkit ];
+  buildInputs = [
+    boost
+    libvorbis
+    libsndfile
+    minizip
+    gtest
+  ] ++ lib.optional withGUI qtwebengine;
+
+  dontWrapQtApps = true;
 
   env.NIX_CFLAGS_COMPILE = "-Wno-error=unused-result -Wno-error=missing-braces";
 
@@ -34,10 +58,8 @@ mkDerivation rec {
 
   meta = with lib; {
     homepage = "https://rcebits.com/lsd2dsl/";
-    description = "Lingvo dictionaries decompiler";
-    longDescription = ''
-      A decompiler for ABBYY Lingvo’s proprietary dictionaries.
-    '';
+    downloadPage = "https://github.com/nongeneric/lsd2dsl/releases";
+    description = "Decompiler for ABBYY Lingvo’s and Duden proprietary dictionaries";
     license = licenses.mit;
     maintainers = with maintainers; [ sikmir ];
     platforms = platforms.unix;


### PR DESCRIPTION
###### Description of changes

- Update from version 0.5.4 to 0.5.6
- Remove Qt's mkDerivation in favour of stdenv.mkDerivation to fix https://github.com/NixOS/nixpkgs/issues/180841
- Replace deprecated qtwebkit with qtwebengine to fix https://github.com/NixOS/nixpkgs/issues/53079
  This relies on this issue with lsd2dsl to be fixed:
  https://github.com/nongeneric/lsd2dsl/issues/20
  As long as this is not done, these changes will not build. That's why I marked this PR as a draft.
  The optional withGUI can of course only be used, if lsd2dsl's developer implements making building the GUI optional, which was suggested in the mentioned issue.
- Refactor to current nixpkgs recommendations

Ping @sikmir as a maintainer. What do you think?

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
