### PR TITLE
plasma5Packages: relax platforms

### DIFF
--- a/pkgs/development/libraries/kde-frameworks/default.nix
+++ b/pkgs/development/libraries/kde-frameworks/default.nix
@@ -82,7 +82,7 @@ let
                 homepage = meta.homepage or "https://kde.org";
                 license = meta.license or license;
                 maintainers = (meta.maintainers or []) ++ maintainers;
-                platforms = meta.platforms or lib.platforms.linux;
+                platforms = meta.platforms or lib.platforms.all;
               };
 
           in mkDerivation (args // {

--- a/pkgs/development/libraries/kde-frameworks/kauth/default.nix
+++ b/pkgs/development/libraries/kde-frameworks/kauth/default.nix
@@ -1,7 +1,7 @@
 {
-  lib, mkDerivation, propagate,
+  lib, stdenv, mkDerivation, propagate,
   extra-cmake-modules, kcoreaddons, qttools,
-  enablePolkit ? true, polkit-qt
+  enablePolkit ? stdenv.isLinux, polkit-qt
 }:
 
 mkDerivation {

--- a/pkgs/development/libraries/kde-frameworks/kcoreaddons.nix
+++ b/pkgs/development/libraries/kde-frameworks/kcoreaddons.nix
@@ -1,5 +1,5 @@
 {
-  mkDerivation, lib,
+  mkDerivation, lib, stdenv,
   extra-cmake-modules,
   qtbase, qttools, shared-mime-info
 }:
@@ -18,4 +18,7 @@ mkDerivation ({
   postInstall = ''
     moveToOutput "mkspecs" "$dev"
   '';
+} // lib.optionalAttrs stdenv.isDarwin {
+  # https://invent.kde.org/frameworks/kcoreaddons/-/merge_requests/327
+  env.NIX_CFLAGS_COMPILE = "-DSOCK_CLOEXEC=0";
 })

--- a/pkgs/development/libraries/kde-frameworks/kdoctools/default.nix
+++ b/pkgs/development/libraries/kde-frameworks/kdoctools/default.nix
@@ -1,5 +1,5 @@
 {
-  mkDerivation,
+  mkDerivation, lib, stdenv, fetchpatch,
   extra-cmake-modules, docbook_xml_dtd_45, docbook_xsl_ns,
   karchive, ki18n, qtbase,
   perl, perlPackages
@@ -20,7 +20,15 @@ mkDerivation {
   ];
   buildInputs = [ karchive ki18n ];
   outputs = [ "out" "dev" ];
-  patches = [ ./kdoctools-no-find-docbook-xml.patch ];
+  patches = [ ./kdoctools-no-find-docbook-xml.patch ]
+    # kf.doctools.core: Error: Could not find kdoctools catalogs
+    ++ lib.optionals stdenv.isDarwin [
+    (fetchpatch {
+      name = "kdoctools-relocate-datapath.patch";
+      url = "https://github.com/msys2/MINGW-packages/raw/0900785a1f4e4146ab9561fb92a1c70fa70fcfc4/mingw-w64-kdoctools-qt5/0001-kdoctools-relocate-datapath.patch";
+      hash = "sha256-MlokdrabXavWHGXYmdz9zZDJQIwAdNxebJBSAH2Z3vI=";
+    })
+  ];
   cmakeFlags = [
     "-DDocBookXML4_DTD_DIR=${docbook_xml_dtd_45}/xml/dtd/docbook"
     "-DDocBookXSL_DIR=${docbook_xsl_ns}/xml/xsl/docbook"

--- a/pkgs/development/libraries/kde-frameworks/ktexteditor.nix
+++ b/pkgs/development/libraries/kde-frameworks/ktexteditor.nix
@@ -1,12 +1,12 @@
 {
-  mkDerivation,
+  mkDerivation, lib, stdenv,
   extra-cmake-modules, perl,
   karchive, kconfig, kguiaddons, ki18n, kiconthemes, kio, kparts, libgit2,
   qtscript, qtxmlpatterns, sonnet, syntax-highlighting, qtquickcontrols,
   editorconfig-core-c
 }:
 
-mkDerivation {
+mkDerivation ({
   pname = "ktexteditor";
   nativeBuildInputs = [ extra-cmake-modules perl ];
   buildInputs = [
@@ -15,4 +15,9 @@ mkDerivation {
     editorconfig-core-c
   ];
   propagatedBuildInputs = [ kparts ];
-}
+} // lib.optionalAttrs stdenv.isDarwin {
+  postPatch = ''
+    substituteInPlace src/part/CMakeLists.txt \
+      --replace "kpart.desktop" "${kparts}/share/kservicetypes5/kpart.desktop"
+  '';
+})


### PR DESCRIPTION
###### Description of changes

The KDE Frameworks officially support macOS (and also Windows, FreeBSD). Why should we limit ourselves to Linux?

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
