### PR TITLE
ocamlPackages.janeStreet: small cleaning of legacy package sets

### DIFF
--- a/pkgs/development/ocaml-modules/conduit/async.nix
+++ b/pkgs/development/ocaml-modules/conduit/async.nix
@@ -1,4 +1,4 @@
-{ lib, buildDunePackage, async, async_ssl, ppx_sexp_conv, ppx_here, uri, conduit
+{ lib, buildDunePackage, async, async_ssl ? null, ppx_sexp_conv, ppx_here, uri, conduit
 , core, ipaddr, ipaddr-sexp, sexplib
 }:
 

--- a/pkgs/development/ocaml-modules/janestreet/0.12.nix
+++ b/pkgs/development/ocaml-modules/janestreet/0.12.nix
@@ -377,18 +377,6 @@ with self;
     propagatedBuildInputs = [ async_extra textutils ];
   };
 
-  async_ssl = janePackage {
-    pname = "async_ssl";
-    hash = "02ard8x5q5c42d9jdqmyzfx624yjq8cxxmvq3zb82hf6p8cc57ml";
-    meta = {
-      description = "An Async-pipe-based interface with OpenSSL";
-      # ctypes no longer works with dune 1
-      # dune 2 no longer supports jbuild
-      broken = true;
-    };
-    propagatedBuildInputs = [ async ctypes openssl ];
-  };
-
   async_find = janePackage {
     pname = "async_find";
     hash = "0qsz9f15s5rlk6za10s810v6nlkdxg2g9p1827lcpa7nhjcpi673";

--- a/pkgs/development/ocaml-modules/janestreet/default.nix
+++ b/pkgs/development/ocaml-modules/janestreet/default.nix
@@ -413,18 +413,6 @@ with self;
     meta.description = "Shell helpers for Async";
   };
 
-  async_ssl = janePackage {
-    pname = "async_ssl";
-    hash = "1p83fzfla4rb820irdrz3f2hp8kq5zrhw47rqmfv6qydlca1bq64";
-    propagatedBuildInputs = [ async ctypes openssl ];
-    meta = {
-      description = "Async wrappers for SSL";
-      # ctypes no longer works with dune 1
-      # dune 2 no longer supports jbuild
-      broken = true;
-    };
-  };
-
   sexp_pretty = janePackage {
     pname = "sexp_pretty";
     hash = "0xskahjggbwvvb82fn0jp1didxbgpmgks76xhwp9s3vqkhgz6918";

--- a/pkgs/development/ocaml-modules/janestreet/janePackage.nix
+++ b/pkgs/development/ocaml-modules/janestreet/janePackage.nix
@@ -5,7 +5,7 @@
 buildDunePackage (args // {
   inherit version buildInputs;
 
-  useDune2 = false;
+  duneVersion = "1";
 
   minimalOCamlVersion = "4.04";
 

--- a/pkgs/development/ocaml-modules/janestreet/janePackage_0_12.nix
+++ b/pkgs/development/ocaml-modules/janestreet/janePackage_0_12.nix
@@ -5,7 +5,7 @@
 buildDunePackage (args // {
   inherit version;
 
-  useDune2 = false;
+  duneVersion = "1";
 
   minimalOCamlVersion = "4.07";
 


### PR DESCRIPTION
###### Description of changes

Remove broken package and use `duneVersion` in place of the legacy `useDune2`.

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
