### PR TITLE
zfs: offer Linux kernel DRM circumvention option to enable ZFS on 6.2+

### DIFF
--- a/pkgs/os-specific/linux/zfs/default.nix
+++ b/pkgs/os-specific/linux/zfs/default.nix
@@ -14,6 +14,7 @@
 # Kernel dependencies
 , kernel ? null
 , enablePython ? true
+, removeLinuxDRM ? false
 
 # for determining the latest compatible linuxPackages
 , linuxPackages_6_1 ? pkgs.linuxKernel.packages.linux_6_1
@@ -238,11 +239,11 @@ in {
     #   zfs-2.1.9<=x<=2.1.10 is broken with aarch64-linux-6.2
     #   for future releases, please delete this condition.
     kernelCompatible =
-      if stdenv'.isx86_64
+      if (stdenv'.isx86_64 || removeLinuxDRM)
       then kernel.kernelOlder "6.3"
       else kernel.kernelOlder "6.2";
     latestCompatibleLinuxPackages =
-      if stdenv'.isx86_64
+      if (stdenv'.isx86_64 || removeLinuxDRM)
       then linuxPackages_6_2
       else linuxPackages_6_1;
 


### PR DESCRIPTION
###### Description of changes

Introduced in https://github.com/torvalds/linux/commit/aaeca98456431a8d9382ecf48ac4843e252c07b3 with the usual disdain for ZFS.

We have been there in the past with
<https://www.phoronix.com/news/NixOS-Linux-5.0-ZFS-FPU-Drop> / https://github.com/NixOS/nixpkgs/pull/61076.

This fixes ZFS on aarch64 until the next breakage.

See https://github.com/openzfs/zfs/issues/14555 for original upstream issue.

I know this can have legal consequences for NixOS, I will submit myself to all scrutiny and bikeshedding :).

###### Things done

Tested through `pkgsCross.aarch64-multiplatform.linuxPackages_6_2.zfs`.

- Built on platform(s)
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
