### PR TITLE
haskell.packages.ghc96.cborg-json: allow base-4.18

### DIFF
--- a/pkgs/development/haskell-modules/configuration-ghc-9.6.x.nix
+++ b/pkgs/development/haskell-modules/configuration-ghc-9.6.x.nix
@@ -106,6 +106,7 @@ self: super: {
   # Forbids base >= 4.18, fix proposed: https://github.com/well-typed/cborg/pull/312
   cborg = assert !(self ? cborg_0_2_8_0); doJailbreak super.cborg;
   cborg-json = assert !(self ? cborg_0_2_5_0); doJailbreak super.cborg-json;
+  serialise = assert !(self ? serialise_0_2_6_0); doJailbreak super.serialise;
 
   #
   # Too strict bounds, waiting on Hackage release in nixpkgs

--- a/pkgs/development/haskell-modules/configuration-ghc-9.6.x.nix
+++ b/pkgs/development/haskell-modules/configuration-ghc-9.6.x.nix
@@ -9,6 +9,11 @@ let
     overrideCabal (old: {
       jailbreak = assert old.revision or "0" == toString rev; true;
     });
+  checkAgainAfter = pkg: ver: msg: act:
+    if builtins.compareVersions pkg.version ver <= 0 then act
+    else
+      builtins.throw "Check if '${msg}' was resolved in ${pkg.pname} ${pkg.version} and update or remove this";
+  jailbreakForCurrentVersion = p: v: checkAgainAfter p v "bad bounds" (doJailbreak p);
 in
 
 self: super: {
@@ -102,19 +107,19 @@ self: super: {
   lukko = doJailbreak super.lukko;
 
   # Forbids base >= 4.18, fix proposed: https://github.com/sjakobi/newtype-generics/pull/25
-  newtype-generics = assert !(self ? newtype-generics_0_6_2); doJailbreak super.newtype-generics;
+  newtype-generics = jailbreakForCurrentVersion super.newtype-generics "0.6.2";
   # Forbids base >= 4.18, fix proposed: https://github.com/well-typed/cborg/pull/312
-  cborg = assert !(self ? cborg_0_2_8_0); doJailbreak super.cborg;
-  cborg-json = assert !(self ? cborg_0_2_5_0); doJailbreak super.cborg-json;
-  serialise = assert !(self ? serialise_0_2_6_0); doJailbreak super.serialise;
+  cborg = jailbreakForCurrentVersion super.cborg "0.2.8.0";
+  cborg-json = jailbreakForCurrentVersion super.cborg-json "0.2.5.0";
+  serialise = jailbreakForCurrentVersion super.serialise "0.2.6.0";
 
   #
   # Too strict bounds, waiting on Hackage release in nixpkgs
   #
 
   # base >= 4.18 is allowed in those newer versions
-  boring = assert !(self ? boring_0_2_1); doJailbreak super.boring;
-  these = assert !(self ? assoc_1_2); doJailbreak super.these;
+  boring = jailbreakForCurrentVersion super.boring "0.2.1";
+  these = jailbreakForCurrentVersion super.these "1.2";
 
   # XXX: We probably should be using semigroupoids 6.0.1 which is intended for 9.6
   semigroupoids = doJailbreak super.semigroupoids;

--- a/pkgs/development/haskell-modules/configuration-ghc-9.6.x.nix
+++ b/pkgs/development/haskell-modules/configuration-ghc-9.6.x.nix
@@ -103,6 +103,9 @@ self: super: {
 
   # Forbids base >= 4.18, fix proposed: https://github.com/sjakobi/newtype-generics/pull/25
   newtype-generics = assert !(self ? newtype-generics_0_6_2); doJailbreak super.newtype-generics;
+  # Forbids base >= 4.18, fix proposed: https://github.com/well-typed/cborg/pull/312
+  cborg = assert !(self ? cborg_0_2_8_0); doJailbreak super.cborg;
+  cborg-json = assert !(self ? cborg_0_2_5_0); doJailbreak super.cborg-json;
 
   #
   # Too strict bounds, waiting on Hackage release in nixpkgs


### PR DESCRIPTION
###### Description of changes

This PR enables building cborg-json: `nix build -L .#haskell.packages.ghc96.cborg-json`

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
