### PR TITLE
whatsapp-emoji-linux: init at 2.22.8.79-1

### DIFF
--- a/pkgs/data/fonts/whatsapp-emoji/default.nix
+++ b/pkgs/data/fonts/whatsapp-emoji/default.nix
@@ -1,0 +1,46 @@
+{ stdenvNoCC
+, lib
+, fetchFromGitHub
+, imagemagick
+, nix-update-script
+, pngquant
+, python3Packages
+, which
+, zopfli
+}:
+
+stdenvNoCC.mkDerivation rec {
+  pname = "whatsapp-emoji-linux";
+  version = "2.22.8.79-1";
+
+  src = fetchFromGitHub {
+    rev = "refs/tags/${version}";
+    owner = "dmlls";
+    repo = "whatsapp-emoji-linux";
+    hash = "sha256-AYdyNZYskBNT3v2wl+M0BAYi5piwmrVIDfucSZ3nfTE=";
+  };
+
+  makeFlags = [
+    "PREFIX=$(out)"
+  ];
+
+  enableParallelBuilding = true;
+
+  nativeBuildInputs = [
+    imagemagick
+    pngquant
+    python3Packages.nototools
+    which
+    zopfli
+  ];
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "WhatsApp Emoji for GNU/Linux";
+    homepage = "https://github.com/dmlls/whatsapp-emoji-linux";
+    maintainers = [ lib.maintainers.lucasew ];
+    sourceProvenance = [ lib.sourceTypes.fromSource ];
+    license = lib.licenses.unfree;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -28637,6 +28637,8 @@ with pkgs;
 
   vollkorn = callPackage ../data/fonts/vollkorn { };
 
+  whatsapp-emoji-font = callPackage ../data/fonts/whatsapp-emoji { };
+
   weather-icons = callPackage ../data/fonts/weather-icons { };
 
   whitesur-gtk-theme = callPackage ../data/themes/whitesur {


### PR DESCRIPTION
###### Description of changes

Add font based on the WhatsApp emoji font.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
