### PR TITLE
feed2imap-go: Set correct LDFLAGS

### DIFF
--- a/pkgs/applications/networking/feedreaders/feed2imap-go/default.nix
+++ b/pkgs/applications/networking/feedreaders/feed2imap-go/default.nix
@@ -11,6 +11,12 @@ buildGoModule rec {
     sha256 = "sha256-Qtpg8DvIFkba+Do8IwemBF0rt85wS4Tq7yOLsdpQFCs=";
   };
 
+  ldflags = [
+    "-s" "-w"
+    "-X github.com/Necoro/feed2imap-go/pkg/version.version=${version}"
+    "-X github.com/Necoro/feed2imap-go/pkg/version.commit=nixpkgs"
+  ];
+
   vendorHash = "sha256-WFbfSzU1N2RAOMfCM7wqiAQ6R1HRaT0EfX4KYhstHJU=";
 
   # The print-cache tool is not an end-user tool (https://github.com/Necoro/feed2imap-go/issues/94)


### PR DESCRIPTION
As is common in Go, version information in the binary is set at compile time via LDFLAGS.

This is similar to the [Arch PKGBUILD](https://aur.archlinux.org/cgit/aur.git/tree/PKGBUILD?h=feed2imap-go) 

This is a minor change that only shows in debugging and version output (show version number and not `dev`).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
