### PR TITLE
forgejo: build from source

### DIFF
--- a/nixos/tests/gitea.nix
+++ b/nixos/tests/gitea.nix
@@ -72,6 +72,7 @@ let
 
       server.wait_for_unit("gitea.service")
       server.wait_for_open_port(3000)
+      server.wait_for_open_port(22)
       server.succeed("curl --fail http://localhost:3000/")
 
       server.succeed(

--- a/pkgs/applications/version-management/forgejo/default.nix
+++ b/pkgs/applications/version-management/forgejo/default.nix
@@ -1,17 +1,11 @@
 { bash
 , brotli
 , buildGoModule
-, common-updater-scripts
-, coreutils
-, curl
-, fetchurl
 , forgejo
 , git
 , gzip
-, jq
 , lib
 , makeWrapper
-, nix
 , nixosTests
 , openssh
 , pam
@@ -20,19 +14,42 @@
 , xorg
 , runCommand
 , stdenv
+, fetchFromGitea
+, buildNpmPackage
 , writeShellApplication
 }:
 
+let
+  frontend = buildNpmPackage rec {
+    pname = "forgejo-frontend";
+    inherit (forgejo) src version;
+
+    npmDepsHash = "sha256-dB/uBuS0kgaTwsPYnqklT450ejLHcPAqBdDs3JT8Uxg=";
+
+    patches = [
+      ./package-json-npm-build-frontend.patch
+    ];
+
+    # override npmInstallHook
+    installPhase = ''
+      mkdir $out
+      cp -R ./public $out/
+    '';
+  };
+in
 buildGoModule rec {
   pname = "forgejo";
   version = "1.19.1-0";
 
-  src = fetchurl {
-    url = "https://codeberg.org/forgejo/forgejo/releases/download/v${version}/forgejo-src-${version}.tar.gz";
-    hash = "sha256-zoYEkUmJx7lt++2Rmjx/jgyZ2Y9uJH4k8VpD++My7mU=";
+  src = fetchFromGitea {
+    domain = "codeberg.org";
+    owner = "forgejo";
+    repo = "forgejo";
+    rev = "v${version}";
+    hash = "sha256-0FmqLxQvr3bbgdzKFeAhRMvJp/xdRPW40WLH6eKNY9s=";
   };
 
-  vendorHash = null;
+  vendorHash = "sha256-g8QJSewQFfyE/34A2JxrVnwk5vmiIRSbwrVE9LqYJrM=";
 
   subPackages = [ "." ];
 
@@ -59,14 +76,24 @@ buildGoModule rec {
     "-X 'main.Tags=${lib.concatStringsSep " " tags}'"
   ];
 
+  preBuild = ''
+    go run build/merge-forgejo-locales.go
+  '';
+
   postInstall = ''
     mkdir $data
-    cp -R ./{public,templates,options} $data
+    cp -R ./{templates,options} ${frontend}/public $data
     mkdir -p $out
     cp -R ./options/locale $out/locale
     wrapProgram $out/bin/gitea \
       --prefix PATH : ${lib.makeBinPath [ bash git gzip openssh ]}
   '';
+
+  # $data is not available in go-modules.drv and preBuild isn't needed
+  overrideModAttrs = (_: {
+    postPatch = null;
+    preBuild = null;
+  });
 
   passthru = {
     data-compressed = runCommand "forgejo-data-compressed" {
@@ -82,44 +109,6 @@ buildGoModule rec {
     '';
 
     tests = nixosTests.forgejo;
-
-    updateScript = lib.getExe (writeShellApplication {
-      name = "update-forgejo";
-      runtimeInputs = [
-        common-updater-scripts
-        coreutils
-        curl
-        jq
-        nix
-      ];
-      text = ''
-        releases=$(curl "https://codeberg.org/api/v1/repos/forgejo/forgejo/releases?draft=false&pre-release=false&limit=1" \
-          --silent \
-          --header "accept: application/json")
-
-        stable=$(jq '.[0]
-          | .tag_name[1:] as $version
-          | ("forgejo-src-\($version).tar.gz") as $filename
-          | { $version, html_url } + (.assets | map(select(.name | startswith($filename)) | {(.name | split(".") | last): .browser_download_url}) | add)' \
-          <<< "$releases")
-
-        checksum_url=$(jq -r .sha256 <<< "$stable")
-        release_url=$(jq -r .html_url <<< "$stable")
-        version=$(jq -r .version <<< "$stable")
-
-        if [[ "${version}" = "$version" ]]; then
-          echo "No new version found (already at $version)"
-          exit 0
-        fi
-
-        echo "Release: $release_url"
-
-        sha256=$(curl "$checksum_url" --silent | cut --delimiter " " --fields 1)
-        sri_hash=$(nix hash to-sri --type sha256 "$sha256")
-
-        update-source-version "${pname}" "$version" "$sri_hash"
-      '';
-    });
   };
 
   meta = with lib; {

--- a/pkgs/applications/version-management/forgejo/package-json-npm-build-frontend.patch
+++ b/pkgs/applications/version-management/forgejo/package-json-npm-build-frontend.patch
@@ -1,0 +1,14 @@
+diff --git a/package.json b/package.json
+index 57dcfc2f7..c9f23dbf7 100644
+--- a/package.json
++++ b/package.json
+@@ -79,5 +79,8 @@
+     "defaults",
+     "not ie > 0",
+     "not ie_mob > 0"
+-  ]
++  ],
++  "scripts": {
++    "build": "node_modules/.bin/webpack"
++  }
+ }


### PR DESCRIPTION
###### Description of changes

Build from source (frontend and backend) instead of relying on the release tarballs published with each release.
This does however add two additional hashes (`vendorHash` and `npmDepsHash`), making it a total of 3 hashes that need to be updated each time.

The old `updateScript` is no longer useful as of this change.
It was originally added because we weren't aware that gitea/forgejo/codeberg have "predictable URLs" for the previously needed release tarball.
Fixed in 0dd0b2103a25d2068462895faa852d535666a977

cc Gitea maintainers, in case they want this in `gitea` as well:
@disassembler @kolaente @Ma27 @techknowlogick

Suggested by @mweinelt in https://github.com/NixOS/nixpkgs/pull/224877#pullrequestreview-1373711014 

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
