### PR TITLE
Add 6 vscode extensions

### DIFF
--- a/pkgs/applications/editors/vscode/extensions/default.nix
+++ b/pkgs/applications/editors/vscode/extensions/default.nix
@@ -420,7 +420,11 @@ let
           sha256 = "sha256-79Yg4I0OkfG7PaDYnTA8HK8jrSxre4FGriq0Baiq7wA=";
         };
         meta = {
+          description = "A Visual Studio Code extension for Spellchecker";
+          changelog = "https://marketplace.visualstudio.com/items/ban.spellright/changelog";
+          homepage = "https://github.com/bartosz-antosik/vscode-spellright";
           license = lib.licenses.mit;
+          maintainers = with lib.maintainers; [ onedragon ];
         };
       };
 
@@ -673,19 +677,17 @@ let
           sha256 = "sha256-blqLK7S+RmEoyr9zktS5/SNC0GeSXnNpbhltyajoAfw=";
         };
         meta = {
-          description  = "A pure vscode translation plug-in";
+          description = "A Visual Studio Code extension to provide purely hover translation";
           longDescription = ''
-            Code Translate 是一款纯粹的滑词翻译软件
-
-            无侵入式的显示翻译结果: 与VS Code代码分析完美结合
-            强大的单词拆分能力: 支持驼峰, 下划线形式等各种单词拆分
-            丰富的本地词库: 包含 340 万+离线单词, 支持各种生僻单词
-            基于丰富的本地词库: Code Translate 拥有超快的查询速度, 每个单词在基本在 10ms 内可查询完毕
-            多端支持: VS Code 桌面版 和 VS Code Online 版本, 插件均可支持
+            Code Translate is a purely hover translation extension
+            - Non-intrusive display of translation results: perfectly integrated with VS Code code analysis.
+            - Powerful word splitting capabilities: supports various forms of word splitting such as camel case and underscore.
+            - Rich local vocabulary: includes 3.4+ million offline words, supporting various rare words.
+            - Based on a rich local vocabulary: Code Translate has super-fast query speed, with each word typically queried in less than 10ms.
+            - Multi-platform support: supports both the desktop version and online version of VS Code, and the plugin can be used on both versions.
           '';
-          repositories = "https://github.com/w88975/code-translate-vscode";
+          homepage = "https://github.com/w88975/code-translate-vscode";
           changelog = "https://marketplace.visualstudio.com/items/w88975.code-translate/changelog";
-          homepage = "https://marketplace.visualstudio.com/items?itemName=w88975.code-translate";
           license = lib.licenses.mit;
           maintainers = with lib.maintainers; [ onedragon ];
         };
@@ -1167,11 +1169,11 @@ let
           sha256 = "sha256-caNcbDTB/F2mdlGpfIfJv13lzY5Wwj7p7r8dAte9+3A=";
         };
         meta = {
-          description   = "汉英英汉词典, 金山词霸, 有道翻译 for vscode";
-          repositories  = "https://github.com/exiahuang/fanyi-vscode.git";
-          homepage      = "https://github.com/exiahuang/fanyi-vscode";
-          changelog     = "https://marketplace.visualstudio.com/items/ExiaHuang.dictionary/changelog";
+          description = "A Visual Studio Code extension of using chinese-english dictonary in right-click menu";
+          homepage = "https://github.com/exiahuang/fanyi-vscode";
+          changelog = "https://marketplace.visualstudio.com/items/ExiaHuang.dictionary/changelog";
           license = lib.licenses.gpl3Only;
+          maintainers = with lib.maintainers; [ onedragon ];
         };
       };
 
@@ -1310,12 +1312,12 @@ let
           sha256 = "sha256-9Vo6lwqD1eE3zY0Gi9ME/6lPwmwuJ3Iq9StHPvncnM4=";
         };
         meta = {
-          description   = "Translate text right in your code";
-          downloadPage  = "https://marketplace.visualstudio.com/items?itemName=funkyremi.vscode-google-translate";
-          homepage      = "https://github.com/funkyremi/vscode-google-translate.git";
-          repositories  = "https://github.com/funkyremi/vscode-google-translate.git";
-          changelog     = "https://marketplace.visualstudio.com/items/funkyremi.vscode-google-translate/changelog";
-          license       = lib.licenses.mit;
+          description = "A Visual Studio Code extension using google translation to helping you quickly translate text right in your code rocket";
+          downloadPage = "https://marketplace.visualstudio.com/items?itemName=funkyremi.vscode-google-translate";
+          homepage = "https://github.com/funkyremi/vscode-google-translate.git";
+          changelog = "https://marketplace.visualstudio.com/items/funkyremi.vscode-google-translate/changelog";
+          license = lib.licenses.mit;
+          maintainers = with lib.maintainers; [ onedragon ];
         };
       };
 
@@ -1581,15 +1583,18 @@ let
           sha256 = "sha256-g6mlScxv8opZuqgWtTJ3k0Yo7W7WzIkwB+8lWf6cMiU=";
         };
         meta = {
-          description = "This plugin uses the Google Translate API to translate comments for the VSCode programming language.";
+          description = "A Visual Studio Code extension to translate the comments for computer language";
+          longDescription = ''
+            This plugin uses the Google Translate API to translate comments for the VSCode programming language.
+          '';
           homepage = "https://github.com/intellism/vscode-comment-translate/blob/HEAD/doc/README.md";
           downloadPage = "https://marketplace.visualstudio.com/items?itemName=intellsmi.comment-translate";
-          repositories = "https://github.com/intellism/vscode-comment-translate.git";
           changelog = "https://marketplace.visualstudio.com/items/intellsmi.comment-translate/changelog";
+          maintainers = with lib.maintainers; [ onedragon ];
           license = lib.licenses.mit;
         };
       };
-      
+
       ionide.ionide-fsharp = buildVscodeMarketplaceExtension {
         mktplcRef = {
           name = "Ionide-fsharp";
@@ -3312,6 +3317,27 @@ let
         };
         meta = {
           license = lib.licenses.mit;
+        };
+      };
+
+      yzhang.dictionary-completion = buildVscodeMarketplaceExtension {
+        mktplcRef = {
+          publisher = "yzhang";
+          name = "dictionary-completion";
+          version = "1.2.2";
+          sha256 = "sha256-dpJcJARRKzRNHfXs/qknud8OQ8xIyeaVnt/EcDq0k4E=";
+        };
+        meta = {
+          description = "A Visual Studio Code extension to help user easyly finish long words ";
+          longDescription = ''
+            Dictionary completion allows user to get a list of keywords, based off of the current word at the cursor.
+            This is useful if you are typing a long word (e.g. acknowledgeable) and don't want to finish typing or don't remember the Spelling
+          '';
+          homepage = "https://github.com/yzhang-gh/vscode-dic-completion#readme";
+          changelog = "https://marketplace.visualstudio.com/items/yzhang.dictionary-completion/changelog";
+          downloadPage = "https://marketplace.visualstudio.com/items?itemName=yzhang.dictionary-completion";
+          license = lib.licenses.mit;
+          maintainers = with lib.maintainers; [ onedragon ];
         };
       };
 

--- a/pkgs/applications/editors/vscode/extensions/default.nix
+++ b/pkgs/applications/editors/vscode/extensions/default.nix
@@ -690,7 +690,7 @@ let
           maintainers = with lib.maintainers; [ onedragon ];
         };
       };
-      
+
       colejcummins.llvm-syntax-highlighting = buildVscodeMarketplaceExtension {
         mktplcRef = {
           name = "llvm-syntax-highlighting";
@@ -1156,6 +1156,22 @@ let
           downloadPage = "https://marketplace.visualstudio.com/items?itemName=evzen-wybitul.magic-racket";
           homepage = "https://github.com/Eugleo/magic-racket";
           license = lib.licenses.agpl3Only;
+        };
+      };
+
+      ExiaHuang.dictionary = buildVscodeMarketplaceExtension {
+        mktplcRef = {
+          publisher = "ExiaHuang";
+          name = "dictionary";
+          version = "0.0.2";
+          sha256 = "sha256-caNcbDTB/F2mdlGpfIfJv13lzY5Wwj7p7r8dAte9+3A=";
+        };
+        meta = {
+          description   = "汉英英汉词典, 金山词霸, 有道翻译 for vscode";
+          repositories  = "https://github.com/exiahuang/fanyi-vscode.git";
+          homepage      = "https://github.com/exiahuang/fanyi-vscode";
+          changelog     = "https://marketplace.visualstudio.com/items/ExiaHuang.dictionary/changelog";
+          license = lib.licenses.gpl3Only;
         };
       };
 

--- a/pkgs/applications/editors/vscode/extensions/default.nix
+++ b/pkgs/applications/editors/vscode/extensions/default.nix
@@ -665,6 +665,32 @@ let
         };
       };
 
+      w88975.code-translate = buildVscodeMarketplaceExtension {
+        mktplcRef = {
+          name = "code-translate";
+          publisher = "w88975";
+          version = "1.0.20";
+          sha256 = "sha256-blqLK7S+RmEoyr9zktS5/SNC0GeSXnNpbhltyajoAfw=";
+        };
+        meta = {
+          description  = "A pure vscode translation plug-in";
+          longDescription = ''
+            Code Translate 是一款纯粹的滑词翻译软件
+
+            无侵入式的显示翻译结果: 与VS Code代码分析完美结合
+            强大的单词拆分能力: 支持驼峰, 下划线形式等各种单词拆分
+            丰富的本地词库: 包含 340 万+离线单词, 支持各种生僻单词
+            基于丰富的本地词库: Code Translate 拥有超快的查询速度, 每个单词在基本在 10ms 内可查询完毕
+            多端支持: VS Code 桌面版 和 VS Code Online 版本, 插件均可支持
+          '';
+          repositories = "https://github.com/w88975/code-translate-vscode";
+          changelog = "https://marketplace.visualstudio.com/items/w88975.code-translate/changelog";
+          homepage = "https://marketplace.visualstudio.com/items?itemName=w88975.code-translate";
+          license = lib.licenses.mit;
+          maintainers = with lib.maintainers; [ onedragon ];
+        };
+      };
+      
       colejcummins.llvm-syntax-highlighting = buildVscodeMarketplaceExtension {
         mktplcRef = {
           name = "llvm-syntax-highlighting";

--- a/pkgs/applications/editors/vscode/extensions/default.nix
+++ b/pkgs/applications/editors/vscode/extensions/default.nix
@@ -1302,6 +1302,21 @@ let
         };
       };
 
+      funkyremi.vscode-google-translate = buildVscodeMarketplaceExtension {
+        mktplcRef = {
+          publisher = "funkyremi";
+          name = "vscode-google-translate";
+          version = "1.4.13";
+          sha256 = "sha256-9Vo6lwqD1eE3zY0Gi9ME/6lPwmwuJ3Iq9StHPvncnM4=";
+        };
+        meta = {
+          description   = "Translate text right in your code";
+          downloadPage  = "https://marketplace.visualstudio.com/items?itemName=funkyremi.vscode-google-translate";
+          homepage      = "https://github.com/funkyremi/vscode-google-translate.git";
+          license       = lib.licenses.mit;
+        };
+      };
+
       gencer.html-slim-scss-css-class-completion = buildVscodeMarketplaceExtension {
         mktplcRef = {
           name = "html-slim-scss-css-class-completion";

--- a/pkgs/applications/editors/vscode/extensions/default.nix
+++ b/pkgs/applications/editors/vscode/extensions/default.nix
@@ -1313,6 +1313,8 @@ let
           description   = "Translate text right in your code";
           downloadPage  = "https://marketplace.visualstudio.com/items?itemName=funkyremi.vscode-google-translate";
           homepage      = "https://github.com/funkyremi/vscode-google-translate.git";
+          repositories  = "https://github.com/funkyremi/vscode-google-translate.git";
+          changelog     = "https://marketplace.visualstudio.com/items/funkyremi.vscode-google-translate/changelog";
           license       = lib.licenses.mit;
         };
       };
@@ -1571,6 +1573,23 @@ let
         };
       };
 
+      intellsmi.comment-translate = buildVscodeMarketplaceExtension {
+        mktplcRef = {
+          publisher = "intellsmi";
+          name = "comment-translate";
+          version = "2.2.4";
+          sha256 = "sha256-g6mlScxv8opZuqgWtTJ3k0Yo7W7WzIkwB+8lWf6cMiU=";
+        };
+        meta = {
+          description = "This plugin uses the Google Translate API to translate comments for the VSCode programming language.";
+          homepage = "https://github.com/intellism/vscode-comment-translate/blob/HEAD/doc/README.md";
+          downloadPage = "https://marketplace.visualstudio.com/items?itemName=intellsmi.comment-translate";
+          repositories = "https://github.com/intellism/vscode-comment-translate.git";
+          changelog = "https://marketplace.visualstudio.com/items/intellsmi.comment-translate/changelog";
+          license = lib.licenses.mit;
+        };
+      };
+      
       ionide.ionide-fsharp = buildVscodeMarketplaceExtension {
         mktplcRef = {
           name = "Ionide-fsharp";

--- a/pkgs/applications/editors/vscode/extensions/default.nix
+++ b/pkgs/applications/editors/vscode/extensions/default.nix
@@ -412,6 +412,18 @@ let
         };
       };
 
+      ban.spellright = buildVscodeMarketplaceExtension {
+        mktplcRef = {
+          publisher = "ban";
+          name = "spellright";
+          version = "3.0.112";
+          sha256 = "sha256-79Yg4I0OkfG7PaDYnTA8HK8jrSxre4FGriq0Baiq7wA=";
+        };
+        meta = {
+          license = lib.licenses.mit;
+        };
+      };
+
       bbenoist.nix = buildVscodeMarketplaceExtension {
         mktplcRef = {
           name = "Nix";


### PR DESCRIPTION
###### Description of changes
adding 5 VS Code extension about translate.

###### Things done
 
I have only test the full function of code-translate, but others haven't been fully tested, which I just add it by the way.
The things that I can promise is all extension could be build successes, and seems in the extension page without any kind of error log.

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
