### PR TITLE
realvnc-vnc-viewer: 6.22.515 -> 7.1.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -11506,6 +11506,12 @@
     githubId = 1538622;
     name = "Michael Reilly";
   };
+  onedragon = {
+    name = "YiLong Liu";
+    email = "18922251299@163.com";
+    github = "jackyliu16";
+    githubId = 50787361;
+  };
   onixie = {
     email = "onixie@gmail.com";
     github = "onixie";

--- a/pkgs/tools/admin/realvnc-vnc-viewer/default.nix
+++ b/pkgs/tools/admin/realvnc-vnc-viewer/default.nix
@@ -1,22 +1,25 @@
-{ lib, stdenv, fetchurl, autoPatchelfHook, rpmextract, libX11, libXext }:
+{ lib
+, stdenv
+, fetchurl
+, autoPatchelfHook
+, rpmextract
+, libX11
+, libXext
+}:
 
 stdenv.mkDerivation rec {
   pname = "realvnc-vnc-viewer";
-  version = "6.22.515";
+  version = "7.1.0";
 
   src = {
     "x86_64-linux" = fetchurl {
-      url = "https://www.realvnc.com/download/file/viewer.files/VNC-Viewer-${version}-Linux-x64.rpm";
-      sha256 = "1l9kfmb1695pv2v9hm8z5yr7y5yhadbbs61s4yf9ksvvfypzwrpn";
-    };
-    "i686-linux" = fetchurl {
-      url = "https://www.realvnc.com/download/file/viewer.files/VNC-Viewer-${version}-Linux-x86.rpm";
-      sha256 = "15fi1siwbsxmy7qi6f8r8ym346a8mx3kqcp9mvwvx39wm3ija6dh";
+      url = "https://downloads.realvnc.com/download/file/viewer.files/VNC-Viewer-${version}-Linux-x64.rpm";
+      sha256 = "sha256-Mn4K2HICK7owHcXH85IJUncnpPZ56zNybkHZNiqYkHY=";
     };
   }.${stdenv.system} or (throw "Unsupported system: ${stdenv.hostPlatform.system}");
 
   nativeBuildInputs = [ autoPatchelfHook rpmextract ];
-  buildInputs = [ libX11 libXext ];
+  buildInputs = [ libX11 libXext stdenv.cc.cc.libgcc or null ];
 
   unpackPhase = ''
     rpmextract $src
@@ -47,7 +50,7 @@ stdenv.mkDerivation rec {
       url = "https://static.realvnc.com/media/documents/LICENSE-4.0a_en.pdf";
       free = false;
     };
-    maintainers = with maintainers; [ emilytrau ];
-    platforms = [ "x86_64-linux" "i686-linux" ];
+    maintainers = with maintainers; [ emilytrau onedragon ];
+    platforms = [ "x86_64-linux" ];
   };
 }


### PR DESCRIPTION
###### Description of changes
update realvnc-vnc-viewer version from 6.22.515 -> 7.1.0
adding build Inputs rely on https://github.com/NixOS/nixpkgs/issues/225963 

###### Things done
- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [x] (Package updates) Added a release notes entry if the change is major or breaking
  - [x] (Module updates) Added a release notes entry if the change is significant
  - [x] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).