### PR TITLE
roadrunner: init at 2023.2.2

### DIFF
--- a/pkgs/servers/roadrunner/default.nix
+++ b/pkgs/servers/roadrunner/default.nix
@@ -1,0 +1,57 @@
+{ lib
+, buildGoModule
+, fetchFromGitHub
+, installShellFiles
+}:
+
+buildGoModule rec {
+  pname = "roadrunner";
+  version = "2023.2.2";
+  src = fetchFromGitHub {
+    repo = "roadrunner";
+    owner = "roadrunner-server";
+    rev = "v${version}";
+    hash = "sha256-tkJ7MDFHWps6bCppFJXMFYQl7+i8OhuDVrk1n78rrUc";
+  };
+
+  nativeBuildInputs = [
+    installShellFiles
+  ];
+
+  # Flags as provided by the build automation of the project:
+  # https://github.com/roadrunner-server/roadrunner/blob/fe572d0eceae8fd05225fbd99ba50a9eb10c4393/.github/workflows/release.yml#L89
+  ldflags = [
+    "-s"
+    "-X github.com/roadrunner-server/roadrunner/v2023/internal/meta.version=${version}"
+    "-X github.com/roadrunner-server/roadrunner/v2023/internal/meta.buildTime=1970-01-01T00:00:00Z"
+  ];
+
+  postInstall = ''
+    installShellCompletion --cmd rr \
+      --bash <($out/bin/rr completion bash) \
+      --zsh <($out/bin/rr zsh) \
+      --fish <($out/bin/rr fish)
+  '';
+
+  postPatch = ''
+    substituteInPlace internal/rpc/client_test.go \
+      --replace "127.0.0.1:55555" "127.0.0.1:55554"
+
+    substituteInPlace internal/rpc/test/config_rpc_ok.yaml \
+      --replace "127.0.0.1:55555" "127.0.0.1:55554"
+
+    substituteInPlace internal/rpc/test/config_rpc_conn_err.yaml \
+      --replace "127.0.0.1:0" "127.0.0.1:55554"
+  '';
+
+  vendorHash = "sha256-pRZaJ1PBtshhna71V86IJ0VKs0u9wCFG27mghcE/8xY";
+
+  meta = {
+    changelog = "https://github.com/roadrunner-server/roadrunner/blob/v${version}/CHANGELOG.md";
+    description = "High-performance PHP application server, process manager written in Go and powered with plugins";
+    homepage = "https://roadrunner.dev";
+    license = lib.licenses.mit;
+    mainProgram = "rr";
+    maintainers = with lib.maintainers; [ shyim ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -40719,6 +40719,8 @@ with pkgs;
 
   rivalcfg = callPackage ../misc/rivalcfg { };
 
+  roadrunner = callPackage ../servers/roadrunner { };
+
   rmfakecloud = callPackage ../servers/rmfakecloud { };
 
   rmfuse = callPackage ../tools/filesystems/rmfuse { };


### PR DESCRIPTION
###### Description of changes

I want to use Roadrunner for my projects. So packaged also for Nixpkgs

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [X] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [X] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).


