### PR TITLE
speedtest-go: 1.5.2 -> 1.6.0

### DIFF
--- a/pkgs/tools/networking/speedtest-go/default.nix
+++ b/pkgs/tools/networking/speedtest-go/default.nix
@@ -5,18 +5,18 @@
 
 buildGoModule rec {
   pname = "speedtest-go";
-  version = "1.5.2";
+  version = "1.6.0";
 
   src = fetchFromGitHub {
     owner = "showwin";
     repo = pname;
     rev = "refs/tags/v${version}";
-    hash = "sha256-9jLreb3tEw5bCVka6/BzGbsd5V3+9OHNzENe/IxL1YM=";
+    hash = "sha256-LpsesUC0Cj9pkc/6c0wDEl6X9Y6GqwACwVv7J31TTg0=";
   };
 
-  vendorHash = "sha256-A54G3fvs1bXSwPHVUNFC9VJqydqYR5t4I2fIBvrVoRE=";
+  vendorHash = "sha256-wQqAX7YuxxTiMWmV9LRoXunGMMzs12UyHbf4VvbQF1E=";
 
-  subPackages = [ "speedtest.go" ];
+  excludedPackages = [ "example" ];
 
   # test suite requires network
   doCheck = false;
@@ -27,6 +27,5 @@ buildGoModule rec {
     changelog = "https://github.com/showwin/speedtest-go/releases/tag/v${version}";
     license = licenses.mit;
     maintainers = with maintainers; [ aleksana ];
-    mainProgram = "speedtest";
   };
 }


### PR DESCRIPTION
###### Description of changes

The main binary name is `speedtest-go` instead of  `speedtest` now. We need to build speedtest.go and task.go together so old ways don't work. (Anyway, the upstream README also implies the binary should be speedtest-go although they use speedtest)

```
$ speedtest --help
usage: speedtest-go [<flags>]
```

The main new feature is an elegant refreshed ui.

```
    😊 speedtest-go v1.6.0 @showwin 😊

✓ ISP: xxx.xxx.xxx.xxx (YJSP Network) [114.514, 191.981] 
✓ Found 24 Public Servers

✓ Test Server: [37267] 19.19km Nippori (Japan) by SKMT
✓ Latency: 67.160275ms Jitter: 568.812µs Min: 66.256268ms Max: 68.26272ms
⠙ Download: 327.27Mbps
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
