### PR TITLE
qt6.qtwebengine: patch to fix xkb layout crash

### DIFF
--- a/pkgs/development/libraries/qt-6/modules/qtwebengine.nix
+++ b/pkgs/development/libraries/qt-6/modules/qtwebengine.nix
@@ -127,10 +127,14 @@ qtModule {
   # which cannot be set at the same time as -Wformat-security
   hardeningDisable = [ "format" ];
 
-  # removes macOS 12+ dependencies
   patches = [
+    # removes macOS 12+ dependencies
     ../patches/qtwebengine-darwin-no-low-latency-flag.patch
     ../patches/qtwebengine-darwin-no-copy-certificate-chain.patch
+    # Don't assume /usr/share/X11, and also respect the XKB_CONFIG_ROOT
+    # environment variable, since NixOS relies on it working.
+    # See https://github.com/NixOS/nixpkgs/issues/226484 for more context.
+    ../patches/qtwebengine-xkb-includes.patch
   ];
 
   postPatch = ''
@@ -161,9 +165,6 @@ qtModule {
 
     sed -i -e '/libpci_loader.*Load/s!"\(libpci\.so\)!"${pciutils}/lib/\1!' \
       src/3rdparty/chromium/gpu/config/gpu_info_collector_linux.cc
-
-    substituteInPlace src/3rdparty/chromium/ui/events/ozone/layout/xkb/xkb_keyboard_layout_engine.cc \
-      --replace "/usr/share/X11/xkb" "${xkeyboard_config}/share/X11/xkb"
   ''
   + lib.optionalString stdenv.isDarwin ''
     substituteInPlace configure.cmake \

--- a/pkgs/development/libraries/qt-6/patches/qtwebengine-xkb-includes.patch
+++ b/pkgs/development/libraries/qt-6/patches/qtwebengine-xkb-includes.patch
@@ -1,0 +1,12 @@
+--- a/src/3rdparty/chromium/ui/events/ozone/layout/xkb/xkb_keyboard_layout_engine.cc	2023-04-19 21:58:29.127258300 +0900
++++ b/src/3rdparty/chromium/ui/events/ozone/layout/xkb/xkb_keyboard_layout_engine.cc	2023-04-19 22:01:35.860196284 +0900
+@@ -637,8 +637,7 @@
+                           .variant = layout_variant.c_str(),
+                           .options = ""};
+   std::unique_ptr<xkb_context, XkbContextDeleter> context;
+-  context.reset(xkb_context_new(XKB_CONTEXT_NO_DEFAULT_INCLUDES));
+-  xkb_context_include_path_append(context.get(), "/usr/share/X11/xkb");
++  context.reset(xkb_context_new(XKB_CONTEXT_NO_FLAGS));
+   std::unique_ptr<xkb_keymap, XkbKeymapDeleter> keymap;
+   keymap.reset(xkb_keymap_new_from_names(context.get(), &names,
+                                          XKB_KEYMAP_COMPILE_NO_FLAGS));


### PR DESCRIPTION
###### Description of changes

See https://github.com/NixOS/nixpkgs/issues/226484

Without this patch, running qt6 applications that make use of qtwebengine while having a custom xkb keyboard layout configured causes a crash like so:

(taken from the linked issue)
```
xkbcommon: ERROR: Couldn't find file "symbols/fc660c" in include paths
xkbcommon: ERROR: 1 include paths searched:
xkbcommon: ERROR:       /nix/store/18kg67dfchk2l7ni9i0hrpbdspbxlrzw-xkeyboard-config-2.33/share/X11/xkb
...
[282321:282350:0416/224135.195895:FATAL:xkb_keyboard_layout_engine.cc(652)] Keymap file failed to load: fc660c
<crash>
```

A fairly minimal repro can be found [here](https://github.com/euank/kitchen-sink/tree/d58cff1793776263091b86e69facf935114b717e/nix/qt6-repro), it's effectively:

```nix
          services.xserver = {
            layout = "test";
            extraLayouts.test = {
              description = "test";
              languages = [ "eng" ];
              symbolsFile = "${pkgs.xkeyboard_config}/share/X11/xkb/symbols/us";
            };
          };
```

And then using x11 and launching a qt6 app like `anki` or `${calibre}/bin/ebook-viewer`

This patch fixes the above crash, and on my machine it appears that alternative layouts work correctly in qt6 applications.

Specifically, I tested if alternate layouts worked by changing `symbols/us` to `symbols/ru` in the above, and then verifying typing in various fields of `ebook-edit` (also in calibre, crashes without this patch) saw `ru` characters.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
