### PR TITLE
Add new OCaml package `opam-0install` and all its dependencies

### DIFF
--- a/pkgs/development/ocaml-modules/0install/default.nix
+++ b/pkgs/development/ocaml-modules/0install/default.nix
@@ -1,0 +1,42 @@
+{ lib, fetchFromGitHub, buildDunePackage
+, yojson, xmlm, lwt, lwt_react, ocurl, sha
+, ounit2, gnupg, unzip
+, ... ## 0install-solver
+}@inputs:
+
+buildDunePackage rec {
+  pname = "0install";
+  version = "2.18";
+
+  duneVersion = "3";
+
+  src = fetchFromGitHub {
+    owner = "0install";
+    repo = "0install";
+    rev = "v${version}";
+    sha256 = "sha256-CxADWMYZBPobs65jeyMQjqu3zmm2PgtNgI/jUsYUp8I=";
+  };
+
+  propagatedBuildInputs = [
+    inputs."0install-solver"
+    yojson
+    xmlm
+    lwt
+    lwt_react
+    ocurl
+    sha
+  ];
+
+  ## REVIEW: Can't get tests to work; it seems some tests try to access `/build`
+  ## and then fail with a Unix error EPERM.
+  doCheck = false;
+  checkInputs = [ ounit2 ];
+  nativeCheckInputs = [ gnupg unzip ];
+
+  meta = {
+    description = "Decentralised installation system";
+    license = lib.licenses.lgpl21Plus;
+    maintainers = [ lib.maintainers.niols ];
+    homepage = "https://github.com/0install/0install";
+  };
+}

--- a/pkgs/development/ocaml-modules/0install/solver.nix
+++ b/pkgs/development/ocaml-modules/0install/solver.nix
@@ -1,0 +1,18 @@
+{ lib, buildDunePackage
+, ounit2
+, ... ## 0install
+}@inputs:
+
+buildDunePackage {
+  pname = "0install-solver";
+  inherit (inputs."0install") version src;
+
+  duneVersion = "3";
+
+  doCheck = true;
+  checkInputs = [ ounit2 ];
+
+  meta = inputs."0install".meta // {
+    description = "Package dependency solver";
+  };
+}

--- a/pkgs/development/ocaml-modules/opam-0install/cudf.nix
+++ b/pkgs/development/ocaml-modules/opam-0install/cudf.nix
@@ -1,0 +1,24 @@
+{ lib, buildDunePackage
+, opam-0install
+, cudf
+, ...
+}@inputs:
+
+buildDunePackage {
+  pname = "opam-0install-cudf";
+  inherit (opam-0install) version src;
+
+  duneVersion = "3";
+
+  propagatedBuildInputs = [
+    cudf
+    inputs."0install-solver"
+  ];
+
+  doCheck = true;
+  checkInputs = [];
+
+  meta = opam-0install.meta // {
+    description = "Opam solver using 0install backend using the CUDF interface";
+  };
+}

--- a/pkgs/development/ocaml-modules/opam-0install/default.nix
+++ b/pkgs/development/ocaml-modules/opam-0install/default.nix
@@ -1,0 +1,42 @@
+{ lib, fetchFromGitHub, buildDunePackage
+, fmt, cmdliner, opam-state, opam-file-format
+, astring, alcotest, opam-client, opam-solver
+, ... ## 0install-solver
+}@inputs:
+
+buildDunePackage rec {
+  pname = "opam-0install";
+  version = "0.4.3";
+
+  duneVersion = "3";
+
+  src = fetchFromGitHub {
+    owner = "ocaml-opam";
+    repo = "opam-0install-solver";
+    rev = "v${version}";
+    sha256 = "sha256-ExF5R2lu5vKJ7uoIn/O8/CMEPuUTOSV4LDA/3W7AKJE=";
+  };
+
+  propagatedBuildInputs = [
+    inputs."0install-solver"
+    cmdliner
+    fmt
+    opam-file-format
+    opam-state
+  ];
+
+  doCheck = true;
+  checkInputs = [
+    astring
+    alcotest
+    opam-client
+    opam-solver
+  ];
+
+  meta = {
+    description = "Opam solver using 0install backend";
+    license = lib.licenses.isc;
+    maintainers = [ lib.maintainers.niols ];
+    homepage = "https://github.com/ocaml-opam/opam-0install-solver";
+  };
+}

--- a/pkgs/development/ocaml-modules/opam-client/default.nix
+++ b/pkgs/development/ocaml-modules/opam-client/default.nix
@@ -1,0 +1,30 @@
+{ lib, buildDunePackage
+, opam, unzip
+, opam-state, opam-solver, base64, opam-repository, re, cmdliner
+}:
+
+buildDunePackage rec {
+  pname = "opam-client";
+  inherit (opam) src version;
+
+  duneVersion = "3";
+
+  nativeBuildInputs = [ unzip ];
+
+  propagatedBuildInputs = [
+    opam-state
+    opam-solver
+    base64
+    opam-repository
+    re
+    cmdliner
+  ];
+
+  # get rid of check for curl at configure time
+  configureFlags = [ "--disable-checks" ];
+
+  meta = opam.meta // {
+    description = "Client library for opam";
+    maintainers = with lib.maintainers; [ niols ];
+  };
+}

--- a/pkgs/development/ocaml-modules/opam-solver/default.nix
+++ b/pkgs/development/ocaml-modules/opam-solver/default.nix
@@ -1,0 +1,30 @@
+{ lib, buildDunePackage
+, opam, unzip
+, opam-format, mccs, dose3, cudf, re, opam-0install-cudf
+}:
+
+buildDunePackage rec {
+  pname = "opam-solver";
+  inherit (opam) src version;
+
+  duneVersion = "3";
+
+  nativeBuildInputs = [ unzip ];
+
+  propagatedBuildInputs = [
+    opam-format
+    mccs
+    dose3
+    cudf
+    re
+    opam-0install-cudf
+  ];
+
+  # get rid of check for curl at configure time
+  configureFlags = [ "--disable-checks" ];
+
+  meta = opam.meta // {
+    description = "Solver library for opam";
+    maintainers = with lib.maintainers; [ niols ];
+  };
+}

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -1221,6 +1221,10 @@ let
 
     omd = callPackage ../development/ocaml-modules/omd { };
 
+    opam-0install = callPackage ../development/ocaml-modules/opam-0install {
+        inherit (self) "0install-solver";
+    };
+
     opam-client = callPackage ../development/ocaml-modules/opam-client { };
 
     opam-core = callPackage ../development/ocaml-modules/opam-core {

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -1227,6 +1227,8 @@ let
       inherit (pkgs) unzip;
     };
 
+    opam-solver = callPackage ../development/ocaml-modules/opam-solver { };
+
     opam-state = callPackage ../development/ocaml-modules/opam-state {
       inherit (pkgs) unzip;
     };

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -14,6 +14,10 @@ let
         inherit (self) "0install-solver";
     };
 
+    "0install-solver" = callPackage ../development/ocaml-modules/0install/solver.nix {
+        inherit (self) "0install";
+    };
+
     ### A ###
 
     afl-persistent = callPackage ../development/ocaml-modules/afl-persistent { };

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -1225,6 +1225,10 @@ let
         inherit (self) "0install-solver";
     };
 
+    opam-0install-cudf = callPackage ../development/ocaml-modules/opam-0install/cudf.nix {
+        inherit (self) "0install-solver";
+    };
+
     opam-client = callPackage ../development/ocaml-modules/opam-client { };
 
     opam-core = callPackage ../development/ocaml-modules/opam-core {

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -1211,6 +1211,8 @@ let
 
     omd = callPackage ../development/ocaml-modules/omd { };
 
+    opam-client = callPackage ../development/ocaml-modules/opam-client { };
+
     opam-core = callPackage ../development/ocaml-modules/opam-core {
       inherit (pkgs) opam unzip;
     };

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -8,6 +8,12 @@ let
   {
     inherit ocaml;
 
+    ### 0 ###
+
+    "0install" = callPackage ../development/ocaml-modules/0install {
+        inherit (self) "0install-solver";
+    };
+
     ### A ###
 
     afl-persistent = callPackage ../development/ocaml-modules/afl-persistent { };


### PR DESCRIPTION
###### Description of changes

Add packages:

- `opam-client`, version 2.1.4 (shipped with [`opam`](https://opam.ocaml.org/)). It is the “client library for opam 2.1," which allows to perform "actions on the opam root, switches, installations, and front-end."
- `opam-solver`, version 2.1.4 (shipped with [`opam`](https://opam.ocaml.org/)). It is the “solver library for opam 2.1,” which takes care of “solver and Cudf interaction.” It “is based on the Cudf and Dose libraries, and handles calls to the external solver from opam.”
- [`0install`](https://0install.net/), version 2.18. It is a “decentralised installation system,” which “works on Linux, Windows and macOS” and is “fully open source.”
- `0install-solver`, version 2.18 (shipped with [`0install`](https://0install.net/)). It is `0install`'s “package dependency solver.
- [`opam-0install`](https://github.com/ocaml-opam/opam-0install-solver), version 0.4.3. It is an “opam solver using 0install backend”.
- `opam-0install-cudf`, version 0.4.3 (shipped with [`opam-0install`](https://github.com/ocaml-opam/opam-0install-solver)). It is an “opam solver using 0install backend using the CUDF interface”.

Change logs:

- [`opam-client` and `opam-server`](https://github.com/ocaml/opam/blob/2.1.4/CHANGES)
- [`0install` and `0install-solver`](https://github.com/0install/0install/blob/v2.18/CHANGES.md)
- [`opam-0install` and `opam-0install-cudf`](https://github.com/ocaml-opam/opam-0install-solver/blob/v0.4.3/CHANGES.md)

The dependencies between those Nix packages are a bit peculiar. Here they are, with an arrow meaning “depends on” (or “uses as input”):

```mermaid
  graph TD;
      opam-0install-cudf --> opam-0install;
      opam-0install-cudf --> 0install-solver;
      opam-0install --> 0install-solver;
      opam-0install --> opam-client;
      opam-0install --> opam-solver;
      0install-solver --> 0install;
      0install --> 0install-solver;
      opam-solver --> opam-0install-cudf
      opam-client --> opam-solver;
```

The peculiarity comes from `opam-0install-cudf` relying on `opam-0install` to provide `version` and `src`, as I've seen done in other groups of packages, while not actually needing it to build. This makes the individual commits hold very little sense, considering that they only work when taken all together.

The motivation behind all this works is to make available `opam-0install` to [play with lower bounds of OCaml packages](https://sim642.eu/blog/2022/03/13/ocaml-dependencies-lower-bounds-ci/).

Follow-up questions:

- Should we make `opam-0install` depend on `opam-0install-cudf` instead of the contrary? This would make `.../opam-0install/default.nix` depend on `.../opam-0install/cudf.nix` which is a bit odd, but it would at least break the dependency cycle. I don't have an opinion or a preference.

- The OPAM package for 0install is indeed called `0install`. In Nix-the-language, it is a tad annoying to manipulate variables with this name but it is doable, and therefore I preferred keeping that name. It forced me to juggle a bit with Nix constructs. Is there a better way to do what I did? (My problem being pattern matching on an attribute set containing a key starting with an integer.) Should we rename the package in eg. `zero-install` instead?

- There is a bunch of packages (including the newly-added `opam-client` and `opam-solver`) that depend on `opam` and all come from the repository or `opam`. Should we move them all to a common directory in `.../ocaml-modules/opam`?

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [X] x86_64-darwin
  - [X] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
