### PR TITLE
systemd-boot: allow splitting entries to xbootldr part

### DIFF
--- a/nixos/modules/system/boot/loader/systemd-boot/systemd-boot.nix
+++ b/nixos/modules/system/boot/loader/systemd-boot/systemd-boot.nix
@@ -33,6 +33,10 @@ let
     inherit (config.system.nixos) distroName;
 
     memtest86 = optionalString cfg.memtest86.enable pkgs.memtest86plus;
+    
+    xbootMountPoint = if cfg.xbootMountPoint != null
+      then cfg.xbootMountPoint
+      else efi.efiSysMountPoint;
 
     netbootxyz = optionalString cfg.netbootxyz.enable pkgs.netbootxyz-efi;
 
@@ -96,6 +100,14 @@ in {
       '';
     };
 
+    xbootMountPoint = mkOption {
+      default = null;
+      type = types.nullOr types.string;
+      description = ''
+        The vfat mount point for installling entries to an XBOOTLOADER partition.
+      '';
+    };
+    
     configurationLimit = mkOption {
       default = null;
       example = 120;


### PR DESCRIPTION
###### Description of changes

This allows `systemd-boot` to be installed to the ESP, while NixOS loader entries and files can exist on the extended boot loader partition.

This is particularly useful on dual boot systems, where Windows is allowed to install first and establishes the ESP partition. Often times it chooses a very small size that is prohibitive with regards to NixOS's boot files.

This PR adds an option that allows the user to redirect the loader entries/files to (what is hopefully their) extended boot loader partition.

Note, I use this PR on systems where this extra partition is in use, AND systems where it is not, so I am not worried about regression(s).

```
~
❯ exa --tree --level=3 /efi
/efi
├── EFI
│  ├── Boot
│  │  └── bootx64.efi
│  ├── Microsoft
│  │  ├── Boot
│  │  └── Recovery
│  └── systemd
│     └── systemd-bootx64.efi
├── loader
│  ├── loader.conf
│  └── random-seed
└── System Volume Information

~
❯ exa --tree --level=3 /boot
/boot
├── EFI
│  ├── Linux
│  └── nixos
│     ├── 5y4wli77bnnjfz76bfran03gb6012y6d-initrd-linux-6.1.23-initrd.efi
│     ├── ady11nphd2fx30yqchq6j2jgf645waw3-linux-6.1.24-bzImage.efi
│     ├── gf7hymimhfqn7qxjh08j04jzjp18djbm-initrd-linux-6.1.23-initrd.efi
│     ├── mnayyi1fzaa4g46lb1qg46r0hjwj15fm-initrd-linux-6.1.24-initrd.efi
│     ├── qsp0g4wa01hlw4g8q4rwqbwk3kybv3z1-initrd-linux-6.1.24-initrd.efi
│     ├── xbf2az1nsckrpshiwccdmjwy2jp8hjzi-initrd-linux-6.1.23-initrd.efi
│     └── z79mf6afiz0ywr8zxbv56s13mbd8mz2h-linux-6.1.23-bzImage.efi
└── loader
   ├── entries
   │  ├── nixos-generation-89-specialisation-legacyboot.conf
   │  ├── nixos-generation-89.conf
   │  ├── nixos-generation-90-specialisation-legacyboot.conf
   │  ├── nixos-generation-90.conf
   │  ├── nixos-generation-91-specialisation-legacyboot.conf
   │  ├── nixos-generation-91.conf
   │  ├── nixos-generation-92-specialisation-legacyboot.conf
   │  └── nixos-generation-92.conf
   └── entries.srel

```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
