### PR TITLE
ocamlPackages.{facile,nonstd}: disable for OCaml ≥ 5.0

### DIFF
--- a/pkgs/development/ocaml-modules/facile/default.nix
+++ b/pkgs/development/ocaml-modules/facile/default.nix
@@ -1,5 +1,8 @@
 { lib, fetchurl, buildDunePackage, ocaml }:
 
+lib.throwIf (lib.versionAtLeast ocaml.version "5.0")
+  "facile is not available for OCaml ≥ 5.0"
+
 buildDunePackage rec {
   pname = "facile";
   version = "1.1.4";
@@ -11,8 +14,8 @@ buildDunePackage rec {
 
   doCheck = true;
 
-  useDune2 = lib.versionAtLeast ocaml.version "4.12";
-  postPatch = lib.optionalString useDune2 "dune upgrade";
+  duneVersion = if lib.versionAtLeast ocaml.version "4.12" then "2" else "1";
+  postPatch = lib.optionalString (duneVersion != "1") "dune upgrade";
 
   meta = {
     homepage = "http://opti.recherche.enac.fr/facile/";

--- a/pkgs/development/ocaml-modules/nonstd/default.nix
+++ b/pkgs/development/ocaml-modules/nonstd/default.nix
@@ -1,5 +1,8 @@
 { lib, fetchzip, buildDunePackage, ocaml }:
 
+lib.throwIf (lib.versionAtLeast ocaml.version "5.0")
+  "nonstd is not available for OCaml ≥ 5.0"
+
 buildDunePackage rec {
   pname = "nonstd";
   version = "0.0.3";
@@ -11,8 +14,8 @@ buildDunePackage rec {
     sha256 = "0ccjwcriwm8fv29ij1cnbc9win054kb6pfga3ygzdbjpjb778j46";
   };
 
-  useDune2 = lib.versionAtLeast ocaml.version "4.12";
-  postPatch = lib.optionalString useDune2 "dune upgrade";
+  duneVersion = if lib.versionAtLeast ocaml.version "4.12" then "2" else "1";
+  postPatch = lib.optionalString (duneVersion != "1") "dune upgrade";
   doCheck = true;
 
   meta = with lib; {


### PR DESCRIPTION
###### Description of changes

These legacy packages won’t build with OCaml 5.

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
