### PR TITLE
iptsd: 1.1.1 -> 1.2.0

### DIFF
--- a/pkgs/applications/misc/iptsd/default.nix
+++ b/pkgs/applications/misc/iptsd/default.nix
@@ -6,6 +6,8 @@
 , ninja
 , pkg-config
 , cli11
+, eigen
+, fmt
 , hidrd
 , inih
 , microsoft_gsl
@@ -15,13 +17,13 @@
 
 stdenv.mkDerivation rec {
   pname = "iptsd";
-  version = "1.1.1";
+  version = "1.2.0";
 
   src = fetchFromGitHub {
     owner = "linux-surface";
     repo = pname;
     rev = "v${version}";
-    hash = "sha256-IwvoqmqJTM6xtEp7AzLgT4dZgRsmXYmu6Zivx3oSm+Q=";
+    hash = "sha256-8RE93pIg5fVAYOOq8zHlWy0uTxep7hrJlowPu48beTs=";
   };
 
   nativeBuildInputs = [
@@ -35,6 +37,8 @@ stdenv.mkDerivation rec {
 
   buildInputs = [
     cli11
+    eigen
+    fmt
     hidrd
     inih
     microsoft_gsl
@@ -47,7 +51,7 @@ stdenv.mkDerivation rec {
     substituteInPlace etc/meson.build \
       --replace "install_dir: unitdir" "install_dir: '$out/etc/systemd/system'" \
       --replace "install_dir: rulesdir" "install_dir: '$out/etc/udev/rules.d'"
-    substituteInPlace etc/udev/50-ipts.rules \
+    substituteInPlace etc/udev/50-iptsd.rules.in \
       --replace "/bin/systemd-escape" "${systemd}/bin/systemd-escape"
   '';
 


### PR DESCRIPTION
###### Description of changes
Diff: https://github.com/linux-surface/iptsd/compare/v1.1.1...v1.2.0

Changelog: https://github.com/linux-surface/iptsd/releases/tag/v1.2.0


<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
