### PR TITLE
salt: 3005.1 -> 3006.0

### DIFF
--- a/pkgs/tools/admin/salt/default.nix
+++ b/pkgs/tools/admin/salt/default.nix
@@ -2,7 +2,6 @@
 , stdenv
 , python3
 , openssl
-, fetchpatch
   # Many Salt modules require various Python modules to be installed,
   # passing them in this array enables Salt to find them.
 , extraInputs ? []
@@ -10,19 +9,21 @@
 
 python3.pkgs.buildPythonApplication rec {
   pname = "salt";
-  version = "3005.1";
+  version = "3006.0";
 
   src = python3.pkgs.fetchPypi {
     inherit pname version;
-    hash = "sha256-+hTF2HP4Y7UJUBIdfiOiRJUCdFSQx8SMDPBFQGz+V8E=";
+    hash = "sha256-7iw4s06oYUCQE8gc8KqFKX1pzxB3O3PuegcQtclC3Mo=";
   };
 
   propagatedBuildInputs = with python3.pkgs; [
     distro
     jinja2
     jmespath
+    looseversion
     markupsafe
     msgpack
+    packaging
     psutil
     pycryptodomex
     pyyaml
@@ -44,14 +45,9 @@ python3.pkgs.buildPythonApplication rec {
     # `extraInputs` like on any other platform
     echo -n > "requirements/darwin.txt"
 
-    # 3004.1: requirement of pyzmq was restricted to <22.0.0; looks like that req was incorrect
-    # https://github.com/saltstack/salt/commit/070597e525bb7d56ffadede1aede325dfb1b73a4
-    # https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=259279
-    # https://github.com/saltstack/salt/pull/61163
+    # Remove windows-only requirement
     substituteInPlace "requirements/zeromq.txt" \
-      --replace 'pyzmq<=20.0.0 ; python_version < "3.6"' "" \
-      --replace 'pyzmq>=17.0.0,<22.0.0 ; python_version < "3.9"' 'pyzmq>=17.0.0 ; python_version < "3.9"' \
-      --replace 'pyzmq>19.0.2,<22.0.0 ; python_version >= "3.9"' 'pyzmq>19.0.2 ; python_version >= "3.9"'
+      --replace 'pyzmq==25.0.2 ; sys_platform == "win32"' ""
   '';
 
   # Don't use fixed dependencies on Darwin


### PR DESCRIPTION
###### Description of changes

Changelog: https://docs.saltproject.io/en/latest/topics/releases/3006.0.html

Includes the looseversion package from #214807.
cc @pelme

Tested and works.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
