### PR TITLE
gtklock-*-module: init at 2.0.{0,1}

### DIFF
--- a/pkgs/tools/wayland/gtklock/playerctl-module.nix
+++ b/pkgs/tools/wayland/gtklock/playerctl-module.nix
@@ -1,0 +1,34 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, pkg-config
+, gtk3
+, playerctl
+, libsoup
+}:
+
+stdenv.mkDerivation rec {
+  pname = "gtklock-playerctl-module";
+  version = "2.0.1";
+
+  src = fetchFromGitHub {
+    owner = "jovanlanik";
+    repo = pname;
+    rev = "v${version}";
+    hash = "sha256-kzGgqFDTeKL6Pfjram7pqVcIm8Avxsvpn1qFrcpd8dw=";
+  };
+
+  nativeBuildInputs = [ pkg-config ];
+
+  buildInputs = [ gtk3 playerctl libsoup ];
+
+  makeFlags = [ "PREFIX=$(out)" ];
+
+  meta = with lib; {
+    description = "Gtklock module adding power controls to the lockscreen";
+    homepage = "https://github.com/jovanlanik/gtklock-powerbar-module";
+    license = licenses.gpl3Only;
+    maintainers = with maintainers; [ aleksana ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/tools/wayland/gtklock/powerbar-module.nix
+++ b/pkgs/tools/wayland/gtklock/powerbar-module.nix
@@ -1,0 +1,32 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, pkg-config
+, gtk3
+}:
+
+stdenv.mkDerivation rec {
+  pname = "gtklock-powerbar-module";
+  version = "2.0.1";
+
+  src = fetchFromGitHub {
+    owner = "jovanlanik";
+    repo = pname;
+    rev = "v${version}";
+    hash = "sha256-Ev6vjtvUSqP/+xTDRAqSYJ436WhZUtFRxSP7LoSK00w=";
+  };
+
+  nativeBuildInputs = [ pkg-config ];
+
+  buildInputs = [ gtk3 ];
+
+  makeFlags = [ "PREFIX=$(out)" ];
+
+  meta = with lib; {
+    description = "Gtklock module adding power controls to the lockscreen";
+    homepage = "https://github.com/jovanlanik/gtklock-powerbar-module";
+    license = licenses.gpl3Only;
+    maintainers = with maintainers; [ aleksana ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/tools/wayland/gtklock/userinfo-module.nix
+++ b/pkgs/tools/wayland/gtklock/userinfo-module.nix
@@ -1,0 +1,34 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, pkg-config
+, gtk3
+, glib
+, accountsservice
+}:
+
+stdenv.mkDerivation rec {
+  pname = "gtklock-userinfo-module";
+  version = "2.0.0";
+
+  src = fetchFromGitHub {
+    owner = "jovanlanik";
+    repo = pname;
+    rev = "v${version}";
+    hash = "sha256-7dtw6GZ7l0fbTxRxMWH4yRj9Zqz9KB3acmwnF/8LALg=";
+  };
+
+  nativeBuildInputs = [ pkg-config ];
+
+  buildInputs = [ gtk3 glib accountsservice ];
+
+  makeFlags = [ "PREFIX=$(out)" ];
+
+  meta = with lib; {
+    description = "Gtklock module adding user info to the lockscreen";
+    homepage = "https://github.com/jovanlanik/gtklock-powerbar-module";
+    license = licenses.gpl3Only;
+    maintainers = with maintainers; [ aleksana ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -30363,6 +30363,8 @@ with pkgs;
 
   gtklock-playerctl-module = callPackage ../tools/wayland/gtklock/playerctl-module.nix { };
 
+  gtklock-powerbar-module = callPackage ../tools/wayland/gtklock/powerbar-module.nix { };
+
   guardian-agent = callPackage ../tools/networking/guardian-agent { };
 
   gv = callPackage ../applications/misc/gv { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -30361,6 +30361,8 @@ with pkgs;
 
   gtklock = callPackage ../tools/wayland/gtklock { };
 
+  gtklock-playerctl-module = callPackage ../tools/wayland/gtklock/playerctl-module.nix { };
+
   guardian-agent = callPackage ../tools/networking/guardian-agent { };
 
   gv = callPackage ../applications/misc/gv { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -30365,6 +30365,8 @@ with pkgs;
 
   gtklock-powerbar-module = callPackage ../tools/wayland/gtklock/powerbar-module.nix { };
 
+  gtklock-userinfo-module = callPackage ../tools/wayland/gtklock/userinfo-module.nix { };
+
   guardian-agent = callPackage ../tools/networking/guardian-agent { };
 
   gv = callPackage ../applications/misc/gv { };


### PR DESCRIPTION
###### Description of changes

Added three gtklock modules written by its main dev jovanlanik. All fully tested. (gtklock seems to block the PrtSc key)

![IMG20230419235618](https://user-images.githubusercontent.com/42209822/233138768-bed5a278-6c77-495d-8767-ae2f372c6e15.jpg)

The author suggests that these plugins should be matched with the corresponding version of gtklock to avoid potential issues. This is something to consider when updating gtklock.

also ping gtklock package maintainer @dit7ya 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
