### PR TITLE
flix: init at 0.35.0

### DIFF
--- a/pkgs/development/compilers/flix/default.nix
+++ b/pkgs/development/compilers/flix/default.nix
@@ -15,10 +15,12 @@ stdenvNoCC.mkDerivation rec {
 
   installPhase = ''
     runHook preInstall
-    export JAR=$out/share/java/${pname}/${pname}.jar
+
+    export JAR=$out/share/java/flix/flix.jar
     install -D $src $JAR
-    makeWrapper ${jre}/bin/java $out/bin/${pname} \
+    makeWrapper ${jre}/bin/java $out/bin/flix \
       --add-flags "-jar $JAR"
+
     runHook postInstall
   '';
 

--- a/pkgs/development/compilers/flix/default.nix
+++ b/pkgs/development/compilers/flix/default.nix
@@ -1,0 +1,33 @@
+{ lib, fetchurl, stdenvNoCC, makeWrapper, jre }:
+
+stdenvNoCC.mkDerivation rec {
+  pname = "flix";
+  version = "0.35.0";
+
+  src = fetchurl {
+    url = "https://github.com/flix/flix/releases/download/v${version}/flix.jar";
+    sha256 = "sha256-liPOAQfdAYc2JlUb+BXQ5KhTOYexC1vBCIuO0nT2jhk=";
+  };
+
+  dontUnpack = true;
+
+  nativeBuildInputs = [ makeWrapper ];
+
+  installPhase = ''
+    runHook preInstall
+    export JAR=$out/share/java/${pname}/${pname}.jar
+    install -D $src $JAR
+    makeWrapper ${jre}/bin/java $out/bin/${pname} \
+      --add-flags "-jar $JAR"
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    description = "The Flix Programming Language";
+    homepage = "https://github.com/flix/flix";
+    sourceProvenance = with sourceTypes; [ binaryBytecode ];
+    license = licenses.asl20;
+    maintainers = with maintainers; [ athas ];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/development/compilers/flix/default.nix
+++ b/pkgs/development/compilers/flix/default.nix
@@ -30,6 +30,6 @@ stdenvNoCC.mkDerivation rec {
     sourceProvenance = with sourceTypes; [ binaryBytecode ];
     license = licenses.asl20;
     maintainers = with maintainers; [ athas ];
-    platforms = platforms.all;
+    inherit (jre.meta) platforms;
   };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2208,6 +2208,8 @@ with pkgs;
 
   flycast = callPackage ../applications/emulators/flycast { };
 
+  flix = callPackage ../development/compilers/flix { };
+
   fsrx = callPackage ../tools/misc/fsrx { };
 
   fsuae = callPackage ../applications/emulators/fs-uae { };


### PR DESCRIPTION
###### Description of changes

Added derivation for the [Flix](https://github.com/flix/flix) compiler, a somewhat popular project (1700 stars on GitHub).

Note that this derivation uses the upstream .jar file, as seems relatively common for Java-based derivations.  I suppose I can change the derivation to use `sbt` to build from source, if that is desirable, but I don't think I know of any existing derivations that use `sbt`.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
