### PR TITLE
web-eid-app: init at 2.2.0

### DIFF
--- a/pkgs/tools/security/web-eid-app/default.nix
+++ b/pkgs/tools/security/web-eid-app/default.nix
@@ -1,0 +1,49 @@
+{ lib
+, mkDerivation
+, fetchFromGitHub
+, cmake
+, gtest
+, pcsclite
+, pkg-config
+, qmake
+, qttranslations
+}:
+
+mkDerivation rec {
+  pname = "web-eid-app";
+  version = "2.2.0";
+
+  src = fetchFromGitHub {
+    owner = "web-eid";
+    repo = "web-eid-app";
+    rev = "v${version}";
+    sha256 = "sha256-TOzOcPY4m7OdCfaAXyc/joIHe2O2YbyDrXiNytPMKSk=";
+    fetchSubmodules = true;
+  };
+
+  nativeBuildInputs = [
+    cmake
+    pkg-config
+  ];
+
+  buildInputs = [
+    gtest # required during build of lib/libelectronic-id/lib/libpcsc-cpp
+    pcsclite
+    qttranslations
+  ];
+
+  meta = with lib; {
+    description = "signing and authentication operations with smart cards for the Web eID browser extension";
+    longDescription = ''
+      The Web eID application performs cryptographic digital signing and
+      authentication operations with electronic ID smart cards for the Web eID
+      browser extension (it is the [native messaging host](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/Native_messaging)
+      for the extension). Also works standalone without the extension in command-line
+      mode.
+    '';
+    homepage = "https://github.com/web-eid/web-eid-app";
+    license = licenses.mit;
+    maintainers = [ maintainers.flokli ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -13757,6 +13757,8 @@ with pkgs;
 
   wdfs = callPackage ../tools/filesystems/wdfs { };
 
+  web-eid-app = libsForQt5.callPackage ../tools/security/web-eid-app { };
+
   wdiff = callPackage ../tools/text/wdiff { };
 
   wdisplays = callPackage ../tools/graphics/wdisplays { };


### PR DESCRIPTION
This adds `web-eid-app`, which is the native companion to the "Web eID" browser extension.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
