### PR TITLE
[Backport release-22.11] mullvad-browser: init at 12.0.4

### DIFF
--- a/pkgs/applications/networking/browsers/mullvad-browser/default.nix
+++ b/pkgs/applications/networking/browsers/mullvad-browser/default.nix
@@ -210,10 +210,14 @@ stdenv.mkDerivation rec {
     runHook postBuild
   '';
 
-  postInstall = ''
+  installPhase = ''
+    runHook preInstall
+
     # Install distribution customizations
     install -Dvm644 ${distributionIni} $out/share/mullvad-browser/distribution/distribution.ini
     install -Dvm644 ${policiesJson} $out/share/mullvad-browser/distribution/policies.json
+
+    runHook postInstall
   '';
 
   meta = with lib; {

--- a/pkgs/applications/networking/browsers/mullvad-browser/default.nix
+++ b/pkgs/applications/networking/browsers/mullvad-browser/default.nix
@@ -1,0 +1,231 @@
+{ lib
+, stdenv
+, fetchurl
+, makeDesktopItem
+, copyDesktopItems
+, makeWrapper
+, writeText
+
+# Common run-time dependencies
+, zlib
+
+# libxul run-time dependencies
+, atk
+, cairo
+, dbus
+, dbus-glib
+, fontconfig
+, freetype
+, gdk-pixbuf
+, glib
+, gtk3
+, libxcb
+, libX11
+, libXext
+, libXrender
+, libXt
+, libXtst
+, mesa
+, pango
+, pciutils
+
+, libnotifySupport ? stdenv.isLinux
+, libnotify
+
+, audioSupport ? mediaSupport
+, pulseaudioSupport ? mediaSupport
+, libpulseaudio
+, apulse
+, alsa-lib
+
+# Media support (implies audio support)
+, mediaSupport ? true
+, ffmpeg
+
+# Extra preferences
+, extraPrefs ? ""
+}:
+
+let
+  libPath = lib.makeLibraryPath (
+    [
+      alsa-lib
+      atk
+      cairo
+      dbus
+      dbus-glib
+      fontconfig
+      freetype
+      gdk-pixbuf
+      glib
+      gtk3
+      libxcb
+      libX11
+      libXext
+      libXrender
+      libXt
+      libXtst
+      mesa # for libgbm
+      pango
+      pciutils
+      stdenv.cc.cc
+      stdenv.cc.libc
+      zlib
+    ] ++ lib.optionals libnotifySupport [ libnotify ]
+      ++ lib.optionals pulseaudioSupport [ libpulseaudio ]
+      ++ lib.optionals mediaSupport [ ffmpeg ]
+  );
+
+  tag = "mullvad-browser-102.9.0esr-12.0-2-build1";
+  version = "12.0.4";
+  lang = "ALL";
+
+  srcs = {
+    x86_64-linux = fetchurl {
+      url = "https://github.com/mullvad/mullvad-browser/releases/download/${tag}/mullvad-browser-linux64-${version}_${lang}.tar.xz";
+      hash = "sha256-q4dTKNQkcqaRwiF25iVOQSvwVLA3tJRlQ4DzC3tuG5A=";
+    };
+  };
+
+  distributionIni = writeText "distribution.ini" (lib.generators.toINI {} {
+    # Some light branding indicating this build uses our distro preferences
+    Global = {
+      id = "nixos";
+      version = "1.0";
+      about = "Mullvad Browser for NixOS";
+    };
+  });
+
+  policiesJson = writeText "policies.json" (builtins.toJSON {
+    policies.DisableAppUpdate = true;
+  });
+in
+stdenv.mkDerivation rec {
+  pname = "mullvad-browser";
+  inherit version;
+
+  src = srcs.${stdenv.hostPlatform.system} or (throw "unsupported system: ${stdenv.hostPlatform.system}");
+
+  nativeBuildInputs = [ copyDesktopItems makeWrapper ];
+
+  preferLocalBuild = true;
+  allowSubstitutes = false;
+
+  desktopItems = [(makeDesktopItem {
+    name = "mullvadbrowser";
+    exec = "mullvad-browser %U";
+    icon = "mullvad-browser";
+    desktopName = "Mullvad Browser";
+    genericName = "Web Browser";
+    comment = meta.description;
+    categories = [ "Network" "WebBrowser" "Security" ];
+  })];
+
+  buildPhase = ''
+    runHook preBuild
+
+    # For convenience ...
+    MB_IN_STORE=$out/share/mullvad-browser
+
+    # Unpack & enter
+    mkdir -p "$MB_IN_STORE"
+    tar xf "$src" -C "$MB_IN_STORE" --strip-components=2
+    pushd "$MB_IN_STORE"
+
+    patchelf --set-interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" "mullvadbrowser.real"
+
+    # mullvadbrowser is a wrapper that checks for a more recent libstdc++ & appends it to the ld path
+    mv mullvadbrowser.real mullvadbrowser
+
+    # store state at `~/.mullvad` instead of relative to executable
+    touch "$MB_IN_STORE/system-install"
+
+    # Add bundled libraries to libPath.
+    libPath=${libPath}:$MB_IN_STORE
+
+    # apulse uses a non-standard library path.  For now special-case it.
+    ${lib.optionalString (audioSupport && !pulseaudioSupport) ''
+      libPath=${apulse}/lib/apulse:$libPath
+    ''}
+
+    # Prepare for autoconfig.
+    #
+    # See https://developer.mozilla.org/en-US/Firefox/Enterprise_deployment
+    cat >defaults/pref/autoconfig.js <<EOF
+    //
+    pref("general.config.filename", "mozilla.cfg");
+    pref("general.config.obscure_value", 0);
+    EOF
+
+    # Hard-coded Firefox preferences.
+    cat >mozilla.cfg <<EOF
+    // First line must be a comment
+
+    // Reset pref that captures store paths.
+    clearPref("extensions.xpiState");
+
+    // Stop obnoxious first-run redirection.
+    lockPref("noscript.firstRunRedirection", false);
+
+    // Allow sandbox access to sound devices if using ALSA directly
+    ${if (audioSupport && !pulseaudioSupport) then ''
+      pref("security.sandbox.content.write_path_whitelist", "/dev/snd/");
+    '' else ''
+      clearPref("security.sandbox.content.write_path_whitelist");
+    ''}
+
+    ${lib.optionalString (extraPrefs != "") ''
+      ${extraPrefs}
+    ''}
+    EOF
+
+    # FONTCONFIG_FILE is required to make fontconfig read the MB
+    # fonts.conf; upstream uses FONTCONFIG_PATH, but FC_DEBUG=1024
+    # indicates the system fonts.conf being used instead.
+    FONTCONFIG_FILE=$MB_IN_STORE/fontconfig/fonts.conf
+    sed -i "$FONTCONFIG_FILE" \
+      -e "s,<dir>fonts</dir>,<dir>$MB_IN_STORE/fonts</dir>,"
+
+    mkdir -p $out/bin
+
+    makeWrapper "$MB_IN_STORE/mullvadbrowser" "$out/bin/mullvad-browser" \
+      --prefix LD_LIBRARY_PATH : "$libPath" \
+      --set FONTCONFIG_FILE "$FONTCONFIG_FILE" \
+      --set-default MOZ_ENABLE_WAYLAND 1
+
+    # Easier access to docs
+    mkdir -p $out/share/doc
+    ln -s $MB_IN_STORE/Data/Docs $out/share/doc/mullvad-browser
+
+    # Install icons
+    for i in 16 32 48 64 128; do
+      mkdir -p $out/share/icons/hicolor/''${i}x''${i}/apps/
+      ln -s $out/share/mullvad-browser/browser/chrome/icons/default/default$i.png $out/share/icons/hicolor/''${i}x''${i}/apps/mullvad-browser.png
+    done
+
+    # Check installed apps
+    echo "Checking mullvad-browser wrapper ..."
+    $out/bin/mullvad-browser --version >/dev/null
+
+    runHook postBuild
+  '';
+
+  postInstall = ''
+    # Install distribution customizations
+    install -Dvm644 ${distributionIni} $out/share/mullvad-browser/distribution/distribution.ini
+    install -Dvm644 ${policiesJson} $out/share/mullvad-browser/distribution/policies.json
+  '';
+
+  meta = with lib; {
+    description = "Privacy-focused browser made in a collaboration between The Tor Project and Mullvad";
+    homepage = "https://www.mullvad.net/en/browser";
+    changelog = "https://github.com/mullvad/mullvad-browser/releases/tag/${tag}";
+    platforms = attrNames srcs;
+    maintainers = with maintainers; [ felschr ];
+    # MPL2.0+, GPL+, &c.  While it's not entirely clear whether
+    # the compound is "libre" in a strict sense (some components place certain
+    # restrictions on redistribution), it's free enough for our purposes.
+    license = with licenses; [ mpl20 lgpl21Plus lgpl3Plus free ];
+    sourceProvenance = with sourceTypes; [ binaryNativeCode ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -23960,6 +23960,8 @@ with pkgs;
 
   mullvad-vpn = callPackage ../applications/networking/mullvad-vpn { };
 
+  mullvad-browser = callPackage ../applications/networking/browsers/mullvad-browser { };
+
   mycorrhiza = callPackage ../servers/mycorrhiza { };
 
   napalm = with python3Packages; toPythonApplication (


### PR DESCRIPTION
###### Description of changes
Backport Mullvad Browser to NixOS 22.11 (#225322 & #226862).

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).