### PR TITLE
maintainers/scripts/update.nix: Increase type annotation coverage

### DIFF
--- a/maintainers/scripts/update.nix
+++ b/maintainers/scripts/update.nix
@@ -209,7 +209,7 @@ let
   args = [ packagesJson ] ++ optionalArgs;
 
   python = pkgs.python3.withPackages (pp: [
-    pp.jsons
+    pp.pydantic
   ]);
 
 in pkgs.stdenv.mkDerivation {

--- a/maintainers/scripts/update.nix
+++ b/maintainers/scripts/update.nix
@@ -208,6 +208,10 @@ let
 
   args = [ packagesJson ] ++ optionalArgs;
 
+  python = pkgs.python3.withPackages (pp: [
+    pp.jsons
+  ]);
+
 in pkgs.stdenv.mkDerivation {
   name = "nixpkgs-update-script";
   buildCommand = ''
@@ -222,6 +226,6 @@ in pkgs.stdenv.mkDerivation {
   '';
   shellHook = ''
     unset shellHook # do not contaminate nested shells
-    exec ${pkgs.python3.interpreter} ${./update.py} ${builtins.concatStringsSep " " args}
+    exec ${python.interpreter} ${./update.py} ${builtins.concatStringsSep " " args}
   '';
 }

--- a/maintainers/scripts/update.py
+++ b/maintainers/scripts/update.py
@@ -83,7 +83,15 @@ async def run_update_script(nixpkgs_root: str, merge_lock: asyncio.Lock, temp_di
             cwd=worktree,
         )
 
-        await merge_changes(merge_lock, package, update_info, temp_dir)
+        try:
+            await merge_changes(merge_lock, package, update_info, temp_dir)
+        except CalledProcessError as e:
+            if keep_going:
+                eprint(f" - {package['name']}: ERROR")
+                eprint()
+                eprint(f"--- FAILED TO MERGE CHANGES FOR {package['name']} ----------------")
+            else:
+                raise UpdateFailedException(f"Merging changes for package {package['name']} failed with exit code {e.process.returncode}")
     except KeyboardInterrupt as e:
         eprint('Cancelling…')
         raise asyncio.exceptions.CancelledError()

--- a/maintainers/scripts/update.py
+++ b/maintainers/scripts/update.py
@@ -12,6 +12,7 @@ import tempfile
 
 class CalledProcessError(Exception):
     process: asyncio.subprocess.Process
+    stderr: Optional[bytes]
 
 class UpdateFailedException(Exception):
     pass
@@ -19,20 +20,23 @@ class UpdateFailedException(Exception):
 def eprint(*args, **kwargs):
     print(*args, file=sys.stderr, **kwargs)
 
-async def check_subprocess(*args, **kwargs):
+async def check_subprocess_output(*args, **kwargs) -> Optional[bytes]:
     """
-    Emulate check argument of subprocess.run function.
+    Emulate check and capture_output arguments of subprocess.run function.
     """
     process = await asyncio.create_subprocess_exec(*args, **kwargs)
-    returncode = await process.wait()
+    # We need to use communicate() instead of wait(), as the OS pipe buffers
+    # can fill up and cause a deadlock.
+    stdout, stderr = await process.communicate()
 
-    if returncode != 0:
+    if process.returncode != 0:
         error = CalledProcessError()
         error.process = process
+        error.stderr = stderr
 
         raise error
 
-    return process
+    return stdout
 
 async def run_update_script(nixpkgs_root: str, merge_lock: asyncio.Lock, temp_dir: Optional[Tuple[str, str]], package: Dict, keep_going: bool):
     worktree: Optional[str] = None
@@ -43,7 +47,7 @@ async def run_update_script(nixpkgs_root: str, merge_lock: asyncio.Lock, temp_di
         worktree, _branch = temp_dir
 
         # Ensure the worktree is clean before update.
-        await check_subprocess('git', 'reset', '--hard', '--quiet', 'HEAD', cwd=worktree)
+        await check_subprocess_output('git', 'reset', '--hard', '--quiet', 'HEAD', cwd=worktree)
 
         # Update scripts can use $(dirname $0) to get their location but we want to run
         # their clones in the git worktree, not in the main nixpkgs repo.
@@ -52,7 +56,7 @@ async def run_update_script(nixpkgs_root: str, merge_lock: asyncio.Lock, temp_di
     eprint(f" - {package['name']}: UPDATING ...")
 
     try:
-        update_process = await check_subprocess(
+        update_info = await check_subprocess_output(
             'env',
             f"UPDATE_NIX_NAME={package['name']}",
             f"UPDATE_NIX_PNAME={package['pname']}",
@@ -63,7 +67,6 @@ async def run_update_script(nixpkgs_root: str, merge_lock: asyncio.Lock, temp_di
             stderr=asyncio.subprocess.PIPE,
             cwd=worktree,
         )
-        update_info = await update_process.stdout.read()
 
         await merge_changes(merge_lock, package, update_info, temp_dir)
     except KeyboardInterrupt as e:
@@ -74,10 +77,9 @@ async def run_update_script(nixpkgs_root: str, merge_lock: asyncio.Lock, temp_di
         eprint()
         eprint(f"--- SHOWING ERROR LOG FOR {package['name']} ----------------------")
         eprint()
-        stderr = await e.process.stderr.read()
-        eprint(stderr.decode('utf-8'))
+        eprint(e.stderr.decode('utf-8'))
         with open(f"{package['pname']}.log", 'wb') as logfile:
-            logfile.write(stderr)
+            logfile.write(e.stderr)
         eprint()
         eprint(f"--- SHOWING ERROR LOG FOR {package['name']} ----------------------")
 
@@ -99,14 +101,14 @@ async def commit_changes(name: str, merge_lock: asyncio.Lock, worktree: str, bra
     for change in changes:
         # Git can only handle a single index operation at a time
         async with merge_lock:
-            await check_subprocess('git', 'add', *change['files'], cwd=worktree)
+            await check_subprocess_output('git', 'add', *change['files'], cwd=worktree)
             commit_message = '{attrPath}: {oldVersion} -> {newVersion}'.format(**change)
             if 'commitMessage' in change:
                 commit_message = change['commitMessage']
             elif 'commitBody' in change:
                 commit_message = commit_message + '\n\n' + change['commitBody']
-            await check_subprocess('git', 'commit', '--quiet', '-m', commit_message, cwd=worktree)
-            await check_subprocess('git', 'cherry-pick', branch)
+            await check_subprocess_output('git', 'commit', '--quiet', '-m', commit_message, cwd=worktree)
+            await check_subprocess_output('git', 'cherry-pick', branch)
 
 async def check_changes(package: Dict, worktree: str, update_info: str):
     if 'commit' in package['supportedFeatures']:
@@ -127,12 +129,12 @@ async def check_changes(package: Dict, worktree: str, update_info: str):
 
         if 'newVersion' not in changes[0]:
             attr_path = changes[0]['attrPath']
-            obtain_new_version_process = await check_subprocess('nix-instantiate', '--expr', f'with import ./. {{}}; lib.getVersion {attr_path}', '--eval', '--strict', '--json', stdout=asyncio.subprocess.PIPE, stderr=asyncio.subprocess.PIPE, cwd=worktree)
-            changes[0]['newVersion'] = json.loads((await obtain_new_version_process.stdout.read()).decode('utf-8'))
+            obtain_new_version_output = await check_subprocess_output('nix-instantiate', '--expr', f'with import ./. {{}}; lib.getVersion {attr_path}', '--eval', '--strict', '--json', stdout=asyncio.subprocess.PIPE, stderr=asyncio.subprocess.PIPE, cwd=worktree)
+            changes[0]['newVersion'] = json.loads(obtain_new_version_output.decode('utf-8'))
 
         if 'files' not in changes[0]:
-            changed_files_process = await check_subprocess('git', 'diff', '--name-only', 'HEAD', stdout=asyncio.subprocess.PIPE, cwd=worktree)
-            changed_files = (await changed_files_process.stdout.read()).splitlines()
+            changed_files_output = await check_subprocess_output('git', 'diff', '--name-only', 'HEAD', stdout=asyncio.subprocess.PIPE, cwd=worktree)
+            changed_files = changed_files_output.splitlines()
             changes[0]['files'] = changed_files
 
             if len(changed_files) == 0:
@@ -174,8 +176,8 @@ async def start_updates(max_workers: int, keep_going: bool, commit: bool, packag
         # Do not create more workers than there are packages.
         num_workers = min(max_workers, len(packages))
 
-        nixpkgs_root_process = await check_subprocess('git', 'rev-parse', '--show-toplevel', stdout=asyncio.subprocess.PIPE)
-        nixpkgs_root = (await nixpkgs_root_process.stdout.read()).decode('utf-8').strip()
+        nixpkgs_root_output = await check_subprocess_output('git', 'rev-parse', '--show-toplevel', stdout=asyncio.subprocess.PIPE)
+        nixpkgs_root = nixpkgs_root_output.decode('utf-8').strip()
 
         # Set up temporary directories when using auto-commit.
         for i in range(num_workers):

--- a/maintainers/scripts/update.py
+++ b/maintainers/scripts/update.py
@@ -1,9 +1,11 @@
-from __future__ import annotations
-from typing import Dict, Generator, List, Optional, Tuple
+from dataclasses import dataclass
+from enum import Enum
+from typing import Any, cast, Generator, Optional
 import argparse
 import asyncio
 import contextlib
 import json
+import jsons
 import os
 import re
 import subprocess
@@ -17,8 +19,34 @@ class CalledProcessError(Exception):
 class UpdateFailedException(Exception):
     pass
 
-def eprint(*args, **kwargs):
-    print(*args, file=sys.stderr, **kwargs)
+T = TypeVar('T')
+
+def make_object_from_json_value(value: Any, t: type[T]) -> T:
+    return cast(T, jsons.load(value, t), strict=True)
+
+def eprint(*args: Any) -> None:
+    print(*args, file=sys.stderr)
+
+class Feature(Enum):
+    COMMIT = 'commit'
+
+@dataclass
+class PackageInfo:
+    name: str
+    pname: str
+    updateScript: list[str]
+    supportedFeatures: set[Feature]
+    oldVersion: str
+    attrPath: str
+
+@dataclass
+class ChangeInfo:
+    attrPath: str
+    oldVersion: str
+    newVersion: str
+    commitMessage: Optional[str]
+    commitBody: Optional[str]
+    files: list[str]
 
 async def check_subprocess_output(
     cmd: list[str],
@@ -48,10 +76,10 @@ async def check_subprocess_output(
 
     return stdout
 
-async def run_update_script(nixpkgs_root: str, merge_lock: asyncio.Lock, temp_dir: Optional[Tuple[str, str]], package: Dict, keep_going: bool):
+async def run_update_script(nixpkgs_root: str, merge_lock: asyncio.Lock, temp_dir: Optional[tuple[str, str]], package: PackageInfo, keep_going: bool) -> None:
     worktree: Optional[str] = None
 
-    update_script_command = package['updateScript']
+    update_script_command = package.updateScript
 
     if temp_dir is not None:
         worktree, _branch = temp_dir
@@ -64,53 +92,55 @@ async def run_update_script(nixpkgs_root: str, merge_lock: asyncio.Lock, temp_di
 
         # Update scripts can use $(dirname $0) to get their location but we want to run
         # their clones in the git worktree, not in the main nixpkgs repo.
-        update_script_command = map(lambda arg: re.sub(r'^{0}'.format(re.escape(nixpkgs_root)), worktree, arg), update_script_command)
+        update_script_command = [re.sub(r'^{0}'.format(re.escape(nixpkgs_root)), worktree, arg) for arg in update_script_command]
 
-    eprint(f" - {package['name']}: UPDATING ...")
+    eprint(f" - {package.name}: UPDATING ...")
 
     try:
         update_info = await check_subprocess_output(
             [
                 'env',
-                f"UPDATE_NIX_NAME={package['name']}",
-                f"UPDATE_NIX_PNAME={package['pname']}",
-                f"UPDATE_NIX_OLD_VERSION={package['oldVersion']}",
-                f"UPDATE_NIX_ATTR_PATH={package['attrPath']}",
+                f"UPDATE_NIX_NAME={package.name}",
+                f"UPDATE_NIX_PNAME={package.pname}",
+                f"UPDATE_NIX_OLD_VERSION={package.oldVersion}",
+                f"UPDATE_NIX_ATTR_PATH={package.attrPath}",
                 *update_script_command,
             ],
             capture_stdout=True,
             capture_stderr=True,
             cwd=worktree,
         )
+        update_info = cast(bytes, update_info)
 
         try:
             await merge_changes(merge_lock, package, update_info, temp_dir)
         except CalledProcessError as e:
             if keep_going:
-                eprint(f" - {package['name']}: ERROR")
+                eprint(f" - {package.name}: ERROR")
                 eprint()
-                eprint(f"--- FAILED TO MERGE CHANGES FOR {package['name']} ----------------")
+                eprint(f"--- FAILED TO MERGE CHANGES FOR {package.name} ----------------")
             else:
-                raise UpdateFailedException(f"Merging changes for package {package['name']} failed with exit code {e.process.returncode}")
+                raise UpdateFailedException(f"Merging changes for package {package.name} failed with exit code {e.process.returncode}")
     except KeyboardInterrupt as e:
         eprint('Cancelling…')
         raise asyncio.exceptions.CancelledError()
     except CalledProcessError as e:
-        eprint(f" - {package['name']}: ERROR")
+        eprint(f" - {package.name}: ERROR")
         eprint()
-        eprint(f"--- SHOWING ERROR LOG FOR {package['name']} ----------------------")
+        eprint(f"--- SHOWING ERROR LOG FOR {package.name} ----------------------")
         eprint()
-        eprint(e.stderr.decode('utf-8'))
-        with open(f"{package['pname']}.log", 'wb') as logfile:
-            logfile.write(e.stderr)
+        stderr = cast(bytes, e.stderr)
+        eprint(stderr.decode('utf-8'))
+        with open(f"{package.pname}.log", 'wb') as logfile:
+            logfile.write(stderr)
         eprint()
-        eprint(f"--- SHOWING ERROR LOG FOR {package['name']} ----------------------")
+        eprint(f"--- SHOWING ERROR LOG FOR {package.name} ----------------------")
 
         if not keep_going:
-            raise UpdateFailedException(f"The update script for {package['name']} failed with exit code {e.process.returncode}")
+            raise UpdateFailedException(f"The update script for {package.name} failed with exit code {e.process.returncode}")
 
 @contextlib.contextmanager
-def make_worktree() -> Generator[Tuple[str, str], None, None]:
+def make_worktree() -> Generator[tuple[str, str], None, None]:
     with tempfile.TemporaryDirectory() as wt:
         branch_name = f'update-{os.path.basename(wt)}'
         target_directory = f'{wt}/nixpkgs'
@@ -120,19 +150,19 @@ def make_worktree() -> Generator[Tuple[str, str], None, None]:
         subprocess.run(['git', 'worktree', 'remove', '--force', target_directory])
         subprocess.run(['git', 'branch', '-D', branch_name])
 
-async def commit_changes(name: str, merge_lock: asyncio.Lock, worktree: str, branch: str, changes: List[Dict]) -> None:
+async def commit_changes(name: str, merge_lock: asyncio.Lock, worktree: str, branch: str, changes: list[ChangeInfo]) -> None:
     for change in changes:
         # Git can only handle a single index operation at a time
         async with merge_lock:
             await check_subprocess_output(
-                ['git', 'add', *change['files']],
+                ['git', 'add', *change.files],
                 cwd=worktree,
             )
-            commit_message = '{attrPath}: {oldVersion} -> {newVersion}'.format(**change)
-            if 'commitMessage' in change:
-                commit_message = change['commitMessage']
-            elif 'commitBody' in change:
-                commit_message = commit_message + '\n\n' + change['commitBody']
+            commit_message = f'{change.attrPath}: {change.oldVersion} -> {change.newVersion}'
+            if change.commitMessage is not None:
+                commit_message = change.commitMessage
+            elif change.commitBody is not None:
+                commit_message = commit_message + '\n\n' + change.commitBody
             await check_subprocess_output(
                 ['git', 'commit', '--quiet', '-m', commit_message],
                 cwd=worktree,
@@ -141,8 +171,8 @@ async def commit_changes(name: str, merge_lock: asyncio.Lock, worktree: str, bra
                 ['git', 'cherry-pick', branch],
             )
 
-async def check_changes(package: Dict, worktree: str, update_info: str):
-    if 'commit' in package['supportedFeatures']:
+async def check_changes(package: PackageInfo, worktree: str, update_info: bytes) -> list[ChangeInfo]:
+    if Feature.COMMIT in package.supportedFeatures:
         changes = json.loads(update_info)
     else:
         changes = [{}]
@@ -152,11 +182,11 @@ async def check_changes(package: Dict, worktree: str, update_info: str):
         # Dynamic data from updater take precedence over static data from passthru.updateScript.
         if 'attrPath' not in changes[0]:
             # update.nix is always passing attrPath
-            changes[0]['attrPath'] = package['attrPath']
+            changes[0]['attrPath'] = package.attrPath
 
         if 'oldVersion' not in changes[0]:
             # update.nix is always passing oldVersion
-            changes[0]['oldVersion'] = package['oldVersion']
+            changes[0]['oldVersion'] = package.oldVersion
 
         if 'newVersion' not in changes[0]:
             attr_path = changes[0]['attrPath']
@@ -166,6 +196,7 @@ async def check_changes(package: Dict, worktree: str, update_info: str):
                 capture_stderr=True,
                 cwd=worktree,
             )
+            obtain_new_version_output = cast(bytes, obtain_new_version_output)
             changes[0]['newVersion'] = json.loads(obtain_new_version_output.decode('utf-8'))
 
         if 'files' not in changes[0]:
@@ -174,44 +205,45 @@ async def check_changes(package: Dict, worktree: str, update_info: str):
                 capture_stdout=True,
                 cwd=worktree,
             )
-            changed_files = changed_files_output.splitlines()
+            changed_files_output = cast(bytes, changed_files_output)
+            changed_files = changed_files_output.decode('utf-8').splitlines()
             changes[0]['files'] = changed_files
 
             if len(changed_files) == 0:
                 return []
 
-    return changes
+    return make_object_from_json_value(changes, list[ChangeInfo])
 
-async def merge_changes(merge_lock: asyncio.Lock, package: Dict, update_info: str, temp_dir: Optional[Tuple[str, str]]) -> None:
+async def merge_changes(merge_lock: asyncio.Lock, package: PackageInfo, update_info: bytes, temp_dir: Optional[tuple[str, str]]) -> None:
     if temp_dir is not None:
         worktree, branch = temp_dir
         changes = await check_changes(package, worktree, update_info)
 
         if len(changes) > 0:
-            await commit_changes(package['name'], merge_lock, worktree, branch, changes)
+            await commit_changes(package.name, merge_lock, worktree, branch, changes)
         else:
-            eprint(f" - {package['name']}: DONE, no changes.")
+            eprint(f" - {package.name}: DONE, no changes.")
     else:
-        eprint(f" - {package['name']}: DONE.")
+        eprint(f" - {package.name}: DONE.")
 
-async def updater(nixpkgs_root: str, temp_dir: Optional[Tuple[str, str]], merge_lock: asyncio.Lock, packages_to_update: asyncio.Queue[Optional[Dict]], keep_going: bool, commit: bool):
+async def updater(nixpkgs_root: str, temp_dir: Optional[tuple[str, str]], merge_lock: asyncio.Lock, packages_to_update: asyncio.Queue[Optional[PackageInfo]], keep_going: bool, commit: bool) -> None:
     while True:
         package = await packages_to_update.get()
         if package is None:
             # A sentinel received, we are done.
             return
 
-        if not ('commit' in package['supportedFeatures'] or 'attrPath' in package):
+        if Feature.COMMIT not in package.supportedFeatures:
             temp_dir = None
 
         await run_update_script(nixpkgs_root, merge_lock, temp_dir, package, keep_going)
 
-async def start_updates(max_workers: int, keep_going: bool, commit: bool, packages: List[Dict]):
+async def start_updates(max_workers: int, keep_going: bool, commit: bool, packages: list[PackageInfo]) -> None:
     merge_lock = asyncio.Lock()
-    packages_to_update: asyncio.Queue[Optional[Dict]] = asyncio.Queue()
+    packages_to_update: asyncio.Queue[Optional[PackageInfo]] = asyncio.Queue()
 
     with contextlib.ExitStack() as stack:
-        temp_dirs: List[Optional[Tuple[str, str]]] = []
+        temp_dirs: list[Optional[tuple[str, str]]] = []
 
         # Do not create more workers than there are packages.
         num_workers = min(max_workers, len(packages))
@@ -220,6 +252,7 @@ async def start_updates(max_workers: int, keep_going: bool, commit: bool, packag
             ['git', 'rev-parse', '--show-toplevel'],
             capture_stdout=True,
         )
+        nixpkgs_root_output = cast(bytes, nixpkgs_root_output)
         nixpkgs_root = nixpkgs_root_output.decode('utf-8').strip()
 
         # Set up temporary directories when using auto-commit.
@@ -254,12 +287,12 @@ async def start_updates(max_workers: int, keep_going: bool, commit: bool, packag
 
 def main(max_workers: int, keep_going: bool, commit: bool, packages_path: str) -> None:
     with open(packages_path) as f:
-        packages = json.load(f)
+        packages = make_object_from_json_value(json.load(f), list[PackageInfo])
 
     eprint()
     eprint('Going to be running update for following packages:')
     for package in packages:
-        eprint(f" - {package['name']}")
+        eprint(f" - {package.name}")
     eprint()
 
     confirm = input('Press Enter key to continue...')


### PR DESCRIPTION
###### Description of changes

Testing with

```
nix-shell -I "nixpkgs=channel:nixos-unstable" -p python3 -p python3.pkgs.mypy python3.pkgs.jsons --run 'python -m mypy --strict maintainers/scripts/update.py'
```


<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
