### PR TITLE
libnvme: fix cross

### DIFF
--- a/pkgs/os-specific/linux/libnvme/default.nix
+++ b/pkgs/os-specific/linux/libnvme/default.nix
@@ -37,7 +37,7 @@ stdenv.mkDerivation rec {
     ninja
     perl # for kernel-doc
     pkg-config
-    python3
+    python3.pythonForBuild
     swig
   ];
 
@@ -46,6 +46,7 @@ stdenv.mkDerivation rec {
     json_c
     openssl
     systemd
+    python3
   ];
 
   mesonFlags = [


### PR DESCRIPTION
without this, pkgsCross.armv7l-hf-multiplatform.libnvme fails to build with

```
[93/811] Compiling C object libnvme/_nvme.cpython-310-x86_64-linux-gnu.so.p/meson-generated_.._nvme_wrap.c.o FAILED: libnvme/_nvme.cpython-310-x86_64-linux-gnu.so.p/meson-generated_.._nvme_wrap.c.o armv7l-unknown-linux-gnueabihf-gcc -Ilibnvme/_nvme.cpython-310-x86_64-linux-gnu.so.p -Ilibnvme -I../libnvme -I. -I.. -Iccan -I../ccan -Isrc -I../src -Iinternal -I../internal -I/nix/store/fg4hibxylq2lhfc2xx2asaih8c02c77m-json-c-armv7l-unknown-linux-gnueabihf-0.16-dev/include -I/nix/store/fg4hibxylq2lhfc2xx2asaih8c02c77m-json-c-armv7l-unknown-linux-gnueabihf-0.16-dev/include/json-c -I/nix/store/fdqpyj613dr0v1l1lrzqhzay7sk4xg87-python3-3.10.10/include/python3.10 -fvisibility=hidden -fdiagnostics-color=always -D_FILE_OFFSET_BITS=64 -Wall -Winvalid-pch -std=gnu99 -fomit-frame-pointer -D_GNU_SOURCE -include internal/config.h -fPIC -MD -MQ libnvme/_nvme.cpython-310-x86_64-linux-gnu.so.p/meson-generated_.._nvme_wrap.c.o -MF libnvme/_nvme.cpython-310-x86_64-linux-gnu.so.p/meson-generated_.._nvme_wrap.c.o.d -o libnvme/_nvme.cpython-310-x86_64-linux-gnu.so.p/meson-generated_.._nvme_wrap.c.o -c libnvme/nvme_wrap.c In file included from /nix/store/fdqpyj613dr0v1l1lrzqhzay7sk4xg87-python3-3.10.10/include/python3.10/Python.h:50,
                 from libnvme/nvme_wrap.c:149:
/nix/store/fdqpyj613dr0v1l1lrzqhzay7sk4xg87-python3-3.10.10/include/python3.10/pyport.h:746:2: error: #error "LONG_BIT definition appears wrong for platform (bad gcc/glibc config?)."
  746 | #error "LONG_BIT definition appears wrong for platform (bad gcc/glibc config?)."
      |  ^~~~~
```

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
