### PR TITLE
cldr-annotations: 42.0 -> 43.0

### DIFF
--- a/pkgs/data/misc/cldr-annotations/default.nix
+++ b/pkgs/data/misc/cldr-annotations/default.nix
@@ -2,12 +2,12 @@
 
 stdenvNoCC.mkDerivation rec {
   pname = "cldr-annotations";
-  version = "42.0";
+  version = "43.0";
 
   src = fetchzip {
     url = "https://unicode.org/Public/cldr/${lib.versions.major version}/cldr-common-${version}.zip";
     stripRoot = false;
-    hash = "sha256-paRon3ecGXNp3ZDnN1DU9RVU2NDWTBiKjy0OP3vcPLE=";
+    hash = "sha256-L8ikzRpSw4mDCV79TiUqhPHWC0PmGi4i4He0OAB54R0=";
   };
 
   installPhase = ''


### PR DESCRIPTION


###### Description of changes

https://cldr.unicode.org/index/downloads/cldr-43

###### Things done
- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Result of `nixpkgs-review` run on x86_64-linux [1](https://github.com/Mic92/nixpkgs-review)
<details>
  <summary>2 packages failed to build:</summary>
  <ul>
    <li>python311Packages.pythonefl</li>
    <li>python311Packages.pythonefl.dist</li>
  </ul>
</details>
<details>
  <summary>77 packages built:</summary>
  <ul>
    <li>adapta-gtk-theme</li>
    <li>budgie.budgie-control-center</li>
    <li>budgie.budgie-control-center.debug</li>
    <li>budgie.budgie-desktop</li>
    <li>budgie.budgie-gsettings-overrides</li>
    <li>cinnamon.cinnamon-gsettings-overrides</li>
    <li>cldr-annotations</li>
    <li>emacsPackages.ac-mozc</li>
    <li>emacsPackages.mozc</li>
    <li>emacsPackages.mozc-cand-posframe</li>
    <li>emacsPackages.mozc-im</li>
    <li>emacsPackages.mozc-popup</li>
    <li>emacsPackages.mozc-temp</li>
    <li>enlightenment.econnman</li>
    <li>enlightenment.ecrire</li>
    <li>enlightenment.efl</li>
    <li>enlightenment.enlightenment</li>
    <li>enlightenment.ephoto</li>
    <li>enlightenment.evisum</li>
    <li>enlightenment.rage</li>
    <li>enlightenment.terminology</li>
    <li>gnome-browser-connector</li>
    <li>gnome.gnome-control-center</li>
    <li>gnome.gnome-control-center.debug</li>
    <li>gnome.gnome-flashback</li>
    <li>gnome.gnome-session</li>
    <li>gnome.gnome-session.debug</li>
    <li>gnome.gnome-session.sessions</li>
    <li>gnome.gnome-shell</li>
    <li>gnome.gnome-shell.debug</li>
    <li>gnome.gnome-shell.devdoc</li>
    <li>gnome.gnome-terminal</li>
    <li>gnome.gnome-tweaks</li>
    <li>gnome.nixos-gsettings-overrides</li>
    <li>gnomeExtensions.easyScreenCast</li>
    <li>gnomeExtensions.gsconnect</li>
    <li>gnomeExtensions.gsconnect.installedTests</li>
    <li>gnomeExtensions.system-monitor</li>
    <li>ibus</li>
    <li>ibus-engines.anthy</li>
    <li>ibus-engines.hangul</li>
    <li>ibus-engines.kkc</li>
    <li>ibus-engines.libpinyin</li>
    <li>ibus-engines.libthai</li>
    <li>ibus-engines.m17n</li>
    <li>ibus-engines.mozc</li>
    <li>ibus-engines.rime</li>
    <li>ibus-engines.table</li>
    <li>ibus-engines.table-chinese</li>
    <li>ibus-engines.table-others</li>
    <li>ibus-engines.typing-booster</li>
    <li>ibus-engines.typing-booster-unwrapped</li>
    <li>ibus-engines.uniemoji</li>
    <li>ibus-qt</li>
    <li>ibus-with-plugins</li>
    <li>ibus.dev</li>
    <li>ibus.installedTests</li>
    <li>libsForQt5.kdeplasma-addons</li>
    <li>libsForQt5.plasma-desktop</li>
    <li>mlterm</li>
    <li>mojave-gtk-theme</li>
    <li>openbangla-keyboard</li>
    <li>pantheon.elementary-greeter</li>
    <li>pantheon.elementary-session-settings</li>
    <li>pantheon.switchboard-plug-keyboard</li>
    <li>pantheon.switchboard-with-plugs</li>
    <li>pantheon.wingpanel-applications-menu</li>
    <li>pantheon.wingpanel-indicator-keyboard</li>
    <li>pantheon.wingpanel-with-indicators</li>
    <li>phosh</li>
    <li>phosh-mobile-settings</li>
    <li>polychromatic</li>
    <li>python310Packages.pythonefl</li>
    <li>python310Packages.pythonefl.dist</li>
    <li>snippetpixie</li>
    <li>vimix-gtk-themes</li>
    <li>whitesur-gtk-theme</li>
  </ul>
</details>
