### PR TITLE
deepin.deepin-editor: 5.10.35 -> 6.0.7

### DIFF
--- a/pkgs/desktops/deepin/apps/deepin-editor/default.nix
+++ b/pkgs/desktops/deepin/apps/deepin-editor/default.nix
@@ -1,47 +1,33 @@
 { stdenv
 , lib
 , fetchFromGitHub
-, fetchpatch
-, dtkwidget
-, qt5integration
-, qt5platform-plugins
-, dde-qt-dbus-factory
 , cmake
 , pkg-config
 , qttools
+, wrapQtAppsHook
+, dtkwidget
+, qt5integration
+, qt5platform-plugins
 , qtbase
 , qtsvg
-, wrapQtAppsHook
+, dde-qt-dbus-factory
 , kcodecs
 , syntax-highlighting
 , libchardet
 , libuchardet
 , libiconv
-, gtest
 }:
 
 stdenv.mkDerivation rec {
   pname = "deepin-editor";
-  version = "5.10.35";
+  version = "6.0.7";
 
   src = fetchFromGitHub {
     owner = "linuxdeepin";
     repo = pname;
     rev = version;
-    sha256 = "sha256-X3tsmtqMUSpYQZqCmgtCLCSGwzSmCZagF7TUWQYJsqU=";
+    sha256 = "sha256-7dHSybjoWZ1alcMsMm4BEEQJjQgNmhC7Eskeo3ZmoS8=";
   };
-
-  patches = [
-    (fetchpatch {
-      name = "chore-use-GNUInstallDirs-in-CmakeLists.patch";
-      url = "https://github.com/linuxdeepin/deepin-editor/commit/7f4314f386a3c8f5cdea3618591b8eb027d034c3.patch";
-      sha256 = "sha256-/aSBa2nILc/YrFchUyhBHHs2c7Mv6N1juwD5Sdc39Uo=";
-    })
-  ];
-
-  postPatch = ''
-    substituteInPlace src/common/utils.h --replace "/usr/share" "$out/share"
-  '';
 
   nativeBuildInputs = [
     cmake
@@ -51,18 +37,17 @@ stdenv.mkDerivation rec {
   ];
 
   buildInputs = [
-    qtbase
-    qtsvg
     dtkwidget
     qt5integration
     qt5platform-plugins
+    qtbase
+    qtsvg
     dde-qt-dbus-factory
     kcodecs
     syntax-highlighting
     libchardet
     libuchardet
     libiconv
-    gtest
   ];
 
   strictDeps = true;


### PR DESCRIPTION
###### Description of changes

Don't need gtest now, only when CMAKE_BUILD_TYPE=Debug will enable unit testing

6.0.6 break original patch，the new pr has been merged：https://github.com/linuxdeepin/deepin-editor/commit/09ec562e153f46d0ca770e045dc2c9dfdd7b6b71

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
