### PR TITLE
klipperscreen: init at 0.3.2

### DIFF
--- a/pkgs/applications/misc/klipperscreen/default.nix
+++ b/pkgs/applications/misc/klipperscreen/default.nix
@@ -1,0 +1,28 @@
+{ lib, stdenv, writeText, python3Packages, fetchFromGitHub, gtk3, gobject-introspection, gdk-pixbuf, wrapGAppsHook, librsvg }:
+python3Packages.buildPythonPackage rec {
+  pname = "KlipperScreen";
+  version = "0.3.2";
+
+  src = fetchFromGitHub {
+    owner = "jordanruthe";
+    repo = pname;
+    rev = "v${version}";
+    hash = "sha256-LweO5EVWr3OxziHrjtQDdWyUBCVUJ17afkw7RCZWgcg=";
+  };
+  patches = [ ./fix-paths.diff ];
+
+  buildInputs = [ gtk3 librsvg ];
+  nativeBuildInputs = [ wrapGAppsHook gdk-pixbuf gobject-introspection ];
+
+  propagatedBuildInputs = with python3Packages; [ jinja2 netifaces requests websocket-client pycairo pygobject3 mpv six dbus-python numpy pycairo ];
+
+  preBuild = ''
+    ln -s ${./setup.py} setup.py
+  '';
+
+  meta = with lib; {
+    description = "Touchscreen GUI for the Klipper 3D printer firmware";
+    homepage = "https://github.com/jordanruthe/${pname}";
+    license = licenses.agpl3;
+  };
+}

--- a/pkgs/applications/misc/klipperscreen/fix-paths.diff
+++ b/pkgs/applications/misc/klipperscreen/fix-paths.diff
@@ -1,0 +1,22 @@
+diff --git a/screen.py b/screen.py
+index 4fd75cd..a10779a 100755
+--- a/screen.py
++++ b/screen.py
+@@ -48,7 +48,7 @@ PRINTER_BASE_STATUS_OBJECTS = [
+     'exclude_object',
+ ]
+ 
+-klipperscreendir = pathlib.Path(__file__).parent.resolve()
++klipperscreendir = pathlib.Path(functions.__file__).parent.parent.resolve()
+ 
+ 
+ def set_text_direction(lang=None):
+@@ -254,7 +254,7 @@ class KlipperScreen(Gtk.Window):
+     def _load_panel(self, panel, *args):
+         if panel not in self.load_panel:
+             logging.debug(f"Loading panel: {panel}")
+-            panel_path = os.path.join(os.path.dirname(__file__), 'panels', f"{panel}.py")
++            panel_path = os.path.join(klipperscreendir, 'panels', f"{panel}.py")
+             logging.info(f"Panel path: {panel_path}")
+             if not os.path.exists(panel_path):
+                 logging.error(f"Panel {panel} does not exist")

--- a/pkgs/applications/misc/klipperscreen/setup.py
+++ b/pkgs/applications/misc/klipperscreen/setup.py
@@ -1,0 +1,11 @@
+from setuptools import setup
+
+setup(
+  name='KlipperScreen',
+  install_requires=[],
+  packages=['styles', 'panels', 'ks_includes', 'ks_includes.widgets'],
+  package_data={'ks_includes': ['defaults.conf', 'locales/**', 'emptyCursor.xbm'], 'styles': ['**']},
+  entry_points={
+      'console_scripts': ['KlipperScreen=screen:main']
+  },
+)

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5176,6 +5176,8 @@ with pkgs;
     inherit (darwin.apple_sdk.frameworks) Security;
   };
 
+  klipperscreen = callPackage ../applications/misc/klipperscreen { };
+
   klog = qt5.callPackage ../applications/radio/klog { };
 
   komga = callPackage ../servers/komga { };


### PR DESCRIPTION
###### Description of changes

Provides https://github.com/jordanruthe/KlipperScreen, a touchscreen GUI for the Klipper 3D printer firmware. Particularly useful on low-powered systems which can't run the popular web-based front-ends like fluidd (which is already packaged).

I don't know much python, and KlipperScreen does not appear to be designed to be packaged at all, so this is a little bit messy, but it starts.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

