### PR TITLE
systemd-stage-1: Revert assertions about initrd commands

### DIFF
--- a/nixos/modules/system/boot/systemd/initrd.nix
+++ b/nixos/modules/system/boot/systemd/initrd.nix
@@ -338,25 +338,6 @@ in {
   };
 
   config = mkIf (config.boot.initrd.enable && cfg.enable) {
-    assertions = map (name: {
-      assertion = config.boot.initrd.${name} == "";
-      message = ''
-        systemd stage 1 does not support 'boot.initrd.${name}'. Please
-        convert it to analogous systemd units in 'boot.initrd.systemd'.
-
-          Definitions:
-          ${lib.concatMapStringsSep "\n" ({ file, ... }: "- ${file}") options.boot.initrd.${name}.definitionsWithLocations}
-      '';
-    }) [
-      "preFailCommands"
-      "preDeviceCommands"
-      "preLVMCommands"
-      "postDeviceCommands"
-      "postMountCommands"
-      "extraUtilsCommands"
-      "extraUtilsCommandsTest"
-    ];
-
     system.build = { inherit initialRamdisk; };
 
     boot.initrd.availableKernelModules = [


### PR DESCRIPTION
###### Description of changes

This assertion was not as well tested as I thought. There are a variety of modules (including ZFS) that break it. We don't need to *implement* all those modules in systemd initrd before adding these assertions back in, but we do at least need to correct them all to avoid triggering these assertions and provide warnings or errors when in use with systemd initrd.