### PR TITLE
grafx2: 2.4.2035 -> 2.8.3091

### DIFF
--- a/pkgs/applications/graphics/grafx2/default.nix
+++ b/pkgs/applications/graphics/grafx2/default.nix
@@ -1,29 +1,41 @@
-{ lib, stdenv, fetchurl, SDL, SDL_image, SDL_ttf, zlib, libpng, pkg-config, lua5 }:
+{ lib
+, stdenv
+, fetchurl
+, SDL
+, SDL_image
+, SDL_ttf
+, fontconfig
+, libpng
+, libtiff
+, lua5
+, pkg-config
+, zlib
+}:
 
 stdenv.mkDerivation rec {
-
-  version = "2.4.2035";
+  version = "2.8.3091";
   pname = "grafx2";
 
   src = fetchurl {
-    url = "https://grafx2.googlecode.com/files/${pname}-${version}-src.tgz";
-    sha256 = "0svsy6rqmdj11b400c242i2ixihyz0hds0dgicqz6g6dcgmcl62q";
+    url = "https://pulkomandy.tk/projects/GrafX2/downloads/65";
+    name = "${pname}-${version}.tar.gz";
+    hash = "sha256-KdY7GUhQp/Q7t/ktLPGxI66ZHy2gDAffn2yB5pmcJCM=";
   };
 
   nativeBuildInputs = [ pkg-config ];
-  buildInputs = [ SDL SDL_image SDL_ttf libpng zlib lua5 ];
+  buildInputs = [
+    SDL
+    SDL_image
+    SDL_ttf
+    fontconfig
+    libpng
+    libtiff
+    lua5
+    zlib
+  ];
 
-  preBuild = "cd src";
-
-  # Workaround build failure on -fno-common toolchains like upstream
-  # gcc-10. Otherwise build fails as:
-  #   ld: ../obj/unix/tiles.o:/build/grafx2/src/global.h:306: multiple definition of
-  #     `Main_selector'; ../obj/unix/main.o:/build/grafx2/src/global.h:306: first defined here
-  env.NIX_CFLAGS_COMPILE = "-fcommon";
-
-  preInstall = '' mkdir -p "$out" '';
-
-  installPhase = ''make install prefix="$out"'';
+  makeFlags = [ "-C src" ];
+  installFlags = [ "-C src" "PREFIX=$(out)" ];
 
   meta = {
     description = "Bitmap paint program inspired by the Amiga programs Deluxe Paint and Brilliance";
@@ -31,5 +43,6 @@ stdenv.mkDerivation rec {
     license = lib.licenses.gpl2;
     platforms = [ "x86_64-linux" "i686-linux" ];
     maintainers = [];
+    mainProgram = "grafx2-sdl";
   };
 }


### PR DESCRIPTION
###### Description of changes
Updates grafx2 to the most recent source bundle point release, 2.8.3091. There was a previous attempt to do this at #57739, but it included a lot more ambitious changes than just updating the existing package, and stalled out a while ago.

###### Things done
- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).