### PR TITLE
Fix & update saleae logic 2 to 2.4.7

### DIFF
--- a/pkgs/development/tools/misc/saleae-logic-2/default.nix
+++ b/pkgs/development/tools/misc/saleae-logic-2/default.nix
@@ -59,7 +59,7 @@ appimageTools.wrapType2 {
     alsa-lib
     at-spi2-core
     cups
-    libxcrypt
+    libxcrypt-legacy
   ];
 
   meta = with lib; {

--- a/pkgs/development/tools/misc/saleae-logic-2/default.nix
+++ b/pkgs/development/tools/misc/saleae-logic-2/default.nix
@@ -1,10 +1,10 @@
 { lib, fetchurl, makeDesktopItem, appimageTools }:
 let
   name = "saleae-logic-2";
-  version = "2.4.6";
+  version = "2.4.7";
   src = fetchurl {
     url = "https://downloads.saleae.com/logic2/Logic-${version}-master.AppImage";
-    hash = "sha256-FYLjg4lzr8M22r4yoKfMIAx2HKGi2fcD28AaV1ChkLk=";
+    hash = "sha256-dMt8XWLatLNothU9oTJqYrBGNZZs0L5dXRMKP9ZeM6E=";
   };
   desktopItem = makeDesktopItem {
     inherit name;


### PR DESCRIPTION
###### Description of changes

- [saleae-logic-2: Fix "Error Connecting to Socket"](https://github.com/NixOS/nixpkgs/commit/ac1b5deba339478394fd4f8d0450116b757ce12c)
  The problem was it couldn't find `libcrypt.so.1` because `libxcrypt` now provides `libcrypt.so.2`
- [saleae-logic-2: 2.4.6 -> 2.4.7](https://github.com/NixOS/nixpkgs/commit/0fc68550d179aa57b06c3c83279b6469ba9fc93f)

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
