### PR TITLE
deepin.deepin-screen-recorder: init at 5.11.23

### DIFF
--- a/pkgs/desktops/deepin/apps/deepin-screen-recorder/default.nix
+++ b/pkgs/desktops/deepin/apps/deepin-screen-recorder/default.nix
@@ -1,0 +1,97 @@
+{ stdenv
+, lib
+, fetchFromGitHub
+, qmake
+, pkg-config
+, qttools
+, wrapQtAppsHook
+, dtkwidget
+, qt5integration
+, dde-qt-dbus-factory
+, dde-dock
+, qtbase
+, qtmultimedia
+, qtx11extras
+, image-editor
+, gsettings-qt
+, xorg
+, libusb1
+, libv4l
+, ffmpeg
+, ffmpegthumbnailer
+, portaudio
+, kwayland
+, udev
+, gst_all_1
+}:
+stdenv.mkDerivation rec {
+  pname = "deepin-screen-recorder";
+  version = "5.11.23";
+
+  src = fetchFromGitHub {
+    owner = "linuxdeepin";
+    repo = pname;
+    rev = version;
+    sha256 = "sha256-yKBF/MmhlgwO5GLwfGgs13ERuzOg8EYjc3bXZ8TvcBU=";
+  };
+
+  patches = [ ./dont_use_libPath.diff ];
+
+  postPatch = ''
+    substituteInPlace screen_shot_recorder.pro deepin-screen-recorder.desktop \
+      src/{src.pro,pin_screenshots/pin_screenshots.pro} \
+      src/dde-dock-plugins/{shotstart/shotstart.pro,recordtime/recordtime.pro} \
+      assets/com.deepin.Screenshot.service \
+     --replace "/usr" "$out"
+  '';
+
+  nativeBuildInputs = [
+    qmake
+    pkg-config
+    qttools
+    wrapQtAppsHook
+  ];
+
+  buildInputs = [
+    dtkwidget
+    dde-qt-dbus-factory
+    dde-dock
+    qtbase
+    qtmultimedia
+    qtx11extras
+    image-editor
+    gsettings-qt
+    xorg.libXdmcp
+    xorg.libXtst
+    xorg.libXcursor
+    libusb1
+    libv4l
+    ffmpeg
+    ffmpegthumbnailer
+    portaudio
+    kwayland
+    udev
+  ] ++ (with gst_all_1; [
+    gstreamer
+    gst-plugins-base
+    gst-plugins-good
+  ]);
+
+  # qt5integration must be placed before qtsvg in QT_PLUGIN_PATH
+  qtWrapperArgs = [
+    "--prefix QT_PLUGIN_PATH : ${qt5integration}/${qtbase.qtPluginPrefix}"
+    "--prefix LD_LIBRARY_PATH : ${lib.makeLibraryPath [ udev gst_all_1.gstreamer ]}"
+  ];
+
+  preFixup = ''
+    qtWrapperArgs+=(--prefix GST_PLUGIN_SYSTEM_PATH_1_0 : "$GST_PLUGIN_SYSTEM_PATH_1_0")
+  '';
+
+  meta = with lib; {
+    description = "Screen recorder application for dde";
+    homepage = "https://github.com/linuxdeepin/deepin-screen-recorder";
+    license = licenses.gpl3Plus;
+    platforms = platforms.linux;
+    maintainers = teams.deepin.members;
+  };
+}

--- a/pkgs/desktops/deepin/apps/deepin-screen-recorder/dont_use_libPath.diff
+++ b/pkgs/desktops/deepin/apps/deepin-screen-recorder/dont_use_libPath.diff
@@ -1,0 +1,36 @@
+diff --git a/src/gstrecord/gstinterface.cpp b/src/gstrecord/gstinterface.cpp
+index b269b01..c075295 100644
+--- a/src/gstrecord/gstinterface.cpp
++++ b/src/gstrecord/gstinterface.cpp
+@@ -48,6 +48,7 @@ gstInterface::gstInterface()
+ }
+ QString gstInterface::libPath(const QString &sLib)
+ {
++    return sLib;
+     qInfo() << "gstreamer lib name is " << sLib;
+     QDir dir;
+     QString path  = QLibraryInfo::location(QLibraryInfo::LibrariesPath);
+diff --git a/src/main_window.cpp b/src/main_window.cpp
+index 7bfc78e..dcbbc2f 100755
+--- a/src/main_window.cpp
++++ b/src/main_window.cpp
+@@ -585,6 +585,7 @@ void MainWindow::initDynamicLibPath()
+ }
+ QString MainWindow::libPath(const QString &strlib)
+ {
++    return strlib;
+     QDir  dir;
+     QString path  = QLibraryInfo::location(QLibraryInfo::LibrariesPath);
+     dir.setPath(path);
+diff --git a/src/waylandrecord/avlibinterface.cpp b/src/waylandrecord/avlibinterface.cpp
+index d7942d6..c5cfdf4 100644
+--- a/src/waylandrecord/avlibinterface.cpp
++++ b/src/waylandrecord/avlibinterface.cpp
+@@ -105,6 +105,7 @@ avlibInterface::avlibInterface()
+ 
+ QString avlibInterface::libPath(const QString &sLib)
+ {
++    return sLib;
+     //qDebug() << sLib;
+     QDir dir;
+     QString path  = QLibraryInfo::location(QLibraryInfo::LibrariesPath);

--- a/pkgs/desktops/deepin/default.nix
+++ b/pkgs/desktops/deepin/default.nix
@@ -48,6 +48,7 @@ let
     deepin-movie-reborn = callPackage ./apps/deepin-movie-reborn { };
     deepin-music = callPackage ./apps/deepin-music { };
     deepin-picker = callPackage ./apps/deepin-picker { };
+    deepin-screen-recorder = callPackage ./apps/deepin-screen-recorder { };
     deepin-shortcut-viewer = callPackage ./apps/deepin-shortcut-viewer { };
     deepin-terminal = callPackage ./apps/deepin-terminal { };
     deepin-reader = callPackage ./apps/deepin-reader { };


### PR DESCRIPTION
###### Description of changes

libPath is is an unnecessary function  ,just use QLibrary to search library

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
