### PR TITLE
gnutls: remove Guile bindings, guile-gnutls: init at 3.7.11

### DIFF
--- a/pkgs/development/guile-modules/guile-gnutls/default.nix
+++ b/pkgs/development/guile-modules/guile-gnutls/default.nix
@@ -1,0 +1,42 @@
+{ lib
+, stdenv
+, fetchurl
+, gnutls
+, guile
+, libtool
+, pkg-config
+, texinfo
+}:
+
+stdenv.mkDerivation rec {
+  pname = "guile-gnutls";
+  version = "3.7.11";
+
+  src = fetchurl {
+    url = "mirror://gnu/gnutls/guile-gnutls-${version}.tar.gz";
+    hash = "sha256-BY6qXHY+Gfv5PotO78ESgPgHBTXBOMmb4R8AzWhWE98=";
+  };
+
+  nativeBuildInputs = [ pkg-config ];
+
+  buildInputs = [
+    gnutls
+    guile
+    libtool
+    texinfo
+  ];
+
+  configureFlags = [
+    "--with-guile-site-dir=${builtins.placeholder "out"}/share/guile/site"
+    "--with-guile-site-ccache-dir=${builtins.placeholder "out"}/share/guile/site"
+    "--with-guile-extension-dir=${builtins.placeholder "out"}/share/guile/extensions"
+  ];
+
+  meta = with lib; {
+    homepage = "https://gitlab.com/gnutls/guile/";
+    description = "Guile bindings for GnuTLS library";
+    license = licenses.lgpl21Plus;
+    maintainers = with maintainers; [ foo-dogsquared ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/development/libraries/gnutls/default.nix
+++ b/pkgs/development/libraries/gnutls/default.nix
@@ -2,7 +2,6 @@
 , perl, gmp, autoconf, automake, libidn2, libiconv
 , unbound, dns-root-data, gettext, util-linux
 , cxxBindings ? !stdenv.hostPlatform.isStatic # tries to link libstdc++.so
-, guileBindings ? config.gnutls.guile or false, guile
 , tpmSupport ? false, trousers, which, nettools, libunistring
 , withP11-kit ? !stdenv.hostPlatform.isStatic, p11-kit
 , Security  # darwin Security.framework
@@ -22,7 +21,6 @@
 , samba
 }:
 
-assert guileBindings -> guile != null;
 let
 
   # XXX: Gnulib's `test-select' fails on FreeBSD:
@@ -74,19 +72,13 @@ stdenv.mkDerivation rec {
     "--with-unbound-root-key-file=${dns-root-data}/root.key"
     (lib.withFeature withP11-kit "p11-kit")
     (lib.enableFeature cxxBindings "cxx")
-  ] ++ lib.optionals guileBindings [
-    "--enable-guile"
-    "--with-guile-site-dir=\${out}/share/guile/site"
-    "--with-guile-site-ccache-dir=\${out}/share/guile/site"
-    "--with-guile-extension-dir=\${out}/share/guile/site"
   ];
 
   enableParallelBuilding = true;
 
   buildInputs = [ lzo lzip libtasn1 libidn2 zlib gmp libunistring unbound gettext libiconv ]
     ++ lib.optional (withP11-kit) p11-kit
-    ++ lib.optional (tpmSupport && stdenv.isLinux) trousers
-    ++ lib.optional guileBindings guile;
+    ++ lib.optional (tpmSupport && stdenv.isLinux) trousers;
 
   nativeBuildInputs = [ perl pkg-config ]
     ++ lib.optionals doCheck [ which nettools util-linux ];

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -17171,6 +17171,8 @@ with pkgs;
 
   guile-git = callPackage ../development/guile-modules/guile-git { };
 
+  guile-gnutls = callPackage ../development/guile-modules/guile-gnutls { };
+
   guile-json = callPackage ../development/guile-modules/guile-json { };
 
   guile-lib = callPackage ../development/guile-modules/guile-lib { };


### PR DESCRIPTION
###### Description of changes

[GnuTLS has dropped its Guile bindings since 3.8.0](https://gitlab.com/gnutls/gnutls/-/blob/3.8.0/NEWS?ref_type=tags#L45-47) and now lives in [a separate repository](https://gitlab.com/gnutls/guile/).

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
