### PR TITLE
nixos/munin: Add munin-node options `port` and `openFirewall`

### DIFF
--- a/nixos/modules/services/monitoring/munin.nix
+++ b/nixos/modules/services/monitoring/munin.nix
@@ -35,7 +35,7 @@ let
     ''
       log_level 3
       log_file Sys::Syslog
-      port 4949
+      port ${toString nodeCfg.port}
       host *
       background 0
       user root
@@ -246,6 +246,24 @@ in
         '';
         example = [ "diskstats" "zfs_usage_*" ];
       };
+
+      port = mkOption {
+        default = 4949;
+        type = types.port;
+        description = lib.mdDoc ''
+          Port the Munin Node agent will listen on.
+        '';
+      };
+
+      openFirewall = mkOption {
+         default = false;
+         type = types.bool;
+         description = lib.mdDoc ''
+           Opens the firewall so that the Munin Node can be accessed by an external munin-cron.
+           Ensure that the correct `allow` stanza is set via `services.munin-node.extraConfig`.
+         '';
+      };
+
     };
 
     services.munin-cron = {
@@ -370,6 +388,8 @@ in
 
     # munin_stats plugin breaks as of 2.0.33 when this doesn't exist
     systemd.tmpfiles.rules = [ "d /run/munin 0755 munin munin -" ];
+
+    networking.firewall.allowedTCPPorts = mkIf nodeCfg.openFirewall [nodeCfg.port];
 
   }) (mkIf cronCfg.enable {
 


### PR DESCRIPTION
Rationale is to ease opening the firewall when the munin node needs to accessed from another host.

The `port` option is just a 'nice to have' to avoid doubling information.


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
