### PR TITLE
ocamlPackages.slug: init at 1.0.1

### DIFF
--- a/pkgs/development/ocaml-modules/slug/default.nix
+++ b/pkgs/development/ocaml-modules/slug/default.nix
@@ -1,0 +1,34 @@
+{ lib, fetchFromGitHub, buildDunePackage
+, re, uunf, uuseg
+, alcotest
+}:
+
+buildDunePackage rec {
+  pname = "slug";
+  version = "1.0.1";
+
+  duneVersion = "3";
+
+  src = fetchFromGitHub {
+    owner = "thangngoc89";
+    repo = "ocaml-slug";
+    rev = version;
+    sha256 = "sha256-pIk/0asSyibXbwmBSBuLwl2SS9aw6dNDDvwO+1VJGf8=";
+  };
+
+  propagatedBuildInputs = [
+    re
+    uunf
+    uuseg
+  ];
+
+  doCheck = true;
+  checkInputs = [ alcotest ];
+
+  meta = {
+    description = "Url safe slug generator for OCaml";
+    license = lib.licenses.mit;
+    maintainers = [ lib.maintainers.niols ];
+    homepage = "https://github.com/thangngoc89/ocaml-slug";
+  };
+}

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -1496,6 +1496,8 @@ let
 
     simple-diff = callPackage ../development/ocaml-modules/simple-diff { };
 
+    slug = callPackage ../development/ocaml-modules/slug {  };
+
     sodium = callPackage ../development/ocaml-modules/sodium { };
 
     sosa = callPackage ../development/ocaml-modules/sosa { };


### PR DESCRIPTION
###### Description of changes

Add an OCaml package for [slug](https://github.com/thangngoc89/ocaml-slug), an URL-safe slug generator for OCaml.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [X] x86_64-darwin
  - [X] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
