### PR TITLE
libdecor: 0.1.0 -> 0.1.1, remove unused dependency

### DIFF
--- a/pkgs/development/libraries/libdecor/default.nix
+++ b/pkgs/development/libraries/libdecor/default.nix
@@ -16,14 +16,14 @@
 
 stdenv.mkDerivation rec {
   pname = "libdecor";
-  version = "0.1.0";
+  version = "0.1.1";
 
   src = fetchFromGitLab {
-    domain = "gitlab.gnome.org";
-    owner = "jadahl";
+    domain = "gitlab.freedesktop.org";
+    owner = "libdecor";
     repo = "libdecor";
     rev = "${version}";
-    sha256 = "0qdg3r7k086wzszr969s0ljlqdvfqm31zpl8p5h397bw076zr6p2";
+    hash = "sha256-8b6qCqOSDDbhYwAeAaUyI71tSopTkGtCJaxZaJw1vQQ=";
   };
 
   strictDeps = true;
@@ -46,7 +46,7 @@ stdenv.mkDerivation rec {
   ];
 
   meta = with lib; {
-    homepage = "https://gitlab.gnome.org/jadahl/libdecor";
+    homepage = "https://gitlab.freedesktop.org/libdecor/libdecor";
     description = "Client-side decorations library for Wayland clients";
     license = licenses.mit;
     platforms = platforms.linux;

--- a/pkgs/development/libraries/libdecor/default.nix
+++ b/pkgs/development/libraries/libdecor/default.nix
@@ -7,11 +7,9 @@
 , wayland
 , wayland-protocols
 , wayland-scanner
-, egl-wayland
 , cairo
 , dbus
 , pango
-, libxkbcommon
 }:
 
 stdenv.mkDerivation rec {
@@ -28,6 +26,10 @@ stdenv.mkDerivation rec {
 
   strictDeps = true;
 
+  mesonFlags = [
+    (lib.mesonBool "demo" false)
+  ];
+
   nativeBuildInputs = [
     meson
     ninja
@@ -38,11 +40,9 @@ stdenv.mkDerivation rec {
   buildInputs = [
     wayland
     wayland-protocols
-    egl-wayland
     cairo
     dbus
     pango
-    libxkbcommon
   ];
 
   meta = with lib; {


### PR DESCRIPTION
###### Description of changes

Prompted by #227457 when investigating why `libdecor` depends on the nvidia egl platform.

- Updated project home per notice on the old repository
- Update to 0.1.1
- Turns out `egl` should be provided by `libGL`, but since it is only required by the unused demo application I just disabled it and removed the dependency.

~@Artturin I noticed that there is an `libdecor-gtk.so` plugin that isn't currently being built. I didn't add a gtk3 dependency since I'm not sure what the purpose of those plugins is but you might want to have a look.~

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
