### PR TITLE
Add two missing `ocamlPackages.cohttp-*` packages

### DIFF
--- a/pkgs/development/ocaml-modules/cohttp/lwt-jsoo.nix
+++ b/pkgs/development/ocaml-modules/cohttp/lwt-jsoo.nix
@@ -1,0 +1,31 @@
+{ lib, buildDunePackage
+, cohttp, cohttp-lwt, logs, lwt, js_of_ocaml, js_of_ocaml-ppx, js_of_ocaml-lwt
+, nodejs, lwt_ppx
+}:
+
+buildDunePackage {
+  pname = "cohttp-lwt-jsoo";
+  inherit (cohttp-lwt) version src;
+
+  duneVersion = "3";
+
+  propagatedBuildInputs = [
+    cohttp
+    cohttp-lwt
+    logs
+    lwt
+    js_of_ocaml
+    js_of_ocaml-ppx
+    js_of_ocaml-lwt
+  ];
+
+  doCheck = true;
+  checkInputs = [
+    nodejs
+    lwt_ppx
+  ];
+
+  meta = cohttp-lwt.meta // {
+    description = "CoHTTP implementation for the Js_of_ocaml JavaScript compiler";
+  };
+}

--- a/pkgs/development/ocaml-modules/cohttp/top.nix
+++ b/pkgs/development/ocaml-modules/cohttp/top.nix
@@ -1,0 +1,16 @@
+{ lib, buildDunePackage, cohttp }:
+
+buildDunePackage {
+  pname = "cohttp-top";
+  inherit (cohttp) version src;
+
+  duneVersion = "3";
+
+  propagatedBuildInputs = [ cohttp ];
+
+  doCheck = true;
+
+  meta = cohttp.meta // {
+    description = "CoHTTP toplevel pretty printers for HTTP types";
+  };
+}

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -215,6 +215,8 @@ let
 
     cohttp-mirage = callPackage ../development/ocaml-modules/cohttp/mirage.nix { };
 
+    cohttp-top = callPackage ../development/ocaml-modules/cohttp/top.nix { };
+
     coin =  callPackage ../development/ocaml-modules/coin { };
 
     color = callPackage ../development/ocaml-modules/color { };

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -209,6 +209,8 @@ let
 
     cohttp-lwt = callPackage ../development/ocaml-modules/cohttp/lwt.nix { };
 
+    cohttp-lwt-jsoo = callPackage ../development/ocaml-modules/cohttp/lwt-jsoo.nix { };
+
     cohttp-lwt-unix = callPackage ../development/ocaml-modules/cohttp/lwt-unix.nix { };
 
     cohttp-mirage = callPackage ../development/ocaml-modules/cohttp/mirage.nix { };


### PR DESCRIPTION
###### Description of changes

As of 5.1.0, [cohttp](https://github.com/mirage/ocaml-cohttp/tree/v5.1.0/) contains two packages that are not in nixpkgs, namely `cohttp-lwt-jsoo` and `cohttp-top`. This PR adds the two packages in question. Three notes:

1. This PR builds on top of #226657. Changes to `pkgs/development/ocaml-modules/cohttp/default.nix` should therefore be discussed there instead. I did this to avoid a situation where (a) we test bumping the version on one hand and (b) we test adding the two packages on the other hand, but we don't (c) test adding the two packages with the bumped version, where (a) and (b) would be fine but (c) wouldn't. The two packages in question already exist in version 5.0.0 of cohttp, though, so if my reasoning isn't the best I could also make this PR independent.

2. By inheriting metadata from `cohttp` and `cohttp-lwt`, I am effectively making you, @vbgl, maintainer of these two new packages. I thought it was odd for me to put myself as maintainer of these two when you were already handling the rest, but this solution is also a bit odd. WDYT?

3. The current `master` branch of `cohttp` includes yet another set of new packages that will probably land in cohttp 6.0.0, namely:

   - `cohttp-bench`
   - `cohttp-curl`
   - `cohttp-curl-async`
   - `cohttp-curl-lwt`
   - `cohttp-eio`
   - `cohttp-server-lwt-unix`
   - `http`


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [X] x86_64-darwin
  - [X] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).