### PR TITLE
zbar: 0.23.90 -> 0.23.92 (+ enable checkPhase)

### DIFF
--- a/pkgs/tools/graphics/zbar/default.nix
+++ b/pkgs/tools/graphics/zbar/default.nix
@@ -24,6 +24,8 @@
 , libintl
 , libiconv
 , Foundation
+, bash
+, python3
 }:
 
 stdenv.mkDerivation rec {
@@ -66,6 +68,18 @@ stdenv.mkDerivation rec {
     qtx11extras
   ];
 
+  nativeCheckInputs = [
+    bash
+    python3
+  ];
+
+  # Note: postConfigure instead of postPatch in order to include some
+  # autoconf-generated files. The template files for the autogen'd scripts are
+  # not chmod +x, so patchShebangs misses them.
+  postConfigure = ''
+    patchShebangs test
+  '';
+
   # Disable assertions which include -dev QtBase file paths.
   env.NIX_CFLAGS_COMPILE = "-DQT_NO_DEBUG";
 
@@ -82,6 +96,8 @@ stdenv.mkDerivation rec {
     "--without-gtk"
     "--without-qt"
   ]);
+
+  doCheck = !stdenv.isDarwin;
 
   dontWrapQtApps = true;
   dontWrapGApps = true;

--- a/pkgs/tools/graphics/zbar/default.nix
+++ b/pkgs/tools/graphics/zbar/default.nix
@@ -28,7 +28,7 @@
 
 stdenv.mkDerivation rec {
   pname = "zbar";
-  version = "0.23.90";
+  version = "0.23.92";
 
   outputs = [ "out" "lib" "dev" "doc" "man" ];
 
@@ -36,7 +36,7 @@ stdenv.mkDerivation rec {
     owner = "mchehab";
     repo = "zbar";
     rev = version;
-    sha256 = "sha256-FvV7TMc4JbOiRjWLka0IhtpGGqGm5fis7h870OmJw2U=";
+    sha256 = "sha256-VhVrngAX7pXZp+szqv95R6RGAJojp3svdbaRKigGb0w=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/tools/graphics/zbar/default.nix
+++ b/pkgs/tools/graphics/zbar/default.nix
@@ -26,6 +26,7 @@
 , Foundation
 , bash
 , python3
+, argp-standalone
 }:
 
 stdenv.mkDerivation rec {
@@ -73,6 +74,10 @@ stdenv.mkDerivation rec {
     python3
   ];
 
+  checkInputs = lib.optionals stdenv.isDarwin [
+    argp-standalone
+  ];
+
   # Note: postConfigure instead of postPatch in order to include some
   # autoconf-generated files. The template files for the autogen'd scripts are
   # not chmod +x, so patchShebangs misses them.
@@ -97,7 +102,11 @@ stdenv.mkDerivation rec {
     "--without-qt"
   ]);
 
-  doCheck = !stdenv.isDarwin;
+  doCheck = true;
+
+  preCheck = lib.optionalString stdenv.isDarwin ''
+    export NIX_LDFLAGS="$NIX_LDFLAGS -largp"
+  '';
 
   dontWrapQtApps = true;
   dontWrapGApps = true;


### PR DESCRIPTION
###### Description of changes

0.23.92 was released a while back but we never bumped to it for some reason. It's only very minor changes over 0.23.90 anyway so I don't think we've missed anything too interesting. Just happened to notice it.

While bumping the package I noticed upstream has unit tests and we're not running them. That's now fixed.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
