### PR TITLE
maintainers/scripts/haskell: Integrate transitive-broken into regeneration script

### DIFF
--- a/maintainers/scripts/haskell/mark-broken.sh
+++ b/maintainers/scripts/haskell/mark-broken.sh
@@ -32,8 +32,6 @@ EOF
 sort -iu "$tmpfile" >> "$broken_config"
 clear="env -u HOME -u NIXPKGS_CONFIG"
 $clear maintainers/scripts/haskell/regenerate-hackage-packages.sh
-$clear maintainers/scripts/haskell/regenerate-transitive-broken-packages.sh
-$clear maintainers/scripts/haskell/regenerate-hackage-packages.sh
 evalline=$(maintainers/scripts/haskell/hydra-report.hs eval-info)
 
 if [[ "${1:-}" == "--do-commit" ]]; then

--- a/maintainers/scripts/haskell/regenerate-hackage-packages.sh
+++ b/maintainers/scripts/haskell/regenerate-hackage-packages.sh
@@ -1,21 +1,68 @@
 #! /usr/bin/env nix-shell
 #! nix-shell -i bash -p coreutils haskellPackages.cabal2nix-unstable git nix -I nixpkgs=.
 
-# This script is used to regenerate nixpkgs' Haskell package set, using the
-# tool hackage2nix from the nixos/cabal2nix repo. hackage2nix looks at the
-# config files in pkgs/development/haskell-modules/configuration-hackage2nix
-# and generates a Nix expression for package version specified there, using the
-# Cabal files from the Hackage database (available under all-cabal-hashes) and
-# its companion tool cabal2nix.
-#
-# Related scripts are update-hackage.sh, for updating the snapshot of the
-# Hackage database used by hackage2nix, and update-cabal2nix-unstable.sh,
-# for updating the version of hackage2nix used to perform this task.
-#
-# Note that this script doesn't gcroot anything, so it may be broken by an
-# unfortunately timed nix-store --gc.
-
 set -euo pipefail
+
+self=$0
+
+print_help () {
+cat <<END_HELP
+Usage: $self [options]
+
+Options:
+   --do-commit    Commit changes to this file.
+   -f | --fast    Do not update the transitive-broken.yaml file.
+   -h | --help    Show this help.
+
+This script is used to regenerate nixpkgs' Haskell package set, using the
+tool hackage2nix from the nixos/cabal2nix repo. hackage2nix looks at the
+config files in pkgs/development/haskell-modules/configuration-hackage2nix
+and generates a Nix expression for package version specified there, using the
+Cabal files from the Hackage database (available under all-cabal-hashes) and
+its companion tool cabal2nix.
+
+Unless --fast is used, it will then use the generated nix expression by
+running regenerate-transitive-broken-packages.sh which updates the transitive-broken.yaml
+file. Then it re-runs hackage2nix.
+
+Related scripts are update-hackage.sh, for updating the snapshot of the
+Hackage database used by hackage2nix, and update-cabal2nix-unstable.sh,
+for updating the version of hackage2nix used to perform this task.
+
+Note that this script doesn't gcroot anything, so it may be broken by an
+unfortunately timed nix-store --gc.
+
+END_HELP
+}
+
+DO_COMMIT=0
+REGENERATE_TRANSITIVE=1
+
+options=$(getopt -o "fh" -l "help,fast,do-commit" -- "$@")
+
+eval set -- "$options"
+
+while true; do
+   case "$1" in
+      --do-commit)
+         DO_COMMIT=1
+         ;;
+      -f|--fast)
+         REGENERATE_TRANSITIVE=0
+         ;;
+      -h|--help)
+         print_help
+         exit 0
+         ;;
+      --)
+         break;;
+      *)
+         print_help
+         exit 1
+         ;;
+   esac
+   shift
+done
 
 HACKAGE2NIX="${HACKAGE2NIX:-hackage2nix}"
 
@@ -25,14 +72,7 @@ export LC_ALL=C.UTF-8
 
 config_dir=pkgs/development/haskell-modules/configuration-hackage2nix
 
-echo "Obtaining Hackage data"
-extraction_derivation='with import ./. {}; runCommandLocal "unpacked-cabal-hashes" { } "tar xf ${all-cabal-hashes} --strip-components=1 --one-top-level=$out"'
-unpacked_hackage="$(nix-build -E "$extraction_derivation" --no-out-link)"
-
-echo "Generating compiler configuration"
-compiler_config="$(nix-build -A haskellPackages.cabal2nix-unstable.compilerConfig --no-out-link)"
-
-echo "Starting hackage2nix to regenerate pkgs/development/haskell-modules/hackage-packages.nix ..."
+run_hackage2nix() {
 "$HACKAGE2NIX" \
    --hackage "$unpacked_hackage" \
    --preferred-versions <(for n in "$unpacked_hackage"/*/preferred-versions; do cat "$n"; echo; done) \
@@ -42,8 +82,33 @@ echo "Starting hackage2nix to regenerate pkgs/development/haskell-modules/hackag
    --config "$config_dir/stackage.yaml" \
    --config "$config_dir/broken.yaml" \
    --config "$config_dir/transitive-broken.yaml"
+}
 
-if [[ "${1:-}" == "--do-commit" ]]; then
+echo "Obtaining Hackage data …"
+extraction_derivation='with import ./. {}; runCommandLocal "unpacked-cabal-hashes" { } "tar xf ${all-cabal-hashes} --strip-components=1 --one-top-level=$out"'
+unpacked_hackage="$(nix-build -E "$extraction_derivation" --no-out-link)"
+
+echo "Generating compiler configuration …"
+compiler_config="$(nix-build -A haskellPackages.cabal2nix-unstable.compilerConfig --no-out-link)"
+
+echo "Running hackage2nix to regenerate pkgs/development/haskell-modules/hackage-packages.nix …"
+run_hackage2nix
+
+if [[ "$REGENERATE_TRANSITIVE" -eq 1 ]]; then
+
+echo "Regenerating transitive-broken.yaml … (pass --fast to $self to skip this step)"
+
+maintainers/scripts/haskell/regenerate-transitive-broken-packages.sh
+
+echo "Running hackage2nix again to reflect changes in transitive-broken.yaml …"
+
+run_hackage2nix
+
+fi
+
+
+if [[ "$DO_COMMIT" -eq 1 ]]; then
+git add pkgs/development/haskell-modules/configuration-hackage2nix/transitive-broken.yaml
 git add pkgs/development/haskell-modules/hackage-packages.nix
 git commit -F - << EOF
 haskellPackages: regenerate package set based on current config

--- a/maintainers/scripts/haskell/regenerate-transitive-broken-packages.sh
+++ b/maintainers/scripts/haskell/regenerate-transitive-broken-packages.sh
@@ -11,5 +11,4 @@ cat > $config_file << EOF
 dont-distribute-packages:
 EOF
 
-echo "Regenerating list of transitive broken packages ..."
 nix-instantiate --eval --option restrict-eval true -I . --strict --json maintainers/scripts/haskell/transitive-broken-packages.nix | jq -r . | LC_ALL=C.UTF-8 sort -i >> $config_file


### PR DESCRIPTION
###### Description of changes

After https://github.com/NixOS/nixpkgs/pull/227424#issuecomment-1518592189
I decided that the current UX is not great and integrate the call regenerate
transitive-broken.yaml into the regenerate-hackage-packages.nix script.

I decided to make the transitive-broken regeneration on by default. The script
is not very fast, but I still think it’s slightly more convenient this way.

I am not very certain about this change, so feedback would be greatly appreciated.
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
