### PR TITLE
frei0r: 1.7.0 -> 1.8.0, and fix/add cudaSupport

### DIFF
--- a/pkgs/development/libraries/frei0r/default.nix
+++ b/pkgs/development/libraries/frei0r/default.nix
@@ -7,8 +7,8 @@
 , opencv
 , pcre
 , pkg-config
-, cudaSupport ? (config.cudaSupport or false)
-, cudaPackages ? { }
+, cudaSupport ? config.cudaSupport or false
+, cudaPackages
 }:
 
 stdenv.mkDerivation rec {

--- a/pkgs/development/libraries/frei0r/default.nix
+++ b/pkgs/development/libraries/frei0r/default.nix
@@ -1,4 +1,16 @@
-{ lib, stdenv, fetchurl, cairo, cmake, opencv, pcre, pkg-config }:
+{ lib
+, config
+, stdenv
+, fetchurl
+, cairo
+, cmake
+, opencv
+, pcre
+, pkg-config
+, cudaSupport ? (config.cudaSupport or false)
+, cudaPackages ? { }
+}:
+
 stdenv.mkDerivation rec {
   pname = "frei0r-plugins";
   version = "1.8.0";
@@ -9,7 +21,14 @@ stdenv.mkDerivation rec {
   };
 
   nativeBuildInputs = [ cmake pkg-config ];
-  buildInputs = [ cairo opencv pcre ];
+  buildInputs = [
+    cairo
+    opencv
+    pcre
+  ] ++ lib.optionals cudaSupport [
+    cudaPackages.cuda_cudart
+    cudaPackages.cuda_nvcc
+  ];
 
   postInstall = lib.optionalString stdenv.hostPlatform.isDarwin ''
     for f in $out/lib/frei0r-1/*.so* ; do

--- a/pkgs/development/libraries/frei0r/default.nix
+++ b/pkgs/development/libraries/frei0r/default.nix
@@ -1,23 +1,12 @@
-{ lib, stdenv, fetchurl, fetchpatch, cairo, cmake, opencv, pcre, pkg-config }:
-
+{ lib, stdenv, fetchurl, cairo, cmake, opencv, pcre, pkg-config }:
 stdenv.mkDerivation rec {
   pname = "frei0r-plugins";
-  version = "1.7.0";
+  version = "1.8.0";
 
   src = fetchurl {
     url = "https://files.dyne.org/frei0r/releases/${pname}-${version}.tar.gz";
-    hash = "sha256-Gx/48Pm8I+7XJOlOmnwdjwJEv+M0JLtP5o5kYMCIUjo=";
+    hash = "sha256-RaKGVcrwVyJ7RCuADKOJnpNJBRXIHiEtIZ/fSnYT9cQ=";
   };
-
-  # A PR to add support for OpenCV 4 was merged in May 2020. This
-  # patch can be removed when a release beyond 1.7.0 is issued.
-  patches = [
-    (fetchpatch {
-      name = "opencv4-support.patch";
-      url = "https://github.com/dyne/frei0r/commit/c0c8eed79fc8abe6c9881a53d7391efb526a3064.patch";
-      sha256 = "sha256-qxUAui4EEBEj8M/SoyMUkj//KegMTTT6FTBDC/Chxz4=";
-    })
-  ];
 
   nativeBuildInputs = [ cmake pkg-config ];
   buildInputs = [ cairo opencv pcre ];
@@ -31,9 +20,8 @@ stdenv.mkDerivation rec {
   meta = with lib; {
     homepage = "https://frei0r.dyne.org";
     description = "Minimalist, cross-platform, shared video plugins";
-    license = licenses.gpl2;
+    license = licenses.gpl2Plus;
     maintainers = [ maintainers.goibhniu ];
     platforms = platforms.linux ++ platforms.darwin;
-
   };
 }


### PR DESCRIPTION
###### Description of changes

Fixes #226374

This updates frei0r to 1.8.0 and fixes building with `config.cudaSupport = true`, that update to 1.8.0 alone triggers a few rebuilds, see `nixpgks-review`:

Result of `nixpkgs-review` run on x86_64-linux [1](https://github.com/Mic92/nixpkgs-review)
<details>
  <summary>1 package marked as broken and skipped:</summary>
  <ul>
    <li>obs-studio-plugins.obs-hyperion</li>
  </ul>
</details>
<details>
  <summary>7 packages failed to build:</summary>
  <ul>
    <li>audiobookshelf</li>
    <li>manim</li>
    <li>obs-studio-plugins.obs-ndi</li>
    <li>pixinsight</li>
    <li>python310Packages.dm-sonnet</li>
    <li>python310Packages.tensorflow-datasets</li>
    <li>tone</li>
  </ul>
</details>
<details>
  <summary>62 packages built:</summary>
  <ul>
    <li>MIDIVisualizer</li>
    <li>arcanPackages.all-wrapped</li>
    <li>arcanPackages.arcan</li>
    <li>arcanPackages.arcan-wrapped</li>
    <li>arcanPackages.cat9-wrapped</li>
    <li>arcanPackages.durden-wrapped</li>
    <li>arcanPackages.ffmpeg</li>
    <li>arcanPackages.pipeworld-wrapped</li>
    <li>arcanPackages.prio-wrapped</li>
    <li>arcanPackages.xarcan</li>
    <li>corrscope</li>
    <li>ffcast</li>
    <li>ffmpeg_4-full</li>
    <li>ffmpeg_6-full</li>
    <li>flowblade</li>
    <li>frei0r</li>
    <li>handbrake</li>
    <li>haruna</li>
    <li>hikounomizu</li>
    <li>imagination</li>
    <li>jellyfin</li>
    <li>jellyfin-ffmpeg</li>
    <li>libsForQt5.kdenlive</li>
    <li>libsForQt5.mlt</li>
    <li>libsForQt5.soundkonverter</li>
    <li>liquidsoap</li>
    <li>mlt</li>
    <li>obs-studio</li>
    <li>obs-studio-plugins.advanced-scene-switcher</li>
    <li>obs-studio-plugins.droidcam-obs</li>
    <li>obs-studio-plugins.input-overlay</li>
    <li>obs-studio-plugins.looking-glass-obs</li>
    <li>obs-studio-plugins.obs-backgroundremoval</li>
    <li>obs-studio-plugins.obs-gstreamer</li>
    <li>obs-studio-plugins.obs-livesplit-one</li>
    <li>obs-studio-plugins.obs-move-transition</li>
    <li>obs-studio-plugins.obs-multi-rtmp</li>
    <li>obs-studio-plugins.obs-nvfbc</li>
    <li>obs-studio-plugins.obs-pipewire-audio-capture</li>
    <li>obs-studio-plugins.obs-source-record</li>
    <li>obs-studio-plugins.obs-vaapi</li>
    <li>obs-studio-plugins.obs-vkcapture</li>
    <li>obs-studio-plugins.wlrobs</li>
    <li>ocamlPackages.frei0r</li>
    <li>olive-editor</li>
    <li>peek</li>
    <li>printrun</li>
    <li>python310Packages.mlt</li>
    <li>python310Packages.moderngl-window</li>
    <li>python310Packages.pydub</li>
    <li>python310Packages.pyglet</li>
    <li>python310Packages.pytmx</li>
    <li>python311Packages.mlt</li>
    <li>python311Packages.moderngl-window</li>
    <li>python311Packages.pydub</li>
    <li>python311Packages.pyglet</li>
    <li>python311Packages.pytmx</li>
    <li>restream</li>
    <li>shotcut</li>
    <li>sunshine</li>
    <li>synfigstudio</li>
    <li>video-trimmer</li>
  </ul>
</details>

The relevant output for the failed builds doesn't seem to be related to this change:

<details>
  <summary>Log excerpt of failing packages</summary>

```
error: builder for '/nix/store/n04w7wl62g4mnvv1wcf735pi92pmxxwy-Install_NDI_SDK_v5_Linux.tar.gz.drv' failed with exit code 1;
       last 10 log lines:
       >
       >   https://ndi.tv/sdk/
       >
       > Once you have downloaded the file, please use the following command and
       > re-run the installation:
       >
       >   $ nix-prefetch-url file://$PWD/Install_NDI_SDK_v5_Linux.tar.gz
       >
       > ***
       >
       For full logs, run 'nix log /nix/store/n04w7wl62g4mnvv1wcf735pi92pmxxwy-Install_NDI_SDK_v5_Linux.tar.gz.drv'.
error: 1 dependencies of derivation '/nix/store/awin4niaza38sl0rb7j317b80wgki7fv-ndi-5.5.2.drv' failed to build
error: builder for '/nix/store/66ss7336hxlmfj8bxnskxzpg16fm40g2-python3.10-tensorflow-datasets-4.8.2.drv' failed with exit code 1;
       last 10 log lines:
       > Processing ./tensorflow_datasets-4.8.2+nightly-py3-none-any.whl
       > Requirement already satisfied: etils[enp,epath]>=0.9.0 in /nix/store/3znsyrry5z8rj6lzaffyyyrnlq9dgknk-python3.10-etils-1.1.0/lib/python3.10/site-packages (from tensorflow-datasets==4.8.2+nightly) (1.1.0)
       > Requirement already satisfied: wrapt in /nix/store/fldmgs8bxrbx98zf7vgqnm56w2k47dyl-python3.10-wrapt-1.14.1/lib/python3.10/site-packages (from tensorflow-datasets==4.8.2+nightly) (1.14.1)
       > Requirement already satisfied: click in /nix/store/c424f8r8i3n7zyd11vzg59yw0d5xf0vn-python3.10-click-8.1.3/lib/python3.10/site-packages (from tensorflow-datasets==4.8.2+nightly) (8.1.3)
       > Requirement already satisfied: toml in /nix/store/fk607z2x9v64g38hy02x3i4byizaj645-python3.10-toml-0.10.2/lib/python3.10/site-packages (from tensorflow-datasets==4.8.2+nightly) (0.10.2)
       > Requirement already satisfied: dill in /nix/store/qrhxh40c2cg581bcvpx3c83pb9d0mc0n-python3.10-dill-0.3.6/lib/python3.10/site-packages (from tensorflow-datasets==4.8.2+nightly) (0.3.6)
       > Requirement already satisfied: numpy in /nix/store/khm35qfxp63pvps6hy9lpg80r7p7h5w4-python3.10-numpy-1.24.2/lib/python3.10/site-packages (from tensorflow-datasets==4.8.2+nightly) (1.24.2)
       > ERROR: Could not find a version that satisfies the requirement psutil (from tensorflow-datasets) (from versions: none)
       > ERROR: No matching distribution found for psutil
       > 
       For full logs, run 'nix log /nix/store/66ss7336hxlmfj8bxnskxzpg16fm40g2-python3.10-tensorflow-datasets-4.8.2.drv'.
error: 1 dependencies of derivation '/nix/store/bysgwshcfqg7b9bryg16a15byncqaf3r-python3.10-dm-sonnet-2.0.0.drv' failed to build
error: builder for '/nix/store/07cr4p3zb4w2bss02kv46dydji7rcka0-manim-0.16.0.post0.drv' failed with exit code 1;
       last 10 log lines:
       > Requirement already satisfied: srt<4.0.0,>=3.5.0 in /nix/store/nd44gk9fm1yray5vwbx3p8mb5whx9lrd-python3.10-srt-3.5.3/lib/python3.10/site-packages (from manim==0.16.0.post0) (3.5.3)
       > Requirement already satisfied: manimpango<0.5.0,>=0.4.0.post0 in /nix/store/0qdvjxf30v76w244wjknbpvpfav23d61-python3.10-manimpango-0.4.3/lib/python3.10/site-packages (from manim==0.16.0.post0) (0.4.3)
       > Requirement already satisfied: cloup in /nix/store/y780286n1n5kww1ra7ppha35q4a97yc3-python3.10-cloup-2.0.0.post1/lib/python3.10/site-packages (from manim==0.16.0.post0) (2.0.0.post1)
       > Requirement already satisfied: rich!=12.0.0,>=6.0 in /nix/store/0h540aw30gaksmfa15v9p4a7n0f79gay-python3.10-rich-13.3.1/lib/python3.10/site-packages (from manim==0.16.0.post0) (13.3.1)
       > Requirement already satisfied: numpy<2.0,>=1.19 in /nix/store/khm35qfxp63pvps6hy9lpg80r7p7h5w4-python3.10-numpy-1.24.2/lib/python3.10/site-packages (from manim==0.16.0.post0) (1.24.2)
       > Requirement already satisfied: tqdm<5.0.0,>=4.62.3 in /nix/store/w1fn2fckw1z6kq68qlhrp9v0m1hcwim7-python3.10-tqdm-4.64.1/lib/python3.10/site-packages (from manim==0.16.0.post0) (4.64.1)
       > Requirement already satisfied: Pillow<10.0,>=9.1 in /nix/store/73a1dapyrngbi11rarfw73q73xdnqlxs-python3.10-pillow-9.4.0/lib/python3.10/site-packages (from manim==0.16.0.post0) (9.4.0)
       > ERROR: Could not find a version that satisfies the requirement networkx<3.0,>=2.5 (from manim) (from versions: none)
       > ERROR: No matching distribution found for networkx<3.0,>=2.5
       > 
       For full logs, run 'nix log /nix/store/07cr4p3zb4w2bss02kv46dydji7rcka0-manim-0.16.0.post0.drv'.
error: builder for '/nix/store/ha4x0k4r5aqijvn4xii8kqks1qgxi569-PI-linux-x64-1.8.9-1-20220518-c.tar.xz.drv' failed with exit code 1;
       last 10 log lines:
       >
       > ***
       > PixInsight is available from https://pixinsight.com/ and requires a commercial (or trial) license.
       > After a license has been obtained, PixInsight can be downloaded from the software distribution
       > (choose Linux 64bit).
       > The PixInsight tarball must be added to the nix-store, i.e. via
       >   nix-prefetch-url --type sha256 file:///path/to/PI-linux-x64-1.8.9-1-20220518-c.tar.xz
       >
       > ***
       >
       For full logs, run 'nix log /nix/store/ha4x0k4r5aqijvn4xii8kqks1qgxi569-PI-linux-x64-1.8.9-1-20220518-c.tar.xz.drv'.
error: 1 dependencies of derivation '/nix/store/v15d23yv6v6zg591hwhkg2gsacic4098-pixinsight-1.8.9-1.drv' failed to build
error: 1 dependencies of derivation '/nix/store/my5zqyxsqlab9l20jg15jnhw2jz9c4va-obs-ndi-4.10.0.drv' failed to build
error: builder for '/nix/store/mx7qpxiyvxb9c80139andsxv4id3xi51-tone-0.1.5.drv' failed with exit code 1;
       last 10 log lines:
       > unpacking sources
       > unpacking source archive /nix/store/ywgpqyqzzaxysmm5sfiwp6ad06y5sh16-source
       > source root is source
       > patching sources
       > configuring
       > Executing dotnetConfigureHook
       >   Determining projects to restore...
       > /build/source/tone/tone.csproj : error NU1102: Unable to find package Microsoft.NETCore.App.Crossgen2.linux-x64 with version (= 6.0.16)
       > /build/source/tone/tone.csproj : error NU1102:   - Found 1 version(s) in nugetSource [ Nearest version: 6.0.15 ]
       >   Failed to restore /build/source/tone/tone.csproj (in 1.12 sec).
       For full logs, run 'nix log /nix/store/mx7qpxiyvxb9c80139andsxv4id3xi51-tone-0.1.5.drv'.
error: 1 dependencies of derivation '/nix/store/g6df9idkl97cvi6z3c67bpklr2c734mp-audiobookshelf-2.2.18.drv' failed to build
warning: error: SQLite database '/nix/var/nix/db/db.sqlite' is busy
error: 7 dependencies of derivation '/nix/store/3nf3i59wx9ijaycxg0aazxk11gcbfr9b-env.drv' failed to build
error: 1 dependencies of derivation '/nix/store/p3i70sljvq3qg0m3b0nr4jaa0rviq893-review-shell.drv' failed to build
```
</details>

I'm not sure if it makes sense to split the update (1.7.0 -> 1.8.0) out of this into it's own PR since the CUDA fix alone shouldn't trigger the rebuild of all these packages and/or target `staging` instead (because of the amount of rebuilds)?

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
