### PR TITLE
firefox-{,bin-}unwrapped: 112.0 -> 112.0.1

### DIFF
--- a/pkgs/applications/networking/browsers/firefox-bin/release_sources.nix
+++ b/pkgs/applications/networking/browsers/firefox-bin/release_sources.nix
@@ -1,1005 +1,1005 @@
 {
-  version = "112.0";
+  version = "112.0.1";
   sources = [
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0/linux-x86_64/ach/firefox-112.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.1/linux-x86_64/ach/firefox-112.0.1.tar.bz2";
       locale = "ach";
       arch = "linux-x86_64";
-      sha256 = "5b3e37c5b934339ff083b0f852a135c6cbb45c6abdf6467ec206a83647a1d8b3";
+      sha256 = "36fd6c7580b7c52be08eeec0cdb078847d85150db5a7589b6170b87680352aee";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0/linux-x86_64/af/firefox-112.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.1/linux-x86_64/af/firefox-112.0.1.tar.bz2";
       locale = "af";
       arch = "linux-x86_64";
-      sha256 = "af22f08c6528fd447515eb4f914822265bc9e47ee314d7c15487b9bbe1dde42a";
+      sha256 = "faadb7dbb35eb85dd5afd2b1fae89a317efbc57d47c55bddf5913633f3a94f5a";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0/linux-x86_64/an/firefox-112.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.1/linux-x86_64/an/firefox-112.0.1.tar.bz2";
       locale = "an";
       arch = "linux-x86_64";
-      sha256 = "0cb1badd023ff3dd7131629229648956596c43e4458affc02273ba5036f810d1";
+      sha256 = "413cc005f597c80e45e21238e6d1efc6b7ea9601a414f17f7a9de649ae100838";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0/linux-x86_64/ar/firefox-112.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.1/linux-x86_64/ar/firefox-112.0.1.tar.bz2";
       locale = "ar";
       arch = "linux-x86_64";
-      sha256 = "673262175ca0f6fa4f7f0c43634ad15f242fea00768c614c97ca0b88abaa5740";
+      sha256 = "ea1da8a30f29b34444140ded31282fbb22376954d5ee2a6a7545d2eddb19edd8";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0/linux-x86_64/ast/firefox-112.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.1/linux-x86_64/ast/firefox-112.0.1.tar.bz2";
       locale = "ast";
       arch = "linux-x86_64";
-      sha256 = "649d9bde87232463ffa532f2fa1a2dbc1732134cff8ab3f4628313f26d573bef";
+      sha256 = "441d682a09325f46cead74d300b4f27200af97b4315fd2990d1fa33ba93412c5";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0/linux-x86_64/az/firefox-112.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.1/linux-x86_64/az/firefox-112.0.1.tar.bz2";
       locale = "az";
       arch = "linux-x86_64";
-      sha256 = "15cd7a54db2df0d6894798e508346ea51ccf05b45ba7237875e7fd32fb2a94d5";
+      sha256 = "24440875e36dcba8c5d4e125715d2d8c61bab534739ff5a4e0c9e41419c3a05a";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0/linux-x86_64/be/firefox-112.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.1/linux-x86_64/be/firefox-112.0.1.tar.bz2";
       locale = "be";
       arch = "linux-x86_64";
-      sha256 = "1b2050268708cb475d8ced0fb8e0365f243c4993e817a553603e65b600ee7f05";
+      sha256 = "5b3e6c637256f9d54e414a56807f8c3e5dcad75e839b97bb26c4ed8391538e53";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0/linux-x86_64/bg/firefox-112.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.1/linux-x86_64/bg/firefox-112.0.1.tar.bz2";
       locale = "bg";
       arch = "linux-x86_64";
-      sha256 = "b6323dd73d10ea547c34cc022bc60312a949f339f0f709fe4d1fbf9cf8859b0e";
+      sha256 = "cb132442599cc876435aeb99ce3d366ecabe583f66ac50b964fc6d34039b7a06";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0/linux-x86_64/bn/firefox-112.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.1/linux-x86_64/bn/firefox-112.0.1.tar.bz2";
       locale = "bn";
       arch = "linux-x86_64";
-      sha256 = "2e6699071dfe0efc6f6860eabb34e3cf64a4de2e11be2292fa5348808e731ab3";
+      sha256 = "8ffa2b5e01300ef62a980d504b9d5c61c17c71e36bc267694d7de6594227f86e";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0/linux-x86_64/br/firefox-112.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.1/linux-x86_64/br/firefox-112.0.1.tar.bz2";
       locale = "br";
       arch = "linux-x86_64";
-      sha256 = "5f488917c05c048fee13153de51a462febb4bd72d2954f2d2f321cd119da5588";
+      sha256 = "ee830d98b21fc9cc74a181c2c3cdb61692a83450df7dd35b7777591fa17cbd16";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0/linux-x86_64/bs/firefox-112.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.1/linux-x86_64/bs/firefox-112.0.1.tar.bz2";
       locale = "bs";
       arch = "linux-x86_64";
-      sha256 = "5860c3f2677ce99622a0b575baef36d3db993d2f371b7c6aec72ef2a9d8e0952";
+      sha256 = "1728f28b2b36feaf09eaf6b1750a2b9bd23e03bbf72b9fc7836e4c2ded27d120";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0/linux-x86_64/ca-valencia/firefox-112.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.1/linux-x86_64/ca-valencia/firefox-112.0.1.tar.bz2";
       locale = "ca-valencia";
       arch = "linux-x86_64";
-      sha256 = "23ddc52776810445fc0352ebf19b27c2b4729fb8cefce11b0fe7df9f9e505dc4";
+      sha256 = "c9cb9c84d03593a2f95071fe4e720fe23b8a70284c9f6b4225f3d501672b0800";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0/linux-x86_64/ca/firefox-112.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.1/linux-x86_64/ca/firefox-112.0.1.tar.bz2";
       locale = "ca";
       arch = "linux-x86_64";
-      sha256 = "2bbe66c628f5fc9c89880d63868eb5469f1284944728adb5e3741bcd85c57b18";
+      sha256 = "633d527b4d9e4ff77474ac9e401290d1f700243588c963e96490a36ff1a9fd92";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0/linux-x86_64/cak/firefox-112.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.1/linux-x86_64/cak/firefox-112.0.1.tar.bz2";
       locale = "cak";
       arch = "linux-x86_64";
-      sha256 = "d319f624941cd354df6bb78434f64cb6de41bad266a1186dbf7ddb0c2cfacec0";
+      sha256 = "a7228264a85d64f8aa7a585452a7ff452535bf23faa4fde823a1d161c9234a19";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0/linux-x86_64/cs/firefox-112.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.1/linux-x86_64/cs/firefox-112.0.1.tar.bz2";
       locale = "cs";
       arch = "linux-x86_64";
-      sha256 = "614fb174a002e469a8dc83005422c102a6406cf0784d53b7120ddb70a0bdc708";
+      sha256 = "133263691738d5a03950bc909ed50b5379c56ab118b43ab1ebf874cf67c448ac";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0/linux-x86_64/cy/firefox-112.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.1/linux-x86_64/cy/firefox-112.0.1.tar.bz2";
       locale = "cy";
       arch = "linux-x86_64";
-      sha256 = "111b820566db4fc682768b4ecc3b6583efc4039c44e880ea7bcf5ca352a62dc0";
+      sha256 = "ac0b70542cb73d62f76619daaa435ec433e766af5922947113239e6d2ba9dcc2";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0/linux-x86_64/da/firefox-112.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.1/linux-x86_64/da/firefox-112.0.1.tar.bz2";
       locale = "da";
       arch = "linux-x86_64";
-      sha256 = "87f670d5a7774d7af54bc20a5c788f47d63f6a1d2dae825889629d8c75057ce2";
+      sha256 = "71167831d1cd3836ef54f8fc0e42ffee0a22116c1f9b512a5a9f4ef6eb94dd6f";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0/linux-x86_64/de/firefox-112.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.1/linux-x86_64/de/firefox-112.0.1.tar.bz2";
       locale = "de";
       arch = "linux-x86_64";
-      sha256 = "36cf31e4b1472f61c80c70a2dde87f1fb56a64cee39484d22b12e76618b73485";
+      sha256 = "c01cf989f29d637504de219af4905769318b93aee07ad2b02ec56b678a733ab6";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0/linux-x86_64/dsb/firefox-112.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.1/linux-x86_64/dsb/firefox-112.0.1.tar.bz2";
       locale = "dsb";
       arch = "linux-x86_64";
-      sha256 = "d068e2632550c03d92e7b3b6e3fee961e8d1c1d2bb19408b696ac483317ddb24";
+      sha256 = "6c442c04e8899cc11055839bfe946a4cf5710fa07daefb858f67e63a749006cf";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0/linux-x86_64/el/firefox-112.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.1/linux-x86_64/el/firefox-112.0.1.tar.bz2";
       locale = "el";
       arch = "linux-x86_64";
-      sha256 = "44115aad6db9d6d105d9418cf5c22cb71183b6b14f69d4e90642b3bf3fb2be57";
+      sha256 = "c8d02a7659d65f47fe95a3528246631ac502c972d9cae5efac34d41175300902";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0/linux-x86_64/en-CA/firefox-112.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.1/linux-x86_64/en-CA/firefox-112.0.1.tar.bz2";
       locale = "en-CA";
       arch = "linux-x86_64";
-      sha256 = "ae4e225641700ae32dc7b9a395352352a8cfb2ffc81636f2820684095709d1ca";
+      sha256 = "69e5c206ff03eef0a2da0b8dafebbb5b7fc75ed83c56915974587ae2bf13c314";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0/linux-x86_64/en-GB/firefox-112.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.1/linux-x86_64/en-GB/firefox-112.0.1.tar.bz2";
       locale = "en-GB";
       arch = "linux-x86_64";
-      sha256 = "0f84ca1a632467ce5eb3f7781b24ab6f361d5641b19d1c36aa03a6df2494230e";
+      sha256 = "8b0111486226ba15b1a145914647ae05c0c3c25280c2d15de2c10e5928eb0926";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0/linux-x86_64/en-US/firefox-112.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.1/linux-x86_64/en-US/firefox-112.0.1.tar.bz2";
       locale = "en-US";
       arch = "linux-x86_64";
-      sha256 = "31d2c3fe549cddaab7576cfde6467ed5a6534b1988adfb921965b60714970349";
+      sha256 = "6ae1a778523203660d1c300dfca88c14e2ea012e417a31238f6b312cfc3902f1";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0/linux-x86_64/eo/firefox-112.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.1/linux-x86_64/eo/firefox-112.0.1.tar.bz2";
       locale = "eo";
       arch = "linux-x86_64";
-      sha256 = "998019dedac2a5f3e15ec6fcfea26f9183effebcf3d9441436c45e87892e7957";
+      sha256 = "b8882e0c5d01432ab35b18e2dd6de92432964366671887d6171020018a87af2e";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0/linux-x86_64/es-AR/firefox-112.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.1/linux-x86_64/es-AR/firefox-112.0.1.tar.bz2";
       locale = "es-AR";
       arch = "linux-x86_64";
-      sha256 = "9bce94e6a9abd75bb74405c5c88d786621703c99a1482f2071cc3ea32e2af07b";
+      sha256 = "fad8033a87c95d50d7959ef7d74186b832a93ae0be590f5d2122651c7f8a8421";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0/linux-x86_64/es-CL/firefox-112.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.1/linux-x86_64/es-CL/firefox-112.0.1.tar.bz2";
       locale = "es-CL";
       arch = "linux-x86_64";
-      sha256 = "9bdf3fe6bdf49cbdd2f2f6345485609b24160f938a7939a33c9029cbddb9e83c";
+      sha256 = "53a70c208fe9599f709bb706f1cfc4dba73c1165ae0308cff42f0bab89f27d68";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0/linux-x86_64/es-ES/firefox-112.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.1/linux-x86_64/es-ES/firefox-112.0.1.tar.bz2";
       locale = "es-ES";
       arch = "linux-x86_64";
-      sha256 = "1692def0e39a94bea876efbaee57651d8a3820d0e47581520ed28e2c94412ddf";
+      sha256 = "a36a7cfd3214b40566e76086dd0554c264bbe58044e170f3a5529a57bf45a96b";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0/linux-x86_64/es-MX/firefox-112.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.1/linux-x86_64/es-MX/firefox-112.0.1.tar.bz2";
       locale = "es-MX";
       arch = "linux-x86_64";
-      sha256 = "948f0d2e110e6b6980c88c59e0bd3b84df920a490b25ef9d683619390fb12bd3";
+      sha256 = "408aa0cdf4199ee4bcedf5167739582bffd4779a55eef529ddb1e55dc5312b08";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0/linux-x86_64/et/firefox-112.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.1/linux-x86_64/et/firefox-112.0.1.tar.bz2";
       locale = "et";
       arch = "linux-x86_64";
-      sha256 = "c20d2fe028e2ad2a5b6d2e58bd2f21de02dd75f143b25faae9293225a2c2e411";
+      sha256 = "17c4dbb7f5833a3ad954891d2f73eadcd464812500e75a11be93142920b1ff8e";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0/linux-x86_64/eu/firefox-112.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.1/linux-x86_64/eu/firefox-112.0.1.tar.bz2";
       locale = "eu";
       arch = "linux-x86_64";
-      sha256 = "a24feef2fb182796593d97cdfeffc4e4eda5f008f8bc11c679861424eacf9141";
+      sha256 = "0db77714cef6bb365f7757d4d9d2c3f9cb8f422a0b1b1f1742e9bb0e69f9ad03";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0/linux-x86_64/fa/firefox-112.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.1/linux-x86_64/fa/firefox-112.0.1.tar.bz2";
       locale = "fa";
       arch = "linux-x86_64";
-      sha256 = "499be0f1463f830c6416939e096e94ebcb4a1d74726558ef9f0547b2ae233247";
+      sha256 = "16ef1cff8506f6c2b51fd511416e87095929824f86f9efa48b4e4908f7fff39a";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0/linux-x86_64/ff/firefox-112.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.1/linux-x86_64/ff/firefox-112.0.1.tar.bz2";
       locale = "ff";
       arch = "linux-x86_64";
-      sha256 = "5ba8e592f4399dd31d95b06823a342cd6662d0ddd7e3794989ae5c5ac2e52aff";
+      sha256 = "0d62047ad33735aa46f745af59baf77ed7fe5f52acad40f08b26a9a477dee9d6";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0/linux-x86_64/fi/firefox-112.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.1/linux-x86_64/fi/firefox-112.0.1.tar.bz2";
       locale = "fi";
       arch = "linux-x86_64";
-      sha256 = "480bafb6c43ef6da5b54543a5f96761e83706a86115247e683393330557cacfb";
+      sha256 = "e0f3cac06f7a949ab17e60599fcadce7c3953df5f079fb88ef7bf2288c57bd3b";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0/linux-x86_64/fr/firefox-112.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.1/linux-x86_64/fr/firefox-112.0.1.tar.bz2";
       locale = "fr";
       arch = "linux-x86_64";
-      sha256 = "b91bb26a3d6293e88ddc0b74882ab2185c7538df893d952eb64d595b0ccdeb1f";
+      sha256 = "c764c8a45e7ba5c2d2843a9abc875cc69e6854d51ff1971574581a96eba46f00";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0/linux-x86_64/fur/firefox-112.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.1/linux-x86_64/fur/firefox-112.0.1.tar.bz2";
       locale = "fur";
       arch = "linux-x86_64";
-      sha256 = "ab91f915296d8208363f6c882c7e29954e9e5506de30ae62b37eceff1d3d7c7b";
+      sha256 = "25bdd7f2ef2082f78fa5791c96991bb5c0a8b8d2e9dea084d8657a1296c47bd8";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0/linux-x86_64/fy-NL/firefox-112.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.1/linux-x86_64/fy-NL/firefox-112.0.1.tar.bz2";
       locale = "fy-NL";
       arch = "linux-x86_64";
-      sha256 = "981ea5abc2c5ff94029b3c01674892f397f8504c1f180a56e3e8620ac370b99f";
+      sha256 = "4bea0e611c5574c481ffc1f6c31ab085225536856f7de8100a75d31651530b89";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0/linux-x86_64/ga-IE/firefox-112.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.1/linux-x86_64/ga-IE/firefox-112.0.1.tar.bz2";
       locale = "ga-IE";
       arch = "linux-x86_64";
-      sha256 = "5eadd57836438871d6ef96a57e02e60fe6cfddd47e2445703b1d8db80a1d2fc7";
+      sha256 = "90e6f28e3aed2288731b3b9e7066b4603846b2ef848a23cfa6d821478879b146";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0/linux-x86_64/gd/firefox-112.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.1/linux-x86_64/gd/firefox-112.0.1.tar.bz2";
       locale = "gd";
       arch = "linux-x86_64";
-      sha256 = "41666cb94981dc30cfa0113c42743b3812add4df3686a39a64f9a0f2baacbee0";
+      sha256 = "3b3fb7d17b4091eca185833f8f486b17b8fe3b9c3ecad316dccb0779aadb4490";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0/linux-x86_64/gl/firefox-112.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.1/linux-x86_64/gl/firefox-112.0.1.tar.bz2";
       locale = "gl";
       arch = "linux-x86_64";
-      sha256 = "820b660761a9a265618be1061544243d24b82cfcd63a5e1fc8d8525ded22c1d5";
+      sha256 = "dde97c135fba0ce84e1e517a77821a7c9cde34ac02230ab23879982c2bc4de77";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0/linux-x86_64/gn/firefox-112.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.1/linux-x86_64/gn/firefox-112.0.1.tar.bz2";
       locale = "gn";
       arch = "linux-x86_64";
-      sha256 = "9ac4fb8d505a53226f36a9dc002ba42246a5c509d7652a2fec05584a34d6d47c";
+      sha256 = "be096c4bd208c339c1882aa22d5ca94139cc6605691a114ff8f2de397946be2f";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0/linux-x86_64/gu-IN/firefox-112.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.1/linux-x86_64/gu-IN/firefox-112.0.1.tar.bz2";
       locale = "gu-IN";
       arch = "linux-x86_64";
-      sha256 = "ddfe903790c3adf8f809e06a4e2790aa0ae876cfc291c4fdb22984376a8df3c4";
+      sha256 = "62c3d524526543f0ea6ef1b5013b3dd2316590eb8f9b2a68184c68e24cd20e43";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0/linux-x86_64/he/firefox-112.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.1/linux-x86_64/he/firefox-112.0.1.tar.bz2";
       locale = "he";
       arch = "linux-x86_64";
-      sha256 = "3e61787c63867631ed76be4c6a9cd9b9853348c912b9c23af06692bdce29315b";
+      sha256 = "5f626f9004889bafbb11a6bce604481f0e8b1e445b372d8159d210798c67cc20";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0/linux-x86_64/hi-IN/firefox-112.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.1/linux-x86_64/hi-IN/firefox-112.0.1.tar.bz2";
       locale = "hi-IN";
       arch = "linux-x86_64";
-      sha256 = "4b179b9e9286daffaf2aef9bfccb896475fa2576c92a289f1e4eb0edcb055688";
+      sha256 = "465bcef608d516b88a5c6a6e0c833f77e871250ccd937f2ff200aa88152a8acf";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0/linux-x86_64/hr/firefox-112.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.1/linux-x86_64/hr/firefox-112.0.1.tar.bz2";
       locale = "hr";
       arch = "linux-x86_64";
-      sha256 = "275cf0e84b2589e70e753d4c98e2c3925b14b603ed224da201878fc8442cc7a7";
+      sha256 = "5dec945d595e193c1971a179224d3f68b3df23b5c0a587375a77afce4d9e0055";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0/linux-x86_64/hsb/firefox-112.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.1/linux-x86_64/hsb/firefox-112.0.1.tar.bz2";
       locale = "hsb";
       arch = "linux-x86_64";
-      sha256 = "c56f94b46d96923eb9c4e75339af0b42a15f3c57e8e39118485bc79636ebfa32";
+      sha256 = "a6db8e61d45a20bbb6797757eccc1150ac8f7d3a24561ff86f7a68b57183a051";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0/linux-x86_64/hu/firefox-112.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.1/linux-x86_64/hu/firefox-112.0.1.tar.bz2";
       locale = "hu";
       arch = "linux-x86_64";
-      sha256 = "1a5b9a4307deff20db53df233864a503befc25ccedb204f7d88ca6bd867e00a8";
+      sha256 = "5d1e84ffe73b3d91d1d2527a8dd08fdbd7f0df50cdbeeefcf9139b0ac359ebde";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0/linux-x86_64/hy-AM/firefox-112.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.1/linux-x86_64/hy-AM/firefox-112.0.1.tar.bz2";
       locale = "hy-AM";
       arch = "linux-x86_64";
-      sha256 = "076f4159bf40e38ad730622decef57eff48fbe8e5988f78a5e2fb556a9f6a2e9";
+      sha256 = "07988bd5220f474ca1b6ca06a7a30f057b3ac93e07dccb2d969d938c74d92388";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0/linux-x86_64/ia/firefox-112.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.1/linux-x86_64/ia/firefox-112.0.1.tar.bz2";
       locale = "ia";
       arch = "linux-x86_64";
-      sha256 = "7bcf54767dd38d42d93d0b96ec5135213a29b5d78352d262d9335cd1576fd704";
+      sha256 = "dd4193ab35b05a767575f332398c1952020dbe698f583e08eeb3012e35ec386e";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0/linux-x86_64/id/firefox-112.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.1/linux-x86_64/id/firefox-112.0.1.tar.bz2";
       locale = "id";
       arch = "linux-x86_64";
-      sha256 = "dde4e712171c26b64e2b14d725ba93336b9e766bcc7f53fb2093d7fb0a8b057b";
+      sha256 = "1b9cb6b5889b32cf5d906a4d85521b8fdc98f74d1ed13ac77a8252bfe7ff84d9";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0/linux-x86_64/is/firefox-112.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.1/linux-x86_64/is/firefox-112.0.1.tar.bz2";
       locale = "is";
       arch = "linux-x86_64";
-      sha256 = "680e69de93ff6c96d9f3debe05392d98bb926e6072e04375e2d61e7387c18ee1";
+      sha256 = "a4b0d7918a259ba34df259366d1db65e7ae1c47feea4e9fb6047c0051eccf52f";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0/linux-x86_64/it/firefox-112.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.1/linux-x86_64/it/firefox-112.0.1.tar.bz2";
       locale = "it";
       arch = "linux-x86_64";
-      sha256 = "3f35ab7843b58d218c6f4e92552549b6b095d71dc1d7d35bdb28f1ef7458d442";
+      sha256 = "e9a5fb694a2b26ee05059340b4d6698261d1b9440e2a838ffa8eed3fab7a967c";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0/linux-x86_64/ja/firefox-112.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.1/linux-x86_64/ja/firefox-112.0.1.tar.bz2";
       locale = "ja";
       arch = "linux-x86_64";
-      sha256 = "3afd18750cf2555fb73d57a753222572fec08e49e7325b16427ecaa1249b51ab";
+      sha256 = "9ed9888d19d21024306163a155df7c49188212e308e1aa4981273fb5f06e2a88";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0/linux-x86_64/ka/firefox-112.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.1/linux-x86_64/ka/firefox-112.0.1.tar.bz2";
       locale = "ka";
       arch = "linux-x86_64";
-      sha256 = "8bd98c293361382940ad26ed0d654bc70390f66eacda19a7aa3d8bba717bb69a";
+      sha256 = "7b573603e74a833fbdcad554b27d006f01a0d6019e94338e6fead0c0be1c56b2";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0/linux-x86_64/kab/firefox-112.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.1/linux-x86_64/kab/firefox-112.0.1.tar.bz2";
       locale = "kab";
       arch = "linux-x86_64";
-      sha256 = "47dd2bab2c7b5e8046fa0499e48717c3cbcc6a633fab2a74d0a37c58cee80cc4";
+      sha256 = "a98b7b01aa07c27075d44d593870fa52dc124103b52e77f30cfaec12f755c194";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0/linux-x86_64/kk/firefox-112.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.1/linux-x86_64/kk/firefox-112.0.1.tar.bz2";
       locale = "kk";
       arch = "linux-x86_64";
-      sha256 = "50068256add6746481c5102dfd35ce87ee2cfbdb23432cf8d3306ed5e2ce6095";
+      sha256 = "74a496d781fea2e845876871bd731d98fa6f30c4b083e19eadc2762c8cd3644f";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0/linux-x86_64/km/firefox-112.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.1/linux-x86_64/km/firefox-112.0.1.tar.bz2";
       locale = "km";
       arch = "linux-x86_64";
-      sha256 = "85045900caa1a361bd79af5058765a3ae7e9a300b1f90975f6f3bc1c07481471";
+      sha256 = "a0b5a577323ae6f20d0bbfb0022c502e9c3228ea0e252cce19bc88df64cb22fb";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0/linux-x86_64/kn/firefox-112.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.1/linux-x86_64/kn/firefox-112.0.1.tar.bz2";
       locale = "kn";
       arch = "linux-x86_64";
-      sha256 = "796ffb0a8130931555e23a21977e8e4f9ab8ea6a9fee54ff4410b48a1e56d553";
+      sha256 = "05c03016b5782ff7b07610cc3e438a9657b226d9150f5335a3fd34906348dc8f";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0/linux-x86_64/ko/firefox-112.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.1/linux-x86_64/ko/firefox-112.0.1.tar.bz2";
       locale = "ko";
       arch = "linux-x86_64";
-      sha256 = "d937b25cc45b3189fce933ef0ba627fd79a79b3a90464eddb0dbb8a366f288c6";
+      sha256 = "9da58cde61b0f0e2208dc01b4de216732786460e8d6fa82533b682bb4d678614";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0/linux-x86_64/lij/firefox-112.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.1/linux-x86_64/lij/firefox-112.0.1.tar.bz2";
       locale = "lij";
       arch = "linux-x86_64";
-      sha256 = "58aab71db6df9d5d277b46d31f8c0197c9d01908adddcd1adf6954118165aa11";
+      sha256 = "85202a3383a179b471d5020469af49fb52e154e4f71cd00833fe7137240c8149";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0/linux-x86_64/lt/firefox-112.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.1/linux-x86_64/lt/firefox-112.0.1.tar.bz2";
       locale = "lt";
       arch = "linux-x86_64";
-      sha256 = "d02bbab7d236ff9b7ada25949337895cfa4c2224470b9ad0f96b25fc34fac870";
+      sha256 = "fbcf75e4b55d6eb423f3d94e363e68d0ca1e33f3e199c4ea4d26f0cfd0b3e4f5";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0/linux-x86_64/lv/firefox-112.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.1/linux-x86_64/lv/firefox-112.0.1.tar.bz2";
       locale = "lv";
       arch = "linux-x86_64";
-      sha256 = "3621f49e44c2cc7dc99303cb454ef330f91a5b19b19c12ba0a1781b908a386e4";
+      sha256 = "d41068cd02315dec5daac3c6dfe37ef7eb9c0f2ebafb9d9f223cc287b8d22115";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0/linux-x86_64/mk/firefox-112.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.1/linux-x86_64/mk/firefox-112.0.1.tar.bz2";
       locale = "mk";
       arch = "linux-x86_64";
-      sha256 = "5be36bd63a6c05b445e27c10aeee9dc16e30b08481af4710aab3ceb9327d226f";
+      sha256 = "ec654f8c5d676506b134c5ba4069c7fe1bea15db644808b191d6474f45c75783";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0/linux-x86_64/mr/firefox-112.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.1/linux-x86_64/mr/firefox-112.0.1.tar.bz2";
       locale = "mr";
       arch = "linux-x86_64";
-      sha256 = "a05c77825c7adf0413649f8f580353d086c63b4daa3da0ad408577061819e9a3";
+      sha256 = "b4f0d9ff4b887b7d2fb657b107547caf834804e695872a422570211d4eeff089";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0/linux-x86_64/ms/firefox-112.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.1/linux-x86_64/ms/firefox-112.0.1.tar.bz2";
       locale = "ms";
       arch = "linux-x86_64";
-      sha256 = "05d77b0eeaccef202b1a712bdbc3a4297658646b55e680ec1360980960e5a2ae";
+      sha256 = "3bcae3c3c59484e7196bf8b7122da9a75f1f5657f68cc8125cd3e37c77f85ebf";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0/linux-x86_64/my/firefox-112.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.1/linux-x86_64/my/firefox-112.0.1.tar.bz2";
       locale = "my";
       arch = "linux-x86_64";
-      sha256 = "f7703567dbe5ebc9cbb12c45361400009e9ea360ccb03585139834b8958b1e85";
+      sha256 = "dc07314c65084877c8c89035b1f821eea79993dcc5b55ecb304754ba6ea6808b";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0/linux-x86_64/nb-NO/firefox-112.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.1/linux-x86_64/nb-NO/firefox-112.0.1.tar.bz2";
       locale = "nb-NO";
       arch = "linux-x86_64";
-      sha256 = "183e9b9ec131621e457f62ede092506189c83f12a2e9a95b6f226478e2b7b445";
+      sha256 = "df4b24e54cd19b30a2d0de40e6efac30ff7a7a4a5542c9f6dd4c63b1f9359af5";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0/linux-x86_64/ne-NP/firefox-112.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.1/linux-x86_64/ne-NP/firefox-112.0.1.tar.bz2";
       locale = "ne-NP";
       arch = "linux-x86_64";
-      sha256 = "cc71c856d696f0314ecd7b1d0727c169e92be7989a7f6c520abec02623ed97bf";
+      sha256 = "ff641ab36ed7c353609c346a66a9a7e5e5ff4f18a789a00d3c22c23bacc2a8a8";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0/linux-x86_64/nl/firefox-112.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.1/linux-x86_64/nl/firefox-112.0.1.tar.bz2";
       locale = "nl";
       arch = "linux-x86_64";
-      sha256 = "f69b8000257b28471a93946ba474dbf8669955c175e5411d848e0aabc2aca3bd";
+      sha256 = "b3161e91e62415101daef2620d747e67cafc649518007da34e16da0a46a881ef";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0/linux-x86_64/nn-NO/firefox-112.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.1/linux-x86_64/nn-NO/firefox-112.0.1.tar.bz2";
       locale = "nn-NO";
       arch = "linux-x86_64";
-      sha256 = "7088ab439789484fca1f97e7500f9096cdef308d3d2b5c003813ef4a0a8873d2";
+      sha256 = "3b298aa6a1957e160d162f36eaf8af2e5f0c36af80dd7d047f50774b9f7d1d09";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0/linux-x86_64/oc/firefox-112.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.1/linux-x86_64/oc/firefox-112.0.1.tar.bz2";
       locale = "oc";
       arch = "linux-x86_64";
-      sha256 = "7093dea0249eae06d00fd45e185a404d166d8822850b98d68628152be8ca3d37";
+      sha256 = "ce50933b0f8e672f1552973791312ef337b71e374c4327ea7bcee7f30da43baf";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0/linux-x86_64/pa-IN/firefox-112.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.1/linux-x86_64/pa-IN/firefox-112.0.1.tar.bz2";
       locale = "pa-IN";
       arch = "linux-x86_64";
-      sha256 = "d2f742748239eb6076024b3c02e557961590a453b17697099ce9c2d8ca3cdf19";
+      sha256 = "8b01acea823d687303fa21f6502a2e6b4ab1a6f3ad3a6e4b3a7e2a0ea0ee55c1";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0/linux-x86_64/pl/firefox-112.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.1/linux-x86_64/pl/firefox-112.0.1.tar.bz2";
       locale = "pl";
       arch = "linux-x86_64";
-      sha256 = "3a543d4a021bf5d7ae434ab97be6c4966b6b101d57731dcd685d05657d4583bb";
+      sha256 = "9d2018e146acac6440bc12ea8c6c410ea7c11e7e18cda5e8f72f33813d5dbd87";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0/linux-x86_64/pt-BR/firefox-112.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.1/linux-x86_64/pt-BR/firefox-112.0.1.tar.bz2";
       locale = "pt-BR";
       arch = "linux-x86_64";
-      sha256 = "ab6e127faf64aa4cf54a00ae5462ea05082a8ebd474cd7c193045c3023cf2b7e";
+      sha256 = "0c4b8b4871c4a2a8374f6cdb5c3c8f8986285d4e0a105797e025608298765253";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0/linux-x86_64/pt-PT/firefox-112.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.1/linux-x86_64/pt-PT/firefox-112.0.1.tar.bz2";
       locale = "pt-PT";
       arch = "linux-x86_64";
-      sha256 = "9f42addf0e2c23daf53a46637aa3fd4fe98269889fb83debe762b50707d29dfd";
+      sha256 = "6e227a07bf2d909763a22f8bf5c2e2b74b39651881685d00bc64bd4fea7d939f";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0/linux-x86_64/rm/firefox-112.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.1/linux-x86_64/rm/firefox-112.0.1.tar.bz2";
       locale = "rm";
       arch = "linux-x86_64";
-      sha256 = "b473c7d80372257d2dbd193ee4582a24f98f0c03cab53c5272bf27c94919cb63";
+      sha256 = "28878ce52ccf14a6745d5e2b57155d20ac966a345822d1d95006fdeaae12a2a7";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0/linux-x86_64/ro/firefox-112.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.1/linux-x86_64/ro/firefox-112.0.1.tar.bz2";
       locale = "ro";
       arch = "linux-x86_64";
-      sha256 = "c9c64e814b2b12f16b8d3033fbd3c146faaa2a3c4b5777161f64252d5d63e998";
+      sha256 = "dd0b021cd9cd6f903d9b253309658da187485f57db7b1ae6e466c186ee49d8b7";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0/linux-x86_64/ru/firefox-112.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.1/linux-x86_64/ru/firefox-112.0.1.tar.bz2";
       locale = "ru";
       arch = "linux-x86_64";
-      sha256 = "f8cf8f416b9a82a1b03d9989e512ede25cfb3aa1b58ddffcda0d17b3ae173ff0";
+      sha256 = "6b0564a7139628b15df935f4a1add5263ca67e686b0558ec70f305258bdc4054";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0/linux-x86_64/sc/firefox-112.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.1/linux-x86_64/sc/firefox-112.0.1.tar.bz2";
       locale = "sc";
       arch = "linux-x86_64";
-      sha256 = "6c1a40a2bb9db2b0d6afe63a3c76a774ef888f60f0a23814c2db5d08c77d43d8";
+      sha256 = "db9e37d5202a44542ea7fb62a946c858eac6716625c63d190a34d0fda7a7b955";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0/linux-x86_64/sco/firefox-112.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.1/linux-x86_64/sco/firefox-112.0.1.tar.bz2";
       locale = "sco";
       arch = "linux-x86_64";
-      sha256 = "0529f55e7b0b6ccc2a3ec92cd0dbdac0210e4c45bbd00d350d08e2d12ece818a";
+      sha256 = "f35499b1b27fa69934a2c9fbc030a15884966c6f7b38e3d07abdfe7d8af8ba28";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0/linux-x86_64/si/firefox-112.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.1/linux-x86_64/si/firefox-112.0.1.tar.bz2";
       locale = "si";
       arch = "linux-x86_64";
-      sha256 = "891a18f8f7049997a62e997a17b8254a454335c65c5edcac45f441e931fd8049";
+      sha256 = "cd90b1bcb2e0c59420f33728b63530f282bebe61cea80e5817dc8eb8abe77d52";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0/linux-x86_64/sk/firefox-112.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.1/linux-x86_64/sk/firefox-112.0.1.tar.bz2";
       locale = "sk";
       arch = "linux-x86_64";
-      sha256 = "5eca1dfd6ed1b75957d6b4d1a7c0aaea2a140b85e10043e72260dea5938e928d";
+      sha256 = "3d34d6502191d06f207c57b8cd15cd33b6cb93533bb962498c240be8b6d8a989";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0/linux-x86_64/sl/firefox-112.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.1/linux-x86_64/sl/firefox-112.0.1.tar.bz2";
       locale = "sl";
       arch = "linux-x86_64";
-      sha256 = "26f9946afc6b6b8c7b42f359049bb0b9586d961f9ff45a1490bf6e3a13330fc3";
+      sha256 = "32a5359344d8580d551d38a03d691eae56c0f868cd1e5810bcf116043cd19f97";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0/linux-x86_64/son/firefox-112.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.1/linux-x86_64/son/firefox-112.0.1.tar.bz2";
       locale = "son";
       arch = "linux-x86_64";
-      sha256 = "df183627ea5817d7e2741bee238a24674a1cad312d72a412fbb7660c3574f173";
+      sha256 = "7ac2c8a8218687638bc3ba9f14b72015020d25cc6a28e192705bd5dfdca83b60";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0/linux-x86_64/sq/firefox-112.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.1/linux-x86_64/sq/firefox-112.0.1.tar.bz2";
       locale = "sq";
       arch = "linux-x86_64";
-      sha256 = "7dca7529a949bef4d7ea32bef0b4dec8be74ec70b28e3467f3e55ce7e559fbe1";
+      sha256 = "6cefb5b63772879cc83a8113afa682499222f0c58b736bca9049699f76ba4403";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0/linux-x86_64/sr/firefox-112.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.1/linux-x86_64/sr/firefox-112.0.1.tar.bz2";
       locale = "sr";
       arch = "linux-x86_64";
-      sha256 = "38fcf34bc58bb6cfabebcfd5968c6b6183b7188f4f93ce88b195501a43842dfd";
+      sha256 = "73a3ef123e3c65f251557cdcad39197684ef258bc9d79973568d8e50641bd6b4";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0/linux-x86_64/sv-SE/firefox-112.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.1/linux-x86_64/sv-SE/firefox-112.0.1.tar.bz2";
       locale = "sv-SE";
       arch = "linux-x86_64";
-      sha256 = "5ca84fc079c62a62714e22eac1b9b93e9fae9948694995313d98961147aa390e";
+      sha256 = "6182cdf106563fd8016765a08169dae772641b7badf581b4f1cd71d22d66a739";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0/linux-x86_64/szl/firefox-112.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.1/linux-x86_64/szl/firefox-112.0.1.tar.bz2";
       locale = "szl";
       arch = "linux-x86_64";
-      sha256 = "aba9805904c45d03ea4ab091c5c15bba4e4ee7392b91ce23a4adc57581c1dd22";
+      sha256 = "808d255d36dc65c0126a62e6acc54231bd4bcc6e171a2ac017f1746607b9c981";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0/linux-x86_64/ta/firefox-112.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.1/linux-x86_64/ta/firefox-112.0.1.tar.bz2";
       locale = "ta";
       arch = "linux-x86_64";
-      sha256 = "fbb368a2b49211242273c93f3930824adf41fa06c69f9b84b3dea4f44a80e2f2";
+      sha256 = "32389f9702b9f2e1dc87c40d6ab64da59c42ae7d0471c56d8f66c8187ddc2fc4";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0/linux-x86_64/te/firefox-112.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.1/linux-x86_64/te/firefox-112.0.1.tar.bz2";
       locale = "te";
       arch = "linux-x86_64";
-      sha256 = "c3e524c50b92f4df65c733eb57957893b840dbe959ccc94fb70af31eb93cfc01";
+      sha256 = "3a0ebea6051d8e495c8bdce885b6880198bae4f72c5c4991611d9f9b58054921";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0/linux-x86_64/th/firefox-112.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.1/linux-x86_64/th/firefox-112.0.1.tar.bz2";
       locale = "th";
       arch = "linux-x86_64";
-      sha256 = "eb077d3503427f54497bf6b23cb8a6f20106bbb3f0a42426d3d68ee8b4570c68";
+      sha256 = "c3987449dc9f22b149c193aab7f618129e6f3f82df87753f21b93a579f4a8c46";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0/linux-x86_64/tl/firefox-112.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.1/linux-x86_64/tl/firefox-112.0.1.tar.bz2";
       locale = "tl";
       arch = "linux-x86_64";
-      sha256 = "ad7b565d757eea9f9332fe58846bdfcb1811a88ce378482f1fee33182cf819b0";
+      sha256 = "f69a1d00396fca338b1ef37fc98566c1f977fd41103950a05bec22f88eca9708";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0/linux-x86_64/tr/firefox-112.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.1/linux-x86_64/tr/firefox-112.0.1.tar.bz2";
       locale = "tr";
       arch = "linux-x86_64";
-      sha256 = "1b44f97c0dc636ad87c24b5f4881dfc058b1cac9ab5702b8500080509d078656";
+      sha256 = "ccdee7f762fae29a3a6f52a50aa3104965fac7c8ea6d0c0be7029dec33d59f48";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0/linux-x86_64/trs/firefox-112.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.1/linux-x86_64/trs/firefox-112.0.1.tar.bz2";
       locale = "trs";
       arch = "linux-x86_64";
-      sha256 = "185e15f0863c6686580e55114513ff77420353d6280b8bab925d3c7cac969723";
+      sha256 = "9ddbd803a3188c69c90b0a62b295cbbef3357f3cd3074080bf6f4d6eb87b94d3";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0/linux-x86_64/uk/firefox-112.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.1/linux-x86_64/uk/firefox-112.0.1.tar.bz2";
       locale = "uk";
       arch = "linux-x86_64";
-      sha256 = "4b60d02bd16d187445c8c33f1ad89fedf60f8d5d0b8c00fa9fc9da61cc3245a3";
+      sha256 = "5409d308337224d5c76a7f20d99d6bae87b0535aa9ba3c56abaac677543dd04e";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0/linux-x86_64/ur/firefox-112.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.1/linux-x86_64/ur/firefox-112.0.1.tar.bz2";
       locale = "ur";
       arch = "linux-x86_64";
-      sha256 = "9d5a717414b66bcfd11e2c1f75ff5056ef1189a371a2c13f568a61adcf4fd9d4";
+      sha256 = "a2aa8fbaef5f1814128a3d39a4780bbb8aa20ab7970f10ecd51165e21e0fbb4d";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0/linux-x86_64/uz/firefox-112.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.1/linux-x86_64/uz/firefox-112.0.1.tar.bz2";
       locale = "uz";
       arch = "linux-x86_64";
-      sha256 = "e7981e8eb720aa9fc241e808d521f0ad6c0222c219e8a6356fdf4331ca628721";
+      sha256 = "55230fd3cde7e5dab7309b7dcfd7688feb332ec3c8370001ba925076c3200bbf";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0/linux-x86_64/vi/firefox-112.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.1/linux-x86_64/vi/firefox-112.0.1.tar.bz2";
       locale = "vi";
       arch = "linux-x86_64";
-      sha256 = "7aef5cf761451e7bbd6569e28af2981b65709d3265bb96ed934d43915a3fcb17";
+      sha256 = "f7a8ecf5eeac44aa6ca156d131ebd05a268ce5e92ff0c88c208c3981a658ef78";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0/linux-x86_64/xh/firefox-112.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.1/linux-x86_64/xh/firefox-112.0.1.tar.bz2";
       locale = "xh";
       arch = "linux-x86_64";
-      sha256 = "d12eab3c301a28871c298f351efa84a1aa2613014029e40d8bb46c073fb7224e";
+      sha256 = "e52862f470202fa07f370a8912023edbf2a5350f1aa7ce5351afa335fc194bc4";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0/linux-x86_64/zh-CN/firefox-112.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.1/linux-x86_64/zh-CN/firefox-112.0.1.tar.bz2";
       locale = "zh-CN";
       arch = "linux-x86_64";
-      sha256 = "92d3ab06e3a09be0691c84ffd48c4f897197253f66e6a178e5272a3d8caadf65";
+      sha256 = "03e0a67ed68413022cb5452e68f1dde9480ec71cfd6726be604cbc54581ce84c";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0/linux-x86_64/zh-TW/firefox-112.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.1/linux-x86_64/zh-TW/firefox-112.0.1.tar.bz2";
       locale = "zh-TW";
       arch = "linux-x86_64";
-      sha256 = "db6dc1a6ed43970404d643cd4f6d1917e9202070719695aa9b4268756278c22c";
+      sha256 = "f4e54e3ef22307cb52c26059cd7d862ce7c45c24e6c7cc365f3b0e45f84afeea";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0/linux-i686/ach/firefox-112.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.1/linux-i686/ach/firefox-112.0.1.tar.bz2";
       locale = "ach";
       arch = "linux-i686";
-      sha256 = "7de9c82fe6edbe0876021f730128344d3fc1ef275191093387d662d58599cbd6";
+      sha256 = "68d790bffa6415c57274d39e1ca04ccafd55c78720b659beaa696746c8a196a4";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0/linux-i686/af/firefox-112.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.1/linux-i686/af/firefox-112.0.1.tar.bz2";
       locale = "af";
       arch = "linux-i686";
-      sha256 = "c5632e4c7f4d313bfe63720855bb5ea02aa3559d96199aacdacd11de34a5d55b";
+      sha256 = "db827c1ece4fa12b217fb7c41af6064cd286c1f73c3deda8f370cc24294829f7";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0/linux-i686/an/firefox-112.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.1/linux-i686/an/firefox-112.0.1.tar.bz2";
       locale = "an";
       arch = "linux-i686";
-      sha256 = "34b0826655c65ac70be63308d2f6339046a859a5fe4d7e64f7969e54bd689f5f";
+      sha256 = "8e43a3008913bbbb33578ffe6725e5cfcc191484d66e9b4ccb80fb4bd1e1822c";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0/linux-i686/ar/firefox-112.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.1/linux-i686/ar/firefox-112.0.1.tar.bz2";
       locale = "ar";
       arch = "linux-i686";
-      sha256 = "ab1b031a4783a3ab87199801104df777b5d46fd6034b47b2f4af29ddd031739f";
+      sha256 = "639cda8d39adf8618b316ed30768306c60b5a2f03c8aacc4e8196b9050f7bc5d";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0/linux-i686/ast/firefox-112.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.1/linux-i686/ast/firefox-112.0.1.tar.bz2";
       locale = "ast";
       arch = "linux-i686";
-      sha256 = "e6e0195900e50612d58cc3f8e7cf2f74868509ce6378402484fcfa6b3611eaa8";
+      sha256 = "76e1b0b2d93728304eca8dd25c6d8b589afd054ab1b1b1ac0ddaf4c20982962b";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0/linux-i686/az/firefox-112.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.1/linux-i686/az/firefox-112.0.1.tar.bz2";
       locale = "az";
       arch = "linux-i686";
-      sha256 = "3aa1eee51d132f20f8ceee9e391e86befad71ce9fbca64e1171af053503492f3";
+      sha256 = "7ce308bcfb41db1149425cb73b3298ea98735c871c46077bec33a9c74d876ac7";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0/linux-i686/be/firefox-112.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.1/linux-i686/be/firefox-112.0.1.tar.bz2";
       locale = "be";
       arch = "linux-i686";
-      sha256 = "77a6ea4c1d9657e4566288156479a878cd6c572770aca97aa7a94daf12ba9255";
+      sha256 = "fde37924c46e1a0d1f7dfe17187abf1756e7f02a5ace60b239acfdca11f9a5b4";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0/linux-i686/bg/firefox-112.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.1/linux-i686/bg/firefox-112.0.1.tar.bz2";
       locale = "bg";
       arch = "linux-i686";
-      sha256 = "4d282c790d8ed4abbb7ad10de56672e8bef57347760d551b32f28a71b64de5b8";
+      sha256 = "8b99e80e883aa1d24612978e085adb0d0d6fb00bc71817e48cdf95bd407eab3e";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0/linux-i686/bn/firefox-112.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.1/linux-i686/bn/firefox-112.0.1.tar.bz2";
       locale = "bn";
       arch = "linux-i686";
-      sha256 = "797b570f75c5cd4cab0fbc5abc4992eb83e1cd109c5ba2588df784827cc29762";
+      sha256 = "82e31e51ecd8d478eef65f437e07d695745bd03d02ee90379364c17506cac7fa";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0/linux-i686/br/firefox-112.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.1/linux-i686/br/firefox-112.0.1.tar.bz2";
       locale = "br";
       arch = "linux-i686";
-      sha256 = "3e4ad574d26492e53a84385a558d75b280952abf066be26771f4193e00c6b328";
+      sha256 = "23a8d61abb4001186847a43b13cf497f9872b8aba5119e515ef4fc5862220410";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0/linux-i686/bs/firefox-112.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.1/linux-i686/bs/firefox-112.0.1.tar.bz2";
       locale = "bs";
       arch = "linux-i686";
-      sha256 = "a4b862924d1c20aba4ab2fa0774b5c65509cb6f80902faeb0cac86f691f8887d";
+      sha256 = "149c6fcba2165f9c16f2df471aa345c75b7effe9d7d34e011a1c59bd4a24992a";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0/linux-i686/ca-valencia/firefox-112.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.1/linux-i686/ca-valencia/firefox-112.0.1.tar.bz2";
       locale = "ca-valencia";
       arch = "linux-i686";
-      sha256 = "9c2a188bc5188b79ca89ea90f4cd300f4a680fec945a1b6e663569f1f6f2e19e";
+      sha256 = "567e3cf76f645820a1b10cae5c1b38967c0348fbf65eda45eeb9fe2fa4d901d8";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0/linux-i686/ca/firefox-112.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.1/linux-i686/ca/firefox-112.0.1.tar.bz2";
       locale = "ca";
       arch = "linux-i686";
-      sha256 = "f6031d641da6e828ea6160aa2ac1a3d9ec31efcbfa69373f33dbcfd1d6282ac0";
+      sha256 = "db7bee1e3fe1be75d7fb92a242d7a436902f5fe86b8aa4c7fa25dfe61f3faac2";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0/linux-i686/cak/firefox-112.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.1/linux-i686/cak/firefox-112.0.1.tar.bz2";
       locale = "cak";
       arch = "linux-i686";
-      sha256 = "9a6553004abc3c548559373a2185405a1a6887898fd2236c4556948fc6faae0f";
+      sha256 = "4eb2cd9f324777fcb8be0af9840eea4d01084921c270278605a4d9e90f69ab41";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0/linux-i686/cs/firefox-112.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.1/linux-i686/cs/firefox-112.0.1.tar.bz2";
       locale = "cs";
       arch = "linux-i686";
-      sha256 = "322f49bd3775410206107645aa1e049cf2ab58f251baf991aa65f0be8bcd867e";
+      sha256 = "d5acd46ffe1c44b8e150cc392c06de3b9886dc996942c82593a326692897c8b0";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0/linux-i686/cy/firefox-112.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.1/linux-i686/cy/firefox-112.0.1.tar.bz2";
       locale = "cy";
       arch = "linux-i686";
-      sha256 = "ab47eaab21c51e37af812e2453f4b1685c98489a15b3bb3ed0582c8284ee4bfc";
+      sha256 = "d086fddb56c18a8189ca6c66c353e76d2e99853c88847675b2b69362741c41a7";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0/linux-i686/da/firefox-112.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.1/linux-i686/da/firefox-112.0.1.tar.bz2";
       locale = "da";
       arch = "linux-i686";
-      sha256 = "188aeb36e3443037cb5bdb84f37db67f238c0a238b71a1ae7cf8ad9fbb49fcc4";
+      sha256 = "b8c6e563c98a1a7e0c583bc3463d501dfa7d5b3f9e5bfdf026fad1f20e94b4b4";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0/linux-i686/de/firefox-112.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.1/linux-i686/de/firefox-112.0.1.tar.bz2";
       locale = "de";
       arch = "linux-i686";
-      sha256 = "5a13dbeca2b4cd0161f5a92df210a6642e7bb6167882f42db8627ceb31d30ec8";
+      sha256 = "8be83652fd8872ece97120f21abc66ef17332900696aea65350d9c36f51aef20";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0/linux-i686/dsb/firefox-112.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.1/linux-i686/dsb/firefox-112.0.1.tar.bz2";
       locale = "dsb";
       arch = "linux-i686";
-      sha256 = "e1e212072872a75e17c1c082a1efdecf8fc2288d88aa44a6a349f35811b27ed8";
+      sha256 = "0b7c5bf0808b4cdb24767aca38983db2769a9dc17182b05f05767f5bdb1510a7";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0/linux-i686/el/firefox-112.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.1/linux-i686/el/firefox-112.0.1.tar.bz2";
       locale = "el";
       arch = "linux-i686";
-      sha256 = "12b61693075bf6037c3333149b77a93a09572e133f43a66b7ffbfaa6984808e3";
+      sha256 = "564fc0fc6cf469254a55756142a7bd221f7e8f5a2a65a7af7884442d405cdcc3";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0/linux-i686/en-CA/firefox-112.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.1/linux-i686/en-CA/firefox-112.0.1.tar.bz2";
       locale = "en-CA";
       arch = "linux-i686";
-      sha256 = "3da37342412a77622c221ca48ea80877d8597b5403b69d11c898ce12aa13fea4";
+      sha256 = "8fe5513b1cd1e4735ead8f7232bfa95e709a7f09e15c998ffcc57e866f0e0177";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0/linux-i686/en-GB/firefox-112.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.1/linux-i686/en-GB/firefox-112.0.1.tar.bz2";
       locale = "en-GB";
       arch = "linux-i686";
-      sha256 = "80ea9f86cf37d64dfd4db5206284eae9807058596e4befa057d19985709cdb89";
+      sha256 = "6d7614935cd1cb93e8dbb843e5725d263655d0042fbcde4656fb90899fc4923e";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0/linux-i686/en-US/firefox-112.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.1/linux-i686/en-US/firefox-112.0.1.tar.bz2";
       locale = "en-US";
       arch = "linux-i686";
-      sha256 = "69a2a692718bdcd031cfe31535b2c993567d8bf6bc8d6814c43a4304e8fa470d";
+      sha256 = "7c30ab48a4cc32e6358d6dd29e34274453b1db998cb52cfc5e2108ebf1f9ba41";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0/linux-i686/eo/firefox-112.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.1/linux-i686/eo/firefox-112.0.1.tar.bz2";
       locale = "eo";
       arch = "linux-i686";
-      sha256 = "9bc2f1ae29f742fdaafedbc6f4626456dabd276a1bfcc8569affeca3252a3311";
+      sha256 = "d0c603545d9e36cc43a0dcf5013d29c2557f7b31fc4c551fe482d5e53b76e7f9";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0/linux-i686/es-AR/firefox-112.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.1/linux-i686/es-AR/firefox-112.0.1.tar.bz2";
       locale = "es-AR";
       arch = "linux-i686";
-      sha256 = "a964125f1c65bd031bd3bd76f79993ea4c44273adbeb95ed36de6ffaf9ad7900";
+      sha256 = "2b3e80b83fe78178074a784c6800ceea0ef449ec0fca0919855c0cfb0d8f3eb8";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0/linux-i686/es-CL/firefox-112.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.1/linux-i686/es-CL/firefox-112.0.1.tar.bz2";
       locale = "es-CL";
       arch = "linux-i686";
-      sha256 = "19ca07a13d4a2218fed1addb3d9297978b00e7e469a37294f8c3cf0aaf4f8998";
+      sha256 = "fa46c867f8daef7b4aebf3c9968f12b26aa5ead295baa5da991730bfd022907d";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0/linux-i686/es-ES/firefox-112.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.1/linux-i686/es-ES/firefox-112.0.1.tar.bz2";
       locale = "es-ES";
       arch = "linux-i686";
-      sha256 = "81ba2970c01d0c1d1465b1f601c2e753b0448d307df09ae49e2ca2257b3ff593";
+      sha256 = "a6c24fef469e0b7e4b8bab3ad7127c569e0c2e0c38c5cbf344dc70ada34016b8";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0/linux-i686/es-MX/firefox-112.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.1/linux-i686/es-MX/firefox-112.0.1.tar.bz2";
       locale = "es-MX";
       arch = "linux-i686";
-      sha256 = "02605c8bdc81077a491791ffc289c6071943e5e8a7983432a96937224d91a324";
+      sha256 = "372403d23deac3dfb397bb3c5da5b10e58c60656b9c5d9126d06435c07b86282";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0/linux-i686/et/firefox-112.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.1/linux-i686/et/firefox-112.0.1.tar.bz2";
       locale = "et";
       arch = "linux-i686";
-      sha256 = "6e83c5ad5eadd62122ebb3d39f6c03239e333a42616f105204ba83482c68b4fc";
+      sha256 = "586efc4af3e4c10e13394967d880e4132e9739da259a505df84488ed069bdb55";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0/linux-i686/eu/firefox-112.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.1/linux-i686/eu/firefox-112.0.1.tar.bz2";
       locale = "eu";
       arch = "linux-i686";
-      sha256 = "64fa6814864a6189bfbccedc191cb9810519e196a2ddf34725a35446595f5eaf";
+      sha256 = "ea16876186a0666cbf4783a114ae32c60d5279e9c0aee9db5ab7404a8ed94ff8";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0/linux-i686/fa/firefox-112.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.1/linux-i686/fa/firefox-112.0.1.tar.bz2";
       locale = "fa";
       arch = "linux-i686";
-      sha256 = "23c05ec2684597172470581c9369bec389709dd93b780bc888cc8ed3421e8b9f";
+      sha256 = "44189a301db4defe04160de90fd4722003b062460c44ccb54466044641eadfa6";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0/linux-i686/ff/firefox-112.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.1/linux-i686/ff/firefox-112.0.1.tar.bz2";
       locale = "ff";
       arch = "linux-i686";
-      sha256 = "ec3e121e10423b0141e94f9bc9fe16cc46c6e284c140acf24add74a3ef6fcb10";
+      sha256 = "6d61ac3ec8652416cbf32449658da95eecd8ea84fbb0fe5ddac4fc8c9ced964e";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0/linux-i686/fi/firefox-112.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.1/linux-i686/fi/firefox-112.0.1.tar.bz2";
       locale = "fi";
       arch = "linux-i686";
-      sha256 = "728d0c84b6d4c9deb81a8d08e3609bbecc8201649a3dac0af4dd13bbc0ac0cfd";
+      sha256 = "09e3ae90365f38d5fe7859c24c6bee640fd0aee3f2283d9cf1cc5840ac9fa70a";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0/linux-i686/fr/firefox-112.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.1/linux-i686/fr/firefox-112.0.1.tar.bz2";
       locale = "fr";
       arch = "linux-i686";
-      sha256 = "742f0ad5974032275c54fae54691061153075045f07ad71d47b93adea1d7b61a";
+      sha256 = "a037725177bd002cb06ff82548efe8e48b99095362c1ed443101dfe00f0c2e87";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0/linux-i686/fur/firefox-112.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.1/linux-i686/fur/firefox-112.0.1.tar.bz2";
       locale = "fur";
       arch = "linux-i686";
-      sha256 = "225f63643a67fac0eb2db946e819afb730ed32a364a61546d80d192cfd89e530";
+      sha256 = "fbfb3357784a0609260e42ef8011f354e3e9312607d116d324bbffa410607f01";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0/linux-i686/fy-NL/firefox-112.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.1/linux-i686/fy-NL/firefox-112.0.1.tar.bz2";
       locale = "fy-NL";
       arch = "linux-i686";
-      sha256 = "24ef6ed559bfb5811a482883bd33cbc3a9412141a3f487121a1aa1f5e5893b2a";
+      sha256 = "1a7348fd973379cb6b639f4651d704267cba9eea65484672858a7e6f55739cde";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0/linux-i686/ga-IE/firefox-112.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.1/linux-i686/ga-IE/firefox-112.0.1.tar.bz2";
       locale = "ga-IE";
       arch = "linux-i686";
-      sha256 = "a8bef67521297b9b6a089cd7c1b5c2c19d5d2a1845bb73b97beb70b1eb046f80";
+      sha256 = "01b7652d854d25745378e612f71e9aacef07d18318f14658a17d491a25724a62";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0/linux-i686/gd/firefox-112.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.1/linux-i686/gd/firefox-112.0.1.tar.bz2";
       locale = "gd";
       arch = "linux-i686";
-      sha256 = "4edfd3f269213dddabc6682893a27c24fc69614160cd19e3da3ca24906a571a8";
+      sha256 = "33bb06317e98eb560bff3599f57aa76b3d686549b32237200c12374fbb95cb7a";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0/linux-i686/gl/firefox-112.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.1/linux-i686/gl/firefox-112.0.1.tar.bz2";
       locale = "gl";
       arch = "linux-i686";
-      sha256 = "4cfb046bbd7e70029ad697abcb40536f34e8d6c22228ea4cc79f4dd36a48d5c2";
+      sha256 = "8ea125896e735709ac7ae1f5ef29740dd7db3eb08de10ee0b5a25e005e1bb1e1";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0/linux-i686/gn/firefox-112.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.1/linux-i686/gn/firefox-112.0.1.tar.bz2";
       locale = "gn";
       arch = "linux-i686";
-      sha256 = "001c3206f38b9c7053e3ae6b068fb245bcde6ace31be322f7bfd5c2c9f4c5f67";
+      sha256 = "f3e546720ac549e6b4c94bceba5c8fa66ef0af771268052fd114141397c5f518";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0/linux-i686/gu-IN/firefox-112.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.1/linux-i686/gu-IN/firefox-112.0.1.tar.bz2";
       locale = "gu-IN";
       arch = "linux-i686";
-      sha256 = "1af0d38f6be210f9f5aa62752982ee95e115d3eade6e10bfbd9b45e699d3c876";
+      sha256 = "e5a671e30fefd9a669b4f6d86b958887320dec0f450a302069ce944327d2b0b9";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0/linux-i686/he/firefox-112.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.1/linux-i686/he/firefox-112.0.1.tar.bz2";
       locale = "he";
       arch = "linux-i686";
-      sha256 = "32d34998b4cb5f30d7f21695bb7c50511c9810f652b387b87566315bd51a6688";
+      sha256 = "ecbea24231080df03d6a884589d1a48f5cdbc61eb9f53111507e438a1442972e";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0/linux-i686/hi-IN/firefox-112.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.1/linux-i686/hi-IN/firefox-112.0.1.tar.bz2";
       locale = "hi-IN";
       arch = "linux-i686";
-      sha256 = "8acdf419e6a3dd191f7e8d10c1d33eac02ef8ec93ea6486278b1ed3182c93536";
+      sha256 = "9ad861c0dfcc7cdf08129948b04a1ff22dbc84c67b0b085621fa11f9b733691a";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0/linux-i686/hr/firefox-112.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.1/linux-i686/hr/firefox-112.0.1.tar.bz2";
       locale = "hr";
       arch = "linux-i686";
-      sha256 = "ebac36e1550d70237306d3f69db9a029333c2e7cdcd0321fc4f0da8dee3c8e9f";
+      sha256 = "66a15a6321789612a15e1f897ba69146a0f48640a452b92e98ee50bc2fc5bee1";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0/linux-i686/hsb/firefox-112.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.1/linux-i686/hsb/firefox-112.0.1.tar.bz2";
       locale = "hsb";
       arch = "linux-i686";
-      sha256 = "6b5eea0bccf7a82484e7a0dab090716ebdb82a79151abc9d77aec1d5032356d3";
+      sha256 = "5e0a10c8abc026543ec9aee297b0246af5726fbc19c8c3defe3816cff96a5306";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0/linux-i686/hu/firefox-112.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.1/linux-i686/hu/firefox-112.0.1.tar.bz2";
       locale = "hu";
       arch = "linux-i686";
-      sha256 = "3abded26ade27554c48c6d0903d6cc5c5f1576766979542c80746c955cdbc9f4";
+      sha256 = "35dfc59a336d1d4c977f393cda08df4aac2ea4b570cb347234b04e36e60ccd7a";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0/linux-i686/hy-AM/firefox-112.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.1/linux-i686/hy-AM/firefox-112.0.1.tar.bz2";
       locale = "hy-AM";
       arch = "linux-i686";
-      sha256 = "50188c1333f393e7bb77d50d2adef4b52950bfa86fca993594f8db01a02f4a48";
+      sha256 = "a44666a2855563a2437a3a5b317858b5d97608c1d84a366e6fc9ca7d500fd908";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0/linux-i686/ia/firefox-112.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.1/linux-i686/ia/firefox-112.0.1.tar.bz2";
       locale = "ia";
       arch = "linux-i686";
-      sha256 = "cd2d66e303293cc7e81d2f571a5ad76f85bacaa59191ec31dff62ea31d4b0ccb";
+      sha256 = "578824cc54bf08eebb5391f7195e0e668684103d57913c73f34323e48fc9b997";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0/linux-i686/id/firefox-112.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.1/linux-i686/id/firefox-112.0.1.tar.bz2";
       locale = "id";
       arch = "linux-i686";
-      sha256 = "f2ebdc1585a49b2b489c8ac95240d0f8aa51473d0b78fdaeac234b6020696083";
+      sha256 = "ec9d5f75f85a97e88fa16eca1e5d365b20453594f23bc7ce6b0accd64a06cd2a";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0/linux-i686/is/firefox-112.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.1/linux-i686/is/firefox-112.0.1.tar.bz2";
       locale = "is";
       arch = "linux-i686";
-      sha256 = "095d254ff1e7fa05ac0723adf48c532e38fc5f7bb6cec81dc10139e0e070049f";
+      sha256 = "c11658c067c6ec8ed7f2cf34c74587b6500a3f96d0d48647105d6218b39dbffa";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0/linux-i686/it/firefox-112.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.1/linux-i686/it/firefox-112.0.1.tar.bz2";
       locale = "it";
       arch = "linux-i686";
-      sha256 = "0b731f69e7a08e6d022f0225b9992812e4d63216195f6519ce7b99ab9d3c368a";
+      sha256 = "0cd5cb70fc40956caed930ca51c01c539159a35a7a5ad5cbf9257a3e12bb9845";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0/linux-i686/ja/firefox-112.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.1/linux-i686/ja/firefox-112.0.1.tar.bz2";
       locale = "ja";
       arch = "linux-i686";
-      sha256 = "f3c84a776baef1a7b5ba7e232ebec5df71d06bf9317bcdd2cb6ab6ff72ef1691";
+      sha256 = "56a73fddb5a0d2d2160e68bcfab172e81f572a2db3981b43b330292057b0e671";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0/linux-i686/ka/firefox-112.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.1/linux-i686/ka/firefox-112.0.1.tar.bz2";
       locale = "ka";
       arch = "linux-i686";
-      sha256 = "cddc9cb826352cc94f42e600068f586c1e74c53d77df6c4cebe4f3008e3a9e90";
+      sha256 = "57bc43faf0e2610fb0e58c5e7e323e7909a9834dcac1bb6b1b3803c0ffe88ab4";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0/linux-i686/kab/firefox-112.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.1/linux-i686/kab/firefox-112.0.1.tar.bz2";
       locale = "kab";
       arch = "linux-i686";
-      sha256 = "dbc1b443083dda4bcf9b6fe76a6d4a032c4628d02555f0eda291b1ad99d597c3";
+      sha256 = "48eca6ab0e3dc3d187f2f296b48f5ddf85481f3c0a14614778fee21d0356ab5c";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0/linux-i686/kk/firefox-112.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.1/linux-i686/kk/firefox-112.0.1.tar.bz2";
       locale = "kk";
       arch = "linux-i686";
-      sha256 = "5e8b8d68697fb75cbfd48e6b78a76bbbd0a972cffc3ae43f8b192696c77c72ed";
+      sha256 = "0e8693939975ef607d1d955b994e047e43018be58654f25436233c8686241baf";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0/linux-i686/km/firefox-112.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.1/linux-i686/km/firefox-112.0.1.tar.bz2";
       locale = "km";
       arch = "linux-i686";
-      sha256 = "737db59818e7ce5fef6cdb9cf2d5bae9ed5205aef2f4924839fd2428fa70d965";
+      sha256 = "453b984e1709b99947d1e4ef4509c89f73de9041d231c62755674f976599b1ac";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0/linux-i686/kn/firefox-112.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.1/linux-i686/kn/firefox-112.0.1.tar.bz2";
       locale = "kn";
       arch = "linux-i686";
-      sha256 = "80a4833c598ae80f7a3dfc8b357041eac8c9061dc2c6dba8c88bea71f9dbd937";
+      sha256 = "a25556c0340257300b205c4ffc4e0f6f59d8dd151a415452e501f041ba868278";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0/linux-i686/ko/firefox-112.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.1/linux-i686/ko/firefox-112.0.1.tar.bz2";
       locale = "ko";
       arch = "linux-i686";
-      sha256 = "2000ff98bbaeab440941b366b2e311d3d73d2d0cdf6aca9873a9fc5016ad7b7b";
+      sha256 = "3fd45baeafaee0f24639388337c659073c19f6892e7ce02a458521fb50fb021f";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0/linux-i686/lij/firefox-112.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.1/linux-i686/lij/firefox-112.0.1.tar.bz2";
       locale = "lij";
       arch = "linux-i686";
-      sha256 = "186699b7517b5d8659a76627127533b204642dc417374a3fccef4914fdc13a24";
+      sha256 = "74d12bfbb8b64d95c583a4d18e3ddeb7c47589206d9e01093e536af83b3c2263";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0/linux-i686/lt/firefox-112.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.1/linux-i686/lt/firefox-112.0.1.tar.bz2";
       locale = "lt";
       arch = "linux-i686";
-      sha256 = "98ad4e67f3ff82c39b83bdc671c9ea91327a5aef0bb1a7c6ca9ea3e5c6ff2879";
+      sha256 = "935a06e6c9418796b262bf11c2bf10e02c799866f9a71cfb1b287387a1e7d429";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0/linux-i686/lv/firefox-112.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.1/linux-i686/lv/firefox-112.0.1.tar.bz2";
       locale = "lv";
       arch = "linux-i686";
-      sha256 = "2cbe7f2765dada8f7c1ff1af7b17f6b51be2ec5257822d76f585ac487645e047";
+      sha256 = "37ba1df6e5300cab332f66e1872ebfd03210a9405b2a6a696c04cb5973e8aa3e";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0/linux-i686/mk/firefox-112.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.1/linux-i686/mk/firefox-112.0.1.tar.bz2";
       locale = "mk";
       arch = "linux-i686";
-      sha256 = "567fcd3722b4664f68952fafe13fb0ab0e04fe858c2b3f6021d2726030a6a483";
+      sha256 = "846f8905382d8ecd621ecb4476364d13a83cc9759f3c6d6fa532f52d868f5081";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0/linux-i686/mr/firefox-112.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.1/linux-i686/mr/firefox-112.0.1.tar.bz2";
       locale = "mr";
       arch = "linux-i686";
-      sha256 = "0ab08deea333ea66b5081a4fc418bdecff8179e2e9a73487de32ef45c59771b0";
+      sha256 = "eb182cf3e62502d7978e8321a43dcf7ce83b2f8871494206b89b36063ee87f9e";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0/linux-i686/ms/firefox-112.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.1/linux-i686/ms/firefox-112.0.1.tar.bz2";
       locale = "ms";
       arch = "linux-i686";
-      sha256 = "0f23f6fd9d3bbe137eb8f321b6de1f22b5fe16a4199dc037e870aa276aa14c0c";
+      sha256 = "ca659d6e58ad5bbda6f5029358ee8d8e2434490ceb315ee9c92777892976eb35";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0/linux-i686/my/firefox-112.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.1/linux-i686/my/firefox-112.0.1.tar.bz2";
       locale = "my";
       arch = "linux-i686";
-      sha256 = "9d08dc125ec7d2984459bcee7496ad931812dcdd18fbef19631c6bd0ea336c68";
+      sha256 = "a3656a0dceaab329a1b66d2559307c95582da97599f0f24afbd1a2f3ac3d8978";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0/linux-i686/nb-NO/firefox-112.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.1/linux-i686/nb-NO/firefox-112.0.1.tar.bz2";
       locale = "nb-NO";
       arch = "linux-i686";
-      sha256 = "1ee31e45e279ba448336d7aa9701b310db153b0ac8ac2fd1d6fc5120488b4e82";
+      sha256 = "79696194984f1789a2e0b1b0ccaddae490077bacaa96184adf4f8d298b75b47b";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0/linux-i686/ne-NP/firefox-112.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.1/linux-i686/ne-NP/firefox-112.0.1.tar.bz2";
       locale = "ne-NP";
       arch = "linux-i686";
-      sha256 = "3b6e001e3982c881106c9f64cfd614f1f8d998ce464bf2205d5826fc88fa49d3";
+      sha256 = "bdcd39bd3d0c0441044f7f1d7ed2dea1d07fc550778e6071ec03d159b30db413";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0/linux-i686/nl/firefox-112.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.1/linux-i686/nl/firefox-112.0.1.tar.bz2";
       locale = "nl";
       arch = "linux-i686";
-      sha256 = "ace49029f77f96ca0f94ba9fc6c2fa3cdd53201b75899cfc3cb9579a6cace0b1";
+      sha256 = "b0e14bad355f3a63a37fae0dc74eb3f974c5a923261ac42dea9d30485ebe61c6";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0/linux-i686/nn-NO/firefox-112.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.1/linux-i686/nn-NO/firefox-112.0.1.tar.bz2";
       locale = "nn-NO";
       arch = "linux-i686";
-      sha256 = "f3d2305b291234eb655050a384190f4510d0f9dba85aeef019106cc0911061eb";
+      sha256 = "2cd11da894f7f3ee53ceb1138ceda8542b4b143341cbcd624a4f9bc808d520ad";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0/linux-i686/oc/firefox-112.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.1/linux-i686/oc/firefox-112.0.1.tar.bz2";
       locale = "oc";
       arch = "linux-i686";
-      sha256 = "0595e5220ac48389ef027f6ec2f03ff8ba3e888e54d48b35973ef45b0b9f60fd";
+      sha256 = "7435492bd6079d7e76cdb4a41f070b42ee4c080d3e891f05a21942046d33d76d";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0/linux-i686/pa-IN/firefox-112.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.1/linux-i686/pa-IN/firefox-112.0.1.tar.bz2";
       locale = "pa-IN";
       arch = "linux-i686";
-      sha256 = "92170c855af452f272443c1f58d32013161b15a442ebd7153e8df238a44c1a08";
+      sha256 = "93c90602e511aac82efa2da0fb4c3043bfadcfa27cb87a39108c803639d52b3e";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0/linux-i686/pl/firefox-112.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.1/linux-i686/pl/firefox-112.0.1.tar.bz2";
       locale = "pl";
       arch = "linux-i686";
-      sha256 = "a04ea9e555b7b07c24768bda598e027a21d2264556d0b04ed86c66d72deab303";
+      sha256 = "a75bfe0ec38e782c939348a34e6acf23598338c3350278f096ab73354c43f3c4";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0/linux-i686/pt-BR/firefox-112.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.1/linux-i686/pt-BR/firefox-112.0.1.tar.bz2";
       locale = "pt-BR";
       arch = "linux-i686";
-      sha256 = "bb233d788561988839b7f598e7e518c5e91812e899741fe70b9937458d3cdf93";
+      sha256 = "67b17c53ec8618064d0fefc0b5a61ee8911f714396fc19b0931fcd242c8d117e";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0/linux-i686/pt-PT/firefox-112.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.1/linux-i686/pt-PT/firefox-112.0.1.tar.bz2";
       locale = "pt-PT";
       arch = "linux-i686";
-      sha256 = "397a54320e2a0d5e48fed911e42f4257b746a9997a158f55674a5e99c16e776b";
+      sha256 = "e4e412aab7cd1e938be7c5e689bee63499a9b44b5e4efa2fafa58d5bb2c12c2a";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0/linux-i686/rm/firefox-112.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.1/linux-i686/rm/firefox-112.0.1.tar.bz2";
       locale = "rm";
       arch = "linux-i686";
-      sha256 = "2d01ae50894853b752001f9157f3c7281dcb14cc09209ec6d7a2113094ba30b3";
+      sha256 = "b86be0830e26e01302f1f99ed9c5acc9a43757d340361dc137267c9b95feeff9";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0/linux-i686/ro/firefox-112.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.1/linux-i686/ro/firefox-112.0.1.tar.bz2";
       locale = "ro";
       arch = "linux-i686";
-      sha256 = "e388080e9eef604cd54aaadd25a8815d52e8fbfaac6479a4198532b9c000be0d";
+      sha256 = "ad830ca7e0c7f0b53031fc85d8884beb6beabedc38dbe570f06324fa4acb0bc6";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0/linux-i686/ru/firefox-112.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.1/linux-i686/ru/firefox-112.0.1.tar.bz2";
       locale = "ru";
       arch = "linux-i686";
-      sha256 = "bec635e4903cecd80828a935381f66638a3be49ab820989976f527fd3484c5f0";
+      sha256 = "9c2778b094dbebe800f8f590d1df5202b1632616d0f78ba94d8db31726ad8b83";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0/linux-i686/sc/firefox-112.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.1/linux-i686/sc/firefox-112.0.1.tar.bz2";
       locale = "sc";
       arch = "linux-i686";
-      sha256 = "373801a06d137c0c7d729e995ed899586aabb23c93d3c141079ed3e6fb0c8c78";
+      sha256 = "4799ac43e8a0d44412e8ff2c50982d494d039430eb1175bd98dda95399b8aadf";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0/linux-i686/sco/firefox-112.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.1/linux-i686/sco/firefox-112.0.1.tar.bz2";
       locale = "sco";
       arch = "linux-i686";
-      sha256 = "98fa91e108fd6ddd6d05d03015250a7a8a6cfdef407cf0e06b4b693a5f783536";
+      sha256 = "135ef70b894fb2ce564c9e8070b65f605b199382b109faa2f2519f9ebbf9c0f9";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0/linux-i686/si/firefox-112.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.1/linux-i686/si/firefox-112.0.1.tar.bz2";
       locale = "si";
       arch = "linux-i686";
-      sha256 = "d48c658c156b90cae5605db1ae65ff0ef413f036b07ed761fcd10b8812ac0f66";
+      sha256 = "52329952a8075a05a248a49d69a5c5ceb41778d6c68b76e5a334b1ebff3d4a1d";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0/linux-i686/sk/firefox-112.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.1/linux-i686/sk/firefox-112.0.1.tar.bz2";
       locale = "sk";
       arch = "linux-i686";
-      sha256 = "a4905df616bb512f764179d2a7befad120fcfefaae922e653ef7f1efecca283b";
+      sha256 = "1b3073d92b6eacabf8c26efa58e00c6895332f560f4be93a57fba4666f328751";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0/linux-i686/sl/firefox-112.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.1/linux-i686/sl/firefox-112.0.1.tar.bz2";
       locale = "sl";
       arch = "linux-i686";
-      sha256 = "b23a531371d80f79a3698cca1e4eaba2326da9318fce7df3dafc3bde62a446a3";
+      sha256 = "4ec9e44b3defcd7b79f60a4304123f228bbbfc4ad615548ef5183366d730c335";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0/linux-i686/son/firefox-112.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.1/linux-i686/son/firefox-112.0.1.tar.bz2";
       locale = "son";
       arch = "linux-i686";
-      sha256 = "89c998c5ee99267e4d001a0be5a99eea34f75cb4d3e2c6af1db72a74a57291b0";
+      sha256 = "1da86784e9dc41d4d2c6b05d35da1a2f96bd133b87b759719768bf085fa07dc4";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0/linux-i686/sq/firefox-112.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.1/linux-i686/sq/firefox-112.0.1.tar.bz2";
       locale = "sq";
       arch = "linux-i686";
-      sha256 = "c353caca756e36a6e1e9434b9992bafd7fc379dcd0408a2f64d5434d99fbe022";
+      sha256 = "06525d8421cc412c8e5ec2c6cb47d91665b9d0e8d622c09b2fb70b21ad0a724c";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0/linux-i686/sr/firefox-112.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.1/linux-i686/sr/firefox-112.0.1.tar.bz2";
       locale = "sr";
       arch = "linux-i686";
-      sha256 = "d8f2caed8388230b2d37d4228ab53bd3b7dde0fd597d7ff16d303e1506f40c1e";
+      sha256 = "358dcc70895bdfd935419b755711dc7001a56866746a0340b534192e58de7948";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0/linux-i686/sv-SE/firefox-112.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.1/linux-i686/sv-SE/firefox-112.0.1.tar.bz2";
       locale = "sv-SE";
       arch = "linux-i686";
-      sha256 = "e82906e6f4d3cf49d644a54d840ad6f1de0c58c9820c07e158193eb659467bb6";
+      sha256 = "91a7e6eaa15b846a6d7f942249b783e51fad059cd13932726ae8a2bfe154b746";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0/linux-i686/szl/firefox-112.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.1/linux-i686/szl/firefox-112.0.1.tar.bz2";
       locale = "szl";
       arch = "linux-i686";
-      sha256 = "84c74dc9358f2ba4db8b37c751b1b694396f66d6c6005dd314506ca16f0868b6";
+      sha256 = "8127eeba4f40a5a1a4c7a85bdb343ac360bcdf2f14721423196f7803c8648bc5";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0/linux-i686/ta/firefox-112.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.1/linux-i686/ta/firefox-112.0.1.tar.bz2";
       locale = "ta";
       arch = "linux-i686";
-      sha256 = "439900ed3e9fb7f3c18fd67ae16e6b42294957bf11c049326e02bced4b88da9d";
+      sha256 = "337ddde6c133d2fd2a4e5850605586ffdf78a4038aa54f291584d522efd06faf";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0/linux-i686/te/firefox-112.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.1/linux-i686/te/firefox-112.0.1.tar.bz2";
       locale = "te";
       arch = "linux-i686";
-      sha256 = "493b1a2e2644689920b506115e15b3153fc492ffd0a0e2287947335f0e3aea6c";
+      sha256 = "602edab53a94b72761f1fcf805621e2871633540e43212602ba85381ca7a0093";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0/linux-i686/th/firefox-112.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.1/linux-i686/th/firefox-112.0.1.tar.bz2";
       locale = "th";
       arch = "linux-i686";
-      sha256 = "febec24221a8cb6004931ae115ee881f8a342a999cd3ba90c06090eb7d65595d";
+      sha256 = "541593a4e696e85281942f57a0276da033c47a1ab2782820f8c77c97d10ab74b";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0/linux-i686/tl/firefox-112.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.1/linux-i686/tl/firefox-112.0.1.tar.bz2";
       locale = "tl";
       arch = "linux-i686";
-      sha256 = "dbacf21e7efd9ada61654027738d5bc1b87862afbcfef951332bd3b80f73ef9b";
+      sha256 = "6d5a977aa0e651bb8a3c1868b4639472c203e791d0cba0ce34ac556ea18a0e27";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0/linux-i686/tr/firefox-112.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.1/linux-i686/tr/firefox-112.0.1.tar.bz2";
       locale = "tr";
       arch = "linux-i686";
-      sha256 = "7fc6816c28abe9db2477b3b96729096e770fca7bf044c38fdfbb21590945536d";
+      sha256 = "2c94db9856cf6dfaa810fe6397185959a8d78222d3cc8e8968906cbe864b3ae4";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0/linux-i686/trs/firefox-112.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.1/linux-i686/trs/firefox-112.0.1.tar.bz2";
       locale = "trs";
       arch = "linux-i686";
-      sha256 = "10d9a48645a7c4eabbc9ffc62855fd998e0dba2b2fa566c83a14a5f5395eb0d8";
+      sha256 = "21742ee25642a258df95f7aa2dc92f422546408e8084071b42792d90b0cb6713";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0/linux-i686/uk/firefox-112.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.1/linux-i686/uk/firefox-112.0.1.tar.bz2";
       locale = "uk";
       arch = "linux-i686";
-      sha256 = "e33d93724003d8b55f76e9565192bb2797997aa66f2d35c12dc7086f200c191a";
+      sha256 = "6f93c32705ce3b72db574c36c318fcf69c91423eaf41b70d144b91f6a71b91d1";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0/linux-i686/ur/firefox-112.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.1/linux-i686/ur/firefox-112.0.1.tar.bz2";
       locale = "ur";
       arch = "linux-i686";
-      sha256 = "aa0cca88be261d10dea5f8449e211c0d7fe72824eb971f46de154be76d5a2df1";
+      sha256 = "8ccea04fb8a753fcf0b7c4a1a2c941e630438ed74b077714355d816c09e5c537";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0/linux-i686/uz/firefox-112.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.1/linux-i686/uz/firefox-112.0.1.tar.bz2";
       locale = "uz";
       arch = "linux-i686";
-      sha256 = "08877588e0d027deb9cd9db2fe45e1169f74dd074f7c886df5d6502343e14c11";
+      sha256 = "707fb054e342b449c79a86788096d25ca61f965ce31f862d8779135d5eed888e";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0/linux-i686/vi/firefox-112.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.1/linux-i686/vi/firefox-112.0.1.tar.bz2";
       locale = "vi";
       arch = "linux-i686";
-      sha256 = "74971ee5d592f65872f71fd2049ce73ce4ed65bbc513b36844e1ae45aa44c807";
+      sha256 = "4019556dd8c934548c0ea646d5c6d3dc557c9bbe4382a30375fd03f564eb034c";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0/linux-i686/xh/firefox-112.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.1/linux-i686/xh/firefox-112.0.1.tar.bz2";
       locale = "xh";
       arch = "linux-i686";
-      sha256 = "9b8579e0c3361e7008aa2e4757645fda1254c63450dc2e63a79a20b032923b31";
+      sha256 = "712d9a1f97b649aa3776a7d80fc38b71c204689afff6e0f49f13a4fcda786092";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0/linux-i686/zh-CN/firefox-112.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.1/linux-i686/zh-CN/firefox-112.0.1.tar.bz2";
       locale = "zh-CN";
       arch = "linux-i686";
-      sha256 = "d2f878182fc94d4630343fe367221a202945d8ef5731a3f790b101193ac0d4d3";
+      sha256 = "59a5c6cbeaae82e0debe411685b1f5b44bd59acf965c93af52c21a715600522b";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0/linux-i686/zh-TW/firefox-112.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.1/linux-i686/zh-TW/firefox-112.0.1.tar.bz2";
       locale = "zh-TW";
       arch = "linux-i686";
-      sha256 = "8e76787f20c6b2b9cf2796e35dcc9b5ab4f335dd441f34627f1ffc505759c0c6";
+      sha256 = "85fe472a78190083dae4e3f275636ef1b8f5518f6d3fda04fe352c0cb702c490";
     }
     ];
 }

--- a/pkgs/applications/networking/browsers/firefox/packages.nix
+++ b/pkgs/applications/networking/browsers/firefox/packages.nix
@@ -3,10 +3,10 @@
 rec {
   firefox = buildMozillaMach rec {
     pname = "firefox";
-    version = "112.0";
+    version = "112.0.1";
     src = fetchurl {
       url = "mirror://mozilla/firefox/releases/${version}/source/firefox-${version}.source.tar.xz";
-      sha512 = "6b2bc8c0c93f3109da27168fe7e8f734c6ab4efb4ca56ff2d5e3a52659da71173bba2104037a000623833be8338621fca482f39f836e3910fe2996e6d0a68b39";
+      sha512 = "23a5cd9c1f165275d8ca7465bebce86018441c72292421f4ed56d7ad8ada9402dc8d22a08467d9d0ef3ef8c62338006dfa3bcbddf12cb8a59eafa0bd7d0cda50";
     };
 
     meta = {


### PR DESCRIPTION
https://www.mozilla.org/en-US/firefox/112.0.1/releasenotes/

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
