### PR TITLE
pythonPackages.pytest-codeblocks: init at 0.16.1

### DIFF
--- a/pkgs/development/python-modules/pytest-codeblocks/default.nix
+++ b/pkgs/development/python-modules/pytest-codeblocks/default.nix
@@ -1,0 +1,53 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, pytestCheckHook
+, pytest
+, pytest-cov
+, setuptools
+}:
+
+buildPythonPackage rec {
+  pname = "pytest-codeblocks";
+  version = "0.16.1";
+  format = "pyproject";
+
+  src = fetchFromGitHub {
+    owner = "nschloe";
+    repo = "pytest-codeblocks";
+    rev = "v${version}";
+    hash = "sha256-mFZ2F31d2irjrXgYS9WufBAXFzdmn9YOXM9zDP5tndY=";
+  };
+
+  propagatedBuildInputs = [
+    pytest
+    setuptools
+  ];
+
+  pythonImportsCheck = [ "pytest_codeblocks" ];
+
+  checkInputs = [
+    pytest-cov
+  ];
+
+  pytestFlagsArray = [
+    "-p"
+    "pytester"
+  ];
+
+  nativeCheckInputs = [
+    pytestCheckHook
+  ];
+
+  disabledTestPaths = [
+    "tests/test_shell.py" # Requires shell usage
+  ];
+
+  meta = {
+    homepage = "https://github.com/nschloe/pytest-codeblocks";
+    changelog = "https://github.com/nschloe/pytest-codeblocks/releases/tag/v${version}";
+    description = "Test code blocks in your READMEs";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ swflint ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -7512,6 +7512,8 @@ self: super: with self; {
 
   pytest-mockito = callPackage ../development/python-modules/pytest-mockito { };
 
+  pytest-codeblocks = callPackage ../development/python-modules/pytest-codeblocks { };
+
   python-codon-tables = callPackage ../development/python-modules/python-codon-tables { };
 
   python-creole = callPackage ../development/python-modules/python-creole { };


### PR DESCRIPTION
###### Description of changes

The pytest-codeblocks package allows pytest to run code blocks within a README.md or similar file.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
