### PR TITLE
blisp: init at 0.0.4

### DIFF
--- a/pkgs/development/tools/misc/blisp/default.nix
+++ b/pkgs/development/tools/misc/blisp/default.nix
@@ -1,0 +1,48 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, cmake
+, IOKit
+, testers
+, blisp
+,
+}:
+let
+  version = "0.0.4";
+in
+stdenv.mkDerivation {
+  pname = "blisp";
+  inherit version;
+
+  src = fetchFromGitHub {
+    owner = "pine64";
+    repo = "blisp";
+    rev = "v${version}";
+    fetchSubmodules = true;
+    sha256 = "sha256-FT0CsxPKKWx4vg6f9woc15jgJj9P4fTAzW+s+ClzkwE=";
+  };
+
+  nativeBuildInputs = [ cmake ];
+
+  cmakeFlags = [ "-DBLISP_BUILD_CLI=ON" ];
+
+  buildInputs = lib.optionals stdenv.isDarwin [ IOKit ];
+
+  passthru.tests.version = testers.testVersion {
+    package = blisp;
+    command = "blisp --version";
+    version = "v${version}";
+  };
+
+  meta = with lib; {
+    homepage = "https://github.com/pine64/blisp";
+    description = "An In-System Programming (ISP) tool for Bouffalo Labs RISC-V MCUs";
+    longDescription = ''
+      In-System Programming (ISP) CLI tool for Bouffalo Labs RISC-V MCUs.
+
+      Used for flashing BL60x, BL61x, BL70x, BL808 SoCs, and products using corresponding MCUs, like Pinecil V2.
+    '';
+    license = licenses.mit;
+    maintainers = with maintainers; [ bdd ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -18876,6 +18876,10 @@ with pkgs;
 
   blackmagic = callPackage ../development/embedded/blackmagic { };
 
+  blisp = callPackage ../development/tools/misc/blisp {
+    inherit (darwin.apple_sdk.frameworks) IOKit;
+  };
+
   bloaty = callPackage ../development/tools/bloaty { };
 
   bloomrpc = callPackage ../development/web/bloomrpc { };


### PR DESCRIPTION
In-System Programming (ISP) tool for Bouffalo Labs RISC-V MCUs.

Used for flashing BL60x, BL61x, BL70x, BL808 SoCs, and products using corresponding MCUs, like Pinecil V2.

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
