### PR TITLE
libgphoto2: update udev rules version

### DIFF
--- a/pkgs/development/libraries/libgphoto2/default.nix
+++ b/pkgs/development/libraries/libgphoto2/default.nix
@@ -58,10 +58,13 @@ stdenv.mkDerivation rec {
           buildPackages.libgphoto2;
     in
     ''
-      mkdir -p $out/lib/udev/rules.d
+      mkdir -p $out/lib/udev/{rules.d,hwdb.d}
       ${executablePrefix}/lib/libgphoto2/print-camera-list \
-          udev-rules version 175 group camera \
-          >$out/lib/udev/rules.d/40-gphoto2.rules
+          udev-rules version 201 group camera \
+          >$out/lib/udev/rules.d/40-libgphoto2.rules
+      ${executablePrefix}/lib/libgphoto2/print-camera-list \
+          hwdb version 201 group camera \
+          >$out/lib/udev/hwdb.d/20-gphoto.hwdb
     '';
 
   meta = {


### PR DESCRIPTION
and add hwdb

https://github.com/gphoto/libgphoto2/blob/48d9bafe1fb9b8bd7485d554b1fec8a6a9bd3f71/packaging/generic/print-camera-list.c#L1407-L1416

paths from
https://github.com/gphoto/libgphoto2/blob/48d9bafe1fb9b8bd7485d554b1fec8a6a9bd3f71/packaging/generic/print-camera-list.c#L1426 and https://github.com/gphoto/libgphoto2/blob/48d9bafe1fb9b8bd7485d554b1fec8a6a9bd3f71/packaging/generic/print-camera-list.c#L1413

ref
https://github.com/archlinux/svntogit-packages/blob/acd9af4de4b07d4fcdb08142f7eb596ae75d81d2/trunk/PKGBUILD#L57 https://src.fedoraproject.org/rpms/libgphoto2/blob/rawhide/f/libgphoto2.spec#_105


Closes https://github.com/NixOS/nixpkgs/issues/145544

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
