### PR TITLE
onnxruntime: 1.13.1 -> 1.15.1 and build on Darwin

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -2778,6 +2778,12 @@
     githubId = 3471749;
     name = "Claudio Bley";
   };
+  cbourjau = {
+    email = "christianb@posteo.de";
+    github = "cbourjau";
+    githubId = 3288058;
+    name = "Christian Bourjau";
+  };
   cbrewster = {
     email = "cbrewster@hey.com";
     github = "cbrewster";

--- a/pkgs/development/libraries/onnxruntime/default.nix
+++ b/pkgs/development/libraries/onnxruntime/default.nix
@@ -1,59 +1,98 @@
 { stdenv
 , lib
 , fetchFromGitHub
+, fetchFromGitLab
 , fetchpatch
 , fetchurl
-, pkg-config
-, cmake
-, python3Packages
-, libpng
-, zlib
-, eigen
-, protobuf
-, howard-hinnant-date
-, nlohmann_json
-, boost
-, oneDNN_2
+, Foundation
 , abseil-cpp
-, gtest
-, pythonSupport ? false
+, cmake
+, libpng
+, nlohmann_json
 , nsync
-, flatbuffers
+, pkg-config
+, python3Packages
+, re2
+, zlib
+, microsoft-gsl
+, iconv
+, gtest
+, protobuf3_21
+, pythonSupport ? true
 }:
 
-# Python Support
-#
-# When enabling Python support a wheel is made and stored in a `dist` output.
-# This wheel is then installed in a separate derivation.
 
-assert pythonSupport -> lib.versionOlder protobuf.version "3.20";
+let
+  howard-hinnant-date = fetchFromGitHub {
+    owner = "HowardHinnant";
+    repo = "date";
+    rev = "v2.4.1";
+    sha256 = "sha256-BYL7wxsYRI45l8C3VwxYIIocn5TzJnBtU0UZ9pHwwZw=";
+  };
 
+  eigen = fetchFromGitLab {
+    owner = "libeigen";
+    repo = "eigen";
+    rev = "d10b27fe37736d2944630ecd7557cefa95cf87c9";
+    sha256 = "sha256-Lmco0s9gIm9sIw7lCr5Iewye3RmrHEE4HLfyzRkQCm0=";
+  };
+
+  mp11 = fetchFromGitHub {
+    owner = "boostorg";
+    repo = "mp11";
+    rev = "boost-1.79.0";
+    sha256 = "sha256-ZxgPDLvpISrjpEHKpLGBowRKGfSwTf6TBfJD18yw+LM=";
+  };
+
+  safeint = fetchFromGitHub {
+    owner = "dcleblanc";
+    repo = "safeint";
+    rev = "ff15c6ada150a5018c5ef2172401cb4529eac9c0";
+    sha256 = "sha256-PK1ce4C0uCR4TzLFg+elZdSk5DdPCRhhwT3LvEwWnPU=";
+  };
+
+  pytorch_cpuinfo = fetchFromGitHub {
+    owner = "pytorch";
+    repo = "cpuinfo";
+    # There are no tags in the repository
+    rev = "5916273f79a21551890fd3d56fc5375a78d1598d";
+    sha256 = "sha256-nXBnloVTuB+AVX59VDU/Wc+Dsx94o92YQuHp3jowx2A=";
+  };
+
+  flatbuffers = fetchFromGitHub {
+    owner = "google";
+    repo = "flatbuffers";
+    rev = "v1.12.0";
+    sha256 = "sha256-L1B5Y/c897Jg9fGwT2J3+vaXsZ+lfXnskp8Gto1p/Tg=";
+  };
+
+  gtest' = gtest.overrideAttrs (oldAttrs: rec {
+    version = "1.13.0";
+    src = fetchFromGitHub {
+      owner = "google";
+      repo = "googletest";
+      rev = "v${version}";
+      hash = "sha256-LVLEn+e7c8013pwiLzJiiIObyrlbBHYaioO/SWbItPQ=";
+    };
+    });
+in
 stdenv.mkDerivation rec {
   pname = "onnxruntime";
-  version = "1.13.1";
+  version = "1.15.1";
 
   src = fetchFromGitHub {
     owner = "microsoft";
     repo = "onnxruntime";
     rev = "v${version}";
-    sha256 = "sha256-paaeq6QeiOzwiibbz0GkYZxEI/V80lvYNYTm6AuyAXQ=";
+    sha256 = "sha256-SnHo2sVACc++fog7Tg6f2LK/Sv/EskFzN7RZS7D113s=";
     fetchSubmodules = true;
   };
-
-  patches = [
-    # Use dnnl from nixpkgs instead of submodules
-    (fetchpatch {
-      name = "system-dnnl.patch";
-      url = "https://aur.archlinux.org/cgit/aur.git/plain/system-dnnl.diff?h=python-onnxruntime&id=9c392fb542979981fe0026e0fe3cc361a5f00a36";
-      sha256 = "sha256-+kedzJHLFU1vMbKO9cn8fr+9A5+IxIuiqzOfR2AfJ0k=";
-    })
-  ];
 
   nativeBuildInputs = [
     cmake
     pkg-config
     python3Packages.python
-    gtest
+    protobuf3_21
   ] ++ lib.optionals pythonSupport (with python3Packages; [
     setuptools
     wheel
@@ -64,17 +103,25 @@ stdenv.mkDerivation rec {
   buildInputs = [
     libpng
     zlib
-    howard-hinnant-date
     nlohmann_json
-    boost
-    oneDNN_2
-    protobuf
-  ] ++ lib.optionals pythonSupport [
     nsync
+    re2
+    microsoft-gsl
+  ] ++ lib.optionals pythonSupport [
     python3Packages.numpy
     python3Packages.pybind11
     python3Packages.packaging
+  ] ++ lib.optionals stdenv.isDarwin [
+    Foundation
+    iconv
   ];
+
+  nativeCheckInputs = lib.optionals pythonSupport (with python3Packages; [
+    gtest'
+    pytest
+    sympy
+    onnx
+  ]);
 
   # TODO: build server, and move .so's to lib output
   # Python's wheel is stored in a separate dist output
@@ -85,15 +132,23 @@ stdenv.mkDerivation rec {
   cmakeDir = "../cmake";
 
   cmakeFlags = [
-    "-Donnxruntime_PREFER_SYSTEM_LIB=ON"
-    "-Donnxruntime_BUILD_SHARED_LIB=ON"
-    "-Donnxruntime_ENABLE_LTO=ON"
-    "-Donnxruntime_BUILD_UNIT_TESTS=ON"
-    "-Donnxruntime_USE_PREINSTALLED_EIGEN=ON"
-    "-Donnxruntime_USE_MPI=ON"
-    "-Deigen_SOURCE_PATH=${eigen.src}"
+    "-DCMAKE_BUILD_TYPE=RELEASE"
+    "-DFETCHCONTENT_FULLY_DISCONNECTED=ON"
+    "-DFETCHCONTENT_QUIET=OFF"
     "-DFETCHCONTENT_SOURCE_DIR_ABSEIL_CPP=${abseil-cpp.src}"
-    "-Donnxruntime_USE_DNNL=YES"
+    "-DFETCHCONTENT_SOURCE_DIR_DATE=${howard-hinnant-date}"
+    "-DFETCHCONTENT_SOURCE_DIR_EIGEN=${eigen}"
+    "-DFETCHCONTENT_SOURCE_DIR_FLATBUFFERS=${flatbuffers}"
+    "-DFETCHCONTENT_SOURCE_DIR_GOOGLE_NSYNC=${nsync.src}"
+    "-DFETCHCONTENT_SOURCE_DIR_MP11=${mp11}"
+    "-DFETCHCONTENT_SOURCE_DIR_ONNX=${python3Packages.onnx.src}"
+    "-DFETCHCONTENT_SOURCE_DIR_PYTORCH_CPUINFO=${pytorch_cpuinfo}"
+    "-DFETCHCONTENT_SOURCE_DIR_SAFEINT=${safeint}"
+    "-DFETCHCONTENT_TRY_FIND_PACKAGE_MODE=ALWAYS"
+    "-Donnxruntime_BUILD_SHARED_LIB=ON"
+    "-Donnxruntime_BUILD_UNIT_TESTS=ON"
+    "-Donnxruntime_ENABLE_LTO=ON"
+    "-Donnxruntime_USE_FULL_PROTOBUF=OFF"
   ] ++ lib.optionals pythonSupport [
     "-Donnxruntime_ENABLE_PYTHON=ON"
   ];
@@ -103,6 +158,9 @@ stdenv.mkDerivation rec {
   postPatch = ''
     substituteInPlace cmake/libonnxruntime.pc.cmake.in \
       --replace '$'{prefix}/@CMAKE_INSTALL_ @CMAKE_INSTALL_
+  '' + lib.optionalString (stdenv.hostPlatform.system == "aarch64-linux") ''
+    # https://github.com/NixOS/nixpkgs/pull/226734#issuecomment-1663028691
+    rm -v onnxruntime/test/optimizer/nhwc_transformer_test.cc
   '';
 
   postBuild = lib.optionalString pythonSupport ''
@@ -118,7 +176,7 @@ stdenv.mkDerivation rec {
   '';
 
   passthru = {
-    inherit protobuf;
+    protobuf = protobuf3_21;
     tests = lib.optionalAttrs pythonSupport {
       python = python3Packages.onnxruntime;
     };
@@ -140,6 +198,6 @@ stdenv.mkDerivation rec {
     # https://github.com/microsoft/onnxruntime/blob/master/BUILD.md#architectures
     platforms = platforms.unix;
     license = licenses.mit;
-    maintainers = with maintainers; [ jonringer puffnfresh ck3d ];
+    maintainers = with maintainers; [ jonringer puffnfresh ck3d cbourjau ];
   };
 }

--- a/pkgs/development/python-modules/onnxruntime/default.nix
+++ b/pkgs/development/python-modules/onnxruntime/default.nix
@@ -1,4 +1,5 @@
 { lib
+, stdenv
 , buildPythonPackage
 , autoPatchelfHook
 , pythonRelaxDepsHook
@@ -7,6 +8,7 @@
 , numpy
 , packaging
 , oneDNN
+, re2
 
 }:
 
@@ -34,8 +36,9 @@ buildPythonPackage {
   '';
 
   nativeBuildInputs = [
-    autoPatchelfHook
     pythonRelaxDepsHook
+  ] ++ lib.optionals stdenv.isLinux [
+    autoPatchelfHook
   ];
 
   # This project requires fairly large dependencies such as sympy which we really don't always need.
@@ -48,6 +51,7 @@ buildPythonPackage {
   # Libraries are not linked correctly.
   buildInputs = [
     oneDNN
+    re2
     onnxruntime.protobuf
   ];
 

--- a/pkgs/tools/audio/piper/default.nix
+++ b/pkgs/tools/audio/piper/default.nix
@@ -25,6 +25,10 @@ stdenv.mkDerivation {
 
   sourceRoot = "source/src/cpp";
 
+  patches = [
+    ./fix-compilation-with-newer-onnxruntime.patch
+  ];
+
   postPatch = ''
     substituteInPlace CMakeLists.txt \
       --replace "/usr/local/include/onnxruntime" "${onnxruntime}"

--- a/pkgs/tools/audio/piper/fix-compilation-with-newer-onnxruntime.patch
+++ b/pkgs/tools/audio/piper/fix-compilation-with-newer-onnxruntime.patch
@@ -1,0 +1,18 @@
+diff --git a/src/cpp/synthesize.hpp b/src/cpp/synthesize.hpp
+index ef61aef..4c7db7a 100644
+--- a/synthesize.hpp
++++ b/synthesize.hpp
+@@ -119,11 +119,11 @@ void synthesize(SynthesisConfig &synthesisConfig, ModelSession &session,
+ 
+   // Clean up
+   for (size_t i = 0; i < outputTensors.size(); i++) {
+-    Ort::OrtRelease(outputTensors[i].release());
++    Ort::detail::OrtRelease(outputTensors[i].release());
+   }
+ 
+   for (size_t i = 0; i < inputTensors.size(); i++) {
+-    Ort::OrtRelease(inputTensors[i].release());
++    Ort::detail::OrtRelease(inputTensors[i].release());
+   }
+ }
+ } // namespace larynx

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5956,7 +5956,7 @@ with pkgs;
   online-judge-tools = with python3.pkgs; toPythonApplication online-judge-tools;
 
   onnxruntime = callPackage ../development/libraries/onnxruntime {
-    protobuf = protobuf3_19;
+    inherit (darwin.apple_sdk.frameworks) Foundation;
   };
 
   xkbd = callPackage ../applications/misc/xkbd { };


### PR DESCRIPTION
###### Description of changes

Update onnxruntime to the latest version and build it on Darwin. The build system saw several changes with the latest release. Most notably upstream has ceased to use git submodules for its dependencies in favor of cmake's `FetchContent` functionality. 

Release notes:
https://github.com/microsoft/onnxruntime/releases/tag/v1.15.0

Other changes:
- mmcv was disabled on Darwin due to pytorch related problems with the
test suite. This is not a regression since it was previously blocked
on this package not being available on Darwin.
- piper-tts gained a patch to deal with a breaking change in the
onnxruntime API

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
