### PR TITLE
unit: drop PHP 8.0 support, add PHP 8.2 support

### DIFF
--- a/pkgs/servers/http/unit/default.nix
+++ b/pkgs/servers/http/unit/default.nix
@@ -2,6 +2,7 @@
 , pcre2
 , withPython3 ? true, python3, ncurses
 , withPHP81 ? true, php81
+, withPHP82 ? false, php82
 , withPerl534 ? false, perl534
 , withPerl536 ? true, perl536
 , withPerldevel ? false, perldevel
@@ -26,6 +27,7 @@ let
   };
 
   php81-unit = php81.override phpConfig;
+  php82-unit = php82.override phpConfig;
 
 in stdenv.mkDerivation rec {
   version = "1.29.1";
@@ -43,6 +45,7 @@ in stdenv.mkDerivation rec {
   buildInputs = [ pcre2.dev ]
     ++ optionals withPython3 [ python3 ncurses ]
     ++ optional withPHP81 php81-unit
+    ++ optional withPHP82 php82-unit
     ++ optional withPerl534 perl534
     ++ optional withPerl536 perl536
     ++ optional withPerldevel perldevel
@@ -66,6 +69,7 @@ in stdenv.mkDerivation rec {
   postConfigure = ''
     ${optionalString withPython3    "./configure python --module=python3  --config=python3-config  --lib-path=${python3}/lib"}
     ${optionalString withPHP81      "./configure php    --module=php81    --config=${php81-unit.unwrapped.dev}/bin/php-config --lib-path=${php81-unit}/lib"}
+    ${optionalString withPHP82      "./configure php    --module=php81    --config=${php82-unit.unwrapped.dev}/bin/php-config --lib-path=${php82-unit}/lib"}
     ${optionalString withPerl534    "./configure perl   --module=perl534  --perl=${perl534}/bin/perl"}
     ${optionalString withPerl536    "./configure perl   --module=perl536  --perl=${perl536}/bin/perl"}
     ${optionalString withPerldevel  "./configure perl   --module=perldev  --perl=${perldevel}/bin/perl"}

--- a/pkgs/servers/http/unit/default.nix
+++ b/pkgs/servers/http/unit/default.nix
@@ -1,7 +1,6 @@
 { lib, stdenv, fetchFromGitHub, nixosTests, which
 , pcre2
 , withPython3 ? true, python3, ncurses
-, withPHP80 ? false, php80
 , withPHP81 ? true, php81
 , withPerl534 ? false, perl534
 , withPerl536 ? true, perl536
@@ -26,7 +25,6 @@ let
     fpmSupport = false;
   };
 
-  php80-unit = php80.override phpConfig;
   php81-unit = php81.override phpConfig;
 
 in stdenv.mkDerivation rec {
@@ -44,7 +42,6 @@ in stdenv.mkDerivation rec {
 
   buildInputs = [ pcre2.dev ]
     ++ optionals withPython3 [ python3 ncurses ]
-    ++ optional withPHP80 php80-unit
     ++ optional withPHP81 php81-unit
     ++ optional withPerl534 perl534
     ++ optional withPerl536 perl536
@@ -64,12 +61,10 @@ in stdenv.mkDerivation rec {
     ++ optional withDebug   "--debug";
 
   # Optionally add the PHP derivations used so they can be addressed in the configs
-  usedPhp80 = optionals withPHP80 php80-unit;
   usedPhp81 = optionals withPHP81 php81-unit;
 
   postConfigure = ''
     ${optionalString withPython3    "./configure python --module=python3  --config=python3-config  --lib-path=${python3}/lib"}
-    ${optionalString withPHP80      "./configure php    --module=php80    --config=${php80-unit.unwrapped.dev}/bin/php-config --lib-path=${php80-unit}/lib"}
     ${optionalString withPHP81      "./configure php    --module=php81    --config=${php81-unit.unwrapped.dev}/bin/php-config --lib-path=${php81-unit}/lib"}
     ${optionalString withPerl534    "./configure perl   --module=perl534  --perl=${perl534}/bin/perl"}
     ${optionalString withPerl536    "./configure perl   --module=perl536  --perl=${perl536}/bin/perl"}


### PR DESCRIPTION
###### Description of changes

Related to #224505

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
Result of `nixpkgs-review` run on x86_64-linux [1](https://github.com/Mic92/nixpkgs-review)
<details>
  <summary>1 package built:</summary>
  <ul>
    <li>unit</li>
  </ul>
</details>