### PR TITLE
tandem-aligner: unstable-2022-09-17 -> 0.1

### DIFF
--- a/pkgs/applications/science/biology/tandem-aligner/default.nix
+++ b/pkgs/applications/science/biology/tandem-aligner/default.nix
@@ -6,14 +6,14 @@
 , zlib
 }:
 
-stdenv.mkDerivation {
+stdenv.mkDerivation (finalAttrs: {
   pname = "TandemAligner";
-  version = "unstable-2022-09-17";
+  version = "0.1";
 
   src = fetchFromGitHub {
     owner = "seryrzu";
     repo = "tandem_aligner";
-    rev = "ac6004f108ad20477045f4d0b037d96051a9df70";
+    rev = "v${finalAttrs.version}";
     hash = "sha256-iMDj1HZ8LzmZckuAM3lbG3eSJSd/5JGVA6SBs7+AgX8=";
   };
 
@@ -63,4 +63,4 @@ stdenv.mkDerivation {
     platforms = lib.platforms.linux;
     mainProgram = "tandem_aligner";
   };
-}
+})

--- a/pkgs/applications/science/biology/tandem-aligner/default.nix
+++ b/pkgs/applications/science/biology/tandem-aligner/default.nix
@@ -58,6 +58,7 @@ stdenv.mkDerivation (finalAttrs: {
   meta = {
     description = "A parameter-free algorithm for sequence alignment";
     homepage = "https://github.com/seryrzu/tandem_aligner";
+    changelog = "https://github.com/seryrzu/tandem_aligner/releases/tag/v${finalAttrs.version}";
     license = lib.licenses.bsd3;
     maintainers = with lib.maintainers; [ amesgen ];
     platforms = lib.platforms.linux;


### PR DESCRIPTION
###### Description of changes

The commit to fetch has not changed, but a new tag has been added.
https://github.com/seryrzu/tandem_aligner/releases/tag/v0.1

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
