### PR TITLE
kodiPackages.infotagger: init at 0.0.7

### DIFF
--- a/pkgs/applications/video/kodi/addons/infotagger/default.nix
+++ b/pkgs/applications/video/kodi/addons/infotagger/default.nix
@@ -1,0 +1,28 @@
+{ lib, buildKodiAddon, fetchFromGitHub, addonUpdateScript }:
+buildKodiAddon rec {
+  pname = "infotagger";
+  namespace = "script.module.infotagger";
+  version = "0.0.7";
+
+  src = fetchFromGitHub {
+    owner = "jurialmunkey";
+    repo = namespace;
+    rev = "v${version}";
+    hash = "sha256-Us7ud0QORGn+ALB4uyISekp0kUYY8nN8uFNg8MlxEB0=";
+  };
+
+  passthru = {
+    # Unusual Python path.
+    pythonPath = "resources/modules";
+    updateScript = addonUpdateScript {
+      attrPath = "kodi.packages.infotagger";
+    };
+  };
+
+  meta = with lib; {
+    homepage = "https://github.com/jurialmunkey/script.module.infotagger";
+    description = "Wrapper for new Nexus InfoTagVideo ListItem methods to maintain backwards compatibility";
+    license = licenses.gpl3Plus;
+    maintainers = teams.kodi.members;
+  };
+}

--- a/pkgs/applications/video/kodi/addons/youtube/default.nix
+++ b/pkgs/applications/video/kodi/addons/youtube/default.nix
@@ -1,4 +1,4 @@
-{ lib, buildKodiAddon, fetchzip, addonUpdateScript, six, requests, inputstreamhelper }:
+{ lib, buildKodiAddon, fetchzip, addonUpdateScript, six, requests, infotagger, inputstreamhelper }:
 
 buildKodiAddon rec {
   pname = "youtube";
@@ -13,6 +13,7 @@ buildKodiAddon rec {
   propagatedBuildInputs = [
     six
     requests
+    infotagger
     inputstreamhelper
   ];
 

--- a/pkgs/top-level/kodi-packages.nix
+++ b/pkgs/top-level/kodi-packages.nix
@@ -120,6 +120,8 @@ let self = rec {
 
   idna = callPackage ../applications/video/kodi/addons/idna { };
 
+  infotagger = callPackage ../applications/video/kodi/addons/infotagger { };
+
   inputstream-adaptive = callPackage ../applications/video/kodi/addons/inputstream-adaptive { };
 
   inputstream-ffmpegdirect = callPackage ../applications/video/kodi/addons/inputstream-ffmpegdirect { };


### PR DESCRIPTION
Fixes https://github.com/NixOS/nixpkgs/issues/226613.

Add `infotagger` plugin and use it.

Two notes on the `infotagger` plugin:

- I used the GitHub source, and not https://kodi.tv/addons/nexus/script.module.infotagger/ which links to http://ftp.halifax.rwth-aachen.de/xbmc/addons/nexus/script.module.infotagger/script.module.infotagger-0.0.7.zip. Not sure if this is a problem (or a feature).

- The `infotagger` plugin has a weird Python path `resources/modules`. I expect this path may change in the upstream module in the future (it is `lib` for all other modules as far as I can see).

I can watch YouTube videos here.

However, this PR does not address the relatively new dependency

```
<import addon="inputstream.adaptive" version="20.3.1"/>
```

I do not get any errors though. I am not sure how to proceed (open another issue?; ignore?).

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
