### PR TITLE
fishPlugins: add sdkman-for-fish

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -5695,6 +5695,12 @@
     githubId = 1713676;
     name = "Luis G. Torres";
   };
+  giorgiga = {
+    email = "giorgio.gallo@bitnic.it";
+    github = "giorgiga";
+    githubId = 471835;
+    name = "Giorgio Gallo";
+  };
   GKasparov = {
     email = "mizozahr@gmail.com";
     github = "GKasparov";

--- a/pkgs/shells/fish/plugins/default.nix
+++ b/pkgs/shells/fish/plugins/default.nix
@@ -48,6 +48,8 @@ lib.makeScope newScope (self: with self; {
 
   pure = callPackage ./pure.nix { };
 
+  sdkman-for-fish = callPackage ./sdkman-for-fish.nix { };
+
   sponge = callPackage ./sponge.nix { };
 
   tide = callPackage ./tide.nix { };

--- a/pkgs/shells/fish/plugins/sdkman-for-fish.nix
+++ b/pkgs/shells/fish/plugins/sdkman-for-fish.nix
@@ -1,0 +1,20 @@
+{ lib, buildFishPlugin, fetchFromGitHub }:
+
+buildFishPlugin rec {
+  pname = "sdkman-for-fish";
+  version = "1.4.0";
+
+  src = fetchFromGitHub {
+    owner = "reitzig";
+    repo = "sdkman-for-fish";
+    rev = "v${version}";
+    hash = "sha256-bfWQ2al0Xy8bnJt5euziHz/+qhyri4qWy47VDoPwQcg=";
+  };
+
+  meta = with lib; {
+    description = "Adds support for SDKMAN! to fish";
+    homepage = "https://github.com/reitzig/sdkman-for-fish";
+    license = licenses.mit;
+    maintainers = with maintainers; [ giorgiga ];
+  };
+}


### PR DESCRIPTION
###### Description of changes

This adds the fish plugin [sdkman-for-fish](https://github.com/reitzig/sdkman-for-fish), which enables [SDKMAN!](https://sdkman.io/) for fish users.

Since SDKMAN! normally only works on bash and similar shells, sdkman-for-fish is quite important for java developers who use the fish shell (an alternative plugin is https://github.com/deather/omf-sdk).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
