### PR TITLE
wrapGAppsHook fixes

### DIFF
--- a/pkgs/applications/editors/texmaker/default.nix
+++ b/pkgs/applications/editors/texmaker/default.nix
@@ -1,4 +1,4 @@
-{ lib, mkDerivation, fetchurl, qtbase, qtscript, qtwebengine, qmake, zlib, pkg-config, poppler }:
+{ lib, mkDerivation, fetchurl, qtbase, qtscript, qtwebengine, qmake, zlib, pkg-config, poppler, wrapGAppsHook }:
 
 mkDerivation rec {
   pname = "texmaker";
@@ -10,7 +10,7 @@ mkDerivation rec {
   };
 
   buildInputs = [ qtbase qtscript poppler zlib qtwebengine ];
-  nativeBuildInputs = [ pkg-config poppler qmake ];
+  nativeBuildInputs = [ pkg-config poppler qmake wrapGAppsHook ];
   env.NIX_CFLAGS_COMPILE = "-I${poppler.dev}/include/poppler";
 
   qmakeFlags = [
@@ -18,6 +18,12 @@ mkDerivation rec {
     "ICONDIR=${placeholder "out"}/share/pixmaps"
     "METAINFODIR=${placeholder "out"}/share/metainfo"
   ];
+
+  dontWrapGApps = true;
+
+  preFixup = ''
+    qtWrapperArgs+=("''${gappsWrapperArgs[@]}")
+  '';
 
   meta = with lib; {
     description = "TeX and LaTeX editor";

--- a/pkgs/applications/kde/spectacle.nix
+++ b/pkgs/applications/kde/spectacle.nix
@@ -5,11 +5,12 @@
 , knotifications, kscreen, kwidgetsaddons, kwindowsystem, kxmlgui, libkipi
 , qtx11extras, knewstuff, kwayland, qttools, kcolorpicker, kimageannotator
 , qcoro, qtquickcontrols2, wayland, plasma-wayland-protocols, kpurpose, kpipewire
+, wrapGAppsHook
 }:
 
 mkDerivation {
   pname = "spectacle";
-  nativeBuildInputs = [ extra-cmake-modules kdoctools ];
+  nativeBuildInputs = [ extra-cmake-modules kdoctools wrapGAppsHook ];
   buildInputs = [
     kconfig kcoreaddons kdbusaddons kdeclarative ki18n kio knotifications
     kscreen kwidgetsaddons kwindowsystem kxmlgui libkipi qtx11extras xcb-util-cursor
@@ -20,6 +21,13 @@ mkDerivation {
     substituteInPlace desktop/org.kde.spectacle.desktop.cmake \
       --replace "Exec=@QtBinariesDir@/qdbus" "Exec=${lib.getBin qttools}/bin/qdbus"
   '';
+
+  dontWrapGApps = true;
+
+  preFixup = ''
+    qtWrapperArgs+=("''${gappsWrapperArgs[@]}")
+  '';
+
   propagatedUserEnvPkgs = [ kipi-plugins libkipi ];
   meta = with lib; {
     homepage = "https://apps.kde.org/spectacle/";

--- a/pkgs/applications/video/vlc/default.nix
+++ b/pkgs/applications/video/vlc/default.nix
@@ -71,7 +71,7 @@
 , onlyLibVLC ? false
 , skins2Support ? !onlyLibVLC, freetype
 , waylandSupport ? true, wayland, wayland-protocols
-, withQt5 ? true, qtbase, qtsvg, qtwayland, qtx11extras, wrapQtAppsHook
+, withQt5 ? true, qtbase, qtsvg, qtwayland, qtx11extras, wrapQtAppsHook, wrapGAppsHook
 }:
 
 # chromecastSupport requires TCP port 8010 to be open for it to work.
@@ -177,6 +177,7 @@ stdenv.mkDerivation rec {
     pkg-config
     removeReferencesTo
     unzip
+    wrapGAppsHook
   ]
   ++ optionals withQt5 [ wrapQtAppsHook ]
   ++ optionals waylandSupport [ wayland wayland-protocols ];
@@ -207,6 +208,14 @@ stdenv.mkDerivation rec {
   postPatch = ''
     substituteInPlace modules/text_renderer/freetype/platform_fonts.h --replace \
       /usr/share/fonts/truetype/freefont ${freefont_ttf}/share/fonts/truetype
+  '';
+
+
+  # to prevent double wrapping of Qtwrap and Gwrap
+  dontWrapGApps = true;
+
+  preFixup = ''
+    qtWrapperArgs+=("''${gappsWrapperArgs[@]}")
   '';
 
   # - Touch plugins (plugins cache keyed off mtime and file size:


### PR DESCRIPTION
I have a found a few packages that crash when attempting to open file pickers with the following error
```
GLib-GIO-ERROR **: 06:51:14.382: No GSettings schemas are installed on the system
```

###### Description of changes

Fixed in the same way for all 3 following what was recommended in #16285

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->


###### Other

I was unsure if this should be 3 separate PR's as they are separate applications if this is preferred, I am happy to split them up.