### PR TITLE
lhs2tex: distribute again

### DIFF
--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -745,9 +745,6 @@ self: super: {
   inline-c-win32 = dontDistribute super.inline-c-win32;
   Southpaw = dontDistribute super.Southpaw;
 
-  # Hydra no longer allows building texlive packages.
-  lhs2tex = dontDistribute super.lhs2tex;
-
   # https://ghc.haskell.org/trac/ghc/ticket/9825
   vimus = overrideCabal (drv: { broken = pkgs.stdenv.isLinux && pkgs.stdenv.isi686; }) super.vimus;
 


### PR DESCRIPTION
In https://github.com/NixOS/nixpkgs/commit/ad6a0e8a63e1 I added `lhs2tex` (a useful tool of its own) to the toplevel  and the `release-haskell.nix` file, so that users will find it on the cache.

Turns out that this didn’t quite work, because it was removed from things to be distributed in `pkgs/development/haskell-modules/configuration-common.nix`, since https://github.com/NixOS/nixpkgs/commit/b6b13e45f8a9 7 years ago. (HT to @vcunat for helping me figure that out.)

I assume (but couldn’t quite reproduce) that at some point in the past, the `lhs2tex` package built the users guide during the build, which pulled in TeXLive during the build, which was not welcome on hydra. But at least today, it seems that this is no longer the case (the build script says “Documentation cannot be rebuilt without pdflatex” and the final package does not contain the users guide).

So I guess we can easily build lhs2tex again.