### PR TITLE
havoc: fix cross

### DIFF
--- a/pkgs/applications/terminal-emulators/havoc/default.nix
+++ b/pkgs/applications/terminal-emulators/havoc/default.nix
@@ -42,6 +42,8 @@ stdenv.mkDerivation rec {
     install -D -m 644 README.md -t $out/share/doc/${pname}-${version}/
   '';
 
+  enableParallelBuilding = true;
+
   meta = with lib; {
     homepage = "https://github.com/ii8/havoc";
     description = "A minimal terminal emulator for Wayland";

--- a/pkgs/applications/terminal-emulators/havoc/default.nix
+++ b/pkgs/applications/terminal-emulators/havoc/default.nix
@@ -3,8 +3,9 @@
 , fetchFromGitHub
 , libxkbcommon
 , pkg-config
-, wayland
 , wayland-protocols
+, wayland-scanner
+, wayland
 }:
 
 stdenv.mkDerivation rec {
@@ -18,14 +19,18 @@ stdenv.mkDerivation rec {
     hash = "sha256-jvGm2gFdMS61otETF7gOEpYn6IuLfqI95IpEVfIv+C4=";
   };
 
-  nativeBuildInputs = [
+  depsBuildBuild = [
     pkg-config
+  ];
+
+  nativeBuildInputs = [
+    wayland-protocols
+    wayland-scanner
   ];
 
   buildInputs = [
     libxkbcommon
     wayland
-    wayland-protocols
   ];
 
   dontConfigure = true;


### PR DESCRIPTION
###### Description of changes

Uses literal "pkg-config" rather than $PKG_CONFIG, but that's fine,
because the only thing it uses for is wayland-protocols, which is
architecture-independent, so we just move it into nativeBuildInputs
and get pkg-config from pkgsBuildBuild.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
