### PR TITLE
Add opentelemetry packages to python3Packages

### DIFF
--- a/pkgs/development/python-modules/opentelemetry-api/default.nix
+++ b/pkgs/development/python-modules/opentelemetry-api/default.nix
@@ -1,0 +1,58 @@
+{ lib
+, buildPythonPackage
+, pythonOlder
+, fetchFromGitHub
+, deprecated
+, hatchling
+, importlib-metadata
+, opentelemetry-test-utils
+, setuptools
+, pytestCheckHook
+}:
+
+let
+  self = buildPythonPackage {
+    pname = "opentelemetry-api";
+    version = "1.18.0";
+    disabled = pythonOlder "3.7";
+
+    src = fetchFromGitHub {
+      owner = "open-telemetry";
+      repo = "opentelemetry-python";
+      rev = "refs/tags/v${self.version}";
+      hash = "sha256-h6XDzM29wYiC51S7OpBXvWFCfZ7DmIyGMG2pFjJV7pI=";
+      sparseCheckout = [ "/${self.pname}" ];
+    } + "/${self.pname}";
+
+    format = "pyproject";
+
+    nativeBuildInputs = [
+      hatchling
+    ];
+
+    propagatedBuildInputs = [
+      deprecated
+      importlib-metadata
+      setuptools
+    ];
+
+    nativeCheckInputs = [
+      opentelemetry-test-utils
+      pytestCheckHook
+    ];
+
+    pythonImportsCheck = [ "opentelemetry" ];
+
+    doCheck = false;
+
+    # Enable tests via passthru to avoid cyclic dependency with opentelemetry-test-utils.
+    passthru.tests.${self.pname} = self.overridePythonAttrs { doCheck = true; };
+
+    meta = with lib; {
+      homepage = "https://opentelemetry.io";
+      description = "OpenTelemetry Python API";
+      license = licenses.asl20;
+      maintainers = teams.deshaw.members;
+    };
+  };
+in self

--- a/pkgs/development/python-modules/opentelemetry-exporter-otlp-proto-common/default.nix
+++ b/pkgs/development/python-modules/opentelemetry-exporter-otlp-proto-common/default.nix
@@ -1,0 +1,49 @@
+{ lib
+, buildPythonPackage
+, pythonOlder
+, fetchFromGitHub
+, hatchling
+, opentelemetry-proto
+, opentelemetry-sdk
+, opentelemetry-test-utils
+, pytestCheckHook
+}:
+
+buildPythonPackage rec {
+  pname = "opentelemetry-exporter-otlp-proto-common";
+  version = "1.18.0";
+  disabled = pythonOlder "3.7";
+
+  src = fetchFromGitHub {
+    owner = "open-telemetry";
+    repo = "opentelemetry-python";
+    rev = "refs/tags/v${version}";
+    hash = "sha256-HNlkbDyYnr0/lDeY1xt0pRxqk+977ljgPdfJzAxL3AQ=";
+    sparseCheckout = [ "/exporter/${pname}" ];
+  } + "/exporter/${pname}";
+
+  format = "pyproject";
+
+  nativeBuildInputs = [
+    hatchling
+  ];
+
+  propagatedBuildInputs = [
+    opentelemetry-sdk
+    opentelemetry-proto
+  ];
+
+  nativeCheckInputs = [
+    opentelemetry-test-utils
+    pytestCheckHook
+  ];
+
+  pythonImportsCheck = [ "opentelemetry.exporter.otlp.proto.common" ];
+
+  meta = with lib; {
+    homepage = "https://github.com/open-telemetry/opentelemetry-python/tree/main/exporter/opentelemetry-exporter-otlp-proto-common";
+    description = "OpenTelemetry Protobuf encoding";
+    license = licenses.asl20;
+    maintainers = teams.deshaw.members;
+  };
+}

--- a/pkgs/development/python-modules/opentelemetry-exporter-otlp-proto-grpc/default.nix
+++ b/pkgs/development/python-modules/opentelemetry-exporter-otlp-proto-grpc/default.nix
@@ -1,0 +1,58 @@
+{ lib
+, buildPythonPackage
+, pythonOlder
+, fetchFromGitHub
+, backoff
+, googleapis-common-protos
+, grpcio
+, hatchling
+, opentelemetry-test-utils
+, opentelemetry-exporter-otlp-proto-common
+, pytest-grpc
+, pytestCheckHook
+}:
+
+buildPythonPackage rec {
+  pname = "opentelemetry-exporter-otlp-proto-grpc";
+  version = "1.18.0";
+  disabled = pythonOlder "3.7";
+
+  src = fetchFromGitHub {
+    owner = "open-telemetry";
+    repo = "opentelemetry-python";
+    rev = "refs/tags/v${version}";
+    hash = "sha256-feAmPL/G3ABIY5tBODlMJIBzxqg6Bl7imJB2EYtEp2o=";
+    sparseCheckout = [ "/exporter/${pname}" ];
+  } + "/exporter/${pname}";
+
+  format = "pyproject";
+
+  nativeBuildInputs = [
+    hatchling
+  ];
+
+  propagatedBuildInputs = [
+    backoff
+    googleapis-common-protos
+    grpcio
+    opentelemetry-exporter-otlp-proto-common
+  ];
+
+  nativeCheckInputs = [
+    opentelemetry-test-utils
+    pytestCheckHook
+  ];
+
+  disabledTestPaths = [
+    "tests/performance/benchmarks/"
+  ];
+
+  pythonImportsCheck = [ "opentelemetry.exporter.otlp.proto.grpc" ];
+
+  meta = with lib; {
+    homepage = "https://github.com/open-telemetry/opentelemetry-python/tree/main/exporter/opentelemetry-exporter-otlp-proto-grpc";
+    description = "OpenTelemetry Collector Protobuf over gRPC Exporter";
+    license = licenses.asl20;
+    maintainers = teams.deshaw.members;
+  };
+}

--- a/pkgs/development/python-modules/opentelemetry-exporter-otlp-proto-http/default.nix
+++ b/pkgs/development/python-modules/opentelemetry-exporter-otlp-proto-http/default.nix
@@ -1,0 +1,55 @@
+{ lib
+, buildPythonPackage
+, pythonOlder
+, fetchFromGitHub
+, backoff
+, googleapis-common-protos
+, hatchling
+, opentelemetry-exporter-otlp-proto-common
+, opentelemetry-test-utils
+, requests
+, responses
+, pytestCheckHook
+}:
+
+buildPythonPackage rec {
+  pname = "opentelemetry-exporter-otlp-proto-http";
+  version = "1.18.0";
+  disabled = pythonOlder "3.7";
+
+  src = fetchFromGitHub {
+    owner = "open-telemetry";
+    repo = "opentelemetry-python";
+    rev = "refs/tags/v${version}";
+    hash = "sha256-r4jvIhRM9E4CuZyS/XvvYO+F9cPxip8ab57CUfip47Q=";
+    sparseCheckout = [ "/exporter/${pname}" ];
+  } + "/exporter/${pname}";
+
+  format = "pyproject";
+
+  nativeBuildInputs = [
+    hatchling
+  ];
+
+  propagatedBuildInputs = [
+    backoff
+    googleapis-common-protos
+    opentelemetry-exporter-otlp-proto-common
+    requests
+  ];
+
+  nativeCheckInputs = [
+    opentelemetry-test-utils
+    pytestCheckHook
+    responses
+  ];
+
+  pythonImportsCheck = [ "opentelemetry.exporter.otlp.proto.http" ];
+
+  meta = with lib; {
+    homepage = "https://github.com/open-telemetry/opentelemetry-python/tree/main/exporter/opentelemetry-exporter-otlp-proto-http";
+    description = "OpenTelemetry Collector Protobuf over HTTP Exporter";
+    license = licenses.asl20;
+    maintainers = teams.deshaw.members;
+  };
+}

--- a/pkgs/development/python-modules/opentelemetry-exporter-otlp/default.nix
+++ b/pkgs/development/python-modules/opentelemetry-exporter-otlp/default.nix
@@ -1,0 +1,48 @@
+{ lib
+, buildPythonPackage
+, pythonOlder
+, fetchFromGitHub
+, backoff
+, hatchling
+, opentelemetry-exporter-otlp-proto-grpc
+, opentelemetry-exporter-otlp-proto-http
+, pytestCheckHook
+}:
+
+buildPythonPackage rec {
+  pname = "opentelemetry-exporter-otlp";
+  version = "1.18.0";
+  disabled = pythonOlder "3.7";
+
+  src = fetchFromGitHub {
+    owner = "open-telemetry";
+    repo = "opentelemetry-python";
+    rev = "refs/tags/v${version}";
+    hash = "sha256-ph9ahT6M8UBvuUJjk6nug68Ou/D7XuuXkfnKHEdD8x8=";
+    sparseCheckout = [ "/exporter/${pname}" ];
+  } + "/exporter/${pname}";
+
+  format = "pyproject";
+
+  nativeBuildInputs = [
+    hatchling
+  ];
+
+  propagatedBuildInputs = [
+    opentelemetry-exporter-otlp-proto-grpc
+    opentelemetry-exporter-otlp-proto-http
+  ];
+
+  nativeCheckInputs = [
+    pytestCheckHook
+  ];
+
+  pythonImportsCheck = [ "opentelemetry.exporter.otlp" ];
+
+  meta = with lib; {
+    homepage = "https://github.com/open-telemetry/opentelemetry-python/tree/main/exporter/opentelemetry-exporter-otlp";
+    description = "OpenTelemetry Collector Exporters";
+    license = licenses.asl20;
+    maintainers = teams.deshaw.members;
+  };
+}

--- a/pkgs/development/python-modules/opentelemetry-exporter-prometheus/default.nix
+++ b/pkgs/development/python-modules/opentelemetry-exporter-prometheus/default.nix
@@ -1,0 +1,51 @@
+{ lib
+, buildPythonPackage
+, pythonOlder
+, fetchFromGitHub
+, hatchling
+, opentelemetry-api
+, opentelemetry-sdk
+, opentelemetry-test-utils
+, prometheus-client
+, pytestCheckHook
+}:
+
+buildPythonPackage rec {
+  pname = "opentelemetry-exporter-prometheus";
+  version = "1.18.0";
+  disabled = pythonOlder "3.7";
+
+  src = fetchFromGitHub {
+    owner = "open-telemetry";
+    repo = "opentelemetry-python";
+    rev = "refs/tags/v${version}";
+    hash = "sha256-vWVLUt3Ett04kqUyoTOBNvRj51/M35X83saBBxeOTZI=";
+    sparseCheckout = [ "/exporter/${pname}" ];
+  } + "/exporter/${pname}";
+
+  format = "pyproject";
+
+  nativeBuildInputs = [
+    hatchling
+  ];
+
+  propagatedBuildInputs = [
+    opentelemetry-api
+    opentelemetry-sdk
+    prometheus-client
+  ];
+
+  nativeCheckInputs = [
+    opentelemetry-test-utils
+    pytestCheckHook
+  ];
+
+  pythonImportsCheck = [ "opentelemetry.exporter.prometheus" ];
+
+  meta = with lib; {
+    homepage = "https://github.com/open-telemetry/opentelemetry-python/tree/main/exporter/opentelemetry-exporter-prometheus";
+    description = "Prometheus Metric Exporter for OpenTelemetry";
+    license = licenses.asl20;
+    maintainers = teams.deshaw.members;
+  };
+}

--- a/pkgs/development/python-modules/opentelemetry-instrumentation-asgi/default.nix
+++ b/pkgs/development/python-modules/opentelemetry-instrumentation-asgi/default.nix
@@ -1,0 +1,55 @@
+{ lib
+, buildPythonPackage
+, pythonOlder
+, fetchFromGitHub
+, asgiref
+, hatchling
+, opentelemetry-api
+, opentelemetry-instrumentation
+, opentelemetry-semantic-conventions
+, opentelemetry-test-utils
+, opentelemetry-util-http
+, pytestCheckHook
+}:
+
+buildPythonPackage rec {
+  pname = "opentelemetry-instrumentation-asgi";
+  version = "0.39b0";
+  disabled = pythonOlder "3.7";
+
+  src = fetchFromGitHub {
+    owner = "open-telemetry";
+    repo = "opentelemetry-python-contrib";
+    rev = "refs/tags/v${version}";
+    hash = "sha256-BfNrbOQwyApdcKOVGF0LqzWOxzLkHZYiYdYVVPkGmdQ=";
+    sparseCheckout = [ "/instrumentation/${pname}" ];
+  } + "/instrumentation/${pname}";
+
+  format = "pyproject";
+
+  nativeBuildInputs = [
+    hatchling
+  ];
+
+  propagatedBuildInputs = [
+    asgiref
+    opentelemetry-instrumentation
+    opentelemetry-api
+    opentelemetry-semantic-conventions
+    opentelemetry-util-http
+  ];
+
+  nativeCheckInputs = [
+    opentelemetry-test-utils
+    pytestCheckHook
+  ];
+
+  pythonImportsCheck = [ "opentelemetry.instrumentation.asgi" ];
+
+  meta = with lib; {
+    homepage = "https://github.com/open-telemetry/opentelemetry-python-contrib/blob/main/instrumentation/opentelemetry-instrumentation-asgi";
+    description = "ASGI instrumentation for OpenTelemetry";
+    license = licenses.asl20;
+    maintainers = teams.deshaw.members;
+  };
+}

--- a/pkgs/development/python-modules/opentelemetry-instrumentation-django/default.nix
+++ b/pkgs/development/python-modules/opentelemetry-instrumentation-django/default.nix
@@ -1,0 +1,59 @@
+{ lib
+, buildPythonPackage
+, pythonOlder
+, fetchFromGitHub
+, django
+, hatchling
+, opentelemetry-api
+, opentelemetry-instrumentation
+, opentelemetry-instrumentation-asgi
+, opentelemetry-instrumentation-wsgi
+, opentelemetry-semantic-conventions
+, opentelemetry-test-utils
+, opentelemetry-util-http
+, pytestCheckHook
+}:
+
+buildPythonPackage rec {
+  pname = "opentelemetry-instrumentation-django";
+  version = "0.39b0";
+  disabled = pythonOlder "3.7";
+
+  src = fetchFromGitHub {
+    owner = "open-telemetry";
+    repo = "opentelemetry-python-contrib";
+    rev = "refs/tags/v${version}";
+    hash = "sha256-5tyLFQTYuJBFAFZirqsaHXCw72Q3TigDctZZFi/2zdI=";
+    sparseCheckout = [ "/instrumentation/${pname}" ];
+  } + "/instrumentation/${pname}";
+
+  format = "pyproject";
+
+  nativeBuildInputs = [
+    hatchling
+  ];
+
+  propagatedBuildInputs = [
+    django
+    opentelemetry-api
+    opentelemetry-instrumentation
+    opentelemetry-instrumentation-asgi
+    opentelemetry-instrumentation-wsgi
+    opentelemetry-semantic-conventions
+    opentelemetry-util-http
+  ];
+
+  nativeCheckInputs = [
+    opentelemetry-test-utils
+    pytestCheckHook
+  ];
+
+  pythonImportsCheck = [ "opentelemetry.instrumentation.django" ];
+
+  meta = with lib; {
+    homepage = "https://github.com/open-telemetry/opentelemetry-python-contrib/blob/main/instrumentation/opentelemetry-instrumentation-django";
+    description = "OpenTelemetry Instrumentation for Django";
+    license = licenses.asl20;
+    maintainers = teams.deshaw.members;
+  };
+}

--- a/pkgs/development/python-modules/opentelemetry-instrumentation-wsgi/default.nix
+++ b/pkgs/development/python-modules/opentelemetry-instrumentation-wsgi/default.nix
@@ -1,0 +1,53 @@
+{ lib
+, buildPythonPackage
+, pythonOlder
+, fetchFromGitHub
+, hatchling
+, opentelemetry-api
+, opentelemetry-instrumentation
+, opentelemetry-semantic-conventions
+, opentelemetry-test-utils
+, opentelemetry-util-http
+, pytestCheckHook
+}:
+
+buildPythonPackage rec {
+  pname = "opentelemetry-instrumentation-wsgi";
+  version = "0.39b0";
+  disabled = pythonOlder "3.7";
+
+  src = fetchFromGitHub {
+    owner = "open-telemetry";
+    repo = "opentelemetry-python-contrib";
+    rev = "refs/tags/v${version}";
+    hash = "sha256-DBZGXY8Y208YC/guk0qUB04UA/JFAtiv3kjsikskTRs=";
+    sparseCheckout = [ "/instrumentation/${pname}" ];
+  } + "/instrumentation/${pname}";
+
+  format = "pyproject";
+
+  nativeBuildInputs = [
+    hatchling
+  ];
+
+  propagatedBuildInputs = [
+    opentelemetry-instrumentation
+    opentelemetry-api
+    opentelemetry-semantic-conventions
+    opentelemetry-util-http
+  ];
+
+  nativeCheckInputs = [
+    opentelemetry-test-utils
+    pytestCheckHook
+  ];
+
+  pythonImportsCheck = [ "opentelemetry.instrumentation.wsgi" ];
+
+  meta = with lib; {
+    homepage = "https://github.com/open-telemetry/opentelemetry-python-contrib/blob/main/instrumentation/opentelemetry-instrumentation-wsgi";
+    description = "WSGI Middleware for OpenTelemetry";
+    license = licenses.asl20;
+    maintainers = teams.deshaw.members;
+  };
+}

--- a/pkgs/development/python-modules/opentelemetry-instrumentation/default.nix
+++ b/pkgs/development/python-modules/opentelemetry-instrumentation/default.nix
@@ -1,0 +1,53 @@
+{ lib
+, buildPythonPackage
+, pythonOlder
+, fetchFromGitHub
+, hatchling
+, opentelemetry-api
+, opentelemetry-sdk
+, opentelemetry-test-utils
+, setuptools
+, wrapt
+, pytestCheckHook
+}:
+
+buildPythonPackage rec {
+  pname = "opentelemetry-instrumentation";
+  version = "0.39b0";
+  disabled = pythonOlder "3.7";
+
+  src = fetchFromGitHub {
+    owner = "open-telemetry";
+    repo = "opentelemetry-python-contrib";
+    rev = "refs/tags/v${version}";
+    hash = "sha256-+zk76A640nyd1L0I55JrMMs7EnQ+SPQdYGAFIyQFc6E=";
+    sparseCheckout = [ "/${pname}" ];
+  } + "/${pname}";
+
+  format = "pyproject";
+
+  nativeBuildInputs = [
+    hatchling
+  ];
+
+  propagatedBuildInputs = [
+    opentelemetry-api
+    opentelemetry-sdk
+    setuptools
+    wrapt
+  ];
+
+  nativeCheckInputs = [
+    opentelemetry-test-utils
+    pytestCheckHook
+  ];
+
+  pythonImportsCheck = [ "opentelemetry.instrumentation" ];
+
+  meta = with lib; {
+    homepage = "https://github.com/open-telemetry/opentelemetry-python-contrib/tree/main/opentelemetry-instrumentation";
+    description = "Instrumentation Tools & Auto Instrumentation for OpenTelemetry Python";
+    license = licenses.asl20;
+    maintainers = teams.deshaw.members;
+  };
+}

--- a/pkgs/development/python-modules/opentelemetry-proto/default.nix
+++ b/pkgs/development/python-modules/opentelemetry-proto/default.nix
@@ -1,0 +1,45 @@
+{ lib
+, buildPythonPackage
+, pythonOlder
+, fetchFromGitHub
+, hatchling
+, protobuf
+, pytestCheckHook
+}:
+
+buildPythonPackage rec {
+  pname = "opentelemetry-proto";
+  version = "1.18.0";
+  disabled = pythonOlder "3.7";
+
+  src = fetchFromGitHub {
+    owner = "open-telemetry";
+    repo = "opentelemetry-python";
+    rev = "refs/tags/v${version}";
+    hash = "sha256-6iB+QlBUqRvIJ9p38NYgP4icW2rYs1P3bNCxI95cOvs=";
+    sparseCheckout = [ "/${pname}" ];
+  } + "/${pname}";
+
+  format = "pyproject";
+
+  nativeBuildInputs = [
+    hatchling
+  ];
+
+  propagatedBuildInputs = [
+    protobuf
+  ];
+
+  nativeCheckInputs = [
+    pytestCheckHook
+  ];
+
+  pythonImportsCheck = [ "opentelemetry.proto" ];
+
+  meta = with lib; {
+    homepage = "https://github.com/open-telemetry/opentelemetry-python/tree/main/opentelemetry-proto";
+    description = "OpenTelemetry Python Proto";
+    license = licenses.asl20;
+    maintainers = teams.deshaw.members;
+  };
+}

--- a/pkgs/development/python-modules/opentelemetry-sdk/default.nix
+++ b/pkgs/development/python-modules/opentelemetry-sdk/default.nix
@@ -1,0 +1,66 @@
+{ lib
+, buildPythonPackage
+, pythonOlder
+, fetchFromGitHub
+, flaky
+, hatchling
+, opentelemetry-api
+, opentelemetry-semantic-conventions
+, opentelemetry-test-utils
+, setuptools
+, typing-extensions
+, pytestCheckHook
+}:
+
+let
+  self = buildPythonPackage {
+    pname = "opentelemetry-sdk";
+    version = "1.18.0";
+    disabled = pythonOlder "3.7";
+
+    src = fetchFromGitHub {
+      owner = "open-telemetry";
+      repo = "opentelemetry-python";
+      rev = "refs/tags/v${self.version}";
+      hash = "sha256-YMFSmzuvm/VA9Fpe7pbF9mnGQHOQpobWMb1iGRt+d3w=";
+      sparseCheckout = [ "/${self.pname}" ];
+    } + "/${self.pname}";
+
+    format = "pyproject";
+
+    nativeBuildInputs = [
+      hatchling
+    ];
+
+    propagatedBuildInputs = [
+      opentelemetry-api
+      opentelemetry-semantic-conventions
+      setuptools
+      typing-extensions
+    ];
+
+    nativeCheckInputs = [
+      flaky
+      opentelemetry-test-utils
+      pytestCheckHook
+    ];
+
+    disabledTestPaths = [
+      "tests/performance/benchmarks/"
+    ];
+
+    pythonImportsCheck = [ "opentelemetry.sdk" ];
+
+    doCheck = false;
+
+    # Enable tests via passthru to avoid cyclic dependency with opentelemetry-test-utils.
+    passthru.tests.${self.pname} = self.overridePythonAttrs { doCheck = true; };
+
+    meta = with lib; {
+      homepage = "https://opentelemetry.io";
+      description = "OpenTelemetry Python API and SDK";
+      license = licenses.asl20;
+      maintainers = teams.deshaw.members;
+    };
+  };
+in self

--- a/pkgs/development/python-modules/opentelemetry-semantic-conventions/default.nix
+++ b/pkgs/development/python-modules/opentelemetry-semantic-conventions/default.nix
@@ -1,0 +1,40 @@
+{ lib
+, buildPythonPackage
+, pythonOlder
+, fetchFromGitHub
+, hatchling
+, pytestCheckHook
+}:
+
+buildPythonPackage rec {
+  pname = "opentelemetry-semantic-conventions";
+  version = "1.18.0";
+  disabled = pythonOlder "3.7";
+
+  src = fetchFromGitHub {
+    owner = "open-telemetry";
+    repo = "opentelemetry-python";
+    rev = "refs/tags/v${version}";
+    hash = "sha256-82L/tDoWgu0r+Li3CS3hjVR99DQQmA5yt3y85+37imI=";
+    sparseCheckout = [ "/${pname}" ];
+  } + "/${pname}";
+
+  format = "pyproject";
+
+  nativeBuildInputs = [
+    hatchling
+  ];
+
+  nativeCheckInputs = [
+    pytestCheckHook
+  ];
+
+  pythonImportsCheck = [ "opentelemetry.semconv" ];
+
+  meta = with lib; {
+    homepage = "https://github.com/open-telemetry/opentelemetry-python/tree/main/opentelemetry-semantic-conventions";
+    description = "OpenTelemetry Semantic Conventions";
+    license = licenses.asl20;
+    maintainers = teams.deshaw.members;
+  };
+}

--- a/pkgs/development/python-modules/opentelemetry-test-utils/default.nix
+++ b/pkgs/development/python-modules/opentelemetry-test-utils/default.nix
@@ -1,0 +1,45 @@
+{ lib
+, callPackage
+, buildPythonPackage
+, pythonOlder
+, fetchFromGitHub
+, asgiref
+, hatchling
+, opentelemetry-api
+, opentelemetry-sdk
+}:
+
+buildPythonPackage rec {
+  pname = "opentelemetry-test-utils";
+  version = "1.18.0";
+  disabled = pythonOlder "3.7";
+
+  src = fetchFromGitHub {
+    owner = "open-telemetry";
+    repo = "opentelemetry-python";
+    rev = "refs/tags/v${version}";
+    hash = "sha256-WRcKTE3eVqOSQUi5gZ3du+RGw8CrMazXHrctdrjgzHo=";
+    sparseCheckout = [ "/tests/${pname}" ];
+  } + "/tests/${pname}";
+
+  format = "pyproject";
+
+  nativeBuildInputs = [
+    hatchling
+  ];
+
+  propagatedBuildInputs = [
+    asgiref
+    opentelemetry-api
+    opentelemetry-sdk
+  ];
+
+  pythonImportsCheck = [ "opentelemetry.test" ];
+
+  meta = with lib; {
+    homepage = "https://github.com/open-telemetry/opentelemetry-python/tree/main/tests/opentelemetry-test-utils";
+    description = "Test utilities for OpenTelemetry unit tests";
+    license = licenses.asl20;
+    maintainers = teams.deshaw.members;
+  };
+}

--- a/pkgs/development/python-modules/opentelemetry-util-http/default.nix
+++ b/pkgs/development/python-modules/opentelemetry-util-http/default.nix
@@ -1,0 +1,51 @@
+{ lib
+, buildPythonPackage
+, pythonOlder
+, fetchFromGitHub
+, hatchling
+, opentelemetry-instrumentation
+, opentelemetry-sdk
+, opentelemetry-semantic-conventions
+, opentelemetry-test-utils
+, pytestCheckHook
+}:
+
+buildPythonPackage rec {
+  pname = "opentelemetry-util-http";
+  version = "0.39b0";
+  disabled = pythonOlder "3.7";
+
+  src = fetchFromGitHub {
+    owner = "open-telemetry";
+    repo = "opentelemetry-python-contrib";
+    rev = "refs/tags/v${version}";
+    hash = "sha256-C20/M5wimQec/8tTKx7+jkIYgfgNPtU9lkPKliIM3Uk=";
+    sparseCheckout = [ "/util/${pname}" ];
+  } + "/util/${pname}";
+
+  format = "pyproject";
+
+  nativeBuildInputs = [
+    hatchling
+  ];
+
+  propagatedBuildInputs = [
+    opentelemetry-instrumentation
+    opentelemetry-sdk
+    opentelemetry-semantic-conventions
+  ];
+
+  nativeCheckInputs = [
+    opentelemetry-test-utils
+    pytestCheckHook
+  ];
+
+  pythonImportsCheck = [ "opentelemetry.util.http" ];
+
+  meta = with lib; {
+    homepage = "https://github.com/open-telemetry/opentelemetry-python-contrib/tree/main/util/opentelemetry-util-http";
+    description = "Web util for OpenTelemetry";
+    license = licenses.asl20;
+    maintainers = teams.deshaw.members;
+  };
+}

--- a/pkgs/development/python-modules/pytest-grpc/default.nix
+++ b/pkgs/development/python-modules/pytest-grpc/default.nix
@@ -1,0 +1,32 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, grpcio
+, pytest
+, pytestCheckHook
+}:
+
+buildPythonPackage rec {
+  pname = "pytest-grpc";
+  version = "0.8.0";
+
+  src = fetchPypi {
+    inherit pname version;
+    hash = "sha256-C9JoP/00GZRE1wfAqwGXCyLgr7umyx3bbVeMhev+Cb0=";
+  };
+
+  buildInputs = [
+    pytest
+  ];
+
+  propagatedBuildInputs = [
+    grpcio
+  ];
+
+  meta = with lib; {
+    description = "pytest plugin for grpc";
+    homepage = "https://github.com/MobileDynasty/pytest-env";
+    license = licenses.mit;
+    maintainers = teams.deshaw.members;
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -7094,6 +7094,8 @@ self: super: with self; {
 
   opentimestamps = callPackage ../development/python-modules/opentimestamps { };
 
+  opentelemetry-semantic-conventions = callPackage ../development/python-modules/opentelemetry-semantic-conventions { };
+
   openturns = toPythonModule (pkgs.openturns.override {
     python3Packages = self;
     enablePython = true;

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -7098,6 +7098,8 @@ self: super: with self; {
 
   opentelemetry-exporter-otlp-proto-common = callPackage ../development/python-modules/opentelemetry-exporter-otlp-proto-common { };
 
+  opentelemetry-exporter-otlp-proto-grpc = callPackage ../development/python-modules/opentelemetry-exporter-otlp-proto-grpc { };
+
   opentelemetry-exporter-prometheus = callPackage ../development/python-modules/opentelemetry-exporter-prometheus { };
 
   opentelemetry-proto = callPackage ../development/python-modules/opentelemetry-proto { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -7096,6 +7096,8 @@ self: super: with self; {
 
   opentelemetry-api = callPackage ../development/python-modules/opentelemetry-api { };
 
+  opentelemetry-exporter-otlp-proto-common = callPackage ../development/python-modules/opentelemetry-exporter-otlp-proto-common { };
+
   opentelemetry-exporter-prometheus = callPackage ../development/python-modules/opentelemetry-exporter-prometheus { };
 
   opentelemetry-proto = callPackage ../development/python-modules/opentelemetry-proto { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -7096,6 +7096,8 @@ self: super: with self; {
 
   opentelemetry-api = callPackage ../development/python-modules/opentelemetry-api { };
 
+  opentelemetry-exporter-otlp = callPackage ../development/python-modules/opentelemetry-exporter-otlp { };
+
   opentelemetry-exporter-otlp-proto-common = callPackage ../development/python-modules/opentelemetry-exporter-otlp-proto-common { };
 
   opentelemetry-exporter-otlp-proto-grpc = callPackage ../development/python-modules/opentelemetry-exporter-otlp-proto-grpc { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -7106,6 +7106,8 @@ self: super: with self; {
 
   opentelemetry-exporter-prometheus = callPackage ../development/python-modules/opentelemetry-exporter-prometheus { };
 
+  opentelemetry-instrumentation = callPackage ../development/python-modules/opentelemetry-instrumentation { };
+
   opentelemetry-proto = callPackage ../development/python-modules/opentelemetry-proto { };
 
   opentelemetry-semantic-conventions = callPackage ../development/python-modules/opentelemetry-semantic-conventions { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -7100,6 +7100,8 @@ self: super: with self; {
 
   opentelemetry-exporter-otlp-proto-grpc = callPackage ../development/python-modules/opentelemetry-exporter-otlp-proto-grpc { };
 
+  opentelemetry-exporter-otlp-proto-http = callPackage ../development/python-modules/opentelemetry-exporter-otlp-proto-http { };
+
   opentelemetry-exporter-prometheus = callPackage ../development/python-modules/opentelemetry-exporter-prometheus { };
 
   opentelemetry-proto = callPackage ../development/python-modules/opentelemetry-proto { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -7108,6 +7108,8 @@ self: super: with self; {
 
   opentelemetry-instrumentation = callPackage ../development/python-modules/opentelemetry-instrumentation { };
 
+  opentelemetry-instrumentation-wsgi = callPackage ../development/python-modules/opentelemetry-instrumentation-wsgi { };
+
   opentelemetry-proto = callPackage ../development/python-modules/opentelemetry-proto { };
 
   opentelemetry-semantic-conventions = callPackage ../development/python-modules/opentelemetry-semantic-conventions { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -9537,6 +9537,8 @@ self: super: with self; {
 
   pytest-golden = callPackage ../development/python-modules/pytest-golden { };
 
+  pytest-grpc = callPackage ../development/python-modules/pytest-grpc { };
+
   pytest-helpers-namespace = callPackage ../development/python-modules/pytest-helpers-namespace { };
 
   pytest-html = callPackage ../development/python-modules/pytest-html { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -7108,6 +7108,8 @@ self: super: with self; {
 
   opentelemetry-instrumentation = callPackage ../development/python-modules/opentelemetry-instrumentation { };
 
+  opentelemetry-instrumentation-asgi = callPackage ../development/python-modules/opentelemetry-instrumentation-asgi { };
+
   opentelemetry-instrumentation-wsgi = callPackage ../development/python-modules/opentelemetry-instrumentation-wsgi { };
 
   opentelemetry-proto = callPackage ../development/python-modules/opentelemetry-proto { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -7096,6 +7096,8 @@ self: super: with self; {
 
   opentelemetry-api = callPackage ../development/python-modules/opentelemetry-api { };
 
+  opentelemetry-exporter-prometheus = callPackage ../development/python-modules/opentelemetry-exporter-prometheus { };
+
   opentelemetry-proto = callPackage ../development/python-modules/opentelemetry-proto { };
 
   opentelemetry-semantic-conventions = callPackage ../development/python-modules/opentelemetry-semantic-conventions { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -7094,6 +7094,8 @@ self: super: with self; {
 
   opentimestamps = callPackage ../development/python-modules/opentimestamps { };
 
+  opentelemetry-proto = callPackage ../development/python-modules/opentelemetry-proto { };
+
   opentelemetry-semantic-conventions = callPackage ../development/python-modules/opentelemetry-semantic-conventions { };
 
   openturns = toPythonModule (pkgs.openturns.override {

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -7102,6 +7102,8 @@ self: super: with self; {
 
   opentelemetry-sdk = callPackage ../development/python-modules/opentelemetry-sdk { };
 
+  opentelemetry-test-utils = callPackage ../development/python-modules/opentelemetry-test-utils { };
+
   openturns = toPythonModule (pkgs.openturns.override {
     python3Packages = self;
     enablePython = true;

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -7100,6 +7100,8 @@ self: super: with self; {
 
   opentelemetry-semantic-conventions = callPackage ../development/python-modules/opentelemetry-semantic-conventions { };
 
+  opentelemetry-sdk = callPackage ../development/python-modules/opentelemetry-sdk { };
+
   openturns = toPythonModule (pkgs.openturns.override {
     python3Packages = self;
     enablePython = true;

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -7110,6 +7110,8 @@ self: super: with self; {
 
   opentelemetry-instrumentation-asgi = callPackage ../development/python-modules/opentelemetry-instrumentation-asgi { };
 
+  opentelemetry-instrumentation-django = callPackage ../development/python-modules/opentelemetry-instrumentation-django { };
+
   opentelemetry-instrumentation-wsgi = callPackage ../development/python-modules/opentelemetry-instrumentation-wsgi { };
 
   opentelemetry-proto = callPackage ../development/python-modules/opentelemetry-proto { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -7116,6 +7116,8 @@ self: super: with self; {
 
   opentelemetry-test-utils = callPackage ../development/python-modules/opentelemetry-test-utils { };
 
+  opentelemetry-util-http = callPackage ../development/python-modules/opentelemetry-util-http { };
+
   openturns = toPythonModule (pkgs.openturns.override {
     python3Packages = self;
     enablePython = true;

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -7094,6 +7094,8 @@ self: super: with self; {
 
   opentimestamps = callPackage ../development/python-modules/opentimestamps { };
 
+  opentelemetry-api = callPackage ../development/python-modules/opentelemetry-api { };
+
   opentelemetry-proto = callPackage ../development/python-modules/opentelemetry-proto { };
 
   opentelemetry-semantic-conventions = callPackage ../development/python-modules/opentelemetry-semantic-conventions { };


### PR DESCRIPTION
###### Description of changes

This PR adds a number of [OpenTelemetry](https://opentelemetry.io/) packages to `python3Packages` to help Python developers utilize OpenTelemetry tooling and OTLP.

The PR is broken into a number of small commits, initializing each package.

Most of these packages do not work with `fetchPypi` and thus are pulled with `fetchFromGitHub`. Even though many of the packages come from the same repository, I intentionally avoided sharing the source between them so that they can be individually upgraded and to match the more standard `fetchPypi` usage as much as possible.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
