### PR TITLE
trurl: 0.4 -> 0.6, add manpage, add passthru.tests.version

### DIFF
--- a/pkgs/tools/networking/trurl/default.nix
+++ b/pkgs/tools/networking/trurl/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchFromGitHub, curl, python3, python3Packages }:
+{ lib, stdenv, fetchFromGitHub, curl, python3, python3Packages, trurl, testers }:
 
 stdenv.mkDerivation rec {
   pname = "trurl";
@@ -23,6 +23,10 @@ stdenv.mkDerivation rec {
   doCheck = true;
   nativeCheckInputs = [ python3 python3Packages.packaging ];
   checkTarget = "test";
+
+  passthru.tests.version = testers.testVersion {
+    package = trurl;
+  };
 
   meta = with lib; {
     description = "A command line tool for URL parsing and manipulation";

--- a/pkgs/tools/networking/trurl/default.nix
+++ b/pkgs/tools/networking/trurl/default.nix
@@ -1,25 +1,27 @@
-{ lib, stdenv, fetchFromGitHub, curl, perl }:
+{ lib, stdenv, fetchFromGitHub, curl, python3, python3Packages }:
 
 stdenv.mkDerivation rec {
   pname = "trurl";
-  version = "0.4";
+  version = "0.6";
 
   src = fetchFromGitHub {
     owner = "curl";
     repo = pname;
     rev = "${pname}-${version}";
-    sha256 = "sha256-f9z0gPtHcn3iWFA6MT6ngok0nXBcd6zJ8Tjnb5Lzf6c=";
+    hash = "sha256-/Gf7T67LPzVPhjAqTvbLiJOqfKeWvwH/WHelJZTH4ZI=";
   };
 
+  outputs = [ "out" "dev" "man" ];
   separateDebugInfo = stdenv.isLinux;
 
   enableParallelBuilding = true;
 
+  nativeBuildInputs = [ curl ];
   buildInputs = [ curl ];
   makeFlags = [ "PREFIX=$(out)" ];
 
   doCheck = true;
-  checkInputs = [ perl ];
+  nativeCheckInputs = [ python3 python3Packages.packaging ];
   checkTarget = "test";
 
   meta = with lib; {


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Changelogs:
 - 0.4 -> 0.5: https://github.com/curl/trurl/releases/tag/trurl-0.5
 - 0.5 -> 0.6: https://github.com/curl/trurl/releases/tag/trurl-0.6

This PR also adds a separate `man` output, as well as a basic `passthru.tests.version`.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
