### PR TITLE
git-cache: init at 2018-06-18

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -9729,6 +9729,12 @@
     githubId = 1187050;
     name = "Maximilian Huber";
   };
+  maxhearnden = {
+    email = "max@hearnden.org.uk";
+    github = "MaxHearnden";
+    githubId = 8320393;
+    name = "Max Hearnden";
+  };
   maxhero = {
     email = "contact@maxhero.dev";
     github = "themaxhero";

--- a/pkgs/applications/version-management/git-cache/default.nix
+++ b/pkgs/applications/version-management/git-cache/default.nix
@@ -1,0 +1,27 @@
+{fetchFromGitHub, lib, stdenv}:
+
+stdenv.mkDerivation rec {
+  pname = "git-cache";
+  version = "2018-06-18";
+
+  src = fetchFromGitHub {
+    owner = "Seb35";
+    repo = "git-cache";
+    rev = "354f661e40b358c5916c06957bd6b2c65426f452";
+    sha256 = "sha256-V7rQOy+s9Lzdc+RTA2QGPfyavw4De/qQ+tWrzYtO2qA=";
+  };
+
+  dontBuild = true;
+
+  installPhase = ''
+    install -Dm555 git-cache $out/bin/git-cache
+  '';
+
+  meta = with lib; {
+    homepage = "https://github.com/Seb35/git-cache";
+    license = lib.licenses.wtfpl;
+    description = "A program to add and manage a system-wide or user-wide cache for remote git repositories";
+    platforms = with platforms; linux ++ darwin;
+    maintainers = [];
+  };
+}

--- a/pkgs/applications/version-management/git-cache/default.nix
+++ b/pkgs/applications/version-management/git-cache/default.nix
@@ -1,6 +1,6 @@
 {fetchFromGitHub, lib, stdenv}:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation {
   pname = "git-cache";
   version = "2018-06-18";
 
@@ -8,7 +8,7 @@ stdenv.mkDerivation rec {
     owner = "Seb35";
     repo = "git-cache";
     rev = "354f661e40b358c5916c06957bd6b2c65426f452";
-    sha256 = "sha256-V7rQOy+s9Lzdc+RTA2QGPfyavw4De/qQ+tWrzYtO2qA=";
+    hash = "sha256-V7rQOy+s9Lzdc+RTA2QGPfyavw4De/qQ+tWrzYtO2qA=";
   };
 
   dontBuild = true;
@@ -19,9 +19,9 @@ stdenv.mkDerivation rec {
 
   meta = with lib; {
     homepage = "https://github.com/Seb35/git-cache";
-    license = lib.licenses.wtfpl;
+    license = licenses.wtfpl;
     description = "A program to add and manage a system-wide or user-wide cache for remote git repositories";
-    platforms = with platforms; linux ++ darwin;
-    maintainers = [];
+    platforms = platforms.unix;
+    maintainers = with maintainers; [ maxhearnden ];
   };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1871,6 +1871,8 @@ with pkgs;
 
   git-bug-migration = callPackage ../applications/version-management/git-bug-migration { };
 
+  git-cache = callPackage ../applications/version-management/git-cache { };
+
   git-chglog = callPackage ../applications/version-management/git-chglog { };
 
   git-cinnabar = callPackage ../applications/version-management/git-cinnabar {


### PR DESCRIPTION
###### Description of changes

Adds git-cache a program to add and manage a system-wide or user-wide cache for remote git repositories

https://github.com/Seb35/git-cache

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
