### PR TITLE
python310Packages.tensorflow-datasets: fix build

### DIFF
--- a/pkgs/development/python-modules/tensorflow-datasets/default.nix
+++ b/pkgs/development/python-modules/tensorflow-datasets/default.nix
@@ -2,6 +2,8 @@
 , attrs
 , beautifulsoup4
 , buildPythonPackage
+, click
+, datasets
 , dill
 , dm-tree
 , fetchFromGitHub
@@ -14,6 +16,7 @@
 , jinja2
 , langdetect
 , lib
+, lxml
 , matplotlib
 , mwparserfromhell
 , networkx
@@ -24,6 +27,7 @@
 , pillow
 , promise
 , protobuf
+, psutil
 , pycocotools
 , pydub
 , pytest-xdist
@@ -65,6 +69,7 @@ buildPythonPackage rec {
     numpy
     promise
     protobuf
+    psutil
     requests
     six
     tensorflow-metadata
@@ -79,12 +84,15 @@ buildPythonPackage rec {
   nativeCheckInputs = [
     apache-beam
     beautifulsoup4
+    click
+    datasets
     ffmpeg
     imagemagick
     jax
     jaxlib
     jinja2
     langdetect
+    lxml
     matplotlib
     mwparserfromhell
     networkx
@@ -109,19 +117,29 @@ buildPythonPackage rec {
     "tensorflow_datasets/core/dataset_info_test.py"
     "tensorflow_datasets/core/features/features_test.py"
     "tensorflow_datasets/core/github_api/github_path_test.py"
+    "tensorflow_datasets/core/registered_test.py"
     "tensorflow_datasets/core/utils/gcs_utils_test.py"
+    "tensorflow_datasets/import_without_tf_test.py"
     "tensorflow_datasets/scripts/cli/build_test.py"
 
     # Requires `pretty_midi` which is not packaged in `nixpkgs`.
-    "tensorflow_datasets/audio/groove_test.py"
+    "tensorflow_datasets/audio/groove.py"
+    "tensorflow_datasets/datasets/groove/groove_dataset_builder_test.py"
 
     # Requires `crepe` which is not packaged in `nixpkgs`.
-    "tensorflow_datasets/audio/nsynth_test.py"
+    "tensorflow_datasets/audio/nsynth.py"
+    "tensorflow_datasets/datasets/nsynth/nsynth_dataset_builder_test.py"
+
+    # Requires `conllu` which is not packaged in `nixpkgs`.
+    "tensorflow_datasets/core/dataset_builders/conll/conllu_dataset_builder_test.py"
+    "tensorflow_datasets/datasets/universal_dependencies/universal_dependencies_dataset_builder_test.py"
+    "tensorflow_datasets/datasets/xtreme_pos/xtreme_pos_dataset_builder_test.py"
 
     # Requires `gcld3` and `pretty_midi` which are not packaged in `nixpkgs`.
     "tensorflow_datasets/core/lazy_imports_lib_test.py"
 
     # Requires `tensorflow_io` which is not packaged in `nixpkgs`.
+    "tensorflow_datasets/core/features/audio_feature_test.py"
     "tensorflow_datasets/image/lsun_test.py"
 
     # Requires `envlogger` which is not packaged in `nixpkgs`.
@@ -132,6 +150,10 @@ buildPythonPackage rec {
     # deep in TF AutoGraph. Doesn't reproduce in Docker with Ubuntu 22.04 => might be related
     # to the differences in some of the dependencies?
     "tensorflow_datasets/rl_unplugged/rlu_atari/rlu_atari_test.py"
+
+    # Fails with `ValueError: setting an array element with a sequence`
+    "tensorflow_datasets/core/dataset_utils_test.py"
+    "tensorflow_datasets/core/features/sequence_feature_test.py"
 
     # Requires `tensorflow_docs` which is not packaged in `nixpkgs` and the test is for documentation anyway.
     "tensorflow_datasets/scripts/documentation/build_api_docs_test.py"


### PR DESCRIPTION
tensorflow-datasets v4.7.0 and greater require python's `click` and `psutil` packages.

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
