### PR TITLE
mpvScripts.autosubsync: init at unstable-2022-12-16

### DIFF
--- a/pkgs/applications/video/mpv/scripts/autosubsync-mpv.nix
+++ b/pkgs/applications/video/mpv/scripts/autosubsync-mpv.nix
@@ -1,0 +1,38 @@
+{
+  lib,
+  fetchFromGitHub,
+  buildLua,
+  alass,
+}:
+
+buildLua {
+  pname = "autosubsync-mpv";
+  version = "0-unstable-2022-12-26";
+
+  src = fetchFromGitHub {
+    owner = "joaquintorres";
+    repo = "autosubsync-mpv";
+    rev = "22cb928ecd94cc8cadaf8c354438123c43e0c70d";
+    sha256 = "sha256-XQPFC7l9MTZAW5FfULRQJfu/7FuGj9bbjQUZhNv0rlc=";
+  };
+
+  # While nixpkgs only packages alass, we might as well make that the default
+  patchPhase = ''
+    runHook prePatch
+    substituteInPlace autosubsync.lua                                            \
+      --replace-warn 'alass_path = ""' 'alass_path = "${alass}/bin/alass-cli"'   \
+      --replace-warn 'audio_subsync_tool = "ask"' 'audio_subsync_tool = "alass"' \
+      --replace-warn 'altsub_subsync_tool = "ask"' 'altsub_subsync_tool = "alass"'
+    runHook postPatch
+  '';
+
+  scriptPath = "./";
+  passthru.scriptName = "autosubsync-mpv";
+
+  meta = with lib; {
+    description = "Automatically sync subtitles in mpv using the `n` button";
+    homepage = "https://github.com/joaquintorres/autosubsync-mpv";
+    maintainers = with maintainers; [ kovirobi ];
+    license = licenses.mit;
+  };
+}

--- a/pkgs/applications/video/mpv/scripts/default.nix
+++ b/pkgs/applications/video/mpv/scripts/default.nix
@@ -95,6 +95,7 @@ let
       inherit (callPackage ./occivink.nix { }) blacklistExtensions seekTo;
 
       buildLua = callPackage ./buildLua.nix { };
+      autosubsync-mpv = callPackage ./autosubsync-mpv.nix { };
       chapterskip = callPackage ./chapterskip.nix { };
       convert = callPackage ./convert.nix { };
       cutter = callPackage ./cutter.nix { };


### PR DESCRIPTION
###### Description of changes

A small MPV script to synchronise subtitles, or to save back manually timed subtitles (e.g using ctrl+shift+left/right arrows, then `n` and save manual timings).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
- Tested in mpv
