### PR TITLE
gitea-actions-runner: unstable-2023-03-18 -> 0.1.2

### DIFF
--- a/pkgs/development/tools/continuous-integration/gitea-actions-runner/default.nix
+++ b/pkgs/development/tools/continuous-integration/gitea-actions-runner/default.nix
@@ -1,29 +1,33 @@
-{ lib, fetchFromGitea, buildGoModule }:
+{ lib
+, fetchFromGitea
+, buildGoModule
+}:
 
 buildGoModule rec {
   pname = "gitea-actions-runner";
-  version = "unstable-2023-03-18";
+  version = "0.1.2";
 
   src = fetchFromGitea {
     domain = "gitea.com";
     owner = "gitea";
     repo = "act_runner";
-    rev = "9eb8b08a69e8b1c699c9c07a06c1ff8e5f6ad0fe";
-    sha256 = "sha256-B8vD+86X8cqZhPmDmEjHgSsq3TdJuCf9h3XgdXC7hQY=";
+    rev = "v${version}";
+    hash = "sha256-0wLBFZdFaGTselRZIJ809wHQFhAjt4sdmZp12LQOB9I=";
   };
 
-  vendorSha256 = "sha256-K/d/ip8icc+rjTmajsGxw5aij1VMW6wJJu4LCkKqaVQ=";
+  vendorHash = "sha256-GBqt5qSM2mDAS7klWdJiC6t5HaVKaP0PjecYnHZBzrc=";
 
   ldflags = [
     "-s"
     "-w"
-    "-X gitea.com/gitea/act_runner/cmd.version=${version}"
+    "-X gitea.com/gitea/act_runner/internal/pkg/ver.version=${version}"
   ];
 
   meta = with lib; {
     mainProgram = "act_runner";
     maintainers = with maintainers; [ techknowlogick ];
     license = licenses.mit;
+    changelog = "https://gitea.com/gitea/act_runner/releases/tag/v${version}";
     homepage = "https://gitea.com/gitea/act_runner";
     description = "A runner for Gitea based on act";
   };


### PR DESCRIPTION
https://gitea.com/gitea/act_runner/releases/tag/v0.1.0
https://gitea.com/gitea/act_runner/releases/tag/v0.1.1
https://gitea.com/gitea/act_runner/releases/tag/v0.1.2

cc @thilobillerbeck

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
