### PR TITLE
texlive.texinfo: fix hash

### DIFF
--- a/pkgs/tools/typesetting/tex/texlive/fixedHashes.nix
+++ b/pkgs/tools/typesetting/tex/texlive/fixedHashes.nix
@@ -8515,7 +8515,7 @@
 "texdate.source-2.0"="0mbcap5nfj5ap8gxn4pyv8w37hcfnq4bm5m6jx43cwkzf2hiwar5";
 "texdimens-1.1"="0fny36zd88qkcz7k3hdxq2qr41dmk9j88skihls4vwf350fy8j98";
 "texdimens.doc-1.1"="1qls1hqs6ypmsg4rqa26dp98m6h7zq18wdg9n6g6895jrmj10qdz";
-"texinfo-6.8"="0zlmch50haqbf0c68pdicdyzc5bq0z374vglaxng9d10151k0kpd";
+"texinfo-6.8"="sha256-V+fSY9kzd40ZyeFpShVh4CtDm9haiUOUEk7k7QAuCP0=";
 "timetable-15878"="1lnl8gi2rrzcy688qb8b1ff9yivwxdqmbcfx2ph49aymkxfym97b";
 "tracklang-1.4"="0dlfwsysadr78dkdrm96ibv3gjizwkqbm8m7pjipmp637vjb70ry";
 "tracklang.doc-1.4"="1dygdc8rj4kmh1gwpkpmqkih35yzx262n9f5n06k0ydf5rr96fqm";


### PR DESCRIPTION
###### Description of changes

```
nix-build . -A texlive.texinfo.pkgs --check
```
currently fails on 22.05 and 22.11
```
checking outputs of '/nix/store/brbni7gd9fxin9bw3jc8nm8mazb5dyn1-texlive-texinfo-6.8.drv'...
error: hash mismatch in fixed-output derivation '/nix/store/brbni7gd9fxin9bw3jc8nm8mazb5dyn1-texlive-texinfo-6.8.drv':
         specified: sha256-7U4wQwkgtPRsV/RtcsYHeBX2fWOxXWQYcAsrCApklX4=
            got:    sha256-V+fSY9kzd40ZyeFpShVh4CtDm9haiUOUEk7k7QAuCP0=
```

```diff
diff -aru old/tex/texinfo/texinfo.tex new/tex/texinfo/texinfo.tex
--- old/tex/texinfo/texinfo.tex	1969-12-31 19:00:01.000000000 -0500
+++ new/tex/texinfo/texinfo.tex	1969-12-31 19:00:01.000000000 -0500
@@ -3,7 +3,7 @@
 % Load plain if necessary, i.e., if running under initex.
 \expandafter\ifx\csname fmtname\endcsname\relax\input plain\fi
 %
-\def\texinfoversion{2021-11-01.16}
+\def\texinfoversion{2022-01-02.12}
 %
 % Copyright 1985, 1986, 1988, 1990-2021 Free Software Foundation, Inc.
 %
@@ -3193,14 +3193,9 @@
 %    \kern-0.4pt\hrule}%
 %  \kern-.06em\raise0.4pt\hbox{\angleright}}}}
 
-% definition of @key with no lozenge.  If the current font is already
-% monospace, don't change it; that way, we respect @kbdinputstyle.  But
-% if it isn't monospace, then use \tt.
-%
-\def\key#1{{\setregularquotes
-  \nohyphenation
-  \ifmonospace\else\tt\fi
-  #1}\null}
+% definition of @key with no lozenge.
+%
+\def\key#1{{\setregularquotes \nohyphenation \tt #1}\null}
 
 % @clicksequence{File @click{} Open ...}
 \def\clicksequence#1{\begingroup #1\endgroup}
@@ -11248,23 +11243,6 @@
   \defbodyindent = .5cm
 }}
 
-% Use @smallerbook to reset parameters for 6x9 trim size.
-% (Just testing, parameters still in flux.)
-\def\smallerbook{{\globaldefs = 1
-  \parskip = 1.5pt plus 1pt
-  \textleading = 12pt
-  %
-  \internalpagesizes{7.4in}{4.8in}%
-                    {-.2in}{-.4in}%
-                    {0pt}{14pt}%
-                    {9in}{6in}%
-  %
-  \lispnarrowing = 0.25in
-  \tolerance = 700
-  \contentsrightmargin = 0pt
-  \defbodyindent = .4cm
-}}
-
 % Use @afourpaper to print on European A4 paper.
 \def\afourpaper{{\globaldefs = 1
   \parskip = 3pt plus 2pt minus 1pt
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
