### PR TITLE
nixos/jitsi-meet: updated prosody, support secure domain setup and Excalidraw whiteboards

### DIFF
--- a/pkgs/servers/jitsi-excalidraw/default.nix
+++ b/pkgs/servers/jitsi-excalidraw/default.nix
@@ -1,0 +1,40 @@
+{ lib
+, buildNpmPackage
+, fetchFromGitHub
+, nodejs
+, python3
+}:
+
+buildNpmPackage rec {
+  pname = "jitsi-excalidraw-backend";
+  version = "17";
+
+  src = fetchFromGitHub {
+    owner = "jitsi";
+    repo = "excalidraw-backend";
+    rev = "x${version}";
+    hash = "sha256-aQePkVA8KRL06VewiD0ePRpj88pAItcV7B2SBnRRtCs=";
+  };
+
+  npmDepsHash = "sha256-BJqjaqTeg5i+ECGMuiBYVToK2i2XCOVP9yeDFz6nP4k=";
+
+  nativeBuildInputs = [ python3 ];
+
+  installPhase = ''
+    mkdir -p $out/share
+    cp -r {node_modules,dist} $out/share
+  '';
+
+  postFixup = ''
+    makeWrapper ${nodejs}/bin/node $out/bin/jitsi-excalidraw-backend \
+      --add-flags dist/index.js \
+      --chdir $out/share
+  '';
+
+  meta = with lib; {
+    description = "Excalidraw collaboration backend for Jitsi";
+    homepage = "https://github.com/jitsi/excalidraw-backend";
+    license = licenses.mit;
+    maintainers = with maintainers; [ camillemndn ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -25149,6 +25149,8 @@ with pkgs;
 
   jicofo = callPackage ../servers/jicofo { };
 
+  jitsi-excalidraw = callPackage ../servers/jitsi-excalidraw { };
+
   jitsi-meet = callPackage ../servers/web-apps/jitsi-meet { };
 
   jitsi-meet-prosody = callPackage ../misc/jitsi-meet-prosody { };


### PR DESCRIPTION
###### Description of changes

This:
- updates the default Prosody config according to more recent version of Prosody example config (https://github.com/jitsi/jitsi-meet/blob/master/doc/debian/jitsi-meet-prosody/prosody.cfg.lua-jvb.example).
- adds the package ```jitsi-excalidraw``` which is the back-end server for whiteboard-enabled conference rooms.
- adds support for whiteboards in the jitsi-meet module
- adds support for secure domain setup (authenticated room creation).

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
