### PR TITLE
ravedude: init at 0.1.5

### DIFF
--- a/pkgs/development/tools/rust/ravedude/default.nix
+++ b/pkgs/development/tools/rust/ravedude/default.nix
@@ -1,0 +1,30 @@
+{ lib
+, rustPlatform
+, fetchCrate
+, pkg-config
+, udev
+}:
+
+rustPlatform.buildRustPackage rec {
+  pname = "ravedude";
+  version = "0.1.5";
+
+  src = fetchCrate {
+    inherit pname version;
+    hash = "sha256-wcY9fvfIn1pWMAh5FI/QFl18CV2xjmRGSwwoRfGvujo=";
+  };
+
+  cargoHash = "sha256-AOIrB0FRagbA2+JEURF41d+th0AbR++U5WKCcZmh4Os=";
+
+  nativeBuildInputs = [ pkg-config ];
+
+  buildInputs = [ udev ];
+
+  meta = with lib; {
+    description = "Tool to easily flash code onto an AVR microcontroller with avrdude";
+    homepage = "https://crates.io/crates/ravedude";
+    license = with licenses; [ mit /* or */ asl20 ];
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ rvarago ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -16233,6 +16233,7 @@ with pkgs;
 
   ograc = callPackage ../development/tools/rust/ograc { };
 
+  ravedude = callPackage ../development/tools/rust/ravedude { };
   rhack = callPackage ../development/tools/rust/rhack { };
   roogle = callPackage ../development/tools/rust/roogle { };
   rustfmt = rustPackages.rustfmt;


### PR DESCRIPTION
###### Description of changes

This is a tool to make Rust development for AVR microcontrollers smoother by wrapping `avrdude`.

https://github.com/Rahix/avr-hal/tree/main/ravedude

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
