### PR TITLE
anki: add missing darwin components

### DIFF
--- a/pkgs/games/anki/default.nix
+++ b/pkgs/games/anki/default.nix
@@ -17,6 +17,8 @@
 , rustPlatform
 , writeShellScriptBin
 , yarn
+, swift
+, AVKit
 , CoreAudio
 }:
 
@@ -138,7 +140,7 @@ python3.pkgs.buildPythonApplication {
     ninja
     qt6.wrapQtAppsHook
     rsync
-  ];
+  ] ++ lib.optional stdenv.isDarwin swift;
   nativeCheckInputs = with python3.pkgs; [ pytest mock astroid  ];
 
   buildInputs = [
@@ -186,7 +188,10 @@ python3.pkgs.buildPythonApplication {
     waitress
     werkzeug
     zipp
-  ] ++ lib.optionals stdenv.isDarwin [ CoreAudio ];
+  ] ++ lib.optionals stdenv.isDarwin [
+    AVKit
+    CoreAudio
+  ];
 
   # Activate optimizations
   RELEASE = true;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -35689,7 +35689,7 @@ with pkgs;
   angband = callPackage ../games/angband { };
 
   anki = callPackage ../games/anki {
-    inherit (darwin.apple_sdk.frameworks) CoreAudio;
+    inherit (darwin.apple_sdk.frameworks) AVKit CoreAudio;
   };
   anki-bin = callPackage ../games/anki/bin.nix { };
 


### PR DESCRIPTION
###### Description of changes

https://hydra.nixos.org/build/216794395/nixlog/1

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- ~[ ] Tested basic functionality of all binary files (usually in `./result/bin/`)~
  ```
  Preparing to run...
  [0420/142020.722444:ERROR:icu_util.cc(247)] Invalid file descriptor to ICU data received.
  [0420/142020.722977:FATAL:content_main_delegate.cc(40)] Check failed: false.
  ```
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
