### PR TITLE
doxygen: enable sqlite3 output

### DIFF
--- a/pkgs/development/tools/documentation/doxygen/default.nix
+++ b/pkgs/development/tools/documentation/doxygen/default.nix
@@ -1,4 +1,15 @@
-{ lib, stdenv, cmake, fetchFromGitHub, python3, flex, bison, qt5, CoreServices, libiconv }:
+{ lib
+, stdenv
+, cmake
+, fetchFromGitHub
+, python3
+, flex
+, bison
+, qt5
+, CoreServices
+, libiconv
+, withSqlite ? true, sqlite
+}:
 
 stdenv.mkDerivation rec {
   pname = "doxygen";
@@ -19,12 +30,13 @@ stdenv.mkDerivation rec {
   ];
 
   buildInputs = [ libiconv ]
+    ++ lib.optionals withSqlite [ sqlite ]
     ++ lib.optionals (qt5 != null) (with qt5; [ qtbase wrapQtAppsHook ])
     ++ lib.optionals stdenv.isDarwin [ CoreServices ];
 
-  cmakeFlags =
-    [ "-DICONV_INCLUDE_DIR=${libiconv}/include" ] ++
-    lib.optional (qt5 != null) "-Dbuild_wizard=YES";
+  cmakeFlags = [ "-DICONV_INCLUDE_DIR=${libiconv}/include" ]
+    ++ lib.optional withSqlite "-Duse_sqlite3=ON"
+    ++ lib.optional (qt5 != null) "-Dbuild_wizard=YES";
 
   env.NIX_CFLAGS_COMPILE =
     lib.optionalString stdenv.isDarwin "-mmacosx-version-min=10.9";

--- a/pkgs/development/tools/documentation/doxygen/default.nix
+++ b/pkgs/development/tools/documentation/doxygen/default.nix
@@ -41,6 +41,12 @@ stdenv.mkDerivation rec {
   env.NIX_CFLAGS_COMPILE =
     lib.optionalString stdenv.isDarwin "-mmacosx-version-min=10.9";
 
+  # put examples in an output so people/tools can test against them
+  outputs = [ "out" "examples" ];
+  postInstall = ''
+    cp -r ../examples $examples
+  '';
+
   meta = {
     license = lib.licenses.gpl2Plus;
     homepage = "https://www.doxygen.nl/";

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -17982,9 +17982,9 @@ with pkgs;
 
   dot2tex = with python3.pkgs; toPythonApplication dot2tex;
 
-  doxygen = callPackage ../development/tools/documentation/doxygen {
+  doxygen = darwin.apple_sdk_11_0.callPackage ../development/tools/documentation/doxygen {
     qt5 = null;
-    inherit (darwin.apple_sdk.frameworks) CoreServices;
+    inherit (darwin.apple_sdk_11_0.frameworks) CoreServices;
   };
 
   doxygen_gui = lowPrio (doxygen.override { inherit qt5; });


### PR DESCRIPTION
###### Description of changes

Doxygen doesn't have a maintainer at the moment, so I'm just pinging the last few people to bump/improve it to see what you think about a few things.

1. For partly selfish reasons, I want to compile support for doxygen's "experimental" sqlite3 output by default. It's a great way to build tools on top of what doxygen parses out of a codebase. I think it wouldn't take much for it to get promoted to full support if it had a few more users leaning on it.

2. While testing it recently I realized the master branch won't compile on Intel-based macs any more. Updating it to use apple_sdk_11_0 early to get out in front of that.

3. I'd like to publish its "examples" as an output. They are the closest thing to a ~reference corpus for it and only weigh a few dozen KiB. They are a place to start if you need to build styles/templates/tooling around Doxygen and don't already have a marked-up documentation corpus to test on.

<details><summary>I'm not sure how much of a worry closure-size impact is here since Nix already uses sqlite, but here's how `nix-tree` suggests that adding sqlite would affect doxygen's closure size:</summary>

- On Linux it's presently about 65.16 MiB; adding sqlite adds about 1.53 MiB.
- On macOS:
  - it's presently about 25.85 MiB; adding sqlite adds about 72.88 MiB, ballooning it to 98.82 MiB
  - however, it looks like updating to apple_sdk_11_0 would cause most of this increase anyways and it's still 98.82 MiB after building it with both sqlite and apple_sdk_11_0
</details>

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
