### PR TITLE
ocamlPackages.ocaml_oasis: 0.4.10 → 0.4.11

### DIFF
--- a/pkgs/development/tools/ocaml/oasis/default.nix
+++ b/pkgs/development/tools/ocaml/oasis/default.nix
@@ -1,14 +1,12 @@
 { lib, stdenv, fetchurl, ocaml, findlib, ocamlbuild, ocamlmod, ocamlify }:
 
 stdenv.mkDerivation {
-  version = "0.4.10";
+  version = "0.4.11";
   pname = "ocaml-oasis";
 
-  # You must manually update the url, not just the version. OCamlforge keys off
-  # the number after download.php, not the filename.
   src = fetchurl {
-    url = "https://forge.ocamlcore.org/frs/download.php/1694/oasis-0.4.10.tar.gz";
-    sha256 = "13ah03pbcvrjv5lmx971hvkm9rvbvimska5wmjfvgvd20ca0gn8w";
+    url = "https://download.ocamlcore.org/oasis/oasis/0.4.11/oasis-0.4.11.tar.gz";
+    hash = "sha256-GLc97vTtbpqDM38ks7vi3tZSaLP/cwn8wA0l5X4dwS4=";
   };
 
   createFindlibDestdir = true;
@@ -40,10 +38,10 @@ stdenv.mkDerivation {
 
   meta = with lib; {
     description = "Configure, build and install system for OCaml projects";
-    homepage = "http://oasis.forge.ocamlcore.org/";
+    homepage = "https://github.com/ocaml/oasis";
     license = licenses.lgpl21;
     maintainers = with maintainers; [ vbgl maggesi ];
     mainProgram = "oasis";
-    platforms = ocaml.meta.platforms or [];
+    inherit (ocaml.meta) platforms;
   };
 }

--- a/pkgs/development/tools/ocaml/ocamlmod/default.nix
+++ b/pkgs/development/tools/ocaml/ocamlmod/default.nix
@@ -5,6 +5,9 @@ let
   doCheck = lib.versionAtLeast ocaml.version "4.04";
 in
 
+lib.throwIf (lib.versionAtLeast ocaml.version "5.0")
+  "ocamlmod is not available for OCaml ≥ 5.0"
+
 stdenv.mkDerivation {
   pname = "ocamlmod";
   version = "0.0.9";


### PR DESCRIPTION
###### Description of changes

https://github.com/ocaml/oasis/blob/0.4.11/CHANGES.txt

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
