### PR TITLE
pahole: 1.24-unstable-2023-03-02 -> 1.25

### DIFF
--- a/pkgs/development/tools/misc/pahole/default.nix
+++ b/pkgs/development/tools/misc/pahole/default.nix
@@ -2,11 +2,10 @@
 
 stdenv.mkDerivation rec {
   pname = "pahole";
-  # Can switch back to release tags if they can build linux_testing.
-  version = "1.24-unstable-2023-03-02";
+  version = "1.25";
   src = fetchzip {
-    url = "https://git.kernel.org/pub/scm/devel/pahole/pahole.git/snapshot/pahole-a9498899109d3be14f17abbc322a8f55a1067bee.tar.gz";
-    sha256 = "xEKA6Fz6NaxNqSggvgswCU+7LlezGSNrK7cmt2JYv1Y=";
+    url = "https://git.kernel.org/pub/scm/devel/pahole/pahole.git/snapshot/pahole-${version}.tar.gz";
+    hash = "sha256-s0YVT2UnMSO8jS/4XCt06wNPV4czHH6bmZRy/snO3jg=";
   };
 
   nativeBuildInputs = [ cmake pkg-config ];

--- a/pkgs/development/tools/misc/pahole/default.nix
+++ b/pkgs/development/tools/misc/pahole/default.nix
@@ -1,4 +1,15 @@
-{ lib, stdenv, fetchzip, pkg-config, libbpf, cmake, elfutils, zlib, argp-standalone, musl-obstack }:
+{ lib
+, stdenv
+, fetchzip
+, pkg-config
+, libbpf
+, cmake
+, elfutils
+, zlib
+, argp-standalone
+, musl-obstack
+, nixosTests
+}:
 
 stdenv.mkDerivation rec {
   pname = "pahole";
@@ -17,6 +28,10 @@ stdenv.mkDerivation rec {
 
   # Put libraries in "lib" subdirectory, not top level of $out
   cmakeFlags = [ "-D__LIB=lib" "-DLIBBPF_EMBEDDED=OFF" ];
+
+  passthru.tests = {
+    inherit (nixosTests) bpf;
+  };
 
   meta = with lib; {
     homepage = "https://git.kernel.org/pub/scm/devel/pahole/pahole.git/";


### PR DESCRIPTION
Use released tarball with latest DWARF changes support.

Changes: https://lore.kernel.org/bpf/ZDG4qxirpIfmbiip@kernel.org/T/

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
