### PR TITLE
nixos/udev: Fix hwdb conflict handling; build with systemdb-hwdb

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2305.section.md
+++ b/nixos/doc/manual/release-notes/rl-2305.section.md
@@ -166,6 +166,8 @@ In addition to numerous new and upgraded packages, this release has the followin
 
 - The option `i18n.inputMethod.fcitx5.enableRimeData` has been removed. Default RIME data is now included in `fcitx5-rime` by default, and can be customized using `fcitx5-rime.override { rimeDataPkgs = [ pkgs.rime-data, package2, ... ]; }`
 
+- The udev hwdb.bin file is now built with systemd-hwdb rather than the [deprecated "udevadm hwdb"](https://github.com/systemd/systemd/pull/25714). This may impact mappings where the same key is defined in multiple matching entries. The updated behavior will select the latest definition in case of conflict. In general, this should be a positive change, as the hwdb source files are designed with this ordering in mind. As an example, the mapping of the HP Dev One keyboard scan code for "mute mic" is corrected by this update. This change may impact users who have worked-around previously incorrect mappings.
+
 - Kime has been updated from 2.5.6 to 3.0.2 and the `i18n.inputMethod.kime.config` option has been removed. Users should use `daemonModules`, `iconColor`, and `extraConfig` options under `i18n.inputMethod.kime` instead.
 
 - `tut` has been updated from 1.0.34 to 2.0.0, and now uses the TOML format for the configuration file instead of INI. Additional information can be found [here](https://github.com/RasmusLindroth/tut/releases/tag/2.0.0).

--- a/nixos/modules/services/hardware/udev.nix
+++ b/nixos/modules/services/hardware/udev.nix
@@ -160,7 +160,7 @@ let
 
       echo "Generating hwdb database..."
       # hwdb --update doesn't return error code even on errors!
-      res="$(${pkgs.buildPackages.udev}/bin/udevadm hwdb --update --root=$(pwd) 2>&1)"
+      res="$(${pkgs.buildPackages.systemd}/bin/systemd-hwdb --root=$(pwd) update 2>&1)"
       echo "$res"
       [ -z "$(echo "$res" | egrep '^Error')" ]
       mv etc/udev/hwdb.bin $out


### PR DESCRIPTION
Switch to systemdb-hwdb to build the udev hwdb.bin, as "udevadm hwdb" is deprecated. This fixes an issue where the order of conflicting keys is not respected.  The systemd-hwdb command creates a newer format (v3) of hwdb.bin that respects the ordering of duplicate keys, with later values replacing earlier occurrences.

A release note is included, as some mappings may be affected.

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
**Additional notes and testing:**
Duplicate keys can occur when there are multiple matching hwdb entries. Consider:
https://github.com/systemd/systemd-stable/blob/v253.2/hwdb.d/60-keyboard.hwdb

At line 566, a generic Hewlett Packard system defines:
  KEYBOARD_KEY_81=fn_esc

At line 813, there is an override for a specific HP Model (HP Dev One):
  KEYBOARD_KEY_81=f20   # Fn+F8; Microphone mute button

When the conflicting entries for KEYBOARD_KEY_81 are processed in the
intended order, the HP Dev One will have its KEYBOARD_KEY_81 scan code
interpreted as f20 (microphone mute). However, when hwdb.bin is built
with "udevadm hwdb", this is not the case.

This can be demonstrated with a simplified query, as follows:

  systemd-hwdb query evdev:atkbd:dmi:bvn:bvr:bd:svnHP:pn:rvnHP:rn8A78: | grep 81

When hwdb.bin is built with "udevadm hwdb", the output is incorrect:
  KEYBOARD_KEY_81=fn_esc

When the hwdb.bin is built with this commit using systemd-hwdb, the
output is correct:
  KEYBOARD_KEY_81=f20

For more information, See the following systemd PRs:

  udevadm: emit deprecation notice in udevadm hwdb
  https://github.com/systemd/systemd/pull/25714

  hwdb: return conflicts in a well-defined order
  https://github.com/systemd/systemd/pull/4199

The way multiple matching records are expected to combine is also described in the man page for hwdb.
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [x ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
