### PR TITLE
[Backport release-22.11] firefox-{beta,devedition}-bin-unwrapped: 112.0b9 -> 113.0b4

### DIFF
--- a/pkgs/applications/networking/browsers/firefox-bin/beta_sources.nix
+++ b/pkgs/applications/networking/browsers/firefox-bin/beta_sources.nix
@@ -1,1015 +1,1015 @@
 {
-  version = "113.0b3";
+  version = "113.0b4";
   sources = [
-    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b3/linux-x86_64/ach/firefox-113.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b4/linux-x86_64/ach/firefox-113.0b4.tar.bz2";
       locale = "ach";
       arch = "linux-x86_64";
-      sha256 = "97d9b5ac89cb6466f4e7b46749058c119fe7155aaeac8b0bbf341745f8dcefa8";
+      sha256 = "bd2ef5cb7f385ed11a813eb70f7599e9a95045b2095c982ddd33ed1d4c9b9938";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b3/linux-x86_64/af/firefox-113.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b4/linux-x86_64/af/firefox-113.0b4.tar.bz2";
       locale = "af";
       arch = "linux-x86_64";
-      sha256 = "2f5c33cfb22d1b77114124148d2dfbd3d82223a24c1a773174839077014a4b04";
+      sha256 = "0f736e3a332bf351703fe6ef3ae5c498497d240891bd722beff3d0cae95b6f42";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b3/linux-x86_64/an/firefox-113.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b4/linux-x86_64/an/firefox-113.0b4.tar.bz2";
       locale = "an";
       arch = "linux-x86_64";
-      sha256 = "9c7ea413f180148c66c32bdf88f23519555a6a93bc8495568d02e39db475b5a2";
+      sha256 = "46575d630aada9e974dc47099ce03388806ce088fe30ed60112695b3e7df16bc";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b3/linux-x86_64/ar/firefox-113.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b4/linux-x86_64/ar/firefox-113.0b4.tar.bz2";
       locale = "ar";
       arch = "linux-x86_64";
-      sha256 = "cf61ace5a5cf0a656a6a5dcc469dd50a3aa440a8c74ba0a45deecf810a2fcc44";
+      sha256 = "06827c3ef613643c4aca61fe608488df1373016f3a601b8352d7f40971f837ca";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b3/linux-x86_64/ast/firefox-113.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b4/linux-x86_64/ast/firefox-113.0b4.tar.bz2";
       locale = "ast";
       arch = "linux-x86_64";
-      sha256 = "5aaf8fed853e4b58b221a1e1a872936f00c13b6544bb42d68a3cfb78b99ba2cb";
+      sha256 = "52b7ed3cf3b4d95a5786dc6ff0ea408268430fb33a702d4e5f15bf101057daec";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b3/linux-x86_64/az/firefox-113.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b4/linux-x86_64/az/firefox-113.0b4.tar.bz2";
       locale = "az";
       arch = "linux-x86_64";
-      sha256 = "d399a2fa5bc8c185a9ddc2447098a7fd71438b442b9dba704973c4837418e953";
+      sha256 = "e4e5c82337aaa5013d96baa0039e441e642e8343cc14f311b1829190cef85c11";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b3/linux-x86_64/be/firefox-113.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b4/linux-x86_64/be/firefox-113.0b4.tar.bz2";
       locale = "be";
       arch = "linux-x86_64";
-      sha256 = "992c5d7db66030cd38595addabd3567e7f88746bd5beadb3763b7c4cdc933f7a";
+      sha256 = "feaab0297cd50411ee66c277056915b09324753dfb9a9ec5ffa4e95826a0321f";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b3/linux-x86_64/bg/firefox-113.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b4/linux-x86_64/bg/firefox-113.0b4.tar.bz2";
       locale = "bg";
       arch = "linux-x86_64";
-      sha256 = "97b6c3d43b9a3c62f29a711cc028c8748cfbf890df4d7d230b56cddad99469a5";
+      sha256 = "6c3bac53c27d2866bde4a3c7c7df722b8f8b199d22a949f8f4b23ba778fd072c";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b3/linux-x86_64/bn/firefox-113.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b4/linux-x86_64/bn/firefox-113.0b4.tar.bz2";
       locale = "bn";
       arch = "linux-x86_64";
-      sha256 = "33fa082099849f0ca36c75ccaa2d039d58f6f6e77e527bbafe148cf90ca894c8";
+      sha256 = "f3a35430f570eca76a18695a6770527d03c3f35f7eb252f3f1ad0ac8a417baf7";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b3/linux-x86_64/br/firefox-113.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b4/linux-x86_64/br/firefox-113.0b4.tar.bz2";
       locale = "br";
       arch = "linux-x86_64";
-      sha256 = "b42bf6737501c8ed71c762968857c7091bb248ca0cef00690855cacb83c7f07e";
+      sha256 = "ff645d57d0dd11952cd38bf3c336638f1ef38c58b7e968871f615a3732124c0e";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b3/linux-x86_64/bs/firefox-113.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b4/linux-x86_64/bs/firefox-113.0b4.tar.bz2";
       locale = "bs";
       arch = "linux-x86_64";
-      sha256 = "d388804d8376e35eab6094f9092d2c9b5a22578b52bd5a2b86760480f2efbff1";
+      sha256 = "c3b5046b06219af95e0e9f53b24325ef620f614800a2cdd51388b0ddfc9f58b2";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b3/linux-x86_64/ca-valencia/firefox-113.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b4/linux-x86_64/ca-valencia/firefox-113.0b4.tar.bz2";
       locale = "ca-valencia";
       arch = "linux-x86_64";
-      sha256 = "785d1f69a0e63076d727246990208e117f05b23d2bd4e896ecaef237715b6153";
+      sha256 = "4381724cdf143d94fe6528ec893f0e66e3eabac31cdf8c42d95cbf1de23c302d";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b3/linux-x86_64/ca/firefox-113.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b4/linux-x86_64/ca/firefox-113.0b4.tar.bz2";
       locale = "ca";
       arch = "linux-x86_64";
-      sha256 = "ff648477c3b23a2d9968addc779bcede1a81fdd52d82a508dbb80420978ed3e9";
+      sha256 = "8a4188c7dd0de8f43273f697915b7339b37f5af9eb87c3298ec3407e10fc1da6";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b3/linux-x86_64/cak/firefox-113.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b4/linux-x86_64/cak/firefox-113.0b4.tar.bz2";
       locale = "cak";
       arch = "linux-x86_64";
-      sha256 = "51cf577d84d2337115714b92bdf7920bd5c05065ed4462e499d78a3514a6a249";
+      sha256 = "83a21e5fc16de4ab21d5917f50941140b167f3301e59b9ee13b58042b5d5e4fe";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b3/linux-x86_64/cs/firefox-113.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b4/linux-x86_64/cs/firefox-113.0b4.tar.bz2";
       locale = "cs";
       arch = "linux-x86_64";
-      sha256 = "fc9de60a742affbdda30953db2a1985ff9ffce32f47ec44201d556ed467f425b";
+      sha256 = "d0bb3f0194490e6a1225606d2f71a8b0f39c6a3bb782286f5f223693f5c94e01";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b3/linux-x86_64/cy/firefox-113.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b4/linux-x86_64/cy/firefox-113.0b4.tar.bz2";
       locale = "cy";
       arch = "linux-x86_64";
-      sha256 = "81bed8e3fd82a92858860c22dc0bf12599d1f6f64f70cae99d8726681d4e52f3";
+      sha256 = "41dd598b8dc8b672e35cfc3c020138c462cfae50dac94213f026684b7b0c24a8";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b3/linux-x86_64/da/firefox-113.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b4/linux-x86_64/da/firefox-113.0b4.tar.bz2";
       locale = "da";
       arch = "linux-x86_64";
-      sha256 = "97e558ad2f53fcf73d25b428987206293a57a8310994bcea653f58ffb2ab4d0b";
+      sha256 = "4568ab93f3589d1b1afea6a28be4bbdcb743b3a6e161f30046c5f4324ee7b188";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b3/linux-x86_64/de/firefox-113.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b4/linux-x86_64/de/firefox-113.0b4.tar.bz2";
       locale = "de";
       arch = "linux-x86_64";
-      sha256 = "8333b7db13cedb6cbecd054fe4e407230ed6043e9e59c2ac492e5670b4f4aad4";
+      sha256 = "4fc35860d8c4c371382a51f28eeced158dd0fceb5d097907350dac6ae25af798";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b3/linux-x86_64/dsb/firefox-113.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b4/linux-x86_64/dsb/firefox-113.0b4.tar.bz2";
       locale = "dsb";
       arch = "linux-x86_64";
-      sha256 = "abce6406ff07e883d3cfb0ff3ac6f82b805b6acd74dc189c19b021294966f848";
+      sha256 = "26d8cd12f60cf3ed44a24f1c16dd4b8f4bfb34095c457df6ac92ba4a56b35dbe";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b3/linux-x86_64/el/firefox-113.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b4/linux-x86_64/el/firefox-113.0b4.tar.bz2";
       locale = "el";
       arch = "linux-x86_64";
-      sha256 = "976afd9b339e12efad18eeca0f367aa663c982088d21ebe629588f96d16bfadf";
+      sha256 = "990a93cb5f325f9b4bdec516a780acbad7585ae26f4b90b6483975c1f1236df8";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b3/linux-x86_64/en-CA/firefox-113.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b4/linux-x86_64/en-CA/firefox-113.0b4.tar.bz2";
       locale = "en-CA";
       arch = "linux-x86_64";
-      sha256 = "ce2e0be3e1eecda5673fa3f22e6b99581dd9ff4d83d44a5e2cbb829fad020cb6";
+      sha256 = "240578f0a61edf14680d4b9a998259301ba0b04fe467ab77c9bb3755f21bf5d5";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b3/linux-x86_64/en-GB/firefox-113.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b4/linux-x86_64/en-GB/firefox-113.0b4.tar.bz2";
       locale = "en-GB";
       arch = "linux-x86_64";
-      sha256 = "1b58726ffc64d3ceff1938fd5802ba9f7327510c044c57c9d48f7bf705e7be25";
+      sha256 = "8afbf0f83369ca4d1a96f7551ae25ab247382fa1d768f2b9ee853a63ab7ec7b3";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b3/linux-x86_64/en-US/firefox-113.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b4/linux-x86_64/en-US/firefox-113.0b4.tar.bz2";
       locale = "en-US";
       arch = "linux-x86_64";
-      sha256 = "db9e0f4f801250a61838e4c97b5c276ba16fca98845458d5179692b4a17f7e96";
+      sha256 = "b7fe5cb9d9cf914175d8f6b12f9e162468a9208e40772fac63a15e8e7c3c9a1a";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b3/linux-x86_64/eo/firefox-113.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b4/linux-x86_64/eo/firefox-113.0b4.tar.bz2";
       locale = "eo";
       arch = "linux-x86_64";
-      sha256 = "a129c8c1b7e8ebe358ec3179f7c8ba3eed0e5774f3dcca8b6abebe864d6617f8";
+      sha256 = "3306326323347a481aa0072b79a5a4a407990f622eae68e220bedc777d3872f1";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b3/linux-x86_64/es-AR/firefox-113.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b4/linux-x86_64/es-AR/firefox-113.0b4.tar.bz2";
       locale = "es-AR";
       arch = "linux-x86_64";
-      sha256 = "7453891a95996e54633c83f196627cac1ef868cf992c963058c7492530e25824";
+      sha256 = "c2b89d9f17b725317c61753e1b3227c3326b5be226514212e8b5d61e6cb7777a";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b3/linux-x86_64/es-CL/firefox-113.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b4/linux-x86_64/es-CL/firefox-113.0b4.tar.bz2";
       locale = "es-CL";
       arch = "linux-x86_64";
-      sha256 = "f76fe51e46aeecca36b80b7d12f08fa459f8963148ae3c1543db00d72682c61b";
+      sha256 = "715f21235295544fc8e4f90d090f8ecdbb8804c168dc7e3d054db88abd0855c9";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b3/linux-x86_64/es-ES/firefox-113.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b4/linux-x86_64/es-ES/firefox-113.0b4.tar.bz2";
       locale = "es-ES";
       arch = "linux-x86_64";
-      sha256 = "c3fd2089cb514b3b7db5503e05b5750b71275d397dc2c90e044fdd013ee84add";
+      sha256 = "db786e3ab0ad59ad1ff8dfed973e738c6fb99283ee715a1539cb00336a7a8416";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b3/linux-x86_64/es-MX/firefox-113.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b4/linux-x86_64/es-MX/firefox-113.0b4.tar.bz2";
       locale = "es-MX";
       arch = "linux-x86_64";
-      sha256 = "c42fe3bbfa88ead27cb8a54801103f38b8de4eea62d8816161ff5639807db7a9";
+      sha256 = "e205fe060805082ada478f5ade6ac2bfc9d3fc6c5261ef84539bddbce0236a56";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b3/linux-x86_64/et/firefox-113.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b4/linux-x86_64/et/firefox-113.0b4.tar.bz2";
       locale = "et";
       arch = "linux-x86_64";
-      sha256 = "595405197e4290f1b1fc69c04cca41b68b8ab2fa65d65efa07905511957c5979";
+      sha256 = "88743293ceab6bb4699f52c6e769b24d5efb039d6186161914f3c40ca02f2441";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b3/linux-x86_64/eu/firefox-113.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b4/linux-x86_64/eu/firefox-113.0b4.tar.bz2";
       locale = "eu";
       arch = "linux-x86_64";
-      sha256 = "49e550e2b5f1a4a8c62f812c1b759fb6366be6a983bfaad1e9529cce22ed5b1f";
+      sha256 = "0eac6d0b26ed55bd5599c9da230af362ed75acaa2d5737d9fa328d5416133feb";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b3/linux-x86_64/fa/firefox-113.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b4/linux-x86_64/fa/firefox-113.0b4.tar.bz2";
       locale = "fa";
       arch = "linux-x86_64";
-      sha256 = "a3f558e9d0eed3f50a6463c58873bc46ef5cb82021a95613cf9f90ddc695f7bd";
+      sha256 = "9cd3e924e7b2ef70c3b5520c32aa006b0f080cf2b6bcc553474f83d00c5f908d";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b3/linux-x86_64/ff/firefox-113.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b4/linux-x86_64/ff/firefox-113.0b4.tar.bz2";
       locale = "ff";
       arch = "linux-x86_64";
-      sha256 = "2ca11444e4e74a6263f50c6d5e724f4500f4657c459e82ae36f1e7c8ec884c16";
+      sha256 = "e512906a47c886c1c2fe50cd666ca354e14b5ce24807c017be323818c66f051f";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b3/linux-x86_64/fi/firefox-113.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b4/linux-x86_64/fi/firefox-113.0b4.tar.bz2";
       locale = "fi";
       arch = "linux-x86_64";
-      sha256 = "254eb5fda287acd189a10ae684e3da3e31315abf1e06791e340e46418bb63bfd";
+      sha256 = "0add16ff8823269962cdbd9e7ef84fcbd0c7674d42de2686f673f9cc8a183a45";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b3/linux-x86_64/fr/firefox-113.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b4/linux-x86_64/fr/firefox-113.0b4.tar.bz2";
       locale = "fr";
       arch = "linux-x86_64";
-      sha256 = "3688a132f31e739dba4a7817b9352fa788d5b4736fcb95c7ad3f589d11f0b752";
+      sha256 = "ed523134172614b65791b5993b3337cbc0f0949edbb2ede11c955757d482b4e8";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b3/linux-x86_64/fur/firefox-113.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b4/linux-x86_64/fur/firefox-113.0b4.tar.bz2";
       locale = "fur";
       arch = "linux-x86_64";
-      sha256 = "bae5ed52fc711330b5697d16e7e5a2e7231ea16f98b00d477f521a37d4a48761";
+      sha256 = "9f8ae3d0d5965958a3bea863e5bb460a9d6d7959c10cca39485ae058fef54684";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b3/linux-x86_64/fy-NL/firefox-113.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b4/linux-x86_64/fy-NL/firefox-113.0b4.tar.bz2";
       locale = "fy-NL";
       arch = "linux-x86_64";
-      sha256 = "2d1c513577d83a24c2f114018ea58f4afcb97d7bd178aeddf298feff3ab35d35";
+      sha256 = "0588b7c79609fcab6771e3663d65af91ebd63cdb33594fbe7beb654f10cc9912";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b3/linux-x86_64/ga-IE/firefox-113.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b4/linux-x86_64/ga-IE/firefox-113.0b4.tar.bz2";
       locale = "ga-IE";
       arch = "linux-x86_64";
-      sha256 = "f20732c4db383f85ab80fddf921d455c0949d9a32dc42150d731c0bb2125044e";
+      sha256 = "84f7447193a5888006838c7dbc7b3df4f5cc81491140f64235079548c0d47fba";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b3/linux-x86_64/gd/firefox-113.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b4/linux-x86_64/gd/firefox-113.0b4.tar.bz2";
       locale = "gd";
       arch = "linux-x86_64";
-      sha256 = "6c296d330d340e1c8f408d8563415c1b02c0fa0970e47aa9cc198c2f53a8bbf0";
+      sha256 = "75a8a8df62ab893c652b7f4b3a714488298fee905855b9123a93fe1ffb0a730f";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b3/linux-x86_64/gl/firefox-113.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b4/linux-x86_64/gl/firefox-113.0b4.tar.bz2";
       locale = "gl";
       arch = "linux-x86_64";
-      sha256 = "ab9308332edb27f07817af57eff40a978f89641ebd949bdc89826e02f5fb01c2";
+      sha256 = "bbfb47bab16dbb83eff9897b6ee223dc4e9147670c9879fc8a16269f0c895556";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b3/linux-x86_64/gn/firefox-113.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b4/linux-x86_64/gn/firefox-113.0b4.tar.bz2";
       locale = "gn";
       arch = "linux-x86_64";
-      sha256 = "c26e1b7e80c504cdddf21b9b9674dfe8eec58690ff400f10624d59ec769b2a22";
+      sha256 = "4a80d30ed2ca80904f975fac1fcad49b3708f9ccc5370b4a124c0408ec44b0a8";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b3/linux-x86_64/gu-IN/firefox-113.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b4/linux-x86_64/gu-IN/firefox-113.0b4.tar.bz2";
       locale = "gu-IN";
       arch = "linux-x86_64";
-      sha256 = "8fc4a17c5cdd2e0cbf15a76ecf091e6c158ba20fd531221e0fb35cb5550667ac";
+      sha256 = "7a12884054a47b62671e640a94b9766cf607cd7072212afed05172d8005a62fc";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b3/linux-x86_64/he/firefox-113.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b4/linux-x86_64/he/firefox-113.0b4.tar.bz2";
       locale = "he";
       arch = "linux-x86_64";
-      sha256 = "8a54d600032f9218bc94aa60ff024ed93d403d41132ebc803b4b80a0c98268fc";
+      sha256 = "fe5b8e14ddb06970d999102e319007c8d18b38db675eee6058b25987be9fb354";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b3/linux-x86_64/hi-IN/firefox-113.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b4/linux-x86_64/hi-IN/firefox-113.0b4.tar.bz2";
       locale = "hi-IN";
       arch = "linux-x86_64";
-      sha256 = "0a1cbaaeb32fedebb41548ed78c12eeb041b8dfffeaf00f3f2f9a3ac75c8564c";
+      sha256 = "48d8dae0392067414ede355d3034220cbba1da2db134744e1940a35210d6a0ed";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b3/linux-x86_64/hr/firefox-113.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b4/linux-x86_64/hr/firefox-113.0b4.tar.bz2";
       locale = "hr";
       arch = "linux-x86_64";
-      sha256 = "52d12b639bf01bf1aa9ae7ffe79f098002975b908ebc9809e2019a1938270037";
+      sha256 = "4783758b0a598d3e937cb0717394500e894112c3aa33fa77c514a97d90bad560";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b3/linux-x86_64/hsb/firefox-113.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b4/linux-x86_64/hsb/firefox-113.0b4.tar.bz2";
       locale = "hsb";
       arch = "linux-x86_64";
-      sha256 = "3f64cab2885bf392cc966a77ee4f1df4fd0849e2b536219036aa876b9339eb72";
+      sha256 = "2d3a1b746fda95228f41490b3b249a4aecf96684cc99ac57284352e1325d6f49";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b3/linux-x86_64/hu/firefox-113.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b4/linux-x86_64/hu/firefox-113.0b4.tar.bz2";
       locale = "hu";
       arch = "linux-x86_64";
-      sha256 = "6bf1180d8c109aee19dd3a1e0228eb9bf7d29a7faa17f31e4fda2000d6c1f7e7";
+      sha256 = "3eddc1704cfe04ae6efcaed6f67cb4fd0f952ed890b3d3c10724812b95e4f18a";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b3/linux-x86_64/hy-AM/firefox-113.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b4/linux-x86_64/hy-AM/firefox-113.0b4.tar.bz2";
       locale = "hy-AM";
       arch = "linux-x86_64";
-      sha256 = "4ca2e09b827f99a3ccf1bfa3d97cc79c1102c038a62c1b40ebcb1bc39dbd09a7";
+      sha256 = "56883c3bc6c5383216031d4933a9a2c59c707769ab8d3d10fde6e8ecc501e4ca";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b3/linux-x86_64/ia/firefox-113.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b4/linux-x86_64/ia/firefox-113.0b4.tar.bz2";
       locale = "ia";
       arch = "linux-x86_64";
-      sha256 = "b3f8ef50e1a4f499208e5551b511395eec96d7c7be590d18b229fc61582c6ae3";
+      sha256 = "658c714e15477f7408f49f8c1aa2b2ecbf82c29f2e7e994a94834a66402b838d";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b3/linux-x86_64/id/firefox-113.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b4/linux-x86_64/id/firefox-113.0b4.tar.bz2";
       locale = "id";
       arch = "linux-x86_64";
-      sha256 = "8e056f4ac46211c52a89d983483f53ef516b851da347e4864ec330a993fdaed1";
+      sha256 = "39d9345f260a0667d407fb0f18ea10e6d9d4853594a7c34e5932009af4d28665";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b3/linux-x86_64/is/firefox-113.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b4/linux-x86_64/is/firefox-113.0b4.tar.bz2";
       locale = "is";
       arch = "linux-x86_64";
-      sha256 = "2b48170c820fa1a25bc94800d1d7aa4fc70ac0cc83366fcc8a276e551d382e91";
+      sha256 = "023cba20d9f4c34845486162353c514bd7a95917f04fcefa3b5d1cc905516eea";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b3/linux-x86_64/it/firefox-113.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b4/linux-x86_64/it/firefox-113.0b4.tar.bz2";
       locale = "it";
       arch = "linux-x86_64";
-      sha256 = "659bc56c0f8bb680d02a253cf7a5b61da2ee065d614ee088f70f55b71f1b1964";
+      sha256 = "ca7f7b524f0e606287b59ab558ca3c8a2da4432d973e58be19d8ede199cd6dff";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b3/linux-x86_64/ja/firefox-113.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b4/linux-x86_64/ja/firefox-113.0b4.tar.bz2";
       locale = "ja";
       arch = "linux-x86_64";
-      sha256 = "6fe45f38f1324e4666bbb0018f75dccd8faeeffc946d2cab5fbd619bd4bfd996";
+      sha256 = "1291da6d5f742f6acdfa7e1ad24a8c6d56f012909794185a320cb3065feadb8b";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b3/linux-x86_64/ka/firefox-113.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b4/linux-x86_64/ka/firefox-113.0b4.tar.bz2";
       locale = "ka";
       arch = "linux-x86_64";
-      sha256 = "e6eb048dfa91f34edb5dd89a98d8094c80eadb2d3768632f5667c56749c0db28";
+      sha256 = "a46ddc99bea340ce7e1faa7ff211971aebc803ea280fdee3a92ed5ef7fbf1f7a";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b3/linux-x86_64/kab/firefox-113.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b4/linux-x86_64/kab/firefox-113.0b4.tar.bz2";
       locale = "kab";
       arch = "linux-x86_64";
-      sha256 = "d7a7c52e66d9d6821e7489c575b2c99c5abbc9bef9908ee05e5e040649ca1e99";
+      sha256 = "4116a67ab0a88c89f262511cfdd8acff95554c38ec5418679bae1478d2d7bfe0";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b3/linux-x86_64/kk/firefox-113.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b4/linux-x86_64/kk/firefox-113.0b4.tar.bz2";
       locale = "kk";
       arch = "linux-x86_64";
-      sha256 = "cf2db01333083441185e3f6367937e3d3bfe8d1fe4b024de79298bf72327a92d";
+      sha256 = "f61e7df2ad9e578b25ad97d0b36b133214f1ca9db5373a724ad863e671a8eba5";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b3/linux-x86_64/km/firefox-113.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b4/linux-x86_64/km/firefox-113.0b4.tar.bz2";
       locale = "km";
       arch = "linux-x86_64";
-      sha256 = "bbfd4e23ce263066b18573861124ba188b36eae1b7e049ac9c0551be938308e5";
+      sha256 = "c03f48eceab957ec36766cfd87acb64eb2e6f522ed9932591da0fcb1311b4de8";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b3/linux-x86_64/kn/firefox-113.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b4/linux-x86_64/kn/firefox-113.0b4.tar.bz2";
       locale = "kn";
       arch = "linux-x86_64";
-      sha256 = "e3b1a0c70714cb5592f4537086645e3b318274853f88ef00655fb4bbfa82f783";
+      sha256 = "39f5df7a0d6e5c981485abded79276c2edd9575a31fd68798434cabc701a4093";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b3/linux-x86_64/ko/firefox-113.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b4/linux-x86_64/ko/firefox-113.0b4.tar.bz2";
       locale = "ko";
       arch = "linux-x86_64";
-      sha256 = "bbd63cfde19fb61ef3c3b9d0c879660cf807e71194571adb2e80f87f490ccb1a";
+      sha256 = "29c40b5b9c327ddd61fa6913a94111b3857d23fba5980874b6d244b92f2afb15";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b3/linux-x86_64/lij/firefox-113.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b4/linux-x86_64/lij/firefox-113.0b4.tar.bz2";
       locale = "lij";
       arch = "linux-x86_64";
-      sha256 = "7c8aced5f625b2ce78ed85e8c26ad92fb7aee15c2bba41fda4c7b10f860efb8f";
+      sha256 = "615923a0deaf6a13c4c8ec4b8dfae5ae46d9e1636747395fbf1fba21c07e96e2";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b3/linux-x86_64/lt/firefox-113.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b4/linux-x86_64/lt/firefox-113.0b4.tar.bz2";
       locale = "lt";
       arch = "linux-x86_64";
-      sha256 = "7c4d2a37457b62fa99b3e9074f238582bb9051d8c9470d5e1e110e8759d8ac90";
+      sha256 = "f6c96722d00c25e11642dacf80a7381d97c87a049a0cbdcc7628ddf9d4e2d8b7";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b3/linux-x86_64/lv/firefox-113.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b4/linux-x86_64/lv/firefox-113.0b4.tar.bz2";
       locale = "lv";
       arch = "linux-x86_64";
-      sha256 = "98a8b4e883c6c8a5aba0bad03c0917726d26f0dd664e7427edac940a89807f3f";
+      sha256 = "bf34546f55d8d0d53e0373c35813a4b5b90d2923dd6334bc77142b809971889e";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b3/linux-x86_64/mk/firefox-113.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b4/linux-x86_64/mk/firefox-113.0b4.tar.bz2";
       locale = "mk";
       arch = "linux-x86_64";
-      sha256 = "dfde6a228fdbaec671993be29d1c3152c25dd2ebac96bd9ad4080c27123567af";
+      sha256 = "e302cec5c63303b66a7a1278200ac169f6c0ae8345fe5fe638350591a54f8ef7";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b3/linux-x86_64/mr/firefox-113.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b4/linux-x86_64/mr/firefox-113.0b4.tar.bz2";
       locale = "mr";
       arch = "linux-x86_64";
-      sha256 = "d8909d1b754f06b4091a1ea052db0d977345fd15875b0e7b68478782b4202399";
+      sha256 = "b9e4c52b4e92d75fa25b596c65cd97d512f93c6d13706e6839b8872588cb9c98";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b3/linux-x86_64/ms/firefox-113.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b4/linux-x86_64/ms/firefox-113.0b4.tar.bz2";
       locale = "ms";
       arch = "linux-x86_64";
-      sha256 = "512c2dce6441e94b0c71fe321dc1443f54948c0eb3a4725a826a4622061302a5";
+      sha256 = "65dcb105a25fed6e9e4f792c5967f5e3465ab1ebb10df3b99e42a218f3790fe2";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b3/linux-x86_64/my/firefox-113.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b4/linux-x86_64/my/firefox-113.0b4.tar.bz2";
       locale = "my";
       arch = "linux-x86_64";
-      sha256 = "933fc7fab439eeffe0abc650a1bfc8eb8cc215e3d90f14dbff323fb448ae47bb";
+      sha256 = "44505363953c5f5640bd94fe7dbe552ee44c3d4ef931a273847c0ee7c1e264d2";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b3/linux-x86_64/nb-NO/firefox-113.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b4/linux-x86_64/nb-NO/firefox-113.0b4.tar.bz2";
       locale = "nb-NO";
       arch = "linux-x86_64";
-      sha256 = "4cc626dfa7f72c197a67b9c3340f54b4a7c4f7d26277d04b23be0021fbae2670";
+      sha256 = "76f81c9d55c602d53a60ac9f71883840dc083664d480042387fdb2a9837b105f";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b3/linux-x86_64/ne-NP/firefox-113.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b4/linux-x86_64/ne-NP/firefox-113.0b4.tar.bz2";
       locale = "ne-NP";
       arch = "linux-x86_64";
-      sha256 = "13e78aa9d426239c459444054bcbc182fa6f0773e363bf694311026ade067835";
+      sha256 = "aeec5fc9f658befca5c3c969ac46148291d5cac68a6d884ac36d0711f014c22f";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b3/linux-x86_64/nl/firefox-113.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b4/linux-x86_64/nl/firefox-113.0b4.tar.bz2";
       locale = "nl";
       arch = "linux-x86_64";
-      sha256 = "1b0abf464c3d116b312097b97747e970c783261fba8e76c3613825f5229360a1";
+      sha256 = "b0b8f373fecd653e0780b7540f8d6707a974953321a0583d2a253a0bc1e250bb";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b3/linux-x86_64/nn-NO/firefox-113.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b4/linux-x86_64/nn-NO/firefox-113.0b4.tar.bz2";
       locale = "nn-NO";
       arch = "linux-x86_64";
-      sha256 = "f768b8f90394c47c4e61e6b216ce2b2913ee0dddeef81a58682701931a941da4";
+      sha256 = "63460ca2e898710807ce2ef5fe2b6487239e994735097a774a07318ae72efe1a";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b3/linux-x86_64/oc/firefox-113.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b4/linux-x86_64/oc/firefox-113.0b4.tar.bz2";
       locale = "oc";
       arch = "linux-x86_64";
-      sha256 = "23f2e83f74623cffa4e5427fe06f1fa71c10a9d8e23e2c24e689811a4059ba2c";
+      sha256 = "2d7394bca2c47900465136a13badd18d558738c3123e3ebc836e186e72182f49";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b3/linux-x86_64/pa-IN/firefox-113.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b4/linux-x86_64/pa-IN/firefox-113.0b4.tar.bz2";
       locale = "pa-IN";
       arch = "linux-x86_64";
-      sha256 = "bd3c761482ac0af1484adab67f25c60a9f34cd5b832c919df8d6c7601cc9c8cd";
+      sha256 = "92ab6a3700deb6385b464dfeece0f69d0ef2cd38bccce7dffdf5c93c4c6b0e7f";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b3/linux-x86_64/pl/firefox-113.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b4/linux-x86_64/pl/firefox-113.0b4.tar.bz2";
       locale = "pl";
       arch = "linux-x86_64";
-      sha256 = "1116be88eadbc6104ddc4044618eff55ecff6cdc86f55ebf1e47b49f1f6e278e";
+      sha256 = "b83928f19a06095f35c3c4f1e79f14c6a5afc7fd5de3435984f6110b7938b4c0";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b3/linux-x86_64/pt-BR/firefox-113.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b4/linux-x86_64/pt-BR/firefox-113.0b4.tar.bz2";
       locale = "pt-BR";
       arch = "linux-x86_64";
-      sha256 = "ba0b99202545dca73ccefa699de75507fc6f8082f40133cf71e9af8465dd97dd";
+      sha256 = "1044aebccdc33a59492a6315cfd54959ef3e7918297253a7de2a22356fc0947a";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b3/linux-x86_64/pt-PT/firefox-113.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b4/linux-x86_64/pt-PT/firefox-113.0b4.tar.bz2";
       locale = "pt-PT";
       arch = "linux-x86_64";
-      sha256 = "2a49f9459477854612fc44c8663cb1ce6cd88779d96d4d51b13a3afce6a2373c";
+      sha256 = "d7999b295a7adc9aba65106e803f7e11ba7317dce074dcb4a0392ff3927291f2";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b3/linux-x86_64/rm/firefox-113.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b4/linux-x86_64/rm/firefox-113.0b4.tar.bz2";
       locale = "rm";
       arch = "linux-x86_64";
-      sha256 = "e13e427123a6adaa01cc39ad0efb06cff49c9377d36447ef8d732d75670b52a1";
+      sha256 = "931ea3976f962b48af6dd8ea1fc3dbd21eab71d82e247307b9c00e3f50459a48";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b3/linux-x86_64/ro/firefox-113.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b4/linux-x86_64/ro/firefox-113.0b4.tar.bz2";
       locale = "ro";
       arch = "linux-x86_64";
-      sha256 = "1c0160e1769f5984f50643c0770ba4220cd54cef1a3aed7fc8440ea0980350cf";
+      sha256 = "5f23a8a62b6246268c98fabed9ba8ca76cfc94f8bb8cdc6608df674438114eda";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b3/linux-x86_64/ru/firefox-113.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b4/linux-x86_64/ru/firefox-113.0b4.tar.bz2";
       locale = "ru";
       arch = "linux-x86_64";
-      sha256 = "29a12a83b2a42f3bc57fc62890977b10fc9bb95d02864be42a43b83bbd7f95f5";
+      sha256 = "76976d869ade535b35ed2e4559333a24e61f206937b02a4da453007077c49274";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b3/linux-x86_64/sc/firefox-113.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b4/linux-x86_64/sc/firefox-113.0b4.tar.bz2";
       locale = "sc";
       arch = "linux-x86_64";
-      sha256 = "9cdc0cf8fc7fcab7a6db73be7b474c44514d3434896c20c65ac76c0f08760366";
+      sha256 = "58c1c69e69d22c2886b5686ddb1ee8ac27c22c91c796ecb116f11cdce75ec472";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b3/linux-x86_64/sco/firefox-113.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b4/linux-x86_64/sco/firefox-113.0b4.tar.bz2";
       locale = "sco";
       arch = "linux-x86_64";
-      sha256 = "15d98ceb6c298d062c749089790f4c7a0d7e4629b1543e2361cd787d468c00a5";
+      sha256 = "5a281ca8c242fe6021225ea13f956d47045fbf7890e95c90ffb0f571af6c9c77";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b3/linux-x86_64/si/firefox-113.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b4/linux-x86_64/si/firefox-113.0b4.tar.bz2";
       locale = "si";
       arch = "linux-x86_64";
-      sha256 = "19da488743c082b36a7e97a9c98444c68690929f0f6ce8e83f6ab3b24cfb819b";
+      sha256 = "3a881bcdc916cfab452f2bc631bdea3fdc7edd028a70e1c848e7497842d43c20";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b3/linux-x86_64/sk/firefox-113.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b4/linux-x86_64/sk/firefox-113.0b4.tar.bz2";
       locale = "sk";
       arch = "linux-x86_64";
-      sha256 = "ce568ae8884ef2c2b1343f21501233b4263cc09e6e7680886b0ae6e77fad63c9";
+      sha256 = "2e49e2e6258388edea5e0901fcc0522017925045361852f204d5d3286805d251";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b3/linux-x86_64/sl/firefox-113.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b4/linux-x86_64/sl/firefox-113.0b4.tar.bz2";
       locale = "sl";
       arch = "linux-x86_64";
-      sha256 = "8a7cf672a655b72bf4191e3141e91852fa3265fdd83f735f9ce5682f2d3c67ee";
+      sha256 = "1fe7987b5a544f876147d6c15293d934921a0da1599a0668ede49f938f1da4aa";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b3/linux-x86_64/son/firefox-113.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b4/linux-x86_64/son/firefox-113.0b4.tar.bz2";
       locale = "son";
       arch = "linux-x86_64";
-      sha256 = "20af0c36f52805bd8d80a941db12858bf899b1d3bfd15127c1796b5952551069";
+      sha256 = "8cf548e594f7397fe2b15a89ea1113ae48bf6999a37d32ea231106d10c06177c";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b3/linux-x86_64/sq/firefox-113.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b4/linux-x86_64/sq/firefox-113.0b4.tar.bz2";
       locale = "sq";
       arch = "linux-x86_64";
-      sha256 = "beaa36d8c13da439ef9082b19e7dd0ff95e09973239f659f4464f8aea4f9caed";
+      sha256 = "0120f4957c375eb78d07188ede2e5e9f7feee53899e93d72e4eb839fbe862200";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b3/linux-x86_64/sr/firefox-113.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b4/linux-x86_64/sr/firefox-113.0b4.tar.bz2";
       locale = "sr";
       arch = "linux-x86_64";
-      sha256 = "d3e48cecfadc1797e0fe458c666d9f3aa14c3a051d0957545bfb08db80e34fc5";
+      sha256 = "ff862d5f965b7afb89f22f0575734509da5ffb59e786442df773f0a1fb174a11";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b3/linux-x86_64/sv-SE/firefox-113.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b4/linux-x86_64/sv-SE/firefox-113.0b4.tar.bz2";
       locale = "sv-SE";
       arch = "linux-x86_64";
-      sha256 = "cc5083018604e1592d07b08ab8be20a2c5b5a2c6abddf032acedbe1d04567996";
+      sha256 = "bdb27a923632e3fe5aebc7247bf77c36fd4e84798bfce483d64b9bfda2712e83";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b3/linux-x86_64/szl/firefox-113.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b4/linux-x86_64/szl/firefox-113.0b4.tar.bz2";
       locale = "szl";
       arch = "linux-x86_64";
-      sha256 = "b4991ea53a1770a6788e5e867f18aef906af53d706fe106dda7d0a4f65e290d4";
+      sha256 = "04b7df5690ca4b9151975ceee725b66eadb62b6568d8eb184c78ab9a77507c55";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b3/linux-x86_64/ta/firefox-113.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b4/linux-x86_64/ta/firefox-113.0b4.tar.bz2";
       locale = "ta";
       arch = "linux-x86_64";
-      sha256 = "17fdfa32e49b0c7701b2953f0d57142e5c7a51bbc6f690ed51780a29a9b88e4b";
+      sha256 = "af7842a9cfe51340119101e769c998e78d5f304b2746fda0bb2b87cbdac032ec";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b3/linux-x86_64/te/firefox-113.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b4/linux-x86_64/te/firefox-113.0b4.tar.bz2";
       locale = "te";
       arch = "linux-x86_64";
-      sha256 = "3070c176bcdc7bfeb22364094e1debcce8df50f4831fe4375d6661db4c6acf56";
+      sha256 = "e42529c812d3ed862979887ef8d08ac35b21fda3df5defe072ee2533634b69d0";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b3/linux-x86_64/tg/firefox-113.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b4/linux-x86_64/tg/firefox-113.0b4.tar.bz2";
       locale = "tg";
       arch = "linux-x86_64";
-      sha256 = "36be8ed845dc32582a4738593d6ac8f2b75165a729988d14dfdb7c410bf7dfe9";
+      sha256 = "ad81d51e62417f9b58aa139cea1f9a0520c472657b4d61b583b724a8eb1593ec";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b3/linux-x86_64/th/firefox-113.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b4/linux-x86_64/th/firefox-113.0b4.tar.bz2";
       locale = "th";
       arch = "linux-x86_64";
-      sha256 = "cd5947ed251b2214a0dbc8c44929c4ddb12cc7ca0a19be9ecf13764d111485a2";
+      sha256 = "0496f3df038d3d4029234c23633bb65b6f6bf665860cdb1a69c6ed596affaf11";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b3/linux-x86_64/tl/firefox-113.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b4/linux-x86_64/tl/firefox-113.0b4.tar.bz2";
       locale = "tl";
       arch = "linux-x86_64";
-      sha256 = "5bba1fee9e86882bdac3af769ce3ec0beaad9468422a1fb782f0d59e7de76b81";
+      sha256 = "c4cba7d19baf14c0d9299ec78937d83d6a6218a2809d77d254e9ebae9ca1c08e";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b3/linux-x86_64/tr/firefox-113.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b4/linux-x86_64/tr/firefox-113.0b4.tar.bz2";
       locale = "tr";
       arch = "linux-x86_64";
-      sha256 = "4175a557d4d09b8e7ffac76844a201e7c30be68c4b3d0af2a42cb20924d364e4";
+      sha256 = "121196bd67ee3ab5f1faf9c0b90d755d3cf50d24176daa5ecaf3fc8745b3f9c6";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b3/linux-x86_64/trs/firefox-113.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b4/linux-x86_64/trs/firefox-113.0b4.tar.bz2";
       locale = "trs";
       arch = "linux-x86_64";
-      sha256 = "85ebfaacdcaf358ef3f0740dff61cf8dad5dff98fdd6bfcddf318f863a5a4d8a";
+      sha256 = "38bdc1e42da4c69046e5ce7004cc07023300011f5a9ecd5036df7eb40d4380fc";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b3/linux-x86_64/uk/firefox-113.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b4/linux-x86_64/uk/firefox-113.0b4.tar.bz2";
       locale = "uk";
       arch = "linux-x86_64";
-      sha256 = "3d12679a7a0d503d88f09cc1d0939b32b5395b302c3aa103b1426981f9cf7eb5";
+      sha256 = "0f431bf61fc940024e25ecc1661b538ba180782fec84e5261c4828eaf1d6a017";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b3/linux-x86_64/ur/firefox-113.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b4/linux-x86_64/ur/firefox-113.0b4.tar.bz2";
       locale = "ur";
       arch = "linux-x86_64";
-      sha256 = "bf8c0406b9812e25b25a4ae73389164e79351f6e1d490e17a702c0fb382552ac";
+      sha256 = "9bd5157175c8ef7145f64659cef0141eae74a97a55fedac097fd8facd3280536";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b3/linux-x86_64/uz/firefox-113.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b4/linux-x86_64/uz/firefox-113.0b4.tar.bz2";
       locale = "uz";
       arch = "linux-x86_64";
-      sha256 = "0567b59aea40ad494b77a5f63695523bc38d8aeed16b10272d3f2f53b249cfe9";
+      sha256 = "7dcdaa9c2113bcbee34627595cf343301633bd1299baa805d9ee34096c992ec7";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b3/linux-x86_64/vi/firefox-113.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b4/linux-x86_64/vi/firefox-113.0b4.tar.bz2";
       locale = "vi";
       arch = "linux-x86_64";
-      sha256 = "f114bc8ecf3ed09af1dd1075cf3fd0b214d1cc2089de14dc41ddc5df56b73d48";
+      sha256 = "8037c30c27316f0be0bd354ef0105728486a0e850d646dff311773fe68707d7a";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b3/linux-x86_64/xh/firefox-113.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b4/linux-x86_64/xh/firefox-113.0b4.tar.bz2";
       locale = "xh";
       arch = "linux-x86_64";
-      sha256 = "1fa8ef52444c81c549c6ea27382108e05a5aa1b9797c3a3c88125b9567e3402c";
+      sha256 = "65b8d38986361fd1a4c47480e7325db93e3de04f534a3d5905e2717121d16fb9";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b3/linux-x86_64/zh-CN/firefox-113.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b4/linux-x86_64/zh-CN/firefox-113.0b4.tar.bz2";
       locale = "zh-CN";
       arch = "linux-x86_64";
-      sha256 = "4dea0d6c011d7a50895c477de5a19311ec395b27c4f2a3a52b5a1de680949cea";
+      sha256 = "ed13763d037cc3256cd66e606231ca9580431b99d6798c1c8bd4e3563fd1be3f";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b3/linux-x86_64/zh-TW/firefox-113.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b4/linux-x86_64/zh-TW/firefox-113.0b4.tar.bz2";
       locale = "zh-TW";
       arch = "linux-x86_64";
-      sha256 = "d595377884546ebffc39a987326fba4c8bebea1bf7105f7fdb7458a5bb469f23";
+      sha256 = "255d3cd276ebef5772cb4c64dd6cb6d48a569df145f52599487c0cf974ea8598";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b3/linux-i686/ach/firefox-113.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b4/linux-i686/ach/firefox-113.0b4.tar.bz2";
       locale = "ach";
       arch = "linux-i686";
-      sha256 = "8728e0f01e83436883a49c94a236164d47e1839ecec12f44ffefe983b714a136";
+      sha256 = "3d8f8203a23f1937bb0bca5ca198ca91a6d1e4e505acd0cf64dba8a1599e7980";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b3/linux-i686/af/firefox-113.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b4/linux-i686/af/firefox-113.0b4.tar.bz2";
       locale = "af";
       arch = "linux-i686";
-      sha256 = "9ffc7ad781be1717e0c4b5f63679f40abcec98e6d1b203233ca969d79c1c5141";
+      sha256 = "2d3a9d197bf96389369f36271ba6b6ac484787e19554d9c50fcc746ffcff3ee8";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b3/linux-i686/an/firefox-113.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b4/linux-i686/an/firefox-113.0b4.tar.bz2";
       locale = "an";
       arch = "linux-i686";
-      sha256 = "839fe205dcd425d04faa48d02793fac8efaea3290efaf9f67225181219997c4e";
+      sha256 = "74944b6bdaec3d713f36c6801868b9c6e0c08b0eeaaab9285c2748c40cbfc6e7";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b3/linux-i686/ar/firefox-113.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b4/linux-i686/ar/firefox-113.0b4.tar.bz2";
       locale = "ar";
       arch = "linux-i686";
-      sha256 = "b1d3282ac081ac22632cbc4d8ecdaf74dbceb0d511ca0a19f02ac0d43cc1e6ab";
+      sha256 = "a2a7a45192845c8d1514a55e24086cc6f873014e10d9a43e430aaa58e0898afc";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b3/linux-i686/ast/firefox-113.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b4/linux-i686/ast/firefox-113.0b4.tar.bz2";
       locale = "ast";
       arch = "linux-i686";
-      sha256 = "d79ab280799de47d1406a6ea3ab80d57d9409a9809472f69eb979ae953640496";
+      sha256 = "4f438dd3afda39c754bb0010e3a81ac3fae4a482576552120683fc22852e3b6f";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b3/linux-i686/az/firefox-113.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b4/linux-i686/az/firefox-113.0b4.tar.bz2";
       locale = "az";
       arch = "linux-i686";
-      sha256 = "518ae701e0dbd05fd326c07387ae70d7247fbb3806ed258cf60c4bef87a3d640";
+      sha256 = "ff3f9abb2b55f84184a722204d966aaabe94731ecce2410755d6d9eb49a132b3";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b3/linux-i686/be/firefox-113.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b4/linux-i686/be/firefox-113.0b4.tar.bz2";
       locale = "be";
       arch = "linux-i686";
-      sha256 = "60d6a6cad8db3c5157e18408db2535c21789d99ea653b5bd41ef73622415fbc2";
+      sha256 = "5788d683bbf2d6f87984a74b283b250baae11572454f91ab187ca7e6da128e0c";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b3/linux-i686/bg/firefox-113.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b4/linux-i686/bg/firefox-113.0b4.tar.bz2";
       locale = "bg";
       arch = "linux-i686";
-      sha256 = "4ec186e57154c2186aa934c4611a897c77fe770fec9c78dd0acd3594485bb98b";
+      sha256 = "1008ea1147e0dd1caae8bc614abed7fda3b5597efa36f0908cf4bcbe0bc89a22";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b3/linux-i686/bn/firefox-113.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b4/linux-i686/bn/firefox-113.0b4.tar.bz2";
       locale = "bn";
       arch = "linux-i686";
-      sha256 = "897370c15b2edda12c31ac02c1bb6fe2d605252aa59ae086cf59d5d88746328e";
+      sha256 = "1c21174ddd85c80a52bd5d1b16c909e247f56a05b97ed587a19b9a0bd417abd8";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b3/linux-i686/br/firefox-113.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b4/linux-i686/br/firefox-113.0b4.tar.bz2";
       locale = "br";
       arch = "linux-i686";
-      sha256 = "81dafb76ac0fa134994cafbd6ed4b3b84f89544eb03b21c66558d3966ad30c18";
+      sha256 = "d25ffcfb920ed4566413a83c84d9b2a4b2338e7d9871a0a45f3fcb5110a83023";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b3/linux-i686/bs/firefox-113.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b4/linux-i686/bs/firefox-113.0b4.tar.bz2";
       locale = "bs";
       arch = "linux-i686";
-      sha256 = "8ad4cf2ec75a776be2c1dabe69d9569ebe1eb9f5dfc997c48ec12f0e721fd3b8";
+      sha256 = "21bea1cbb19f76a82ae561d3ca9408e796373ccf297bd7925292e2b7ce57b74c";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b3/linux-i686/ca-valencia/firefox-113.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b4/linux-i686/ca-valencia/firefox-113.0b4.tar.bz2";
       locale = "ca-valencia";
       arch = "linux-i686";
-      sha256 = "080b8c4a3ef62e1be3591b09f881dd6898cd55c193dcafe32d0689ee9285b531";
+      sha256 = "49b426208d239603a27c2f60e7309065ba63b84c9a7d54f0cab63e7108cf47b7";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b3/linux-i686/ca/firefox-113.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b4/linux-i686/ca/firefox-113.0b4.tar.bz2";
       locale = "ca";
       arch = "linux-i686";
-      sha256 = "02b24230fc52ef367f3beef455e038d4758750bd886571708188fc76712adde2";
+      sha256 = "8bfb905dc540af1dc0b5dc18d5ce0199559a11d3be64f6d737588ca4df438b6d";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b3/linux-i686/cak/firefox-113.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b4/linux-i686/cak/firefox-113.0b4.tar.bz2";
       locale = "cak";
       arch = "linux-i686";
-      sha256 = "7ded3141ca0eae6f5f2f700d6dde870c4f4fbae12b9a84c190f186b3628b3380";
+      sha256 = "cc99d3f74eaaac8b7e6c73b6613f1bea75ef62faeef836e49a1355857dfb18d5";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b3/linux-i686/cs/firefox-113.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b4/linux-i686/cs/firefox-113.0b4.tar.bz2";
       locale = "cs";
       arch = "linux-i686";
-      sha256 = "5440247b433343b612ab670baeb1aea375a0041837d1dbb0c4e7ee98fa1c4d15";
+      sha256 = "ea41a1b5dd5452408a8f30a425c40dab8cc93969dd0270dd135e0d69af7f714f";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b3/linux-i686/cy/firefox-113.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b4/linux-i686/cy/firefox-113.0b4.tar.bz2";
       locale = "cy";
       arch = "linux-i686";
-      sha256 = "71e28c55e3b808f357e7a4940770e306517b20fc7dd1ac86527c3bedbd232c5a";
+      sha256 = "4f292f687cd087107218ca7a4559e302686bf0e721515d360c3a9d230a71586a";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b3/linux-i686/da/firefox-113.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b4/linux-i686/da/firefox-113.0b4.tar.bz2";
       locale = "da";
       arch = "linux-i686";
-      sha256 = "e2663c27d53b0e62702703b8d1298302f81e644a287efef2785cab91773f6228";
+      sha256 = "ba24357939ad19eac0cd60aab308e9601526029f6c4d1703e6b6ce77126127e1";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b3/linux-i686/de/firefox-113.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b4/linux-i686/de/firefox-113.0b4.tar.bz2";
       locale = "de";
       arch = "linux-i686";
-      sha256 = "3e5623a3d1251c4bacf46b740e61d669aefbcbf84fdc6b3ee052c5d51a0292ef";
+      sha256 = "f21b0581ec94aaf6c402d700ed3ffe82a35ca6f9b7be140a573eb8f912d15cd8";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b3/linux-i686/dsb/firefox-113.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b4/linux-i686/dsb/firefox-113.0b4.tar.bz2";
       locale = "dsb";
       arch = "linux-i686";
-      sha256 = "f3771e6182aa343c4155ff6632da8ccf88a1702665d38f29f6d613b65580b336";
+      sha256 = "6f7624a3efc1a7ca08406dbf73bc0ea7eb8444a146d60579bb079eb0c748508d";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b3/linux-i686/el/firefox-113.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b4/linux-i686/el/firefox-113.0b4.tar.bz2";
       locale = "el";
       arch = "linux-i686";
-      sha256 = "bf13f06cab00922ec5678cb4db3d2f8b4e7ba05b0fe3a7ebbc3520f1fecff42d";
+      sha256 = "8daa34a6de7a3be7a3d7280a14c5b0bbd78582017b15a4680aad0a1eab2ff791";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b3/linux-i686/en-CA/firefox-113.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b4/linux-i686/en-CA/firefox-113.0b4.tar.bz2";
       locale = "en-CA";
       arch = "linux-i686";
-      sha256 = "6d0ed002a0845f817eee536e2cf1a680e3a20270d05386471a47e0da9878c896";
+      sha256 = "6f9091352b42d23262a9858676fa6a22844881f52385595704a8b2cad2f8b285";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b3/linux-i686/en-GB/firefox-113.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b4/linux-i686/en-GB/firefox-113.0b4.tar.bz2";
       locale = "en-GB";
       arch = "linux-i686";
-      sha256 = "f31564bff77c11ac12088bb446be1b8d30b9e99d394967a17d4b2fc429b3858c";
+      sha256 = "8e9bfaab64dc066d1e1087b3efb6aa3b40e4321a1925034653730bd917137fca";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b3/linux-i686/en-US/firefox-113.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b4/linux-i686/en-US/firefox-113.0b4.tar.bz2";
       locale = "en-US";
       arch = "linux-i686";
-      sha256 = "b6aa66646a956e2b366723d69c9a839854ba985bb130a7e1533a19e50726796d";
+      sha256 = "d73ecdeec81e643f57e1c231a99bffd96bbedefa085f5629f8ea9e0ba29cdf55";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b3/linux-i686/eo/firefox-113.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b4/linux-i686/eo/firefox-113.0b4.tar.bz2";
       locale = "eo";
       arch = "linux-i686";
-      sha256 = "57bcf89d9d860513685d72e85cb122fdb3cb8f7028caaa58353d2664af0d0741";
+      sha256 = "99230cbde8f0d0203f3afe9ab51026d3311c8372c15a1a73c4d17499bd659bd6";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b3/linux-i686/es-AR/firefox-113.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b4/linux-i686/es-AR/firefox-113.0b4.tar.bz2";
       locale = "es-AR";
       arch = "linux-i686";
-      sha256 = "312fc1c029c377dd402425637e620bf48bae21fa666f1cc5ca341fb87c4257ad";
+      sha256 = "a4eb35fd6425983b9f39b397ace40199f7db80b8604181e66a5f006a0046386c";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b3/linux-i686/es-CL/firefox-113.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b4/linux-i686/es-CL/firefox-113.0b4.tar.bz2";
       locale = "es-CL";
       arch = "linux-i686";
-      sha256 = "f2a61f17cc416e8a96b0292d8b298347a3693b9e9cee238fbb7d9a2c25b5441b";
+      sha256 = "138eae3a0bf3f5153cb8869e97fd2c73d0f0a929420eced07e6972a5a59a7af2";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b3/linux-i686/es-ES/firefox-113.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b4/linux-i686/es-ES/firefox-113.0b4.tar.bz2";
       locale = "es-ES";
       arch = "linux-i686";
-      sha256 = "97ed6e13083df4a0bbef1304f88730a6f1bfe52cf6b5e9fefaa11584d691a6c9";
+      sha256 = "4bb9af1ccfe569cd1661b9a4781991ef60220142f73b77a10f943cce57dc4c63";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b3/linux-i686/es-MX/firefox-113.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b4/linux-i686/es-MX/firefox-113.0b4.tar.bz2";
       locale = "es-MX";
       arch = "linux-i686";
-      sha256 = "f172976aebc3b660d5d79f6a5f12438a9fed530e4061e145ffd3aada8987433f";
+      sha256 = "e9999b0af6ccb84ad6ab143a00a676ce65377c3b81a796d796c691ee222e92da";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b3/linux-i686/et/firefox-113.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b4/linux-i686/et/firefox-113.0b4.tar.bz2";
       locale = "et";
       arch = "linux-i686";
-      sha256 = "50c5970aec24af4c2aa099a9aa0a80c1be02acbfd735c7802be615abdcdf875d";
+      sha256 = "e91688eaf4ad293d097b5bbaab95a3c04ba3e7292176aad116aee201d0fa25f5";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b3/linux-i686/eu/firefox-113.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b4/linux-i686/eu/firefox-113.0b4.tar.bz2";
       locale = "eu";
       arch = "linux-i686";
-      sha256 = "39c3e18625ba3f6dd107275d35c295d247a87db1eb5a38f590ceba087933e580";
+      sha256 = "563fbfde720e65905e4df5063389f9f0cf3ac7b435f0e48fea4943781287abe8";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b3/linux-i686/fa/firefox-113.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b4/linux-i686/fa/firefox-113.0b4.tar.bz2";
       locale = "fa";
       arch = "linux-i686";
-      sha256 = "fcf316aba06ff5f7a8b38f9873a9387074580f59395f8e0eb808f58ac9d8bdee";
+      sha256 = "0d8d95804aaadf0abe3f6efd6ca463d99248dc20ac7f45252705de6044694583";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b3/linux-i686/ff/firefox-113.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b4/linux-i686/ff/firefox-113.0b4.tar.bz2";
       locale = "ff";
       arch = "linux-i686";
-      sha256 = "7132fe3326ff273108c507e9ebecc1e5b942dc5ba824297cf61afc9cdad2356d";
+      sha256 = "63c231f6956ad1305b80c2f60dd48792a50aa1c69ba72e5aca082c675c11941a";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b3/linux-i686/fi/firefox-113.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b4/linux-i686/fi/firefox-113.0b4.tar.bz2";
       locale = "fi";
       arch = "linux-i686";
-      sha256 = "2beee337bd5f1e5aae2cc7d86a92902bc470c87fddcc06863b438e2cf55efcac";
+      sha256 = "82e9e91201582324d55c38ba19b036422076d084ae32625aaec08e404ff53ee6";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b3/linux-i686/fr/firefox-113.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b4/linux-i686/fr/firefox-113.0b4.tar.bz2";
       locale = "fr";
       arch = "linux-i686";
-      sha256 = "63d18c5a4de119d8372053fd2c1f8cfe8488b242921fe9de65bb10d2f22044e1";
+      sha256 = "543f408db05692407be94c1d216768e0095b1e19c8ff5d4497a179a2a6892037";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b3/linux-i686/fur/firefox-113.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b4/linux-i686/fur/firefox-113.0b4.tar.bz2";
       locale = "fur";
       arch = "linux-i686";
-      sha256 = "c1087ba2f7c59f488a774ab5eeeae445dbc00b20077090ba1e09eb5ebc52cf5c";
+      sha256 = "8538f3309b76d455a33fef08e66189c798539ee57d485016093c5b3efc26d991";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b3/linux-i686/fy-NL/firefox-113.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b4/linux-i686/fy-NL/firefox-113.0b4.tar.bz2";
       locale = "fy-NL";
       arch = "linux-i686";
-      sha256 = "ed71d8285f99a714c402305d59e7e3b12d53e4f38f4fba496411097b2da28d2b";
+      sha256 = "1db4fc67530c2d8a6d5810254181f35cf7c267940f8f70c6c8dae14044b6055b";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b3/linux-i686/ga-IE/firefox-113.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b4/linux-i686/ga-IE/firefox-113.0b4.tar.bz2";
       locale = "ga-IE";
       arch = "linux-i686";
-      sha256 = "a169ed3ce324b965f9d0f54d6daa300a74e76a329f7dd8082cb87ffd00dd947b";
+      sha256 = "a64302e2d33594c898186a15f462745d18cf37ab26d3bad72738bd2ee5274a55";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b3/linux-i686/gd/firefox-113.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b4/linux-i686/gd/firefox-113.0b4.tar.bz2";
       locale = "gd";
       arch = "linux-i686";
-      sha256 = "f4faefc88c59f901c865f2e4e720f9acd7b9cf4b194327b847f2077d62dd7d07";
+      sha256 = "85a8af67e1311df497f2090ebe311b2759170ef227d8091238f74b923d608342";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b3/linux-i686/gl/firefox-113.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b4/linux-i686/gl/firefox-113.0b4.tar.bz2";
       locale = "gl";
       arch = "linux-i686";
-      sha256 = "5f0d4cd603d82e4cc67f0f2b357027930fe9dc1fa07a6ac4b30a576bcff23ce3";
+      sha256 = "76db7d4d8b99a19b37270b8daa2049d4e85c5db8db2b172cd2fffb8f5b8d22da";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b3/linux-i686/gn/firefox-113.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b4/linux-i686/gn/firefox-113.0b4.tar.bz2";
       locale = "gn";
       arch = "linux-i686";
-      sha256 = "de11b7da29f4c8b14dc7344977e8d01b2c6f662e274c0b921e8aacee0526abb4";
+      sha256 = "39c52d434405b28ab44162d1c8f72acb60843278a9b67eeae61875de4ef046d4";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b3/linux-i686/gu-IN/firefox-113.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b4/linux-i686/gu-IN/firefox-113.0b4.tar.bz2";
       locale = "gu-IN";
       arch = "linux-i686";
-      sha256 = "e1dd62aa9f39b1a7206a314aede814c0ccd2597b4f8a977d4e94b67ed00633bc";
+      sha256 = "f5e5a2db396ad33837f3815594ac8a60e85deea7f3bda96c2aed0b8aabaa4af1";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b3/linux-i686/he/firefox-113.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b4/linux-i686/he/firefox-113.0b4.tar.bz2";
       locale = "he";
       arch = "linux-i686";
-      sha256 = "8096d914ab544fccd11d14b6d9ff6b730dd03ce7b45ed05485ce49e803792a96";
+      sha256 = "943ce126ed6eef3aea32227e22ad0093e3128ac14be020eaccbd9d6ea8a412cd";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b3/linux-i686/hi-IN/firefox-113.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b4/linux-i686/hi-IN/firefox-113.0b4.tar.bz2";
       locale = "hi-IN";
       arch = "linux-i686";
-      sha256 = "7e4c174ff52f4ddb8bda8eb628bf3b7074ad08ab8da1fb91e53fba71c2c395ca";
+      sha256 = "f412eeac8e736de6517ac7a05e3f3ab044d02f102e7ec3c4a8bb1f44244214c0";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b3/linux-i686/hr/firefox-113.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b4/linux-i686/hr/firefox-113.0b4.tar.bz2";
       locale = "hr";
       arch = "linux-i686";
-      sha256 = "6a43972a81b3e4425c48b420b7610f1cd70216b388f4dfff8e071e8a7395ef61";
+      sha256 = "224333f514de3d39f3cc5b320ee21c2e10ae38a3477d447957261684177cf024";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b3/linux-i686/hsb/firefox-113.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b4/linux-i686/hsb/firefox-113.0b4.tar.bz2";
       locale = "hsb";
       arch = "linux-i686";
-      sha256 = "d85619f23ff912769a377b4d8fa06bfbecf5155fdd433982ea38a9602e35b528";
+      sha256 = "1928199d49b1511157bd3c59dafc11e5515d793d3525e19be98fef64328d11ff";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b3/linux-i686/hu/firefox-113.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b4/linux-i686/hu/firefox-113.0b4.tar.bz2";
       locale = "hu";
       arch = "linux-i686";
-      sha256 = "281e887c73d63aafddbfa54c29eef0a81036628ced989d2dd00c6783dc78d4f9";
+      sha256 = "1d48af7e9b91fa4b6985fca5b418d3c954e8a538ef48602e778378894b1ffbb5";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b3/linux-i686/hy-AM/firefox-113.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b4/linux-i686/hy-AM/firefox-113.0b4.tar.bz2";
       locale = "hy-AM";
       arch = "linux-i686";
-      sha256 = "3453381c146cc3c8a48e6f683dbc5b077b4620a06161ef6abab6014e06a45920";
+      sha256 = "67b6ccb3f52ba0cbba784f07255a9c6c242d21efb63a37b2beab2959bbeac308";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b3/linux-i686/ia/firefox-113.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b4/linux-i686/ia/firefox-113.0b4.tar.bz2";
       locale = "ia";
       arch = "linux-i686";
-      sha256 = "abd90f2b0cb5ce5b00ddeb97140100960f9771a04aee0c1c414c02d907a1e9b9";
+      sha256 = "375f35e4faea3cc87dc9879e0dd601ffcc50f253f03149677b59ef781f4150c8";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b3/linux-i686/id/firefox-113.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b4/linux-i686/id/firefox-113.0b4.tar.bz2";
       locale = "id";
       arch = "linux-i686";
-      sha256 = "ec0119eaca15d4a8d6f4b8cdfd389ee781742c7d93700383453ba772be31597f";
+      sha256 = "8fbeaab86851d3c30348b0c592046020bcaca9b986b684520db90a1dc3a56975";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b3/linux-i686/is/firefox-113.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b4/linux-i686/is/firefox-113.0b4.tar.bz2";
       locale = "is";
       arch = "linux-i686";
-      sha256 = "85bcaba93dcf7d240c5df71cb0cb4186f23a95716b4575897cd686dcb7fe3914";
+      sha256 = "b88ffd3bbdf06b20f35d313858f9c9b10e85a2fd22c30f95fd5be5ce0568c01f";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b3/linux-i686/it/firefox-113.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b4/linux-i686/it/firefox-113.0b4.tar.bz2";
       locale = "it";
       arch = "linux-i686";
-      sha256 = "34d7962c9d7d8d02958068a1ebb1dc597099e64b645cda700e5f288ca4c88b9b";
+      sha256 = "793ba7db4e7f51896f4ece5f2a3fd2f609f8cc760258f9c23f7694f0746923f4";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b3/linux-i686/ja/firefox-113.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b4/linux-i686/ja/firefox-113.0b4.tar.bz2";
       locale = "ja";
       arch = "linux-i686";
-      sha256 = "591a15f2fd101bbf60b78810b00adbe277c7b5384e556e76348d223c9132c258";
+      sha256 = "3dc65531a0b02f2a6c55a8aaeb0e620308e52a5bf63ab471dbb4b30983e24c2c";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b3/linux-i686/ka/firefox-113.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b4/linux-i686/ka/firefox-113.0b4.tar.bz2";
       locale = "ka";
       arch = "linux-i686";
-      sha256 = "cd5c0addbbfdee2893ef0ff3550a5b028d818c998c01fe48238b3bd91a368696";
+      sha256 = "74665643f67b46bb9e9ac03b8d82e307afacc6807876ae8711698edaac1abb76";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b3/linux-i686/kab/firefox-113.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b4/linux-i686/kab/firefox-113.0b4.tar.bz2";
       locale = "kab";
       arch = "linux-i686";
-      sha256 = "527034d170443d8ca638d60d7f8cc1d97129b042831ed3de97d205e64d210c16";
+      sha256 = "35a692235355f535020292957a0fe44fbd77ecbbb43124e75b9a1a6a01152cc3";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b3/linux-i686/kk/firefox-113.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b4/linux-i686/kk/firefox-113.0b4.tar.bz2";
       locale = "kk";
       arch = "linux-i686";
-      sha256 = "d1f48d85db19bb2733c7007a973dd4be7d1c6aa2794561d4fd4268b18e1c1592";
+      sha256 = "6bcddf4e6ffbb8c9f14dff7da8191cea82f45752f1b1b93cedd89998448c94f5";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b3/linux-i686/km/firefox-113.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b4/linux-i686/km/firefox-113.0b4.tar.bz2";
       locale = "km";
       arch = "linux-i686";
-      sha256 = "fc357dcff63b938fba393629815db295065d0621bf9e9c56cc1e1a93380a7da8";
+      sha256 = "a205d8c307dda1f226b8a3053120ebe6611668690f31175b12bfedebbde195ab";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b3/linux-i686/kn/firefox-113.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b4/linux-i686/kn/firefox-113.0b4.tar.bz2";
       locale = "kn";
       arch = "linux-i686";
-      sha256 = "e3c30927f3e7b52771b6b970226bbe907b3058fe87c8aa5a4b62a9b76b336f91";
+      sha256 = "0c09b9596b356712c83a94555d2b997de97a7ad675a189645267c0942d2c034c";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b3/linux-i686/ko/firefox-113.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b4/linux-i686/ko/firefox-113.0b4.tar.bz2";
       locale = "ko";
       arch = "linux-i686";
-      sha256 = "b13226710e271945b0eec4b23caa3c7620ef96bad0fa792c42489711d36f6491";
+      sha256 = "05e25a992dc4f56ff4fc5a55a2dbc70b36fc29483c6ccf628afbf8b8ad44f13f";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b3/linux-i686/lij/firefox-113.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b4/linux-i686/lij/firefox-113.0b4.tar.bz2";
       locale = "lij";
       arch = "linux-i686";
-      sha256 = "56b847ff2f9b15d1192423ddcf1ad1d7f5a074ca8893afd4c098c3bd16c0548e";
+      sha256 = "11305dd713791ecb98508deeffaf1ce51b47b7e629c60d80316436cd9ea2fad1";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b3/linux-i686/lt/firefox-113.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b4/linux-i686/lt/firefox-113.0b4.tar.bz2";
       locale = "lt";
       arch = "linux-i686";
-      sha256 = "87a4765aa615fa1d22a606c8974b030f6e40f34df7b66fd604db81dc205c5ab0";
+      sha256 = "9dbabb8719251d033f604434fb28cf02ec63187dbb74fdb33e0513bf49729976";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b3/linux-i686/lv/firefox-113.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b4/linux-i686/lv/firefox-113.0b4.tar.bz2";
       locale = "lv";
       arch = "linux-i686";
-      sha256 = "8975fda0b3f8793dd87aa6f4d321b6f130abd14853389c4bae4e40528b054ff6";
+      sha256 = "1c447d4fa5d995645cd7ffcab3f2051fddd0a3bd9e5d12ead7290268bccbf9e5";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b3/linux-i686/mk/firefox-113.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b4/linux-i686/mk/firefox-113.0b4.tar.bz2";
       locale = "mk";
       arch = "linux-i686";
-      sha256 = "142a03aa8f98779a3702cb394896c53315294c5a42a4bf10fbfde77bf218dbc7";
+      sha256 = "5f066039eccab51a5683f133dc66511c39026a9ce1b70dd1dbbd87bc0cb96093";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b3/linux-i686/mr/firefox-113.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b4/linux-i686/mr/firefox-113.0b4.tar.bz2";
       locale = "mr";
       arch = "linux-i686";
-      sha256 = "cf77d649c2f3b0eee3adbfee9e5e1f5313467fa319573d2d003126517edc9315";
+      sha256 = "4aa8eb39d12ff6ba0569dc251ed13110f2edc7c92368d7d35b9854b14d8cf619";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b3/linux-i686/ms/firefox-113.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b4/linux-i686/ms/firefox-113.0b4.tar.bz2";
       locale = "ms";
       arch = "linux-i686";
-      sha256 = "96dad8549b33de1e2066357142afa7c76af0cfd332b414a5742cd73b76a8c2fd";
+      sha256 = "1538f31ca131746558746236d9ce1132cdfba2dc479916969276470cc48714d3";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b3/linux-i686/my/firefox-113.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b4/linux-i686/my/firefox-113.0b4.tar.bz2";
       locale = "my";
       arch = "linux-i686";
-      sha256 = "ea462387085af4cf05a4c20a1de23cf587743c98c649f1188e47a97a0a98e358";
+      sha256 = "6be6fbb63f2100479069d70032cd4b99f6c65ca88be4f4e1f157d390b49f570a";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b3/linux-i686/nb-NO/firefox-113.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b4/linux-i686/nb-NO/firefox-113.0b4.tar.bz2";
       locale = "nb-NO";
       arch = "linux-i686";
-      sha256 = "c5c3865dba1cc9be1a6d982a1a4ee89de8ab8eed7ee61895e7ef8b67eaf0428a";
+      sha256 = "7e3e90b7f2dd3e7285d751eb2aace580b0346235942394f2cc17da79eb0c4b72";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b3/linux-i686/ne-NP/firefox-113.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b4/linux-i686/ne-NP/firefox-113.0b4.tar.bz2";
       locale = "ne-NP";
       arch = "linux-i686";
-      sha256 = "97a0bb774f1a300e8f2c760743ce60cb46607f02126b0120eb231777fa03e15c";
+      sha256 = "2c606e573aa44ad8f434e6c70704786db879259408495a00f2a99f0c1d2c5d84";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b3/linux-i686/nl/firefox-113.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b4/linux-i686/nl/firefox-113.0b4.tar.bz2";
       locale = "nl";
       arch = "linux-i686";
-      sha256 = "aea347773b8edbaec0333282bf24db829d1f0636f4d41448e077722a9bf0d188";
+      sha256 = "a2444c1d68dbcea7192207771889f12c4963c70616b7cc8b56772a5c9956ae5b";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b3/linux-i686/nn-NO/firefox-113.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b4/linux-i686/nn-NO/firefox-113.0b4.tar.bz2";
       locale = "nn-NO";
       arch = "linux-i686";
-      sha256 = "09febd1c0f5b547c4fe6b2d5f40b9edfa75b0107486f0098331a9653dc76b72a";
+      sha256 = "93c1d0d4a5472fee193fef5414b7ce66261c99274fa5229f71e9f2146c915d4f";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b3/linux-i686/oc/firefox-113.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b4/linux-i686/oc/firefox-113.0b4.tar.bz2";
       locale = "oc";
       arch = "linux-i686";
-      sha256 = "9592cf6e5ca7a77d4b95eabc7f8a645ee4b696488aaf1892769a77bf60140e90";
+      sha256 = "701105e4dced9844f08e1f746691604c59319f4dcde89e74d29f66079f16fe1e";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b3/linux-i686/pa-IN/firefox-113.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b4/linux-i686/pa-IN/firefox-113.0b4.tar.bz2";
       locale = "pa-IN";
       arch = "linux-i686";
-      sha256 = "254669e447346ded2118428ad15b552e48747891d5ba0734d139d126239b1828";
+      sha256 = "49d05fe43a1ec88b45d1dd04dd9e980a61db203da49f872017f361179a4bebeb";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b3/linux-i686/pl/firefox-113.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b4/linux-i686/pl/firefox-113.0b4.tar.bz2";
       locale = "pl";
       arch = "linux-i686";
-      sha256 = "cda12e8e2dc6dba6b2f733bfda99a1c0c1967d7c71f635a2b3b1b7bdb01c7d81";
+      sha256 = "b90306abb2e6127d2d123451b70fa4a776e72a47eda8b427c134297a629bf426";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b3/linux-i686/pt-BR/firefox-113.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b4/linux-i686/pt-BR/firefox-113.0b4.tar.bz2";
       locale = "pt-BR";
       arch = "linux-i686";
-      sha256 = "b0a0d4da5cfd345f4144e9869ce1cf1c42786522b6d127f962a0f8588efab815";
+      sha256 = "761fa6623ec00fb7b518e43f73ac76a02c8194603ea262fd823b059b1d9f2593";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b3/linux-i686/pt-PT/firefox-113.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b4/linux-i686/pt-PT/firefox-113.0b4.tar.bz2";
       locale = "pt-PT";
       arch = "linux-i686";
-      sha256 = "c9be8a754616abde67a3b4971b986d25fa3b53d29f59aed1c726ed12715724f6";
+      sha256 = "18b3e492d284bf78317c58f239f7f39f14a4f37df2663ffc81b878c62efb7493";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b3/linux-i686/rm/firefox-113.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b4/linux-i686/rm/firefox-113.0b4.tar.bz2";
       locale = "rm";
       arch = "linux-i686";
-      sha256 = "4774abdccb8c0792df62fc629e1c31f220c54fd25acb46b40caa1ae64e4611fd";
+      sha256 = "092f0bae7448482f0ff1fb8d7cde47205508ec42d99d3531c3f3efade0cf59ef";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b3/linux-i686/ro/firefox-113.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b4/linux-i686/ro/firefox-113.0b4.tar.bz2";
       locale = "ro";
       arch = "linux-i686";
-      sha256 = "58e84206b762788f592bbcba2e6771fe6e0fc4340ffe2adfe2b398e03ef2f4e9";
+      sha256 = "457bc780c54c626e50b8252aa87b2d140433aaab5d96f49893fe16d0f4c22e6f";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b3/linux-i686/ru/firefox-113.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b4/linux-i686/ru/firefox-113.0b4.tar.bz2";
       locale = "ru";
       arch = "linux-i686";
-      sha256 = "f1ce5ca47ced81353741edf020b798d6c7483e92520ed34b1d9d844353b0b0e2";
+      sha256 = "63ae2db68cb0a21c06ede98873e65c680e3edd4e751d660d7b8adf9363d9ef88";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b3/linux-i686/sc/firefox-113.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b4/linux-i686/sc/firefox-113.0b4.tar.bz2";
       locale = "sc";
       arch = "linux-i686";
-      sha256 = "be97c79e8ddf09ac6aedcb8abc4466a0e6073e12e11d6651f233072282caf492";
+      sha256 = "d22bb9f57c3ef7c57d8f35ad5ccf875390509c7a3526d71ae82abb465e3ca102";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b3/linux-i686/sco/firefox-113.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b4/linux-i686/sco/firefox-113.0b4.tar.bz2";
       locale = "sco";
       arch = "linux-i686";
-      sha256 = "3fd7e1d538d42cbb58700a87584da7b04866ea323928eaa85f487e6030a574e8";
+      sha256 = "17b5df121066163f0d07b8a19e4bd9c33a00748863a28806862a40f8cb34cd5f";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b3/linux-i686/si/firefox-113.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b4/linux-i686/si/firefox-113.0b4.tar.bz2";
       locale = "si";
       arch = "linux-i686";
-      sha256 = "c77c11cb2105fb4bbc583c3ee6e88a9f1345ebb285cb440fc55017d5cdb23977";
+      sha256 = "59ca4a57fc0012526fe8bb1b256a377939bca310ecade0ad2b067d32357d1227";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b3/linux-i686/sk/firefox-113.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b4/linux-i686/sk/firefox-113.0b4.tar.bz2";
       locale = "sk";
       arch = "linux-i686";
-      sha256 = "ef257f2dc5a903d17c7c6c3d310bdd527412dd2c7ef49b449ac48aacfb2f03e6";
+      sha256 = "ff7ce0af4e5f9fd3c0add9772dc08989463d46949fe1b7b33ee73e18b4b508f5";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b3/linux-i686/sl/firefox-113.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b4/linux-i686/sl/firefox-113.0b4.tar.bz2";
       locale = "sl";
       arch = "linux-i686";
-      sha256 = "c3cec451900cb21dc24e9fe05f33f363cc3e6307d10253a9cb2e54b55131e689";
+      sha256 = "21e7ffc5c0618fa50a5b1e5ccc073c2fffcc638d80f3abf40893a5e52aa43dcc";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b3/linux-i686/son/firefox-113.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b4/linux-i686/son/firefox-113.0b4.tar.bz2";
       locale = "son";
       arch = "linux-i686";
-      sha256 = "0110e8168ae2b7a7a6f925b468284ef261798516680433159e2810e65578bf9a";
+      sha256 = "a6d27a518aa43eafa46b137824d7151bd0293feace506ee7d1f7a083d85c940f";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b3/linux-i686/sq/firefox-113.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b4/linux-i686/sq/firefox-113.0b4.tar.bz2";
       locale = "sq";
       arch = "linux-i686";
-      sha256 = "7b52edcfc17de10392c6a62a6318c92288faabbacf24bba78a430089ad6e818a";
+      sha256 = "b745dd2a0c887e23fda2fbad199a16a7416e33068328c6e194a9726c03ffbe54";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b3/linux-i686/sr/firefox-113.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b4/linux-i686/sr/firefox-113.0b4.tar.bz2";
       locale = "sr";
       arch = "linux-i686";
-      sha256 = "87f9b9807eed9fde78bb23b6b68fc6cf3e2b49c1274c24a0f28fc4b26e200348";
+      sha256 = "c2f35ae6041a1e958ec8f68937ea0d0f844a709c403af03a5727396e12c6758f";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b3/linux-i686/sv-SE/firefox-113.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b4/linux-i686/sv-SE/firefox-113.0b4.tar.bz2";
       locale = "sv-SE";
       arch = "linux-i686";
-      sha256 = "dfbb3851dc393e32f44acdc2e22b5e33a46910d64e77062e62e0b642b926e1ac";
+      sha256 = "a3192a4838032800f991da43c5c2b318b2d15b9407e7dc23a706cf19c755cf2f";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b3/linux-i686/szl/firefox-113.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b4/linux-i686/szl/firefox-113.0b4.tar.bz2";
       locale = "szl";
       arch = "linux-i686";
-      sha256 = "8e72af5cc9c9cdf1c7a979e98c3f71fe17d0bc1a35963a213b1753ea7672ce72";
+      sha256 = "7e2a1c32a8ff9950ad66223b28a79eb0d3c6cff4166851f96ed7ab6ba95e8546";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b3/linux-i686/ta/firefox-113.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b4/linux-i686/ta/firefox-113.0b4.tar.bz2";
       locale = "ta";
       arch = "linux-i686";
-      sha256 = "58b1d265464a80cdab75617d29259c282a3e7ab66086c7986a90f4c993a2ee95";
+      sha256 = "cc67465e38045b741ae259eab51a27414f7f3bf757785411d5ced4b98984eded";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b3/linux-i686/te/firefox-113.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b4/linux-i686/te/firefox-113.0b4.tar.bz2";
       locale = "te";
       arch = "linux-i686";
-      sha256 = "2cd403ed816fcc89eba033a66e88f7d1722bddb2b9327b9d3991c18bbe3e11a1";
+      sha256 = "be2a5747ca247cd68607497824da890dd7da8e983470f0873311c6ec26524003";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b3/linux-i686/tg/firefox-113.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b4/linux-i686/tg/firefox-113.0b4.tar.bz2";
       locale = "tg";
       arch = "linux-i686";
-      sha256 = "571b82815314b677eb6d2eeb08c56b1d8ac3a3e7fbc27cb9b33a69fe9579c850";
+      sha256 = "7fda21f7489d052d438c5d5033e2ea045cfcadee6c9408b6c50a59c201e886cd";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b3/linux-i686/th/firefox-113.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b4/linux-i686/th/firefox-113.0b4.tar.bz2";
       locale = "th";
       arch = "linux-i686";
-      sha256 = "261ef2d25274266871bc298cd36213f2fa929e3bdf57df44cb0cad936827ef27";
+      sha256 = "8f9144d196b6a2c3f5856763b956dadb7602425e3e4ffe3ea30f7c48946b5f63";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b3/linux-i686/tl/firefox-113.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b4/linux-i686/tl/firefox-113.0b4.tar.bz2";
       locale = "tl";
       arch = "linux-i686";
-      sha256 = "12f940213af8b7dda0dd05ccfd1c68bbdfe140ac24501834d7d8f584b5a719f8";
+      sha256 = "127d9264a48a3b6ffa2fe0add6d46a29a190920e0646d080305e7b7bd9b5922e";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b3/linux-i686/tr/firefox-113.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b4/linux-i686/tr/firefox-113.0b4.tar.bz2";
       locale = "tr";
       arch = "linux-i686";
-      sha256 = "adebe58e10782049e7abdf983962b84e1bfc63cf4bc176b514842a88aaf12e3f";
+      sha256 = "6b46075ca55880d2ef1aa73a5cb92fbbf4b838eabca6c86d041cdf51b9d64dd8";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b3/linux-i686/trs/firefox-113.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b4/linux-i686/trs/firefox-113.0b4.tar.bz2";
       locale = "trs";
       arch = "linux-i686";
-      sha256 = "51d1a429763f326b3ae91961450114620ba1255d0d21ea56526af1d735f5ae7c";
+      sha256 = "3efabc75692552a301377bf8d819fb6ee46136c75c3cc3b58a5d63f9ef7d8ae9";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b3/linux-i686/uk/firefox-113.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b4/linux-i686/uk/firefox-113.0b4.tar.bz2";
       locale = "uk";
       arch = "linux-i686";
-      sha256 = "7d417510c93643b54476164aaf61c5bc2dfdf12b9f2b8de89bc1411e85b37dd4";
+      sha256 = "757dd41529c2c9a3f4564a0c6af3e369ba53a03e17572efb9a9c793b370bbc84";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b3/linux-i686/ur/firefox-113.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b4/linux-i686/ur/firefox-113.0b4.tar.bz2";
       locale = "ur";
       arch = "linux-i686";
-      sha256 = "da24527a8cc107ee5287efbd63c6b6fb2d27653e2166e6d752f47c51683b0fda";
+      sha256 = "47675d1d8851f84398cbdbcf3efd631c873c5b422280e51e7c996668fbdb57e5";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b3/linux-i686/uz/firefox-113.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b4/linux-i686/uz/firefox-113.0b4.tar.bz2";
       locale = "uz";
       arch = "linux-i686";
-      sha256 = "d55f111ba517de1c17633eeb2d384b12187ea0ffa32ef69d11ba73b05e1dc318";
+      sha256 = "0fbb8d13adff4ffbfd3e9b1b3f1c9eb673bacad69d4a2e89bc47014977948d23";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b3/linux-i686/vi/firefox-113.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b4/linux-i686/vi/firefox-113.0b4.tar.bz2";
       locale = "vi";
       arch = "linux-i686";
-      sha256 = "2d10d28d08c7b948c4aa832250d3080aba2aab5b08d220f213c8b744884a7842";
+      sha256 = "a607c5e943f84c466ac1671cd9a4ceebc3601bf51709f815fe7f392d3b5c6308";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b3/linux-i686/xh/firefox-113.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b4/linux-i686/xh/firefox-113.0b4.tar.bz2";
       locale = "xh";
       arch = "linux-i686";
-      sha256 = "5d5e8144d39561e1b51c93c1d89f2e3a9fa7a0c4670c067eca69320361787f9f";
+      sha256 = "fd38317380cf41829a49fc3af8b18c65094bd8eba8732691f1cb809bf96b72aa";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b3/linux-i686/zh-CN/firefox-113.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b4/linux-i686/zh-CN/firefox-113.0b4.tar.bz2";
       locale = "zh-CN";
       arch = "linux-i686";
-      sha256 = "ff4efa9d9a16903b9644ce7b65d5ddf411f8743d70ad9ab88b380893cfa66844";
+      sha256 = "7b5600dc2743e3c8f506cb5dece02da7d7b0c40704c569fc963353391c58cb17";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b3/linux-i686/zh-TW/firefox-113.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b4/linux-i686/zh-TW/firefox-113.0b4.tar.bz2";
       locale = "zh-TW";
       arch = "linux-i686";
-      sha256 = "7b0df44217e77681c7294781685ed1ce1d317ec34d13e894a32e2824e549c009";
+      sha256 = "b3395791485ff4c6adb0886f3c77ea9b9fea4b6ffb298349ac109a948a7dc377";
     }
     ];
 }

--- a/pkgs/applications/networking/browsers/firefox-bin/beta_sources.nix
+++ b/pkgs/applications/networking/browsers/firefox-bin/beta_sources.nix
@@ -1,1005 +1,1015 @@
 {
-  version = "112.0b9";
+  version = "113.0b2";
   sources = [
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b9/linux-x86_64/ach/firefox-112.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b2/linux-x86_64/ach/firefox-113.0b2.tar.bz2";
       locale = "ach";
       arch = "linux-x86_64";
-      sha256 = "c91087958058c4b5754f6963f676f2bbac87c3d2f2b13f1b7ae7ad449a7a9f25";
+      sha256 = "63bc87c112ea0550bf859e5531870a3ca88ead4782fe2b8cd064f29820dd9072";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b9/linux-x86_64/af/firefox-112.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b2/linux-x86_64/af/firefox-113.0b2.tar.bz2";
       locale = "af";
       arch = "linux-x86_64";
-      sha256 = "3310d41e3b0167dae3cdf364da748f5adb41e5ad903ae09377c5966b4c61c9f3";
+      sha256 = "69c91441b99ed38a4e492c9103f541ee729922aed7f7e1dfc85a62925654b1dd";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b9/linux-x86_64/an/firefox-112.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b2/linux-x86_64/an/firefox-113.0b2.tar.bz2";
       locale = "an";
       arch = "linux-x86_64";
-      sha256 = "112dd28095ced2b4eb183f3ca320b171004c2543f7551ea84f6d0bbe2a60d15f";
+      sha256 = "1650b2fab644b920829d55ec7d54267edb3cd46d0ea9a6e9cab27df512882874";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b9/linux-x86_64/ar/firefox-112.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b2/linux-x86_64/ar/firefox-113.0b2.tar.bz2";
       locale = "ar";
       arch = "linux-x86_64";
-      sha256 = "14a0b63620dfbd1becbe36b45f94a1773c9329c3fed50b81fbe689d1e7ba5d5a";
+      sha256 = "8a1e7d94309dd4eeb90638b197b85b8d3538fc6314d2444659f05f673cb89781";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b9/linux-x86_64/ast/firefox-112.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b2/linux-x86_64/ast/firefox-113.0b2.tar.bz2";
       locale = "ast";
       arch = "linux-x86_64";
-      sha256 = "34a5dd3aae37ede37a8425af5a5905bb8f4e1288132ede86b191eae05cdaa9da";
+      sha256 = "3eaa57e4d7c92acad0c27764e1c1328a6056aa6e9499ea3d1be43694526a2966";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b9/linux-x86_64/az/firefox-112.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b2/linux-x86_64/az/firefox-113.0b2.tar.bz2";
       locale = "az";
       arch = "linux-x86_64";
-      sha256 = "477c4bbeb522b47cdc5ec0009ce55ec81d5f5ffb1d5c49fcc57904d8f1fe0aa4";
+      sha256 = "4d1baac45cd347ef8fd22c3c5971b8b18115fac37044095fd8342e1826b456aa";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b9/linux-x86_64/be/firefox-112.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b2/linux-x86_64/be/firefox-113.0b2.tar.bz2";
       locale = "be";
       arch = "linux-x86_64";
-      sha256 = "ea066f5d7ca3f7f33e1b7be303708ee59323fea46f1acbfb6037144768cfdc16";
+      sha256 = "82c87b414801cb3b3cc7a48d6e253042154b6668453219d809be040f1b26b663";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b9/linux-x86_64/bg/firefox-112.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b2/linux-x86_64/bg/firefox-113.0b2.tar.bz2";
       locale = "bg";
       arch = "linux-x86_64";
-      sha256 = "a15fc91adafa49629692b00257bc20ef8f75af2a387493de5887319b51f495e1";
+      sha256 = "a2c5c5cb89cc6a648dbf385cc37a51cd1f27659655c87be464a732cad51cc425";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b9/linux-x86_64/bn/firefox-112.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b2/linux-x86_64/bn/firefox-113.0b2.tar.bz2";
       locale = "bn";
       arch = "linux-x86_64";
-      sha256 = "d20d14593232e3e19c82245846120e44f40fe224c0a8a925fecbc326d1d41731";
+      sha256 = "eb61b01a24ca166f735691e6fce4c08ace175e7dc419763f9f6936ddaecc2682";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b9/linux-x86_64/br/firefox-112.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b2/linux-x86_64/br/firefox-113.0b2.tar.bz2";
       locale = "br";
       arch = "linux-x86_64";
-      sha256 = "6dfe902d2a46e6c81e94fd451e4a698e615f151c86c54ed17493de38b641089d";
+      sha256 = "42a1b2c36648d6ae8f253df6be9a4965f206cbf09e4d1a24bed21292ddd23efc";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b9/linux-x86_64/bs/firefox-112.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b2/linux-x86_64/bs/firefox-113.0b2.tar.bz2";
       locale = "bs";
       arch = "linux-x86_64";
-      sha256 = "98dfc8936651c15a5685ef29c35382cdda66c1ba8b4aa335ef824227093144f1";
+      sha256 = "6ed113b4831d29b2b52ce12172399a6e3afbf3310a8cb47114e1f8dc81131739";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b9/linux-x86_64/ca-valencia/firefox-112.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b2/linux-x86_64/ca-valencia/firefox-113.0b2.tar.bz2";
       locale = "ca-valencia";
       arch = "linux-x86_64";
-      sha256 = "6ea7553b2eaf81698dc82a144731326773cba371d7ce8903abcfb4f3bc46683e";
+      sha256 = "6dc38c703dc9d54e369b0082952624b8d8dbf24e3cb6216601076e910f1067ef";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b9/linux-x86_64/ca/firefox-112.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b2/linux-x86_64/ca/firefox-113.0b2.tar.bz2";
       locale = "ca";
       arch = "linux-x86_64";
-      sha256 = "5b5d9c296c619786bd5ef3362610796e7d2b51a7f3520f04bc62a675bc32345f";
+      sha256 = "9926a0525fd056e5bff59aaf57f8129ab51e03f65e47abf0f6f7404275916efc";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b9/linux-x86_64/cak/firefox-112.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b2/linux-x86_64/cak/firefox-113.0b2.tar.bz2";
       locale = "cak";
       arch = "linux-x86_64";
-      sha256 = "ac11d4d349861efc3d19e0d486e3bf7aac7aedf0d4c523487dd0d688d72fbdbc";
+      sha256 = "d4afaf2e2b3f9f1130bbed7936d0debd6f44f8e8a856f2400600cb04974b681b";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b9/linux-x86_64/cs/firefox-112.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b2/linux-x86_64/cs/firefox-113.0b2.tar.bz2";
       locale = "cs";
       arch = "linux-x86_64";
-      sha256 = "d850b6adff4f6605b3e836d928f4bc0dd306cc8fa6ac12536b3cfe38a1e309e2";
+      sha256 = "5c77cfb25086ac444a213f256b02f105f18c887b38bebb6c614ca079d5335a1d";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b9/linux-x86_64/cy/firefox-112.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b2/linux-x86_64/cy/firefox-113.0b2.tar.bz2";
       locale = "cy";
       arch = "linux-x86_64";
-      sha256 = "8067968db0cdf0a3cd01e07953d91702341b23b79cbbf6728caefd0f3de346e6";
+      sha256 = "6ee073b90ac7dd16f974c931fff45a2c1360c0a094862fcdaef457d1c7d13cf0";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b9/linux-x86_64/da/firefox-112.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b2/linux-x86_64/da/firefox-113.0b2.tar.bz2";
       locale = "da";
       arch = "linux-x86_64";
-      sha256 = "52fe4a02dd5b545e5f43e77037588b85cdc3495274e03ef96cf8186350ce91f1";
+      sha256 = "f33e59dd6a8a5398915908a91d12c6dae070f7c96a179b72bdceee68ce69369d";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b9/linux-x86_64/de/firefox-112.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b2/linux-x86_64/de/firefox-113.0b2.tar.bz2";
       locale = "de";
       arch = "linux-x86_64";
-      sha256 = "13965286b1837f441cf5c7a864024221c7d0c81f7ade67d2c6935f778786cc32";
+      sha256 = "6168ab1245c4952d94533db0de4bce39be144ad5ae35b9d4637f62e6e60598be";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b9/linux-x86_64/dsb/firefox-112.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b2/linux-x86_64/dsb/firefox-113.0b2.tar.bz2";
       locale = "dsb";
       arch = "linux-x86_64";
-      sha256 = "ab5d69a055950b52ffc795485a2a6cbdb99d1a5b376ab859da7f2ce5da12a99a";
+      sha256 = "b6b881aade26c207768a6ce5f111eaf6dfec7cb0bcad3d1e1ef94e700db6f3a4";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b9/linux-x86_64/el/firefox-112.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b2/linux-x86_64/el/firefox-113.0b2.tar.bz2";
       locale = "el";
       arch = "linux-x86_64";
-      sha256 = "8e29c5f596ac93fef337ebab39f20870d84c3183901e3b8e3512b60d1ff263cd";
+      sha256 = "d44620052f215b9e1037d6f271f9b4fb23a1184d8c9bbde146c7fe1fc3fb3593";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b9/linux-x86_64/en-CA/firefox-112.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b2/linux-x86_64/en-CA/firefox-113.0b2.tar.bz2";
       locale = "en-CA";
       arch = "linux-x86_64";
-      sha256 = "4e7d5b51cb77ceebcc99870ba66413aef3d3d585058c443b642a412f2254aa09";
+      sha256 = "e699de7bf03c8387f5a0d49d9456231d9153833fa89e0b71f23b9749cd009a57";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b9/linux-x86_64/en-GB/firefox-112.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b2/linux-x86_64/en-GB/firefox-113.0b2.tar.bz2";
       locale = "en-GB";
       arch = "linux-x86_64";
-      sha256 = "9f09899c1cb5a9c7a1b2779fc6a43b52bfd00d96b4a03ee8479e6a05ef9e91da";
+      sha256 = "6c27aad74c8b8f9462141ef67d0ad68aacf658097136943fadae4e7e0096ba1d";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b9/linux-x86_64/en-US/firefox-112.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b2/linux-x86_64/en-US/firefox-113.0b2.tar.bz2";
       locale = "en-US";
       arch = "linux-x86_64";
-      sha256 = "7f317521402574db83930e9d5792b3abeaf5643810633c7ff6294936bef9744f";
+      sha256 = "511e1eefba5a10cd88ec89eba0c409cf3144de025995931111a8ab269d6e2075";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b9/linux-x86_64/eo/firefox-112.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b2/linux-x86_64/eo/firefox-113.0b2.tar.bz2";
       locale = "eo";
       arch = "linux-x86_64";
-      sha256 = "f70719d08ab219cfaa0df7507ca1b6fafa7d02d88308f12b9f671dfa4f8935cf";
+      sha256 = "b5a15bc9a92b292607eb1dffa4c40823ace30a158d313f86dc67e5538898bb26";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b9/linux-x86_64/es-AR/firefox-112.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b2/linux-x86_64/es-AR/firefox-113.0b2.tar.bz2";
       locale = "es-AR";
       arch = "linux-x86_64";
-      sha256 = "832b173660c95269e0f76009d8b5f9b6af4094a397f40080960be2d6b746be24";
+      sha256 = "a53d3d6ba1826668866ad38bee908fd0d4e4b53ac7a1157f5b0f8eaa55ccb3ec";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b9/linux-x86_64/es-CL/firefox-112.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b2/linux-x86_64/es-CL/firefox-113.0b2.tar.bz2";
       locale = "es-CL";
       arch = "linux-x86_64";
-      sha256 = "e7f1135fa7fc8108cb7fde420caa6a9ed724f0910c7f07678d71c30d0132b93d";
+      sha256 = "f5646ea1adca35f428024f126b14046007c07e062e6afeb1299f51d4adc75093";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b9/linux-x86_64/es-ES/firefox-112.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b2/linux-x86_64/es-ES/firefox-113.0b2.tar.bz2";
       locale = "es-ES";
       arch = "linux-x86_64";
-      sha256 = "f2293b64fed57fdeccb05e868b03e60dc2b9a6ed777db5f38c85a36f8c367b3a";
+      sha256 = "b7a7bb21d651699fc58f6451ddfbe506aede2d0fe261c62442074c6f28ed43c0";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b9/linux-x86_64/es-MX/firefox-112.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b2/linux-x86_64/es-MX/firefox-113.0b2.tar.bz2";
       locale = "es-MX";
       arch = "linux-x86_64";
-      sha256 = "1df136aa779e5ba69fb85139e82e80f667973294a99e18a78f7874ed36f162de";
+      sha256 = "156a2ac4486f887a95fc5ddf08d4769effffd90a1e544a66ff53a46a41411b18";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b9/linux-x86_64/et/firefox-112.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b2/linux-x86_64/et/firefox-113.0b2.tar.bz2";
       locale = "et";
       arch = "linux-x86_64";
-      sha256 = "0f849766885159cfaccdc84fa82f63e934c412c2eed102f4d4b9e81eba3e9ec2";
+      sha256 = "7da54891f5047b7fa86b1c1ad5dcded253c6619a2f9b72826269b4256a021568";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b9/linux-x86_64/eu/firefox-112.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b2/linux-x86_64/eu/firefox-113.0b2.tar.bz2";
       locale = "eu";
       arch = "linux-x86_64";
-      sha256 = "19450d79c3afafe0e952bba089432f2ebaa6de852962f08130c0fb08b91dffb6";
+      sha256 = "02cad7594db80a1b9031b0a83eecde16c0deb2d2e7b40368b85e8b5424863959";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b9/linux-x86_64/fa/firefox-112.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b2/linux-x86_64/fa/firefox-113.0b2.tar.bz2";
       locale = "fa";
       arch = "linux-x86_64";
-      sha256 = "8f780dd33aa83a6ea125a25345109fef9ea0e41e1ff3ad18373bf5427926dc18";
+      sha256 = "8acd02298cc36dda92fa5ab61d4750d6af931c6292d0688d10895c7e24355e13";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b9/linux-x86_64/ff/firefox-112.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b2/linux-x86_64/ff/firefox-113.0b2.tar.bz2";
       locale = "ff";
       arch = "linux-x86_64";
-      sha256 = "693324571bf5093c56441b2ead289badaed3b6816fe55529575be6440e8dd803";
+      sha256 = "e29869d59e460ce85cae8444f3d01385ce1512694cc321bba37cede7c6d575f4";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b9/linux-x86_64/fi/firefox-112.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b2/linux-x86_64/fi/firefox-113.0b2.tar.bz2";
       locale = "fi";
       arch = "linux-x86_64";
-      sha256 = "00752c61bf9782863317133c5650d8a6357afe513b343615d3d89e24fea0ed4c";
+      sha256 = "56744eba15b28a99fd9c3bee3e42f7176ff91aab678dd5b533991f9b08138958";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b9/linux-x86_64/fr/firefox-112.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b2/linux-x86_64/fr/firefox-113.0b2.tar.bz2";
       locale = "fr";
       arch = "linux-x86_64";
-      sha256 = "f7651898bbc14c1d320072408b5030ed9a63c53c168804706639cefc0857dd72";
+      sha256 = "5ebebcdff31ed8fb2e0c0facff94b09d39d5554f32a117fcce57fcf917c43d6a";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b9/linux-x86_64/fur/firefox-112.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b2/linux-x86_64/fur/firefox-113.0b2.tar.bz2";
       locale = "fur";
       arch = "linux-x86_64";
-      sha256 = "d8799c511e0fe687c2c9844d7222654bcb37efd14d0cf49ec84b68c7168259e3";
+      sha256 = "e6ea051bbc5a5fca3dbc85801a1d875e1acba534b64a1c3fd0d17a89e446f457";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b9/linux-x86_64/fy-NL/firefox-112.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b2/linux-x86_64/fy-NL/firefox-113.0b2.tar.bz2";
       locale = "fy-NL";
       arch = "linux-x86_64";
-      sha256 = "8f65f1afe53d5f5390c6c830698afc6e6404e21f16aa5569876c4c5d7988fb4e";
+      sha256 = "cb6d6ece58907e8e3b94fd72990e8a45b79c5b16b7fa10025e7d411f4020e28f";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b9/linux-x86_64/ga-IE/firefox-112.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b2/linux-x86_64/ga-IE/firefox-113.0b2.tar.bz2";
       locale = "ga-IE";
       arch = "linux-x86_64";
-      sha256 = "8f570a58e9057c17c1ca09af3570c54366d03c780c7932f5c50d479038387ef7";
+      sha256 = "5f15ece920201a51fa11dc05cfefd5e1c95d94805937c68562b39ed64cdd2de8";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b9/linux-x86_64/gd/firefox-112.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b2/linux-x86_64/gd/firefox-113.0b2.tar.bz2";
       locale = "gd";
       arch = "linux-x86_64";
-      sha256 = "88b0b08c4152e154eea9e8d3bba04e2a7d23a12cdca5ce9ba1474f5f95240092";
+      sha256 = "5f741f15b45961000de625412e6409ba12811eebb1a46c5c549adfc36996f115";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b9/linux-x86_64/gl/firefox-112.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b2/linux-x86_64/gl/firefox-113.0b2.tar.bz2";
       locale = "gl";
       arch = "linux-x86_64";
-      sha256 = "dd1b5fcf0dbf72ba3a2da6a8ee6d5cd314443d97182843399f54ec195174e412";
+      sha256 = "54644d3e6d222e2e5baf2e7067e1854be0ea39134c6c5109718c94ff6e874907";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b9/linux-x86_64/gn/firefox-112.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b2/linux-x86_64/gn/firefox-113.0b2.tar.bz2";
       locale = "gn";
       arch = "linux-x86_64";
-      sha256 = "a0d3af8127b6100a645a54e8955f2c303b58284a70a151255408c980c507da2d";
+      sha256 = "5e635b012a7cf872454dffa4966e693e50d9f9857b6f2c64231f34c4791e68f7";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b9/linux-x86_64/gu-IN/firefox-112.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b2/linux-x86_64/gu-IN/firefox-113.0b2.tar.bz2";
       locale = "gu-IN";
       arch = "linux-x86_64";
-      sha256 = "40b36cef0c9f9affd3d9e3a2ac048d3e199928260dd3434ef51f8b93a6a6a8bb";
+      sha256 = "a32aaac1ee9444aab09d86f3a9e0663c85d256a0012e94e7d68aa369124a4fdf";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b9/linux-x86_64/he/firefox-112.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b2/linux-x86_64/he/firefox-113.0b2.tar.bz2";
       locale = "he";
       arch = "linux-x86_64";
-      sha256 = "6f5e3f0ebe69f2e1e4f326c3f182e835d1dc8cba4b60fb06eb98ba48bb54ddef";
+      sha256 = "852a5608aad550d92ab265f01be4e7a36781390d6a07d6eb006e2cb95c78f5c3";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b9/linux-x86_64/hi-IN/firefox-112.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b2/linux-x86_64/hi-IN/firefox-113.0b2.tar.bz2";
       locale = "hi-IN";
       arch = "linux-x86_64";
-      sha256 = "af347c086bfb88b37153b6c00e8c6ff609c0e55755915df567d4ffd448affbc2";
+      sha256 = "58f4a003137d7103ffbef22f47966324c18a45c22d2f0d8544011fef57f0c39a";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b9/linux-x86_64/hr/firefox-112.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b2/linux-x86_64/hr/firefox-113.0b2.tar.bz2";
       locale = "hr";
       arch = "linux-x86_64";
-      sha256 = "6700d8222630003eea6ce7167bcd2c722482c0be47403c2fc744b4c5b3526a5d";
+      sha256 = "6ea7add25edb7443919df9de132aa61bad58e4c5c1f8852ebb913743d1fbd91c";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b9/linux-x86_64/hsb/firefox-112.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b2/linux-x86_64/hsb/firefox-113.0b2.tar.bz2";
       locale = "hsb";
       arch = "linux-x86_64";
-      sha256 = "fac03681f8b57f3ad7fd0179288e8462405afa6158b1db73275d4c08e0e89da8";
+      sha256 = "2947b75607e4ee22edf7a95e71f3950903a115ffc4672781ca390e4a3cacc684";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b9/linux-x86_64/hu/firefox-112.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b2/linux-x86_64/hu/firefox-113.0b2.tar.bz2";
       locale = "hu";
       arch = "linux-x86_64";
-      sha256 = "406b66fac8c6fa8cc9805946d4466a40ffe2f13a05ef5282d10416423ec0f969";
+      sha256 = "5f072e596885cb52ee65bd68c9e7f66a01a42c87e7aa3c82b99197905fa79835";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b9/linux-x86_64/hy-AM/firefox-112.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b2/linux-x86_64/hy-AM/firefox-113.0b2.tar.bz2";
       locale = "hy-AM";
       arch = "linux-x86_64";
-      sha256 = "9c6cb600a01dce15c33e626183960915d57ac83ac52de3ca9908b2d23e68ebad";
+      sha256 = "73bed6cd2ea7c9c3141eb70680916e0fb423e55a22713b34dea23d73b1357fe5";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b9/linux-x86_64/ia/firefox-112.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b2/linux-x86_64/ia/firefox-113.0b2.tar.bz2";
       locale = "ia";
       arch = "linux-x86_64";
-      sha256 = "2dfa86e4afa8cc2b22f9d4f4611d20febdbd794864da035c162cfd9891006524";
+      sha256 = "638018d469edd63dab0eaa392427a0e8cee69ed91de4067a7e9f4e080d78c641";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b9/linux-x86_64/id/firefox-112.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b2/linux-x86_64/id/firefox-113.0b2.tar.bz2";
       locale = "id";
       arch = "linux-x86_64";
-      sha256 = "747b9d17bc0a20ae2cf7b6532cb4ad597a32f7bebcda03657144d8b5994246af";
+      sha256 = "ebb3ffad8375b991c52230d6539871959957b5717646c1f7c8efdbd80d118464";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b9/linux-x86_64/is/firefox-112.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b2/linux-x86_64/is/firefox-113.0b2.tar.bz2";
       locale = "is";
       arch = "linux-x86_64";
-      sha256 = "c6bd6f66c31048162d617865178f0c826abdb41ebe924e2ff5e1c3fa072754b3";
+      sha256 = "45c6a761078cc1c97967d50a09321f7a158ed448c93c1b2b7458255fdb572848";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b9/linux-x86_64/it/firefox-112.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b2/linux-x86_64/it/firefox-113.0b2.tar.bz2";
       locale = "it";
       arch = "linux-x86_64";
-      sha256 = "b2c63ab01dfffb914cae739a75290c6be50e87a21d16fb8f3310199bfb2e507d";
+      sha256 = "ceb093143b2168afd3d3a71f024e764f01c8da462374683c6a29dc8ceb58b4d7";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b9/linux-x86_64/ja/firefox-112.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b2/linux-x86_64/ja/firefox-113.0b2.tar.bz2";
       locale = "ja";
       arch = "linux-x86_64";
-      sha256 = "1d997906bbb6307441995981052ade53f5beb77362b7644fc8880facf7d8b483";
+      sha256 = "a2710d710c6012fcc98e60f226101585c59a4bad97f77c7d4aba38c64c7e0627";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b9/linux-x86_64/ka/firefox-112.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b2/linux-x86_64/ka/firefox-113.0b2.tar.bz2";
       locale = "ka";
       arch = "linux-x86_64";
-      sha256 = "a2b73a567171b2e2db8176c214fdaba76b0c315ed456c601db88e0ab71fcf837";
+      sha256 = "be3b41064878163cb0056e3776506bba5c752bcdd5b0eecf9abac6e2b896e68e";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b9/linux-x86_64/kab/firefox-112.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b2/linux-x86_64/kab/firefox-113.0b2.tar.bz2";
       locale = "kab";
       arch = "linux-x86_64";
-      sha256 = "e6cecce0cde14c1eef3a497c555855b1edbea8bcf71e68eed14c10200183a734";
+      sha256 = "1797c12f10888794cfcdc07641523221b082a96c66846ad1ad52b2376b46ce52";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b9/linux-x86_64/kk/firefox-112.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b2/linux-x86_64/kk/firefox-113.0b2.tar.bz2";
       locale = "kk";
       arch = "linux-x86_64";
-      sha256 = "a0337d8b84b94e80dd81edf0a87a1fdd7c212dd5f5664c47cb906d43ea5b2a90";
+      sha256 = "c9b20975678bf04c6b121ebaae79c6a09f75d9272163ba51c0e452449acb3259";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b9/linux-x86_64/km/firefox-112.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b2/linux-x86_64/km/firefox-113.0b2.tar.bz2";
       locale = "km";
       arch = "linux-x86_64";
-      sha256 = "85b2dac6ffc335e9e81cdf4d964d6f6d2905268eb5b013e7d4e023ffb5fdfbc4";
+      sha256 = "84381384b0834591fc80eafb8b2c041097a3a86fa9fed6462d76dc54fabdefa6";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b9/linux-x86_64/kn/firefox-112.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b2/linux-x86_64/kn/firefox-113.0b2.tar.bz2";
       locale = "kn";
       arch = "linux-x86_64";
-      sha256 = "2e08b43b852f7be3dcd784f5475cd26703deb9ad93f7df10285ab24cfd82a49d";
+      sha256 = "a4445f7fb17a4f2217eb06d0b860e8ea31d97aa15d8f7f68c37218a2e97d60ab";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b9/linux-x86_64/ko/firefox-112.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b2/linux-x86_64/ko/firefox-113.0b2.tar.bz2";
       locale = "ko";
       arch = "linux-x86_64";
-      sha256 = "87d952317527c50a458bb5fe5f244ba52347602bad07045d599e1aa3c1cbc8db";
+      sha256 = "c6d03c3746416e2f4072caf05dc7af45f71ab6216217ebc744a49d224ad2f2d1";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b9/linux-x86_64/lij/firefox-112.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b2/linux-x86_64/lij/firefox-113.0b2.tar.bz2";
       locale = "lij";
       arch = "linux-x86_64";
-      sha256 = "7fc982962a030da5576761f2a23c3f85b17c2a715b8553d5aeb79a1994e2e5e1";
+      sha256 = "ff5ed7606d7fa7c97bd2febf0dba608eadbdbdfcebe9cbb4c8448ed0b4929c0f";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b9/linux-x86_64/lt/firefox-112.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b2/linux-x86_64/lt/firefox-113.0b2.tar.bz2";
       locale = "lt";
       arch = "linux-x86_64";
-      sha256 = "dacd492905102cfcee1fabc7690816df39c5adcee081eb14b978c15565d02989";
+      sha256 = "73595635f255299b96020a8e1866d3ecb95db344859ab1300ef83ae8a054986c";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b9/linux-x86_64/lv/firefox-112.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b2/linux-x86_64/lv/firefox-113.0b2.tar.bz2";
       locale = "lv";
       arch = "linux-x86_64";
-      sha256 = "1182fcc2818f0a1d81cf14e0240b7d66a9edb070dd73cf01a4a6cd3ba7d44232";
+      sha256 = "9e8933b9856bef61d9bfb4ebfb14b10884cad9212516d39c9222b248649c9a4f";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b9/linux-x86_64/mk/firefox-112.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b2/linux-x86_64/mk/firefox-113.0b2.tar.bz2";
       locale = "mk";
       arch = "linux-x86_64";
-      sha256 = "40451812d7c27d67a0ceb03a96e501bc3aa0882387dcc44bcdb864e954455574";
+      sha256 = "3e3d93556f43b0aeafb13730f10e7ed90a93909c79f240a052049003109d987c";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b9/linux-x86_64/mr/firefox-112.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b2/linux-x86_64/mr/firefox-113.0b2.tar.bz2";
       locale = "mr";
       arch = "linux-x86_64";
-      sha256 = "725cd79039f740876c74489185e782800d77b52eae382efa6ac878367e83107c";
+      sha256 = "5f35e43cbfc7556e9da67973a9a082dea4407287dd44b5991a9d7ccc68024922";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b9/linux-x86_64/ms/firefox-112.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b2/linux-x86_64/ms/firefox-113.0b2.tar.bz2";
       locale = "ms";
       arch = "linux-x86_64";
-      sha256 = "f9c7216817b683da598024b322e1cb3a6e7f4b2e2f22415b9b08c44d6503f71d";
+      sha256 = "29463450a3493e98a3b405df26d4a2860d6dc0df755d6344d9d3005a4d7fb201";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b9/linux-x86_64/my/firefox-112.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b2/linux-x86_64/my/firefox-113.0b2.tar.bz2";
       locale = "my";
       arch = "linux-x86_64";
-      sha256 = "732c2b0615039a004a63382e8f016d8708c1b72804b9bee77c6faf29b4011e94";
+      sha256 = "107f169060e961724aeafb4844909779eb72021566e3c8d120e4214e3fc0844d";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b9/linux-x86_64/nb-NO/firefox-112.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b2/linux-x86_64/nb-NO/firefox-113.0b2.tar.bz2";
       locale = "nb-NO";
       arch = "linux-x86_64";
-      sha256 = "a29b80ee29f1e552d50943693fc244c9c7014bee4291e9c92549555d62dbd0cd";
+      sha256 = "9f8dbee66447fa699a75a536c17e4654db185ae32b9b2d9c8f5e538d1eb3366b";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b9/linux-x86_64/ne-NP/firefox-112.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b2/linux-x86_64/ne-NP/firefox-113.0b2.tar.bz2";
       locale = "ne-NP";
       arch = "linux-x86_64";
-      sha256 = "a45b0b7a6118961cf79c0095b6d2f774204493e6635e44ef8dc98097f2b6e25a";
+      sha256 = "70bd560bc212cdc6b1fedc60b1e6fb21da744afa8e634b7afc7da864aae7b755";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b9/linux-x86_64/nl/firefox-112.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b2/linux-x86_64/nl/firefox-113.0b2.tar.bz2";
       locale = "nl";
       arch = "linux-x86_64";
-      sha256 = "a0a0b20a92fe9839b5f88af8e4658eca0221a40bb7cdacdfba7ea08a949b1bf9";
+      sha256 = "d9dbfc99d928d9a9bb6385aa10ad82444cc24632c078ab8850c311bc362f6fbd";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b9/linux-x86_64/nn-NO/firefox-112.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b2/linux-x86_64/nn-NO/firefox-113.0b2.tar.bz2";
       locale = "nn-NO";
       arch = "linux-x86_64";
-      sha256 = "660c9e979aac5fbd431771c1f4c6b3cafcdc7077b9e02aa70bccb8189e85ebb1";
+      sha256 = "12b907e10cc99cab346537e079739475994469297d3b13b1bc29943511d8c068";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b9/linux-x86_64/oc/firefox-112.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b2/linux-x86_64/oc/firefox-113.0b2.tar.bz2";
       locale = "oc";
       arch = "linux-x86_64";
-      sha256 = "7b50d8d0f9e84a91d2975770aeec54cf1c1c1c8c021e91e078ea966ae3240d24";
+      sha256 = "e98d3985affc2edeb7ea64d2230752f1eb3472c87e1d055d77928020883b78b0";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b9/linux-x86_64/pa-IN/firefox-112.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b2/linux-x86_64/pa-IN/firefox-113.0b2.tar.bz2";
       locale = "pa-IN";
       arch = "linux-x86_64";
-      sha256 = "fd569c37a2785f84aba84da769aec856eb53c7d045a911e48cd83a4d3dd54ccd";
+      sha256 = "8a083a756f1110bba2e9fc39e521314bd9ffd4749ef8e89edbd9205bf8536f19";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b9/linux-x86_64/pl/firefox-112.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b2/linux-x86_64/pl/firefox-113.0b2.tar.bz2";
       locale = "pl";
       arch = "linux-x86_64";
-      sha256 = "b8bc32cd7a3bca6b53fb2902e5ce07169a2a940886cb86050280e55a7a563548";
+      sha256 = "d3cb6e418f381957a076bd49f9f3149ba7f5c0bba434a80a054f2fdcd088683e";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b9/linux-x86_64/pt-BR/firefox-112.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b2/linux-x86_64/pt-BR/firefox-113.0b2.tar.bz2";
       locale = "pt-BR";
       arch = "linux-x86_64";
-      sha256 = "7a8dab23a431d69224c8a7e4ebe1d2f5895ed49ba4b528d4b855001d1152c095";
+      sha256 = "4036dcc9896d715b3b0488e5b04b89d3b4c1404ec51c5e0ee6bb598bc390af34";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b9/linux-x86_64/pt-PT/firefox-112.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b2/linux-x86_64/pt-PT/firefox-113.0b2.tar.bz2";
       locale = "pt-PT";
       arch = "linux-x86_64";
-      sha256 = "dc15ab170a81b9983179ce1f7cada72b33724a6743069d2049efea049d511e7c";
+      sha256 = "46dfc3c95698fe6365fa5b29fee671b4eab92c1a73e98c6f88f76d7bfe948383";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b9/linux-x86_64/rm/firefox-112.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b2/linux-x86_64/rm/firefox-113.0b2.tar.bz2";
       locale = "rm";
       arch = "linux-x86_64";
-      sha256 = "9d1985d608397f35b27103176512102dff24a2958ba5f1e9d119b95fd1aa1748";
+      sha256 = "d51294ac0be7b50df0417d6da3d89ba0995e3ece2a32268c7476866677ffad3e";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b9/linux-x86_64/ro/firefox-112.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b2/linux-x86_64/ro/firefox-113.0b2.tar.bz2";
       locale = "ro";
       arch = "linux-x86_64";
-      sha256 = "9d05495ececb294c3bb29fd729e4e5e9a9e3fde86b9774a91ea06963a8b491a4";
+      sha256 = "df68f0e0d7b8fabe6ad82005dd020c3767392ab51728634e1372cdb2094ddfa5";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b9/linux-x86_64/ru/firefox-112.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b2/linux-x86_64/ru/firefox-113.0b2.tar.bz2";
       locale = "ru";
       arch = "linux-x86_64";
-      sha256 = "8e3e666acebcd426a14aca3f45b2d3c372b0904dbf1582151a8c3983be7a7d61";
+      sha256 = "dce8b6ae4ca661b64177d81427fa7ebc3b39c261cf841695f3df9fdcc7aeb8bb";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b9/linux-x86_64/sc/firefox-112.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b2/linux-x86_64/sc/firefox-113.0b2.tar.bz2";
       locale = "sc";
       arch = "linux-x86_64";
-      sha256 = "2b3520e7d46fc8604b7a7bda838fb9f875a5916ed20892acf6fc48a7de869e73";
+      sha256 = "ff9e38fa62fd1f6fddd937ad1e9a11f0e846aa9364959df5243c92a0a6959a9b";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b9/linux-x86_64/sco/firefox-112.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b2/linux-x86_64/sco/firefox-113.0b2.tar.bz2";
       locale = "sco";
       arch = "linux-x86_64";
-      sha256 = "38b16f2289e84fb6ecc9d8ab69cc9ce9c676500ea43649f777f39b9592bdf292";
+      sha256 = "7b5548e52c69a894bf459b83ef13b2339af3195c102759cd42f0e3e6e1bb180e";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b9/linux-x86_64/si/firefox-112.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b2/linux-x86_64/si/firefox-113.0b2.tar.bz2";
       locale = "si";
       arch = "linux-x86_64";
-      sha256 = "3a48e41b4de39c8f0bc84e14f120860bd12004912d0aa4246d0c9247b11320f6";
+      sha256 = "f9be178f10a22a330e0f7a9dadd177523d41f6e5e6d338c3410bef86492ad719";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b9/linux-x86_64/sk/firefox-112.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b2/linux-x86_64/sk/firefox-113.0b2.tar.bz2";
       locale = "sk";
       arch = "linux-x86_64";
-      sha256 = "1abcf1c4de65e1f02a63e98e3d4465effc06b30f26a3d1ed8dc827258185df21";
+      sha256 = "e24cdc5481c18415aad067427e047106daffb7f8b9976d85f7dd26eec3d42525";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b9/linux-x86_64/sl/firefox-112.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b2/linux-x86_64/sl/firefox-113.0b2.tar.bz2";
       locale = "sl";
       arch = "linux-x86_64";
-      sha256 = "3090db10e9f989b9e1eaa107af3b72b5746c597b50a25ad91d7de903ac059631";
+      sha256 = "888a60ece2a7e953229b1eb8c8d1ed215f9b2c87adb3d7db9dfa8c062bda14a5";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b9/linux-x86_64/son/firefox-112.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b2/linux-x86_64/son/firefox-113.0b2.tar.bz2";
       locale = "son";
       arch = "linux-x86_64";
-      sha256 = "0b23cfe755a48e47408b1625cfd8ff82c00c4925ac2be19b3ceb7b1f5b0ee669";
+      sha256 = "a44e0ea0ee749e9a18eb1b3249449e41aeb37d79570020a067749d6b6dfd640a";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b9/linux-x86_64/sq/firefox-112.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b2/linux-x86_64/sq/firefox-113.0b2.tar.bz2";
       locale = "sq";
       arch = "linux-x86_64";
-      sha256 = "00b5a49bbdfe5466edf4bf6e2b004d59fe19484d5037e5d378fdefc8e598a20f";
+      sha256 = "21109ec7c815decefbd7a309ec7b8b33d16ef44a3f6d1c4b7154d7af8bdbdea0";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b9/linux-x86_64/sr/firefox-112.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b2/linux-x86_64/sr/firefox-113.0b2.tar.bz2";
       locale = "sr";
       arch = "linux-x86_64";
-      sha256 = "47d9e5648f97fcdb6f500e06f77e7410a3e2b86859ed61977e62a87becfe641a";
+      sha256 = "f7bd9de44d69c4830cb57ff4504bc09697d9a81558e019dbe6819c5356c62a51";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b9/linux-x86_64/sv-SE/firefox-112.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b2/linux-x86_64/sv-SE/firefox-113.0b2.tar.bz2";
       locale = "sv-SE";
       arch = "linux-x86_64";
-      sha256 = "92a2a272fd9230a41bab143d4de030c13c57aa9858328b17e90647dfe4942887";
+      sha256 = "79bd4619beea13d92abba8840d9308d7574e2bda4d8846952cc9809d4ea7e6af";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b9/linux-x86_64/szl/firefox-112.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b2/linux-x86_64/szl/firefox-113.0b2.tar.bz2";
       locale = "szl";
       arch = "linux-x86_64";
-      sha256 = "f35d7d58313dd9f9a95d2b22906aa67d7d125015bacb78136c19026068cdc93d";
+      sha256 = "c754fb35fa39bd887f1afa1614efa08819e6c155aea5c223ff2ee8f4203cdfcc";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b9/linux-x86_64/ta/firefox-112.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b2/linux-x86_64/ta/firefox-113.0b2.tar.bz2";
       locale = "ta";
       arch = "linux-x86_64";
-      sha256 = "5337aa72997e8a76ed924d120b7fd97a6613b850f8fbb6713e35baa0c9b5ebbb";
+      sha256 = "2993e39d026dc827b3083ba0f458b8fee6ded006135f136efeb89fe4d9096cb5";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b9/linux-x86_64/te/firefox-112.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b2/linux-x86_64/te/firefox-113.0b2.tar.bz2";
       locale = "te";
       arch = "linux-x86_64";
-      sha256 = "484a05ce013e11c8903d362d36eb7f22efb562d82ccfa228d2e4d7a7323e45ac";
+      sha256 = "1689d369fb0cb5cd81f591287963ee5b307f78cc37480fcb631d5bc50674f52a";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b9/linux-x86_64/th/firefox-112.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b2/linux-x86_64/tg/firefox-113.0b2.tar.bz2";
+      locale = "tg";
+      arch = "linux-x86_64";
+      sha256 = "d8d9a0c1fc3adfdaad371c87ecffacbad7ad593f12bd917c94dc0e87a5f89db6";
+    }
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b2/linux-x86_64/th/firefox-113.0b2.tar.bz2";
       locale = "th";
       arch = "linux-x86_64";
-      sha256 = "85a27c2dbaf72fd321727810ba2779f4bdc660cd96984f4d7b2191abe7cdf0dc";
+      sha256 = "076c1af96d6cf33c9e0fe981ddb1b4c8349ac8f518fe42197359ec69ab9735a7";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b9/linux-x86_64/tl/firefox-112.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b2/linux-x86_64/tl/firefox-113.0b2.tar.bz2";
       locale = "tl";
       arch = "linux-x86_64";
-      sha256 = "2aebae6fe3952b6ccf128b78fcf372065c20ab687f7d319ec5bcbfef83adbb6f";
+      sha256 = "15a4275803e9791429258cd9131b92806d3487dfa256d99121dca8716810c97d";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b9/linux-x86_64/tr/firefox-112.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b2/linux-x86_64/tr/firefox-113.0b2.tar.bz2";
       locale = "tr";
       arch = "linux-x86_64";
-      sha256 = "0a64883bd34d2973404757ab585158e14e146b23b5919d4329f5deaabea0dc15";
+      sha256 = "4f1f4359da847e91c0ccc534ea7928fcc6504b2a9ec57fced57a5eaa6f1ec5a6";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b9/linux-x86_64/trs/firefox-112.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b2/linux-x86_64/trs/firefox-113.0b2.tar.bz2";
       locale = "trs";
       arch = "linux-x86_64";
-      sha256 = "667b276c10440880a5168005cbf73ca65865584e006ef148543216d07e252b4f";
+      sha256 = "e26b79a7b60414b5b9db4de99f1bf66183a0ad88ad6137f6bc0be3d633d1f568";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b9/linux-x86_64/uk/firefox-112.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b2/linux-x86_64/uk/firefox-113.0b2.tar.bz2";
       locale = "uk";
       arch = "linux-x86_64";
-      sha256 = "958d00d6d6677587097081438176577b3c47b0bf45cbd685923ae265d89da026";
+      sha256 = "9bb0ffc850339665522e87115ac1667995d577b7e1d20147511c8c4c3f3716b3";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b9/linux-x86_64/ur/firefox-112.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b2/linux-x86_64/ur/firefox-113.0b2.tar.bz2";
       locale = "ur";
       arch = "linux-x86_64";
-      sha256 = "327e41a6f45db5eb0a5117267ce36c69643017168955b234fb76cdd7d669a049";
+      sha256 = "152b6c150f70e9785465c2cac092faca9d0904aed239c62c805a51ac95b089ae";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b9/linux-x86_64/uz/firefox-112.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b2/linux-x86_64/uz/firefox-113.0b2.tar.bz2";
       locale = "uz";
       arch = "linux-x86_64";
-      sha256 = "f638ee8433306b7b3c674fa75a65506c91306691665084cf9b0d97a9bf65586e";
+      sha256 = "5adfaecd15f74e75bd1ef909fa8abee130933d180efbb7cbdd431ffcb236e527";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b9/linux-x86_64/vi/firefox-112.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b2/linux-x86_64/vi/firefox-113.0b2.tar.bz2";
       locale = "vi";
       arch = "linux-x86_64";
-      sha256 = "a5dd6da3ac7822e4a03f281beca68568414572faf189c4e1f6413ec7ccf80ad0";
+      sha256 = "20b36d56fd558e427853b88678244552320623bd91367d9446057bb2b337463c";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b9/linux-x86_64/xh/firefox-112.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b2/linux-x86_64/xh/firefox-113.0b2.tar.bz2";
       locale = "xh";
       arch = "linux-x86_64";
-      sha256 = "f040d2b117c3e0ce55d5c644ed5ddb0d56ffe731afcd4258cd072fc3b7a67be3";
+      sha256 = "853a1d27d2e1697ab7ad85c0a848038a4a7851b00a43fb4244cc6c7e1a27378d";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b9/linux-x86_64/zh-CN/firefox-112.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b2/linux-x86_64/zh-CN/firefox-113.0b2.tar.bz2";
       locale = "zh-CN";
       arch = "linux-x86_64";
-      sha256 = "e3b43d1ca778407228f541e1c505177f584b080af007a79bc3367cea01945e81";
+      sha256 = "08a426059b4db42966ec5d67528042b9773d05ad22fcf24d16d7b4b45f9b201d";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b9/linux-x86_64/zh-TW/firefox-112.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b2/linux-x86_64/zh-TW/firefox-113.0b2.tar.bz2";
       locale = "zh-TW";
       arch = "linux-x86_64";
-      sha256 = "5ad9fbf8efc1f5e9421b159b4de131ca039408b4d50d5484f6ddf0dda9aeb636";
+      sha256 = "6bf733ce74e53fa33b7e4be729cd82dab829013903fd6420403ec62abfa4d999";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b9/linux-i686/ach/firefox-112.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b2/linux-i686/ach/firefox-113.0b2.tar.bz2";
       locale = "ach";
       arch = "linux-i686";
-      sha256 = "001c62c8746bd1af868005c8e5b3d11736f90752e0df2c416a2091ea3ad36e0b";
+      sha256 = "25c80b08b6449c4c6591c422ac732b1ce3fda4784999f746214b1f82a7589937";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b9/linux-i686/af/firefox-112.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b2/linux-i686/af/firefox-113.0b2.tar.bz2";
       locale = "af";
       arch = "linux-i686";
-      sha256 = "fbb4789c2bb201ec502438825412af985e8e5a8a7ee6065dd0f1dfecb4d70336";
+      sha256 = "4022146c820c99235953a2d345bce4795386216a610cb03ab0c481102f969b2a";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b9/linux-i686/an/firefox-112.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b2/linux-i686/an/firefox-113.0b2.tar.bz2";
       locale = "an";
       arch = "linux-i686";
-      sha256 = "d539b0245033c3f67e2ed770c012de9ab838018f927a8fc7fcc920767788b9b8";
+      sha256 = "ab35594cad8c996a49aad657a702e199f7451f14846c7f8529233c997c8cf035";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b9/linux-i686/ar/firefox-112.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b2/linux-i686/ar/firefox-113.0b2.tar.bz2";
       locale = "ar";
       arch = "linux-i686";
-      sha256 = "a562eddc3915e008b494c26d1bca3a7cff734ef45d79860aac498007622d49d4";
+      sha256 = "3b660e4ac36332308c987a27ce9d5be421ff8dbb59da4e15e7a66a3047d1ff95";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b9/linux-i686/ast/firefox-112.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b2/linux-i686/ast/firefox-113.0b2.tar.bz2";
       locale = "ast";
       arch = "linux-i686";
-      sha256 = "fcf2cf56b269a6bd3fa902052f3fe9e273c4354f6592e30cd5fec0f193e7386f";
+      sha256 = "6b70a696b733272b22fb4f04e469b69e93ff0ea6b0a8a67beb8c2ae3bbc2628b";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b9/linux-i686/az/firefox-112.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b2/linux-i686/az/firefox-113.0b2.tar.bz2";
       locale = "az";
       arch = "linux-i686";
-      sha256 = "824142e74794384514ca6b5b0a05b11303efde83de0065f87035bd1810ce902f";
+      sha256 = "f3e9ae9a134b27c314871caac99b86cc2b01003073d1a98d2bc7fa28f6df6dcf";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b9/linux-i686/be/firefox-112.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b2/linux-i686/be/firefox-113.0b2.tar.bz2";
       locale = "be";
       arch = "linux-i686";
-      sha256 = "3f41f87f2182a22a00f8c7e6420c7da9b71ba0c9e1f5efe8858b8f8e5caf450e";
+      sha256 = "bc8581c0af5dd902fd4fd8f66181efe0a82cec166a20fd9051db06c0b361a12d";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b9/linux-i686/bg/firefox-112.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b2/linux-i686/bg/firefox-113.0b2.tar.bz2";
       locale = "bg";
       arch = "linux-i686";
-      sha256 = "7f158c167e788dbba7e0eabbd8e9b281c0de1d6d8aa526d69ae5a8ec69926e5f";
+      sha256 = "98d00d667b04678f46ccfcb47ec752956e9e9585261f56e527eef172e216231e";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b9/linux-i686/bn/firefox-112.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b2/linux-i686/bn/firefox-113.0b2.tar.bz2";
       locale = "bn";
       arch = "linux-i686";
-      sha256 = "fc342a5d06299ca9018174f5c83ba9cb72c044aea2fe7e59c061612a1a40628e";
+      sha256 = "0f051452dc221b2a7b00e08534105f587f94bc470eb013d4bf44a15187f5dcbd";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b9/linux-i686/br/firefox-112.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b2/linux-i686/br/firefox-113.0b2.tar.bz2";
       locale = "br";
       arch = "linux-i686";
-      sha256 = "3ddfc1faea2933ae87860cec4fb789e58ff89c0c1bc056d8e1708c44f9749514";
+      sha256 = "25009effb796030cfd228ce9c9d7bf0efdd318e24ff8be92005d11d114ae90d9";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b9/linux-i686/bs/firefox-112.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b2/linux-i686/bs/firefox-113.0b2.tar.bz2";
       locale = "bs";
       arch = "linux-i686";
-      sha256 = "891e67716653251518709ee89ecd92cc8f03e660678744bd180f616ac48e1b69";
+      sha256 = "46d7b9302a325e03e9dfa60aea07db46999297f03a91b08e5c3e89ba2c57aed5";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b9/linux-i686/ca-valencia/firefox-112.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b2/linux-i686/ca-valencia/firefox-113.0b2.tar.bz2";
       locale = "ca-valencia";
       arch = "linux-i686";
-      sha256 = "4c6fbf059bd2baadd4d56c9fcb39afff2a3cac19172a9a5b44fa81c59a6ac2ac";
+      sha256 = "a1b3149aefc45c49baf3d6b2a8c5c86c3c5b37c2285547eb323158f3e1720679";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b9/linux-i686/ca/firefox-112.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b2/linux-i686/ca/firefox-113.0b2.tar.bz2";
       locale = "ca";
       arch = "linux-i686";
-      sha256 = "aed5d1e5f9f0b36039e441cff1734dd6c9a19beb42df6f4751fd5c2435c0b78d";
+      sha256 = "0e368731ef17dcb9565be063013688727dc10b78444fc9f593864c0d8910efcf";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b9/linux-i686/cak/firefox-112.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b2/linux-i686/cak/firefox-113.0b2.tar.bz2";
       locale = "cak";
       arch = "linux-i686";
-      sha256 = "5f90a690e0c73087f041f84a43b7b0c59886d1d7cbdd8c4f24c4bbe7e45203d6";
+      sha256 = "df6eb229362831945150ea37ab36d05b27a602851b1ad5d2a729d3b4e8e997ca";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b9/linux-i686/cs/firefox-112.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b2/linux-i686/cs/firefox-113.0b2.tar.bz2";
       locale = "cs";
       arch = "linux-i686";
-      sha256 = "c8d0f07d810d330400484b065c31d7ada75ce1bf7fd06cad5b5839cc8de05fb7";
+      sha256 = "be28a9e5cbdfd4b45d28b01c650eee85b39375876265475013b96b14ff22341e";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b9/linux-i686/cy/firefox-112.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b2/linux-i686/cy/firefox-113.0b2.tar.bz2";
       locale = "cy";
       arch = "linux-i686";
-      sha256 = "243b4578c636320cbb54b8c6b753300758dfe1cacf4c7b0bf59f9fab88d7918a";
+      sha256 = "de2ecfe65b76b99ccd362a1afd93c2a07a40b854751b379b1072a6a7968efdce";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b9/linux-i686/da/firefox-112.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b2/linux-i686/da/firefox-113.0b2.tar.bz2";
       locale = "da";
       arch = "linux-i686";
-      sha256 = "c6453746d7cd3ce1b447c2c31b551d72e63a3f7672cde7d63cf043709b04f82b";
+      sha256 = "b66bbfb949e8ddb10aefca3f75389edeeae1ca49f7d9a478c0b6cf034c19f4e9";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b9/linux-i686/de/firefox-112.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b2/linux-i686/de/firefox-113.0b2.tar.bz2";
       locale = "de";
       arch = "linux-i686";
-      sha256 = "c6d75e3b0085c550891491e74bf287d5afd50b5b4c2ea5962ea78c30a924a28a";
+      sha256 = "b6e41955558e0fdcdf7a654e19c8940f66dd90cb079b98b8ccde3d7c4e7ce667";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b9/linux-i686/dsb/firefox-112.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b2/linux-i686/dsb/firefox-113.0b2.tar.bz2";
       locale = "dsb";
       arch = "linux-i686";
-      sha256 = "697787ee71435999eea79f068c1df0cc985d8f3d1e4cd0ce656f843a5f1a84b2";
+      sha256 = "32dac237ecf5610ab49ded77f6b1956efbcc1d99c8ebb521c729e851401b83d0";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b9/linux-i686/el/firefox-112.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b2/linux-i686/el/firefox-113.0b2.tar.bz2";
       locale = "el";
       arch = "linux-i686";
-      sha256 = "3e44427cb177f2e557622d0c0c96b495f1b129d6583aafd6a89f159ba8832657";
+      sha256 = "3272116d9091b9d55ef73c92028983bade69fc2f3cd4f754c47f7351aa0cde46";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b9/linux-i686/en-CA/firefox-112.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b2/linux-i686/en-CA/firefox-113.0b2.tar.bz2";
       locale = "en-CA";
       arch = "linux-i686";
-      sha256 = "07791c9b1e6dadd6778298e988b81a282b076de1a8486a77863cb5a0e88e66ac";
+      sha256 = "4ce06a3ab094ae75546d747d6f634b6db84d3daedecd56a1e32659e2620f3f94";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b9/linux-i686/en-GB/firefox-112.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b2/linux-i686/en-GB/firefox-113.0b2.tar.bz2";
       locale = "en-GB";
       arch = "linux-i686";
-      sha256 = "b298bc8b95c09ee8f8f4698a46d878142af3751e105264b8ae3b2b6c9d831f80";
+      sha256 = "dbbeef8008322dc494c14fb1d73341fc02652ac56574251624b30dfcfd352aa6";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b9/linux-i686/en-US/firefox-112.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b2/linux-i686/en-US/firefox-113.0b2.tar.bz2";
       locale = "en-US";
       arch = "linux-i686";
-      sha256 = "572b485dbade05c1ca2a325068df1d0b0ecf61ea04672043721411a8338f7d40";
+      sha256 = "36996c36bd4b30b71bd31569ac499f5b4f2e00104e96ecddadb17acc58d98b2d";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b9/linux-i686/eo/firefox-112.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b2/linux-i686/eo/firefox-113.0b2.tar.bz2";
       locale = "eo";
       arch = "linux-i686";
-      sha256 = "af6dbaa0a264a509932d02468a4641d47213fab1fed3a1e0992f2d46c541f923";
+      sha256 = "68f064f735685a2da5f1a3645554d1fbed80cf20c69203d4f6602ad760691d53";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b9/linux-i686/es-AR/firefox-112.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b2/linux-i686/es-AR/firefox-113.0b2.tar.bz2";
       locale = "es-AR";
       arch = "linux-i686";
-      sha256 = "7db3733d8acb6f40c52c4d30ed72fd6a35fbc1da4ae09f2102eb10dcfc66447f";
+      sha256 = "eeb70a6492c90ab04b5c75d81bd6c7713a462ba4be3ecb71ec2be4226c145e8e";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b9/linux-i686/es-CL/firefox-112.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b2/linux-i686/es-CL/firefox-113.0b2.tar.bz2";
       locale = "es-CL";
       arch = "linux-i686";
-      sha256 = "02aaae0db0a2d1a3fb878ad0b766f8d13a3a032da55c74abed3cdd7446e0fa5c";
+      sha256 = "c9444d002912d9898c81926085e617bb01f64d3aecf5d87ae4c6df802f2a72de";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b9/linux-i686/es-ES/firefox-112.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b2/linux-i686/es-ES/firefox-113.0b2.tar.bz2";
       locale = "es-ES";
       arch = "linux-i686";
-      sha256 = "6faccf46b02eac9ca64e0dbf4a73e0c28bfbb22c11a98c92b57e2967faabad58";
+      sha256 = "56c48a1d5db84c6f7a1485422ff5eaef16a4a154b5e0f12f566afac44470325e";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b9/linux-i686/es-MX/firefox-112.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b2/linux-i686/es-MX/firefox-113.0b2.tar.bz2";
       locale = "es-MX";
       arch = "linux-i686";
-      sha256 = "a9445244afc264af5fe4b5002346a0337922e1893dd2d48d061e1990bebd815f";
+      sha256 = "12d4d2eb36051dc9b5e983ab64129a6b9f304ade261e4194779ee49338c46750";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b9/linux-i686/et/firefox-112.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b2/linux-i686/et/firefox-113.0b2.tar.bz2";
       locale = "et";
       arch = "linux-i686";
-      sha256 = "034225685aad456489a44a9099ec22a044a7e9d360da262cf86d5a39451a0af4";
+      sha256 = "592d29f1a9f6cfcb54e8ca5ca6c62ae4e0c184076e86c0b3e58394fff85c771c";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b9/linux-i686/eu/firefox-112.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b2/linux-i686/eu/firefox-113.0b2.tar.bz2";
       locale = "eu";
       arch = "linux-i686";
-      sha256 = "ca6ac23940ec4382037b4a4eded4dbbe1693acb95831a5fc00e2017ce8fdbd5b";
+      sha256 = "1c552711fe28cbdb144b44f932c7a9da269a08905331a8695db9475a7bc4aef2";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b9/linux-i686/fa/firefox-112.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b2/linux-i686/fa/firefox-113.0b2.tar.bz2";
       locale = "fa";
       arch = "linux-i686";
-      sha256 = "974d705494078320428d090ae0031f72d2a6acdb25b9eb9bcebaca7a439d0b23";
+      sha256 = "756e2ae0c3732af4a29b4b6b28aec2c3b974fe05f19d4ed85f720a78b7ee5493";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b9/linux-i686/ff/firefox-112.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b2/linux-i686/ff/firefox-113.0b2.tar.bz2";
       locale = "ff";
       arch = "linux-i686";
-      sha256 = "a14b310c0c707cd0bce8384eae06102245503662abc25c0058257208788895e7";
+      sha256 = "736f3c42d9b57a4bc1c8406020ca0903c238415df6cb34712169e1827beda85e";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b9/linux-i686/fi/firefox-112.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b2/linux-i686/fi/firefox-113.0b2.tar.bz2";
       locale = "fi";
       arch = "linux-i686";
-      sha256 = "307c35ee6515def64a9e251c3cebd463bc6c24b13092de1405535a98753fe4be";
+      sha256 = "0caba4bc0029568095b87978d11b3e67ad0601fc12c8639ee58aec8238626008";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b9/linux-i686/fr/firefox-112.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b2/linux-i686/fr/firefox-113.0b2.tar.bz2";
       locale = "fr";
       arch = "linux-i686";
-      sha256 = "c2f2629a15300b048caf402fa4d562d336f651a6a18fe623a0f6dbd5f679b056";
+      sha256 = "baee5dcec73f37213412bfc1b57bd1d638b329b74c7b18926b6a0f304eea2730";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b9/linux-i686/fur/firefox-112.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b2/linux-i686/fur/firefox-113.0b2.tar.bz2";
       locale = "fur";
       arch = "linux-i686";
-      sha256 = "cbacdb7d7c2d7a4583449d803d968d8ddf38f8c93589d7127c79d90418286fd0";
+      sha256 = "fbcaeebf213729b9ce2a1d6e4527befe6098c4e861119a9729b69ab7cef30964";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b9/linux-i686/fy-NL/firefox-112.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b2/linux-i686/fy-NL/firefox-113.0b2.tar.bz2";
       locale = "fy-NL";
       arch = "linux-i686";
-      sha256 = "9a186e8cfa60299b3da75971fd3c2d9df39606cd871d8b31ea58d8f8eb3a4138";
+      sha256 = "ed32ffab533b1e0c298705c69bed835cc7967264018749bde7965451a533d6fd";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b9/linux-i686/ga-IE/firefox-112.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b2/linux-i686/ga-IE/firefox-113.0b2.tar.bz2";
       locale = "ga-IE";
       arch = "linux-i686";
-      sha256 = "e6d378c32b14f2ad2d8d449af1d5c7d2d8a6f4cade905e1a2d661c9909523960";
+      sha256 = "4ae634c4f5bf1a5762d5d72126242c5de391d95f04300f97deb7ea029c8daa8b";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b9/linux-i686/gd/firefox-112.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b2/linux-i686/gd/firefox-113.0b2.tar.bz2";
       locale = "gd";
       arch = "linux-i686";
-      sha256 = "ac655198f738c3d4e98426ec55523ad4a72e1561a7adda5d844a2dd282c537f3";
+      sha256 = "affbd3fc866d0f543a2ec0a029b6b2371de40a0c2569d6f4363e0a6105d538b7";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b9/linux-i686/gl/firefox-112.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b2/linux-i686/gl/firefox-113.0b2.tar.bz2";
       locale = "gl";
       arch = "linux-i686";
-      sha256 = "606f45c27a0e735f78d909ba0d455258fe01582cd711442b0eba2711ffb7d59a";
+      sha256 = "0f423c8bd4db91f877f9727c5e0333c83d667d62ee3a8903224f4c24ced6ac3c";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b9/linux-i686/gn/firefox-112.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b2/linux-i686/gn/firefox-113.0b2.tar.bz2";
       locale = "gn";
       arch = "linux-i686";
-      sha256 = "4928f236bf60dbdf8edeb5e67feb51502568955f400f3fc7397203c94984f564";
+      sha256 = "458cc6f2b07dd78c2bcea089ab7e8ee93ca239b48f4f709249e87049eee8054d";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b9/linux-i686/gu-IN/firefox-112.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b2/linux-i686/gu-IN/firefox-113.0b2.tar.bz2";
       locale = "gu-IN";
       arch = "linux-i686";
-      sha256 = "735307d42e67fe9f261ebcb8d6dacf0e42f61f300e9cf98c32ea250432f1555c";
+      sha256 = "3209d74f326961e92a37bc790a48f856db982ffbb36ffd4577a88620b165474f";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b9/linux-i686/he/firefox-112.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b2/linux-i686/he/firefox-113.0b2.tar.bz2";
       locale = "he";
       arch = "linux-i686";
-      sha256 = "e69c30edd0dbaa7f013def86a664b9249d587f34f3acd39ca79f03f82b2393db";
+      sha256 = "86d01b21223eb0bb9c81582aec36596b184f093a12f6c5ecd76769ff0157ecad";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b9/linux-i686/hi-IN/firefox-112.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b2/linux-i686/hi-IN/firefox-113.0b2.tar.bz2";
       locale = "hi-IN";
       arch = "linux-i686";
-      sha256 = "be7aff57357dd7edfb06d7c027aef25551defe14c8a731d5ef7990943b3f6657";
+      sha256 = "12d9affd3e4377326bde74e2fc191790010b44eff389871b83e0d31c112a1453";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b9/linux-i686/hr/firefox-112.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b2/linux-i686/hr/firefox-113.0b2.tar.bz2";
       locale = "hr";
       arch = "linux-i686";
-      sha256 = "407e181d5dde4f8b0e9c1aed7fcd8da1bda4a52839adb2723fae56dc64074e0d";
+      sha256 = "1cb8a3f8e2905de618cbbd624e8572d436e5321c112574159efdb8658e1c0a4a";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b9/linux-i686/hsb/firefox-112.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b2/linux-i686/hsb/firefox-113.0b2.tar.bz2";
       locale = "hsb";
       arch = "linux-i686";
-      sha256 = "925841926afe7d51a1b2524c746aefaf0fe11dc870d2966d83d31fb1581e57b9";
+      sha256 = "9da23dc61e373990da0a6368020f25f630bb2650716a4159aef1813d0ce0a4ae";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b9/linux-i686/hu/firefox-112.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b2/linux-i686/hu/firefox-113.0b2.tar.bz2";
       locale = "hu";
       arch = "linux-i686";
-      sha256 = "e7ab694ae0fa9cd6938b1ab2d776edf2a30df17acde162f78de33b6b352f29e6";
+      sha256 = "f889ba28f8911db4c7e764cb80de5277d8544c10a9bcddea42d0277410f45a55";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b9/linux-i686/hy-AM/firefox-112.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b2/linux-i686/hy-AM/firefox-113.0b2.tar.bz2";
       locale = "hy-AM";
       arch = "linux-i686";
-      sha256 = "9e612d263cfbb2c75938857f8c6ca16aa38b4e8f9fa902772e2e2b1b0b2dd4d3";
+      sha256 = "95b1094b4545acd195a09bd95aa1fbad0b938d0989840804e8513eb245a7a27a";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b9/linux-i686/ia/firefox-112.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b2/linux-i686/ia/firefox-113.0b2.tar.bz2";
       locale = "ia";
       arch = "linux-i686";
-      sha256 = "00084df7281843c958824edea5364f254cec0febd03bf44c1394f50ed6a0cbe9";
+      sha256 = "8bd0750da123edc1335d716b5d07857ec18928df6621d5b590fd71e229ad7559";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b9/linux-i686/id/firefox-112.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b2/linux-i686/id/firefox-113.0b2.tar.bz2";
       locale = "id";
       arch = "linux-i686";
-      sha256 = "e9868ea3677cdad0da7428df00f41c2d7a6d890b5e6d54da6399d371a570c09c";
+      sha256 = "80a874cde7ec122faa1f9a6c85d01c85b111e0dd7a251bda39020fbe31dff579";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b9/linux-i686/is/firefox-112.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b2/linux-i686/is/firefox-113.0b2.tar.bz2";
       locale = "is";
       arch = "linux-i686";
-      sha256 = "231a8843d23304693f0507df7b8469c6b6bd08a947eac93f1f69c4e9e487bfa5";
+      sha256 = "db16f7232e3412768d21482dab1fddbdd84dca1bbe5afb91f2a6f2f89a3faa96";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b9/linux-i686/it/firefox-112.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b2/linux-i686/it/firefox-113.0b2.tar.bz2";
       locale = "it";
       arch = "linux-i686";
-      sha256 = "c94519aee1ce82168831cb88dee1ec6871f01b7c688c8a5cde0f853ce57f76ee";
+      sha256 = "5654aaccc62016507920116019b48f87b4afc42bd8e6daf784a93fae75141d48";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b9/linux-i686/ja/firefox-112.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b2/linux-i686/ja/firefox-113.0b2.tar.bz2";
       locale = "ja";
       arch = "linux-i686";
-      sha256 = "bea3afeb1156b7743dba2e53eeca6776544cf1df6fe9df2ebd346adaab11a58e";
+      sha256 = "01b49eeb6d4a8589bc6f2d1d7a2559ff68a1d63c77f1cfdb4befe5af3e877a16";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b9/linux-i686/ka/firefox-112.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b2/linux-i686/ka/firefox-113.0b2.tar.bz2";
       locale = "ka";
       arch = "linux-i686";
-      sha256 = "92946165ddeae4d2bd630839ef0586498cd87d24085362a98dd3b53acd23cca8";
+      sha256 = "d9ecef01c514b7b8eea2dca5e565ac859a0ec0dfc58749019c200e0e5ae4340a";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b9/linux-i686/kab/firefox-112.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b2/linux-i686/kab/firefox-113.0b2.tar.bz2";
       locale = "kab";
       arch = "linux-i686";
-      sha256 = "5c950ecbc8f6c33fae46f123725cbfb4923d1a64300aee62faffe2cc646bca54";
+      sha256 = "7c6fbd36e41b724cd4d4d21810be4893e29c12483fa07438c91c7d302efd40c9";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b9/linux-i686/kk/firefox-112.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b2/linux-i686/kk/firefox-113.0b2.tar.bz2";
       locale = "kk";
       arch = "linux-i686";
-      sha256 = "ab6b432b3b163b3d0422f2369a67676003e7b4deaebe76ea86ac14022ee99618";
+      sha256 = "b9e3e3604c85f9aa17050381a6422eea90f37550951bbc496aab27a2a180aee3";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b9/linux-i686/km/firefox-112.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b2/linux-i686/km/firefox-113.0b2.tar.bz2";
       locale = "km";
       arch = "linux-i686";
-      sha256 = "86428e0f0aeb4904c7c29e54af90ba072c4acec2e4e8485c9caf860be3bcb7ea";
+      sha256 = "cb3948ff88e269aa3a5c2c0bad8527d0542eaff1be9fdb1d97d00c310e94816a";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b9/linux-i686/kn/firefox-112.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b2/linux-i686/kn/firefox-113.0b2.tar.bz2";
       locale = "kn";
       arch = "linux-i686";
-      sha256 = "ca73f4d509954c9a35445527a69c5d0d47875cf6307f94424ed51bc9c3ba917a";
+      sha256 = "e81f78712ae816e0612958055cf57c27b24842c56fafcdbf03af73dfa126a709";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b9/linux-i686/ko/firefox-112.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b2/linux-i686/ko/firefox-113.0b2.tar.bz2";
       locale = "ko";
       arch = "linux-i686";
-      sha256 = "69bba62a5da1995f312e692f3c05f9538718fdeb9c3d02fb5b7c807ab35f052e";
+      sha256 = "09c85a9ed01c7331b881f0e651aaf558a0034842d9a8a067ab95313d8644d957";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b9/linux-i686/lij/firefox-112.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b2/linux-i686/lij/firefox-113.0b2.tar.bz2";
       locale = "lij";
       arch = "linux-i686";
-      sha256 = "4e8d99986a57d5482946eae060220e0005bc4d95bf0da4c3cd707e5f58a03c5b";
+      sha256 = "b7286511fb34b36557a04adb998a6710439484bad006922f5bfec5880275dc96";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b9/linux-i686/lt/firefox-112.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b2/linux-i686/lt/firefox-113.0b2.tar.bz2";
       locale = "lt";
       arch = "linux-i686";
-      sha256 = "60ad6de0d423568454de600b90890b040c024a51d2b51eba0d09c6d754445148";
+      sha256 = "ed60ae9290c507666ab77fea3a45c97712a529d679b1ee2fd428c3878ac3a01c";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b9/linux-i686/lv/firefox-112.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b2/linux-i686/lv/firefox-113.0b2.tar.bz2";
       locale = "lv";
       arch = "linux-i686";
-      sha256 = "160b9432b3cea0db06d8a2baac55777d05aa5b9a31a1fc6587262895cf9233b2";
+      sha256 = "b5fb4547164814e7def4d7715783618de4442e178b3fc299071a6922ad560794";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b9/linux-i686/mk/firefox-112.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b2/linux-i686/mk/firefox-113.0b2.tar.bz2";
       locale = "mk";
       arch = "linux-i686";
-      sha256 = "91dfcd69c383631c86906a01c89d929e1e7cc3514527c6492675d4109a8154ca";
+      sha256 = "72a891731624feec69a5be90fc6e8b372ad6b09972277c4ab1ba0bed45330fbf";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b9/linux-i686/mr/firefox-112.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b2/linux-i686/mr/firefox-113.0b2.tar.bz2";
       locale = "mr";
       arch = "linux-i686";
-      sha256 = "9b55606492b94540e168f62f7f4480863410979030f391b776a27c4e9f1b9b0a";
+      sha256 = "7e8a5c084df7e96d7133566ff49557ff2adfbb09b8700979aedaacd99e38f864";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b9/linux-i686/ms/firefox-112.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b2/linux-i686/ms/firefox-113.0b2.tar.bz2";
       locale = "ms";
       arch = "linux-i686";
-      sha256 = "75f46a267f2b78f8b25867596f8a3b9c950a834dd1b34e49155f364cdadb7f83";
+      sha256 = "221335d17918344c91b3c71ac6a37a0622698cfd816015d02abacb8b5de8b618";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b9/linux-i686/my/firefox-112.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b2/linux-i686/my/firefox-113.0b2.tar.bz2";
       locale = "my";
       arch = "linux-i686";
-      sha256 = "3aa2d313e43c296a0b965e7f7558a6edfe3a979dabdb8219df72a277715dd36d";
+      sha256 = "9c463212def05e00e261bdb496de4fc27eecfa80f44b2933e2089c4e344a511d";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b9/linux-i686/nb-NO/firefox-112.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b2/linux-i686/nb-NO/firefox-113.0b2.tar.bz2";
       locale = "nb-NO";
       arch = "linux-i686";
-      sha256 = "0825f596c96bb4e21fa4eef7aab3af28e26c3278ceffd86d03e36f410f23c548";
+      sha256 = "1120376de5ee3980cb7acd5b7dcc8a02c2b599fd9813f0b9c8340e9fa3d9530a";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b9/linux-i686/ne-NP/firefox-112.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b2/linux-i686/ne-NP/firefox-113.0b2.tar.bz2";
       locale = "ne-NP";
       arch = "linux-i686";
-      sha256 = "d3e0da616c813daba18e7925a298459568b672f6e2036386f3586dc0a9367681";
+      sha256 = "55bfb471db78c5b88867403ff77d4c7a4cb447f85d55c0423d8b802a0efe791b";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b9/linux-i686/nl/firefox-112.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b2/linux-i686/nl/firefox-113.0b2.tar.bz2";
       locale = "nl";
       arch = "linux-i686";
-      sha256 = "48abc93fa80dc7eac44abd59808ad9b4ad0dd749ace3d9099bf8c880d971e9d6";
+      sha256 = "2e13d5b4075024852d689dbab5993cc3589b14bc436d116a27a1a5eddb42d41f";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b9/linux-i686/nn-NO/firefox-112.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b2/linux-i686/nn-NO/firefox-113.0b2.tar.bz2";
       locale = "nn-NO";
       arch = "linux-i686";
-      sha256 = "dca656673d88ec5d8357c8015a4450933410d5df583b8a640aada866c87c0a13";
+      sha256 = "df3b8437cd4cc3df848e6ce0c12b3b27f9dc375b31dd9b639b31c73f90f54ed5";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b9/linux-i686/oc/firefox-112.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b2/linux-i686/oc/firefox-113.0b2.tar.bz2";
       locale = "oc";
       arch = "linux-i686";
-      sha256 = "81d5cb390b84aade67cc19e3a0de280a7d2535dbf785cbfd7ddf48dec0600332";
+      sha256 = "5d85733c0b8f6d505c2cc5436d0e3d2baca9203ab74c6e3c99ebf37af83d0a84";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b9/linux-i686/pa-IN/firefox-112.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b2/linux-i686/pa-IN/firefox-113.0b2.tar.bz2";
       locale = "pa-IN";
       arch = "linux-i686";
-      sha256 = "a0c284e96d18a1ba1c7368265691da61301ca4f50c2e1e0e627a7efc4a888b1f";
+      sha256 = "0992d97ee3659cc2fc2b32151e30981e555ae17060e0fb42004b841057d66051";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b9/linux-i686/pl/firefox-112.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b2/linux-i686/pl/firefox-113.0b2.tar.bz2";
       locale = "pl";
       arch = "linux-i686";
-      sha256 = "ed1c17add82a3c8e718ec3c4c001e74b89ad6783a877a320f7c0d4fc0b59b637";
+      sha256 = "32a3aff1f99fa59f6daaca54211edeaeffe46e1d9ffc0801afbba6bc795cc1f5";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b9/linux-i686/pt-BR/firefox-112.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b2/linux-i686/pt-BR/firefox-113.0b2.tar.bz2";
       locale = "pt-BR";
       arch = "linux-i686";
-      sha256 = "ad6e81cc096117fb7dcb13aedd7b478076d401334294ab3432f5dc5e7301bc4b";
+      sha256 = "7da9456483f0d70791fc91536407d54ead98c2da671b9f4380a692f835f82fe4";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b9/linux-i686/pt-PT/firefox-112.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b2/linux-i686/pt-PT/firefox-113.0b2.tar.bz2";
       locale = "pt-PT";
       arch = "linux-i686";
-      sha256 = "66b5f05e316fdcff6b6311650ee1ca575dc857174c7a69a8f00cfb7a543857fd";
+      sha256 = "6cd1fba52e5150ee435308187aba7ae2da40e081276eeceb031b336719bcc06f";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b9/linux-i686/rm/firefox-112.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b2/linux-i686/rm/firefox-113.0b2.tar.bz2";
       locale = "rm";
       arch = "linux-i686";
-      sha256 = "0a60fa14df631b8ad5ab93cd29b6d9d80325c581765b1206bdef6ed2cf294575";
+      sha256 = "8c3cebd21618bd6c86cfdf4955f01ab6b6c374be1da27ac981f4cad0a653abad";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b9/linux-i686/ro/firefox-112.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b2/linux-i686/ro/firefox-113.0b2.tar.bz2";
       locale = "ro";
       arch = "linux-i686";
-      sha256 = "99b4d0a7a329f44b5c97ac8fdb0d23e20b93fa938f5a398b356436ea11879348";
+      sha256 = "92eeb23cf62e805c52afedaa1a4ae9cd9760dac4e1a6df4c3e3e934176560ddb";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b9/linux-i686/ru/firefox-112.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b2/linux-i686/ru/firefox-113.0b2.tar.bz2";
       locale = "ru";
       arch = "linux-i686";
-      sha256 = "440e1bdf4c385acc9d82a7cd51642f6915c3f3d0168227f967acffab5101bfc8";
+      sha256 = "f2ddf1dd5405aef513ff4d7264bd03a82357aa2aacf837c2a8f7574bc751fbee";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b9/linux-i686/sc/firefox-112.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b2/linux-i686/sc/firefox-113.0b2.tar.bz2";
       locale = "sc";
       arch = "linux-i686";
-      sha256 = "2128ae7c222c3d30c80840281917645ca9a9d925eb71d10e5254ee4604538db3";
+      sha256 = "ca082a336b1217cc9291af1ec4d46ee3a37808662801b524191842da30d5e599";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b9/linux-i686/sco/firefox-112.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b2/linux-i686/sco/firefox-113.0b2.tar.bz2";
       locale = "sco";
       arch = "linux-i686";
-      sha256 = "c4d32b4a961a0a6df1a2fb56c55cff1f4bf64a010c8f8a032beb1e6ecb28eadb";
+      sha256 = "d8759316bf1afd7679170cb13c422af131764887188a4df9ce9c4cac8aad7abe";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b9/linux-i686/si/firefox-112.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b2/linux-i686/si/firefox-113.0b2.tar.bz2";
       locale = "si";
       arch = "linux-i686";
-      sha256 = "7ac3992fac1ee7c11a461d834dcb8d7dfb3fd73787b2ec3e78378d4d6449eaab";
+      sha256 = "7bc492417f6848ccc3bde701587e551299ca3fcfba55696a75576b6801d7b43c";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b9/linux-i686/sk/firefox-112.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b2/linux-i686/sk/firefox-113.0b2.tar.bz2";
       locale = "sk";
       arch = "linux-i686";
-      sha256 = "5ec27a162a2d08030dee7b6e0ca425ae18df436f05a0e1341bc1558a5b6b5567";
+      sha256 = "3bbf4e5a03759bf84e0cb5b2a04db845f1353e01c770141500cb7fd3482a5b4d";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b9/linux-i686/sl/firefox-112.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b2/linux-i686/sl/firefox-113.0b2.tar.bz2";
       locale = "sl";
       arch = "linux-i686";
-      sha256 = "46abdc79f08ac80a7e39744c1072d220da3f1cac13d0976b63cdb270eea4041d";
+      sha256 = "6b322afdb495a73274ab89e8b215b5f880baec4e9e704a979ee7ce6715cca728";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b9/linux-i686/son/firefox-112.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b2/linux-i686/son/firefox-113.0b2.tar.bz2";
       locale = "son";
       arch = "linux-i686";
-      sha256 = "9625fc87c1d5b149ef5c7569860bac3cbd949af60fc361541ebea1bdd71ec252";
+      sha256 = "a748cb1643585beed1ae72eb10b017f6b9de7e98306e79c0e8c92c5768f16cfa";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b9/linux-i686/sq/firefox-112.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b2/linux-i686/sq/firefox-113.0b2.tar.bz2";
       locale = "sq";
       arch = "linux-i686";
-      sha256 = "102b9c55b92a496d675f6a81189c478e950cd4463e6f1d40c285e08d63add7dc";
+      sha256 = "3581f7290766cfc1848fc453643dceced3d2f5a0e6f21a6f18ca63e697484356";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b9/linux-i686/sr/firefox-112.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b2/linux-i686/sr/firefox-113.0b2.tar.bz2";
       locale = "sr";
       arch = "linux-i686";
-      sha256 = "60f6228683899cc014d7b7ca45859f68e2614e749a12b6c0102750125fe97b12";
+      sha256 = "2a63d295f7b675d9bf3cbfd07f9dd96e52fd25f16b795762f349d6c035c7ba79";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b9/linux-i686/sv-SE/firefox-112.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b2/linux-i686/sv-SE/firefox-113.0b2.tar.bz2";
       locale = "sv-SE";
       arch = "linux-i686";
-      sha256 = "a47a098f0ff5e453619fa9cf64da42c6f275a6b730c3f1a13b6ca3701b4226dc";
+      sha256 = "9426ac6aa8d5aeadab85ab4fd921331195b3ccdba03f0e1e591d8584f3133390";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b9/linux-i686/szl/firefox-112.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b2/linux-i686/szl/firefox-113.0b2.tar.bz2";
       locale = "szl";
       arch = "linux-i686";
-      sha256 = "7c9ccf7499edad29049c01bd1e0ae210a010d8593e3387e7112ace7dd704530e";
+      sha256 = "1e7045194f7373d66eec1aef95ea57213451063a9db14950a08d53329db1a12b";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b9/linux-i686/ta/firefox-112.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b2/linux-i686/ta/firefox-113.0b2.tar.bz2";
       locale = "ta";
       arch = "linux-i686";
-      sha256 = "f24bf63835bc49f47138cb1625e24e414c83b8045b6e1761926966015c91f942";
+      sha256 = "6d28d89df6dc978c2d5a0e7402fe5c732de8c5e45c8d2874309046d8d5774774";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b9/linux-i686/te/firefox-112.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b2/linux-i686/te/firefox-113.0b2.tar.bz2";
       locale = "te";
       arch = "linux-i686";
-      sha256 = "766ffcf699160ead50f7b87eb17fd6e6c7bdf88b55a5c32c5cf9b879454739f2";
+      sha256 = "c2303fa30544c23d535f0b557641f35b42715a46fc6145dbfbcde55fe787825b";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b9/linux-i686/th/firefox-112.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b2/linux-i686/tg/firefox-113.0b2.tar.bz2";
+      locale = "tg";
+      arch = "linux-i686";
+      sha256 = "31a0fce5b8577aed2ef5e7d6cfee2e471966c8f4433c458ab64e7b10fbccbe84";
+    }
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b2/linux-i686/th/firefox-113.0b2.tar.bz2";
       locale = "th";
       arch = "linux-i686";
-      sha256 = "b6b886cef3e8497af341a464b8e776f87ba8820c3ee3d408ecbf7943ae358f17";
+      sha256 = "998e6b7ae0cdbcc0391175bab992d8d3a0ea1b8561436dd154f3a70734a4ec83";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b9/linux-i686/tl/firefox-112.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b2/linux-i686/tl/firefox-113.0b2.tar.bz2";
       locale = "tl";
       arch = "linux-i686";
-      sha256 = "e6db1429e802bf36007e44f0f286ecd4f3900b599985f11a83c729a1160663b8";
+      sha256 = "c0292071106bb58658dd5c9b5067518d3d021eaa75230bb021ae1b17c429e881";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b9/linux-i686/tr/firefox-112.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b2/linux-i686/tr/firefox-113.0b2.tar.bz2";
       locale = "tr";
       arch = "linux-i686";
-      sha256 = "db2bfc2cf8c644df3ca773ccea4f1ddd23eac5236fc9eb24176d240db4ff7544";
+      sha256 = "c526afd4f552d7a42a6a934201173acbb8752f2943b1140a100f965a4a0f19b0";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b9/linux-i686/trs/firefox-112.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b2/linux-i686/trs/firefox-113.0b2.tar.bz2";
       locale = "trs";
       arch = "linux-i686";
-      sha256 = "5409112c980ec74dc459bfa7f72a0b014b563314d864fac54af7ee5d6c98e569";
+      sha256 = "20b49f4b2e5e9e69c04a35fb6ac6f1518800e7aa59e167b57db657343dcea3d9";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b9/linux-i686/uk/firefox-112.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b2/linux-i686/uk/firefox-113.0b2.tar.bz2";
       locale = "uk";
       arch = "linux-i686";
-      sha256 = "7a4be0b621b6ecc524c882c38f8d1097c833b3a8d5452109ffb90976a586b4a2";
+      sha256 = "09013fe489d551074f5a23854618c79b513661c0393d94448ccfaa46140db393";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b9/linux-i686/ur/firefox-112.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b2/linux-i686/ur/firefox-113.0b2.tar.bz2";
       locale = "ur";
       arch = "linux-i686";
-      sha256 = "2b4dc07d6ff51183be77f3785d636cba98e34c2b2a3d0cd8213315f552ed8f0b";
+      sha256 = "d498a2e342a8c508f6ca897f24fff724abe154530985cb86c2c41f4148248947";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b9/linux-i686/uz/firefox-112.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b2/linux-i686/uz/firefox-113.0b2.tar.bz2";
       locale = "uz";
       arch = "linux-i686";
-      sha256 = "9cb37a4268c0323f4eadf9fd615577aab6aee163ac0378fcbfdf04694d8e4638";
+      sha256 = "88e1cded70f32e4ef609455f66372e20529cd76c3ff7f7752c2dfdc76ed145ef";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b9/linux-i686/vi/firefox-112.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b2/linux-i686/vi/firefox-113.0b2.tar.bz2";
       locale = "vi";
       arch = "linux-i686";
-      sha256 = "4d98d721f9193ec02def0d87ae9be17f461f56e4505153b1247416bd8cae3276";
+      sha256 = "e8ac1558d68b66e263b8bccf7f4e4713b3285e685135225ec0a059bb9bc8e1f8";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b9/linux-i686/xh/firefox-112.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b2/linux-i686/xh/firefox-113.0b2.tar.bz2";
       locale = "xh";
       arch = "linux-i686";
-      sha256 = "6ab5df34d91eded96f9ca4d81338743f8d41e108b738a56c0782181802d2793d";
+      sha256 = "5711801a00bb2ce5dc0463257a026b0bc50ecdbcbe9906427ff0f6d7d1261d34";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b9/linux-i686/zh-CN/firefox-112.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b2/linux-i686/zh-CN/firefox-113.0b2.tar.bz2";
       locale = "zh-CN";
       arch = "linux-i686";
-      sha256 = "48c9b0e2947a076b1b03442a429472f6bbb8f69dacf07e4155ffb42610fa9e2d";
+      sha256 = "78eace2a264fbd0086c3e37c66b616c80d53686d8bbcaa9991ef8993f3d72674";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0b9/linux-i686/zh-TW/firefox-112.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b2/linux-i686/zh-TW/firefox-113.0b2.tar.bz2";
       locale = "zh-TW";
       arch = "linux-i686";
-      sha256 = "0f89adf447b3b837eecbaaef1f19533ca4761413ae4808a62ae33f779494e853";
+      sha256 = "4a875e17b79d33b434df4c29f485cbf5d3d4cc9e07914edf549227ac76e83c79";
     }
     ];
 }

--- a/pkgs/applications/networking/browsers/firefox-bin/beta_sources.nix
+++ b/pkgs/applications/networking/browsers/firefox-bin/beta_sources.nix
@@ -1,1015 +1,1015 @@
 {
-  version = "113.0b2";
+  version = "113.0b3";
   sources = [
-    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b2/linux-x86_64/ach/firefox-113.0b2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b3/linux-x86_64/ach/firefox-113.0b3.tar.bz2";
       locale = "ach";
       arch = "linux-x86_64";
-      sha256 = "63bc87c112ea0550bf859e5531870a3ca88ead4782fe2b8cd064f29820dd9072";
+      sha256 = "97d9b5ac89cb6466f4e7b46749058c119fe7155aaeac8b0bbf341745f8dcefa8";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b2/linux-x86_64/af/firefox-113.0b2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b3/linux-x86_64/af/firefox-113.0b3.tar.bz2";
       locale = "af";
       arch = "linux-x86_64";
-      sha256 = "69c91441b99ed38a4e492c9103f541ee729922aed7f7e1dfc85a62925654b1dd";
+      sha256 = "2f5c33cfb22d1b77114124148d2dfbd3d82223a24c1a773174839077014a4b04";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b2/linux-x86_64/an/firefox-113.0b2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b3/linux-x86_64/an/firefox-113.0b3.tar.bz2";
       locale = "an";
       arch = "linux-x86_64";
-      sha256 = "1650b2fab644b920829d55ec7d54267edb3cd46d0ea9a6e9cab27df512882874";
+      sha256 = "9c7ea413f180148c66c32bdf88f23519555a6a93bc8495568d02e39db475b5a2";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b2/linux-x86_64/ar/firefox-113.0b2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b3/linux-x86_64/ar/firefox-113.0b3.tar.bz2";
       locale = "ar";
       arch = "linux-x86_64";
-      sha256 = "8a1e7d94309dd4eeb90638b197b85b8d3538fc6314d2444659f05f673cb89781";
+      sha256 = "cf61ace5a5cf0a656a6a5dcc469dd50a3aa440a8c74ba0a45deecf810a2fcc44";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b2/linux-x86_64/ast/firefox-113.0b2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b3/linux-x86_64/ast/firefox-113.0b3.tar.bz2";
       locale = "ast";
       arch = "linux-x86_64";
-      sha256 = "3eaa57e4d7c92acad0c27764e1c1328a6056aa6e9499ea3d1be43694526a2966";
+      sha256 = "5aaf8fed853e4b58b221a1e1a872936f00c13b6544bb42d68a3cfb78b99ba2cb";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b2/linux-x86_64/az/firefox-113.0b2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b3/linux-x86_64/az/firefox-113.0b3.tar.bz2";
       locale = "az";
       arch = "linux-x86_64";
-      sha256 = "4d1baac45cd347ef8fd22c3c5971b8b18115fac37044095fd8342e1826b456aa";
+      sha256 = "d399a2fa5bc8c185a9ddc2447098a7fd71438b442b9dba704973c4837418e953";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b2/linux-x86_64/be/firefox-113.0b2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b3/linux-x86_64/be/firefox-113.0b3.tar.bz2";
       locale = "be";
       arch = "linux-x86_64";
-      sha256 = "82c87b414801cb3b3cc7a48d6e253042154b6668453219d809be040f1b26b663";
+      sha256 = "992c5d7db66030cd38595addabd3567e7f88746bd5beadb3763b7c4cdc933f7a";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b2/linux-x86_64/bg/firefox-113.0b2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b3/linux-x86_64/bg/firefox-113.0b3.tar.bz2";
       locale = "bg";
       arch = "linux-x86_64";
-      sha256 = "a2c5c5cb89cc6a648dbf385cc37a51cd1f27659655c87be464a732cad51cc425";
+      sha256 = "97b6c3d43b9a3c62f29a711cc028c8748cfbf890df4d7d230b56cddad99469a5";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b2/linux-x86_64/bn/firefox-113.0b2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b3/linux-x86_64/bn/firefox-113.0b3.tar.bz2";
       locale = "bn";
       arch = "linux-x86_64";
-      sha256 = "eb61b01a24ca166f735691e6fce4c08ace175e7dc419763f9f6936ddaecc2682";
+      sha256 = "33fa082099849f0ca36c75ccaa2d039d58f6f6e77e527bbafe148cf90ca894c8";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b2/linux-x86_64/br/firefox-113.0b2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b3/linux-x86_64/br/firefox-113.0b3.tar.bz2";
       locale = "br";
       arch = "linux-x86_64";
-      sha256 = "42a1b2c36648d6ae8f253df6be9a4965f206cbf09e4d1a24bed21292ddd23efc";
+      sha256 = "b42bf6737501c8ed71c762968857c7091bb248ca0cef00690855cacb83c7f07e";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b2/linux-x86_64/bs/firefox-113.0b2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b3/linux-x86_64/bs/firefox-113.0b3.tar.bz2";
       locale = "bs";
       arch = "linux-x86_64";
-      sha256 = "6ed113b4831d29b2b52ce12172399a6e3afbf3310a8cb47114e1f8dc81131739";
+      sha256 = "d388804d8376e35eab6094f9092d2c9b5a22578b52bd5a2b86760480f2efbff1";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b2/linux-x86_64/ca-valencia/firefox-113.0b2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b3/linux-x86_64/ca-valencia/firefox-113.0b3.tar.bz2";
       locale = "ca-valencia";
       arch = "linux-x86_64";
-      sha256 = "6dc38c703dc9d54e369b0082952624b8d8dbf24e3cb6216601076e910f1067ef";
+      sha256 = "785d1f69a0e63076d727246990208e117f05b23d2bd4e896ecaef237715b6153";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b2/linux-x86_64/ca/firefox-113.0b2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b3/linux-x86_64/ca/firefox-113.0b3.tar.bz2";
       locale = "ca";
       arch = "linux-x86_64";
-      sha256 = "9926a0525fd056e5bff59aaf57f8129ab51e03f65e47abf0f6f7404275916efc";
+      sha256 = "ff648477c3b23a2d9968addc779bcede1a81fdd52d82a508dbb80420978ed3e9";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b2/linux-x86_64/cak/firefox-113.0b2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b3/linux-x86_64/cak/firefox-113.0b3.tar.bz2";
       locale = "cak";
       arch = "linux-x86_64";
-      sha256 = "d4afaf2e2b3f9f1130bbed7936d0debd6f44f8e8a856f2400600cb04974b681b";
+      sha256 = "51cf577d84d2337115714b92bdf7920bd5c05065ed4462e499d78a3514a6a249";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b2/linux-x86_64/cs/firefox-113.0b2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b3/linux-x86_64/cs/firefox-113.0b3.tar.bz2";
       locale = "cs";
       arch = "linux-x86_64";
-      sha256 = "5c77cfb25086ac444a213f256b02f105f18c887b38bebb6c614ca079d5335a1d";
+      sha256 = "fc9de60a742affbdda30953db2a1985ff9ffce32f47ec44201d556ed467f425b";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b2/linux-x86_64/cy/firefox-113.0b2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b3/linux-x86_64/cy/firefox-113.0b3.tar.bz2";
       locale = "cy";
       arch = "linux-x86_64";
-      sha256 = "6ee073b90ac7dd16f974c931fff45a2c1360c0a094862fcdaef457d1c7d13cf0";
+      sha256 = "81bed8e3fd82a92858860c22dc0bf12599d1f6f64f70cae99d8726681d4e52f3";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b2/linux-x86_64/da/firefox-113.0b2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b3/linux-x86_64/da/firefox-113.0b3.tar.bz2";
       locale = "da";
       arch = "linux-x86_64";
-      sha256 = "f33e59dd6a8a5398915908a91d12c6dae070f7c96a179b72bdceee68ce69369d";
+      sha256 = "97e558ad2f53fcf73d25b428987206293a57a8310994bcea653f58ffb2ab4d0b";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b2/linux-x86_64/de/firefox-113.0b2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b3/linux-x86_64/de/firefox-113.0b3.tar.bz2";
       locale = "de";
       arch = "linux-x86_64";
-      sha256 = "6168ab1245c4952d94533db0de4bce39be144ad5ae35b9d4637f62e6e60598be";
+      sha256 = "8333b7db13cedb6cbecd054fe4e407230ed6043e9e59c2ac492e5670b4f4aad4";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b2/linux-x86_64/dsb/firefox-113.0b2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b3/linux-x86_64/dsb/firefox-113.0b3.tar.bz2";
       locale = "dsb";
       arch = "linux-x86_64";
-      sha256 = "b6b881aade26c207768a6ce5f111eaf6dfec7cb0bcad3d1e1ef94e700db6f3a4";
+      sha256 = "abce6406ff07e883d3cfb0ff3ac6f82b805b6acd74dc189c19b021294966f848";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b2/linux-x86_64/el/firefox-113.0b2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b3/linux-x86_64/el/firefox-113.0b3.tar.bz2";
       locale = "el";
       arch = "linux-x86_64";
-      sha256 = "d44620052f215b9e1037d6f271f9b4fb23a1184d8c9bbde146c7fe1fc3fb3593";
+      sha256 = "976afd9b339e12efad18eeca0f367aa663c982088d21ebe629588f96d16bfadf";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b2/linux-x86_64/en-CA/firefox-113.0b2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b3/linux-x86_64/en-CA/firefox-113.0b3.tar.bz2";
       locale = "en-CA";
       arch = "linux-x86_64";
-      sha256 = "e699de7bf03c8387f5a0d49d9456231d9153833fa89e0b71f23b9749cd009a57";
+      sha256 = "ce2e0be3e1eecda5673fa3f22e6b99581dd9ff4d83d44a5e2cbb829fad020cb6";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b2/linux-x86_64/en-GB/firefox-113.0b2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b3/linux-x86_64/en-GB/firefox-113.0b3.tar.bz2";
       locale = "en-GB";
       arch = "linux-x86_64";
-      sha256 = "6c27aad74c8b8f9462141ef67d0ad68aacf658097136943fadae4e7e0096ba1d";
+      sha256 = "1b58726ffc64d3ceff1938fd5802ba9f7327510c044c57c9d48f7bf705e7be25";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b2/linux-x86_64/en-US/firefox-113.0b2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b3/linux-x86_64/en-US/firefox-113.0b3.tar.bz2";
       locale = "en-US";
       arch = "linux-x86_64";
-      sha256 = "511e1eefba5a10cd88ec89eba0c409cf3144de025995931111a8ab269d6e2075";
+      sha256 = "db9e0f4f801250a61838e4c97b5c276ba16fca98845458d5179692b4a17f7e96";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b2/linux-x86_64/eo/firefox-113.0b2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b3/linux-x86_64/eo/firefox-113.0b3.tar.bz2";
       locale = "eo";
       arch = "linux-x86_64";
-      sha256 = "b5a15bc9a92b292607eb1dffa4c40823ace30a158d313f86dc67e5538898bb26";
+      sha256 = "a129c8c1b7e8ebe358ec3179f7c8ba3eed0e5774f3dcca8b6abebe864d6617f8";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b2/linux-x86_64/es-AR/firefox-113.0b2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b3/linux-x86_64/es-AR/firefox-113.0b3.tar.bz2";
       locale = "es-AR";
       arch = "linux-x86_64";
-      sha256 = "a53d3d6ba1826668866ad38bee908fd0d4e4b53ac7a1157f5b0f8eaa55ccb3ec";
+      sha256 = "7453891a95996e54633c83f196627cac1ef868cf992c963058c7492530e25824";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b2/linux-x86_64/es-CL/firefox-113.0b2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b3/linux-x86_64/es-CL/firefox-113.0b3.tar.bz2";
       locale = "es-CL";
       arch = "linux-x86_64";
-      sha256 = "f5646ea1adca35f428024f126b14046007c07e062e6afeb1299f51d4adc75093";
+      sha256 = "f76fe51e46aeecca36b80b7d12f08fa459f8963148ae3c1543db00d72682c61b";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b2/linux-x86_64/es-ES/firefox-113.0b2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b3/linux-x86_64/es-ES/firefox-113.0b3.tar.bz2";
       locale = "es-ES";
       arch = "linux-x86_64";
-      sha256 = "b7a7bb21d651699fc58f6451ddfbe506aede2d0fe261c62442074c6f28ed43c0";
+      sha256 = "c3fd2089cb514b3b7db5503e05b5750b71275d397dc2c90e044fdd013ee84add";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b2/linux-x86_64/es-MX/firefox-113.0b2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b3/linux-x86_64/es-MX/firefox-113.0b3.tar.bz2";
       locale = "es-MX";
       arch = "linux-x86_64";
-      sha256 = "156a2ac4486f887a95fc5ddf08d4769effffd90a1e544a66ff53a46a41411b18";
+      sha256 = "c42fe3bbfa88ead27cb8a54801103f38b8de4eea62d8816161ff5639807db7a9";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b2/linux-x86_64/et/firefox-113.0b2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b3/linux-x86_64/et/firefox-113.0b3.tar.bz2";
       locale = "et";
       arch = "linux-x86_64";
-      sha256 = "7da54891f5047b7fa86b1c1ad5dcded253c6619a2f9b72826269b4256a021568";
+      sha256 = "595405197e4290f1b1fc69c04cca41b68b8ab2fa65d65efa07905511957c5979";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b2/linux-x86_64/eu/firefox-113.0b2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b3/linux-x86_64/eu/firefox-113.0b3.tar.bz2";
       locale = "eu";
       arch = "linux-x86_64";
-      sha256 = "02cad7594db80a1b9031b0a83eecde16c0deb2d2e7b40368b85e8b5424863959";
+      sha256 = "49e550e2b5f1a4a8c62f812c1b759fb6366be6a983bfaad1e9529cce22ed5b1f";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b2/linux-x86_64/fa/firefox-113.0b2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b3/linux-x86_64/fa/firefox-113.0b3.tar.bz2";
       locale = "fa";
       arch = "linux-x86_64";
-      sha256 = "8acd02298cc36dda92fa5ab61d4750d6af931c6292d0688d10895c7e24355e13";
+      sha256 = "a3f558e9d0eed3f50a6463c58873bc46ef5cb82021a95613cf9f90ddc695f7bd";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b2/linux-x86_64/ff/firefox-113.0b2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b3/linux-x86_64/ff/firefox-113.0b3.tar.bz2";
       locale = "ff";
       arch = "linux-x86_64";
-      sha256 = "e29869d59e460ce85cae8444f3d01385ce1512694cc321bba37cede7c6d575f4";
+      sha256 = "2ca11444e4e74a6263f50c6d5e724f4500f4657c459e82ae36f1e7c8ec884c16";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b2/linux-x86_64/fi/firefox-113.0b2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b3/linux-x86_64/fi/firefox-113.0b3.tar.bz2";
       locale = "fi";
       arch = "linux-x86_64";
-      sha256 = "56744eba15b28a99fd9c3bee3e42f7176ff91aab678dd5b533991f9b08138958";
+      sha256 = "254eb5fda287acd189a10ae684e3da3e31315abf1e06791e340e46418bb63bfd";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b2/linux-x86_64/fr/firefox-113.0b2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b3/linux-x86_64/fr/firefox-113.0b3.tar.bz2";
       locale = "fr";
       arch = "linux-x86_64";
-      sha256 = "5ebebcdff31ed8fb2e0c0facff94b09d39d5554f32a117fcce57fcf917c43d6a";
+      sha256 = "3688a132f31e739dba4a7817b9352fa788d5b4736fcb95c7ad3f589d11f0b752";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b2/linux-x86_64/fur/firefox-113.0b2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b3/linux-x86_64/fur/firefox-113.0b3.tar.bz2";
       locale = "fur";
       arch = "linux-x86_64";
-      sha256 = "e6ea051bbc5a5fca3dbc85801a1d875e1acba534b64a1c3fd0d17a89e446f457";
+      sha256 = "bae5ed52fc711330b5697d16e7e5a2e7231ea16f98b00d477f521a37d4a48761";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b2/linux-x86_64/fy-NL/firefox-113.0b2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b3/linux-x86_64/fy-NL/firefox-113.0b3.tar.bz2";
       locale = "fy-NL";
       arch = "linux-x86_64";
-      sha256 = "cb6d6ece58907e8e3b94fd72990e8a45b79c5b16b7fa10025e7d411f4020e28f";
+      sha256 = "2d1c513577d83a24c2f114018ea58f4afcb97d7bd178aeddf298feff3ab35d35";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b2/linux-x86_64/ga-IE/firefox-113.0b2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b3/linux-x86_64/ga-IE/firefox-113.0b3.tar.bz2";
       locale = "ga-IE";
       arch = "linux-x86_64";
-      sha256 = "5f15ece920201a51fa11dc05cfefd5e1c95d94805937c68562b39ed64cdd2de8";
+      sha256 = "f20732c4db383f85ab80fddf921d455c0949d9a32dc42150d731c0bb2125044e";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b2/linux-x86_64/gd/firefox-113.0b2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b3/linux-x86_64/gd/firefox-113.0b3.tar.bz2";
       locale = "gd";
       arch = "linux-x86_64";
-      sha256 = "5f741f15b45961000de625412e6409ba12811eebb1a46c5c549adfc36996f115";
+      sha256 = "6c296d330d340e1c8f408d8563415c1b02c0fa0970e47aa9cc198c2f53a8bbf0";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b2/linux-x86_64/gl/firefox-113.0b2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b3/linux-x86_64/gl/firefox-113.0b3.tar.bz2";
       locale = "gl";
       arch = "linux-x86_64";
-      sha256 = "54644d3e6d222e2e5baf2e7067e1854be0ea39134c6c5109718c94ff6e874907";
+      sha256 = "ab9308332edb27f07817af57eff40a978f89641ebd949bdc89826e02f5fb01c2";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b2/linux-x86_64/gn/firefox-113.0b2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b3/linux-x86_64/gn/firefox-113.0b3.tar.bz2";
       locale = "gn";
       arch = "linux-x86_64";
-      sha256 = "5e635b012a7cf872454dffa4966e693e50d9f9857b6f2c64231f34c4791e68f7";
+      sha256 = "c26e1b7e80c504cdddf21b9b9674dfe8eec58690ff400f10624d59ec769b2a22";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b2/linux-x86_64/gu-IN/firefox-113.0b2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b3/linux-x86_64/gu-IN/firefox-113.0b3.tar.bz2";
       locale = "gu-IN";
       arch = "linux-x86_64";
-      sha256 = "a32aaac1ee9444aab09d86f3a9e0663c85d256a0012e94e7d68aa369124a4fdf";
+      sha256 = "8fc4a17c5cdd2e0cbf15a76ecf091e6c158ba20fd531221e0fb35cb5550667ac";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b2/linux-x86_64/he/firefox-113.0b2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b3/linux-x86_64/he/firefox-113.0b3.tar.bz2";
       locale = "he";
       arch = "linux-x86_64";
-      sha256 = "852a5608aad550d92ab265f01be4e7a36781390d6a07d6eb006e2cb95c78f5c3";
+      sha256 = "8a54d600032f9218bc94aa60ff024ed93d403d41132ebc803b4b80a0c98268fc";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b2/linux-x86_64/hi-IN/firefox-113.0b2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b3/linux-x86_64/hi-IN/firefox-113.0b3.tar.bz2";
       locale = "hi-IN";
       arch = "linux-x86_64";
-      sha256 = "58f4a003137d7103ffbef22f47966324c18a45c22d2f0d8544011fef57f0c39a";
+      sha256 = "0a1cbaaeb32fedebb41548ed78c12eeb041b8dfffeaf00f3f2f9a3ac75c8564c";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b2/linux-x86_64/hr/firefox-113.0b2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b3/linux-x86_64/hr/firefox-113.0b3.tar.bz2";
       locale = "hr";
       arch = "linux-x86_64";
-      sha256 = "6ea7add25edb7443919df9de132aa61bad58e4c5c1f8852ebb913743d1fbd91c";
+      sha256 = "52d12b639bf01bf1aa9ae7ffe79f098002975b908ebc9809e2019a1938270037";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b2/linux-x86_64/hsb/firefox-113.0b2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b3/linux-x86_64/hsb/firefox-113.0b3.tar.bz2";
       locale = "hsb";
       arch = "linux-x86_64";
-      sha256 = "2947b75607e4ee22edf7a95e71f3950903a115ffc4672781ca390e4a3cacc684";
+      sha256 = "3f64cab2885bf392cc966a77ee4f1df4fd0849e2b536219036aa876b9339eb72";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b2/linux-x86_64/hu/firefox-113.0b2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b3/linux-x86_64/hu/firefox-113.0b3.tar.bz2";
       locale = "hu";
       arch = "linux-x86_64";
-      sha256 = "5f072e596885cb52ee65bd68c9e7f66a01a42c87e7aa3c82b99197905fa79835";
+      sha256 = "6bf1180d8c109aee19dd3a1e0228eb9bf7d29a7faa17f31e4fda2000d6c1f7e7";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b2/linux-x86_64/hy-AM/firefox-113.0b2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b3/linux-x86_64/hy-AM/firefox-113.0b3.tar.bz2";
       locale = "hy-AM";
       arch = "linux-x86_64";
-      sha256 = "73bed6cd2ea7c9c3141eb70680916e0fb423e55a22713b34dea23d73b1357fe5";
+      sha256 = "4ca2e09b827f99a3ccf1bfa3d97cc79c1102c038a62c1b40ebcb1bc39dbd09a7";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b2/linux-x86_64/ia/firefox-113.0b2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b3/linux-x86_64/ia/firefox-113.0b3.tar.bz2";
       locale = "ia";
       arch = "linux-x86_64";
-      sha256 = "638018d469edd63dab0eaa392427a0e8cee69ed91de4067a7e9f4e080d78c641";
+      sha256 = "b3f8ef50e1a4f499208e5551b511395eec96d7c7be590d18b229fc61582c6ae3";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b2/linux-x86_64/id/firefox-113.0b2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b3/linux-x86_64/id/firefox-113.0b3.tar.bz2";
       locale = "id";
       arch = "linux-x86_64";
-      sha256 = "ebb3ffad8375b991c52230d6539871959957b5717646c1f7c8efdbd80d118464";
+      sha256 = "8e056f4ac46211c52a89d983483f53ef516b851da347e4864ec330a993fdaed1";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b2/linux-x86_64/is/firefox-113.0b2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b3/linux-x86_64/is/firefox-113.0b3.tar.bz2";
       locale = "is";
       arch = "linux-x86_64";
-      sha256 = "45c6a761078cc1c97967d50a09321f7a158ed448c93c1b2b7458255fdb572848";
+      sha256 = "2b48170c820fa1a25bc94800d1d7aa4fc70ac0cc83366fcc8a276e551d382e91";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b2/linux-x86_64/it/firefox-113.0b2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b3/linux-x86_64/it/firefox-113.0b3.tar.bz2";
       locale = "it";
       arch = "linux-x86_64";
-      sha256 = "ceb093143b2168afd3d3a71f024e764f01c8da462374683c6a29dc8ceb58b4d7";
+      sha256 = "659bc56c0f8bb680d02a253cf7a5b61da2ee065d614ee088f70f55b71f1b1964";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b2/linux-x86_64/ja/firefox-113.0b2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b3/linux-x86_64/ja/firefox-113.0b3.tar.bz2";
       locale = "ja";
       arch = "linux-x86_64";
-      sha256 = "a2710d710c6012fcc98e60f226101585c59a4bad97f77c7d4aba38c64c7e0627";
+      sha256 = "6fe45f38f1324e4666bbb0018f75dccd8faeeffc946d2cab5fbd619bd4bfd996";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b2/linux-x86_64/ka/firefox-113.0b2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b3/linux-x86_64/ka/firefox-113.0b3.tar.bz2";
       locale = "ka";
       arch = "linux-x86_64";
-      sha256 = "be3b41064878163cb0056e3776506bba5c752bcdd5b0eecf9abac6e2b896e68e";
+      sha256 = "e6eb048dfa91f34edb5dd89a98d8094c80eadb2d3768632f5667c56749c0db28";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b2/linux-x86_64/kab/firefox-113.0b2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b3/linux-x86_64/kab/firefox-113.0b3.tar.bz2";
       locale = "kab";
       arch = "linux-x86_64";
-      sha256 = "1797c12f10888794cfcdc07641523221b082a96c66846ad1ad52b2376b46ce52";
+      sha256 = "d7a7c52e66d9d6821e7489c575b2c99c5abbc9bef9908ee05e5e040649ca1e99";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b2/linux-x86_64/kk/firefox-113.0b2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b3/linux-x86_64/kk/firefox-113.0b3.tar.bz2";
       locale = "kk";
       arch = "linux-x86_64";
-      sha256 = "c9b20975678bf04c6b121ebaae79c6a09f75d9272163ba51c0e452449acb3259";
+      sha256 = "cf2db01333083441185e3f6367937e3d3bfe8d1fe4b024de79298bf72327a92d";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b2/linux-x86_64/km/firefox-113.0b2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b3/linux-x86_64/km/firefox-113.0b3.tar.bz2";
       locale = "km";
       arch = "linux-x86_64";
-      sha256 = "84381384b0834591fc80eafb8b2c041097a3a86fa9fed6462d76dc54fabdefa6";
+      sha256 = "bbfd4e23ce263066b18573861124ba188b36eae1b7e049ac9c0551be938308e5";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b2/linux-x86_64/kn/firefox-113.0b2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b3/linux-x86_64/kn/firefox-113.0b3.tar.bz2";
       locale = "kn";
       arch = "linux-x86_64";
-      sha256 = "a4445f7fb17a4f2217eb06d0b860e8ea31d97aa15d8f7f68c37218a2e97d60ab";
+      sha256 = "e3b1a0c70714cb5592f4537086645e3b318274853f88ef00655fb4bbfa82f783";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b2/linux-x86_64/ko/firefox-113.0b2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b3/linux-x86_64/ko/firefox-113.0b3.tar.bz2";
       locale = "ko";
       arch = "linux-x86_64";
-      sha256 = "c6d03c3746416e2f4072caf05dc7af45f71ab6216217ebc744a49d224ad2f2d1";
+      sha256 = "bbd63cfde19fb61ef3c3b9d0c879660cf807e71194571adb2e80f87f490ccb1a";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b2/linux-x86_64/lij/firefox-113.0b2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b3/linux-x86_64/lij/firefox-113.0b3.tar.bz2";
       locale = "lij";
       arch = "linux-x86_64";
-      sha256 = "ff5ed7606d7fa7c97bd2febf0dba608eadbdbdfcebe9cbb4c8448ed0b4929c0f";
+      sha256 = "7c8aced5f625b2ce78ed85e8c26ad92fb7aee15c2bba41fda4c7b10f860efb8f";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b2/linux-x86_64/lt/firefox-113.0b2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b3/linux-x86_64/lt/firefox-113.0b3.tar.bz2";
       locale = "lt";
       arch = "linux-x86_64";
-      sha256 = "73595635f255299b96020a8e1866d3ecb95db344859ab1300ef83ae8a054986c";
+      sha256 = "7c4d2a37457b62fa99b3e9074f238582bb9051d8c9470d5e1e110e8759d8ac90";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b2/linux-x86_64/lv/firefox-113.0b2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b3/linux-x86_64/lv/firefox-113.0b3.tar.bz2";
       locale = "lv";
       arch = "linux-x86_64";
-      sha256 = "9e8933b9856bef61d9bfb4ebfb14b10884cad9212516d39c9222b248649c9a4f";
+      sha256 = "98a8b4e883c6c8a5aba0bad03c0917726d26f0dd664e7427edac940a89807f3f";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b2/linux-x86_64/mk/firefox-113.0b2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b3/linux-x86_64/mk/firefox-113.0b3.tar.bz2";
       locale = "mk";
       arch = "linux-x86_64";
-      sha256 = "3e3d93556f43b0aeafb13730f10e7ed90a93909c79f240a052049003109d987c";
+      sha256 = "dfde6a228fdbaec671993be29d1c3152c25dd2ebac96bd9ad4080c27123567af";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b2/linux-x86_64/mr/firefox-113.0b2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b3/linux-x86_64/mr/firefox-113.0b3.tar.bz2";
       locale = "mr";
       arch = "linux-x86_64";
-      sha256 = "5f35e43cbfc7556e9da67973a9a082dea4407287dd44b5991a9d7ccc68024922";
+      sha256 = "d8909d1b754f06b4091a1ea052db0d977345fd15875b0e7b68478782b4202399";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b2/linux-x86_64/ms/firefox-113.0b2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b3/linux-x86_64/ms/firefox-113.0b3.tar.bz2";
       locale = "ms";
       arch = "linux-x86_64";
-      sha256 = "29463450a3493e98a3b405df26d4a2860d6dc0df755d6344d9d3005a4d7fb201";
+      sha256 = "512c2dce6441e94b0c71fe321dc1443f54948c0eb3a4725a826a4622061302a5";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b2/linux-x86_64/my/firefox-113.0b2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b3/linux-x86_64/my/firefox-113.0b3.tar.bz2";
       locale = "my";
       arch = "linux-x86_64";
-      sha256 = "107f169060e961724aeafb4844909779eb72021566e3c8d120e4214e3fc0844d";
+      sha256 = "933fc7fab439eeffe0abc650a1bfc8eb8cc215e3d90f14dbff323fb448ae47bb";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b2/linux-x86_64/nb-NO/firefox-113.0b2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b3/linux-x86_64/nb-NO/firefox-113.0b3.tar.bz2";
       locale = "nb-NO";
       arch = "linux-x86_64";
-      sha256 = "9f8dbee66447fa699a75a536c17e4654db185ae32b9b2d9c8f5e538d1eb3366b";
+      sha256 = "4cc626dfa7f72c197a67b9c3340f54b4a7c4f7d26277d04b23be0021fbae2670";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b2/linux-x86_64/ne-NP/firefox-113.0b2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b3/linux-x86_64/ne-NP/firefox-113.0b3.tar.bz2";
       locale = "ne-NP";
       arch = "linux-x86_64";
-      sha256 = "70bd560bc212cdc6b1fedc60b1e6fb21da744afa8e634b7afc7da864aae7b755";
+      sha256 = "13e78aa9d426239c459444054bcbc182fa6f0773e363bf694311026ade067835";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b2/linux-x86_64/nl/firefox-113.0b2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b3/linux-x86_64/nl/firefox-113.0b3.tar.bz2";
       locale = "nl";
       arch = "linux-x86_64";
-      sha256 = "d9dbfc99d928d9a9bb6385aa10ad82444cc24632c078ab8850c311bc362f6fbd";
+      sha256 = "1b0abf464c3d116b312097b97747e970c783261fba8e76c3613825f5229360a1";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b2/linux-x86_64/nn-NO/firefox-113.0b2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b3/linux-x86_64/nn-NO/firefox-113.0b3.tar.bz2";
       locale = "nn-NO";
       arch = "linux-x86_64";
-      sha256 = "12b907e10cc99cab346537e079739475994469297d3b13b1bc29943511d8c068";
+      sha256 = "f768b8f90394c47c4e61e6b216ce2b2913ee0dddeef81a58682701931a941da4";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b2/linux-x86_64/oc/firefox-113.0b2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b3/linux-x86_64/oc/firefox-113.0b3.tar.bz2";
       locale = "oc";
       arch = "linux-x86_64";
-      sha256 = "e98d3985affc2edeb7ea64d2230752f1eb3472c87e1d055d77928020883b78b0";
+      sha256 = "23f2e83f74623cffa4e5427fe06f1fa71c10a9d8e23e2c24e689811a4059ba2c";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b2/linux-x86_64/pa-IN/firefox-113.0b2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b3/linux-x86_64/pa-IN/firefox-113.0b3.tar.bz2";
       locale = "pa-IN";
       arch = "linux-x86_64";
-      sha256 = "8a083a756f1110bba2e9fc39e521314bd9ffd4749ef8e89edbd9205bf8536f19";
+      sha256 = "bd3c761482ac0af1484adab67f25c60a9f34cd5b832c919df8d6c7601cc9c8cd";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b2/linux-x86_64/pl/firefox-113.0b2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b3/linux-x86_64/pl/firefox-113.0b3.tar.bz2";
       locale = "pl";
       arch = "linux-x86_64";
-      sha256 = "d3cb6e418f381957a076bd49f9f3149ba7f5c0bba434a80a054f2fdcd088683e";
+      sha256 = "1116be88eadbc6104ddc4044618eff55ecff6cdc86f55ebf1e47b49f1f6e278e";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b2/linux-x86_64/pt-BR/firefox-113.0b2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b3/linux-x86_64/pt-BR/firefox-113.0b3.tar.bz2";
       locale = "pt-BR";
       arch = "linux-x86_64";
-      sha256 = "4036dcc9896d715b3b0488e5b04b89d3b4c1404ec51c5e0ee6bb598bc390af34";
+      sha256 = "ba0b99202545dca73ccefa699de75507fc6f8082f40133cf71e9af8465dd97dd";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b2/linux-x86_64/pt-PT/firefox-113.0b2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b3/linux-x86_64/pt-PT/firefox-113.0b3.tar.bz2";
       locale = "pt-PT";
       arch = "linux-x86_64";
-      sha256 = "46dfc3c95698fe6365fa5b29fee671b4eab92c1a73e98c6f88f76d7bfe948383";
+      sha256 = "2a49f9459477854612fc44c8663cb1ce6cd88779d96d4d51b13a3afce6a2373c";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b2/linux-x86_64/rm/firefox-113.0b2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b3/linux-x86_64/rm/firefox-113.0b3.tar.bz2";
       locale = "rm";
       arch = "linux-x86_64";
-      sha256 = "d51294ac0be7b50df0417d6da3d89ba0995e3ece2a32268c7476866677ffad3e";
+      sha256 = "e13e427123a6adaa01cc39ad0efb06cff49c9377d36447ef8d732d75670b52a1";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b2/linux-x86_64/ro/firefox-113.0b2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b3/linux-x86_64/ro/firefox-113.0b3.tar.bz2";
       locale = "ro";
       arch = "linux-x86_64";
-      sha256 = "df68f0e0d7b8fabe6ad82005dd020c3767392ab51728634e1372cdb2094ddfa5";
+      sha256 = "1c0160e1769f5984f50643c0770ba4220cd54cef1a3aed7fc8440ea0980350cf";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b2/linux-x86_64/ru/firefox-113.0b2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b3/linux-x86_64/ru/firefox-113.0b3.tar.bz2";
       locale = "ru";
       arch = "linux-x86_64";
-      sha256 = "dce8b6ae4ca661b64177d81427fa7ebc3b39c261cf841695f3df9fdcc7aeb8bb";
+      sha256 = "29a12a83b2a42f3bc57fc62890977b10fc9bb95d02864be42a43b83bbd7f95f5";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b2/linux-x86_64/sc/firefox-113.0b2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b3/linux-x86_64/sc/firefox-113.0b3.tar.bz2";
       locale = "sc";
       arch = "linux-x86_64";
-      sha256 = "ff9e38fa62fd1f6fddd937ad1e9a11f0e846aa9364959df5243c92a0a6959a9b";
+      sha256 = "9cdc0cf8fc7fcab7a6db73be7b474c44514d3434896c20c65ac76c0f08760366";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b2/linux-x86_64/sco/firefox-113.0b2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b3/linux-x86_64/sco/firefox-113.0b3.tar.bz2";
       locale = "sco";
       arch = "linux-x86_64";
-      sha256 = "7b5548e52c69a894bf459b83ef13b2339af3195c102759cd42f0e3e6e1bb180e";
+      sha256 = "15d98ceb6c298d062c749089790f4c7a0d7e4629b1543e2361cd787d468c00a5";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b2/linux-x86_64/si/firefox-113.0b2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b3/linux-x86_64/si/firefox-113.0b3.tar.bz2";
       locale = "si";
       arch = "linux-x86_64";
-      sha256 = "f9be178f10a22a330e0f7a9dadd177523d41f6e5e6d338c3410bef86492ad719";
+      sha256 = "19da488743c082b36a7e97a9c98444c68690929f0f6ce8e83f6ab3b24cfb819b";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b2/linux-x86_64/sk/firefox-113.0b2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b3/linux-x86_64/sk/firefox-113.0b3.tar.bz2";
       locale = "sk";
       arch = "linux-x86_64";
-      sha256 = "e24cdc5481c18415aad067427e047106daffb7f8b9976d85f7dd26eec3d42525";
+      sha256 = "ce568ae8884ef2c2b1343f21501233b4263cc09e6e7680886b0ae6e77fad63c9";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b2/linux-x86_64/sl/firefox-113.0b2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b3/linux-x86_64/sl/firefox-113.0b3.tar.bz2";
       locale = "sl";
       arch = "linux-x86_64";
-      sha256 = "888a60ece2a7e953229b1eb8c8d1ed215f9b2c87adb3d7db9dfa8c062bda14a5";
+      sha256 = "8a7cf672a655b72bf4191e3141e91852fa3265fdd83f735f9ce5682f2d3c67ee";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b2/linux-x86_64/son/firefox-113.0b2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b3/linux-x86_64/son/firefox-113.0b3.tar.bz2";
       locale = "son";
       arch = "linux-x86_64";
-      sha256 = "a44e0ea0ee749e9a18eb1b3249449e41aeb37d79570020a067749d6b6dfd640a";
+      sha256 = "20af0c36f52805bd8d80a941db12858bf899b1d3bfd15127c1796b5952551069";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b2/linux-x86_64/sq/firefox-113.0b2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b3/linux-x86_64/sq/firefox-113.0b3.tar.bz2";
       locale = "sq";
       arch = "linux-x86_64";
-      sha256 = "21109ec7c815decefbd7a309ec7b8b33d16ef44a3f6d1c4b7154d7af8bdbdea0";
+      sha256 = "beaa36d8c13da439ef9082b19e7dd0ff95e09973239f659f4464f8aea4f9caed";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b2/linux-x86_64/sr/firefox-113.0b2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b3/linux-x86_64/sr/firefox-113.0b3.tar.bz2";
       locale = "sr";
       arch = "linux-x86_64";
-      sha256 = "f7bd9de44d69c4830cb57ff4504bc09697d9a81558e019dbe6819c5356c62a51";
+      sha256 = "d3e48cecfadc1797e0fe458c666d9f3aa14c3a051d0957545bfb08db80e34fc5";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b2/linux-x86_64/sv-SE/firefox-113.0b2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b3/linux-x86_64/sv-SE/firefox-113.0b3.tar.bz2";
       locale = "sv-SE";
       arch = "linux-x86_64";
-      sha256 = "79bd4619beea13d92abba8840d9308d7574e2bda4d8846952cc9809d4ea7e6af";
+      sha256 = "cc5083018604e1592d07b08ab8be20a2c5b5a2c6abddf032acedbe1d04567996";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b2/linux-x86_64/szl/firefox-113.0b2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b3/linux-x86_64/szl/firefox-113.0b3.tar.bz2";
       locale = "szl";
       arch = "linux-x86_64";
-      sha256 = "c754fb35fa39bd887f1afa1614efa08819e6c155aea5c223ff2ee8f4203cdfcc";
+      sha256 = "b4991ea53a1770a6788e5e867f18aef906af53d706fe106dda7d0a4f65e290d4";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b2/linux-x86_64/ta/firefox-113.0b2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b3/linux-x86_64/ta/firefox-113.0b3.tar.bz2";
       locale = "ta";
       arch = "linux-x86_64";
-      sha256 = "2993e39d026dc827b3083ba0f458b8fee6ded006135f136efeb89fe4d9096cb5";
+      sha256 = "17fdfa32e49b0c7701b2953f0d57142e5c7a51bbc6f690ed51780a29a9b88e4b";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b2/linux-x86_64/te/firefox-113.0b2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b3/linux-x86_64/te/firefox-113.0b3.tar.bz2";
       locale = "te";
       arch = "linux-x86_64";
-      sha256 = "1689d369fb0cb5cd81f591287963ee5b307f78cc37480fcb631d5bc50674f52a";
+      sha256 = "3070c176bcdc7bfeb22364094e1debcce8df50f4831fe4375d6661db4c6acf56";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b2/linux-x86_64/tg/firefox-113.0b2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b3/linux-x86_64/tg/firefox-113.0b3.tar.bz2";
       locale = "tg";
       arch = "linux-x86_64";
-      sha256 = "d8d9a0c1fc3adfdaad371c87ecffacbad7ad593f12bd917c94dc0e87a5f89db6";
+      sha256 = "36be8ed845dc32582a4738593d6ac8f2b75165a729988d14dfdb7c410bf7dfe9";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b2/linux-x86_64/th/firefox-113.0b2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b3/linux-x86_64/th/firefox-113.0b3.tar.bz2";
       locale = "th";
       arch = "linux-x86_64";
-      sha256 = "076c1af96d6cf33c9e0fe981ddb1b4c8349ac8f518fe42197359ec69ab9735a7";
+      sha256 = "cd5947ed251b2214a0dbc8c44929c4ddb12cc7ca0a19be9ecf13764d111485a2";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b2/linux-x86_64/tl/firefox-113.0b2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b3/linux-x86_64/tl/firefox-113.0b3.tar.bz2";
       locale = "tl";
       arch = "linux-x86_64";
-      sha256 = "15a4275803e9791429258cd9131b92806d3487dfa256d99121dca8716810c97d";
+      sha256 = "5bba1fee9e86882bdac3af769ce3ec0beaad9468422a1fb782f0d59e7de76b81";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b2/linux-x86_64/tr/firefox-113.0b2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b3/linux-x86_64/tr/firefox-113.0b3.tar.bz2";
       locale = "tr";
       arch = "linux-x86_64";
-      sha256 = "4f1f4359da847e91c0ccc534ea7928fcc6504b2a9ec57fced57a5eaa6f1ec5a6";
+      sha256 = "4175a557d4d09b8e7ffac76844a201e7c30be68c4b3d0af2a42cb20924d364e4";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b2/linux-x86_64/trs/firefox-113.0b2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b3/linux-x86_64/trs/firefox-113.0b3.tar.bz2";
       locale = "trs";
       arch = "linux-x86_64";
-      sha256 = "e26b79a7b60414b5b9db4de99f1bf66183a0ad88ad6137f6bc0be3d633d1f568";
+      sha256 = "85ebfaacdcaf358ef3f0740dff61cf8dad5dff98fdd6bfcddf318f863a5a4d8a";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b2/linux-x86_64/uk/firefox-113.0b2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b3/linux-x86_64/uk/firefox-113.0b3.tar.bz2";
       locale = "uk";
       arch = "linux-x86_64";
-      sha256 = "9bb0ffc850339665522e87115ac1667995d577b7e1d20147511c8c4c3f3716b3";
+      sha256 = "3d12679a7a0d503d88f09cc1d0939b32b5395b302c3aa103b1426981f9cf7eb5";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b2/linux-x86_64/ur/firefox-113.0b2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b3/linux-x86_64/ur/firefox-113.0b3.tar.bz2";
       locale = "ur";
       arch = "linux-x86_64";
-      sha256 = "152b6c150f70e9785465c2cac092faca9d0904aed239c62c805a51ac95b089ae";
+      sha256 = "bf8c0406b9812e25b25a4ae73389164e79351f6e1d490e17a702c0fb382552ac";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b2/linux-x86_64/uz/firefox-113.0b2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b3/linux-x86_64/uz/firefox-113.0b3.tar.bz2";
       locale = "uz";
       arch = "linux-x86_64";
-      sha256 = "5adfaecd15f74e75bd1ef909fa8abee130933d180efbb7cbdd431ffcb236e527";
+      sha256 = "0567b59aea40ad494b77a5f63695523bc38d8aeed16b10272d3f2f53b249cfe9";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b2/linux-x86_64/vi/firefox-113.0b2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b3/linux-x86_64/vi/firefox-113.0b3.tar.bz2";
       locale = "vi";
       arch = "linux-x86_64";
-      sha256 = "20b36d56fd558e427853b88678244552320623bd91367d9446057bb2b337463c";
+      sha256 = "f114bc8ecf3ed09af1dd1075cf3fd0b214d1cc2089de14dc41ddc5df56b73d48";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b2/linux-x86_64/xh/firefox-113.0b2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b3/linux-x86_64/xh/firefox-113.0b3.tar.bz2";
       locale = "xh";
       arch = "linux-x86_64";
-      sha256 = "853a1d27d2e1697ab7ad85c0a848038a4a7851b00a43fb4244cc6c7e1a27378d";
+      sha256 = "1fa8ef52444c81c549c6ea27382108e05a5aa1b9797c3a3c88125b9567e3402c";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b2/linux-x86_64/zh-CN/firefox-113.0b2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b3/linux-x86_64/zh-CN/firefox-113.0b3.tar.bz2";
       locale = "zh-CN";
       arch = "linux-x86_64";
-      sha256 = "08a426059b4db42966ec5d67528042b9773d05ad22fcf24d16d7b4b45f9b201d";
+      sha256 = "4dea0d6c011d7a50895c477de5a19311ec395b27c4f2a3a52b5a1de680949cea";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b2/linux-x86_64/zh-TW/firefox-113.0b2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b3/linux-x86_64/zh-TW/firefox-113.0b3.tar.bz2";
       locale = "zh-TW";
       arch = "linux-x86_64";
-      sha256 = "6bf733ce74e53fa33b7e4be729cd82dab829013903fd6420403ec62abfa4d999";
+      sha256 = "d595377884546ebffc39a987326fba4c8bebea1bf7105f7fdb7458a5bb469f23";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b2/linux-i686/ach/firefox-113.0b2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b3/linux-i686/ach/firefox-113.0b3.tar.bz2";
       locale = "ach";
       arch = "linux-i686";
-      sha256 = "25c80b08b6449c4c6591c422ac732b1ce3fda4784999f746214b1f82a7589937";
+      sha256 = "8728e0f01e83436883a49c94a236164d47e1839ecec12f44ffefe983b714a136";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b2/linux-i686/af/firefox-113.0b2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b3/linux-i686/af/firefox-113.0b3.tar.bz2";
       locale = "af";
       arch = "linux-i686";
-      sha256 = "4022146c820c99235953a2d345bce4795386216a610cb03ab0c481102f969b2a";
+      sha256 = "9ffc7ad781be1717e0c4b5f63679f40abcec98e6d1b203233ca969d79c1c5141";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b2/linux-i686/an/firefox-113.0b2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b3/linux-i686/an/firefox-113.0b3.tar.bz2";
       locale = "an";
       arch = "linux-i686";
-      sha256 = "ab35594cad8c996a49aad657a702e199f7451f14846c7f8529233c997c8cf035";
+      sha256 = "839fe205dcd425d04faa48d02793fac8efaea3290efaf9f67225181219997c4e";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b2/linux-i686/ar/firefox-113.0b2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b3/linux-i686/ar/firefox-113.0b3.tar.bz2";
       locale = "ar";
       arch = "linux-i686";
-      sha256 = "3b660e4ac36332308c987a27ce9d5be421ff8dbb59da4e15e7a66a3047d1ff95";
+      sha256 = "b1d3282ac081ac22632cbc4d8ecdaf74dbceb0d511ca0a19f02ac0d43cc1e6ab";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b2/linux-i686/ast/firefox-113.0b2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b3/linux-i686/ast/firefox-113.0b3.tar.bz2";
       locale = "ast";
       arch = "linux-i686";
-      sha256 = "6b70a696b733272b22fb4f04e469b69e93ff0ea6b0a8a67beb8c2ae3bbc2628b";
+      sha256 = "d79ab280799de47d1406a6ea3ab80d57d9409a9809472f69eb979ae953640496";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b2/linux-i686/az/firefox-113.0b2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b3/linux-i686/az/firefox-113.0b3.tar.bz2";
       locale = "az";
       arch = "linux-i686";
-      sha256 = "f3e9ae9a134b27c314871caac99b86cc2b01003073d1a98d2bc7fa28f6df6dcf";
+      sha256 = "518ae701e0dbd05fd326c07387ae70d7247fbb3806ed258cf60c4bef87a3d640";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b2/linux-i686/be/firefox-113.0b2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b3/linux-i686/be/firefox-113.0b3.tar.bz2";
       locale = "be";
       arch = "linux-i686";
-      sha256 = "bc8581c0af5dd902fd4fd8f66181efe0a82cec166a20fd9051db06c0b361a12d";
+      sha256 = "60d6a6cad8db3c5157e18408db2535c21789d99ea653b5bd41ef73622415fbc2";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b2/linux-i686/bg/firefox-113.0b2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b3/linux-i686/bg/firefox-113.0b3.tar.bz2";
       locale = "bg";
       arch = "linux-i686";
-      sha256 = "98d00d667b04678f46ccfcb47ec752956e9e9585261f56e527eef172e216231e";
+      sha256 = "4ec186e57154c2186aa934c4611a897c77fe770fec9c78dd0acd3594485bb98b";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b2/linux-i686/bn/firefox-113.0b2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b3/linux-i686/bn/firefox-113.0b3.tar.bz2";
       locale = "bn";
       arch = "linux-i686";
-      sha256 = "0f051452dc221b2a7b00e08534105f587f94bc470eb013d4bf44a15187f5dcbd";
+      sha256 = "897370c15b2edda12c31ac02c1bb6fe2d605252aa59ae086cf59d5d88746328e";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b2/linux-i686/br/firefox-113.0b2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b3/linux-i686/br/firefox-113.0b3.tar.bz2";
       locale = "br";
       arch = "linux-i686";
-      sha256 = "25009effb796030cfd228ce9c9d7bf0efdd318e24ff8be92005d11d114ae90d9";
+      sha256 = "81dafb76ac0fa134994cafbd6ed4b3b84f89544eb03b21c66558d3966ad30c18";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b2/linux-i686/bs/firefox-113.0b2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b3/linux-i686/bs/firefox-113.0b3.tar.bz2";
       locale = "bs";
       arch = "linux-i686";
-      sha256 = "46d7b9302a325e03e9dfa60aea07db46999297f03a91b08e5c3e89ba2c57aed5";
+      sha256 = "8ad4cf2ec75a776be2c1dabe69d9569ebe1eb9f5dfc997c48ec12f0e721fd3b8";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b2/linux-i686/ca-valencia/firefox-113.0b2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b3/linux-i686/ca-valencia/firefox-113.0b3.tar.bz2";
       locale = "ca-valencia";
       arch = "linux-i686";
-      sha256 = "a1b3149aefc45c49baf3d6b2a8c5c86c3c5b37c2285547eb323158f3e1720679";
+      sha256 = "080b8c4a3ef62e1be3591b09f881dd6898cd55c193dcafe32d0689ee9285b531";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b2/linux-i686/ca/firefox-113.0b2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b3/linux-i686/ca/firefox-113.0b3.tar.bz2";
       locale = "ca";
       arch = "linux-i686";
-      sha256 = "0e368731ef17dcb9565be063013688727dc10b78444fc9f593864c0d8910efcf";
+      sha256 = "02b24230fc52ef367f3beef455e038d4758750bd886571708188fc76712adde2";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b2/linux-i686/cak/firefox-113.0b2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b3/linux-i686/cak/firefox-113.0b3.tar.bz2";
       locale = "cak";
       arch = "linux-i686";
-      sha256 = "df6eb229362831945150ea37ab36d05b27a602851b1ad5d2a729d3b4e8e997ca";
+      sha256 = "7ded3141ca0eae6f5f2f700d6dde870c4f4fbae12b9a84c190f186b3628b3380";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b2/linux-i686/cs/firefox-113.0b2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b3/linux-i686/cs/firefox-113.0b3.tar.bz2";
       locale = "cs";
       arch = "linux-i686";
-      sha256 = "be28a9e5cbdfd4b45d28b01c650eee85b39375876265475013b96b14ff22341e";
+      sha256 = "5440247b433343b612ab670baeb1aea375a0041837d1dbb0c4e7ee98fa1c4d15";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b2/linux-i686/cy/firefox-113.0b2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b3/linux-i686/cy/firefox-113.0b3.tar.bz2";
       locale = "cy";
       arch = "linux-i686";
-      sha256 = "de2ecfe65b76b99ccd362a1afd93c2a07a40b854751b379b1072a6a7968efdce";
+      sha256 = "71e28c55e3b808f357e7a4940770e306517b20fc7dd1ac86527c3bedbd232c5a";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b2/linux-i686/da/firefox-113.0b2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b3/linux-i686/da/firefox-113.0b3.tar.bz2";
       locale = "da";
       arch = "linux-i686";
-      sha256 = "b66bbfb949e8ddb10aefca3f75389edeeae1ca49f7d9a478c0b6cf034c19f4e9";
+      sha256 = "e2663c27d53b0e62702703b8d1298302f81e644a287efef2785cab91773f6228";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b2/linux-i686/de/firefox-113.0b2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b3/linux-i686/de/firefox-113.0b3.tar.bz2";
       locale = "de";
       arch = "linux-i686";
-      sha256 = "b6e41955558e0fdcdf7a654e19c8940f66dd90cb079b98b8ccde3d7c4e7ce667";
+      sha256 = "3e5623a3d1251c4bacf46b740e61d669aefbcbf84fdc6b3ee052c5d51a0292ef";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b2/linux-i686/dsb/firefox-113.0b2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b3/linux-i686/dsb/firefox-113.0b3.tar.bz2";
       locale = "dsb";
       arch = "linux-i686";
-      sha256 = "32dac237ecf5610ab49ded77f6b1956efbcc1d99c8ebb521c729e851401b83d0";
+      sha256 = "f3771e6182aa343c4155ff6632da8ccf88a1702665d38f29f6d613b65580b336";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b2/linux-i686/el/firefox-113.0b2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b3/linux-i686/el/firefox-113.0b3.tar.bz2";
       locale = "el";
       arch = "linux-i686";
-      sha256 = "3272116d9091b9d55ef73c92028983bade69fc2f3cd4f754c47f7351aa0cde46";
+      sha256 = "bf13f06cab00922ec5678cb4db3d2f8b4e7ba05b0fe3a7ebbc3520f1fecff42d";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b2/linux-i686/en-CA/firefox-113.0b2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b3/linux-i686/en-CA/firefox-113.0b3.tar.bz2";
       locale = "en-CA";
       arch = "linux-i686";
-      sha256 = "4ce06a3ab094ae75546d747d6f634b6db84d3daedecd56a1e32659e2620f3f94";
+      sha256 = "6d0ed002a0845f817eee536e2cf1a680e3a20270d05386471a47e0da9878c896";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b2/linux-i686/en-GB/firefox-113.0b2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b3/linux-i686/en-GB/firefox-113.0b3.tar.bz2";
       locale = "en-GB";
       arch = "linux-i686";
-      sha256 = "dbbeef8008322dc494c14fb1d73341fc02652ac56574251624b30dfcfd352aa6";
+      sha256 = "f31564bff77c11ac12088bb446be1b8d30b9e99d394967a17d4b2fc429b3858c";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b2/linux-i686/en-US/firefox-113.0b2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b3/linux-i686/en-US/firefox-113.0b3.tar.bz2";
       locale = "en-US";
       arch = "linux-i686";
-      sha256 = "36996c36bd4b30b71bd31569ac499f5b4f2e00104e96ecddadb17acc58d98b2d";
+      sha256 = "b6aa66646a956e2b366723d69c9a839854ba985bb130a7e1533a19e50726796d";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b2/linux-i686/eo/firefox-113.0b2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b3/linux-i686/eo/firefox-113.0b3.tar.bz2";
       locale = "eo";
       arch = "linux-i686";
-      sha256 = "68f064f735685a2da5f1a3645554d1fbed80cf20c69203d4f6602ad760691d53";
+      sha256 = "57bcf89d9d860513685d72e85cb122fdb3cb8f7028caaa58353d2664af0d0741";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b2/linux-i686/es-AR/firefox-113.0b2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b3/linux-i686/es-AR/firefox-113.0b3.tar.bz2";
       locale = "es-AR";
       arch = "linux-i686";
-      sha256 = "eeb70a6492c90ab04b5c75d81bd6c7713a462ba4be3ecb71ec2be4226c145e8e";
+      sha256 = "312fc1c029c377dd402425637e620bf48bae21fa666f1cc5ca341fb87c4257ad";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b2/linux-i686/es-CL/firefox-113.0b2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b3/linux-i686/es-CL/firefox-113.0b3.tar.bz2";
       locale = "es-CL";
       arch = "linux-i686";
-      sha256 = "c9444d002912d9898c81926085e617bb01f64d3aecf5d87ae4c6df802f2a72de";
+      sha256 = "f2a61f17cc416e8a96b0292d8b298347a3693b9e9cee238fbb7d9a2c25b5441b";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b2/linux-i686/es-ES/firefox-113.0b2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b3/linux-i686/es-ES/firefox-113.0b3.tar.bz2";
       locale = "es-ES";
       arch = "linux-i686";
-      sha256 = "56c48a1d5db84c6f7a1485422ff5eaef16a4a154b5e0f12f566afac44470325e";
+      sha256 = "97ed6e13083df4a0bbef1304f88730a6f1bfe52cf6b5e9fefaa11584d691a6c9";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b2/linux-i686/es-MX/firefox-113.0b2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b3/linux-i686/es-MX/firefox-113.0b3.tar.bz2";
       locale = "es-MX";
       arch = "linux-i686";
-      sha256 = "12d4d2eb36051dc9b5e983ab64129a6b9f304ade261e4194779ee49338c46750";
+      sha256 = "f172976aebc3b660d5d79f6a5f12438a9fed530e4061e145ffd3aada8987433f";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b2/linux-i686/et/firefox-113.0b2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b3/linux-i686/et/firefox-113.0b3.tar.bz2";
       locale = "et";
       arch = "linux-i686";
-      sha256 = "592d29f1a9f6cfcb54e8ca5ca6c62ae4e0c184076e86c0b3e58394fff85c771c";
+      sha256 = "50c5970aec24af4c2aa099a9aa0a80c1be02acbfd735c7802be615abdcdf875d";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b2/linux-i686/eu/firefox-113.0b2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b3/linux-i686/eu/firefox-113.0b3.tar.bz2";
       locale = "eu";
       arch = "linux-i686";
-      sha256 = "1c552711fe28cbdb144b44f932c7a9da269a08905331a8695db9475a7bc4aef2";
+      sha256 = "39c3e18625ba3f6dd107275d35c295d247a87db1eb5a38f590ceba087933e580";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b2/linux-i686/fa/firefox-113.0b2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b3/linux-i686/fa/firefox-113.0b3.tar.bz2";
       locale = "fa";
       arch = "linux-i686";
-      sha256 = "756e2ae0c3732af4a29b4b6b28aec2c3b974fe05f19d4ed85f720a78b7ee5493";
+      sha256 = "fcf316aba06ff5f7a8b38f9873a9387074580f59395f8e0eb808f58ac9d8bdee";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b2/linux-i686/ff/firefox-113.0b2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b3/linux-i686/ff/firefox-113.0b3.tar.bz2";
       locale = "ff";
       arch = "linux-i686";
-      sha256 = "736f3c42d9b57a4bc1c8406020ca0903c238415df6cb34712169e1827beda85e";
+      sha256 = "7132fe3326ff273108c507e9ebecc1e5b942dc5ba824297cf61afc9cdad2356d";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b2/linux-i686/fi/firefox-113.0b2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b3/linux-i686/fi/firefox-113.0b3.tar.bz2";
       locale = "fi";
       arch = "linux-i686";
-      sha256 = "0caba4bc0029568095b87978d11b3e67ad0601fc12c8639ee58aec8238626008";
+      sha256 = "2beee337bd5f1e5aae2cc7d86a92902bc470c87fddcc06863b438e2cf55efcac";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b2/linux-i686/fr/firefox-113.0b2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b3/linux-i686/fr/firefox-113.0b3.tar.bz2";
       locale = "fr";
       arch = "linux-i686";
-      sha256 = "baee5dcec73f37213412bfc1b57bd1d638b329b74c7b18926b6a0f304eea2730";
+      sha256 = "63d18c5a4de119d8372053fd2c1f8cfe8488b242921fe9de65bb10d2f22044e1";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b2/linux-i686/fur/firefox-113.0b2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b3/linux-i686/fur/firefox-113.0b3.tar.bz2";
       locale = "fur";
       arch = "linux-i686";
-      sha256 = "fbcaeebf213729b9ce2a1d6e4527befe6098c4e861119a9729b69ab7cef30964";
+      sha256 = "c1087ba2f7c59f488a774ab5eeeae445dbc00b20077090ba1e09eb5ebc52cf5c";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b2/linux-i686/fy-NL/firefox-113.0b2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b3/linux-i686/fy-NL/firefox-113.0b3.tar.bz2";
       locale = "fy-NL";
       arch = "linux-i686";
-      sha256 = "ed32ffab533b1e0c298705c69bed835cc7967264018749bde7965451a533d6fd";
+      sha256 = "ed71d8285f99a714c402305d59e7e3b12d53e4f38f4fba496411097b2da28d2b";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b2/linux-i686/ga-IE/firefox-113.0b2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b3/linux-i686/ga-IE/firefox-113.0b3.tar.bz2";
       locale = "ga-IE";
       arch = "linux-i686";
-      sha256 = "4ae634c4f5bf1a5762d5d72126242c5de391d95f04300f97deb7ea029c8daa8b";
+      sha256 = "a169ed3ce324b965f9d0f54d6daa300a74e76a329f7dd8082cb87ffd00dd947b";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b2/linux-i686/gd/firefox-113.0b2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b3/linux-i686/gd/firefox-113.0b3.tar.bz2";
       locale = "gd";
       arch = "linux-i686";
-      sha256 = "affbd3fc866d0f543a2ec0a029b6b2371de40a0c2569d6f4363e0a6105d538b7";
+      sha256 = "f4faefc88c59f901c865f2e4e720f9acd7b9cf4b194327b847f2077d62dd7d07";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b2/linux-i686/gl/firefox-113.0b2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b3/linux-i686/gl/firefox-113.0b3.tar.bz2";
       locale = "gl";
       arch = "linux-i686";
-      sha256 = "0f423c8bd4db91f877f9727c5e0333c83d667d62ee3a8903224f4c24ced6ac3c";
+      sha256 = "5f0d4cd603d82e4cc67f0f2b357027930fe9dc1fa07a6ac4b30a576bcff23ce3";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b2/linux-i686/gn/firefox-113.0b2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b3/linux-i686/gn/firefox-113.0b3.tar.bz2";
       locale = "gn";
       arch = "linux-i686";
-      sha256 = "458cc6f2b07dd78c2bcea089ab7e8ee93ca239b48f4f709249e87049eee8054d";
+      sha256 = "de11b7da29f4c8b14dc7344977e8d01b2c6f662e274c0b921e8aacee0526abb4";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b2/linux-i686/gu-IN/firefox-113.0b2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b3/linux-i686/gu-IN/firefox-113.0b3.tar.bz2";
       locale = "gu-IN";
       arch = "linux-i686";
-      sha256 = "3209d74f326961e92a37bc790a48f856db982ffbb36ffd4577a88620b165474f";
+      sha256 = "e1dd62aa9f39b1a7206a314aede814c0ccd2597b4f8a977d4e94b67ed00633bc";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b2/linux-i686/he/firefox-113.0b2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b3/linux-i686/he/firefox-113.0b3.tar.bz2";
       locale = "he";
       arch = "linux-i686";
-      sha256 = "86d01b21223eb0bb9c81582aec36596b184f093a12f6c5ecd76769ff0157ecad";
+      sha256 = "8096d914ab544fccd11d14b6d9ff6b730dd03ce7b45ed05485ce49e803792a96";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b2/linux-i686/hi-IN/firefox-113.0b2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b3/linux-i686/hi-IN/firefox-113.0b3.tar.bz2";
       locale = "hi-IN";
       arch = "linux-i686";
-      sha256 = "12d9affd3e4377326bde74e2fc191790010b44eff389871b83e0d31c112a1453";
+      sha256 = "7e4c174ff52f4ddb8bda8eb628bf3b7074ad08ab8da1fb91e53fba71c2c395ca";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b2/linux-i686/hr/firefox-113.0b2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b3/linux-i686/hr/firefox-113.0b3.tar.bz2";
       locale = "hr";
       arch = "linux-i686";
-      sha256 = "1cb8a3f8e2905de618cbbd624e8572d436e5321c112574159efdb8658e1c0a4a";
+      sha256 = "6a43972a81b3e4425c48b420b7610f1cd70216b388f4dfff8e071e8a7395ef61";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b2/linux-i686/hsb/firefox-113.0b2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b3/linux-i686/hsb/firefox-113.0b3.tar.bz2";
       locale = "hsb";
       arch = "linux-i686";
-      sha256 = "9da23dc61e373990da0a6368020f25f630bb2650716a4159aef1813d0ce0a4ae";
+      sha256 = "d85619f23ff912769a377b4d8fa06bfbecf5155fdd433982ea38a9602e35b528";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b2/linux-i686/hu/firefox-113.0b2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b3/linux-i686/hu/firefox-113.0b3.tar.bz2";
       locale = "hu";
       arch = "linux-i686";
-      sha256 = "f889ba28f8911db4c7e764cb80de5277d8544c10a9bcddea42d0277410f45a55";
+      sha256 = "281e887c73d63aafddbfa54c29eef0a81036628ced989d2dd00c6783dc78d4f9";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b2/linux-i686/hy-AM/firefox-113.0b2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b3/linux-i686/hy-AM/firefox-113.0b3.tar.bz2";
       locale = "hy-AM";
       arch = "linux-i686";
-      sha256 = "95b1094b4545acd195a09bd95aa1fbad0b938d0989840804e8513eb245a7a27a";
+      sha256 = "3453381c146cc3c8a48e6f683dbc5b077b4620a06161ef6abab6014e06a45920";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b2/linux-i686/ia/firefox-113.0b2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b3/linux-i686/ia/firefox-113.0b3.tar.bz2";
       locale = "ia";
       arch = "linux-i686";
-      sha256 = "8bd0750da123edc1335d716b5d07857ec18928df6621d5b590fd71e229ad7559";
+      sha256 = "abd90f2b0cb5ce5b00ddeb97140100960f9771a04aee0c1c414c02d907a1e9b9";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b2/linux-i686/id/firefox-113.0b2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b3/linux-i686/id/firefox-113.0b3.tar.bz2";
       locale = "id";
       arch = "linux-i686";
-      sha256 = "80a874cde7ec122faa1f9a6c85d01c85b111e0dd7a251bda39020fbe31dff579";
+      sha256 = "ec0119eaca15d4a8d6f4b8cdfd389ee781742c7d93700383453ba772be31597f";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b2/linux-i686/is/firefox-113.0b2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b3/linux-i686/is/firefox-113.0b3.tar.bz2";
       locale = "is";
       arch = "linux-i686";
-      sha256 = "db16f7232e3412768d21482dab1fddbdd84dca1bbe5afb91f2a6f2f89a3faa96";
+      sha256 = "85bcaba93dcf7d240c5df71cb0cb4186f23a95716b4575897cd686dcb7fe3914";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b2/linux-i686/it/firefox-113.0b2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b3/linux-i686/it/firefox-113.0b3.tar.bz2";
       locale = "it";
       arch = "linux-i686";
-      sha256 = "5654aaccc62016507920116019b48f87b4afc42bd8e6daf784a93fae75141d48";
+      sha256 = "34d7962c9d7d8d02958068a1ebb1dc597099e64b645cda700e5f288ca4c88b9b";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b2/linux-i686/ja/firefox-113.0b2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b3/linux-i686/ja/firefox-113.0b3.tar.bz2";
       locale = "ja";
       arch = "linux-i686";
-      sha256 = "01b49eeb6d4a8589bc6f2d1d7a2559ff68a1d63c77f1cfdb4befe5af3e877a16";
+      sha256 = "591a15f2fd101bbf60b78810b00adbe277c7b5384e556e76348d223c9132c258";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b2/linux-i686/ka/firefox-113.0b2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b3/linux-i686/ka/firefox-113.0b3.tar.bz2";
       locale = "ka";
       arch = "linux-i686";
-      sha256 = "d9ecef01c514b7b8eea2dca5e565ac859a0ec0dfc58749019c200e0e5ae4340a";
+      sha256 = "cd5c0addbbfdee2893ef0ff3550a5b028d818c998c01fe48238b3bd91a368696";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b2/linux-i686/kab/firefox-113.0b2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b3/linux-i686/kab/firefox-113.0b3.tar.bz2";
       locale = "kab";
       arch = "linux-i686";
-      sha256 = "7c6fbd36e41b724cd4d4d21810be4893e29c12483fa07438c91c7d302efd40c9";
+      sha256 = "527034d170443d8ca638d60d7f8cc1d97129b042831ed3de97d205e64d210c16";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b2/linux-i686/kk/firefox-113.0b2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b3/linux-i686/kk/firefox-113.0b3.tar.bz2";
       locale = "kk";
       arch = "linux-i686";
-      sha256 = "b9e3e3604c85f9aa17050381a6422eea90f37550951bbc496aab27a2a180aee3";
+      sha256 = "d1f48d85db19bb2733c7007a973dd4be7d1c6aa2794561d4fd4268b18e1c1592";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b2/linux-i686/km/firefox-113.0b2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b3/linux-i686/km/firefox-113.0b3.tar.bz2";
       locale = "km";
       arch = "linux-i686";
-      sha256 = "cb3948ff88e269aa3a5c2c0bad8527d0542eaff1be9fdb1d97d00c310e94816a";
+      sha256 = "fc357dcff63b938fba393629815db295065d0621bf9e9c56cc1e1a93380a7da8";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b2/linux-i686/kn/firefox-113.0b2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b3/linux-i686/kn/firefox-113.0b3.tar.bz2";
       locale = "kn";
       arch = "linux-i686";
-      sha256 = "e81f78712ae816e0612958055cf57c27b24842c56fafcdbf03af73dfa126a709";
+      sha256 = "e3c30927f3e7b52771b6b970226bbe907b3058fe87c8aa5a4b62a9b76b336f91";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b2/linux-i686/ko/firefox-113.0b2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b3/linux-i686/ko/firefox-113.0b3.tar.bz2";
       locale = "ko";
       arch = "linux-i686";
-      sha256 = "09c85a9ed01c7331b881f0e651aaf558a0034842d9a8a067ab95313d8644d957";
+      sha256 = "b13226710e271945b0eec4b23caa3c7620ef96bad0fa792c42489711d36f6491";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b2/linux-i686/lij/firefox-113.0b2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b3/linux-i686/lij/firefox-113.0b3.tar.bz2";
       locale = "lij";
       arch = "linux-i686";
-      sha256 = "b7286511fb34b36557a04adb998a6710439484bad006922f5bfec5880275dc96";
+      sha256 = "56b847ff2f9b15d1192423ddcf1ad1d7f5a074ca8893afd4c098c3bd16c0548e";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b2/linux-i686/lt/firefox-113.0b2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b3/linux-i686/lt/firefox-113.0b3.tar.bz2";
       locale = "lt";
       arch = "linux-i686";
-      sha256 = "ed60ae9290c507666ab77fea3a45c97712a529d679b1ee2fd428c3878ac3a01c";
+      sha256 = "87a4765aa615fa1d22a606c8974b030f6e40f34df7b66fd604db81dc205c5ab0";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b2/linux-i686/lv/firefox-113.0b2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b3/linux-i686/lv/firefox-113.0b3.tar.bz2";
       locale = "lv";
       arch = "linux-i686";
-      sha256 = "b5fb4547164814e7def4d7715783618de4442e178b3fc299071a6922ad560794";
+      sha256 = "8975fda0b3f8793dd87aa6f4d321b6f130abd14853389c4bae4e40528b054ff6";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b2/linux-i686/mk/firefox-113.0b2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b3/linux-i686/mk/firefox-113.0b3.tar.bz2";
       locale = "mk";
       arch = "linux-i686";
-      sha256 = "72a891731624feec69a5be90fc6e8b372ad6b09972277c4ab1ba0bed45330fbf";
+      sha256 = "142a03aa8f98779a3702cb394896c53315294c5a42a4bf10fbfde77bf218dbc7";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b2/linux-i686/mr/firefox-113.0b2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b3/linux-i686/mr/firefox-113.0b3.tar.bz2";
       locale = "mr";
       arch = "linux-i686";
-      sha256 = "7e8a5c084df7e96d7133566ff49557ff2adfbb09b8700979aedaacd99e38f864";
+      sha256 = "cf77d649c2f3b0eee3adbfee9e5e1f5313467fa319573d2d003126517edc9315";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b2/linux-i686/ms/firefox-113.0b2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b3/linux-i686/ms/firefox-113.0b3.tar.bz2";
       locale = "ms";
       arch = "linux-i686";
-      sha256 = "221335d17918344c91b3c71ac6a37a0622698cfd816015d02abacb8b5de8b618";
+      sha256 = "96dad8549b33de1e2066357142afa7c76af0cfd332b414a5742cd73b76a8c2fd";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b2/linux-i686/my/firefox-113.0b2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b3/linux-i686/my/firefox-113.0b3.tar.bz2";
       locale = "my";
       arch = "linux-i686";
-      sha256 = "9c463212def05e00e261bdb496de4fc27eecfa80f44b2933e2089c4e344a511d";
+      sha256 = "ea462387085af4cf05a4c20a1de23cf587743c98c649f1188e47a97a0a98e358";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b2/linux-i686/nb-NO/firefox-113.0b2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b3/linux-i686/nb-NO/firefox-113.0b3.tar.bz2";
       locale = "nb-NO";
       arch = "linux-i686";
-      sha256 = "1120376de5ee3980cb7acd5b7dcc8a02c2b599fd9813f0b9c8340e9fa3d9530a";
+      sha256 = "c5c3865dba1cc9be1a6d982a1a4ee89de8ab8eed7ee61895e7ef8b67eaf0428a";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b2/linux-i686/ne-NP/firefox-113.0b2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b3/linux-i686/ne-NP/firefox-113.0b3.tar.bz2";
       locale = "ne-NP";
       arch = "linux-i686";
-      sha256 = "55bfb471db78c5b88867403ff77d4c7a4cb447f85d55c0423d8b802a0efe791b";
+      sha256 = "97a0bb774f1a300e8f2c760743ce60cb46607f02126b0120eb231777fa03e15c";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b2/linux-i686/nl/firefox-113.0b2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b3/linux-i686/nl/firefox-113.0b3.tar.bz2";
       locale = "nl";
       arch = "linux-i686";
-      sha256 = "2e13d5b4075024852d689dbab5993cc3589b14bc436d116a27a1a5eddb42d41f";
+      sha256 = "aea347773b8edbaec0333282bf24db829d1f0636f4d41448e077722a9bf0d188";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b2/linux-i686/nn-NO/firefox-113.0b2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b3/linux-i686/nn-NO/firefox-113.0b3.tar.bz2";
       locale = "nn-NO";
       arch = "linux-i686";
-      sha256 = "df3b8437cd4cc3df848e6ce0c12b3b27f9dc375b31dd9b639b31c73f90f54ed5";
+      sha256 = "09febd1c0f5b547c4fe6b2d5f40b9edfa75b0107486f0098331a9653dc76b72a";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b2/linux-i686/oc/firefox-113.0b2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b3/linux-i686/oc/firefox-113.0b3.tar.bz2";
       locale = "oc";
       arch = "linux-i686";
-      sha256 = "5d85733c0b8f6d505c2cc5436d0e3d2baca9203ab74c6e3c99ebf37af83d0a84";
+      sha256 = "9592cf6e5ca7a77d4b95eabc7f8a645ee4b696488aaf1892769a77bf60140e90";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b2/linux-i686/pa-IN/firefox-113.0b2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b3/linux-i686/pa-IN/firefox-113.0b3.tar.bz2";
       locale = "pa-IN";
       arch = "linux-i686";
-      sha256 = "0992d97ee3659cc2fc2b32151e30981e555ae17060e0fb42004b841057d66051";
+      sha256 = "254669e447346ded2118428ad15b552e48747891d5ba0734d139d126239b1828";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b2/linux-i686/pl/firefox-113.0b2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b3/linux-i686/pl/firefox-113.0b3.tar.bz2";
       locale = "pl";
       arch = "linux-i686";
-      sha256 = "32a3aff1f99fa59f6daaca54211edeaeffe46e1d9ffc0801afbba6bc795cc1f5";
+      sha256 = "cda12e8e2dc6dba6b2f733bfda99a1c0c1967d7c71f635a2b3b1b7bdb01c7d81";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b2/linux-i686/pt-BR/firefox-113.0b2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b3/linux-i686/pt-BR/firefox-113.0b3.tar.bz2";
       locale = "pt-BR";
       arch = "linux-i686";
-      sha256 = "7da9456483f0d70791fc91536407d54ead98c2da671b9f4380a692f835f82fe4";
+      sha256 = "b0a0d4da5cfd345f4144e9869ce1cf1c42786522b6d127f962a0f8588efab815";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b2/linux-i686/pt-PT/firefox-113.0b2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b3/linux-i686/pt-PT/firefox-113.0b3.tar.bz2";
       locale = "pt-PT";
       arch = "linux-i686";
-      sha256 = "6cd1fba52e5150ee435308187aba7ae2da40e081276eeceb031b336719bcc06f";
+      sha256 = "c9be8a754616abde67a3b4971b986d25fa3b53d29f59aed1c726ed12715724f6";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b2/linux-i686/rm/firefox-113.0b2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b3/linux-i686/rm/firefox-113.0b3.tar.bz2";
       locale = "rm";
       arch = "linux-i686";
-      sha256 = "8c3cebd21618bd6c86cfdf4955f01ab6b6c374be1da27ac981f4cad0a653abad";
+      sha256 = "4774abdccb8c0792df62fc629e1c31f220c54fd25acb46b40caa1ae64e4611fd";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b2/linux-i686/ro/firefox-113.0b2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b3/linux-i686/ro/firefox-113.0b3.tar.bz2";
       locale = "ro";
       arch = "linux-i686";
-      sha256 = "92eeb23cf62e805c52afedaa1a4ae9cd9760dac4e1a6df4c3e3e934176560ddb";
+      sha256 = "58e84206b762788f592bbcba2e6771fe6e0fc4340ffe2adfe2b398e03ef2f4e9";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b2/linux-i686/ru/firefox-113.0b2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b3/linux-i686/ru/firefox-113.0b3.tar.bz2";
       locale = "ru";
       arch = "linux-i686";
-      sha256 = "f2ddf1dd5405aef513ff4d7264bd03a82357aa2aacf837c2a8f7574bc751fbee";
+      sha256 = "f1ce5ca47ced81353741edf020b798d6c7483e92520ed34b1d9d844353b0b0e2";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b2/linux-i686/sc/firefox-113.0b2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b3/linux-i686/sc/firefox-113.0b3.tar.bz2";
       locale = "sc";
       arch = "linux-i686";
-      sha256 = "ca082a336b1217cc9291af1ec4d46ee3a37808662801b524191842da30d5e599";
+      sha256 = "be97c79e8ddf09ac6aedcb8abc4466a0e6073e12e11d6651f233072282caf492";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b2/linux-i686/sco/firefox-113.0b2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b3/linux-i686/sco/firefox-113.0b3.tar.bz2";
       locale = "sco";
       arch = "linux-i686";
-      sha256 = "d8759316bf1afd7679170cb13c422af131764887188a4df9ce9c4cac8aad7abe";
+      sha256 = "3fd7e1d538d42cbb58700a87584da7b04866ea323928eaa85f487e6030a574e8";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b2/linux-i686/si/firefox-113.0b2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b3/linux-i686/si/firefox-113.0b3.tar.bz2";
       locale = "si";
       arch = "linux-i686";
-      sha256 = "7bc492417f6848ccc3bde701587e551299ca3fcfba55696a75576b6801d7b43c";
+      sha256 = "c77c11cb2105fb4bbc583c3ee6e88a9f1345ebb285cb440fc55017d5cdb23977";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b2/linux-i686/sk/firefox-113.0b2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b3/linux-i686/sk/firefox-113.0b3.tar.bz2";
       locale = "sk";
       arch = "linux-i686";
-      sha256 = "3bbf4e5a03759bf84e0cb5b2a04db845f1353e01c770141500cb7fd3482a5b4d";
+      sha256 = "ef257f2dc5a903d17c7c6c3d310bdd527412dd2c7ef49b449ac48aacfb2f03e6";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b2/linux-i686/sl/firefox-113.0b2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b3/linux-i686/sl/firefox-113.0b3.tar.bz2";
       locale = "sl";
       arch = "linux-i686";
-      sha256 = "6b322afdb495a73274ab89e8b215b5f880baec4e9e704a979ee7ce6715cca728";
+      sha256 = "c3cec451900cb21dc24e9fe05f33f363cc3e6307d10253a9cb2e54b55131e689";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b2/linux-i686/son/firefox-113.0b2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b3/linux-i686/son/firefox-113.0b3.tar.bz2";
       locale = "son";
       arch = "linux-i686";
-      sha256 = "a748cb1643585beed1ae72eb10b017f6b9de7e98306e79c0e8c92c5768f16cfa";
+      sha256 = "0110e8168ae2b7a7a6f925b468284ef261798516680433159e2810e65578bf9a";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b2/linux-i686/sq/firefox-113.0b2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b3/linux-i686/sq/firefox-113.0b3.tar.bz2";
       locale = "sq";
       arch = "linux-i686";
-      sha256 = "3581f7290766cfc1848fc453643dceced3d2f5a0e6f21a6f18ca63e697484356";
+      sha256 = "7b52edcfc17de10392c6a62a6318c92288faabbacf24bba78a430089ad6e818a";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b2/linux-i686/sr/firefox-113.0b2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b3/linux-i686/sr/firefox-113.0b3.tar.bz2";
       locale = "sr";
       arch = "linux-i686";
-      sha256 = "2a63d295f7b675d9bf3cbfd07f9dd96e52fd25f16b795762f349d6c035c7ba79";
+      sha256 = "87f9b9807eed9fde78bb23b6b68fc6cf3e2b49c1274c24a0f28fc4b26e200348";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b2/linux-i686/sv-SE/firefox-113.0b2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b3/linux-i686/sv-SE/firefox-113.0b3.tar.bz2";
       locale = "sv-SE";
       arch = "linux-i686";
-      sha256 = "9426ac6aa8d5aeadab85ab4fd921331195b3ccdba03f0e1e591d8584f3133390";
+      sha256 = "dfbb3851dc393e32f44acdc2e22b5e33a46910d64e77062e62e0b642b926e1ac";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b2/linux-i686/szl/firefox-113.0b2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b3/linux-i686/szl/firefox-113.0b3.tar.bz2";
       locale = "szl";
       arch = "linux-i686";
-      sha256 = "1e7045194f7373d66eec1aef95ea57213451063a9db14950a08d53329db1a12b";
+      sha256 = "8e72af5cc9c9cdf1c7a979e98c3f71fe17d0bc1a35963a213b1753ea7672ce72";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b2/linux-i686/ta/firefox-113.0b2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b3/linux-i686/ta/firefox-113.0b3.tar.bz2";
       locale = "ta";
       arch = "linux-i686";
-      sha256 = "6d28d89df6dc978c2d5a0e7402fe5c732de8c5e45c8d2874309046d8d5774774";
+      sha256 = "58b1d265464a80cdab75617d29259c282a3e7ab66086c7986a90f4c993a2ee95";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b2/linux-i686/te/firefox-113.0b2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b3/linux-i686/te/firefox-113.0b3.tar.bz2";
       locale = "te";
       arch = "linux-i686";
-      sha256 = "c2303fa30544c23d535f0b557641f35b42715a46fc6145dbfbcde55fe787825b";
+      sha256 = "2cd403ed816fcc89eba033a66e88f7d1722bddb2b9327b9d3991c18bbe3e11a1";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b2/linux-i686/tg/firefox-113.0b2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b3/linux-i686/tg/firefox-113.0b3.tar.bz2";
       locale = "tg";
       arch = "linux-i686";
-      sha256 = "31a0fce5b8577aed2ef5e7d6cfee2e471966c8f4433c458ab64e7b10fbccbe84";
+      sha256 = "571b82815314b677eb6d2eeb08c56b1d8ac3a3e7fbc27cb9b33a69fe9579c850";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b2/linux-i686/th/firefox-113.0b2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b3/linux-i686/th/firefox-113.0b3.tar.bz2";
       locale = "th";
       arch = "linux-i686";
-      sha256 = "998e6b7ae0cdbcc0391175bab992d8d3a0ea1b8561436dd154f3a70734a4ec83";
+      sha256 = "261ef2d25274266871bc298cd36213f2fa929e3bdf57df44cb0cad936827ef27";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b2/linux-i686/tl/firefox-113.0b2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b3/linux-i686/tl/firefox-113.0b3.tar.bz2";
       locale = "tl";
       arch = "linux-i686";
-      sha256 = "c0292071106bb58658dd5c9b5067518d3d021eaa75230bb021ae1b17c429e881";
+      sha256 = "12f940213af8b7dda0dd05ccfd1c68bbdfe140ac24501834d7d8f584b5a719f8";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b2/linux-i686/tr/firefox-113.0b2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b3/linux-i686/tr/firefox-113.0b3.tar.bz2";
       locale = "tr";
       arch = "linux-i686";
-      sha256 = "c526afd4f552d7a42a6a934201173acbb8752f2943b1140a100f965a4a0f19b0";
+      sha256 = "adebe58e10782049e7abdf983962b84e1bfc63cf4bc176b514842a88aaf12e3f";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b2/linux-i686/trs/firefox-113.0b2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b3/linux-i686/trs/firefox-113.0b3.tar.bz2";
       locale = "trs";
       arch = "linux-i686";
-      sha256 = "20b49f4b2e5e9e69c04a35fb6ac6f1518800e7aa59e167b57db657343dcea3d9";
+      sha256 = "51d1a429763f326b3ae91961450114620ba1255d0d21ea56526af1d735f5ae7c";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b2/linux-i686/uk/firefox-113.0b2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b3/linux-i686/uk/firefox-113.0b3.tar.bz2";
       locale = "uk";
       arch = "linux-i686";
-      sha256 = "09013fe489d551074f5a23854618c79b513661c0393d94448ccfaa46140db393";
+      sha256 = "7d417510c93643b54476164aaf61c5bc2dfdf12b9f2b8de89bc1411e85b37dd4";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b2/linux-i686/ur/firefox-113.0b2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b3/linux-i686/ur/firefox-113.0b3.tar.bz2";
       locale = "ur";
       arch = "linux-i686";
-      sha256 = "d498a2e342a8c508f6ca897f24fff724abe154530985cb86c2c41f4148248947";
+      sha256 = "da24527a8cc107ee5287efbd63c6b6fb2d27653e2166e6d752f47c51683b0fda";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b2/linux-i686/uz/firefox-113.0b2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b3/linux-i686/uz/firefox-113.0b3.tar.bz2";
       locale = "uz";
       arch = "linux-i686";
-      sha256 = "88e1cded70f32e4ef609455f66372e20529cd76c3ff7f7752c2dfdc76ed145ef";
+      sha256 = "d55f111ba517de1c17633eeb2d384b12187ea0ffa32ef69d11ba73b05e1dc318";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b2/linux-i686/vi/firefox-113.0b2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b3/linux-i686/vi/firefox-113.0b3.tar.bz2";
       locale = "vi";
       arch = "linux-i686";
-      sha256 = "e8ac1558d68b66e263b8bccf7f4e4713b3285e685135225ec0a059bb9bc8e1f8";
+      sha256 = "2d10d28d08c7b948c4aa832250d3080aba2aab5b08d220f213c8b744884a7842";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b2/linux-i686/xh/firefox-113.0b2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b3/linux-i686/xh/firefox-113.0b3.tar.bz2";
       locale = "xh";
       arch = "linux-i686";
-      sha256 = "5711801a00bb2ce5dc0463257a026b0bc50ecdbcbe9906427ff0f6d7d1261d34";
+      sha256 = "5d5e8144d39561e1b51c93c1d89f2e3a9fa7a0c4670c067eca69320361787f9f";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b2/linux-i686/zh-CN/firefox-113.0b2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b3/linux-i686/zh-CN/firefox-113.0b3.tar.bz2";
       locale = "zh-CN";
       arch = "linux-i686";
-      sha256 = "78eace2a264fbd0086c3e37c66b616c80d53686d8bbcaa9991ef8993f3d72674";
+      sha256 = "ff4efa9d9a16903b9644ce7b65d5ddf411f8743d70ad9ab88b380893cfa66844";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b2/linux-i686/zh-TW/firefox-113.0b2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/113.0b3/linux-i686/zh-TW/firefox-113.0b3.tar.bz2";
       locale = "zh-TW";
       arch = "linux-i686";
-      sha256 = "4a875e17b79d33b434df4c29f485cbf5d3d4cc9e07914edf549227ac76e83c79";
+      sha256 = "7b0df44217e77681c7294781685ed1ce1d317ec34d13e894a32e2824e549c009";
     }
     ];
 }

--- a/pkgs/applications/networking/browsers/firefox-bin/devedition_sources.nix
+++ b/pkgs/applications/networking/browsers/firefox-bin/devedition_sources.nix
@@ -1,1015 +1,1015 @@
 {
-  version = "113.0b3";
+  version = "113.0b4";
   sources = [
-    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b3/linux-x86_64/ach/firefox-113.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b4/linux-x86_64/ach/firefox-113.0b4.tar.bz2";
       locale = "ach";
       arch = "linux-x86_64";
-      sha256 = "454955bfaaa3049adac17e36781b4417088800e08a20bf1d70b0f841316721ac";
+      sha256 = "0fb6cc894e45447bb6ba1f5638e716619f3554c71fffe85e240a817811d1753f";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b3/linux-x86_64/af/firefox-113.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b4/linux-x86_64/af/firefox-113.0b4.tar.bz2";
       locale = "af";
       arch = "linux-x86_64";
-      sha256 = "5516240f7956aa9b46145fc5cdfbedf96464884296a78b27d71ebb3d2a617992";
+      sha256 = "2524ea4c6a0c7dfe51f496cbff0790599550bbb62a191ede3a696ae09cb4ce2f";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b3/linux-x86_64/an/firefox-113.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b4/linux-x86_64/an/firefox-113.0b4.tar.bz2";
       locale = "an";
       arch = "linux-x86_64";
-      sha256 = "47132a2df4f6f223614005c1c9fdfef79d4f9efa1bc1513c8a54d50417ff555b";
+      sha256 = "efab5b1fea7d0f04ff72dec207f31794ea728e4c95a645b6ed69d6491ec07d72";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b3/linux-x86_64/ar/firefox-113.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b4/linux-x86_64/ar/firefox-113.0b4.tar.bz2";
       locale = "ar";
       arch = "linux-x86_64";
-      sha256 = "5375505b78a205984de1dc0e23c7c0b6dd73d6e3103a3038098800efa9bff853";
+      sha256 = "a46096e83028a1026c1123d13a05823138bf19971cf12b84f8bd3806e668d13e";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b3/linux-x86_64/ast/firefox-113.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b4/linux-x86_64/ast/firefox-113.0b4.tar.bz2";
       locale = "ast";
       arch = "linux-x86_64";
-      sha256 = "e81c6cd7a02590292186e75481324613f793e126e84b5b3364b330ca8fb7bd59";
+      sha256 = "41320331326b8cac13cda8963027a867c77a4cbbb2ea495e413080cd0c41eea8";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b3/linux-x86_64/az/firefox-113.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b4/linux-x86_64/az/firefox-113.0b4.tar.bz2";
       locale = "az";
       arch = "linux-x86_64";
-      sha256 = "09ad87cda099302595d7829b2b7abceb52396dee79f2e3bdf174567e5a0efb68";
+      sha256 = "543670c4f3ec4823fcf594f45ef2c1a297f76f53aee3501012e7a4372ae211e7";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b3/linux-x86_64/be/firefox-113.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b4/linux-x86_64/be/firefox-113.0b4.tar.bz2";
       locale = "be";
       arch = "linux-x86_64";
-      sha256 = "9cdaac1ab79c08f2e6839aad93294c6031d6f5d58dd2fdae9d508895b727ce65";
+      sha256 = "a3b801f43fa0c19a1a17d9ffb979782f0450ed318e061dfa85c1f7b00be51ff9";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b3/linux-x86_64/bg/firefox-113.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b4/linux-x86_64/bg/firefox-113.0b4.tar.bz2";
       locale = "bg";
       arch = "linux-x86_64";
-      sha256 = "3ac3eb80ed229dd0a8455713cad8792f9ce288369a82f624ab451d0e7572e944";
+      sha256 = "e71ae08e0ff78139cfbd35f98203df9398ba64e98d5fb4618ce899a5b3ca3f08";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b3/linux-x86_64/bn/firefox-113.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b4/linux-x86_64/bn/firefox-113.0b4.tar.bz2";
       locale = "bn";
       arch = "linux-x86_64";
-      sha256 = "64a258dfc45297dd06fdc5685a666a9558ded0cf4450517d6653b13a7a18d828";
+      sha256 = "a9475fb211a305dc7d3614f7ba2f9eb259cc94852c2b2a4d2009400a3433aab3";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b3/linux-x86_64/br/firefox-113.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b4/linux-x86_64/br/firefox-113.0b4.tar.bz2";
       locale = "br";
       arch = "linux-x86_64";
-      sha256 = "8eb8fb80921bca450f15024b97c3cf628cdfc58ec33f60bdfb65e2cada5397e6";
+      sha256 = "8f5ff443b2ec5eaa68e732b3487983443a1cb2e6dbc9fc97b521662862fe78fe";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b3/linux-x86_64/bs/firefox-113.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b4/linux-x86_64/bs/firefox-113.0b4.tar.bz2";
       locale = "bs";
       arch = "linux-x86_64";
-      sha256 = "b4924c6a3c72a8b8fb9c7dc502ca1a912215f1f565b6ca3976b234b36da98476";
+      sha256 = "cd311989d74d7192b7b5011901317a8fcaecbf1b35eb8d9eafcbfcfd65b31d50";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b3/linux-x86_64/ca-valencia/firefox-113.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b4/linux-x86_64/ca-valencia/firefox-113.0b4.tar.bz2";
       locale = "ca-valencia";
       arch = "linux-x86_64";
-      sha256 = "ba0837a8cd6856afdab11de6e1fe190750958eda1ddb9142fcdfa85af9683f5b";
+      sha256 = "020ddd0e07609a6a8d74c3b7a8f84986320fbd711df7a846eede70f57c92fa61";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b3/linux-x86_64/ca/firefox-113.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b4/linux-x86_64/ca/firefox-113.0b4.tar.bz2";
       locale = "ca";
       arch = "linux-x86_64";
-      sha256 = "80bb919bf727977e8dea121d8ccc41bd1001bfe02cf6f00f611b5450471337a5";
+      sha256 = "5242da58d848163ed6f6c0950f6b15bb2695039f1e36766c843d4e6d24029a21";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b3/linux-x86_64/cak/firefox-113.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b4/linux-x86_64/cak/firefox-113.0b4.tar.bz2";
       locale = "cak";
       arch = "linux-x86_64";
-      sha256 = "ebdc8be7d14ea5044b5befad5a04f2c07c61b029acdc8e62c9d729a217e8218c";
+      sha256 = "8f8be24b896cb9dc91832f85afacd07fda9cea47b44d4885b758b6f42f4ba8f2";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b3/linux-x86_64/cs/firefox-113.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b4/linux-x86_64/cs/firefox-113.0b4.tar.bz2";
       locale = "cs";
       arch = "linux-x86_64";
-      sha256 = "066674fd2bfc166f152140f6ac7491039295555db1eb69a2ea13ea2d3c1ff6e6";
+      sha256 = "13d4316d04e1dc777318c7fa45ac162904bc073947ea535c1085c394e9ade361";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b3/linux-x86_64/cy/firefox-113.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b4/linux-x86_64/cy/firefox-113.0b4.tar.bz2";
       locale = "cy";
       arch = "linux-x86_64";
-      sha256 = "03bec22656be7aa2f543fee2cea3292760f3843975d2d45af2fcfd28f778d83d";
+      sha256 = "bca6e4745d235399627caa12e64d06b6ee98c21656d686d15ee27d7bc53d81ab";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b3/linux-x86_64/da/firefox-113.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b4/linux-x86_64/da/firefox-113.0b4.tar.bz2";
       locale = "da";
       arch = "linux-x86_64";
-      sha256 = "8c61889417531ad06fb609fbcf2609df372784c173c7ae4f6d8100ae72e9abfa";
+      sha256 = "6d9e212af96a91dd994c5fbda78e17038e8366ba366ee9cb6ef2cb0bbd6db6ab";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b3/linux-x86_64/de/firefox-113.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b4/linux-x86_64/de/firefox-113.0b4.tar.bz2";
       locale = "de";
       arch = "linux-x86_64";
-      sha256 = "0b067f160e87b1a8ea6d46cae3e783aed06366fa8b29f781e936f0576882bb0a";
+      sha256 = "33cc3250cba675b4b100240965db4cda1969c1fcda7eabc83d28cf3496162296";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b3/linux-x86_64/dsb/firefox-113.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b4/linux-x86_64/dsb/firefox-113.0b4.tar.bz2";
       locale = "dsb";
       arch = "linux-x86_64";
-      sha256 = "12d7be3669eb0d370c70bd7bfaa75e54eada19dbec02d4dc2129716263a8ac99";
+      sha256 = "b7d1f3759e36600b0294f3067075117c74f951867704a6a87a1807608b760b79";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b3/linux-x86_64/el/firefox-113.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b4/linux-x86_64/el/firefox-113.0b4.tar.bz2";
       locale = "el";
       arch = "linux-x86_64";
-      sha256 = "c21e1f981f76e04c29208d0f8650634603efff437051a3b73f0edf39eac23376";
+      sha256 = "a5e8f807f9f0afc83da34b5f684d1251b9057b1a48f0ea55dcb3a6d2b0b5827f";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b3/linux-x86_64/en-CA/firefox-113.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b4/linux-x86_64/en-CA/firefox-113.0b4.tar.bz2";
       locale = "en-CA";
       arch = "linux-x86_64";
-      sha256 = "4048b9db329b077e301ae045566037d97b31cd93f313472c217edc590c004c63";
+      sha256 = "655a6ac0aabc242fbfe3e17bd6a4e0aaf4bc35aafbaa32f776e85f4c8a4fd947";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b3/linux-x86_64/en-GB/firefox-113.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b4/linux-x86_64/en-GB/firefox-113.0b4.tar.bz2";
       locale = "en-GB";
       arch = "linux-x86_64";
-      sha256 = "fd24a96b77c2eb6cfff80a649bf3a5380c7cafaeae4f0f9122dab37014753516";
+      sha256 = "9d59ddeb52188ed384791ad39d6fab27456164ed9fefb05c3a715a86ddb73199";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b3/linux-x86_64/en-US/firefox-113.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b4/linux-x86_64/en-US/firefox-113.0b4.tar.bz2";
       locale = "en-US";
       arch = "linux-x86_64";
-      sha256 = "62f8f041348fda32922ccdbc2a3bc64e7276ab76037f90153cc9e2eb1dcbe145";
+      sha256 = "335d6eebce1d079832dc165b938a2e94438bbdd7e4067b96a5f8c524cb3fdc10";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b3/linux-x86_64/eo/firefox-113.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b4/linux-x86_64/eo/firefox-113.0b4.tar.bz2";
       locale = "eo";
       arch = "linux-x86_64";
-      sha256 = "265a6de63d9610860db612b9cb02c5fca34d2a4a346bd907fc9782605c8300f4";
+      sha256 = "b5dcd0aba20d3041d05c3fb70e1f73d95129fca80ddd53a1eb6eaa862bb5f309";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b3/linux-x86_64/es-AR/firefox-113.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b4/linux-x86_64/es-AR/firefox-113.0b4.tar.bz2";
       locale = "es-AR";
       arch = "linux-x86_64";
-      sha256 = "e6c8533bdbe199cbb130065a3265707faf8ca562c7049d6729ebc2b61d48d013";
+      sha256 = "59df349819e4c7881696f1224b7beb933420fbf7b7c6c6bf2abcdae15d6c8ef3";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b3/linux-x86_64/es-CL/firefox-113.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b4/linux-x86_64/es-CL/firefox-113.0b4.tar.bz2";
       locale = "es-CL";
       arch = "linux-x86_64";
-      sha256 = "aacc0496ddb3402e9429eb630b8e9dc9b9725771ef1960b1eafb1f1f39f59182";
+      sha256 = "243e5fb75f8fb0ec083bab5e83774d6d05e1298db707c746a24a0803cc725e9f";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b3/linux-x86_64/es-ES/firefox-113.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b4/linux-x86_64/es-ES/firefox-113.0b4.tar.bz2";
       locale = "es-ES";
       arch = "linux-x86_64";
-      sha256 = "7f35e414501dc48d1e170ccc581c4d486fc48d9a53aa421192885b26e8fc5704";
+      sha256 = "60fc4ef8ee54e662df20b7cf425b5777ddc36354e3ebe58cb41555a30a1498e2";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b3/linux-x86_64/es-MX/firefox-113.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b4/linux-x86_64/es-MX/firefox-113.0b4.tar.bz2";
       locale = "es-MX";
       arch = "linux-x86_64";
-      sha256 = "4520ee509d0c216d58d4940d1759d53faf94f00ec42ee17a4cd17261d99bb8b8";
+      sha256 = "563d0f9ef8bf7c69d5197358522235a24782b49907989c186040d7170ae79c87";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b3/linux-x86_64/et/firefox-113.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b4/linux-x86_64/et/firefox-113.0b4.tar.bz2";
       locale = "et";
       arch = "linux-x86_64";
-      sha256 = "b987e5cd8b92c5cd0839091a6b37bd9bc38422f49733207152ddca9190d0cf68";
+      sha256 = "68185bd9cd373634cffd669740f6023e866eb4f37ae3241fac2d9c864342c1ef";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b3/linux-x86_64/eu/firefox-113.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b4/linux-x86_64/eu/firefox-113.0b4.tar.bz2";
       locale = "eu";
       arch = "linux-x86_64";
-      sha256 = "c1fa09e40302ff66eea7f2d23fb220c81b6d6f33c03d93a2b14470fb78393f3c";
+      sha256 = "13b5e024b8c288f934669f54a00478fed905a2885e4b0c1379d4fe00438af3a4";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b3/linux-x86_64/fa/firefox-113.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b4/linux-x86_64/fa/firefox-113.0b4.tar.bz2";
       locale = "fa";
       arch = "linux-x86_64";
-      sha256 = "75a205b628c45cb344de05f1a00b9e64388522633b41bd49ea156650a0459991";
+      sha256 = "4d349fe8db19a5766d7c5e8add14a7ab94ad2403df932ff1e656786fdcd93b6b";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b3/linux-x86_64/ff/firefox-113.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b4/linux-x86_64/ff/firefox-113.0b4.tar.bz2";
       locale = "ff";
       arch = "linux-x86_64";
-      sha256 = "82e9bf057bb04ef8af8f98cf73ae912edc7d6b42817df29fa0ddab4e9918c70c";
+      sha256 = "c86494bd989c0f777d4d90ad950b72fc69a768b2ff728092f6c53a24cb9844f2";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b3/linux-x86_64/fi/firefox-113.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b4/linux-x86_64/fi/firefox-113.0b4.tar.bz2";
       locale = "fi";
       arch = "linux-x86_64";
-      sha256 = "52d032fe3498a17888b113e4ecab04f6cdfcea99fe37469dcbad029c0c6dd4da";
+      sha256 = "e05070b60800ba97773d00bd6a1fc397c268b489e535848d17f144396c2e690b";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b3/linux-x86_64/fr/firefox-113.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b4/linux-x86_64/fr/firefox-113.0b4.tar.bz2";
       locale = "fr";
       arch = "linux-x86_64";
-      sha256 = "1b5256b2771d8fcd2eae5c9a3351b44a34a266d096eb991cf1d165b9966af687";
+      sha256 = "aa94ee3eff97c7e9ca31f25c45cfd40f0292a27ebc7e399a4318dfcb3e893cef";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b3/linux-x86_64/fur/firefox-113.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b4/linux-x86_64/fur/firefox-113.0b4.tar.bz2";
       locale = "fur";
       arch = "linux-x86_64";
-      sha256 = "5164c611c004949afde262073b4900ce189a18e1fb95142b960468251a07ae0f";
+      sha256 = "71592b4a094dbf4fa153a25f368fedeb4338bd4bbcd990ed8779afe72c90c8c5";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b3/linux-x86_64/fy-NL/firefox-113.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b4/linux-x86_64/fy-NL/firefox-113.0b4.tar.bz2";
       locale = "fy-NL";
       arch = "linux-x86_64";
-      sha256 = "dbaed3e1fdb4ce0a7433d44ecba96797b2246cdd346a1c8fedb1922e71a7fe3b";
+      sha256 = "93c4035a51d20fd83d3513670618b53213c8cab25bd496a0665b2a0849d24a70";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b3/linux-x86_64/ga-IE/firefox-113.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b4/linux-x86_64/ga-IE/firefox-113.0b4.tar.bz2";
       locale = "ga-IE";
       arch = "linux-x86_64";
-      sha256 = "02ecfdf8cdf1fff1857ae5abb39576454ca3f92662dda528142d0565a483bf8b";
+      sha256 = "24db4cef5050cfa47827acb0da6d539d480ea2c847dd73700ee5879c8759a3aa";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b3/linux-x86_64/gd/firefox-113.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b4/linux-x86_64/gd/firefox-113.0b4.tar.bz2";
       locale = "gd";
       arch = "linux-x86_64";
-      sha256 = "b5ba1f1f76439e31f9fb42ae8a3e8f52e6e40029938d15302bba06caf930d097";
+      sha256 = "97d8d4fceb01fd352220e9b98e107338c7642c00bb960f20fb68aefc7b189b00";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b3/linux-x86_64/gl/firefox-113.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b4/linux-x86_64/gl/firefox-113.0b4.tar.bz2";
       locale = "gl";
       arch = "linux-x86_64";
-      sha256 = "9e25d84cd18818fc3be0cd8bf080a91752b766f75d5a7bc37b12dc7857cec8f4";
+      sha256 = "2b91f7aed363e5fa3b10a14b3a5b479546cd67e17490715d4d714634f0245b1d";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b3/linux-x86_64/gn/firefox-113.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b4/linux-x86_64/gn/firefox-113.0b4.tar.bz2";
       locale = "gn";
       arch = "linux-x86_64";
-      sha256 = "1dba1e4cb47af3ed5ba281d094e00e14394bfbbcc86b68d2519145185759374a";
+      sha256 = "292d36b9a37dd7ad6421082f317b8ce9b2e01230e24e524418cad8166a8d7423";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b3/linux-x86_64/gu-IN/firefox-113.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b4/linux-x86_64/gu-IN/firefox-113.0b4.tar.bz2";
       locale = "gu-IN";
       arch = "linux-x86_64";
-      sha256 = "940081f48755b911c8141839d1effb2ac76374812c3f78b1265ef673c29ec13b";
+      sha256 = "68a5ddc18975de60ff79732f07c6471f79e7db6977b4a7f59709d4661efdf3b7";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b3/linux-x86_64/he/firefox-113.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b4/linux-x86_64/he/firefox-113.0b4.tar.bz2";
       locale = "he";
       arch = "linux-x86_64";
-      sha256 = "452aa702e8edf4d87a5dfda8c71a9cda95dd451b805af1406a0811c4f8b30738";
+      sha256 = "dcd8876a30d4807a831d771ff4450711098373c23bfa43c0d7810dafb8b67c57";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b3/linux-x86_64/hi-IN/firefox-113.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b4/linux-x86_64/hi-IN/firefox-113.0b4.tar.bz2";
       locale = "hi-IN";
       arch = "linux-x86_64";
-      sha256 = "3d8cacae64d177e04f9788894c9b59d9456f7a7e7feda3467e887d8364f48574";
+      sha256 = "375ab1e64b8ecb2b2b42b9348f64254a01a11213a8b1ba6dd7febe6c5b5bf242";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b3/linux-x86_64/hr/firefox-113.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b4/linux-x86_64/hr/firefox-113.0b4.tar.bz2";
       locale = "hr";
       arch = "linux-x86_64";
-      sha256 = "0546b19ee355fb86cf14bcfe6b904b155eb4a7b258507dbeed89433bfebf5335";
+      sha256 = "bcd791204b366c601bfffabf8815e3f50fd5baf16ed7dc4005e4d567be37adbd";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b3/linux-x86_64/hsb/firefox-113.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b4/linux-x86_64/hsb/firefox-113.0b4.tar.bz2";
       locale = "hsb";
       arch = "linux-x86_64";
-      sha256 = "914bc26e16658602ca6cc57c072c9137b0691b20c2d7b945308c23002e15ce0d";
+      sha256 = "8ed56ed8e9b4323d6a2e6138e7756d384331fe975f5ac792ddbe744dacbde748";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b3/linux-x86_64/hu/firefox-113.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b4/linux-x86_64/hu/firefox-113.0b4.tar.bz2";
       locale = "hu";
       arch = "linux-x86_64";
-      sha256 = "4457022a3507ee97467fed2f0e494b2b13a9bc50c87009ac559862bc6967a3fe";
+      sha256 = "038ee88979fa635c4b436e9f52a64fda9e9bf552d9687246c1d70a7332272b9b";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b3/linux-x86_64/hy-AM/firefox-113.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b4/linux-x86_64/hy-AM/firefox-113.0b4.tar.bz2";
       locale = "hy-AM";
       arch = "linux-x86_64";
-      sha256 = "f4b6c03dd522aaab26a48c05fff31afab82a92c184796bcd424e0687e6494093";
+      sha256 = "f8276de6b8ccae8c7c08c0f58f2987755b0d56ce450a90dba807541bf415c595";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b3/linux-x86_64/ia/firefox-113.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b4/linux-x86_64/ia/firefox-113.0b4.tar.bz2";
       locale = "ia";
       arch = "linux-x86_64";
-      sha256 = "d22c2581b8cc36713f53bf1096c84f15f7e5c23c5fe5724a78d8f2ec4b735abc";
+      sha256 = "46282849748878cc2238c86f9bf7ae0c72fa9e364d13e63050be4776e39fa7af";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b3/linux-x86_64/id/firefox-113.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b4/linux-x86_64/id/firefox-113.0b4.tar.bz2";
       locale = "id";
       arch = "linux-x86_64";
-      sha256 = "a1550c292b9b3e24f9b1c2d1d6f2db41f73f927950da1714ecd4fa0d7d63838c";
+      sha256 = "1423f4e631414d9485598624c4537b04173eb3cece13461a86d0d511d5ac66e5";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b3/linux-x86_64/is/firefox-113.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b4/linux-x86_64/is/firefox-113.0b4.tar.bz2";
       locale = "is";
       arch = "linux-x86_64";
-      sha256 = "93750fa307621ae233030cea0752a5af553e6283d08ff3fda45493e7632e5d29";
+      sha256 = "f286d939beb07e9f30bdcfe66b48b499cd6f74b4fe99ee4f07f87834ab5e7e35";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b3/linux-x86_64/it/firefox-113.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b4/linux-x86_64/it/firefox-113.0b4.tar.bz2";
       locale = "it";
       arch = "linux-x86_64";
-      sha256 = "fccbfd7a418236a3d8c43f401146f1b28cfb0ff86a0297a18b7131610839efb0";
+      sha256 = "38e9effdb34a6c65899e5fa121256d63dc9f6fa213a7b70e0305ed41d01ec279";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b3/linux-x86_64/ja/firefox-113.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b4/linux-x86_64/ja/firefox-113.0b4.tar.bz2";
       locale = "ja";
       arch = "linux-x86_64";
-      sha256 = "97814e060681870e279f55d7611b248dad7135255297ed9cd7b5f20639da9b7a";
+      sha256 = "bf8aea1bee94db6069d01115c388dee548676e1fb63c09a61d2241c3317a4e01";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b3/linux-x86_64/ka/firefox-113.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b4/linux-x86_64/ka/firefox-113.0b4.tar.bz2";
       locale = "ka";
       arch = "linux-x86_64";
-      sha256 = "95381c4aa6fb6d9085e24e0e9f2a1150db965e4d6fd37a20666b2137d1f0b6c6";
+      sha256 = "80af1ec4f933906c50f5511e389da05df1f969cdffeedc4ab36ad869ddd34e60";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b3/linux-x86_64/kab/firefox-113.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b4/linux-x86_64/kab/firefox-113.0b4.tar.bz2";
       locale = "kab";
       arch = "linux-x86_64";
-      sha256 = "22acda1a93ddb602706dfaccd03c0997756ab6eaed9e01e3f1c4b54eb868c1ee";
+      sha256 = "47d4c4047f2021e9acb5746f5ff7f4850c4f94d62fa7ab4d364ad29af227561a";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b3/linux-x86_64/kk/firefox-113.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b4/linux-x86_64/kk/firefox-113.0b4.tar.bz2";
       locale = "kk";
       arch = "linux-x86_64";
-      sha256 = "99ff6df59b85ad1db0de2e76f925570a013c5708a805214b45304bcaf47a809a";
+      sha256 = "b6faf1396886c0acb36061ce0b2b0a67fdd71be82067bd62b2adcff21500e081";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b3/linux-x86_64/km/firefox-113.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b4/linux-x86_64/km/firefox-113.0b4.tar.bz2";
       locale = "km";
       arch = "linux-x86_64";
-      sha256 = "0e4352dcc4b6f1e3caec06a8b82619db27d704a6a5a9e85c78b9d1b7aca946d2";
+      sha256 = "82622ac8d0127113ac2a6e540c47150c37b8905d751f077a1f32641b89287816";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b3/linux-x86_64/kn/firefox-113.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b4/linux-x86_64/kn/firefox-113.0b4.tar.bz2";
       locale = "kn";
       arch = "linux-x86_64";
-      sha256 = "593fe4f56b5c70238af12f657fbd3fa87e976a89a1190902da847c67c1927ddd";
+      sha256 = "228717419016c7592c90702176d432e49c768bed9003335dbbb7421370bef866";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b3/linux-x86_64/ko/firefox-113.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b4/linux-x86_64/ko/firefox-113.0b4.tar.bz2";
       locale = "ko";
       arch = "linux-x86_64";
-      sha256 = "5b15e8312d666836a28030bbf22573a354a6925498f24d40d9728bbeef9ab754";
+      sha256 = "4969f9f7ce79a4bba078be41fe7b920f31f9f0b9c850e3781e2ee5002aac2483";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b3/linux-x86_64/lij/firefox-113.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b4/linux-x86_64/lij/firefox-113.0b4.tar.bz2";
       locale = "lij";
       arch = "linux-x86_64";
-      sha256 = "b24793b43541f63c5aa9e97d26ff42f984aacedf0d979cdee8c6c6347337943d";
+      sha256 = "9011c0d250d33ea3774311bf7c3906e17ae692c3bfefa40d494f87825a87a3c4";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b3/linux-x86_64/lt/firefox-113.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b4/linux-x86_64/lt/firefox-113.0b4.tar.bz2";
       locale = "lt";
       arch = "linux-x86_64";
-      sha256 = "6752ad55f7c9f091bddd5a84b6d7d81fcb6e8f80064c1513a3bd789af5695819";
+      sha256 = "f5fb60877d144485be0be40df901f6cb54d32933029d4970983a504ddf3ac0c3";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b3/linux-x86_64/lv/firefox-113.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b4/linux-x86_64/lv/firefox-113.0b4.tar.bz2";
       locale = "lv";
       arch = "linux-x86_64";
-      sha256 = "14cf1c6b4485d6d3175be0560377f59443e436b50993b65f53d751664f686b4c";
+      sha256 = "03b08f0cc65ecf085db89ffffab11380f29d7e7c4869a8aa6c63a4664f6d56c9";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b3/linux-x86_64/mk/firefox-113.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b4/linux-x86_64/mk/firefox-113.0b4.tar.bz2";
       locale = "mk";
       arch = "linux-x86_64";
-      sha256 = "1f072ca8bc3d28c14b215d0fca8f1cbdbb2995faee9f6b69926684c33e47fcad";
+      sha256 = "8c1125c0a57e32d228d92f87250aeaf4957d28f8b29fab696492fe25fef40100";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b3/linux-x86_64/mr/firefox-113.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b4/linux-x86_64/mr/firefox-113.0b4.tar.bz2";
       locale = "mr";
       arch = "linux-x86_64";
-      sha256 = "68da899c4770565f7e9a0f9557ecbb8543a128784ef53934235e182631d2c999";
+      sha256 = "560af9575fb685cdf45e65a539db6b750044b1282d8529d7b6e96111161449e0";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b3/linux-x86_64/ms/firefox-113.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b4/linux-x86_64/ms/firefox-113.0b4.tar.bz2";
       locale = "ms";
       arch = "linux-x86_64";
-      sha256 = "ba878607c14a21826b74dfb2ec7635401cd606a74ccfe8e715899149ecedfb28";
+      sha256 = "c9184543f1f8aeb7cf1b4215666a51f454a8503a36eebd8b4d6398ba9cc3dfdf";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b3/linux-x86_64/my/firefox-113.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b4/linux-x86_64/my/firefox-113.0b4.tar.bz2";
       locale = "my";
       arch = "linux-x86_64";
-      sha256 = "931df6cc939a18c8df7d5fee59e9a50fa390527653c4aa4fc6a72c421c251cac";
+      sha256 = "c1ba7a95eeee9f83f94d603ff97ff4e3cfaa2c45da285f10a923d0f635f33444";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b3/linux-x86_64/nb-NO/firefox-113.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b4/linux-x86_64/nb-NO/firefox-113.0b4.tar.bz2";
       locale = "nb-NO";
       arch = "linux-x86_64";
-      sha256 = "3bf023b72b72d4e6fdc4a6644508feeca3a7e54cb8c56feab77c4551a9585ca6";
+      sha256 = "0214c5f94fb2ab276109c8b058548ba2761a88e9b306d00cb0bbc0cc9ed82598";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b3/linux-x86_64/ne-NP/firefox-113.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b4/linux-x86_64/ne-NP/firefox-113.0b4.tar.bz2";
       locale = "ne-NP";
       arch = "linux-x86_64";
-      sha256 = "dd9e2159fbbaa7f76a1a29c96bb8c3d330b305c2a6a9df9de692b3eea30a2be4";
+      sha256 = "2370de43beb5baf22bcfadc5c4c36e80bdfc4165948b2bb7ad3051b559074945";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b3/linux-x86_64/nl/firefox-113.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b4/linux-x86_64/nl/firefox-113.0b4.tar.bz2";
       locale = "nl";
       arch = "linux-x86_64";
-      sha256 = "b577c155e6c7f4138c30d3a1345312f1554c6ee20eb327babbe8ad282f4194c2";
+      sha256 = "ea7b19a009498e0e30e10bc8dcc180d2b564e8e01b2c85c3ca1c9d44c6571c6e";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b3/linux-x86_64/nn-NO/firefox-113.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b4/linux-x86_64/nn-NO/firefox-113.0b4.tar.bz2";
       locale = "nn-NO";
       arch = "linux-x86_64";
-      sha256 = "b37e8fe61a930efa905723d11aec90974662d86c149b0124aebe40e5a40bf95b";
+      sha256 = "e8f79357a90ca197a547e27215ea3f85cc6ea88190e0238fabec0cb07baa9d99";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b3/linux-x86_64/oc/firefox-113.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b4/linux-x86_64/oc/firefox-113.0b4.tar.bz2";
       locale = "oc";
       arch = "linux-x86_64";
-      sha256 = "8e0b144d174aa54f18e189db2a89bdfe22663af7984a622f90ce645164ddc0a5";
+      sha256 = "185146385971b16174ffc56c5a9e7e3dadea43a1288c32759929db0fe8412ced";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b3/linux-x86_64/pa-IN/firefox-113.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b4/linux-x86_64/pa-IN/firefox-113.0b4.tar.bz2";
       locale = "pa-IN";
       arch = "linux-x86_64";
-      sha256 = "60eb78e313e909cad6cfb72ad3ddeaf1a70950c2d9143a5cedc0f5947a7aba71";
+      sha256 = "4e2cd0af0bd3109b98db82ffc5bee0932e9a5dd3e43136e1a0b82bdc58bd6af2";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b3/linux-x86_64/pl/firefox-113.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b4/linux-x86_64/pl/firefox-113.0b4.tar.bz2";
       locale = "pl";
       arch = "linux-x86_64";
-      sha256 = "25c841c67b699cdb36386356abd93ae7d7506b8fec628788273c565dec2f7e16";
+      sha256 = "89e76380d3acc65eb9fcb82f982ae436f7a863d8f3f48e9e2df57d00253c5496";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b3/linux-x86_64/pt-BR/firefox-113.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b4/linux-x86_64/pt-BR/firefox-113.0b4.tar.bz2";
       locale = "pt-BR";
       arch = "linux-x86_64";
-      sha256 = "ec535f28ae1390378bf64598bc58b0b05909183ea4159f843f8d638bc247dbf6";
+      sha256 = "39543bee91267117a0470adf00b69d9f21348a6fc3de1e27077dd2b5807b2613";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b3/linux-x86_64/pt-PT/firefox-113.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b4/linux-x86_64/pt-PT/firefox-113.0b4.tar.bz2";
       locale = "pt-PT";
       arch = "linux-x86_64";
-      sha256 = "edd20ce65ab20ff48f7c30f69df84db85ec0831a47f9933ff3f6d94affc04825";
+      sha256 = "78353c4e7e4a14466a276cf45421c5783a408e2ad9a3fdf967cc23e6b000800a";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b3/linux-x86_64/rm/firefox-113.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b4/linux-x86_64/rm/firefox-113.0b4.tar.bz2";
       locale = "rm";
       arch = "linux-x86_64";
-      sha256 = "fc7b426b48cf4622a65d86d3d64492a3a37adfefddcaf5b2963a3d3d1a28f5c6";
+      sha256 = "1ed52804ef3d9186d7f911f3301f2660b751bc6685cff531844bdde4b5e5b040";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b3/linux-x86_64/ro/firefox-113.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b4/linux-x86_64/ro/firefox-113.0b4.tar.bz2";
       locale = "ro";
       arch = "linux-x86_64";
-      sha256 = "37ef32f187a9b051663c9030d3a74ca142f7497542805d15cdc5d100d3314a09";
+      sha256 = "d5da1b3c4186f52f87dd312b55ca148e3c7bf846fcb76d88c066d2dee253fe61";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b3/linux-x86_64/ru/firefox-113.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b4/linux-x86_64/ru/firefox-113.0b4.tar.bz2";
       locale = "ru";
       arch = "linux-x86_64";
-      sha256 = "ee6d259239dd7bca7181380de4c78b2a4735fcc56af9dd50e61472ad5d2269f6";
+      sha256 = "a3be2839119265612c68a68fe9933cc80e8d2d770aa4805cd8f4a39a8bde5ea7";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b3/linux-x86_64/sc/firefox-113.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b4/linux-x86_64/sc/firefox-113.0b4.tar.bz2";
       locale = "sc";
       arch = "linux-x86_64";
-      sha256 = "b1e6584b241b2036902aa5ebc4b41886be34c4a0b051500f135b365441e890ef";
+      sha256 = "b2e9d9cce625130180c36a97496a26efce2b647fed7cd2722c6c140bcfe62cd9";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b3/linux-x86_64/sco/firefox-113.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b4/linux-x86_64/sco/firefox-113.0b4.tar.bz2";
       locale = "sco";
       arch = "linux-x86_64";
-      sha256 = "d872486432a53c499b00e97dfa5c2e23b8b7241021000ee5f46fdd78f6d96a5c";
+      sha256 = "95ac4a4211d2b30dbb378dbd7b76be67933809b7cb5a38fa1ee9cb67bbfbe741";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b3/linux-x86_64/si/firefox-113.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b4/linux-x86_64/si/firefox-113.0b4.tar.bz2";
       locale = "si";
       arch = "linux-x86_64";
-      sha256 = "b2e59be4c213a6b3c32c68bd83ce519c2325b80c5a1dd1a9d8ab3cb96c23772e";
+      sha256 = "cf509aeeabd75e0017aead58d26f964c86d8dabe6bed4a21e2b9ca96b69da40c";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b3/linux-x86_64/sk/firefox-113.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b4/linux-x86_64/sk/firefox-113.0b4.tar.bz2";
       locale = "sk";
       arch = "linux-x86_64";
-      sha256 = "2e46ac9f106e041d6ec575da271c42870f04d1ac23d315d8716216f942c5b76c";
+      sha256 = "3dfd87d0bec5ada439d55b0cf30f6ee368b7fcedef7a1f55347f89ae29bb70fd";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b3/linux-x86_64/sl/firefox-113.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b4/linux-x86_64/sl/firefox-113.0b4.tar.bz2";
       locale = "sl";
       arch = "linux-x86_64";
-      sha256 = "b65270523cdad9d7db735fcc5cfa938fd83e87c8ce2f17bdca2ee7b876210fb9";
+      sha256 = "c16f872446ccacdbf561b4492f05238f1eaffa7eec2da53dac5e1244faef1223";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b3/linux-x86_64/son/firefox-113.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b4/linux-x86_64/son/firefox-113.0b4.tar.bz2";
       locale = "son";
       arch = "linux-x86_64";
-      sha256 = "e1d866ff9517b5e410327bc01a1511fc387f4c5c8022bc8d18a7f4b62cbe3934";
+      sha256 = "fca55d28673767468d1eecf79c2ecac9466d0299aa47e15cc98318e7f62c9482";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b3/linux-x86_64/sq/firefox-113.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b4/linux-x86_64/sq/firefox-113.0b4.tar.bz2";
       locale = "sq";
       arch = "linux-x86_64";
-      sha256 = "68cf83cbe439a895199a7020143064242c1bf70484a265905733905687a3b33c";
+      sha256 = "8d0022b899cbccfb0393083767b8a1d3751521e60a4b000ffc92ebebd0f9147c";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b3/linux-x86_64/sr/firefox-113.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b4/linux-x86_64/sr/firefox-113.0b4.tar.bz2";
       locale = "sr";
       arch = "linux-x86_64";
-      sha256 = "5762245c8f817607baa239a103c53ebe2f6fbea9e2e4c455d00df02c85e46f95";
+      sha256 = "0ca3277be4e770c2fa36dd63048595bd462ec02d6b59d15738b6bbbe82bac525";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b3/linux-x86_64/sv-SE/firefox-113.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b4/linux-x86_64/sv-SE/firefox-113.0b4.tar.bz2";
       locale = "sv-SE";
       arch = "linux-x86_64";
-      sha256 = "e88f9d915800be482b8e623920b1d10e59eb6bbb4198d1c67c3daf195f794ec6";
+      sha256 = "d1267346ef9c96ad80c615ba4824677c7f0d2abbadea41633c9a60594a22eacc";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b3/linux-x86_64/szl/firefox-113.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b4/linux-x86_64/szl/firefox-113.0b4.tar.bz2";
       locale = "szl";
       arch = "linux-x86_64";
-      sha256 = "4ba1838d9f8325a1f13b98553c28618e14f7d98801e4d9fcde89c853faad8122";
+      sha256 = "596eff230be38686e66b87fad5f00eb8795fa6d9d42f996c6cbf4c3979ebc6fa";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b3/linux-x86_64/ta/firefox-113.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b4/linux-x86_64/ta/firefox-113.0b4.tar.bz2";
       locale = "ta";
       arch = "linux-x86_64";
-      sha256 = "9329390fc6db472358399a9055fe1e903520bc51be425b61b3d9f8d6ad0ade7c";
+      sha256 = "33048dba43825b4a5beec7183125bcc7e8d9b9c7ea005a57a58506888c432e62";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b3/linux-x86_64/te/firefox-113.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b4/linux-x86_64/te/firefox-113.0b4.tar.bz2";
       locale = "te";
       arch = "linux-x86_64";
-      sha256 = "2ba356eb834bc7c6da2324028b1964c2a580fa8d7ccd17ec04ef5bb7f5c54519";
+      sha256 = "873676b3f7b9f331fb9d98d1740739504dd4a56df179bbd244a9b3a3591a9fda";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b3/linux-x86_64/tg/firefox-113.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b4/linux-x86_64/tg/firefox-113.0b4.tar.bz2";
       locale = "tg";
       arch = "linux-x86_64";
-      sha256 = "7f6d61f46830319ad8f4cf5d5c4557bac6b8771809c80ea25ebf18c04b1d74f4";
+      sha256 = "274336b778a16ef103890bf1b6cd57e402ebb845e7a801d3dd922bb35808e1e6";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b3/linux-x86_64/th/firefox-113.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b4/linux-x86_64/th/firefox-113.0b4.tar.bz2";
       locale = "th";
       arch = "linux-x86_64";
-      sha256 = "6bde25dacdc360e0caeb4872c58d48527c1e318ae0db1ae988f5937e08fed951";
+      sha256 = "b20f4884edb96ee00310fec3c3692bc42f011ad648590d033e78c1afed666dd5";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b3/linux-x86_64/tl/firefox-113.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b4/linux-x86_64/tl/firefox-113.0b4.tar.bz2";
       locale = "tl";
       arch = "linux-x86_64";
-      sha256 = "db4e37593a3eda7822ef230b03b8564cb7bc4c47852ce894be3ab3c5bb78a8a3";
+      sha256 = "264be78a43678db6eb62a70dc35a41720a5729eb476cb424ca6b72cff2dc1f05";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b3/linux-x86_64/tr/firefox-113.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b4/linux-x86_64/tr/firefox-113.0b4.tar.bz2";
       locale = "tr";
       arch = "linux-x86_64";
-      sha256 = "cdc31496924058b80639e2abbbde526f94ffd608ea5698b325e8fde29260c9c6";
+      sha256 = "aa17646494f43a8eeb760147c344e5b420c686612901067761ed3d0aca083026";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b3/linux-x86_64/trs/firefox-113.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b4/linux-x86_64/trs/firefox-113.0b4.tar.bz2";
       locale = "trs";
       arch = "linux-x86_64";
-      sha256 = "2d6eaea56eab42363937069aee623be1c4b71a86c229d3b7059b9c66a9cd180e";
+      sha256 = "c1a02c9c46c7f711ba337569b088b3e1884def1f0d200558e95bbffbabd088d5";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b3/linux-x86_64/uk/firefox-113.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b4/linux-x86_64/uk/firefox-113.0b4.tar.bz2";
       locale = "uk";
       arch = "linux-x86_64";
-      sha256 = "6d32526fa62064489ceac40b66910c7c1e6a5087c7c63496491b80db1e295107";
+      sha256 = "c69c6b60d83c75c0a043113c46ff7d246b68c3ccee3297bbc9f777d2cefb27fa";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b3/linux-x86_64/ur/firefox-113.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b4/linux-x86_64/ur/firefox-113.0b4.tar.bz2";
       locale = "ur";
       arch = "linux-x86_64";
-      sha256 = "c58611940001dd9ffac65ddc72d0c6255c5d7e00f6a5ad27898e97ea6da7120d";
+      sha256 = "42d44f5032f7fe9ff52594f9a255cfc2bfd36724c44e3e3aa499743b25444731";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b3/linux-x86_64/uz/firefox-113.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b4/linux-x86_64/uz/firefox-113.0b4.tar.bz2";
       locale = "uz";
       arch = "linux-x86_64";
-      sha256 = "3574c03b2dc9d94ce83618e325fd15e41b9d25a5c8152319013c4b7c183412e2";
+      sha256 = "9ce18b6b5aea21119fa363717ab33d4ec371d662dc622dcd994adaafd6af73df";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b3/linux-x86_64/vi/firefox-113.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b4/linux-x86_64/vi/firefox-113.0b4.tar.bz2";
       locale = "vi";
       arch = "linux-x86_64";
-      sha256 = "75d221e4e1e3f365f5a71cdb69a3dbe84f711d32b6011ca7d26f4a5599b139a5";
+      sha256 = "c72b4501ed8cec57839e1bc0b5185b29d8f02fa4860af9157a1389345aafa34d";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b3/linux-x86_64/xh/firefox-113.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b4/linux-x86_64/xh/firefox-113.0b4.tar.bz2";
       locale = "xh";
       arch = "linux-x86_64";
-      sha256 = "ccfb81fec0cf3c075dbbb2b01ecaa39349822abb0ce442f92516138f5dfd973b";
+      sha256 = "5c1e3a51f7acd068bafc97e0c44c0760ae95e79878e7a8875c044595919563f0";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b3/linux-x86_64/zh-CN/firefox-113.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b4/linux-x86_64/zh-CN/firefox-113.0b4.tar.bz2";
       locale = "zh-CN";
       arch = "linux-x86_64";
-      sha256 = "c462f64394ef41dffc4a940dec5b878fc7892f1b5806585f1336cb0e665dbce4";
+      sha256 = "4d9e592f2d50195d58e912f41ee4ad0a3eb081edf3e9f9975e9f81317b0e9cce";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b3/linux-x86_64/zh-TW/firefox-113.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b4/linux-x86_64/zh-TW/firefox-113.0b4.tar.bz2";
       locale = "zh-TW";
       arch = "linux-x86_64";
-      sha256 = "93cb7046f2fe0401a2616f6198cbabdb86b7ff145f68f49f24f60e2fd320b06e";
+      sha256 = "6070b4f82733768a8d5a8a2b96a4458b908f754c752d42522fdd735eb89378b4";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b3/linux-i686/ach/firefox-113.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b4/linux-i686/ach/firefox-113.0b4.tar.bz2";
       locale = "ach";
       arch = "linux-i686";
-      sha256 = "d959e56e36f95123231ba286f485f10f64a458aba0e4abc84bfd56f38a20afb5";
+      sha256 = "936e06c50e1f8c3c2072fa73fab8c421614dcecc65678543fe6c67510c5eeb0f";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b3/linux-i686/af/firefox-113.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b4/linux-i686/af/firefox-113.0b4.tar.bz2";
       locale = "af";
       arch = "linux-i686";
-      sha256 = "4260c954a444ee8a3902ab5ac990d483569343c2e80f94121e292b5ba0202d16";
+      sha256 = "3079c5e96e5302a8847ca4a4071f3024f1d6f39e46a462b9dbb1042deb18c827";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b3/linux-i686/an/firefox-113.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b4/linux-i686/an/firefox-113.0b4.tar.bz2";
       locale = "an";
       arch = "linux-i686";
-      sha256 = "f21fac56dfd25f680e9334c561d8de8d332fadf74dfdca6a2b922cc5bd463e9c";
+      sha256 = "76f086e64b6be05a48c37670186de699e359b54fa16ba5f68697ac752d7bafe2";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b3/linux-i686/ar/firefox-113.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b4/linux-i686/ar/firefox-113.0b4.tar.bz2";
       locale = "ar";
       arch = "linux-i686";
-      sha256 = "1c2486c0de3044ec1e2234383af39f7c144fb9758149067a16ad675c5c1a3fe9";
+      sha256 = "b0c1ff9cf42030a36a556359f3ef83e614086032553f0203a9c38dc70f10736f";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b3/linux-i686/ast/firefox-113.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b4/linux-i686/ast/firefox-113.0b4.tar.bz2";
       locale = "ast";
       arch = "linux-i686";
-      sha256 = "58cc1f38490baf4124619676f0db4e0a78812cac04ca514edcf2c2faf461af7d";
+      sha256 = "3a0bd2384b91e8adce81cd256936e1a2862d29be5e069eb85cf9ca7975e3344c";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b3/linux-i686/az/firefox-113.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b4/linux-i686/az/firefox-113.0b4.tar.bz2";
       locale = "az";
       arch = "linux-i686";
-      sha256 = "01b4d389e8d48e7068fde7776e54706c584fc0654a931a084ef5a5e50d23b37b";
+      sha256 = "0b2e6a98270c89a70ff66aebaa69695e172a1067c7d54b2023f184c3c9774221";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b3/linux-i686/be/firefox-113.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b4/linux-i686/be/firefox-113.0b4.tar.bz2";
       locale = "be";
       arch = "linux-i686";
-      sha256 = "bcd2a0a3c5e045dbb3f2645db51de0cc8364422143621442265f147eef54e054";
+      sha256 = "a64d1846226a617d573871cf542dd5d2349a674d49f0a9b52532bc5a4c80e8c7";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b3/linux-i686/bg/firefox-113.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b4/linux-i686/bg/firefox-113.0b4.tar.bz2";
       locale = "bg";
       arch = "linux-i686";
-      sha256 = "9217c39c1bbddfc3cb059c53a63b655a06860fcda979b1009c36309dbb2b47ec";
+      sha256 = "4d1d2a660e8dd2e4cc2ba6ee9535382a7912e9849d74474337676e1fd9cd52e9";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b3/linux-i686/bn/firefox-113.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b4/linux-i686/bn/firefox-113.0b4.tar.bz2";
       locale = "bn";
       arch = "linux-i686";
-      sha256 = "7da8600216ad1e74404ecc5c851f88c045aa0579cd99c1e2fa5662d71455b93e";
+      sha256 = "64c394d10b8983b8bf15a0767c1a6b51d6d53040b76e16b0847ef5406ad891a4";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b3/linux-i686/br/firefox-113.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b4/linux-i686/br/firefox-113.0b4.tar.bz2";
       locale = "br";
       arch = "linux-i686";
-      sha256 = "b41a359404ad0565bd3ab862de9fea64bbb9a1fc264739879cbd593604dfab5e";
+      sha256 = "aa4b5ab4f50d6c4cc3453b2d5bb58b41dab9005530c4b9269f8c47dca16e6ecc";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b3/linux-i686/bs/firefox-113.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b4/linux-i686/bs/firefox-113.0b4.tar.bz2";
       locale = "bs";
       arch = "linux-i686";
-      sha256 = "11672e3cb4e24b09e331e49806dd2acd1bb937622bc30c7a022d1d9be15bcfac";
+      sha256 = "2c0a110869de26ea45bb443fc2edcb9418d278dc9ceafee6f22d34dc22d2b88f";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b3/linux-i686/ca-valencia/firefox-113.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b4/linux-i686/ca-valencia/firefox-113.0b4.tar.bz2";
       locale = "ca-valencia";
       arch = "linux-i686";
-      sha256 = "bd7fa35708b72f9ae976dd4d08bfc9ba8d5f2ceef5bf271a05b15ca16d086ff8";
+      sha256 = "d67683b661851496ee79494fa546420f9f5fb22d33a245eea82097801a5eeaf9";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b3/linux-i686/ca/firefox-113.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b4/linux-i686/ca/firefox-113.0b4.tar.bz2";
       locale = "ca";
       arch = "linux-i686";
-      sha256 = "443f9633d2c507468d8630915e5675ad5861eafb36e8daae9ed7db527a2d912f";
+      sha256 = "c3f16e4d7021ce63e47a452e6edb0c6075fef3c09e8f128879d679dfbe403b0e";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b3/linux-i686/cak/firefox-113.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b4/linux-i686/cak/firefox-113.0b4.tar.bz2";
       locale = "cak";
       arch = "linux-i686";
-      sha256 = "d76b743c938ba652f7498c89e924891a5e37ff415fbfdf4303b38d86a0e4bc1b";
+      sha256 = "9d81f66eaaf19bc9135e9d52aea1a021ceed08a2d9d94ef07f8bf686ae663942";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b3/linux-i686/cs/firefox-113.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b4/linux-i686/cs/firefox-113.0b4.tar.bz2";
       locale = "cs";
       arch = "linux-i686";
-      sha256 = "ea7119d173b42dbae0997b433173ecaf858fb735406048deff25454b17010f17";
+      sha256 = "7ac035c2c731e604c83b130e36036c9843769b98f3a86b47fd075fdfa1af783a";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b3/linux-i686/cy/firefox-113.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b4/linux-i686/cy/firefox-113.0b4.tar.bz2";
       locale = "cy";
       arch = "linux-i686";
-      sha256 = "99ce3b241667ee71e7b6a54c7c2bf37f8b115ddf440e17ae51d83240e2e10a80";
+      sha256 = "1cedddda8ac30189cebc851754b625c5ef76efa454e33316cab1416e0351cd07";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b3/linux-i686/da/firefox-113.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b4/linux-i686/da/firefox-113.0b4.tar.bz2";
       locale = "da";
       arch = "linux-i686";
-      sha256 = "aba3e315f6e30fef53ff0dc3fbc5e62ad93e4caae795c920285536c19cf4cd6d";
+      sha256 = "148906e2dc9fce96b7bceeab47374741995944472276d3cd8c5bed5546196118";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b3/linux-i686/de/firefox-113.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b4/linux-i686/de/firefox-113.0b4.tar.bz2";
       locale = "de";
       arch = "linux-i686";
-      sha256 = "5c3b614f317be6bd9d707ea2a8d29dae76df3dedf7ad193972d81fcd42cfb637";
+      sha256 = "7d4fb199aa20dac726af832c42579642775a31a7ddbca5af95a0a12aa52e85d8";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b3/linux-i686/dsb/firefox-113.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b4/linux-i686/dsb/firefox-113.0b4.tar.bz2";
       locale = "dsb";
       arch = "linux-i686";
-      sha256 = "00ba4f16f921463baee89cc8d6183cb1d9110ecd5f4b7f272410437d7852fd61";
+      sha256 = "85e1203438dee275e0adfd2797cd48f3af482fc96d04c7ef0e7ec501de371db1";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b3/linux-i686/el/firefox-113.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b4/linux-i686/el/firefox-113.0b4.tar.bz2";
       locale = "el";
       arch = "linux-i686";
-      sha256 = "b6d559f153af24c31ab54040538349645f8861de63702f47ce8deed39a7183dc";
+      sha256 = "f186e11acf6eacff7e053c84796f2f0f53f87c2294a86e1ad77cec621d51a9f8";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b3/linux-i686/en-CA/firefox-113.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b4/linux-i686/en-CA/firefox-113.0b4.tar.bz2";
       locale = "en-CA";
       arch = "linux-i686";
-      sha256 = "f83541420907b5d477096e7218caabb4a1dba3e0e9b3c3d439df448d9a31f4d3";
+      sha256 = "a21f967a04c242b63be3cad6177bf14bdf67d5f1ea60d77158dbcd46c75be175";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b3/linux-i686/en-GB/firefox-113.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b4/linux-i686/en-GB/firefox-113.0b4.tar.bz2";
       locale = "en-GB";
       arch = "linux-i686";
-      sha256 = "adeb91ecfcc869623d8f8dc375f9f85c6382b7ca1f013ff62937d0cf3ee1af4a";
+      sha256 = "61021f235a7365ebae4702edd4481f8e085324e1f741bb6e939623e79e0602d1";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b3/linux-i686/en-US/firefox-113.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b4/linux-i686/en-US/firefox-113.0b4.tar.bz2";
       locale = "en-US";
       arch = "linux-i686";
-      sha256 = "4de540533e8c908470575c928af050b6b2c853d98402e4d035e9f80f01cdf06a";
+      sha256 = "91eb6d71d80f467bf090ea6667376dc4d93295ca4ae1343c1f30eff473edf367";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b3/linux-i686/eo/firefox-113.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b4/linux-i686/eo/firefox-113.0b4.tar.bz2";
       locale = "eo";
       arch = "linux-i686";
-      sha256 = "408d650c3fcc209960cd2e1529de8176ff3b78190c0f09e39bb8efa8e665c33e";
+      sha256 = "96e23c25b698f5fbc6cf71ba96c98e4bc3cd8f10bbae985801703afac46c04dc";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b3/linux-i686/es-AR/firefox-113.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b4/linux-i686/es-AR/firefox-113.0b4.tar.bz2";
       locale = "es-AR";
       arch = "linux-i686";
-      sha256 = "9e4573796ddbbdfe737928a1bfbdfa110a35b5207800811f3ac14984a8bdfa89";
+      sha256 = "c2014a1a80116f35e5626280c32ecaae3e2ebe431364c83b54ebba76bfd87420";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b3/linux-i686/es-CL/firefox-113.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b4/linux-i686/es-CL/firefox-113.0b4.tar.bz2";
       locale = "es-CL";
       arch = "linux-i686";
-      sha256 = "5dafe888b3df1c3339b23c481db45fb73c2d30f6d6a5182a398544f943aaab86";
+      sha256 = "05d321538080fed98010477334d86e62d8713c2ae877a7c9c9ec927ec69d781d";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b3/linux-i686/es-ES/firefox-113.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b4/linux-i686/es-ES/firefox-113.0b4.tar.bz2";
       locale = "es-ES";
       arch = "linux-i686";
-      sha256 = "f8412bb19917f239a590de10e60e7a8079f56f8ce13796caeee08d7dde0d12b9";
+      sha256 = "0fb5ffabf790deb1cb8f7950645a8ee84aa6305c2935f4164a5db3bfa0b80b71";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b3/linux-i686/es-MX/firefox-113.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b4/linux-i686/es-MX/firefox-113.0b4.tar.bz2";
       locale = "es-MX";
       arch = "linux-i686";
-      sha256 = "2f440403538f46f0b8b277379440ca165c88a2ae663d5f98e84c1b2b0c7a0b1b";
+      sha256 = "6cc687f8c2a5719734c3c80cf53e4e850cea87762d444525fe1668727794159f";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b3/linux-i686/et/firefox-113.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b4/linux-i686/et/firefox-113.0b4.tar.bz2";
       locale = "et";
       arch = "linux-i686";
-      sha256 = "e592ba23073bc12e71cd19c12afe007e7696931b8f620edf791e35887704fe6c";
+      sha256 = "4b65caba627743b26ee2b88a1468e0e59ed646c7afaef99a02d0ceee0ed3e20b";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b3/linux-i686/eu/firefox-113.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b4/linux-i686/eu/firefox-113.0b4.tar.bz2";
       locale = "eu";
       arch = "linux-i686";
-      sha256 = "5545fdfd1208be27518d63f408a61b128d8eb50529d760f2fe5077ba75a990d0";
+      sha256 = "7e32b1640385f70aeea5a7cf893ee64b171f3f6582f17f7652928d0427e33894";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b3/linux-i686/fa/firefox-113.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b4/linux-i686/fa/firefox-113.0b4.tar.bz2";
       locale = "fa";
       arch = "linux-i686";
-      sha256 = "04d49cc088915d6bd91cc91b4f1ed85e8490be175f5c22748e2116d26e2b0b6e";
+      sha256 = "bacce7d98476eeae20c3763526d5058aed1af5397f451b23bd9357a5900ecbf2";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b3/linux-i686/ff/firefox-113.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b4/linux-i686/ff/firefox-113.0b4.tar.bz2";
       locale = "ff";
       arch = "linux-i686";
-      sha256 = "e40eb861f9d0e8a4d09817543303be761723032c7e7c18768ca2d36a8eefbc70";
+      sha256 = "9684cd278984810d1fa0ece1e76938ddc755bf376e046801c75a5c1eb4831cc8";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b3/linux-i686/fi/firefox-113.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b4/linux-i686/fi/firefox-113.0b4.tar.bz2";
       locale = "fi";
       arch = "linux-i686";
-      sha256 = "4370d6c95842175935832f05d2999701cb60ea0388ed416cf7a3402e2ec7aebe";
+      sha256 = "3b089f8e6adc58219f59910aa56f8c5d1f337342a6eb42f5528e471c1e283386";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b3/linux-i686/fr/firefox-113.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b4/linux-i686/fr/firefox-113.0b4.tar.bz2";
       locale = "fr";
       arch = "linux-i686";
-      sha256 = "ba526563c7e57cb06484b88369f273b2ff6bde7f057ba6702a7efac7d42fa824";
+      sha256 = "f0d6eb3a151c190248bc1fb7f02be9cfbab275d3386bf521a2eaba01e43e0630";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b3/linux-i686/fur/firefox-113.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b4/linux-i686/fur/firefox-113.0b4.tar.bz2";
       locale = "fur";
       arch = "linux-i686";
-      sha256 = "c0ab3ad6693dc6abf544085c5087c12fd31b7574bf83b0a44ca9da24da693472";
+      sha256 = "4cd849954469bc09633ce1aac32d81bb98e50e50172e57ff56a5190640968af8";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b3/linux-i686/fy-NL/firefox-113.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b4/linux-i686/fy-NL/firefox-113.0b4.tar.bz2";
       locale = "fy-NL";
       arch = "linux-i686";
-      sha256 = "f5844bb05a3696f72332cc446791ab2cfda14194994c46aaaac727f27640f827";
+      sha256 = "de53ad4263cc6c171a1e38d47432c8bea4fe5ea60232bc57bc7e8ee13b363791";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b3/linux-i686/ga-IE/firefox-113.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b4/linux-i686/ga-IE/firefox-113.0b4.tar.bz2";
       locale = "ga-IE";
       arch = "linux-i686";
-      sha256 = "c3193007d8f453b6e2f3dfac982dccec8baf71a0974632a5524fd63ded1ad474";
+      sha256 = "97eaebaf3909a03f7155cd3a3bc6b2790f0b3baa3067c3d05da9c9290ded9c21";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b3/linux-i686/gd/firefox-113.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b4/linux-i686/gd/firefox-113.0b4.tar.bz2";
       locale = "gd";
       arch = "linux-i686";
-      sha256 = "e9ada9c33b15005a0cf2cdb6828e1fecd7311ae5c571631ecb9786c5304dbf83";
+      sha256 = "23ca706b7451cfb8eaa635b53c1456d9afef76bff42b1df2d192cea357e2cbcd";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b3/linux-i686/gl/firefox-113.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b4/linux-i686/gl/firefox-113.0b4.tar.bz2";
       locale = "gl";
       arch = "linux-i686";
-      sha256 = "f5f18d848930735d269d814b201edc299624f786add5410241f6399802f18831";
+      sha256 = "fc0767d413d57ec70f2b21d314cec297621593f6b58bca2915135e07b51ec13d";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b3/linux-i686/gn/firefox-113.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b4/linux-i686/gn/firefox-113.0b4.tar.bz2";
       locale = "gn";
       arch = "linux-i686";
-      sha256 = "9e11c0cc92d361ac1e4c64a271675929c376cf6617d1d663b28ff8cb347c8f41";
+      sha256 = "50ab4d236ed416e2bb65b33739ad01ab873f4fe10c4b4d6ed7ec4677dc391ec9";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b3/linux-i686/gu-IN/firefox-113.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b4/linux-i686/gu-IN/firefox-113.0b4.tar.bz2";
       locale = "gu-IN";
       arch = "linux-i686";
-      sha256 = "68593c692b7c0361a129562041fbde3b9d80f10c167393f253cfa0ba21a6f81c";
+      sha256 = "20172e82d455f5f1732c927647256528128c17c459b2c347b699657a77354458";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b3/linux-i686/he/firefox-113.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b4/linux-i686/he/firefox-113.0b4.tar.bz2";
       locale = "he";
       arch = "linux-i686";
-      sha256 = "d20f5dcdf02d61a3dba490b168fe4252357f7e254f526a2f140d283e749f823a";
+      sha256 = "0e1dffc25c0223be04aa762ce9edd1980406f02c0e208a0a51fe71afde10d84c";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b3/linux-i686/hi-IN/firefox-113.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b4/linux-i686/hi-IN/firefox-113.0b4.tar.bz2";
       locale = "hi-IN";
       arch = "linux-i686";
-      sha256 = "828dbab83575e518ccd30e4a79288b0615ec618208f9518e27e7d432996e46dd";
+      sha256 = "419642c9a24e6603878ca14c6a8399a05eb7cf7f6acd5314356e767f6a332d53";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b3/linux-i686/hr/firefox-113.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b4/linux-i686/hr/firefox-113.0b4.tar.bz2";
       locale = "hr";
       arch = "linux-i686";
-      sha256 = "4b339bb5d6821ffdc3b04c2dbc6e640eb892f6bb24f25a78818d19542b9f959c";
+      sha256 = "5a5eadeda99a91187b6a0aef1d22e9f5ad033adf45bfcb3bd3c71febd23b4362";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b3/linux-i686/hsb/firefox-113.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b4/linux-i686/hsb/firefox-113.0b4.tar.bz2";
       locale = "hsb";
       arch = "linux-i686";
-      sha256 = "a94feaadc391f30c0c53dda154418ad08205bd9f680120976a2f02973057225e";
+      sha256 = "43c1fa154ac67e1115646a4d92e3a4bb6437a28e7ec57bf87af947d6d8a1c437";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b3/linux-i686/hu/firefox-113.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b4/linux-i686/hu/firefox-113.0b4.tar.bz2";
       locale = "hu";
       arch = "linux-i686";
-      sha256 = "84b7f8a7a963f8062d353f4462ed48c120ac48908fe13ea5688e4139a7e50767";
+      sha256 = "218738d4563f707a858a911b1dd4de19ee27a99b2e6c8fcd3ee8843e301a9395";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b3/linux-i686/hy-AM/firefox-113.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b4/linux-i686/hy-AM/firefox-113.0b4.tar.bz2";
       locale = "hy-AM";
       arch = "linux-i686";
-      sha256 = "4a44431ec691d8b6393efca6255edddb24e08342782ed55886a30cacd2604dae";
+      sha256 = "a8c8e514a94c975b26addd2879effc7760d3cee48e26f549aa8a7f5e8f48d5a3";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b3/linux-i686/ia/firefox-113.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b4/linux-i686/ia/firefox-113.0b4.tar.bz2";
       locale = "ia";
       arch = "linux-i686";
-      sha256 = "dd0f36ba8bd8f059011990b6571fc5da8fabdb0460c401ad51ac3e4d66588b8c";
+      sha256 = "a2bd5401daa1a68e67d3c787489cec2711fd1b67be69048441a0dd5589336982";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b3/linux-i686/id/firefox-113.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b4/linux-i686/id/firefox-113.0b4.tar.bz2";
       locale = "id";
       arch = "linux-i686";
-      sha256 = "3674b91ce5fc9cc3c331dc36328274648c0e371bcaadc6f831d4f215150d8fd1";
+      sha256 = "f68a1a3c3b2bb50c5250f15d9317c0928c17833395f1724892e7378df30639d5";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b3/linux-i686/is/firefox-113.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b4/linux-i686/is/firefox-113.0b4.tar.bz2";
       locale = "is";
       arch = "linux-i686";
-      sha256 = "a4eb60808ea2415276e6b426190f3c027b771dc0abb6c4f805110123bb01a603";
+      sha256 = "f9288d857a73c66530c28aab9f263792c8ff90e324016f1bb3221bab2afcbee2";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b3/linux-i686/it/firefox-113.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b4/linux-i686/it/firefox-113.0b4.tar.bz2";
       locale = "it";
       arch = "linux-i686";
-      sha256 = "42b2f7cfeb82e2f23f23004a2098ece9e973cc522dd9aca1291666a83d57c1bc";
+      sha256 = "85bf83f5e43d295826d50a8f9bbb0b21fd17de3719b986d4ff3680855e4595ce";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b3/linux-i686/ja/firefox-113.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b4/linux-i686/ja/firefox-113.0b4.tar.bz2";
       locale = "ja";
       arch = "linux-i686";
-      sha256 = "3f6224dc41afa16f63483432273029feecd0df8b6384f03d29bfcc8befcf772d";
+      sha256 = "85fd36480c8420bff78890fc6be958335b9af840888dfad6beb5915dd03f8c8f";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b3/linux-i686/ka/firefox-113.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b4/linux-i686/ka/firefox-113.0b4.tar.bz2";
       locale = "ka";
       arch = "linux-i686";
-      sha256 = "6ced1ae480d4e08e4b905a336684a8034bf046293b93310f90e00e0b2c40ef0e";
+      sha256 = "c8390a86f9bd11b850be5d92b46ee51aa2f26c1fd7596ea0d663e9015c403cb6";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b3/linux-i686/kab/firefox-113.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b4/linux-i686/kab/firefox-113.0b4.tar.bz2";
       locale = "kab";
       arch = "linux-i686";
-      sha256 = "fd9452c0400a4b739c9b21784bd14e223704bcc85af10a5b4dcf48221d48eb9a";
+      sha256 = "067ff3f08728615b35c84f58f8dd52702a9d7fd4e1d5aace74a8ec20f7deed7c";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b3/linux-i686/kk/firefox-113.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b4/linux-i686/kk/firefox-113.0b4.tar.bz2";
       locale = "kk";
       arch = "linux-i686";
-      sha256 = "5f15fe68caea6539a4aa511abbdf643640e0c225d58817c3c2b3ed0372810ffc";
+      sha256 = "2c0621f9698a8309009624d71b34ae306e686db08d5796afc3e029313aaade2b";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b3/linux-i686/km/firefox-113.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b4/linux-i686/km/firefox-113.0b4.tar.bz2";
       locale = "km";
       arch = "linux-i686";
-      sha256 = "ea9fc2a94e64aea79994dbd44f01e1b555bb7c736b11a6709867c6cba3184562";
+      sha256 = "2a9250fa99dd237f124c99cd561dc596d42d4475d7368a7f806216be270a2adb";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b3/linux-i686/kn/firefox-113.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b4/linux-i686/kn/firefox-113.0b4.tar.bz2";
       locale = "kn";
       arch = "linux-i686";
-      sha256 = "c0ac728a51a87ba9ad7b130aa1927233eb245a16bd969fdb3fd818db1abc63e2";
+      sha256 = "db57ddfb1b32995464263c209aef78da6ae316d6b95ceb1d9aeb91cca82164a2";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b3/linux-i686/ko/firefox-113.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b4/linux-i686/ko/firefox-113.0b4.tar.bz2";
       locale = "ko";
       arch = "linux-i686";
-      sha256 = "e1860224f8b80eebac87115654bbe0d312fc0a18f6fc13fa7c8eab8930d1dd9b";
+      sha256 = "a5b977fab95ae026dbfb1a41f7ea1e212da81cabb296d54364161f979b243a94";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b3/linux-i686/lij/firefox-113.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b4/linux-i686/lij/firefox-113.0b4.tar.bz2";
       locale = "lij";
       arch = "linux-i686";
-      sha256 = "3626dd6fce6b376d8dda79935663c601a94fcaac000fd64060650836d9509927";
+      sha256 = "810f62f0cdd576f898f26fb41579f3b4d4064d229415686bc1617d47a357f328";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b3/linux-i686/lt/firefox-113.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b4/linux-i686/lt/firefox-113.0b4.tar.bz2";
       locale = "lt";
       arch = "linux-i686";
-      sha256 = "a0269dee095dabf5914ec4b2fc0913858f18972ca5b25ae38f4c1c2c609ff33f";
+      sha256 = "2c7d5403413d0010a058b324b74358b86943060ba5449e5c762e745e7582df7d";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b3/linux-i686/lv/firefox-113.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b4/linux-i686/lv/firefox-113.0b4.tar.bz2";
       locale = "lv";
       arch = "linux-i686";
-      sha256 = "21756ab19c478eccde3258107056ec943a8e597406c73876ed82b5b7e05bc822";
+      sha256 = "95439ee735358e46fbea69779e76dcd697a4e2599c4ee55794dd7f9e39d9eb55";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b3/linux-i686/mk/firefox-113.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b4/linux-i686/mk/firefox-113.0b4.tar.bz2";
       locale = "mk";
       arch = "linux-i686";
-      sha256 = "17a2dee37e0dc1f55f44fa46fbb021221c1231b1a0ae59ee20a241f1a05ef0d5";
+      sha256 = "9ffa65f36282c6a697275cf4626aa5f3c1fcc96f559b7678370f89354c1bf51d";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b3/linux-i686/mr/firefox-113.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b4/linux-i686/mr/firefox-113.0b4.tar.bz2";
       locale = "mr";
       arch = "linux-i686";
-      sha256 = "dc0e7f5b79c6053f126742c8935c9130ee7bf8f6921fecb195b2eb1ff1b619e7";
+      sha256 = "a65149e47a1b5c61964ced5b91c10967e619af1f5a653e409d1a5b69a4c20db5";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b3/linux-i686/ms/firefox-113.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b4/linux-i686/ms/firefox-113.0b4.tar.bz2";
       locale = "ms";
       arch = "linux-i686";
-      sha256 = "c607a7e268a6d94dc1f377b61b87f1fb24f18746cc88ea4d3f399e39d50079d2";
+      sha256 = "cc3a14463edbd0cf8beab80166264a31039d4e0a57b12d11278fbe410b7dbf93";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b3/linux-i686/my/firefox-113.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b4/linux-i686/my/firefox-113.0b4.tar.bz2";
       locale = "my";
       arch = "linux-i686";
-      sha256 = "a5a552c4b092851169a521b45e67325bb7444688ae3c2b3eec7fd366317d617e";
+      sha256 = "958570b1d5673cbeb557737ccdab62d08cad015cea256754c0703b7018e9462d";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b3/linux-i686/nb-NO/firefox-113.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b4/linux-i686/nb-NO/firefox-113.0b4.tar.bz2";
       locale = "nb-NO";
       arch = "linux-i686";
-      sha256 = "5b7d00fe9a158463b1ab52a9dc2b9f9f63585f9bc58d78888d868903a82417a0";
+      sha256 = "f1da12060e3cbceffe88311e7d23f0d30a2f637776ce4513972554bf5f1b3ad5";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b3/linux-i686/ne-NP/firefox-113.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b4/linux-i686/ne-NP/firefox-113.0b4.tar.bz2";
       locale = "ne-NP";
       arch = "linux-i686";
-      sha256 = "48cf294727f083fdd7c2a6a6cd5316588de212ba080cdee7c4abc8940c603e07";
+      sha256 = "ea76e71f5402fb38df5d422cf25ee2a6040d752dc8ca980610e1fd46b7d3d86a";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b3/linux-i686/nl/firefox-113.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b4/linux-i686/nl/firefox-113.0b4.tar.bz2";
       locale = "nl";
       arch = "linux-i686";
-      sha256 = "35ec42660d5676f1ae204c87b878fdf8765b7c8492d1b8d6ce51be3f906614b3";
+      sha256 = "310908604a5f3d82340bbfcee1bd16288d9837dc42b71afd9a58c7e4bf8f1f70";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b3/linux-i686/nn-NO/firefox-113.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b4/linux-i686/nn-NO/firefox-113.0b4.tar.bz2";
       locale = "nn-NO";
       arch = "linux-i686";
-      sha256 = "a3a5a78ec1ea72f820470142edb6ec17816774f7bb651022379ae2e89b5520a1";
+      sha256 = "1716a0909521e28b3422822eaef677cd65f680fefc3734cbec3bdae98ab50115";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b3/linux-i686/oc/firefox-113.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b4/linux-i686/oc/firefox-113.0b4.tar.bz2";
       locale = "oc";
       arch = "linux-i686";
-      sha256 = "d7d0e7a10452e4dfa787adaed0c09a877ba196a42d19bb037d012b5655be36b9";
+      sha256 = "15daca31128922441b384d6e00a59e4bdb7dd8b1e765f908b53dca432b1f2ddc";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b3/linux-i686/pa-IN/firefox-113.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b4/linux-i686/pa-IN/firefox-113.0b4.tar.bz2";
       locale = "pa-IN";
       arch = "linux-i686";
-      sha256 = "5c1e9b1484fdf8dd739a0606b7f987aa1852e2f93ff066654b5c7b18ba956416";
+      sha256 = "553594b9d63977e855b072249b5ccfd3b2d9765f8e0dadbcc9cd7a2d8a66083d";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b3/linux-i686/pl/firefox-113.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b4/linux-i686/pl/firefox-113.0b4.tar.bz2";
       locale = "pl";
       arch = "linux-i686";
-      sha256 = "b87d6ea603ff4dc924b8f6fdc9765b72ab8d070e46d1c9a8470ed72c0c96de19";
+      sha256 = "afe71cca35b72d204cd9745ce2d1cda8499fd2ad5be565aab164c2ea46d23ae7";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b3/linux-i686/pt-BR/firefox-113.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b4/linux-i686/pt-BR/firefox-113.0b4.tar.bz2";
       locale = "pt-BR";
       arch = "linux-i686";
-      sha256 = "b183c703285b94c24aa3abeaa341d0f3bc14ffee5767abf3a022feba43c3da96";
+      sha256 = "9bc09269a0287e785c18b66863199772f3fd29efce96e26c7382f3b092ed9adc";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b3/linux-i686/pt-PT/firefox-113.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b4/linux-i686/pt-PT/firefox-113.0b4.tar.bz2";
       locale = "pt-PT";
       arch = "linux-i686";
-      sha256 = "b20926b57460f8ae8b5032ef3a7abe16a47de7fa88c0db51d1d6c105f584b0d5";
+      sha256 = "b23d3a6e71580d6e1037f79a20dca96c670daf94525ce5ce40ec0f4ae11a26f2";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b3/linux-i686/rm/firefox-113.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b4/linux-i686/rm/firefox-113.0b4.tar.bz2";
       locale = "rm";
       arch = "linux-i686";
-      sha256 = "f6f184830237c9d6bc620303742a7d1480c06e08a94908443d95c4dbe2460d51";
+      sha256 = "33c3bda8431458a8dc838dc4a11cd565487fb74844ae3e55bbe4c475a0513aa7";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b3/linux-i686/ro/firefox-113.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b4/linux-i686/ro/firefox-113.0b4.tar.bz2";
       locale = "ro";
       arch = "linux-i686";
-      sha256 = "a844f8a16922208942326a5f96399fa9c733f6909f465d13a8bc4a01879d2597";
+      sha256 = "8f29fbe62d6c208894f87dcc8c3d4d6103e3de863a67516b5015d951457b90a6";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b3/linux-i686/ru/firefox-113.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b4/linux-i686/ru/firefox-113.0b4.tar.bz2";
       locale = "ru";
       arch = "linux-i686";
-      sha256 = "516d30f23ec9e1539532a55f02ed42a801181cbd1e4c57f394b3c36525d84c57";
+      sha256 = "e70ab287dfeb0fb888c85ac71b279b9d7524d1a0ef93c787d1f207349cac56e8";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b3/linux-i686/sc/firefox-113.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b4/linux-i686/sc/firefox-113.0b4.tar.bz2";
       locale = "sc";
       arch = "linux-i686";
-      sha256 = "46113c900464e685e42bb50263f5debd1d1f66cafadb0fce2e3cfb6f92370f2d";
+      sha256 = "534292fbbab374db489b168f6d4d81ce976fef4c40b3d95408a8bae0b9279b24";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b3/linux-i686/sco/firefox-113.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b4/linux-i686/sco/firefox-113.0b4.tar.bz2";
       locale = "sco";
       arch = "linux-i686";
-      sha256 = "54ec5f069421788f2201dcbdc68ba06743d26207f10abf147db22b8602d88e5e";
+      sha256 = "d7a0f577037fb1ac64cf9831448ef8ac5f49b17b81c171742e99aa1d0e25de01";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b3/linux-i686/si/firefox-113.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b4/linux-i686/si/firefox-113.0b4.tar.bz2";
       locale = "si";
       arch = "linux-i686";
-      sha256 = "8f8db369359834b8dff2f27342b525d8cd8871380671dcc5e6a3b392dc1d2a68";
+      sha256 = "dce56847aa598fd4300b80f9fa264219a1aa5db2bed10db6320ba10f60495ce5";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b3/linux-i686/sk/firefox-113.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b4/linux-i686/sk/firefox-113.0b4.tar.bz2";
       locale = "sk";
       arch = "linux-i686";
-      sha256 = "9c49a02e6f2b7f9256bc56d5cb92eaae61566d6819a104a20f794a5e77e49fc1";
+      sha256 = "6bf4ec218b7219ef7210c3ed73712286f505d3a9beb0afb5d962370758e1ef49";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b3/linux-i686/sl/firefox-113.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b4/linux-i686/sl/firefox-113.0b4.tar.bz2";
       locale = "sl";
       arch = "linux-i686";
-      sha256 = "a5edb5008a0323656eadd07ca75221ffe1245f4e435131d67fe1bfa648ff24cd";
+      sha256 = "3a8e18d2fbf73be9f7df357a78774d87b28b051e5e3d3c491333f893d063b717";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b3/linux-i686/son/firefox-113.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b4/linux-i686/son/firefox-113.0b4.tar.bz2";
       locale = "son";
       arch = "linux-i686";
-      sha256 = "aa603e3f6f9ed2fcb1a95610504cfe22df05cfc95f62e652f20f4b38ec438467";
+      sha256 = "852667eb0d6307b711a25da361bb8c05cf48c54da245d4ab940739380fc81d1f";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b3/linux-i686/sq/firefox-113.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b4/linux-i686/sq/firefox-113.0b4.tar.bz2";
       locale = "sq";
       arch = "linux-i686";
-      sha256 = "ed23e2a3ba333f495f8d729f0946e9e27003653ac4be99e0d6b6cad5c807d71e";
+      sha256 = "f190df34c60bbdda8982a89f1a205c3dc24ec474025a7ed76c1c9f5bba875d0b";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b3/linux-i686/sr/firefox-113.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b4/linux-i686/sr/firefox-113.0b4.tar.bz2";
       locale = "sr";
       arch = "linux-i686";
-      sha256 = "a26c668cc70a5254c94c42c53b5233bd43013a8d6b40f40f4d5efdee02a442a1";
+      sha256 = "87dda2312559b3a0c726267658cc7aad81c7e27df02c8ebf63e171c48653a07c";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b3/linux-i686/sv-SE/firefox-113.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b4/linux-i686/sv-SE/firefox-113.0b4.tar.bz2";
       locale = "sv-SE";
       arch = "linux-i686";
-      sha256 = "a98ba404537886bae95649da25b531cfa68d46ba871902f80d07ff3d76f12e47";
+      sha256 = "3ec0a222252f42b593feec33b11ed82478435185e20d67eb2ecf74efeef67a42";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b3/linux-i686/szl/firefox-113.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b4/linux-i686/szl/firefox-113.0b4.tar.bz2";
       locale = "szl";
       arch = "linux-i686";
-      sha256 = "7822dc83c9e0f2e818842e8eddaf1d60a6f20ee5c5121762178d038412df4802";
+      sha256 = "a2a65d6d63ee3a4fa74741481ba9f54d58b5a381c8568e90130f4a9dfd239f9a";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b3/linux-i686/ta/firefox-113.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b4/linux-i686/ta/firefox-113.0b4.tar.bz2";
       locale = "ta";
       arch = "linux-i686";
-      sha256 = "cf57bedcc9b96b95bd742cff48b731c9c2164a485bea912f4a2f8cc4726837f5";
+      sha256 = "8a9aa1a5972e635d606454a5ff5a955b3158df858f4b47fe9b55fa393e5079d3";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b3/linux-i686/te/firefox-113.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b4/linux-i686/te/firefox-113.0b4.tar.bz2";
       locale = "te";
       arch = "linux-i686";
-      sha256 = "2b28faa3bce6375eb72a81d506ca3af28dc313b1ddb65d10b2dda7104cd2bbaa";
+      sha256 = "c738e9501ce7f6baa2b1424aeb2706c5f8313394db0fdbddc82704a234b8947c";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b3/linux-i686/tg/firefox-113.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b4/linux-i686/tg/firefox-113.0b4.tar.bz2";
       locale = "tg";
       arch = "linux-i686";
-      sha256 = "32f2a3135cf9b59003b279db16d5faaabbcfab96437e2dee38347b5b2c1d1465";
+      sha256 = "26971632a8a33e85cd6b457b4a281ac3429661f78d1d4c2cd5a2aedd90aadf5a";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b3/linux-i686/th/firefox-113.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b4/linux-i686/th/firefox-113.0b4.tar.bz2";
       locale = "th";
       arch = "linux-i686";
-      sha256 = "0ef9b1c0f40b08ee9c27362a64863a8214dda8782d37f8067be028e05de67c13";
+      sha256 = "9a01fa61b73e3c59d425ee693934120dc40b116708886c444223ae2d3e9eb73b";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b3/linux-i686/tl/firefox-113.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b4/linux-i686/tl/firefox-113.0b4.tar.bz2";
       locale = "tl";
       arch = "linux-i686";
-      sha256 = "7753f626ac53e5bae98783a7375f22cc228ec358b24a75782769f3bca2c598ef";
+      sha256 = "4ab70ad927a290357855955f9f295451fb9ea0a01d5e071897e40fa4e8919561";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b3/linux-i686/tr/firefox-113.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b4/linux-i686/tr/firefox-113.0b4.tar.bz2";
       locale = "tr";
       arch = "linux-i686";
-      sha256 = "1e1259677aad82255ee1773c18cadd9c442d747c8872593c6cd472b909bafc6a";
+      sha256 = "170b7116604420e2cf96edac326111812461fd26ce98af92ec1e52bb6bf0bfb7";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b3/linux-i686/trs/firefox-113.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b4/linux-i686/trs/firefox-113.0b4.tar.bz2";
       locale = "trs";
       arch = "linux-i686";
-      sha256 = "7a553e5121be371eb3623adb022bfcd3d7259e69eaa6d1b8a970b34013804d3e";
+      sha256 = "43a9405e4752ced41686f4daf7667e9cdcf51afe33379308a1936e5ef19906fb";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b3/linux-i686/uk/firefox-113.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b4/linux-i686/uk/firefox-113.0b4.tar.bz2";
       locale = "uk";
       arch = "linux-i686";
-      sha256 = "36123f237696c00b9d305d8309e675d8efccbd95b1984361f1c4e883f2de744a";
+      sha256 = "35444329df7c31f12f46ea4a6a04d93b4c2cbfe4d54ce13f7ec4ba5e354d395e";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b3/linux-i686/ur/firefox-113.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b4/linux-i686/ur/firefox-113.0b4.tar.bz2";
       locale = "ur";
       arch = "linux-i686";
-      sha256 = "9995c4978ffa96c0cf8770296171a0c342a832906fad0f98b6f984d331b858bd";
+      sha256 = "b7238872782a714e18cc86fa9dc4aa7160b3046d2820d2878a00bf65100f214a";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b3/linux-i686/uz/firefox-113.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b4/linux-i686/uz/firefox-113.0b4.tar.bz2";
       locale = "uz";
       arch = "linux-i686";
-      sha256 = "0b13df0eb7d9218fe70723dbf1d3f6127b2f1ea2ddbf82d6124dc614bab71ea6";
+      sha256 = "c25aa114828d68598b360f198c6ebb0e5349bf307c4d5ffdc19dd6a722008a88";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b3/linux-i686/vi/firefox-113.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b4/linux-i686/vi/firefox-113.0b4.tar.bz2";
       locale = "vi";
       arch = "linux-i686";
-      sha256 = "f7ee7443c586b02b04bba4f009caf7db3edf8a43852ef7ef6c7535cb8eedd831";
+      sha256 = "3414b1be971af656b0084a8d9c20feccf3d78c8e06327150147056235232dcee";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b3/linux-i686/xh/firefox-113.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b4/linux-i686/xh/firefox-113.0b4.tar.bz2";
       locale = "xh";
       arch = "linux-i686";
-      sha256 = "ccfcfce33d5be862bd06f20e0476eb98070c2a0f536eede0d0b782a64a739bc8";
+      sha256 = "1beb794e9d9c83662479452fe5aa4b0b09afe3bde104d61526241570df24b4ec";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b3/linux-i686/zh-CN/firefox-113.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b4/linux-i686/zh-CN/firefox-113.0b4.tar.bz2";
       locale = "zh-CN";
       arch = "linux-i686";
-      sha256 = "60448307837618d108a7026e72bb4558cb1ebae0f3cbabb36bced7bc25fd8e14";
+      sha256 = "854977638ccb4618f230545a69913071df90578eb5ad477245fe21a6c64e59dc";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b3/linux-i686/zh-TW/firefox-113.0b3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b4/linux-i686/zh-TW/firefox-113.0b4.tar.bz2";
       locale = "zh-TW";
       arch = "linux-i686";
-      sha256 = "50f9a14a021535ec6f433b6f5d79f6a8881b4a9d3424a8f384e77a87d97284fb";
+      sha256 = "f5cc0d5d03f5a1ab207535c52f2459a72ee0d11a20673636925e3e28cec729ff";
     }
     ];
 }

--- a/pkgs/applications/networking/browsers/firefox-bin/devedition_sources.nix
+++ b/pkgs/applications/networking/browsers/firefox-bin/devedition_sources.nix
@@ -1,1005 +1,1015 @@
 {
-  version = "112.0b9";
+  version = "113.0b2";
   sources = [
-    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b9/linux-x86_64/ach/firefox-112.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b2/linux-x86_64/ach/firefox-113.0b2.tar.bz2";
       locale = "ach";
       arch = "linux-x86_64";
-      sha256 = "14d3b8259d9e2d65ce5fb3c7c307cf61b8e50d9867f4e65c3a3457c989ac9d51";
+      sha256 = "f40dd5b35d1cfd958a380010c427381e83aa2ec691e68a90afde6ccad102867a";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b9/linux-x86_64/af/firefox-112.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b2/linux-x86_64/af/firefox-113.0b2.tar.bz2";
       locale = "af";
       arch = "linux-x86_64";
-      sha256 = "db187cbaa5a1018d7dc62d95d36277ef717268cf15d1185d8584563819951d68";
+      sha256 = "ed3f289a69663d4d9d31498bb3ab6de0a84df008230e793412d8a10ce26be2ff";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b9/linux-x86_64/an/firefox-112.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b2/linux-x86_64/an/firefox-113.0b2.tar.bz2";
       locale = "an";
       arch = "linux-x86_64";
-      sha256 = "b812dc045e28bc3e046ab1b2b4baacc9ebd07bd98718bc94f004e6de0bb162a3";
+      sha256 = "305f9e24169e66965d639755f01d0a6429aa41d43fce32deab8308f4b55b6bcc";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b9/linux-x86_64/ar/firefox-112.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b2/linux-x86_64/ar/firefox-113.0b2.tar.bz2";
       locale = "ar";
       arch = "linux-x86_64";
-      sha256 = "c52824da48b5aae83cdfe9eed6ea5a62ce1bfd8258e2a9915f25bcca2cecf7f5";
+      sha256 = "2300df3512b9f4e869edaf6b20dc572d8261aa64e106205a718c3ebbc1db7b1f";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b9/linux-x86_64/ast/firefox-112.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b2/linux-x86_64/ast/firefox-113.0b2.tar.bz2";
       locale = "ast";
       arch = "linux-x86_64";
-      sha256 = "d7fecf9e053c1b13ed0fae47ed320b7ff18013406d0240f4cc75f40a31bb28cb";
+      sha256 = "85e3154bf99d52caea920d3e1bff4adbc1ed896d35124c674115272b2c6efcff";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b9/linux-x86_64/az/firefox-112.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b2/linux-x86_64/az/firefox-113.0b2.tar.bz2";
       locale = "az";
       arch = "linux-x86_64";
-      sha256 = "f9f47b7889ea53be84577b12434f76c172e4e5775db4e03eb0b817f2dae0ba7b";
+      sha256 = "961ef8ef27f7751e29610ae86d3807ba407d5c2181df27c062ae347b8ba3688a";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b9/linux-x86_64/be/firefox-112.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b2/linux-x86_64/be/firefox-113.0b2.tar.bz2";
       locale = "be";
       arch = "linux-x86_64";
-      sha256 = "c901627a339c44e8e16621aa707c781e4fa1743d48aa8df5df9fc5d738397e3f";
+      sha256 = "514abecd7c77f2f73f6e188857cb5d806daf6112a44f867cbdee2f2e65bf4dad";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b9/linux-x86_64/bg/firefox-112.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b2/linux-x86_64/bg/firefox-113.0b2.tar.bz2";
       locale = "bg";
       arch = "linux-x86_64";
-      sha256 = "c3edcfc6827b73d176da28ad07a97c89b081c791dabbab516d854dde49b43003";
+      sha256 = "e240e39e868ccb4899576320875f805705750393e1d7c63b589c3326cdd79869";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b9/linux-x86_64/bn/firefox-112.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b2/linux-x86_64/bn/firefox-113.0b2.tar.bz2";
       locale = "bn";
       arch = "linux-x86_64";
-      sha256 = "fc533e2add5f4db8517148e611214a6398247830f475ccb42b90c74d31035880";
+      sha256 = "3f930072feb66165d47211a5a337456cca69ff5eae5fdae6ab4c78a85efcef0b";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b9/linux-x86_64/br/firefox-112.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b2/linux-x86_64/br/firefox-113.0b2.tar.bz2";
       locale = "br";
       arch = "linux-x86_64";
-      sha256 = "fb490a436e4f12d82cf15341bbd3d97916ef504010fa73173e8ca73cf4001de4";
+      sha256 = "75def5d5dc5b6bb1e4ed2d728d572822e261a7eebcaed0eace8124a2cca81bbc";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b9/linux-x86_64/bs/firefox-112.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b2/linux-x86_64/bs/firefox-113.0b2.tar.bz2";
       locale = "bs";
       arch = "linux-x86_64";
-      sha256 = "65dc7a81916e4ca1a76cdb49647facb4608810f95355b759dadbae2e5642330b";
+      sha256 = "bfbfae79cf0edbba7508456f6786ab781b59d691074419078bffe1021becd97f";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b9/linux-x86_64/ca-valencia/firefox-112.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b2/linux-x86_64/ca-valencia/firefox-113.0b2.tar.bz2";
       locale = "ca-valencia";
       arch = "linux-x86_64";
-      sha256 = "3457074d65ddf6e8daf940a48658658b8fdeba1fe20adcd609a19d5cc0146252";
+      sha256 = "d15a2f7ab07a7b5cdb25b9e80ca93c7f204f7eae12275299c418f7510a9713dd";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b9/linux-x86_64/ca/firefox-112.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b2/linux-x86_64/ca/firefox-113.0b2.tar.bz2";
       locale = "ca";
       arch = "linux-x86_64";
-      sha256 = "7338285adc5bcee541f9a607ffa1432d599f3f1539ff79d450b7146cf85fdf0c";
+      sha256 = "b45cd595fe5ef06f141730b2edd419509345978fe5160bc3fb3728143af50639";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b9/linux-x86_64/cak/firefox-112.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b2/linux-x86_64/cak/firefox-113.0b2.tar.bz2";
       locale = "cak";
       arch = "linux-x86_64";
-      sha256 = "dcaf4a9cbf4a7fb5be413848e6b839adad6e9d7529225dcae53362cd3cdb5b6b";
+      sha256 = "5246f87d31d17bb0d7cbdd747e996820f752cfe089f67713443e7e06c45de0ac";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b9/linux-x86_64/cs/firefox-112.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b2/linux-x86_64/cs/firefox-113.0b2.tar.bz2";
       locale = "cs";
       arch = "linux-x86_64";
-      sha256 = "d8a9209917d7f6fd4f1bff1772590335c179cf352d92229e1559a8ff6b40ed5f";
+      sha256 = "bd6347d3c5010af6428541199739bab58be8e1bfba2f5dbcad8aaac3b76779a7";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b9/linux-x86_64/cy/firefox-112.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b2/linux-x86_64/cy/firefox-113.0b2.tar.bz2";
       locale = "cy";
       arch = "linux-x86_64";
-      sha256 = "e0ae7beba555b6a205251ba304fed23c527c83f9b27a7b6986f5530a62c08deb";
+      sha256 = "83500899f0b492093dca2c18c96f12c8a023b4a57d20183a6430b868e89bfff1";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b9/linux-x86_64/da/firefox-112.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b2/linux-x86_64/da/firefox-113.0b2.tar.bz2";
       locale = "da";
       arch = "linux-x86_64";
-      sha256 = "b7846920f2620e7d42d949574e55444bf971cc145e494e2a5ca763cac0544e38";
+      sha256 = "58d94b112eb891936f42155173f94ffe184469a342506bc6394ef8183d7a968d";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b9/linux-x86_64/de/firefox-112.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b2/linux-x86_64/de/firefox-113.0b2.tar.bz2";
       locale = "de";
       arch = "linux-x86_64";
-      sha256 = "e66b5305871ef8ee1be9be91ea198102e468a9c79eecbb326695bf92d5de0d86";
+      sha256 = "d97615778271ea8c9a14f3dcb50612b2d170e0327856658e049e746bb51416bb";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b9/linux-x86_64/dsb/firefox-112.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b2/linux-x86_64/dsb/firefox-113.0b2.tar.bz2";
       locale = "dsb";
       arch = "linux-x86_64";
-      sha256 = "47a6c4879c3a20ce467a1797cd675f82345cf99f537e5a0151d7d99aa83d930c";
+      sha256 = "653394c180595785a29c1e0eac655f2d90e9dcc7578c813b2cd9a71c5d56d026";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b9/linux-x86_64/el/firefox-112.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b2/linux-x86_64/el/firefox-113.0b2.tar.bz2";
       locale = "el";
       arch = "linux-x86_64";
-      sha256 = "52b1d2988ea3f5e736736c2993c254ce8463a089353d9f6b67aeb7934025f48b";
+      sha256 = "960c639ae098478e9f9805e38dc9a56359f84b5cec6b2c120ad8b5174b54fd32";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b9/linux-x86_64/en-CA/firefox-112.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b2/linux-x86_64/en-CA/firefox-113.0b2.tar.bz2";
       locale = "en-CA";
       arch = "linux-x86_64";
-      sha256 = "c2d13c20543b2e264de0b6a8ddf00abb81f9990f5c8d845bf49b8faf760be384";
+      sha256 = "1fea26bf92425c4d80cda1694804633251da696fe3990fcb84c18cfa41c84b85";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b9/linux-x86_64/en-GB/firefox-112.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b2/linux-x86_64/en-GB/firefox-113.0b2.tar.bz2";
       locale = "en-GB";
       arch = "linux-x86_64";
-      sha256 = "61f3679a3b366ca493dd9edf20e3706659caab11ac6a7d9a66f7b4d6f9eab1ee";
+      sha256 = "6881e868e7adf125d67872aa79000975635480e5107655d0c060dcb8dbfb2d81";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b9/linux-x86_64/en-US/firefox-112.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b2/linux-x86_64/en-US/firefox-113.0b2.tar.bz2";
       locale = "en-US";
       arch = "linux-x86_64";
-      sha256 = "c20b68a2391eea7bb3a46da86d4d3bf79cf73026b84b87555c46306e85278ef1";
+      sha256 = "d61b8422e344e6873c9b8b9d23c0610aadd90c71b458d971c2d077324a77b64d";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b9/linux-x86_64/eo/firefox-112.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b2/linux-x86_64/eo/firefox-113.0b2.tar.bz2";
       locale = "eo";
       arch = "linux-x86_64";
-      sha256 = "923be915a414e0ff79e281455de59595c2913b4050d290d070f64c8cb93f62ac";
+      sha256 = "3d459fbe28d3d1673e2ea98c25a267023bd8e9eb3217ae87a6f69972cdb58d03";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b9/linux-x86_64/es-AR/firefox-112.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b2/linux-x86_64/es-AR/firefox-113.0b2.tar.bz2";
       locale = "es-AR";
       arch = "linux-x86_64";
-      sha256 = "00eb3cc8a00d6b4dd1603471f295942d1c8c26cec51ba515cfff41cd02d81596";
+      sha256 = "6fbdd2a0396dfe0e5caf491287218f0fcccb9311175e0b75c571e1f3a92d7bc4";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b9/linux-x86_64/es-CL/firefox-112.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b2/linux-x86_64/es-CL/firefox-113.0b2.tar.bz2";
       locale = "es-CL";
       arch = "linux-x86_64";
-      sha256 = "cde98bd8189c8339d5e18e36247beb1d476acde5d883329bd345813bf626d8d0";
+      sha256 = "41ab6d9e3f635d43c9a187932a93a8484263b00e194e9f8450ce4f1c0fe28f38";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b9/linux-x86_64/es-ES/firefox-112.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b2/linux-x86_64/es-ES/firefox-113.0b2.tar.bz2";
       locale = "es-ES";
       arch = "linux-x86_64";
-      sha256 = "25d8cfd0c5118a744349d6498c3a4ec53f6e963bb105706ebd2a15397dee5104";
+      sha256 = "18028d9ca42a8f6372ddd777943d86cce7ecbfa0f0e6998ef879a7ee676e9eee";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b9/linux-x86_64/es-MX/firefox-112.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b2/linux-x86_64/es-MX/firefox-113.0b2.tar.bz2";
       locale = "es-MX";
       arch = "linux-x86_64";
-      sha256 = "fa60ad1c352522597e1ff036d6dd5d6041820076386de6491e48fb90e72cd29d";
+      sha256 = "79502a45f906bdff7e3c3fbf89624034717ba4e70d6ffc753a8ba4ef024ceac6";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b9/linux-x86_64/et/firefox-112.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b2/linux-x86_64/et/firefox-113.0b2.tar.bz2";
       locale = "et";
       arch = "linux-x86_64";
-      sha256 = "5e3b4dc30fd2d2c475ace1cf5a070a07b93e284ddf62146ff3cb6a185abc4305";
+      sha256 = "c401de7797bb35f3f89e2a6efdf08b9458b765243d0764fc00badb5a9d01995c";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b9/linux-x86_64/eu/firefox-112.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b2/linux-x86_64/eu/firefox-113.0b2.tar.bz2";
       locale = "eu";
       arch = "linux-x86_64";
-      sha256 = "a14a0c0c801881f9bd5ab1cf3d872931401a05cf179893c58fb06bb10719ac73";
+      sha256 = "0d1071eb565fd3fca4e7ec50a886f5c27af4a4ed4ee5da1237efa39f508a45e7";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b9/linux-x86_64/fa/firefox-112.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b2/linux-x86_64/fa/firefox-113.0b2.tar.bz2";
       locale = "fa";
       arch = "linux-x86_64";
-      sha256 = "30eb43d6430689134807be057bbd8b88be1a5226a22886a71bd6ec457c2dd1cb";
+      sha256 = "bcd12e119c3203e1955af4595121bcb451460dd4960186f309238ad4ad2603af";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b9/linux-x86_64/ff/firefox-112.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b2/linux-x86_64/ff/firefox-113.0b2.tar.bz2";
       locale = "ff";
       arch = "linux-x86_64";
-      sha256 = "78bdd7b220d43fd09e1ac785651f762f5dfd22d797fab41bc484f1593f3be99e";
+      sha256 = "96e9f283c7ad4b8c2adb8a04c7d8ac4e0648f1db1775d1e4a8f963ca5ab4bfc7";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b9/linux-x86_64/fi/firefox-112.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b2/linux-x86_64/fi/firefox-113.0b2.tar.bz2";
       locale = "fi";
       arch = "linux-x86_64";
-      sha256 = "e302d1ca154ef7cb8f03d9a08558cdea6f0c5a81ba73cd5fa140c26f5aa66275";
+      sha256 = "f4f3fd6e01a17154ccbaac98e8366feee42a577213b8ad8ee6bb98cd4eccc63c";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b9/linux-x86_64/fr/firefox-112.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b2/linux-x86_64/fr/firefox-113.0b2.tar.bz2";
       locale = "fr";
       arch = "linux-x86_64";
-      sha256 = "740e37ad6c1adcbf26839ba98390ca48dc36cfa8a781ef5ef6efebfa343b9c7f";
+      sha256 = "e3cf2f06d1672f7811f61a72c621ac7b02c52fc5c95c693e5b7ca3e6a312ef65";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b9/linux-x86_64/fur/firefox-112.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b2/linux-x86_64/fur/firefox-113.0b2.tar.bz2";
       locale = "fur";
       arch = "linux-x86_64";
-      sha256 = "6c551c21b3197931f855d203569fc48ed88135674039b4dace90466397014e28";
+      sha256 = "a443bab872692889d186876c8021f4dac8e7066bcad9cf07859d9a64e68e36d0";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b9/linux-x86_64/fy-NL/firefox-112.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b2/linux-x86_64/fy-NL/firefox-113.0b2.tar.bz2";
       locale = "fy-NL";
       arch = "linux-x86_64";
-      sha256 = "d5ea3dc8a420f4b1ce431e31ab960648c8db4d5757c481ca85b57e3280e05b4e";
+      sha256 = "2fc833b2832048e90fb5a54a8a1e26e2ec24dfc16756d25da2b27c206f2ec152";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b9/linux-x86_64/ga-IE/firefox-112.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b2/linux-x86_64/ga-IE/firefox-113.0b2.tar.bz2";
       locale = "ga-IE";
       arch = "linux-x86_64";
-      sha256 = "35cee6f755d1161201106bcda6bc74bd2cc5b7e4ab800d8ccb9ac3395a262053";
+      sha256 = "e3156719d5ea92690afe387a083c298d879971c38709c6a02560af3b1204b27a";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b9/linux-x86_64/gd/firefox-112.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b2/linux-x86_64/gd/firefox-113.0b2.tar.bz2";
       locale = "gd";
       arch = "linux-x86_64";
-      sha256 = "9ea267696100d481baa754d9e9e4968316630237ad7d71f864203eea5a21f513";
+      sha256 = "4bba581ea6859fb0ca0e92bc4c64e221010202887422846cf23122b3ae10a25e";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b9/linux-x86_64/gl/firefox-112.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b2/linux-x86_64/gl/firefox-113.0b2.tar.bz2";
       locale = "gl";
       arch = "linux-x86_64";
-      sha256 = "577b34e526da0107f362432854a1ee18c40e97e9e27e061b023d07da9863d04a";
+      sha256 = "1de0db04d4977b71e78173a1d738f188ee8a6798da25473d21216dd6eda928c0";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b9/linux-x86_64/gn/firefox-112.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b2/linux-x86_64/gn/firefox-113.0b2.tar.bz2";
       locale = "gn";
       arch = "linux-x86_64";
-      sha256 = "3a79deb8f9557553b9ef17e78b8315d789cf87eb9c905c53ca079a03e009dd0f";
+      sha256 = "4ec41348ded1d24cefe64841b276d760749b8eb8385646249b01cf180471b7b1";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b9/linux-x86_64/gu-IN/firefox-112.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b2/linux-x86_64/gu-IN/firefox-113.0b2.tar.bz2";
       locale = "gu-IN";
       arch = "linux-x86_64";
-      sha256 = "9e4d46b7dcfd4f01ebd61ab4400854efe7c4c6ae801acb0bbde7c5e4c828de06";
+      sha256 = "fb99b010d7fd6b619d43db12c66b80d222ae2eb1dc03eab0f39e10ed54fc975f";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b9/linux-x86_64/he/firefox-112.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b2/linux-x86_64/he/firefox-113.0b2.tar.bz2";
       locale = "he";
       arch = "linux-x86_64";
-      sha256 = "83b5a933dffd7f82ae11c8da27d023ed95a10646aa78090b1ae98b860a2456e4";
+      sha256 = "c8616d73659cff46dba05f155f942845f00782c291fa616dcc7f8e110c17d2d0";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b9/linux-x86_64/hi-IN/firefox-112.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b2/linux-x86_64/hi-IN/firefox-113.0b2.tar.bz2";
       locale = "hi-IN";
       arch = "linux-x86_64";
-      sha256 = "c70d1edfc326b21557e1b9b286533a326c593fa4cac20741a6fd74bbf198a9de";
+      sha256 = "e613194a2efe8d7ccb800c23bd253f80b8acfb6748e03e109c71dda6dfe3db2e";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b9/linux-x86_64/hr/firefox-112.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b2/linux-x86_64/hr/firefox-113.0b2.tar.bz2";
       locale = "hr";
       arch = "linux-x86_64";
-      sha256 = "3c0269b9b2b7ef327b5ec0b09b5a9467a0259b12149b8ca79156eed5eed69bf3";
+      sha256 = "dec738c4d3603fea5f0c93ce0ed0814a9901e691c5126192eee55476314312c3";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b9/linux-x86_64/hsb/firefox-112.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b2/linux-x86_64/hsb/firefox-113.0b2.tar.bz2";
       locale = "hsb";
       arch = "linux-x86_64";
-      sha256 = "389e8dba95fbf251c8dd5285b8ddd0968ae776828f85f048a8fea419e301e937";
+      sha256 = "959e7a1d909f0b1013a4c5abfbf9eaacc9e4b0c145af0d6f1b7bb532645ce18a";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b9/linux-x86_64/hu/firefox-112.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b2/linux-x86_64/hu/firefox-113.0b2.tar.bz2";
       locale = "hu";
       arch = "linux-x86_64";
-      sha256 = "8f42deca7e0e9e31db669367c849fc0743b8db3b7e1aeca97808df35c5e00599";
+      sha256 = "09f7adfc674063f277b210bc6e502c165298a9bb206145dd4889922e5df67f79";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b9/linux-x86_64/hy-AM/firefox-112.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b2/linux-x86_64/hy-AM/firefox-113.0b2.tar.bz2";
       locale = "hy-AM";
       arch = "linux-x86_64";
-      sha256 = "f8e85f74e3c000ef8c130686f7ca82844040efc24110b5007f9ea452a4d31d8e";
+      sha256 = "23e1e355f25befa9b5cb0968d4c1f3242bf6fa1ec3ea27f1670ce75e59f1bdd4";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b9/linux-x86_64/ia/firefox-112.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b2/linux-x86_64/ia/firefox-113.0b2.tar.bz2";
       locale = "ia";
       arch = "linux-x86_64";
-      sha256 = "77830f9c1c83ede9eeb4ffc5167bdd9b12e14573523d7f81eb92ad41f66d6d1d";
+      sha256 = "a9f53465f58d491de332f855f5669e0c4d0288a994410d6ef849466e2b432299";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b9/linux-x86_64/id/firefox-112.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b2/linux-x86_64/id/firefox-113.0b2.tar.bz2";
       locale = "id";
       arch = "linux-x86_64";
-      sha256 = "9fdfd3398294ae12a73948bdc7a49e781c459273d0213cfa43d01da5a0f8b8f5";
+      sha256 = "3377495a450130db9aa14a52598f50b254c97a942a9ae2546a721104a9b08048";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b9/linux-x86_64/is/firefox-112.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b2/linux-x86_64/is/firefox-113.0b2.tar.bz2";
       locale = "is";
       arch = "linux-x86_64";
-      sha256 = "acf9556611d9227c833daec3b1c77f460aac9856a0a77a599e3aa50eca71ef5f";
+      sha256 = "dba7136591869347cf5a07503f3a0cfd705eef9b69217fc19785d7584dc9525a";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b9/linux-x86_64/it/firefox-112.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b2/linux-x86_64/it/firefox-113.0b2.tar.bz2";
       locale = "it";
       arch = "linux-x86_64";
-      sha256 = "b9f0f22523e1b702e589f9cde4301545cb8ed21b31121db87ccd1202eb0b0f4d";
+      sha256 = "6d14dfaa7c40fa27d1099dd7ca3dbe99731e7bdc9a22ce2b5c1fb0caa5e53dd8";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b9/linux-x86_64/ja/firefox-112.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b2/linux-x86_64/ja/firefox-113.0b2.tar.bz2";
       locale = "ja";
       arch = "linux-x86_64";
-      sha256 = "242fcd51d46fba53ff5677dc6fa82f2d9f60b2a0aafce7cd8a9c616006ce1689";
+      sha256 = "01b78c71ab26948e8f2eaf199b7360a55d3e2c423acb008bf5d00a171d2f8198";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b9/linux-x86_64/ka/firefox-112.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b2/linux-x86_64/ka/firefox-113.0b2.tar.bz2";
       locale = "ka";
       arch = "linux-x86_64";
-      sha256 = "7d43d33b89ae777f8b1fa0bc8952bb32d09e0c7daea455ae22c1019b6bd5a227";
+      sha256 = "f067e6190ceda4f314da7c56f9390425ad648ae20607afdc473ae5dc4d8dc261";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b9/linux-x86_64/kab/firefox-112.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b2/linux-x86_64/kab/firefox-113.0b2.tar.bz2";
       locale = "kab";
       arch = "linux-x86_64";
-      sha256 = "baa1eba4754b306595f24481d8ace5081a75014e77fba7a002369f36fff52581";
+      sha256 = "a1b15015972ca9e114462f0b217b51b8f758df64c4d3ebc1542575063700e7c0";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b9/linux-x86_64/kk/firefox-112.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b2/linux-x86_64/kk/firefox-113.0b2.tar.bz2";
       locale = "kk";
       arch = "linux-x86_64";
-      sha256 = "b7c3de9101bfb0347cc37f8e005082e452ff05befbf739c7556b2625233f44ea";
+      sha256 = "2f2e21dfd26cd4a074c531a85ba4401ef29fa6237d885a1eca3de6de07891c71";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b9/linux-x86_64/km/firefox-112.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b2/linux-x86_64/km/firefox-113.0b2.tar.bz2";
       locale = "km";
       arch = "linux-x86_64";
-      sha256 = "7ad924897d632113c8ae216ecf5bb4e100a9e9f8e3e3723ae5dd89f8b92a5a14";
+      sha256 = "6a22f3696198bb87e920261328a99460160cf7de22c1c79f1c6b50bb9395cc78";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b9/linux-x86_64/kn/firefox-112.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b2/linux-x86_64/kn/firefox-113.0b2.tar.bz2";
       locale = "kn";
       arch = "linux-x86_64";
-      sha256 = "fe2d436265c88188dad970809ae0010c98443c3368015954be84719607c5ef08";
+      sha256 = "cc94c675a5e228921c448a773470a480be3fbaf62094abb9d2b759db3fd814cc";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b9/linux-x86_64/ko/firefox-112.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b2/linux-x86_64/ko/firefox-113.0b2.tar.bz2";
       locale = "ko";
       arch = "linux-x86_64";
-      sha256 = "1ce08126d751fdf3e06ee8a2b488d6a78b5a2fb5254e98d861e9ff6f6095e00c";
+      sha256 = "bab90c97c6350822c8ebadc047dd0363e7d03740c296d24c1b272ff2fa259a7a";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b9/linux-x86_64/lij/firefox-112.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b2/linux-x86_64/lij/firefox-113.0b2.tar.bz2";
       locale = "lij";
       arch = "linux-x86_64";
-      sha256 = "f96c104e826680d2c8796c9dfb4ee9171b99164ed8c8b3b3257e461073c0dad7";
+      sha256 = "145cbf712b14ebb73fcd8bc311c56aeb6698eb25ebb2a4c9c3a8a62bd1c02bf8";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b9/linux-x86_64/lt/firefox-112.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b2/linux-x86_64/lt/firefox-113.0b2.tar.bz2";
       locale = "lt";
       arch = "linux-x86_64";
-      sha256 = "3a9890426d2054d191c981dffc289bb71111704aa121eb9cfb9fd8702f287362";
+      sha256 = "2cd40821b72e570ee1c877d56701724cd7715285670b7929ea434d041406eca9";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b9/linux-x86_64/lv/firefox-112.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b2/linux-x86_64/lv/firefox-113.0b2.tar.bz2";
       locale = "lv";
       arch = "linux-x86_64";
-      sha256 = "52f607cc06ca3b3a7b8ffd5ba3451009669b54b4ea80aa51e22f3b28522b7c63";
+      sha256 = "23bccb2ba57c061ad5875365842be19a518887ff3f71d551b85abbd69a53d636";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b9/linux-x86_64/mk/firefox-112.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b2/linux-x86_64/mk/firefox-113.0b2.tar.bz2";
       locale = "mk";
       arch = "linux-x86_64";
-      sha256 = "81c53806597904fa1eca2373d0624e0705643e9be209d7332d9b45267e89d3b3";
+      sha256 = "62444e8914cf6a7a734b577e107ec22a4ccd7ca39bce4b7b6a66e970dbb6e371";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b9/linux-x86_64/mr/firefox-112.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b2/linux-x86_64/mr/firefox-113.0b2.tar.bz2";
       locale = "mr";
       arch = "linux-x86_64";
-      sha256 = "6c691e4a1a59821aca8fb7296346e44952f86f819bafa34a81fce6a1a50675e9";
+      sha256 = "23355ea5c25eb79534fe80e59a660f4b5d2719bf68863a547a78aaeec8d0d6c6";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b9/linux-x86_64/ms/firefox-112.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b2/linux-x86_64/ms/firefox-113.0b2.tar.bz2";
       locale = "ms";
       arch = "linux-x86_64";
-      sha256 = "a1cbe33f591edbafb8ffd788bcfdca57e0aadbc72b25c53c90321b3cb85973e4";
+      sha256 = "8c834e38b172656656c57292c3a735c49ca5d3444ca374f6958e684ae22bd086";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b9/linux-x86_64/my/firefox-112.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b2/linux-x86_64/my/firefox-113.0b2.tar.bz2";
       locale = "my";
       arch = "linux-x86_64";
-      sha256 = "aafdf40d468a0fbe3963c0c209536e48cff38e9f04f109a3074c03f54f2651de";
+      sha256 = "4cd70e346aa9fd7a877ce45378fcead5fe1cbf990a54defd073ca0d8d9b30a34";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b9/linux-x86_64/nb-NO/firefox-112.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b2/linux-x86_64/nb-NO/firefox-113.0b2.tar.bz2";
       locale = "nb-NO";
       arch = "linux-x86_64";
-      sha256 = "f191a4d2f2c16eff77b8e1bc0b62dcd73853ddf7be2e37f1c02cd579c549c882";
+      sha256 = "4ceaf249c39e2b108ed1e493fdaa62cb52ad04b67aabae58a86944cd42964335";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b9/linux-x86_64/ne-NP/firefox-112.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b2/linux-x86_64/ne-NP/firefox-113.0b2.tar.bz2";
       locale = "ne-NP";
       arch = "linux-x86_64";
-      sha256 = "bd77efa143cde29fa0a612c0c4abc88e9cb6d4b200d325a8c96c982d87605461";
+      sha256 = "6f8c0df71ab020b718625433dc5c25f2382342922e15f44fc72ac20b5258e441";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b9/linux-x86_64/nl/firefox-112.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b2/linux-x86_64/nl/firefox-113.0b2.tar.bz2";
       locale = "nl";
       arch = "linux-x86_64";
-      sha256 = "7da465a94a0b5473d8a8eaa19223c83aec2e93f0cd82d70c8c7cb3edf6a26a30";
+      sha256 = "4be0cf4ecb47dd9ec5aeb8c7acd1ca93ad886b0bcbfb95f2a30e16fb41d4340f";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b9/linux-x86_64/nn-NO/firefox-112.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b2/linux-x86_64/nn-NO/firefox-113.0b2.tar.bz2";
       locale = "nn-NO";
       arch = "linux-x86_64";
-      sha256 = "d821d00911c5bfab3dd59a10293a8b855329d66ecf492d97927e03aaba5db94b";
+      sha256 = "f38689e40e019cffd73966ed9fa58ac542f62025cab1f156e22cf3b137389322";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b9/linux-x86_64/oc/firefox-112.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b2/linux-x86_64/oc/firefox-113.0b2.tar.bz2";
       locale = "oc";
       arch = "linux-x86_64";
-      sha256 = "0a1f1f543ad9fdd4db3649cf6d5ac4e4d3547305d0d9eda25ffc9e654b0455e4";
+      sha256 = "67be4afbf41722f201cc2ad63821ba56efd212606684d66d9094087ce28e116b";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b9/linux-x86_64/pa-IN/firefox-112.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b2/linux-x86_64/pa-IN/firefox-113.0b2.tar.bz2";
       locale = "pa-IN";
       arch = "linux-x86_64";
-      sha256 = "8204c629b42dd8cc160f9c06162164a3e73d223fe934d3104815d667af379e83";
+      sha256 = "80b97a5b0c195b20844067001d05d0995812b51aad40db631da35de018239f86";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b9/linux-x86_64/pl/firefox-112.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b2/linux-x86_64/pl/firefox-113.0b2.tar.bz2";
       locale = "pl";
       arch = "linux-x86_64";
-      sha256 = "3b8d9f7149b52859525d10f86df56974b13edbd5c2a9400f2ba118b25388d6cd";
+      sha256 = "71137cacdf82696e3c9e4b8e42882cc77c4d3f66ad540ad04224c347ca30bf72";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b9/linux-x86_64/pt-BR/firefox-112.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b2/linux-x86_64/pt-BR/firefox-113.0b2.tar.bz2";
       locale = "pt-BR";
       arch = "linux-x86_64";
-      sha256 = "5f9457aef6112f2d8aeb41a46048e6e66022e70f5ed94b25abcecb1d4ed59243";
+      sha256 = "e978a8e53285137c14392f3928beb462ea4bb78b49f8266bae2505bb751bfcb6";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b9/linux-x86_64/pt-PT/firefox-112.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b2/linux-x86_64/pt-PT/firefox-113.0b2.tar.bz2";
       locale = "pt-PT";
       arch = "linux-x86_64";
-      sha256 = "6e71242cb5b53c1819748af4c5b46376bac8461b1e44431aea4bb5e27f6fc36e";
+      sha256 = "6c355c30efdc1c60d6e2fb77f06c39d6f62613aee81ee7584cf58db7d9bfe918";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b9/linux-x86_64/rm/firefox-112.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b2/linux-x86_64/rm/firefox-113.0b2.tar.bz2";
       locale = "rm";
       arch = "linux-x86_64";
-      sha256 = "0a40ec006f769549d11bb03dedcb9cba6d63223c59730fd7b1a3d9439ddedc48";
+      sha256 = "2e65b2a382220719a0f0341640317085524fca87776a864375ca4358f96132b3";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b9/linux-x86_64/ro/firefox-112.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b2/linux-x86_64/ro/firefox-113.0b2.tar.bz2";
       locale = "ro";
       arch = "linux-x86_64";
-      sha256 = "a67633dab6822d72db5ddce84be42095cf74bf279552b96c9fb1693d30a46043";
+      sha256 = "5ed6ce88efb537ab23c454009fd6e33bfcc0473555f47a4a61f252e03999c103";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b9/linux-x86_64/ru/firefox-112.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b2/linux-x86_64/ru/firefox-113.0b2.tar.bz2";
       locale = "ru";
       arch = "linux-x86_64";
-      sha256 = "bf9a714ab7f07d781fd7cd3437f60f86494a21e5c7b437980977550df9da9b06";
+      sha256 = "a003fc303e2478af1596336aaea883acf3211867e7b8ebf576f843ef270422ec";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b9/linux-x86_64/sc/firefox-112.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b2/linux-x86_64/sc/firefox-113.0b2.tar.bz2";
       locale = "sc";
       arch = "linux-x86_64";
-      sha256 = "0ccb2114341dc8126fb5eeabe247f428f98e7b4a497813d3452f1fd5ecad2524";
+      sha256 = "6d5e84c3554bf931ea44f67c8cf2005916db0599ffbf78a0a3572eaca81d59a9";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b9/linux-x86_64/sco/firefox-112.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b2/linux-x86_64/sco/firefox-113.0b2.tar.bz2";
       locale = "sco";
       arch = "linux-x86_64";
-      sha256 = "f55281f7d574ac9e89d1bdfcf1616b61d0aa56283e7d89824c47264a9e790cff";
+      sha256 = "9d6e834a4c0d88900ace756e2ad0d96437cee23104fde9212143a03baa063987";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b9/linux-x86_64/si/firefox-112.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b2/linux-x86_64/si/firefox-113.0b2.tar.bz2";
       locale = "si";
       arch = "linux-x86_64";
-      sha256 = "d9c0c625b2f9b2bd4c0efb63342baecde07c24b20501df4069e1bcbac4d759ef";
+      sha256 = "52a89fcf78fd864540b732ab415b06dc41584a057d11779061c870ccf1026bf3";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b9/linux-x86_64/sk/firefox-112.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b2/linux-x86_64/sk/firefox-113.0b2.tar.bz2";
       locale = "sk";
       arch = "linux-x86_64";
-      sha256 = "f5ed9cd87b43380c417fcb0a245530daf5dc9b4bf4cd246ec4228d4bc37b5c6b";
+      sha256 = "a33b82d3c3e32d3c43d88b3613f796b0073c9d8c6fc7082b5329f877fe243d1a";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b9/linux-x86_64/sl/firefox-112.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b2/linux-x86_64/sl/firefox-113.0b2.tar.bz2";
       locale = "sl";
       arch = "linux-x86_64";
-      sha256 = "b91d7c6b54dac7e4759d1f6c5cb906e5e13bd5592eb92ba10b01fcd0c9aab99d";
+      sha256 = "9d46d77c6841357971b3867e8d3659b674cca1892862d9668e608f99983a5b4e";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b9/linux-x86_64/son/firefox-112.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b2/linux-x86_64/son/firefox-113.0b2.tar.bz2";
       locale = "son";
       arch = "linux-x86_64";
-      sha256 = "10bfbf7229849a83a31a0a55e8bcfe366c33028e92af765ac5340e18013a8445";
+      sha256 = "22559f8e961ede16392c01a297c69e43395ec93623d5f9897887b9673dbaef1a";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b9/linux-x86_64/sq/firefox-112.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b2/linux-x86_64/sq/firefox-113.0b2.tar.bz2";
       locale = "sq";
       arch = "linux-x86_64";
-      sha256 = "18ef58367831aa47b9d8697842c333e3381c125ac734dbfb68b1a8c2a561492d";
+      sha256 = "bb29f522e16897bd83946b291d3162eff71cbacca4da9e1b4a7b16b4fd17a0e4";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b9/linux-x86_64/sr/firefox-112.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b2/linux-x86_64/sr/firefox-113.0b2.tar.bz2";
       locale = "sr";
       arch = "linux-x86_64";
-      sha256 = "1ace53e69f0bd453f0400d01cfbbfbbf34e5cefae1555d383b8acbf309bdca10";
+      sha256 = "92cdb6e5528c6aed0516364a6c01bce28e29f7ff6c1de971400298449682f025";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b9/linux-x86_64/sv-SE/firefox-112.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b2/linux-x86_64/sv-SE/firefox-113.0b2.tar.bz2";
       locale = "sv-SE";
       arch = "linux-x86_64";
-      sha256 = "56065d1d5ff2be2c39e825c74f603e7d98ac4db60b94a409206a5b24f4fe2dd4";
+      sha256 = "63540925589dfa61530be3a97c38c6af82869d65d989784564e84ee042dfd6b1";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b9/linux-x86_64/szl/firefox-112.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b2/linux-x86_64/szl/firefox-113.0b2.tar.bz2";
       locale = "szl";
       arch = "linux-x86_64";
-      sha256 = "2aee3f428565748ba1ac1000f9b4514bc45d75feb46c63ac5408af8666941364";
+      sha256 = "6ecd2dc91186d5c349de5a04e314f88ca6c7ead3e6f3e194a8e20ff4495800f7";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b9/linux-x86_64/ta/firefox-112.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b2/linux-x86_64/ta/firefox-113.0b2.tar.bz2";
       locale = "ta";
       arch = "linux-x86_64";
-      sha256 = "40527cf34c10283c2c9adb20e56d2f69aeaf80dc1ea3999f4e36aee1d5343677";
+      sha256 = "ceb8ceb46279bb485bb03bb24a75c82fcd9a4f0c161697e3fd659a7003c5e616";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b9/linux-x86_64/te/firefox-112.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b2/linux-x86_64/te/firefox-113.0b2.tar.bz2";
       locale = "te";
       arch = "linux-x86_64";
-      sha256 = "1a08ef30a532bad9cc25c3aa22214a29b65da98e817068ddef2d0dbf792babb9";
+      sha256 = "625a76a8cdef039ffba056bb791e4bdb82104f8851c4e510fecc75f31c93e5c9";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b9/linux-x86_64/th/firefox-112.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b2/linux-x86_64/tg/firefox-113.0b2.tar.bz2";
+      locale = "tg";
+      arch = "linux-x86_64";
+      sha256 = "b009d02955816d28edc6bbcb974dea276ed384a0a9d0d35f9c353e8009965007";
+    }
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b2/linux-x86_64/th/firefox-113.0b2.tar.bz2";
       locale = "th";
       arch = "linux-x86_64";
-      sha256 = "8297b3c16acde1d61ddf55bb9eda8146fcfb3dfea7c922ac2e82c968cb55ac3c";
+      sha256 = "34a6852d0017a6ff299ca448d8dbec13c5a440031e4b7cb5fef2a3ac120eb733";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b9/linux-x86_64/tl/firefox-112.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b2/linux-x86_64/tl/firefox-113.0b2.tar.bz2";
       locale = "tl";
       arch = "linux-x86_64";
-      sha256 = "a8619906c9d94af9644c9bedd16ecb1cd0a324e2e0c142750934b3664f1c7b43";
+      sha256 = "9d6a1360430702a02e37ce754ab5650d5b3ebd8b866fcaecf98e5ee464ea32a2";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b9/linux-x86_64/tr/firefox-112.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b2/linux-x86_64/tr/firefox-113.0b2.tar.bz2";
       locale = "tr";
       arch = "linux-x86_64";
-      sha256 = "ad62288f0872a13baf8ed870cd3ba377433f054c72f476d75cfa6960ab68afa5";
+      sha256 = "4bf7f0e2c26821510f0645d6048ed771fb28592e5546304c1dd3a312c545fee6";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b9/linux-x86_64/trs/firefox-112.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b2/linux-x86_64/trs/firefox-113.0b2.tar.bz2";
       locale = "trs";
       arch = "linux-x86_64";
-      sha256 = "eb94693acccfce8c2bfcf0bdf113fe6581b7c29e76c0f4c37a06a8846621d917";
+      sha256 = "b95ee3abba19a905fb7d7cf981a0cc8a8510878cf099920610b884aacdebd513";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b9/linux-x86_64/uk/firefox-112.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b2/linux-x86_64/uk/firefox-113.0b2.tar.bz2";
       locale = "uk";
       arch = "linux-x86_64";
-      sha256 = "7bba087cae9bbe38838186cae5a3377389f23e595eac83e6cf6f1f3ea85df577";
+      sha256 = "dd1007354eeb86263c6e3d4db90c5049d73021a053fd8856cd1b8b9174e5ed38";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b9/linux-x86_64/ur/firefox-112.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b2/linux-x86_64/ur/firefox-113.0b2.tar.bz2";
       locale = "ur";
       arch = "linux-x86_64";
-      sha256 = "8d922fd02396ae63f92000256df30366e5407dff5b9a220d8ce2fc36fae923e5";
+      sha256 = "f8a9044c3fb7a352fbe3f2e04a994be8573a748f4368bb9a327a53e4c954a816";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b9/linux-x86_64/uz/firefox-112.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b2/linux-x86_64/uz/firefox-113.0b2.tar.bz2";
       locale = "uz";
       arch = "linux-x86_64";
-      sha256 = "8c697b389c3012a656368d6386c048d3d72abb8386d873825b4c9e71bf5224b4";
+      sha256 = "c43e984f241a9bd97c575474f2e80387b676d067fdd5eb9c21646ca03235c7b1";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b9/linux-x86_64/vi/firefox-112.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b2/linux-x86_64/vi/firefox-113.0b2.tar.bz2";
       locale = "vi";
       arch = "linux-x86_64";
-      sha256 = "c3e1358a053978a889b5fed9e25d6d9ab12c6a3f911b5b2e71dee4300a051095";
+      sha256 = "c57dd83122a52e96675d1d52030c6896d430bc222a0aa297e3dac4de95bc76dc";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b9/linux-x86_64/xh/firefox-112.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b2/linux-x86_64/xh/firefox-113.0b2.tar.bz2";
       locale = "xh";
       arch = "linux-x86_64";
-      sha256 = "b3f990841a9724385fcb20bb3e3cf44dd0ff89a10b63c8410c0b1671df488edf";
+      sha256 = "954de48e49a0f95431b8fda717dff54fd39b59091e732a9b097ba6f12936f0fd";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b9/linux-x86_64/zh-CN/firefox-112.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b2/linux-x86_64/zh-CN/firefox-113.0b2.tar.bz2";
       locale = "zh-CN";
       arch = "linux-x86_64";
-      sha256 = "0ce22e1bf397ebfc6275e1140c0d9dce5bb76f5221f6944d8a86e003151f86bc";
+      sha256 = "30f2ed6ce51ae526b7c32e0174303348045f4907b9aab67a59fbeea7110674b5";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b9/linux-x86_64/zh-TW/firefox-112.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b2/linux-x86_64/zh-TW/firefox-113.0b2.tar.bz2";
       locale = "zh-TW";
       arch = "linux-x86_64";
-      sha256 = "a614632f44a397e0dc96dce09ad9995ceb7b8bbaf7c4ec22199e65507d81b351";
+      sha256 = "2fe54cd40a0c09a6e7e71d8870c5a2d8e7c3a70036ac246eb0c3659536197323";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b9/linux-i686/ach/firefox-112.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b2/linux-i686/ach/firefox-113.0b2.tar.bz2";
       locale = "ach";
       arch = "linux-i686";
-      sha256 = "dbeee7bee78c5f80672362c571835fa60de87e187b14fd0bb6eea798fc11df12";
+      sha256 = "b52ae8cbc95a39e33881b9825a242247cc369e177a7927c0807134aa600b8b0b";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b9/linux-i686/af/firefox-112.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b2/linux-i686/af/firefox-113.0b2.tar.bz2";
       locale = "af";
       arch = "linux-i686";
-      sha256 = "a66c2f01f1a70cac06c6d8bfbeae915f83f99b42cff642f2230ba1b63125e7b6";
+      sha256 = "bbb4433e14a32a50fa461f7f44f28eecb47d23434335a3613ea6c5c45a7ddbbf";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b9/linux-i686/an/firefox-112.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b2/linux-i686/an/firefox-113.0b2.tar.bz2";
       locale = "an";
       arch = "linux-i686";
-      sha256 = "d1c11274d71ccc60740667e69f7fb32b7d28fc9931dec4c34257ddfc1cd3709a";
+      sha256 = "73382955959b8b2fb13db3b780559a501b65634a01a2e42cc48545fafb330ce5";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b9/linux-i686/ar/firefox-112.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b2/linux-i686/ar/firefox-113.0b2.tar.bz2";
       locale = "ar";
       arch = "linux-i686";
-      sha256 = "d3014dc83dfbf8132c54c3f501ba501641360248451e12b7c8773ce72400644c";
+      sha256 = "51958d006b680020cf9f76dfb7c339e99ac471c84cf27e54af686416fe10e129";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b9/linux-i686/ast/firefox-112.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b2/linux-i686/ast/firefox-113.0b2.tar.bz2";
       locale = "ast";
       arch = "linux-i686";
-      sha256 = "95ec058fd689e6439efaebf2a1ce4fbdf4630f44d07de7fbcbbf8f4938d219ad";
+      sha256 = "49247ac5fc5f4da6e94d544f2005818fdd6d8934e06e6bc1880c4e4d8b8579d7";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b9/linux-i686/az/firefox-112.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b2/linux-i686/az/firefox-113.0b2.tar.bz2";
       locale = "az";
       arch = "linux-i686";
-      sha256 = "e57b88318cb4b7d8677997dd524c0d75dcb873b57ed62cd5f7d09edf95791ce4";
+      sha256 = "ee4098f0d74a87caa95c10b6a8b3b35ee13d7531047df897b0e70a04efde693a";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b9/linux-i686/be/firefox-112.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b2/linux-i686/be/firefox-113.0b2.tar.bz2";
       locale = "be";
       arch = "linux-i686";
-      sha256 = "7375449539a0992741f7c8a54da6fe5d1db9af50d707d9cd1415cd09cf33eddf";
+      sha256 = "5d6e2492d6b59bb3651ab9066cb7b8c5b3784c9814b172c837a01a057c353578";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b9/linux-i686/bg/firefox-112.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b2/linux-i686/bg/firefox-113.0b2.tar.bz2";
       locale = "bg";
       arch = "linux-i686";
-      sha256 = "f749a041413a34da71dd46e0a584fa9181ad0658d19ec89d7e6c20d417ac2b1c";
+      sha256 = "569945ca1d1c7b5d47affc9037d22a55c2840640048c0b312f55bddabc38e16f";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b9/linux-i686/bn/firefox-112.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b2/linux-i686/bn/firefox-113.0b2.tar.bz2";
       locale = "bn";
       arch = "linux-i686";
-      sha256 = "5c4063683ce344c9fee3c100b4c737813a31416c8e86f242576ef9f4bd94b332";
+      sha256 = "31b29f6a3baed2827e18641bc2fc3cf09b9c1830cf062000c9c7802a533c29c9";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b9/linux-i686/br/firefox-112.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b2/linux-i686/br/firefox-113.0b2.tar.bz2";
       locale = "br";
       arch = "linux-i686";
-      sha256 = "c8d738500e696b776494897f9cb27210b566e6459ff58fa2916272b883c3e534";
+      sha256 = "95d538f34defbced0994b7cc8cab3d90ba9f190031638facbfbfcc9eb8167f23";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b9/linux-i686/bs/firefox-112.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b2/linux-i686/bs/firefox-113.0b2.tar.bz2";
       locale = "bs";
       arch = "linux-i686";
-      sha256 = "d81b34fb97f7fb39ae6c9ff83f53ed5ea21770656ee00d962c5fa337784a20bb";
+      sha256 = "a690168f0089b97fd6ab52e8dcfa0bf04a27a3ba2e825a47392bc57aa453f32a";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b9/linux-i686/ca-valencia/firefox-112.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b2/linux-i686/ca-valencia/firefox-113.0b2.tar.bz2";
       locale = "ca-valencia";
       arch = "linux-i686";
-      sha256 = "eccdd0693103809b833e6beeb885325cd40f1e4ce5d77932f10ba6e73fd30194";
+      sha256 = "51be5b54589d6eeb5fc62eb29d568c8fb259dc862fd0a6f281957433f5c85724";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b9/linux-i686/ca/firefox-112.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b2/linux-i686/ca/firefox-113.0b2.tar.bz2";
       locale = "ca";
       arch = "linux-i686";
-      sha256 = "5da0eb117ecc1bea59a7da773be9712a83e22cda716e72323fdbe92650d4048a";
+      sha256 = "3020b12f49cbe97eac546600f2f03a81ebf696888c47c82727b9559027c8b28e";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b9/linux-i686/cak/firefox-112.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b2/linux-i686/cak/firefox-113.0b2.tar.bz2";
       locale = "cak";
       arch = "linux-i686";
-      sha256 = "23916f6e5f7fcf52224ff0ccf2f89cbbc875072e553028bac413603247b1c0b7";
+      sha256 = "9697a4cca82fcbaaa933ba9a736d66ff2033bc4ed6f6e73f4010714ea9a126d4";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b9/linux-i686/cs/firefox-112.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b2/linux-i686/cs/firefox-113.0b2.tar.bz2";
       locale = "cs";
       arch = "linux-i686";
-      sha256 = "b0f8565992048be1e57468df4a0918247264e6b220ccaf2f4513edb2eba9ed0e";
+      sha256 = "9868e3cdcd3e4d291a5250ab2aadf12e3dedf4de28e97d62cf648f8b2a2e1553";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b9/linux-i686/cy/firefox-112.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b2/linux-i686/cy/firefox-113.0b2.tar.bz2";
       locale = "cy";
       arch = "linux-i686";
-      sha256 = "0a76334c6fd018d5846294215abc4bcf90c406378b829bea17e47b8fbab3c19f";
+      sha256 = "f11f150633369cf19d8a77547a822df1184844f499c4d60148d5e58695123777";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b9/linux-i686/da/firefox-112.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b2/linux-i686/da/firefox-113.0b2.tar.bz2";
       locale = "da";
       arch = "linux-i686";
-      sha256 = "0dfc849b5b8e71da29ec9961f373e701b4ac64263f60e3baa229e82210e4b33f";
+      sha256 = "1e5eac58597ac3e1c5ef0ad277928d6b0f5c878701b58c87ab56bcdb1e1bc257";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b9/linux-i686/de/firefox-112.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b2/linux-i686/de/firefox-113.0b2.tar.bz2";
       locale = "de";
       arch = "linux-i686";
-      sha256 = "dd2b4f2a90eab01fac82b87645ca59ec246d21117e5e9acc6c878b0cb2f32637";
+      sha256 = "bd34829a241eeab046def54d9cea77e61f582811955f1793a2b9c751ae1a358c";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b9/linux-i686/dsb/firefox-112.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b2/linux-i686/dsb/firefox-113.0b2.tar.bz2";
       locale = "dsb";
       arch = "linux-i686";
-      sha256 = "21f16d8ff038bdf10886f0b5d9fbba3fd0c341b5f27c648d42d16b58c5ae34b4";
+      sha256 = "8d5fc54d686f8584ef0dc54203a468c9580c4d2a2487a809cacad4fef1b665a5";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b9/linux-i686/el/firefox-112.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b2/linux-i686/el/firefox-113.0b2.tar.bz2";
       locale = "el";
       arch = "linux-i686";
-      sha256 = "7ee94f78c0a466d4691fd32d49b07187249b6d6f59681a039cee4ed14bfca499";
+      sha256 = "2c4809947c46ba8f11f8c668e3544d04daa964c69c838f284a364f4b9a9543a4";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b9/linux-i686/en-CA/firefox-112.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b2/linux-i686/en-CA/firefox-113.0b2.tar.bz2";
       locale = "en-CA";
       arch = "linux-i686";
-      sha256 = "8f055b12c122b258fafc4be914e898af7e0b3fb94a1fcfa96480c285b4048ad0";
+      sha256 = "3b5bb27a027ea16bb022a340e7e7c97cd5de92766aae660dde9df1fa6cad8535";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b9/linux-i686/en-GB/firefox-112.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b2/linux-i686/en-GB/firefox-113.0b2.tar.bz2";
       locale = "en-GB";
       arch = "linux-i686";
-      sha256 = "779e43e31a561eac73581b2b4fc28677850f2c7861c014fb7fdf1635f21a6d62";
+      sha256 = "712a68f9e4d0bc40c3d504aef551f1e691fdc2402380bf1c9c4a1a754cbefcca";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b9/linux-i686/en-US/firefox-112.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b2/linux-i686/en-US/firefox-113.0b2.tar.bz2";
       locale = "en-US";
       arch = "linux-i686";
-      sha256 = "25c64c4b17b8dcf9fce641be3d002fa9718adcb555e2aff179c487e405f90b93";
+      sha256 = "1b387ac6604a4ef040b3a52ef930b760c3a0bab5b6363ff46f66079aace298d7";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b9/linux-i686/eo/firefox-112.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b2/linux-i686/eo/firefox-113.0b2.tar.bz2";
       locale = "eo";
       arch = "linux-i686";
-      sha256 = "f0a3250e3cc260d1f9ae05f18912c082f3027caf20fb9b9324553d50cce011ae";
+      sha256 = "a649c80036ca73800995a95f8c1523affdcc46338cb10d807291aa05f2b5249b";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b9/linux-i686/es-AR/firefox-112.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b2/linux-i686/es-AR/firefox-113.0b2.tar.bz2";
       locale = "es-AR";
       arch = "linux-i686";
-      sha256 = "b539cf941825864a4f83129a3104b4bc662b1a6bb707d8de0db4ab0f8e3ff2ad";
+      sha256 = "6a87ff7c6a28ace5a1edf6802a02df20d3f8ba2e787f2afac9f7663f78b1d2dc";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b9/linux-i686/es-CL/firefox-112.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b2/linux-i686/es-CL/firefox-113.0b2.tar.bz2";
       locale = "es-CL";
       arch = "linux-i686";
-      sha256 = "820a8228489595747767e62f2fba6e1f4784f0f42cf172794e49d752c9345d56";
+      sha256 = "8dbe070659185e60b7c103d8c11904ea8b19f86ba427782482fd5ba9aadbd5a4";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b9/linux-i686/es-ES/firefox-112.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b2/linux-i686/es-ES/firefox-113.0b2.tar.bz2";
       locale = "es-ES";
       arch = "linux-i686";
-      sha256 = "c8b8ca226b25e8cc3356d65bb5718931ceb89a026aba6dbf21dc6093ef2bd13c";
+      sha256 = "3dcea12f324a982a51e5c2de4740e201c48f5df4eb29eb115c1e50d3b599de67";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b9/linux-i686/es-MX/firefox-112.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b2/linux-i686/es-MX/firefox-113.0b2.tar.bz2";
       locale = "es-MX";
       arch = "linux-i686";
-      sha256 = "0548558f5035a0d4d9a0ac786da82dcff921100cdd2548ee68164b00c084dbd2";
+      sha256 = "fe234fc3c9c3b3e99ebc8f7de0e91b786bcc9f3ea195fb73ac87c746a3140ce8";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b9/linux-i686/et/firefox-112.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b2/linux-i686/et/firefox-113.0b2.tar.bz2";
       locale = "et";
       arch = "linux-i686";
-      sha256 = "cd50a4d857ffdc11e5176e75ded4ee7f5423e2f76dd6b97e350588f31bfe36bc";
+      sha256 = "1e575b5cdc9ae42bf29e6fda615711fd2f4928fda81f499ab4b1c8e61d024f41";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b9/linux-i686/eu/firefox-112.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b2/linux-i686/eu/firefox-113.0b2.tar.bz2";
       locale = "eu";
       arch = "linux-i686";
-      sha256 = "e53eb71791ac5d4b7c146397436953bcb13ef523bbf87c8bb635dda75bc6aad6";
+      sha256 = "b3951c49a4326812d513ef69fce3682bacb47e7dc5160c43fd5f27962c531384";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b9/linux-i686/fa/firefox-112.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b2/linux-i686/fa/firefox-113.0b2.tar.bz2";
       locale = "fa";
       arch = "linux-i686";
-      sha256 = "7236e47b47458bd976ad2c8e31d15dbac86c858aafe0fef9a759b7c1b692ee25";
+      sha256 = "34145541738f6f3fd04ac25e7580eb563baa830f45edd88e836a8c8e9026c555";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b9/linux-i686/ff/firefox-112.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b2/linux-i686/ff/firefox-113.0b2.tar.bz2";
       locale = "ff";
       arch = "linux-i686";
-      sha256 = "fb918621850bfbdf20b24fae1d4a707fc26990a9ec2886f99241a946c46bc521";
+      sha256 = "04aba41be169c3708cfb8af994849e076908a46cf625ac715959da5d406d9d43";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b9/linux-i686/fi/firefox-112.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b2/linux-i686/fi/firefox-113.0b2.tar.bz2";
       locale = "fi";
       arch = "linux-i686";
-      sha256 = "a53e107f03b778d8efe35a3abe5d4654b0e630b26123f48be7c71d499d7e0f8d";
+      sha256 = "8f82c3d4a660d5f89dec6957c815fc2bf9cda623d7cbb7ec98892ba168a005fa";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b9/linux-i686/fr/firefox-112.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b2/linux-i686/fr/firefox-113.0b2.tar.bz2";
       locale = "fr";
       arch = "linux-i686";
-      sha256 = "1fe21320a28ccc4eebe82736014ab35a220756bb53863a602367e7d0ab48069b";
+      sha256 = "dacf22f18a4c85c6d2e8d41f59a403b007f33bd8cceb8e51bb44ea9b2a85f0e7";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b9/linux-i686/fur/firefox-112.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b2/linux-i686/fur/firefox-113.0b2.tar.bz2";
       locale = "fur";
       arch = "linux-i686";
-      sha256 = "261d16147d9322f25f270cc54b95a83320dfa65e348f77c3c3a8761281738c85";
+      sha256 = "4e9bc1058879d906d1fba8a80743211345488c94d8a5f1ec259defe4c503d669";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b9/linux-i686/fy-NL/firefox-112.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b2/linux-i686/fy-NL/firefox-113.0b2.tar.bz2";
       locale = "fy-NL";
       arch = "linux-i686";
-      sha256 = "e03aa664a31fb07d8b3ec4e2eaf5cea06328b1e0a17c74213acc20a441eb527b";
+      sha256 = "0ffa34e28fbfd4b3d2199ec2cf66d82a896ff80d3f1dd13e40f26a65e4dd80fa";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b9/linux-i686/ga-IE/firefox-112.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b2/linux-i686/ga-IE/firefox-113.0b2.tar.bz2";
       locale = "ga-IE";
       arch = "linux-i686";
-      sha256 = "4fa8df21724ef4fdd8af994b82e106e7eb885543d0137506885d6fba12adaca5";
+      sha256 = "f6f15273a14ee83bf63b23fee5f0115cfe6d8a27dd5e43be9b2e929834c459e7";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b9/linux-i686/gd/firefox-112.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b2/linux-i686/gd/firefox-113.0b2.tar.bz2";
       locale = "gd";
       arch = "linux-i686";
-      sha256 = "9538252e56a8971dc1ea7235fb4f9999fafa49c3b2a9581161d72df92c150ec6";
+      sha256 = "199643d9030143d4288a48e058194c6781a591cd0397893f272b7768858d6d72";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b9/linux-i686/gl/firefox-112.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b2/linux-i686/gl/firefox-113.0b2.tar.bz2";
       locale = "gl";
       arch = "linux-i686";
-      sha256 = "6b4972948eac477a0232d560f77568c9f5beb4197cb3ce23b751f1199bf71d17";
+      sha256 = "6746335a05b354f44fc060a1b0f50e897b46cbe4c7aa45b37dc22d71732f1659";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b9/linux-i686/gn/firefox-112.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b2/linux-i686/gn/firefox-113.0b2.tar.bz2";
       locale = "gn";
       arch = "linux-i686";
-      sha256 = "1e99274ec03597bb075e2863f973bae15e31edf206143baa5a8297cafd9d533f";
+      sha256 = "64df184234de243d866598b4de7b4dec72a7512379d10e0a6e37bcbae6b8e00e";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b9/linux-i686/gu-IN/firefox-112.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b2/linux-i686/gu-IN/firefox-113.0b2.tar.bz2";
       locale = "gu-IN";
       arch = "linux-i686";
-      sha256 = "730af60e5398bda4fa0a7235a79796e3ddbc94f4515246ee61a0b8630fea4ee7";
+      sha256 = "700fbc38ab74ecdcaa356f1adb0b612fdcb630dae6e5a4898f1f55200d4e7562";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b9/linux-i686/he/firefox-112.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b2/linux-i686/he/firefox-113.0b2.tar.bz2";
       locale = "he";
       arch = "linux-i686";
-      sha256 = "eef42078a61308baeb9bad18b73ef04284b8d596e208abdac3ba978a87aec101";
+      sha256 = "fd28c284170b434d2b8a7b89c3e598ad83426b40fffaea22f0db4b339fb6fee2";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b9/linux-i686/hi-IN/firefox-112.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b2/linux-i686/hi-IN/firefox-113.0b2.tar.bz2";
       locale = "hi-IN";
       arch = "linux-i686";
-      sha256 = "137d94dc6aab34b1afe2f9f01dbb56a720c852b21928907eb3e13b677302b1b5";
+      sha256 = "91a0da5a09ac27ed6263eff55926a9665bba062fa86120262364d8a1f1ac7649";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b9/linux-i686/hr/firefox-112.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b2/linux-i686/hr/firefox-113.0b2.tar.bz2";
       locale = "hr";
       arch = "linux-i686";
-      sha256 = "3613e9210f985224cfb2fe8cb444953c9435ee53ef1dc54ac372dc0c421815b9";
+      sha256 = "cbd4b966ce765436416962d23d100f372bfd108227702a4e83e677436824da73";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b9/linux-i686/hsb/firefox-112.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b2/linux-i686/hsb/firefox-113.0b2.tar.bz2";
       locale = "hsb";
       arch = "linux-i686";
-      sha256 = "4c99ce772ba3665a67f759e730c416f6fa9d3ce43e6321d3babf5f853b778074";
+      sha256 = "754ddd67d4d382b6b32500eb2cb66773194238c5dea22648b5e24a192b0aa2d2";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b9/linux-i686/hu/firefox-112.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b2/linux-i686/hu/firefox-113.0b2.tar.bz2";
       locale = "hu";
       arch = "linux-i686";
-      sha256 = "292f5be8074bed7f6b50bf2820d4b19b95fa9ec246d0b49999fffa6e0932552c";
+      sha256 = "88283fb67c2145bf42d2676b6b767d01fd4d43b732e918388bb030be3deee567";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b9/linux-i686/hy-AM/firefox-112.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b2/linux-i686/hy-AM/firefox-113.0b2.tar.bz2";
       locale = "hy-AM";
       arch = "linux-i686";
-      sha256 = "419177cf4b483ae9c28772dc3041d8d08c081ad3f65de44f7ce4cda260ef6bcf";
+      sha256 = "0d0c913226d0481cafb6f36bd2b0319580b89b28bde3dfac051c1670d8f529a7";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b9/linux-i686/ia/firefox-112.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b2/linux-i686/ia/firefox-113.0b2.tar.bz2";
       locale = "ia";
       arch = "linux-i686";
-      sha256 = "de00ee9c794cd03d6b88ab8f8ff18c93b85c7d57123eae66f605de60a015d9be";
+      sha256 = "29c736d62794f7e6dddb612fd7d893f0d5183c152febb31a681cbec6b6aafc10";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b9/linux-i686/id/firefox-112.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b2/linux-i686/id/firefox-113.0b2.tar.bz2";
       locale = "id";
       arch = "linux-i686";
-      sha256 = "161a435320690cc77f3c560e2dcc5832cf7e567e902bd2c5355d3b99a655329c";
+      sha256 = "bec649feb60cad4b94e88969731da86810421ce7496546829308f94f1b5d80cb";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b9/linux-i686/is/firefox-112.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b2/linux-i686/is/firefox-113.0b2.tar.bz2";
       locale = "is";
       arch = "linux-i686";
-      sha256 = "ca6932f16206e076c0c774bb0ba37c8e402d1517af49f94572077dd181f52747";
+      sha256 = "cab32fe4560851ed31b6bba8be302307a390017efd96acc5619fab5a4991278c";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b9/linux-i686/it/firefox-112.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b2/linux-i686/it/firefox-113.0b2.tar.bz2";
       locale = "it";
       arch = "linux-i686";
-      sha256 = "12e951633190af37bc946139060c42bdfe54f2d19c82c38ce38737915ccc3c8d";
+      sha256 = "16b571b4ed4700d53fa10e340866218344edf1ed066a6d34a385cbba0b548dae";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b9/linux-i686/ja/firefox-112.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b2/linux-i686/ja/firefox-113.0b2.tar.bz2";
       locale = "ja";
       arch = "linux-i686";
-      sha256 = "5f67aaa9b6766f75006c8afc523f76eded9b896df025832b1e6dd39cefcb552c";
+      sha256 = "d24ac44261ada6f13a8160b565817739b6335940fa015d7369a0f32290f8ab1c";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b9/linux-i686/ka/firefox-112.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b2/linux-i686/ka/firefox-113.0b2.tar.bz2";
       locale = "ka";
       arch = "linux-i686";
-      sha256 = "39994e2f83615b8c3783dc16a743c01f50ae0acd34bc84cfea2220d444d86709";
+      sha256 = "dd638504c554209cef24f3ef307eedc0c30876ee59c7265a3effdc3b957a9f46";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b9/linux-i686/kab/firefox-112.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b2/linux-i686/kab/firefox-113.0b2.tar.bz2";
       locale = "kab";
       arch = "linux-i686";
-      sha256 = "10cdf68edc4dd686964e7eb86ccc2b7fe40297b142ac677e2a66956a3558488c";
+      sha256 = "e1788279f6c5f9e8b2d405a59ce6c05b9ce54ca408ce599a5a9bf2d8cb31f648";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b9/linux-i686/kk/firefox-112.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b2/linux-i686/kk/firefox-113.0b2.tar.bz2";
       locale = "kk";
       arch = "linux-i686";
-      sha256 = "c79bfb00636de01b471e2f1e54c2188de1981402fd6e6decef086b09d21b59f7";
+      sha256 = "e2beb70dcf74bdc81e39ff741929bf2661c7abd80d79a09b3921260db45cf800";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b9/linux-i686/km/firefox-112.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b2/linux-i686/km/firefox-113.0b2.tar.bz2";
       locale = "km";
       arch = "linux-i686";
-      sha256 = "e99a160126c6f1f2e52ba26d5a2472f7b3b33c97081a11ad83cc5678068a80b2";
+      sha256 = "7162a19636ffc9cdc4a5c570e573c656fb659fe977c528def18dd127262507e7";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b9/linux-i686/kn/firefox-112.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b2/linux-i686/kn/firefox-113.0b2.tar.bz2";
       locale = "kn";
       arch = "linux-i686";
-      sha256 = "d061898a5ab1e649494512e876bcf44c180b304727d24fba59d21d8cecfdff81";
+      sha256 = "b948e3b83e5bc386d1155ae2fb17a639a9ce3183b74cfea1d01d7891834ebc93";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b9/linux-i686/ko/firefox-112.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b2/linux-i686/ko/firefox-113.0b2.tar.bz2";
       locale = "ko";
       arch = "linux-i686";
-      sha256 = "3f2ae9061fdf3921da0049d28b55a7ede78127958befa86c0631e03cf48392ac";
+      sha256 = "1f6c577aa5b92ceaaceeb7f20c45fb8c6b1c8f2c86ae1c32ac9ff37d7bc22efd";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b9/linux-i686/lij/firefox-112.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b2/linux-i686/lij/firefox-113.0b2.tar.bz2";
       locale = "lij";
       arch = "linux-i686";
-      sha256 = "a24e564bba652430850f4dbdcc0016093d42b3d7abe59e9af6ee0779b389d598";
+      sha256 = "0cabbebe77055cf07b8f69d130c48d7adf1f140a92944cdaf2d4f6e5e0aa1560";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b9/linux-i686/lt/firefox-112.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b2/linux-i686/lt/firefox-113.0b2.tar.bz2";
       locale = "lt";
       arch = "linux-i686";
-      sha256 = "a23381acf6a20be2eb4fabd8e655fd82de0f371178e059dc780d0e93fbe0ed37";
+      sha256 = "d9723a3741df335382b82ed4903a032e26232f96bbf6ecc467d478d44e552700";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b9/linux-i686/lv/firefox-112.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b2/linux-i686/lv/firefox-113.0b2.tar.bz2";
       locale = "lv";
       arch = "linux-i686";
-      sha256 = "f25f0023a39d2cb75a91e53b610b9cd5cd578085034f71b8b6699ecc5b4a70ad";
+      sha256 = "6232345a0e6034ff8409630ebe1e5d95d80d33a4c9a4f6301c5cfd07d9560679";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b9/linux-i686/mk/firefox-112.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b2/linux-i686/mk/firefox-113.0b2.tar.bz2";
       locale = "mk";
       arch = "linux-i686";
-      sha256 = "30bfae2b5862d920b1c4bab628beebef0d84c3a86bc5f3ec6f16716c79e5a8a8";
+      sha256 = "8539c5bf7f3959d2f526b8f41e985ab7d5f71c8b5077e3b094d1228be813a2c8";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b9/linux-i686/mr/firefox-112.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b2/linux-i686/mr/firefox-113.0b2.tar.bz2";
       locale = "mr";
       arch = "linux-i686";
-      sha256 = "0b6d868246682b953ebd15c6b8f9e062c2172e63a6575979e68f3cae4d4310b3";
+      sha256 = "b8365ba21b55e5cf774a6b25fa51a15c8053110beb330f3dad5adac9b4aff20d";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b9/linux-i686/ms/firefox-112.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b2/linux-i686/ms/firefox-113.0b2.tar.bz2";
       locale = "ms";
       arch = "linux-i686";
-      sha256 = "d1d44a9a35c11cb6f9d37c295aeb5cc2cb8f90ac8d8847b7db730d659f567ba6";
+      sha256 = "020d3317b4752bde5a0d4b545fcdd0a353192d439fe429e62dcf414a5bc62561";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b9/linux-i686/my/firefox-112.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b2/linux-i686/my/firefox-113.0b2.tar.bz2";
       locale = "my";
       arch = "linux-i686";
-      sha256 = "4e59fef9898aac1d34ebaefdf1c4aff1c159d7a8b01b82c0d2a23deee8d7e7fe";
+      sha256 = "b4215ca0a36cce9aeb362852682bbf4a6a087349fd72fc494e7b5a672164798e";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b9/linux-i686/nb-NO/firefox-112.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b2/linux-i686/nb-NO/firefox-113.0b2.tar.bz2";
       locale = "nb-NO";
       arch = "linux-i686";
-      sha256 = "71de49987238a557a21980b756d455c6d3301e3af22ccd7518ceeb144a5ceb05";
+      sha256 = "634c26c0c8debc4f26ff0267cd9b4a33a968f142fbfa5718797c5b98cf6b326c";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b9/linux-i686/ne-NP/firefox-112.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b2/linux-i686/ne-NP/firefox-113.0b2.tar.bz2";
       locale = "ne-NP";
       arch = "linux-i686";
-      sha256 = "185e525f708dc8e1d1f2267bcf813f278162230341e597d19be8eb36b591b196";
+      sha256 = "98819132fb3d40696ec2a68b2fa2211d8423877366b86240a40936a901af641c";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b9/linux-i686/nl/firefox-112.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b2/linux-i686/nl/firefox-113.0b2.tar.bz2";
       locale = "nl";
       arch = "linux-i686";
-      sha256 = "45bef7cd4fbddc40a07772b69957d917cbf2fd46aa791c0cc80d8564df8137ab";
+      sha256 = "982169887d9dafc4d16b058df1dbfbd92330d6555679636734f70eae34cebaa5";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b9/linux-i686/nn-NO/firefox-112.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b2/linux-i686/nn-NO/firefox-113.0b2.tar.bz2";
       locale = "nn-NO";
       arch = "linux-i686";
-      sha256 = "52889289331cb278d248aa99b067d824cfb380ff9e206d51a62de7092ec4c66b";
+      sha256 = "5636846839fb83e1d40e64115d2f9fbf67e94e4f6271cd5e2a1a6237d9f389b1";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b9/linux-i686/oc/firefox-112.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b2/linux-i686/oc/firefox-113.0b2.tar.bz2";
       locale = "oc";
       arch = "linux-i686";
-      sha256 = "da31d005b42c12ec543e69663bc5c11e88cb7e4022becdc165f78498b93281c6";
+      sha256 = "f4927c21e8a3f6151e8e571bf2f08a13716164775daf95748e804975ce7f5e0d";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b9/linux-i686/pa-IN/firefox-112.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b2/linux-i686/pa-IN/firefox-113.0b2.tar.bz2";
       locale = "pa-IN";
       arch = "linux-i686";
-      sha256 = "7504f525116b060d2a32ef21e0d047c64e5214d3ee2be75094718623ec5d2487";
+      sha256 = "286e43d9bbe70b75d6ce8adf12617d2d4ab120bb3285812047fdd5d296e69dfc";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b9/linux-i686/pl/firefox-112.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b2/linux-i686/pl/firefox-113.0b2.tar.bz2";
       locale = "pl";
       arch = "linux-i686";
-      sha256 = "26bcbb819370de9a319fa9ab78dee86f4f0ceda8fd7970323d4170415e163a5b";
+      sha256 = "2d0b7741f9b8156f25b989bf49508e66bf1e4126a95576e4fdb1c8006d0cbfaf";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b9/linux-i686/pt-BR/firefox-112.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b2/linux-i686/pt-BR/firefox-113.0b2.tar.bz2";
       locale = "pt-BR";
       arch = "linux-i686";
-      sha256 = "5decee49196cd32ac8099e34008133c6586aaf76b2b727d9224838b39ff1ec37";
+      sha256 = "279211754415ab644c2dfcd114b007d82e8c684204f8541a8ee55279df827842";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b9/linux-i686/pt-PT/firefox-112.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b2/linux-i686/pt-PT/firefox-113.0b2.tar.bz2";
       locale = "pt-PT";
       arch = "linux-i686";
-      sha256 = "79971e1d9ea66396797e86a9b5a6cef874eefa408e985e902171fa67bd2ef379";
+      sha256 = "ef89429a5a950589df7fd7cadd56c1da24c482fa50ed6f4e44fb184f557bef3e";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b9/linux-i686/rm/firefox-112.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b2/linux-i686/rm/firefox-113.0b2.tar.bz2";
       locale = "rm";
       arch = "linux-i686";
-      sha256 = "50b9f5d2fb7c4783511282a7a8a9c619f72aa7afc30f927f5e939318f8669677";
+      sha256 = "23371559057b49d19eaea74f22771fedf8cc4a18a4f63a574b67f06c431ec804";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b9/linux-i686/ro/firefox-112.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b2/linux-i686/ro/firefox-113.0b2.tar.bz2";
       locale = "ro";
       arch = "linux-i686";
-      sha256 = "2f1c61bfedbad282615d29f32e04b38555c8599ca3df7a682cbee1ec6b626f1e";
+      sha256 = "c185c9592dce479af6f8536a888cbac9b21a6a9b4d18a9aca696bf88ae0da6db";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b9/linux-i686/ru/firefox-112.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b2/linux-i686/ru/firefox-113.0b2.tar.bz2";
       locale = "ru";
       arch = "linux-i686";
-      sha256 = "af34ab546737c8783bda33717a3c70e34d12cd02e163785d968a0c8807b0cc55";
+      sha256 = "6b167db7ecf184551574d4c32e31ccef8f60bf41d672e7f5693fbe7f8c3c5e47";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b9/linux-i686/sc/firefox-112.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b2/linux-i686/sc/firefox-113.0b2.tar.bz2";
       locale = "sc";
       arch = "linux-i686";
-      sha256 = "6eef5281d7d8264ef48b18d5a44ec1f6e9d90ff2007317c959a388e73398a431";
+      sha256 = "da80b35b18b2a9b5dca3e7328242fdcd61e3af4d6cfff9789c508986262957c5";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b9/linux-i686/sco/firefox-112.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b2/linux-i686/sco/firefox-113.0b2.tar.bz2";
       locale = "sco";
       arch = "linux-i686";
-      sha256 = "9ef6ea368005ef655b6691d36fb45fd52356f09406c1a8f5e099e8acf4912193";
+      sha256 = "7ecf3f0a8b60aab8867493588f407d1e1ecca8914195549bfdacc6d4c3004ecc";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b9/linux-i686/si/firefox-112.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b2/linux-i686/si/firefox-113.0b2.tar.bz2";
       locale = "si";
       arch = "linux-i686";
-      sha256 = "fa3bb662d0318931ef1fd06a7805f7dbbaf09a8be680b6b23c6f254f221b04e3";
+      sha256 = "7bca2536a121fdd2a6e2b4bb166ee9ea8ae0b89a91725a6b03e0696beb3acdca";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b9/linux-i686/sk/firefox-112.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b2/linux-i686/sk/firefox-113.0b2.tar.bz2";
       locale = "sk";
       arch = "linux-i686";
-      sha256 = "797817df30d67c77382997887e2997515651431eadec6952cb0712d082440a59";
+      sha256 = "9ab8f73f31a3f2c7dddc53d0a8b1a25aa0f3aff7750f6bf1f8df84421808ad2f";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b9/linux-i686/sl/firefox-112.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b2/linux-i686/sl/firefox-113.0b2.tar.bz2";
       locale = "sl";
       arch = "linux-i686";
-      sha256 = "3e9e9b81e369efd7c561877d4f460f20e1ad1f2af077f86acc1a4012dfb95dd6";
+      sha256 = "03ab5e7bf573ee935b3e341f750d4dc77b164c51445830f0d45d58c208ab53e8";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b9/linux-i686/son/firefox-112.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b2/linux-i686/son/firefox-113.0b2.tar.bz2";
       locale = "son";
       arch = "linux-i686";
-      sha256 = "a8532bd84d1053568eaf532eb77e3c69dbc408711551f7b72f0a44f39428d619";
+      sha256 = "654d602dadc8bd4b1b3c2423e605b7979a30ceb6c459fbed7f4fff5001ea60df";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b9/linux-i686/sq/firefox-112.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b2/linux-i686/sq/firefox-113.0b2.tar.bz2";
       locale = "sq";
       arch = "linux-i686";
-      sha256 = "d6a714a82b0ea50b922b9bb98d8898e1745895f0f1c92a60fdbd8ca1e0b42acb";
+      sha256 = "643968cee647ff76165ccf4d2a764cd6191a567fba91ae3b33c8ff93a49e8164";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b9/linux-i686/sr/firefox-112.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b2/linux-i686/sr/firefox-113.0b2.tar.bz2";
       locale = "sr";
       arch = "linux-i686";
-      sha256 = "43cad271b65f2678d44bb5bbe64fc836bb1a9ac97bc8f8c7945edb60dfdb6a39";
+      sha256 = "f13aeb85a98fe603440e09aa18bd54a16a69ae36d740bcd9e5e42dcc0bf39e74";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b9/linux-i686/sv-SE/firefox-112.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b2/linux-i686/sv-SE/firefox-113.0b2.tar.bz2";
       locale = "sv-SE";
       arch = "linux-i686";
-      sha256 = "92ca723f06dd1a1ae031fa90eac0d851de3d525ad3b1ec4d2c9b53ae1779e2fd";
+      sha256 = "b7fda09aadecfd8c3eb54e3d52b3e9bf5b861bbe9eb242331be1d13a87cfca7f";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b9/linux-i686/szl/firefox-112.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b2/linux-i686/szl/firefox-113.0b2.tar.bz2";
       locale = "szl";
       arch = "linux-i686";
-      sha256 = "e33b8c132ce3a190a2d95b9b586bac4dabc91e90c3fbb3f7a0b5b38ba516a928";
+      sha256 = "33f3e095b3c81f6d2d735e26bd13abd44f2de8ff4f0961acf07575c7a1c8540d";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b9/linux-i686/ta/firefox-112.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b2/linux-i686/ta/firefox-113.0b2.tar.bz2";
       locale = "ta";
       arch = "linux-i686";
-      sha256 = "22bbda22f0d0822ce3514983b0cbf252b787abf717130cc3e20e0e17d8ff3c65";
+      sha256 = "78b7288a4554bcc45adccc08613a3ed3251442e165e21479591382cc13dd450e";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b9/linux-i686/te/firefox-112.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b2/linux-i686/te/firefox-113.0b2.tar.bz2";
       locale = "te";
       arch = "linux-i686";
-      sha256 = "1c3a65b3a2b8163d77d2b2010d01d91537720c72d12df389bff1f9d59b8c309c";
+      sha256 = "9e2de8945ad24b6e172ba8682bb8a49364258d87bd7a9f07c1aae99b76e4a916";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b9/linux-i686/th/firefox-112.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b2/linux-i686/tg/firefox-113.0b2.tar.bz2";
+      locale = "tg";
+      arch = "linux-i686";
+      sha256 = "7b1078f672c6a8f39d2a181eec7d2ac7418af19c4ac84dd632b81599b14f84b2";
+    }
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b2/linux-i686/th/firefox-113.0b2.tar.bz2";
       locale = "th";
       arch = "linux-i686";
-      sha256 = "86d431b1caf9182d1ea8bb26d58d498014198433002725c422b6850eddb5eaf9";
+      sha256 = "af0e5f9fcf2f3032b53bf14f89c9b4594721bcead28cd86fb01902a52d10d1cf";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b9/linux-i686/tl/firefox-112.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b2/linux-i686/tl/firefox-113.0b2.tar.bz2";
       locale = "tl";
       arch = "linux-i686";
-      sha256 = "8bfb89a87921a8f912ab9502d802ba060aa1ad60364465f231b9121d6134ee3d";
+      sha256 = "921f13e434aa76d2dafa57065337ab8087d572426b7269f9368e574f395d40ec";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b9/linux-i686/tr/firefox-112.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b2/linux-i686/tr/firefox-113.0b2.tar.bz2";
       locale = "tr";
       arch = "linux-i686";
-      sha256 = "0a81097984bb2e9374a7f7aaec8041ed78640fda55f982ed852121f53218f553";
+      sha256 = "c83bac81d80180993b1bc754ade6420865d1fe0f1239548dbb96913e28ac06be";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b9/linux-i686/trs/firefox-112.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b2/linux-i686/trs/firefox-113.0b2.tar.bz2";
       locale = "trs";
       arch = "linux-i686";
-      sha256 = "dc72511645f769678ba696a909ce1c62b6b6ef8bb8de227c0e0baa8b14bfb75e";
+      sha256 = "18cc5f9e830195e08f3243bef085a08d9f7b4b72b35f33e5ab7fb2f5ef9bfb06";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b9/linux-i686/uk/firefox-112.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b2/linux-i686/uk/firefox-113.0b2.tar.bz2";
       locale = "uk";
       arch = "linux-i686";
-      sha256 = "3eea691202fb0c5231d1385f0dfb7f47aa4205b5e0791351d908bb7cc9377df2";
+      sha256 = "f03a3ddf8b48630ba6f3f550d7e3e8dbd6f3f3e7aac9f9ed27e93919d20bd744";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b9/linux-i686/ur/firefox-112.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b2/linux-i686/ur/firefox-113.0b2.tar.bz2";
       locale = "ur";
       arch = "linux-i686";
-      sha256 = "664e45452ef12bdaff731213bfbdf0e7706512ab3a0ca30774ce6ba803cfc64e";
+      sha256 = "719cd7c8b9ff0bea03e27e8c804b83845849d9358ea6faa2bbf7516564fa8535";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b9/linux-i686/uz/firefox-112.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b2/linux-i686/uz/firefox-113.0b2.tar.bz2";
       locale = "uz";
       arch = "linux-i686";
-      sha256 = "77b9ed6ce3aeb2f86d45937449c0d1fe3d2c1bdd81afa0df7ab1ff5ed01c557f";
+      sha256 = "5c622ce64af91bb2a97f94f9303f71f127536b5bca447cd8468efd0bd78c2f1d";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b9/linux-i686/vi/firefox-112.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b2/linux-i686/vi/firefox-113.0b2.tar.bz2";
       locale = "vi";
       arch = "linux-i686";
-      sha256 = "8d0574109f296a3b9c8b4b4b48eb9009bbb3ceb8943af2a80292378b0589e03d";
+      sha256 = "d0b64d4673dc3f31126202d739c118aa1a22c7d62f4750ed1c6fc9929ccfbef6";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b9/linux-i686/xh/firefox-112.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b2/linux-i686/xh/firefox-113.0b2.tar.bz2";
       locale = "xh";
       arch = "linux-i686";
-      sha256 = "0ca131a2014f5158d51cf493f21ef0b1088f7a8e0923ebefe003f9eecf3f8050";
+      sha256 = "b2796891a1055758f0a07f7f008f7c675b5e39d629f80cda17ffc54ce9c2422e";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b9/linux-i686/zh-CN/firefox-112.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b2/linux-i686/zh-CN/firefox-113.0b2.tar.bz2";
       locale = "zh-CN";
       arch = "linux-i686";
-      sha256 = "222c1555846eeeb7864356a081fd51af1c29a17a0e1f2fa031bad6c10b4615ee";
+      sha256 = "1be837eb7baf745d3cce35a560ddbcc41190006ff00ef6391442470ac3ef5d32";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/112.0b9/linux-i686/zh-TW/firefox-112.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b2/linux-i686/zh-TW/firefox-113.0b2.tar.bz2";
       locale = "zh-TW";
       arch = "linux-i686";
-      sha256 = "4ffb560396e144afe416123f3f0e9e15c85421eb9e3cca6c78fc27a9353d4e3e";
+      sha256 = "c3aa1828615a5ac80df646fb090aadda6ced6de4b312f8fb4114db7be838e8ec";
     }
     ];
 }

--- a/pkgs/applications/networking/browsers/firefox-bin/devedition_sources.nix
+++ b/pkgs/applications/networking/browsers/firefox-bin/devedition_sources.nix
@@ -1,1015 +1,1015 @@
 {
-  version = "113.0b2";
+  version = "113.0b3";
   sources = [
-    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b2/linux-x86_64/ach/firefox-113.0b2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b3/linux-x86_64/ach/firefox-113.0b3.tar.bz2";
       locale = "ach";
       arch = "linux-x86_64";
-      sha256 = "f40dd5b35d1cfd958a380010c427381e83aa2ec691e68a90afde6ccad102867a";
+      sha256 = "454955bfaaa3049adac17e36781b4417088800e08a20bf1d70b0f841316721ac";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b2/linux-x86_64/af/firefox-113.0b2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b3/linux-x86_64/af/firefox-113.0b3.tar.bz2";
       locale = "af";
       arch = "linux-x86_64";
-      sha256 = "ed3f289a69663d4d9d31498bb3ab6de0a84df008230e793412d8a10ce26be2ff";
+      sha256 = "5516240f7956aa9b46145fc5cdfbedf96464884296a78b27d71ebb3d2a617992";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b2/linux-x86_64/an/firefox-113.0b2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b3/linux-x86_64/an/firefox-113.0b3.tar.bz2";
       locale = "an";
       arch = "linux-x86_64";
-      sha256 = "305f9e24169e66965d639755f01d0a6429aa41d43fce32deab8308f4b55b6bcc";
+      sha256 = "47132a2df4f6f223614005c1c9fdfef79d4f9efa1bc1513c8a54d50417ff555b";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b2/linux-x86_64/ar/firefox-113.0b2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b3/linux-x86_64/ar/firefox-113.0b3.tar.bz2";
       locale = "ar";
       arch = "linux-x86_64";
-      sha256 = "2300df3512b9f4e869edaf6b20dc572d8261aa64e106205a718c3ebbc1db7b1f";
+      sha256 = "5375505b78a205984de1dc0e23c7c0b6dd73d6e3103a3038098800efa9bff853";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b2/linux-x86_64/ast/firefox-113.0b2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b3/linux-x86_64/ast/firefox-113.0b3.tar.bz2";
       locale = "ast";
       arch = "linux-x86_64";
-      sha256 = "85e3154bf99d52caea920d3e1bff4adbc1ed896d35124c674115272b2c6efcff";
+      sha256 = "e81c6cd7a02590292186e75481324613f793e126e84b5b3364b330ca8fb7bd59";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b2/linux-x86_64/az/firefox-113.0b2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b3/linux-x86_64/az/firefox-113.0b3.tar.bz2";
       locale = "az";
       arch = "linux-x86_64";
-      sha256 = "961ef8ef27f7751e29610ae86d3807ba407d5c2181df27c062ae347b8ba3688a";
+      sha256 = "09ad87cda099302595d7829b2b7abceb52396dee79f2e3bdf174567e5a0efb68";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b2/linux-x86_64/be/firefox-113.0b2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b3/linux-x86_64/be/firefox-113.0b3.tar.bz2";
       locale = "be";
       arch = "linux-x86_64";
-      sha256 = "514abecd7c77f2f73f6e188857cb5d806daf6112a44f867cbdee2f2e65bf4dad";
+      sha256 = "9cdaac1ab79c08f2e6839aad93294c6031d6f5d58dd2fdae9d508895b727ce65";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b2/linux-x86_64/bg/firefox-113.0b2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b3/linux-x86_64/bg/firefox-113.0b3.tar.bz2";
       locale = "bg";
       arch = "linux-x86_64";
-      sha256 = "e240e39e868ccb4899576320875f805705750393e1d7c63b589c3326cdd79869";
+      sha256 = "3ac3eb80ed229dd0a8455713cad8792f9ce288369a82f624ab451d0e7572e944";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b2/linux-x86_64/bn/firefox-113.0b2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b3/linux-x86_64/bn/firefox-113.0b3.tar.bz2";
       locale = "bn";
       arch = "linux-x86_64";
-      sha256 = "3f930072feb66165d47211a5a337456cca69ff5eae5fdae6ab4c78a85efcef0b";
+      sha256 = "64a258dfc45297dd06fdc5685a666a9558ded0cf4450517d6653b13a7a18d828";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b2/linux-x86_64/br/firefox-113.0b2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b3/linux-x86_64/br/firefox-113.0b3.tar.bz2";
       locale = "br";
       arch = "linux-x86_64";
-      sha256 = "75def5d5dc5b6bb1e4ed2d728d572822e261a7eebcaed0eace8124a2cca81bbc";
+      sha256 = "8eb8fb80921bca450f15024b97c3cf628cdfc58ec33f60bdfb65e2cada5397e6";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b2/linux-x86_64/bs/firefox-113.0b2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b3/linux-x86_64/bs/firefox-113.0b3.tar.bz2";
       locale = "bs";
       arch = "linux-x86_64";
-      sha256 = "bfbfae79cf0edbba7508456f6786ab781b59d691074419078bffe1021becd97f";
+      sha256 = "b4924c6a3c72a8b8fb9c7dc502ca1a912215f1f565b6ca3976b234b36da98476";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b2/linux-x86_64/ca-valencia/firefox-113.0b2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b3/linux-x86_64/ca-valencia/firefox-113.0b3.tar.bz2";
       locale = "ca-valencia";
       arch = "linux-x86_64";
-      sha256 = "d15a2f7ab07a7b5cdb25b9e80ca93c7f204f7eae12275299c418f7510a9713dd";
+      sha256 = "ba0837a8cd6856afdab11de6e1fe190750958eda1ddb9142fcdfa85af9683f5b";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b2/linux-x86_64/ca/firefox-113.0b2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b3/linux-x86_64/ca/firefox-113.0b3.tar.bz2";
       locale = "ca";
       arch = "linux-x86_64";
-      sha256 = "b45cd595fe5ef06f141730b2edd419509345978fe5160bc3fb3728143af50639";
+      sha256 = "80bb919bf727977e8dea121d8ccc41bd1001bfe02cf6f00f611b5450471337a5";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b2/linux-x86_64/cak/firefox-113.0b2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b3/linux-x86_64/cak/firefox-113.0b3.tar.bz2";
       locale = "cak";
       arch = "linux-x86_64";
-      sha256 = "5246f87d31d17bb0d7cbdd747e996820f752cfe089f67713443e7e06c45de0ac";
+      sha256 = "ebdc8be7d14ea5044b5befad5a04f2c07c61b029acdc8e62c9d729a217e8218c";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b2/linux-x86_64/cs/firefox-113.0b2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b3/linux-x86_64/cs/firefox-113.0b3.tar.bz2";
       locale = "cs";
       arch = "linux-x86_64";
-      sha256 = "bd6347d3c5010af6428541199739bab58be8e1bfba2f5dbcad8aaac3b76779a7";
+      sha256 = "066674fd2bfc166f152140f6ac7491039295555db1eb69a2ea13ea2d3c1ff6e6";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b2/linux-x86_64/cy/firefox-113.0b2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b3/linux-x86_64/cy/firefox-113.0b3.tar.bz2";
       locale = "cy";
       arch = "linux-x86_64";
-      sha256 = "83500899f0b492093dca2c18c96f12c8a023b4a57d20183a6430b868e89bfff1";
+      sha256 = "03bec22656be7aa2f543fee2cea3292760f3843975d2d45af2fcfd28f778d83d";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b2/linux-x86_64/da/firefox-113.0b2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b3/linux-x86_64/da/firefox-113.0b3.tar.bz2";
       locale = "da";
       arch = "linux-x86_64";
-      sha256 = "58d94b112eb891936f42155173f94ffe184469a342506bc6394ef8183d7a968d";
+      sha256 = "8c61889417531ad06fb609fbcf2609df372784c173c7ae4f6d8100ae72e9abfa";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b2/linux-x86_64/de/firefox-113.0b2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b3/linux-x86_64/de/firefox-113.0b3.tar.bz2";
       locale = "de";
       arch = "linux-x86_64";
-      sha256 = "d97615778271ea8c9a14f3dcb50612b2d170e0327856658e049e746bb51416bb";
+      sha256 = "0b067f160e87b1a8ea6d46cae3e783aed06366fa8b29f781e936f0576882bb0a";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b2/linux-x86_64/dsb/firefox-113.0b2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b3/linux-x86_64/dsb/firefox-113.0b3.tar.bz2";
       locale = "dsb";
       arch = "linux-x86_64";
-      sha256 = "653394c180595785a29c1e0eac655f2d90e9dcc7578c813b2cd9a71c5d56d026";
+      sha256 = "12d7be3669eb0d370c70bd7bfaa75e54eada19dbec02d4dc2129716263a8ac99";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b2/linux-x86_64/el/firefox-113.0b2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b3/linux-x86_64/el/firefox-113.0b3.tar.bz2";
       locale = "el";
       arch = "linux-x86_64";
-      sha256 = "960c639ae098478e9f9805e38dc9a56359f84b5cec6b2c120ad8b5174b54fd32";
+      sha256 = "c21e1f981f76e04c29208d0f8650634603efff437051a3b73f0edf39eac23376";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b2/linux-x86_64/en-CA/firefox-113.0b2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b3/linux-x86_64/en-CA/firefox-113.0b3.tar.bz2";
       locale = "en-CA";
       arch = "linux-x86_64";
-      sha256 = "1fea26bf92425c4d80cda1694804633251da696fe3990fcb84c18cfa41c84b85";
+      sha256 = "4048b9db329b077e301ae045566037d97b31cd93f313472c217edc590c004c63";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b2/linux-x86_64/en-GB/firefox-113.0b2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b3/linux-x86_64/en-GB/firefox-113.0b3.tar.bz2";
       locale = "en-GB";
       arch = "linux-x86_64";
-      sha256 = "6881e868e7adf125d67872aa79000975635480e5107655d0c060dcb8dbfb2d81";
+      sha256 = "fd24a96b77c2eb6cfff80a649bf3a5380c7cafaeae4f0f9122dab37014753516";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b2/linux-x86_64/en-US/firefox-113.0b2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b3/linux-x86_64/en-US/firefox-113.0b3.tar.bz2";
       locale = "en-US";
       arch = "linux-x86_64";
-      sha256 = "d61b8422e344e6873c9b8b9d23c0610aadd90c71b458d971c2d077324a77b64d";
+      sha256 = "62f8f041348fda32922ccdbc2a3bc64e7276ab76037f90153cc9e2eb1dcbe145";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b2/linux-x86_64/eo/firefox-113.0b2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b3/linux-x86_64/eo/firefox-113.0b3.tar.bz2";
       locale = "eo";
       arch = "linux-x86_64";
-      sha256 = "3d459fbe28d3d1673e2ea98c25a267023bd8e9eb3217ae87a6f69972cdb58d03";
+      sha256 = "265a6de63d9610860db612b9cb02c5fca34d2a4a346bd907fc9782605c8300f4";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b2/linux-x86_64/es-AR/firefox-113.0b2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b3/linux-x86_64/es-AR/firefox-113.0b3.tar.bz2";
       locale = "es-AR";
       arch = "linux-x86_64";
-      sha256 = "6fbdd2a0396dfe0e5caf491287218f0fcccb9311175e0b75c571e1f3a92d7bc4";
+      sha256 = "e6c8533bdbe199cbb130065a3265707faf8ca562c7049d6729ebc2b61d48d013";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b2/linux-x86_64/es-CL/firefox-113.0b2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b3/linux-x86_64/es-CL/firefox-113.0b3.tar.bz2";
       locale = "es-CL";
       arch = "linux-x86_64";
-      sha256 = "41ab6d9e3f635d43c9a187932a93a8484263b00e194e9f8450ce4f1c0fe28f38";
+      sha256 = "aacc0496ddb3402e9429eb630b8e9dc9b9725771ef1960b1eafb1f1f39f59182";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b2/linux-x86_64/es-ES/firefox-113.0b2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b3/linux-x86_64/es-ES/firefox-113.0b3.tar.bz2";
       locale = "es-ES";
       arch = "linux-x86_64";
-      sha256 = "18028d9ca42a8f6372ddd777943d86cce7ecbfa0f0e6998ef879a7ee676e9eee";
+      sha256 = "7f35e414501dc48d1e170ccc581c4d486fc48d9a53aa421192885b26e8fc5704";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b2/linux-x86_64/es-MX/firefox-113.0b2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b3/linux-x86_64/es-MX/firefox-113.0b3.tar.bz2";
       locale = "es-MX";
       arch = "linux-x86_64";
-      sha256 = "79502a45f906bdff7e3c3fbf89624034717ba4e70d6ffc753a8ba4ef024ceac6";
+      sha256 = "4520ee509d0c216d58d4940d1759d53faf94f00ec42ee17a4cd17261d99bb8b8";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b2/linux-x86_64/et/firefox-113.0b2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b3/linux-x86_64/et/firefox-113.0b3.tar.bz2";
       locale = "et";
       arch = "linux-x86_64";
-      sha256 = "c401de7797bb35f3f89e2a6efdf08b9458b765243d0764fc00badb5a9d01995c";
+      sha256 = "b987e5cd8b92c5cd0839091a6b37bd9bc38422f49733207152ddca9190d0cf68";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b2/linux-x86_64/eu/firefox-113.0b2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b3/linux-x86_64/eu/firefox-113.0b3.tar.bz2";
       locale = "eu";
       arch = "linux-x86_64";
-      sha256 = "0d1071eb565fd3fca4e7ec50a886f5c27af4a4ed4ee5da1237efa39f508a45e7";
+      sha256 = "c1fa09e40302ff66eea7f2d23fb220c81b6d6f33c03d93a2b14470fb78393f3c";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b2/linux-x86_64/fa/firefox-113.0b2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b3/linux-x86_64/fa/firefox-113.0b3.tar.bz2";
       locale = "fa";
       arch = "linux-x86_64";
-      sha256 = "bcd12e119c3203e1955af4595121bcb451460dd4960186f309238ad4ad2603af";
+      sha256 = "75a205b628c45cb344de05f1a00b9e64388522633b41bd49ea156650a0459991";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b2/linux-x86_64/ff/firefox-113.0b2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b3/linux-x86_64/ff/firefox-113.0b3.tar.bz2";
       locale = "ff";
       arch = "linux-x86_64";
-      sha256 = "96e9f283c7ad4b8c2adb8a04c7d8ac4e0648f1db1775d1e4a8f963ca5ab4bfc7";
+      sha256 = "82e9bf057bb04ef8af8f98cf73ae912edc7d6b42817df29fa0ddab4e9918c70c";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b2/linux-x86_64/fi/firefox-113.0b2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b3/linux-x86_64/fi/firefox-113.0b3.tar.bz2";
       locale = "fi";
       arch = "linux-x86_64";
-      sha256 = "f4f3fd6e01a17154ccbaac98e8366feee42a577213b8ad8ee6bb98cd4eccc63c";
+      sha256 = "52d032fe3498a17888b113e4ecab04f6cdfcea99fe37469dcbad029c0c6dd4da";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b2/linux-x86_64/fr/firefox-113.0b2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b3/linux-x86_64/fr/firefox-113.0b3.tar.bz2";
       locale = "fr";
       arch = "linux-x86_64";
-      sha256 = "e3cf2f06d1672f7811f61a72c621ac7b02c52fc5c95c693e5b7ca3e6a312ef65";
+      sha256 = "1b5256b2771d8fcd2eae5c9a3351b44a34a266d096eb991cf1d165b9966af687";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b2/linux-x86_64/fur/firefox-113.0b2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b3/linux-x86_64/fur/firefox-113.0b3.tar.bz2";
       locale = "fur";
       arch = "linux-x86_64";
-      sha256 = "a443bab872692889d186876c8021f4dac8e7066bcad9cf07859d9a64e68e36d0";
+      sha256 = "5164c611c004949afde262073b4900ce189a18e1fb95142b960468251a07ae0f";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b2/linux-x86_64/fy-NL/firefox-113.0b2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b3/linux-x86_64/fy-NL/firefox-113.0b3.tar.bz2";
       locale = "fy-NL";
       arch = "linux-x86_64";
-      sha256 = "2fc833b2832048e90fb5a54a8a1e26e2ec24dfc16756d25da2b27c206f2ec152";
+      sha256 = "dbaed3e1fdb4ce0a7433d44ecba96797b2246cdd346a1c8fedb1922e71a7fe3b";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b2/linux-x86_64/ga-IE/firefox-113.0b2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b3/linux-x86_64/ga-IE/firefox-113.0b3.tar.bz2";
       locale = "ga-IE";
       arch = "linux-x86_64";
-      sha256 = "e3156719d5ea92690afe387a083c298d879971c38709c6a02560af3b1204b27a";
+      sha256 = "02ecfdf8cdf1fff1857ae5abb39576454ca3f92662dda528142d0565a483bf8b";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b2/linux-x86_64/gd/firefox-113.0b2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b3/linux-x86_64/gd/firefox-113.0b3.tar.bz2";
       locale = "gd";
       arch = "linux-x86_64";
-      sha256 = "4bba581ea6859fb0ca0e92bc4c64e221010202887422846cf23122b3ae10a25e";
+      sha256 = "b5ba1f1f76439e31f9fb42ae8a3e8f52e6e40029938d15302bba06caf930d097";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b2/linux-x86_64/gl/firefox-113.0b2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b3/linux-x86_64/gl/firefox-113.0b3.tar.bz2";
       locale = "gl";
       arch = "linux-x86_64";
-      sha256 = "1de0db04d4977b71e78173a1d738f188ee8a6798da25473d21216dd6eda928c0";
+      sha256 = "9e25d84cd18818fc3be0cd8bf080a91752b766f75d5a7bc37b12dc7857cec8f4";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b2/linux-x86_64/gn/firefox-113.0b2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b3/linux-x86_64/gn/firefox-113.0b3.tar.bz2";
       locale = "gn";
       arch = "linux-x86_64";
-      sha256 = "4ec41348ded1d24cefe64841b276d760749b8eb8385646249b01cf180471b7b1";
+      sha256 = "1dba1e4cb47af3ed5ba281d094e00e14394bfbbcc86b68d2519145185759374a";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b2/linux-x86_64/gu-IN/firefox-113.0b2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b3/linux-x86_64/gu-IN/firefox-113.0b3.tar.bz2";
       locale = "gu-IN";
       arch = "linux-x86_64";
-      sha256 = "fb99b010d7fd6b619d43db12c66b80d222ae2eb1dc03eab0f39e10ed54fc975f";
+      sha256 = "940081f48755b911c8141839d1effb2ac76374812c3f78b1265ef673c29ec13b";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b2/linux-x86_64/he/firefox-113.0b2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b3/linux-x86_64/he/firefox-113.0b3.tar.bz2";
       locale = "he";
       arch = "linux-x86_64";
-      sha256 = "c8616d73659cff46dba05f155f942845f00782c291fa616dcc7f8e110c17d2d0";
+      sha256 = "452aa702e8edf4d87a5dfda8c71a9cda95dd451b805af1406a0811c4f8b30738";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b2/linux-x86_64/hi-IN/firefox-113.0b2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b3/linux-x86_64/hi-IN/firefox-113.0b3.tar.bz2";
       locale = "hi-IN";
       arch = "linux-x86_64";
-      sha256 = "e613194a2efe8d7ccb800c23bd253f80b8acfb6748e03e109c71dda6dfe3db2e";
+      sha256 = "3d8cacae64d177e04f9788894c9b59d9456f7a7e7feda3467e887d8364f48574";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b2/linux-x86_64/hr/firefox-113.0b2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b3/linux-x86_64/hr/firefox-113.0b3.tar.bz2";
       locale = "hr";
       arch = "linux-x86_64";
-      sha256 = "dec738c4d3603fea5f0c93ce0ed0814a9901e691c5126192eee55476314312c3";
+      sha256 = "0546b19ee355fb86cf14bcfe6b904b155eb4a7b258507dbeed89433bfebf5335";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b2/linux-x86_64/hsb/firefox-113.0b2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b3/linux-x86_64/hsb/firefox-113.0b3.tar.bz2";
       locale = "hsb";
       arch = "linux-x86_64";
-      sha256 = "959e7a1d909f0b1013a4c5abfbf9eaacc9e4b0c145af0d6f1b7bb532645ce18a";
+      sha256 = "914bc26e16658602ca6cc57c072c9137b0691b20c2d7b945308c23002e15ce0d";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b2/linux-x86_64/hu/firefox-113.0b2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b3/linux-x86_64/hu/firefox-113.0b3.tar.bz2";
       locale = "hu";
       arch = "linux-x86_64";
-      sha256 = "09f7adfc674063f277b210bc6e502c165298a9bb206145dd4889922e5df67f79";
+      sha256 = "4457022a3507ee97467fed2f0e494b2b13a9bc50c87009ac559862bc6967a3fe";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b2/linux-x86_64/hy-AM/firefox-113.0b2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b3/linux-x86_64/hy-AM/firefox-113.0b3.tar.bz2";
       locale = "hy-AM";
       arch = "linux-x86_64";
-      sha256 = "23e1e355f25befa9b5cb0968d4c1f3242bf6fa1ec3ea27f1670ce75e59f1bdd4";
+      sha256 = "f4b6c03dd522aaab26a48c05fff31afab82a92c184796bcd424e0687e6494093";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b2/linux-x86_64/ia/firefox-113.0b2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b3/linux-x86_64/ia/firefox-113.0b3.tar.bz2";
       locale = "ia";
       arch = "linux-x86_64";
-      sha256 = "a9f53465f58d491de332f855f5669e0c4d0288a994410d6ef849466e2b432299";
+      sha256 = "d22c2581b8cc36713f53bf1096c84f15f7e5c23c5fe5724a78d8f2ec4b735abc";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b2/linux-x86_64/id/firefox-113.0b2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b3/linux-x86_64/id/firefox-113.0b3.tar.bz2";
       locale = "id";
       arch = "linux-x86_64";
-      sha256 = "3377495a450130db9aa14a52598f50b254c97a942a9ae2546a721104a9b08048";
+      sha256 = "a1550c292b9b3e24f9b1c2d1d6f2db41f73f927950da1714ecd4fa0d7d63838c";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b2/linux-x86_64/is/firefox-113.0b2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b3/linux-x86_64/is/firefox-113.0b3.tar.bz2";
       locale = "is";
       arch = "linux-x86_64";
-      sha256 = "dba7136591869347cf5a07503f3a0cfd705eef9b69217fc19785d7584dc9525a";
+      sha256 = "93750fa307621ae233030cea0752a5af553e6283d08ff3fda45493e7632e5d29";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b2/linux-x86_64/it/firefox-113.0b2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b3/linux-x86_64/it/firefox-113.0b3.tar.bz2";
       locale = "it";
       arch = "linux-x86_64";
-      sha256 = "6d14dfaa7c40fa27d1099dd7ca3dbe99731e7bdc9a22ce2b5c1fb0caa5e53dd8";
+      sha256 = "fccbfd7a418236a3d8c43f401146f1b28cfb0ff86a0297a18b7131610839efb0";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b2/linux-x86_64/ja/firefox-113.0b2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b3/linux-x86_64/ja/firefox-113.0b3.tar.bz2";
       locale = "ja";
       arch = "linux-x86_64";
-      sha256 = "01b78c71ab26948e8f2eaf199b7360a55d3e2c423acb008bf5d00a171d2f8198";
+      sha256 = "97814e060681870e279f55d7611b248dad7135255297ed9cd7b5f20639da9b7a";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b2/linux-x86_64/ka/firefox-113.0b2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b3/linux-x86_64/ka/firefox-113.0b3.tar.bz2";
       locale = "ka";
       arch = "linux-x86_64";
-      sha256 = "f067e6190ceda4f314da7c56f9390425ad648ae20607afdc473ae5dc4d8dc261";
+      sha256 = "95381c4aa6fb6d9085e24e0e9f2a1150db965e4d6fd37a20666b2137d1f0b6c6";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b2/linux-x86_64/kab/firefox-113.0b2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b3/linux-x86_64/kab/firefox-113.0b3.tar.bz2";
       locale = "kab";
       arch = "linux-x86_64";
-      sha256 = "a1b15015972ca9e114462f0b217b51b8f758df64c4d3ebc1542575063700e7c0";
+      sha256 = "22acda1a93ddb602706dfaccd03c0997756ab6eaed9e01e3f1c4b54eb868c1ee";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b2/linux-x86_64/kk/firefox-113.0b2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b3/linux-x86_64/kk/firefox-113.0b3.tar.bz2";
       locale = "kk";
       arch = "linux-x86_64";
-      sha256 = "2f2e21dfd26cd4a074c531a85ba4401ef29fa6237d885a1eca3de6de07891c71";
+      sha256 = "99ff6df59b85ad1db0de2e76f925570a013c5708a805214b45304bcaf47a809a";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b2/linux-x86_64/km/firefox-113.0b2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b3/linux-x86_64/km/firefox-113.0b3.tar.bz2";
       locale = "km";
       arch = "linux-x86_64";
-      sha256 = "6a22f3696198bb87e920261328a99460160cf7de22c1c79f1c6b50bb9395cc78";
+      sha256 = "0e4352dcc4b6f1e3caec06a8b82619db27d704a6a5a9e85c78b9d1b7aca946d2";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b2/linux-x86_64/kn/firefox-113.0b2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b3/linux-x86_64/kn/firefox-113.0b3.tar.bz2";
       locale = "kn";
       arch = "linux-x86_64";
-      sha256 = "cc94c675a5e228921c448a773470a480be3fbaf62094abb9d2b759db3fd814cc";
+      sha256 = "593fe4f56b5c70238af12f657fbd3fa87e976a89a1190902da847c67c1927ddd";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b2/linux-x86_64/ko/firefox-113.0b2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b3/linux-x86_64/ko/firefox-113.0b3.tar.bz2";
       locale = "ko";
       arch = "linux-x86_64";
-      sha256 = "bab90c97c6350822c8ebadc047dd0363e7d03740c296d24c1b272ff2fa259a7a";
+      sha256 = "5b15e8312d666836a28030bbf22573a354a6925498f24d40d9728bbeef9ab754";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b2/linux-x86_64/lij/firefox-113.0b2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b3/linux-x86_64/lij/firefox-113.0b3.tar.bz2";
       locale = "lij";
       arch = "linux-x86_64";
-      sha256 = "145cbf712b14ebb73fcd8bc311c56aeb6698eb25ebb2a4c9c3a8a62bd1c02bf8";
+      sha256 = "b24793b43541f63c5aa9e97d26ff42f984aacedf0d979cdee8c6c6347337943d";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b2/linux-x86_64/lt/firefox-113.0b2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b3/linux-x86_64/lt/firefox-113.0b3.tar.bz2";
       locale = "lt";
       arch = "linux-x86_64";
-      sha256 = "2cd40821b72e570ee1c877d56701724cd7715285670b7929ea434d041406eca9";
+      sha256 = "6752ad55f7c9f091bddd5a84b6d7d81fcb6e8f80064c1513a3bd789af5695819";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b2/linux-x86_64/lv/firefox-113.0b2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b3/linux-x86_64/lv/firefox-113.0b3.tar.bz2";
       locale = "lv";
       arch = "linux-x86_64";
-      sha256 = "23bccb2ba57c061ad5875365842be19a518887ff3f71d551b85abbd69a53d636";
+      sha256 = "14cf1c6b4485d6d3175be0560377f59443e436b50993b65f53d751664f686b4c";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b2/linux-x86_64/mk/firefox-113.0b2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b3/linux-x86_64/mk/firefox-113.0b3.tar.bz2";
       locale = "mk";
       arch = "linux-x86_64";
-      sha256 = "62444e8914cf6a7a734b577e107ec22a4ccd7ca39bce4b7b6a66e970dbb6e371";
+      sha256 = "1f072ca8bc3d28c14b215d0fca8f1cbdbb2995faee9f6b69926684c33e47fcad";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b2/linux-x86_64/mr/firefox-113.0b2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b3/linux-x86_64/mr/firefox-113.0b3.tar.bz2";
       locale = "mr";
       arch = "linux-x86_64";
-      sha256 = "23355ea5c25eb79534fe80e59a660f4b5d2719bf68863a547a78aaeec8d0d6c6";
+      sha256 = "68da899c4770565f7e9a0f9557ecbb8543a128784ef53934235e182631d2c999";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b2/linux-x86_64/ms/firefox-113.0b2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b3/linux-x86_64/ms/firefox-113.0b3.tar.bz2";
       locale = "ms";
       arch = "linux-x86_64";
-      sha256 = "8c834e38b172656656c57292c3a735c49ca5d3444ca374f6958e684ae22bd086";
+      sha256 = "ba878607c14a21826b74dfb2ec7635401cd606a74ccfe8e715899149ecedfb28";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b2/linux-x86_64/my/firefox-113.0b2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b3/linux-x86_64/my/firefox-113.0b3.tar.bz2";
       locale = "my";
       arch = "linux-x86_64";
-      sha256 = "4cd70e346aa9fd7a877ce45378fcead5fe1cbf990a54defd073ca0d8d9b30a34";
+      sha256 = "931df6cc939a18c8df7d5fee59e9a50fa390527653c4aa4fc6a72c421c251cac";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b2/linux-x86_64/nb-NO/firefox-113.0b2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b3/linux-x86_64/nb-NO/firefox-113.0b3.tar.bz2";
       locale = "nb-NO";
       arch = "linux-x86_64";
-      sha256 = "4ceaf249c39e2b108ed1e493fdaa62cb52ad04b67aabae58a86944cd42964335";
+      sha256 = "3bf023b72b72d4e6fdc4a6644508feeca3a7e54cb8c56feab77c4551a9585ca6";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b2/linux-x86_64/ne-NP/firefox-113.0b2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b3/linux-x86_64/ne-NP/firefox-113.0b3.tar.bz2";
       locale = "ne-NP";
       arch = "linux-x86_64";
-      sha256 = "6f8c0df71ab020b718625433dc5c25f2382342922e15f44fc72ac20b5258e441";
+      sha256 = "dd9e2159fbbaa7f76a1a29c96bb8c3d330b305c2a6a9df9de692b3eea30a2be4";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b2/linux-x86_64/nl/firefox-113.0b2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b3/linux-x86_64/nl/firefox-113.0b3.tar.bz2";
       locale = "nl";
       arch = "linux-x86_64";
-      sha256 = "4be0cf4ecb47dd9ec5aeb8c7acd1ca93ad886b0bcbfb95f2a30e16fb41d4340f";
+      sha256 = "b577c155e6c7f4138c30d3a1345312f1554c6ee20eb327babbe8ad282f4194c2";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b2/linux-x86_64/nn-NO/firefox-113.0b2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b3/linux-x86_64/nn-NO/firefox-113.0b3.tar.bz2";
       locale = "nn-NO";
       arch = "linux-x86_64";
-      sha256 = "f38689e40e019cffd73966ed9fa58ac542f62025cab1f156e22cf3b137389322";
+      sha256 = "b37e8fe61a930efa905723d11aec90974662d86c149b0124aebe40e5a40bf95b";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b2/linux-x86_64/oc/firefox-113.0b2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b3/linux-x86_64/oc/firefox-113.0b3.tar.bz2";
       locale = "oc";
       arch = "linux-x86_64";
-      sha256 = "67be4afbf41722f201cc2ad63821ba56efd212606684d66d9094087ce28e116b";
+      sha256 = "8e0b144d174aa54f18e189db2a89bdfe22663af7984a622f90ce645164ddc0a5";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b2/linux-x86_64/pa-IN/firefox-113.0b2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b3/linux-x86_64/pa-IN/firefox-113.0b3.tar.bz2";
       locale = "pa-IN";
       arch = "linux-x86_64";
-      sha256 = "80b97a5b0c195b20844067001d05d0995812b51aad40db631da35de018239f86";
+      sha256 = "60eb78e313e909cad6cfb72ad3ddeaf1a70950c2d9143a5cedc0f5947a7aba71";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b2/linux-x86_64/pl/firefox-113.0b2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b3/linux-x86_64/pl/firefox-113.0b3.tar.bz2";
       locale = "pl";
       arch = "linux-x86_64";
-      sha256 = "71137cacdf82696e3c9e4b8e42882cc77c4d3f66ad540ad04224c347ca30bf72";
+      sha256 = "25c841c67b699cdb36386356abd93ae7d7506b8fec628788273c565dec2f7e16";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b2/linux-x86_64/pt-BR/firefox-113.0b2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b3/linux-x86_64/pt-BR/firefox-113.0b3.tar.bz2";
       locale = "pt-BR";
       arch = "linux-x86_64";
-      sha256 = "e978a8e53285137c14392f3928beb462ea4bb78b49f8266bae2505bb751bfcb6";
+      sha256 = "ec535f28ae1390378bf64598bc58b0b05909183ea4159f843f8d638bc247dbf6";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b2/linux-x86_64/pt-PT/firefox-113.0b2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b3/linux-x86_64/pt-PT/firefox-113.0b3.tar.bz2";
       locale = "pt-PT";
       arch = "linux-x86_64";
-      sha256 = "6c355c30efdc1c60d6e2fb77f06c39d6f62613aee81ee7584cf58db7d9bfe918";
+      sha256 = "edd20ce65ab20ff48f7c30f69df84db85ec0831a47f9933ff3f6d94affc04825";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b2/linux-x86_64/rm/firefox-113.0b2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b3/linux-x86_64/rm/firefox-113.0b3.tar.bz2";
       locale = "rm";
       arch = "linux-x86_64";
-      sha256 = "2e65b2a382220719a0f0341640317085524fca87776a864375ca4358f96132b3";
+      sha256 = "fc7b426b48cf4622a65d86d3d64492a3a37adfefddcaf5b2963a3d3d1a28f5c6";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b2/linux-x86_64/ro/firefox-113.0b2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b3/linux-x86_64/ro/firefox-113.0b3.tar.bz2";
       locale = "ro";
       arch = "linux-x86_64";
-      sha256 = "5ed6ce88efb537ab23c454009fd6e33bfcc0473555f47a4a61f252e03999c103";
+      sha256 = "37ef32f187a9b051663c9030d3a74ca142f7497542805d15cdc5d100d3314a09";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b2/linux-x86_64/ru/firefox-113.0b2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b3/linux-x86_64/ru/firefox-113.0b3.tar.bz2";
       locale = "ru";
       arch = "linux-x86_64";
-      sha256 = "a003fc303e2478af1596336aaea883acf3211867e7b8ebf576f843ef270422ec";
+      sha256 = "ee6d259239dd7bca7181380de4c78b2a4735fcc56af9dd50e61472ad5d2269f6";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b2/linux-x86_64/sc/firefox-113.0b2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b3/linux-x86_64/sc/firefox-113.0b3.tar.bz2";
       locale = "sc";
       arch = "linux-x86_64";
-      sha256 = "6d5e84c3554bf931ea44f67c8cf2005916db0599ffbf78a0a3572eaca81d59a9";
+      sha256 = "b1e6584b241b2036902aa5ebc4b41886be34c4a0b051500f135b365441e890ef";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b2/linux-x86_64/sco/firefox-113.0b2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b3/linux-x86_64/sco/firefox-113.0b3.tar.bz2";
       locale = "sco";
       arch = "linux-x86_64";
-      sha256 = "9d6e834a4c0d88900ace756e2ad0d96437cee23104fde9212143a03baa063987";
+      sha256 = "d872486432a53c499b00e97dfa5c2e23b8b7241021000ee5f46fdd78f6d96a5c";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b2/linux-x86_64/si/firefox-113.0b2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b3/linux-x86_64/si/firefox-113.0b3.tar.bz2";
       locale = "si";
       arch = "linux-x86_64";
-      sha256 = "52a89fcf78fd864540b732ab415b06dc41584a057d11779061c870ccf1026bf3";
+      sha256 = "b2e59be4c213a6b3c32c68bd83ce519c2325b80c5a1dd1a9d8ab3cb96c23772e";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b2/linux-x86_64/sk/firefox-113.0b2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b3/linux-x86_64/sk/firefox-113.0b3.tar.bz2";
       locale = "sk";
       arch = "linux-x86_64";
-      sha256 = "a33b82d3c3e32d3c43d88b3613f796b0073c9d8c6fc7082b5329f877fe243d1a";
+      sha256 = "2e46ac9f106e041d6ec575da271c42870f04d1ac23d315d8716216f942c5b76c";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b2/linux-x86_64/sl/firefox-113.0b2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b3/linux-x86_64/sl/firefox-113.0b3.tar.bz2";
       locale = "sl";
       arch = "linux-x86_64";
-      sha256 = "9d46d77c6841357971b3867e8d3659b674cca1892862d9668e608f99983a5b4e";
+      sha256 = "b65270523cdad9d7db735fcc5cfa938fd83e87c8ce2f17bdca2ee7b876210fb9";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b2/linux-x86_64/son/firefox-113.0b2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b3/linux-x86_64/son/firefox-113.0b3.tar.bz2";
       locale = "son";
       arch = "linux-x86_64";
-      sha256 = "22559f8e961ede16392c01a297c69e43395ec93623d5f9897887b9673dbaef1a";
+      sha256 = "e1d866ff9517b5e410327bc01a1511fc387f4c5c8022bc8d18a7f4b62cbe3934";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b2/linux-x86_64/sq/firefox-113.0b2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b3/linux-x86_64/sq/firefox-113.0b3.tar.bz2";
       locale = "sq";
       arch = "linux-x86_64";
-      sha256 = "bb29f522e16897bd83946b291d3162eff71cbacca4da9e1b4a7b16b4fd17a0e4";
+      sha256 = "68cf83cbe439a895199a7020143064242c1bf70484a265905733905687a3b33c";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b2/linux-x86_64/sr/firefox-113.0b2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b3/linux-x86_64/sr/firefox-113.0b3.tar.bz2";
       locale = "sr";
       arch = "linux-x86_64";
-      sha256 = "92cdb6e5528c6aed0516364a6c01bce28e29f7ff6c1de971400298449682f025";
+      sha256 = "5762245c8f817607baa239a103c53ebe2f6fbea9e2e4c455d00df02c85e46f95";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b2/linux-x86_64/sv-SE/firefox-113.0b2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b3/linux-x86_64/sv-SE/firefox-113.0b3.tar.bz2";
       locale = "sv-SE";
       arch = "linux-x86_64";
-      sha256 = "63540925589dfa61530be3a97c38c6af82869d65d989784564e84ee042dfd6b1";
+      sha256 = "e88f9d915800be482b8e623920b1d10e59eb6bbb4198d1c67c3daf195f794ec6";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b2/linux-x86_64/szl/firefox-113.0b2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b3/linux-x86_64/szl/firefox-113.0b3.tar.bz2";
       locale = "szl";
       arch = "linux-x86_64";
-      sha256 = "6ecd2dc91186d5c349de5a04e314f88ca6c7ead3e6f3e194a8e20ff4495800f7";
+      sha256 = "4ba1838d9f8325a1f13b98553c28618e14f7d98801e4d9fcde89c853faad8122";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b2/linux-x86_64/ta/firefox-113.0b2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b3/linux-x86_64/ta/firefox-113.0b3.tar.bz2";
       locale = "ta";
       arch = "linux-x86_64";
-      sha256 = "ceb8ceb46279bb485bb03bb24a75c82fcd9a4f0c161697e3fd659a7003c5e616";
+      sha256 = "9329390fc6db472358399a9055fe1e903520bc51be425b61b3d9f8d6ad0ade7c";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b2/linux-x86_64/te/firefox-113.0b2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b3/linux-x86_64/te/firefox-113.0b3.tar.bz2";
       locale = "te";
       arch = "linux-x86_64";
-      sha256 = "625a76a8cdef039ffba056bb791e4bdb82104f8851c4e510fecc75f31c93e5c9";
+      sha256 = "2ba356eb834bc7c6da2324028b1964c2a580fa8d7ccd17ec04ef5bb7f5c54519";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b2/linux-x86_64/tg/firefox-113.0b2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b3/linux-x86_64/tg/firefox-113.0b3.tar.bz2";
       locale = "tg";
       arch = "linux-x86_64";
-      sha256 = "b009d02955816d28edc6bbcb974dea276ed384a0a9d0d35f9c353e8009965007";
+      sha256 = "7f6d61f46830319ad8f4cf5d5c4557bac6b8771809c80ea25ebf18c04b1d74f4";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b2/linux-x86_64/th/firefox-113.0b2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b3/linux-x86_64/th/firefox-113.0b3.tar.bz2";
       locale = "th";
       arch = "linux-x86_64";
-      sha256 = "34a6852d0017a6ff299ca448d8dbec13c5a440031e4b7cb5fef2a3ac120eb733";
+      sha256 = "6bde25dacdc360e0caeb4872c58d48527c1e318ae0db1ae988f5937e08fed951";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b2/linux-x86_64/tl/firefox-113.0b2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b3/linux-x86_64/tl/firefox-113.0b3.tar.bz2";
       locale = "tl";
       arch = "linux-x86_64";
-      sha256 = "9d6a1360430702a02e37ce754ab5650d5b3ebd8b866fcaecf98e5ee464ea32a2";
+      sha256 = "db4e37593a3eda7822ef230b03b8564cb7bc4c47852ce894be3ab3c5bb78a8a3";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b2/linux-x86_64/tr/firefox-113.0b2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b3/linux-x86_64/tr/firefox-113.0b3.tar.bz2";
       locale = "tr";
       arch = "linux-x86_64";
-      sha256 = "4bf7f0e2c26821510f0645d6048ed771fb28592e5546304c1dd3a312c545fee6";
+      sha256 = "cdc31496924058b80639e2abbbde526f94ffd608ea5698b325e8fde29260c9c6";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b2/linux-x86_64/trs/firefox-113.0b2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b3/linux-x86_64/trs/firefox-113.0b3.tar.bz2";
       locale = "trs";
       arch = "linux-x86_64";
-      sha256 = "b95ee3abba19a905fb7d7cf981a0cc8a8510878cf099920610b884aacdebd513";
+      sha256 = "2d6eaea56eab42363937069aee623be1c4b71a86c229d3b7059b9c66a9cd180e";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b2/linux-x86_64/uk/firefox-113.0b2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b3/linux-x86_64/uk/firefox-113.0b3.tar.bz2";
       locale = "uk";
       arch = "linux-x86_64";
-      sha256 = "dd1007354eeb86263c6e3d4db90c5049d73021a053fd8856cd1b8b9174e5ed38";
+      sha256 = "6d32526fa62064489ceac40b66910c7c1e6a5087c7c63496491b80db1e295107";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b2/linux-x86_64/ur/firefox-113.0b2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b3/linux-x86_64/ur/firefox-113.0b3.tar.bz2";
       locale = "ur";
       arch = "linux-x86_64";
-      sha256 = "f8a9044c3fb7a352fbe3f2e04a994be8573a748f4368bb9a327a53e4c954a816";
+      sha256 = "c58611940001dd9ffac65ddc72d0c6255c5d7e00f6a5ad27898e97ea6da7120d";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b2/linux-x86_64/uz/firefox-113.0b2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b3/linux-x86_64/uz/firefox-113.0b3.tar.bz2";
       locale = "uz";
       arch = "linux-x86_64";
-      sha256 = "c43e984f241a9bd97c575474f2e80387b676d067fdd5eb9c21646ca03235c7b1";
+      sha256 = "3574c03b2dc9d94ce83618e325fd15e41b9d25a5c8152319013c4b7c183412e2";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b2/linux-x86_64/vi/firefox-113.0b2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b3/linux-x86_64/vi/firefox-113.0b3.tar.bz2";
       locale = "vi";
       arch = "linux-x86_64";
-      sha256 = "c57dd83122a52e96675d1d52030c6896d430bc222a0aa297e3dac4de95bc76dc";
+      sha256 = "75d221e4e1e3f365f5a71cdb69a3dbe84f711d32b6011ca7d26f4a5599b139a5";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b2/linux-x86_64/xh/firefox-113.0b2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b3/linux-x86_64/xh/firefox-113.0b3.tar.bz2";
       locale = "xh";
       arch = "linux-x86_64";
-      sha256 = "954de48e49a0f95431b8fda717dff54fd39b59091e732a9b097ba6f12936f0fd";
+      sha256 = "ccfb81fec0cf3c075dbbb2b01ecaa39349822abb0ce442f92516138f5dfd973b";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b2/linux-x86_64/zh-CN/firefox-113.0b2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b3/linux-x86_64/zh-CN/firefox-113.0b3.tar.bz2";
       locale = "zh-CN";
       arch = "linux-x86_64";
-      sha256 = "30f2ed6ce51ae526b7c32e0174303348045f4907b9aab67a59fbeea7110674b5";
+      sha256 = "c462f64394ef41dffc4a940dec5b878fc7892f1b5806585f1336cb0e665dbce4";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b2/linux-x86_64/zh-TW/firefox-113.0b2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b3/linux-x86_64/zh-TW/firefox-113.0b3.tar.bz2";
       locale = "zh-TW";
       arch = "linux-x86_64";
-      sha256 = "2fe54cd40a0c09a6e7e71d8870c5a2d8e7c3a70036ac246eb0c3659536197323";
+      sha256 = "93cb7046f2fe0401a2616f6198cbabdb86b7ff145f68f49f24f60e2fd320b06e";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b2/linux-i686/ach/firefox-113.0b2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b3/linux-i686/ach/firefox-113.0b3.tar.bz2";
       locale = "ach";
       arch = "linux-i686";
-      sha256 = "b52ae8cbc95a39e33881b9825a242247cc369e177a7927c0807134aa600b8b0b";
+      sha256 = "d959e56e36f95123231ba286f485f10f64a458aba0e4abc84bfd56f38a20afb5";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b2/linux-i686/af/firefox-113.0b2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b3/linux-i686/af/firefox-113.0b3.tar.bz2";
       locale = "af";
       arch = "linux-i686";
-      sha256 = "bbb4433e14a32a50fa461f7f44f28eecb47d23434335a3613ea6c5c45a7ddbbf";
+      sha256 = "4260c954a444ee8a3902ab5ac990d483569343c2e80f94121e292b5ba0202d16";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b2/linux-i686/an/firefox-113.0b2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b3/linux-i686/an/firefox-113.0b3.tar.bz2";
       locale = "an";
       arch = "linux-i686";
-      sha256 = "73382955959b8b2fb13db3b780559a501b65634a01a2e42cc48545fafb330ce5";
+      sha256 = "f21fac56dfd25f680e9334c561d8de8d332fadf74dfdca6a2b922cc5bd463e9c";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b2/linux-i686/ar/firefox-113.0b2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b3/linux-i686/ar/firefox-113.0b3.tar.bz2";
       locale = "ar";
       arch = "linux-i686";
-      sha256 = "51958d006b680020cf9f76dfb7c339e99ac471c84cf27e54af686416fe10e129";
+      sha256 = "1c2486c0de3044ec1e2234383af39f7c144fb9758149067a16ad675c5c1a3fe9";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b2/linux-i686/ast/firefox-113.0b2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b3/linux-i686/ast/firefox-113.0b3.tar.bz2";
       locale = "ast";
       arch = "linux-i686";
-      sha256 = "49247ac5fc5f4da6e94d544f2005818fdd6d8934e06e6bc1880c4e4d8b8579d7";
+      sha256 = "58cc1f38490baf4124619676f0db4e0a78812cac04ca514edcf2c2faf461af7d";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b2/linux-i686/az/firefox-113.0b2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b3/linux-i686/az/firefox-113.0b3.tar.bz2";
       locale = "az";
       arch = "linux-i686";
-      sha256 = "ee4098f0d74a87caa95c10b6a8b3b35ee13d7531047df897b0e70a04efde693a";
+      sha256 = "01b4d389e8d48e7068fde7776e54706c584fc0654a931a084ef5a5e50d23b37b";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b2/linux-i686/be/firefox-113.0b2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b3/linux-i686/be/firefox-113.0b3.tar.bz2";
       locale = "be";
       arch = "linux-i686";
-      sha256 = "5d6e2492d6b59bb3651ab9066cb7b8c5b3784c9814b172c837a01a057c353578";
+      sha256 = "bcd2a0a3c5e045dbb3f2645db51de0cc8364422143621442265f147eef54e054";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b2/linux-i686/bg/firefox-113.0b2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b3/linux-i686/bg/firefox-113.0b3.tar.bz2";
       locale = "bg";
       arch = "linux-i686";
-      sha256 = "569945ca1d1c7b5d47affc9037d22a55c2840640048c0b312f55bddabc38e16f";
+      sha256 = "9217c39c1bbddfc3cb059c53a63b655a06860fcda979b1009c36309dbb2b47ec";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b2/linux-i686/bn/firefox-113.0b2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b3/linux-i686/bn/firefox-113.0b3.tar.bz2";
       locale = "bn";
       arch = "linux-i686";
-      sha256 = "31b29f6a3baed2827e18641bc2fc3cf09b9c1830cf062000c9c7802a533c29c9";
+      sha256 = "7da8600216ad1e74404ecc5c851f88c045aa0579cd99c1e2fa5662d71455b93e";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b2/linux-i686/br/firefox-113.0b2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b3/linux-i686/br/firefox-113.0b3.tar.bz2";
       locale = "br";
       arch = "linux-i686";
-      sha256 = "95d538f34defbced0994b7cc8cab3d90ba9f190031638facbfbfcc9eb8167f23";
+      sha256 = "b41a359404ad0565bd3ab862de9fea64bbb9a1fc264739879cbd593604dfab5e";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b2/linux-i686/bs/firefox-113.0b2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b3/linux-i686/bs/firefox-113.0b3.tar.bz2";
       locale = "bs";
       arch = "linux-i686";
-      sha256 = "a690168f0089b97fd6ab52e8dcfa0bf04a27a3ba2e825a47392bc57aa453f32a";
+      sha256 = "11672e3cb4e24b09e331e49806dd2acd1bb937622bc30c7a022d1d9be15bcfac";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b2/linux-i686/ca-valencia/firefox-113.0b2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b3/linux-i686/ca-valencia/firefox-113.0b3.tar.bz2";
       locale = "ca-valencia";
       arch = "linux-i686";
-      sha256 = "51be5b54589d6eeb5fc62eb29d568c8fb259dc862fd0a6f281957433f5c85724";
+      sha256 = "bd7fa35708b72f9ae976dd4d08bfc9ba8d5f2ceef5bf271a05b15ca16d086ff8";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b2/linux-i686/ca/firefox-113.0b2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b3/linux-i686/ca/firefox-113.0b3.tar.bz2";
       locale = "ca";
       arch = "linux-i686";
-      sha256 = "3020b12f49cbe97eac546600f2f03a81ebf696888c47c82727b9559027c8b28e";
+      sha256 = "443f9633d2c507468d8630915e5675ad5861eafb36e8daae9ed7db527a2d912f";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b2/linux-i686/cak/firefox-113.0b2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b3/linux-i686/cak/firefox-113.0b3.tar.bz2";
       locale = "cak";
       arch = "linux-i686";
-      sha256 = "9697a4cca82fcbaaa933ba9a736d66ff2033bc4ed6f6e73f4010714ea9a126d4";
+      sha256 = "d76b743c938ba652f7498c89e924891a5e37ff415fbfdf4303b38d86a0e4bc1b";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b2/linux-i686/cs/firefox-113.0b2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b3/linux-i686/cs/firefox-113.0b3.tar.bz2";
       locale = "cs";
       arch = "linux-i686";
-      sha256 = "9868e3cdcd3e4d291a5250ab2aadf12e3dedf4de28e97d62cf648f8b2a2e1553";
+      sha256 = "ea7119d173b42dbae0997b433173ecaf858fb735406048deff25454b17010f17";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b2/linux-i686/cy/firefox-113.0b2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b3/linux-i686/cy/firefox-113.0b3.tar.bz2";
       locale = "cy";
       arch = "linux-i686";
-      sha256 = "f11f150633369cf19d8a77547a822df1184844f499c4d60148d5e58695123777";
+      sha256 = "99ce3b241667ee71e7b6a54c7c2bf37f8b115ddf440e17ae51d83240e2e10a80";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b2/linux-i686/da/firefox-113.0b2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b3/linux-i686/da/firefox-113.0b3.tar.bz2";
       locale = "da";
       arch = "linux-i686";
-      sha256 = "1e5eac58597ac3e1c5ef0ad277928d6b0f5c878701b58c87ab56bcdb1e1bc257";
+      sha256 = "aba3e315f6e30fef53ff0dc3fbc5e62ad93e4caae795c920285536c19cf4cd6d";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b2/linux-i686/de/firefox-113.0b2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b3/linux-i686/de/firefox-113.0b3.tar.bz2";
       locale = "de";
       arch = "linux-i686";
-      sha256 = "bd34829a241eeab046def54d9cea77e61f582811955f1793a2b9c751ae1a358c";
+      sha256 = "5c3b614f317be6bd9d707ea2a8d29dae76df3dedf7ad193972d81fcd42cfb637";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b2/linux-i686/dsb/firefox-113.0b2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b3/linux-i686/dsb/firefox-113.0b3.tar.bz2";
       locale = "dsb";
       arch = "linux-i686";
-      sha256 = "8d5fc54d686f8584ef0dc54203a468c9580c4d2a2487a809cacad4fef1b665a5";
+      sha256 = "00ba4f16f921463baee89cc8d6183cb1d9110ecd5f4b7f272410437d7852fd61";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b2/linux-i686/el/firefox-113.0b2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b3/linux-i686/el/firefox-113.0b3.tar.bz2";
       locale = "el";
       arch = "linux-i686";
-      sha256 = "2c4809947c46ba8f11f8c668e3544d04daa964c69c838f284a364f4b9a9543a4";
+      sha256 = "b6d559f153af24c31ab54040538349645f8861de63702f47ce8deed39a7183dc";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b2/linux-i686/en-CA/firefox-113.0b2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b3/linux-i686/en-CA/firefox-113.0b3.tar.bz2";
       locale = "en-CA";
       arch = "linux-i686";
-      sha256 = "3b5bb27a027ea16bb022a340e7e7c97cd5de92766aae660dde9df1fa6cad8535";
+      sha256 = "f83541420907b5d477096e7218caabb4a1dba3e0e9b3c3d439df448d9a31f4d3";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b2/linux-i686/en-GB/firefox-113.0b2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b3/linux-i686/en-GB/firefox-113.0b3.tar.bz2";
       locale = "en-GB";
       arch = "linux-i686";
-      sha256 = "712a68f9e4d0bc40c3d504aef551f1e691fdc2402380bf1c9c4a1a754cbefcca";
+      sha256 = "adeb91ecfcc869623d8f8dc375f9f85c6382b7ca1f013ff62937d0cf3ee1af4a";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b2/linux-i686/en-US/firefox-113.0b2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b3/linux-i686/en-US/firefox-113.0b3.tar.bz2";
       locale = "en-US";
       arch = "linux-i686";
-      sha256 = "1b387ac6604a4ef040b3a52ef930b760c3a0bab5b6363ff46f66079aace298d7";
+      sha256 = "4de540533e8c908470575c928af050b6b2c853d98402e4d035e9f80f01cdf06a";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b2/linux-i686/eo/firefox-113.0b2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b3/linux-i686/eo/firefox-113.0b3.tar.bz2";
       locale = "eo";
       arch = "linux-i686";
-      sha256 = "a649c80036ca73800995a95f8c1523affdcc46338cb10d807291aa05f2b5249b";
+      sha256 = "408d650c3fcc209960cd2e1529de8176ff3b78190c0f09e39bb8efa8e665c33e";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b2/linux-i686/es-AR/firefox-113.0b2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b3/linux-i686/es-AR/firefox-113.0b3.tar.bz2";
       locale = "es-AR";
       arch = "linux-i686";
-      sha256 = "6a87ff7c6a28ace5a1edf6802a02df20d3f8ba2e787f2afac9f7663f78b1d2dc";
+      sha256 = "9e4573796ddbbdfe737928a1bfbdfa110a35b5207800811f3ac14984a8bdfa89";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b2/linux-i686/es-CL/firefox-113.0b2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b3/linux-i686/es-CL/firefox-113.0b3.tar.bz2";
       locale = "es-CL";
       arch = "linux-i686";
-      sha256 = "8dbe070659185e60b7c103d8c11904ea8b19f86ba427782482fd5ba9aadbd5a4";
+      sha256 = "5dafe888b3df1c3339b23c481db45fb73c2d30f6d6a5182a398544f943aaab86";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b2/linux-i686/es-ES/firefox-113.0b2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b3/linux-i686/es-ES/firefox-113.0b3.tar.bz2";
       locale = "es-ES";
       arch = "linux-i686";
-      sha256 = "3dcea12f324a982a51e5c2de4740e201c48f5df4eb29eb115c1e50d3b599de67";
+      sha256 = "f8412bb19917f239a590de10e60e7a8079f56f8ce13796caeee08d7dde0d12b9";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b2/linux-i686/es-MX/firefox-113.0b2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b3/linux-i686/es-MX/firefox-113.0b3.tar.bz2";
       locale = "es-MX";
       arch = "linux-i686";
-      sha256 = "fe234fc3c9c3b3e99ebc8f7de0e91b786bcc9f3ea195fb73ac87c746a3140ce8";
+      sha256 = "2f440403538f46f0b8b277379440ca165c88a2ae663d5f98e84c1b2b0c7a0b1b";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b2/linux-i686/et/firefox-113.0b2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b3/linux-i686/et/firefox-113.0b3.tar.bz2";
       locale = "et";
       arch = "linux-i686";
-      sha256 = "1e575b5cdc9ae42bf29e6fda615711fd2f4928fda81f499ab4b1c8e61d024f41";
+      sha256 = "e592ba23073bc12e71cd19c12afe007e7696931b8f620edf791e35887704fe6c";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b2/linux-i686/eu/firefox-113.0b2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b3/linux-i686/eu/firefox-113.0b3.tar.bz2";
       locale = "eu";
       arch = "linux-i686";
-      sha256 = "b3951c49a4326812d513ef69fce3682bacb47e7dc5160c43fd5f27962c531384";
+      sha256 = "5545fdfd1208be27518d63f408a61b128d8eb50529d760f2fe5077ba75a990d0";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b2/linux-i686/fa/firefox-113.0b2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b3/linux-i686/fa/firefox-113.0b3.tar.bz2";
       locale = "fa";
       arch = "linux-i686";
-      sha256 = "34145541738f6f3fd04ac25e7580eb563baa830f45edd88e836a8c8e9026c555";
+      sha256 = "04d49cc088915d6bd91cc91b4f1ed85e8490be175f5c22748e2116d26e2b0b6e";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b2/linux-i686/ff/firefox-113.0b2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b3/linux-i686/ff/firefox-113.0b3.tar.bz2";
       locale = "ff";
       arch = "linux-i686";
-      sha256 = "04aba41be169c3708cfb8af994849e076908a46cf625ac715959da5d406d9d43";
+      sha256 = "e40eb861f9d0e8a4d09817543303be761723032c7e7c18768ca2d36a8eefbc70";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b2/linux-i686/fi/firefox-113.0b2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b3/linux-i686/fi/firefox-113.0b3.tar.bz2";
       locale = "fi";
       arch = "linux-i686";
-      sha256 = "8f82c3d4a660d5f89dec6957c815fc2bf9cda623d7cbb7ec98892ba168a005fa";
+      sha256 = "4370d6c95842175935832f05d2999701cb60ea0388ed416cf7a3402e2ec7aebe";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b2/linux-i686/fr/firefox-113.0b2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b3/linux-i686/fr/firefox-113.0b3.tar.bz2";
       locale = "fr";
       arch = "linux-i686";
-      sha256 = "dacf22f18a4c85c6d2e8d41f59a403b007f33bd8cceb8e51bb44ea9b2a85f0e7";
+      sha256 = "ba526563c7e57cb06484b88369f273b2ff6bde7f057ba6702a7efac7d42fa824";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b2/linux-i686/fur/firefox-113.0b2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b3/linux-i686/fur/firefox-113.0b3.tar.bz2";
       locale = "fur";
       arch = "linux-i686";
-      sha256 = "4e9bc1058879d906d1fba8a80743211345488c94d8a5f1ec259defe4c503d669";
+      sha256 = "c0ab3ad6693dc6abf544085c5087c12fd31b7574bf83b0a44ca9da24da693472";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b2/linux-i686/fy-NL/firefox-113.0b2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b3/linux-i686/fy-NL/firefox-113.0b3.tar.bz2";
       locale = "fy-NL";
       arch = "linux-i686";
-      sha256 = "0ffa34e28fbfd4b3d2199ec2cf66d82a896ff80d3f1dd13e40f26a65e4dd80fa";
+      sha256 = "f5844bb05a3696f72332cc446791ab2cfda14194994c46aaaac727f27640f827";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b2/linux-i686/ga-IE/firefox-113.0b2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b3/linux-i686/ga-IE/firefox-113.0b3.tar.bz2";
       locale = "ga-IE";
       arch = "linux-i686";
-      sha256 = "f6f15273a14ee83bf63b23fee5f0115cfe6d8a27dd5e43be9b2e929834c459e7";
+      sha256 = "c3193007d8f453b6e2f3dfac982dccec8baf71a0974632a5524fd63ded1ad474";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b2/linux-i686/gd/firefox-113.0b2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b3/linux-i686/gd/firefox-113.0b3.tar.bz2";
       locale = "gd";
       arch = "linux-i686";
-      sha256 = "199643d9030143d4288a48e058194c6781a591cd0397893f272b7768858d6d72";
+      sha256 = "e9ada9c33b15005a0cf2cdb6828e1fecd7311ae5c571631ecb9786c5304dbf83";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b2/linux-i686/gl/firefox-113.0b2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b3/linux-i686/gl/firefox-113.0b3.tar.bz2";
       locale = "gl";
       arch = "linux-i686";
-      sha256 = "6746335a05b354f44fc060a1b0f50e897b46cbe4c7aa45b37dc22d71732f1659";
+      sha256 = "f5f18d848930735d269d814b201edc299624f786add5410241f6399802f18831";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b2/linux-i686/gn/firefox-113.0b2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b3/linux-i686/gn/firefox-113.0b3.tar.bz2";
       locale = "gn";
       arch = "linux-i686";
-      sha256 = "64df184234de243d866598b4de7b4dec72a7512379d10e0a6e37bcbae6b8e00e";
+      sha256 = "9e11c0cc92d361ac1e4c64a271675929c376cf6617d1d663b28ff8cb347c8f41";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b2/linux-i686/gu-IN/firefox-113.0b2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b3/linux-i686/gu-IN/firefox-113.0b3.tar.bz2";
       locale = "gu-IN";
       arch = "linux-i686";
-      sha256 = "700fbc38ab74ecdcaa356f1adb0b612fdcb630dae6e5a4898f1f55200d4e7562";
+      sha256 = "68593c692b7c0361a129562041fbde3b9d80f10c167393f253cfa0ba21a6f81c";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b2/linux-i686/he/firefox-113.0b2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b3/linux-i686/he/firefox-113.0b3.tar.bz2";
       locale = "he";
       arch = "linux-i686";
-      sha256 = "fd28c284170b434d2b8a7b89c3e598ad83426b40fffaea22f0db4b339fb6fee2";
+      sha256 = "d20f5dcdf02d61a3dba490b168fe4252357f7e254f526a2f140d283e749f823a";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b2/linux-i686/hi-IN/firefox-113.0b2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b3/linux-i686/hi-IN/firefox-113.0b3.tar.bz2";
       locale = "hi-IN";
       arch = "linux-i686";
-      sha256 = "91a0da5a09ac27ed6263eff55926a9665bba062fa86120262364d8a1f1ac7649";
+      sha256 = "828dbab83575e518ccd30e4a79288b0615ec618208f9518e27e7d432996e46dd";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b2/linux-i686/hr/firefox-113.0b2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b3/linux-i686/hr/firefox-113.0b3.tar.bz2";
       locale = "hr";
       arch = "linux-i686";
-      sha256 = "cbd4b966ce765436416962d23d100f372bfd108227702a4e83e677436824da73";
+      sha256 = "4b339bb5d6821ffdc3b04c2dbc6e640eb892f6bb24f25a78818d19542b9f959c";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b2/linux-i686/hsb/firefox-113.0b2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b3/linux-i686/hsb/firefox-113.0b3.tar.bz2";
       locale = "hsb";
       arch = "linux-i686";
-      sha256 = "754ddd67d4d382b6b32500eb2cb66773194238c5dea22648b5e24a192b0aa2d2";
+      sha256 = "a94feaadc391f30c0c53dda154418ad08205bd9f680120976a2f02973057225e";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b2/linux-i686/hu/firefox-113.0b2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b3/linux-i686/hu/firefox-113.0b3.tar.bz2";
       locale = "hu";
       arch = "linux-i686";
-      sha256 = "88283fb67c2145bf42d2676b6b767d01fd4d43b732e918388bb030be3deee567";
+      sha256 = "84b7f8a7a963f8062d353f4462ed48c120ac48908fe13ea5688e4139a7e50767";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b2/linux-i686/hy-AM/firefox-113.0b2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b3/linux-i686/hy-AM/firefox-113.0b3.tar.bz2";
       locale = "hy-AM";
       arch = "linux-i686";
-      sha256 = "0d0c913226d0481cafb6f36bd2b0319580b89b28bde3dfac051c1670d8f529a7";
+      sha256 = "4a44431ec691d8b6393efca6255edddb24e08342782ed55886a30cacd2604dae";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b2/linux-i686/ia/firefox-113.0b2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b3/linux-i686/ia/firefox-113.0b3.tar.bz2";
       locale = "ia";
       arch = "linux-i686";
-      sha256 = "29c736d62794f7e6dddb612fd7d893f0d5183c152febb31a681cbec6b6aafc10";
+      sha256 = "dd0f36ba8bd8f059011990b6571fc5da8fabdb0460c401ad51ac3e4d66588b8c";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b2/linux-i686/id/firefox-113.0b2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b3/linux-i686/id/firefox-113.0b3.tar.bz2";
       locale = "id";
       arch = "linux-i686";
-      sha256 = "bec649feb60cad4b94e88969731da86810421ce7496546829308f94f1b5d80cb";
+      sha256 = "3674b91ce5fc9cc3c331dc36328274648c0e371bcaadc6f831d4f215150d8fd1";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b2/linux-i686/is/firefox-113.0b2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b3/linux-i686/is/firefox-113.0b3.tar.bz2";
       locale = "is";
       arch = "linux-i686";
-      sha256 = "cab32fe4560851ed31b6bba8be302307a390017efd96acc5619fab5a4991278c";
+      sha256 = "a4eb60808ea2415276e6b426190f3c027b771dc0abb6c4f805110123bb01a603";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b2/linux-i686/it/firefox-113.0b2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b3/linux-i686/it/firefox-113.0b3.tar.bz2";
       locale = "it";
       arch = "linux-i686";
-      sha256 = "16b571b4ed4700d53fa10e340866218344edf1ed066a6d34a385cbba0b548dae";
+      sha256 = "42b2f7cfeb82e2f23f23004a2098ece9e973cc522dd9aca1291666a83d57c1bc";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b2/linux-i686/ja/firefox-113.0b2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b3/linux-i686/ja/firefox-113.0b3.tar.bz2";
       locale = "ja";
       arch = "linux-i686";
-      sha256 = "d24ac44261ada6f13a8160b565817739b6335940fa015d7369a0f32290f8ab1c";
+      sha256 = "3f6224dc41afa16f63483432273029feecd0df8b6384f03d29bfcc8befcf772d";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b2/linux-i686/ka/firefox-113.0b2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b3/linux-i686/ka/firefox-113.0b3.tar.bz2";
       locale = "ka";
       arch = "linux-i686";
-      sha256 = "dd638504c554209cef24f3ef307eedc0c30876ee59c7265a3effdc3b957a9f46";
+      sha256 = "6ced1ae480d4e08e4b905a336684a8034bf046293b93310f90e00e0b2c40ef0e";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b2/linux-i686/kab/firefox-113.0b2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b3/linux-i686/kab/firefox-113.0b3.tar.bz2";
       locale = "kab";
       arch = "linux-i686";
-      sha256 = "e1788279f6c5f9e8b2d405a59ce6c05b9ce54ca408ce599a5a9bf2d8cb31f648";
+      sha256 = "fd9452c0400a4b739c9b21784bd14e223704bcc85af10a5b4dcf48221d48eb9a";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b2/linux-i686/kk/firefox-113.0b2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b3/linux-i686/kk/firefox-113.0b3.tar.bz2";
       locale = "kk";
       arch = "linux-i686";
-      sha256 = "e2beb70dcf74bdc81e39ff741929bf2661c7abd80d79a09b3921260db45cf800";
+      sha256 = "5f15fe68caea6539a4aa511abbdf643640e0c225d58817c3c2b3ed0372810ffc";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b2/linux-i686/km/firefox-113.0b2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b3/linux-i686/km/firefox-113.0b3.tar.bz2";
       locale = "km";
       arch = "linux-i686";
-      sha256 = "7162a19636ffc9cdc4a5c570e573c656fb659fe977c528def18dd127262507e7";
+      sha256 = "ea9fc2a94e64aea79994dbd44f01e1b555bb7c736b11a6709867c6cba3184562";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b2/linux-i686/kn/firefox-113.0b2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b3/linux-i686/kn/firefox-113.0b3.tar.bz2";
       locale = "kn";
       arch = "linux-i686";
-      sha256 = "b948e3b83e5bc386d1155ae2fb17a639a9ce3183b74cfea1d01d7891834ebc93";
+      sha256 = "c0ac728a51a87ba9ad7b130aa1927233eb245a16bd969fdb3fd818db1abc63e2";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b2/linux-i686/ko/firefox-113.0b2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b3/linux-i686/ko/firefox-113.0b3.tar.bz2";
       locale = "ko";
       arch = "linux-i686";
-      sha256 = "1f6c577aa5b92ceaaceeb7f20c45fb8c6b1c8f2c86ae1c32ac9ff37d7bc22efd";
+      sha256 = "e1860224f8b80eebac87115654bbe0d312fc0a18f6fc13fa7c8eab8930d1dd9b";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b2/linux-i686/lij/firefox-113.0b2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b3/linux-i686/lij/firefox-113.0b3.tar.bz2";
       locale = "lij";
       arch = "linux-i686";
-      sha256 = "0cabbebe77055cf07b8f69d130c48d7adf1f140a92944cdaf2d4f6e5e0aa1560";
+      sha256 = "3626dd6fce6b376d8dda79935663c601a94fcaac000fd64060650836d9509927";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b2/linux-i686/lt/firefox-113.0b2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b3/linux-i686/lt/firefox-113.0b3.tar.bz2";
       locale = "lt";
       arch = "linux-i686";
-      sha256 = "d9723a3741df335382b82ed4903a032e26232f96bbf6ecc467d478d44e552700";
+      sha256 = "a0269dee095dabf5914ec4b2fc0913858f18972ca5b25ae38f4c1c2c609ff33f";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b2/linux-i686/lv/firefox-113.0b2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b3/linux-i686/lv/firefox-113.0b3.tar.bz2";
       locale = "lv";
       arch = "linux-i686";
-      sha256 = "6232345a0e6034ff8409630ebe1e5d95d80d33a4c9a4f6301c5cfd07d9560679";
+      sha256 = "21756ab19c478eccde3258107056ec943a8e597406c73876ed82b5b7e05bc822";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b2/linux-i686/mk/firefox-113.0b2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b3/linux-i686/mk/firefox-113.0b3.tar.bz2";
       locale = "mk";
       arch = "linux-i686";
-      sha256 = "8539c5bf7f3959d2f526b8f41e985ab7d5f71c8b5077e3b094d1228be813a2c8";
+      sha256 = "17a2dee37e0dc1f55f44fa46fbb021221c1231b1a0ae59ee20a241f1a05ef0d5";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b2/linux-i686/mr/firefox-113.0b2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b3/linux-i686/mr/firefox-113.0b3.tar.bz2";
       locale = "mr";
       arch = "linux-i686";
-      sha256 = "b8365ba21b55e5cf774a6b25fa51a15c8053110beb330f3dad5adac9b4aff20d";
+      sha256 = "dc0e7f5b79c6053f126742c8935c9130ee7bf8f6921fecb195b2eb1ff1b619e7";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b2/linux-i686/ms/firefox-113.0b2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b3/linux-i686/ms/firefox-113.0b3.tar.bz2";
       locale = "ms";
       arch = "linux-i686";
-      sha256 = "020d3317b4752bde5a0d4b545fcdd0a353192d439fe429e62dcf414a5bc62561";
+      sha256 = "c607a7e268a6d94dc1f377b61b87f1fb24f18746cc88ea4d3f399e39d50079d2";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b2/linux-i686/my/firefox-113.0b2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b3/linux-i686/my/firefox-113.0b3.tar.bz2";
       locale = "my";
       arch = "linux-i686";
-      sha256 = "b4215ca0a36cce9aeb362852682bbf4a6a087349fd72fc494e7b5a672164798e";
+      sha256 = "a5a552c4b092851169a521b45e67325bb7444688ae3c2b3eec7fd366317d617e";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b2/linux-i686/nb-NO/firefox-113.0b2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b3/linux-i686/nb-NO/firefox-113.0b3.tar.bz2";
       locale = "nb-NO";
       arch = "linux-i686";
-      sha256 = "634c26c0c8debc4f26ff0267cd9b4a33a968f142fbfa5718797c5b98cf6b326c";
+      sha256 = "5b7d00fe9a158463b1ab52a9dc2b9f9f63585f9bc58d78888d868903a82417a0";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b2/linux-i686/ne-NP/firefox-113.0b2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b3/linux-i686/ne-NP/firefox-113.0b3.tar.bz2";
       locale = "ne-NP";
       arch = "linux-i686";
-      sha256 = "98819132fb3d40696ec2a68b2fa2211d8423877366b86240a40936a901af641c";
+      sha256 = "48cf294727f083fdd7c2a6a6cd5316588de212ba080cdee7c4abc8940c603e07";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b2/linux-i686/nl/firefox-113.0b2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b3/linux-i686/nl/firefox-113.0b3.tar.bz2";
       locale = "nl";
       arch = "linux-i686";
-      sha256 = "982169887d9dafc4d16b058df1dbfbd92330d6555679636734f70eae34cebaa5";
+      sha256 = "35ec42660d5676f1ae204c87b878fdf8765b7c8492d1b8d6ce51be3f906614b3";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b2/linux-i686/nn-NO/firefox-113.0b2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b3/linux-i686/nn-NO/firefox-113.0b3.tar.bz2";
       locale = "nn-NO";
       arch = "linux-i686";
-      sha256 = "5636846839fb83e1d40e64115d2f9fbf67e94e4f6271cd5e2a1a6237d9f389b1";
+      sha256 = "a3a5a78ec1ea72f820470142edb6ec17816774f7bb651022379ae2e89b5520a1";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b2/linux-i686/oc/firefox-113.0b2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b3/linux-i686/oc/firefox-113.0b3.tar.bz2";
       locale = "oc";
       arch = "linux-i686";
-      sha256 = "f4927c21e8a3f6151e8e571bf2f08a13716164775daf95748e804975ce7f5e0d";
+      sha256 = "d7d0e7a10452e4dfa787adaed0c09a877ba196a42d19bb037d012b5655be36b9";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b2/linux-i686/pa-IN/firefox-113.0b2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b3/linux-i686/pa-IN/firefox-113.0b3.tar.bz2";
       locale = "pa-IN";
       arch = "linux-i686";
-      sha256 = "286e43d9bbe70b75d6ce8adf12617d2d4ab120bb3285812047fdd5d296e69dfc";
+      sha256 = "5c1e9b1484fdf8dd739a0606b7f987aa1852e2f93ff066654b5c7b18ba956416";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b2/linux-i686/pl/firefox-113.0b2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b3/linux-i686/pl/firefox-113.0b3.tar.bz2";
       locale = "pl";
       arch = "linux-i686";
-      sha256 = "2d0b7741f9b8156f25b989bf49508e66bf1e4126a95576e4fdb1c8006d0cbfaf";
+      sha256 = "b87d6ea603ff4dc924b8f6fdc9765b72ab8d070e46d1c9a8470ed72c0c96de19";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b2/linux-i686/pt-BR/firefox-113.0b2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b3/linux-i686/pt-BR/firefox-113.0b3.tar.bz2";
       locale = "pt-BR";
       arch = "linux-i686";
-      sha256 = "279211754415ab644c2dfcd114b007d82e8c684204f8541a8ee55279df827842";
+      sha256 = "b183c703285b94c24aa3abeaa341d0f3bc14ffee5767abf3a022feba43c3da96";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b2/linux-i686/pt-PT/firefox-113.0b2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b3/linux-i686/pt-PT/firefox-113.0b3.tar.bz2";
       locale = "pt-PT";
       arch = "linux-i686";
-      sha256 = "ef89429a5a950589df7fd7cadd56c1da24c482fa50ed6f4e44fb184f557bef3e";
+      sha256 = "b20926b57460f8ae8b5032ef3a7abe16a47de7fa88c0db51d1d6c105f584b0d5";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b2/linux-i686/rm/firefox-113.0b2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b3/linux-i686/rm/firefox-113.0b3.tar.bz2";
       locale = "rm";
       arch = "linux-i686";
-      sha256 = "23371559057b49d19eaea74f22771fedf8cc4a18a4f63a574b67f06c431ec804";
+      sha256 = "f6f184830237c9d6bc620303742a7d1480c06e08a94908443d95c4dbe2460d51";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b2/linux-i686/ro/firefox-113.0b2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b3/linux-i686/ro/firefox-113.0b3.tar.bz2";
       locale = "ro";
       arch = "linux-i686";
-      sha256 = "c185c9592dce479af6f8536a888cbac9b21a6a9b4d18a9aca696bf88ae0da6db";
+      sha256 = "a844f8a16922208942326a5f96399fa9c733f6909f465d13a8bc4a01879d2597";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b2/linux-i686/ru/firefox-113.0b2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b3/linux-i686/ru/firefox-113.0b3.tar.bz2";
       locale = "ru";
       arch = "linux-i686";
-      sha256 = "6b167db7ecf184551574d4c32e31ccef8f60bf41d672e7f5693fbe7f8c3c5e47";
+      sha256 = "516d30f23ec9e1539532a55f02ed42a801181cbd1e4c57f394b3c36525d84c57";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b2/linux-i686/sc/firefox-113.0b2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b3/linux-i686/sc/firefox-113.0b3.tar.bz2";
       locale = "sc";
       arch = "linux-i686";
-      sha256 = "da80b35b18b2a9b5dca3e7328242fdcd61e3af4d6cfff9789c508986262957c5";
+      sha256 = "46113c900464e685e42bb50263f5debd1d1f66cafadb0fce2e3cfb6f92370f2d";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b2/linux-i686/sco/firefox-113.0b2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b3/linux-i686/sco/firefox-113.0b3.tar.bz2";
       locale = "sco";
       arch = "linux-i686";
-      sha256 = "7ecf3f0a8b60aab8867493588f407d1e1ecca8914195549bfdacc6d4c3004ecc";
+      sha256 = "54ec5f069421788f2201dcbdc68ba06743d26207f10abf147db22b8602d88e5e";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b2/linux-i686/si/firefox-113.0b2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b3/linux-i686/si/firefox-113.0b3.tar.bz2";
       locale = "si";
       arch = "linux-i686";
-      sha256 = "7bca2536a121fdd2a6e2b4bb166ee9ea8ae0b89a91725a6b03e0696beb3acdca";
+      sha256 = "8f8db369359834b8dff2f27342b525d8cd8871380671dcc5e6a3b392dc1d2a68";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b2/linux-i686/sk/firefox-113.0b2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b3/linux-i686/sk/firefox-113.0b3.tar.bz2";
       locale = "sk";
       arch = "linux-i686";
-      sha256 = "9ab8f73f31a3f2c7dddc53d0a8b1a25aa0f3aff7750f6bf1f8df84421808ad2f";
+      sha256 = "9c49a02e6f2b7f9256bc56d5cb92eaae61566d6819a104a20f794a5e77e49fc1";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b2/linux-i686/sl/firefox-113.0b2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b3/linux-i686/sl/firefox-113.0b3.tar.bz2";
       locale = "sl";
       arch = "linux-i686";
-      sha256 = "03ab5e7bf573ee935b3e341f750d4dc77b164c51445830f0d45d58c208ab53e8";
+      sha256 = "a5edb5008a0323656eadd07ca75221ffe1245f4e435131d67fe1bfa648ff24cd";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b2/linux-i686/son/firefox-113.0b2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b3/linux-i686/son/firefox-113.0b3.tar.bz2";
       locale = "son";
       arch = "linux-i686";
-      sha256 = "654d602dadc8bd4b1b3c2423e605b7979a30ceb6c459fbed7f4fff5001ea60df";
+      sha256 = "aa603e3f6f9ed2fcb1a95610504cfe22df05cfc95f62e652f20f4b38ec438467";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b2/linux-i686/sq/firefox-113.0b2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b3/linux-i686/sq/firefox-113.0b3.tar.bz2";
       locale = "sq";
       arch = "linux-i686";
-      sha256 = "643968cee647ff76165ccf4d2a764cd6191a567fba91ae3b33c8ff93a49e8164";
+      sha256 = "ed23e2a3ba333f495f8d729f0946e9e27003653ac4be99e0d6b6cad5c807d71e";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b2/linux-i686/sr/firefox-113.0b2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b3/linux-i686/sr/firefox-113.0b3.tar.bz2";
       locale = "sr";
       arch = "linux-i686";
-      sha256 = "f13aeb85a98fe603440e09aa18bd54a16a69ae36d740bcd9e5e42dcc0bf39e74";
+      sha256 = "a26c668cc70a5254c94c42c53b5233bd43013a8d6b40f40f4d5efdee02a442a1";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b2/linux-i686/sv-SE/firefox-113.0b2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b3/linux-i686/sv-SE/firefox-113.0b3.tar.bz2";
       locale = "sv-SE";
       arch = "linux-i686";
-      sha256 = "b7fda09aadecfd8c3eb54e3d52b3e9bf5b861bbe9eb242331be1d13a87cfca7f";
+      sha256 = "a98ba404537886bae95649da25b531cfa68d46ba871902f80d07ff3d76f12e47";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b2/linux-i686/szl/firefox-113.0b2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b3/linux-i686/szl/firefox-113.0b3.tar.bz2";
       locale = "szl";
       arch = "linux-i686";
-      sha256 = "33f3e095b3c81f6d2d735e26bd13abd44f2de8ff4f0961acf07575c7a1c8540d";
+      sha256 = "7822dc83c9e0f2e818842e8eddaf1d60a6f20ee5c5121762178d038412df4802";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b2/linux-i686/ta/firefox-113.0b2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b3/linux-i686/ta/firefox-113.0b3.tar.bz2";
       locale = "ta";
       arch = "linux-i686";
-      sha256 = "78b7288a4554bcc45adccc08613a3ed3251442e165e21479591382cc13dd450e";
+      sha256 = "cf57bedcc9b96b95bd742cff48b731c9c2164a485bea912f4a2f8cc4726837f5";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b2/linux-i686/te/firefox-113.0b2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b3/linux-i686/te/firefox-113.0b3.tar.bz2";
       locale = "te";
       arch = "linux-i686";
-      sha256 = "9e2de8945ad24b6e172ba8682bb8a49364258d87bd7a9f07c1aae99b76e4a916";
+      sha256 = "2b28faa3bce6375eb72a81d506ca3af28dc313b1ddb65d10b2dda7104cd2bbaa";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b2/linux-i686/tg/firefox-113.0b2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b3/linux-i686/tg/firefox-113.0b3.tar.bz2";
       locale = "tg";
       arch = "linux-i686";
-      sha256 = "7b1078f672c6a8f39d2a181eec7d2ac7418af19c4ac84dd632b81599b14f84b2";
+      sha256 = "32f2a3135cf9b59003b279db16d5faaabbcfab96437e2dee38347b5b2c1d1465";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b2/linux-i686/th/firefox-113.0b2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b3/linux-i686/th/firefox-113.0b3.tar.bz2";
       locale = "th";
       arch = "linux-i686";
-      sha256 = "af0e5f9fcf2f3032b53bf14f89c9b4594721bcead28cd86fb01902a52d10d1cf";
+      sha256 = "0ef9b1c0f40b08ee9c27362a64863a8214dda8782d37f8067be028e05de67c13";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b2/linux-i686/tl/firefox-113.0b2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b3/linux-i686/tl/firefox-113.0b3.tar.bz2";
       locale = "tl";
       arch = "linux-i686";
-      sha256 = "921f13e434aa76d2dafa57065337ab8087d572426b7269f9368e574f395d40ec";
+      sha256 = "7753f626ac53e5bae98783a7375f22cc228ec358b24a75782769f3bca2c598ef";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b2/linux-i686/tr/firefox-113.0b2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b3/linux-i686/tr/firefox-113.0b3.tar.bz2";
       locale = "tr";
       arch = "linux-i686";
-      sha256 = "c83bac81d80180993b1bc754ade6420865d1fe0f1239548dbb96913e28ac06be";
+      sha256 = "1e1259677aad82255ee1773c18cadd9c442d747c8872593c6cd472b909bafc6a";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b2/linux-i686/trs/firefox-113.0b2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b3/linux-i686/trs/firefox-113.0b3.tar.bz2";
       locale = "trs";
       arch = "linux-i686";
-      sha256 = "18cc5f9e830195e08f3243bef085a08d9f7b4b72b35f33e5ab7fb2f5ef9bfb06";
+      sha256 = "7a553e5121be371eb3623adb022bfcd3d7259e69eaa6d1b8a970b34013804d3e";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b2/linux-i686/uk/firefox-113.0b2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b3/linux-i686/uk/firefox-113.0b3.tar.bz2";
       locale = "uk";
       arch = "linux-i686";
-      sha256 = "f03a3ddf8b48630ba6f3f550d7e3e8dbd6f3f3e7aac9f9ed27e93919d20bd744";
+      sha256 = "36123f237696c00b9d305d8309e675d8efccbd95b1984361f1c4e883f2de744a";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b2/linux-i686/ur/firefox-113.0b2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b3/linux-i686/ur/firefox-113.0b3.tar.bz2";
       locale = "ur";
       arch = "linux-i686";
-      sha256 = "719cd7c8b9ff0bea03e27e8c804b83845849d9358ea6faa2bbf7516564fa8535";
+      sha256 = "9995c4978ffa96c0cf8770296171a0c342a832906fad0f98b6f984d331b858bd";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b2/linux-i686/uz/firefox-113.0b2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b3/linux-i686/uz/firefox-113.0b3.tar.bz2";
       locale = "uz";
       arch = "linux-i686";
-      sha256 = "5c622ce64af91bb2a97f94f9303f71f127536b5bca447cd8468efd0bd78c2f1d";
+      sha256 = "0b13df0eb7d9218fe70723dbf1d3f6127b2f1ea2ddbf82d6124dc614bab71ea6";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b2/linux-i686/vi/firefox-113.0b2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b3/linux-i686/vi/firefox-113.0b3.tar.bz2";
       locale = "vi";
       arch = "linux-i686";
-      sha256 = "d0b64d4673dc3f31126202d739c118aa1a22c7d62f4750ed1c6fc9929ccfbef6";
+      sha256 = "f7ee7443c586b02b04bba4f009caf7db3edf8a43852ef7ef6c7535cb8eedd831";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b2/linux-i686/xh/firefox-113.0b2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b3/linux-i686/xh/firefox-113.0b3.tar.bz2";
       locale = "xh";
       arch = "linux-i686";
-      sha256 = "b2796891a1055758f0a07f7f008f7c675b5e39d629f80cda17ffc54ce9c2422e";
+      sha256 = "ccfcfce33d5be862bd06f20e0476eb98070c2a0f536eede0d0b782a64a739bc8";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b2/linux-i686/zh-CN/firefox-113.0b2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b3/linux-i686/zh-CN/firefox-113.0b3.tar.bz2";
       locale = "zh-CN";
       arch = "linux-i686";
-      sha256 = "1be837eb7baf745d3cce35a560ddbcc41190006ff00ef6391442470ac3ef5d32";
+      sha256 = "60448307837618d108a7026e72bb4558cb1ebae0f3cbabb36bced7bc25fd8e14";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b2/linux-i686/zh-TW/firefox-113.0b2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/113.0b3/linux-i686/zh-TW/firefox-113.0b3.tar.bz2";
       locale = "zh-TW";
       arch = "linux-i686";
-      sha256 = "c3aa1828615a5ac80df646fb090aadda6ced6de4b312f8fb4114db7be838e8ec";
+      sha256 = "50f9a14a021535ec6f433b6f5d79f6a8881b4a9d3424a8f384e77a87d97284fb";
     }
     ];
 }


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
