### PR TITLE
androidenv: update repo.json with a new strategy to expire

### DIFF
--- a/pkgs/development/mobile/androidenv/compose-android-packages.nix
+++ b/pkgs/development/mobile/androidenv/compose-android-packages.nix
@@ -2,12 +2,12 @@
 , licenseAccepted ? false
 }:
 
-{ cmdLineToolsVersion ? "8.0"
+{ cmdLineToolsVersion ? "9.0"
 , toolsVersion ? "26.1.1"
-, platformToolsVersion ? "33.0.3"
-, buildToolsVersions ? [ "33.0.1" ]
+, platformToolsVersion ? "34.0.1"
+, buildToolsVersions ? [ "33.0.2" ]
 , includeEmulator ? false
-, emulatorVersion ? "31.3.14"
+, emulatorVersion ? "33.1.6"
 , platformVersions ? []
 , includeSources ? false
 , includeSystemImages ? false
@@ -15,7 +15,7 @@
 , abiVersions ? [ "armeabi-v7a" "arm64-v8a" ]
 , cmakeVersions ? [ ]
 , includeNDK ? false
-, ndkVersion ? "25.1.8937393"
+, ndkVersion ? "25.2.9519653"
 , ndkVersions ? [ndkVersion]
 , useGoogleAPIs ? false
 , useGoogleTVAddOns ? false

--- a/pkgs/development/mobile/androidenv/examples/shell-with-emulator.nix
+++ b/pkgs/development/mobile/androidenv/examples/shell-with-emulator.nix
@@ -115,7 +115,7 @@ pkgs.mkShell rec {
       echo "installed_packages_section: ''${installed_packages_section}"
 
       packages=(
-        "build-tools;33.0.1" "cmdline-tools;8.0" \
+        "build-tools;33.0.2" "cmdline-tools;9.0" \
         "emulator" "patcher;v4" "platform-tools" "platforms;android-33" \
         "system-images;android-33;google_apis;arm64-v8a" \
         "system-images;android-33;google_apis;x86_64"

--- a/pkgs/development/mobile/androidenv/examples/shell.nix
+++ b/pkgs/development/mobile/androidenv/examples/shell.nix
@@ -25,15 +25,15 @@ let
   # versions may be used in multiple places in this Nix expression.
   android = {
     versions = {
-      cmdLineToolsVersion = "8.0";
-      platformTools = "33.0.3";
-      buildTools = "30.0.3";
+      cmdLineToolsVersion = "9.0";
+      platformTools = "34.0.1";
+      buildTools = "33.0.2";
       ndk = [
         "25.1.8937393" # LTS NDK
-        "24.0.8215888"
+        "25.2.9519653"
       ];
-      cmake = "3.22.1";
-      emulator = "31.3.14";
+      cmake = "3.6.4111459";
+      emulator = "33.1.6";
     };
 
     platforms = ["23" "24" "25" "26" "27" "28" "29" "30" "31" "32" "33"];
@@ -165,7 +165,7 @@ pkgs.mkShell rec {
       installed_packages_section=$(echo "''${output%%Available Packages*}" | awk 'NR>4 {print $1}')
 
       packages=(
-        "build-tools;30.0.3" "platform-tools" \
+        "build-tools;33.0.2" "platform-tools" \
         "platforms;android-23" "platforms;android-24" "platforms;android-25" "platforms;android-26" \
         "platforms;android-27" "platforms;android-28" "platforms;android-29" "platforms;android-30" \
         "platforms;android-31" "platforms;android-32" "platforms;android-33" \

--- a/pkgs/development/mobile/androidenv/mkrepo.sh
+++ b/pkgs/development/mobile/androidenv/mkrepo.sh
@@ -1,12 +1,12 @@
 #!/usr/bin/env nix-shell
-#!nix-shell -i bash -p "ruby.withPackages (pkgs: with pkgs; [ slop nokogiri ])"
+#!nix-shell -i bash -p "ruby.withPackages (pkgs: with pkgs; [ slop nokogiri moreutils ])"
 
 set -e
 
 pushd "$(dirname "$0")" &>/dev/null || exit 1
 
 echo "Writing repo.json" >&2
-ruby mkrepo.rb \
+cat ./repo.json | ruby mkrepo.rb \
     --packages ./xml/repository2-1.xml \
     --images ./xml/android-sys-img2-1.xml \
     --images ./xml/android-tv-sys-img2-1.xml \
@@ -14,6 +14,7 @@ ruby mkrepo.rb \
     --images ./xml/android-wear-sys-img2-1.xml \
     --images ./xml/google_apis-sys-img2-1.xml \
     --images ./xml/google_apis_playstore-sys-img2-1.xml \
-    --addons ./xml/addon2-1.xml > repo.json
+    --addons ./xml/addon2-1.xml \
+         | sponge repo.json
 
 popd &>/dev/null

--- a/pkgs/development/mobile/androidenv/repo.json
+++ b/pkgs/development/mobile/androidenv/repo.json
@@ -11,6 +11,7 @@
           }
         ],
         "displayName": "Google APIs",
+        "last-available-day": 19489,
         "license": "android-sdk-license",
         "name": "google_apis",
         "path": "add-ons/addon-google_apis-google-10",
@@ -63,6 +64,7 @@
           }
         ],
         "displayName": "Google APIs",
+        "last-available-day": 19489,
         "license": "android-sdk-license",
         "name": "google_apis",
         "path": "add-ons/addon-google_apis-google-11",
@@ -108,6 +110,7 @@
           }
         ],
         "displayName": "Google APIs",
+        "last-available-day": 19489,
         "license": "android-sdk-license",
         "name": "google_apis",
         "path": "add-ons/addon-google_apis-google-12",
@@ -158,6 +161,7 @@
           }
         ],
         "displayName": "Google TV Addon",
+        "last-available-day": 19489,
         "license": "android-googletv-license",
         "name": "google_tv_addon",
         "path": "add-ons/addon-google_tv_addon-google-12",
@@ -194,6 +198,7 @@
           }
         ],
         "displayName": "Google APIs",
+        "last-available-day": 19489,
         "license": "android-sdk-license",
         "name": "google_apis",
         "path": "add-ons/addon-google_apis-google-13",
@@ -244,6 +249,7 @@
           }
         ],
         "displayName": "Google TV Addon",
+        "last-available-day": 19489,
         "license": "android-googletv-license",
         "name": "google_tv_addon",
         "path": "add-ons/addon-google_tv_addon-google-13",
@@ -280,6 +286,7 @@
           }
         ],
         "displayName": "Google APIs",
+        "last-available-day": 19489,
         "license": "android-sdk-license",
         "name": "google_apis",
         "path": "add-ons/addon-google_apis-google-14",
@@ -332,6 +339,7 @@
           }
         ],
         "displayName": "Google APIs",
+        "last-available-day": 19489,
         "license": "android-sdk-license",
         "name": "google_apis",
         "path": "add-ons/addon-google_apis-google-15",
@@ -391,6 +399,7 @@
           }
         ],
         "displayName": "Google APIs",
+        "last-available-day": 19489,
         "license": "android-sdk-license",
         "name": "google_apis",
         "path": "add-ons/addon-google_apis-google-16",
@@ -450,6 +459,7 @@
           }
         ],
         "displayName": "Google APIs",
+        "last-available-day": 19489,
         "license": "android-sdk-license",
         "name": "google_apis",
         "path": "add-ons/addon-google_apis-google-17",
@@ -509,6 +519,7 @@
           }
         ],
         "displayName": "Google APIs",
+        "last-available-day": 19489,
         "license": "android-sdk-license",
         "name": "google_apis",
         "path": "add-ons/addon-google_apis-google-18",
@@ -568,6 +579,7 @@
           }
         ],
         "displayName": "Google APIs",
+        "last-available-day": 19489,
         "license": "android-sdk-license",
         "name": "google_apis",
         "path": "add-ons/addon-google_apis-google-19",
@@ -627,6 +639,7 @@
           }
         ],
         "displayName": "Google APIs",
+        "last-available-day": 19489,
         "license": "android-sdk-license",
         "name": "google_apis",
         "path": "add-ons/addon-google_apis-google-21",
@@ -686,6 +699,7 @@
           }
         ],
         "displayName": "Google APIs",
+        "last-available-day": 19489,
         "license": "android-sdk-license",
         "name": "google_apis",
         "path": "add-ons/addon-google_apis-google-22",
@@ -745,6 +759,7 @@
           }
         ],
         "displayName": "Google APIs",
+        "last-available-day": 19489,
         "license": "android-sdk-license",
         "name": "google_apis",
         "path": "add-ons/addon-google_apis-google-23",
@@ -804,6 +819,7 @@
           }
         ],
         "displayName": "Google APIs",
+        "last-available-day": 19489,
         "license": "android-sdk-license",
         "name": "google_apis",
         "path": "add-ons/addon-google_apis-google-24",
@@ -863,6 +879,7 @@
           }
         ],
         "displayName": "Google APIs",
+        "last-available-day": 19489,
         "license": "android-sdk-license",
         "name": "google_apis",
         "path": "add-ons/addon-google_apis-google-25",
@@ -922,6 +939,7 @@
           }
         ],
         "displayName": "Google APIs",
+        "last-available-day": 19489,
         "license": "android-sdk-license",
         "name": "google_apis",
         "path": "add-ons/addon-google_apis-google-3",
@@ -967,6 +985,7 @@
           }
         ],
         "displayName": "Google APIs",
+        "last-available-day": 19489,
         "license": "android-sdk-license",
         "name": "google_apis",
         "path": "add-ons/addon-google_apis-google-4",
@@ -1012,6 +1031,7 @@
           }
         ],
         "displayName": "Google APIs",
+        "last-available-day": 19489,
         "license": "android-sdk-license",
         "name": "google_apis",
         "path": "add-ons/addon-google_apis-google-5",
@@ -1057,6 +1077,7 @@
           }
         ],
         "displayName": "Google APIs",
+        "last-available-day": 19489,
         "license": "android-sdk-license",
         "name": "google_apis",
         "path": "add-ons/addon-google_apis-google-6",
@@ -1102,6 +1123,7 @@
           }
         ],
         "displayName": "Google APIs",
+        "last-available-day": 19489,
         "license": "android-sdk-license",
         "name": "google_apis",
         "path": "add-ons/addon-google_apis-google-7",
@@ -1147,6 +1169,7 @@
           }
         ],
         "displayName": "Google APIs",
+        "last-available-day": 19489,
         "license": "android-sdk-license",
         "name": "google_apis",
         "path": "add-ons/addon-google_apis-google-8",
@@ -1192,6 +1215,7 @@
           }
         ],
         "displayName": "Google APIs",
+        "last-available-day": 19489,
         "license": "android-sdk-license",
         "name": "google_apis",
         "path": "add-ons/addon-google_apis-google-9",
@@ -1238,6 +1262,7 @@
         }
       ],
       "displayName": "Android Support Repository",
+      "last-available-day": 19489,
       "license": "android-sdk-license",
       "name": "extras-android-m2repository",
       "path": "extras/android/m2repository",
@@ -1261,12 +1286,13 @@
       "archives": [
         {
           "os": "windows",
-          "sha1": "7be9c46e3bbf4ab107fa614e426f925584ce310b",
-          "size": 166975,
-          "url": "https://dl.google.com/android/repository/gvm-windows_v1_8_0.zip"
+          "sha1": "1a4ef9875cb0adfe5500632ad7140027cfb080d9",
+          "size": 168741,
+          "url": "https://dl.google.com/android/repository/gvm-windows_v2_0_0.zip"
         }
       ],
-      "displayName": "Android Emulator Hypervisor Driver for AMD Processors (installer)",
+      "displayName": "Android Emulator Hypervisor Driver for AMD Processors (installer: Deprecated)",
+      "last-available-day": 19489,
       "license": "android-sdk-license",
       "name": "extras-google-Android_Emulator_Hypervisor_Driver",
       "path": "extras/google/Android_Emulator_Hypervisor_Driver",
@@ -1296,6 +1322,7 @@
         }
       ],
       "displayName": "Google AdMob Ads SDK",
+      "last-available-day": 19489,
       "license": "android-sdk-license",
       "name": "extras-google-admob_ads_sdk",
       "path": "extras/google/admob_ads_sdk",
@@ -1323,6 +1350,7 @@
         }
       ],
       "displayName": "Google Analytics App Tracking SDK",
+      "last-available-day": 19489,
       "license": "android-sdk-license",
       "name": "extras-google-analytics_sdk_v2",
       "path": "extras/google/analytics_sdk_v2",
@@ -1350,6 +1378,7 @@
         }
       ],
       "displayName": "Google Cloud Messaging for Android Library",
+      "last-available-day": 19489,
       "license": "android-sdk-license",
       "name": "extras-google-gcm",
       "path": "extras/google/gcm",
@@ -1384,6 +1413,7 @@
         }
       },
       "displayName": "Google Play services",
+      "last-available-day": 19489,
       "license": "android-sdk-license",
       "name": "extras-google-google_play_services",
       "path": "extras/google/google_play_services",
@@ -1411,6 +1441,7 @@
         }
       ],
       "displayName": "Google Play services for Froyo",
+      "last-available-day": 19489,
       "license": "android-sdk-license",
       "name": "extras-google-google_play_services_froyo",
       "path": "extras/google/google_play_services_froyo",
@@ -1438,6 +1469,7 @@
         }
       ],
       "displayName": "Google Play Instant Development SDK",
+      "last-available-day": 19489,
       "license": "android-sdk-license",
       "name": "extras-google-instantapps",
       "path": "extras/google/instantapps",
@@ -1474,6 +1506,7 @@
         }
       },
       "displayName": "Google Repository",
+      "last-available-day": 19489,
       "license": "android-sdk-license",
       "name": "extras-google-m2repository",
       "path": "extras/google/m2repository",
@@ -1501,6 +1534,7 @@
         }
       ],
       "displayName": "Google Play APK Expansion library",
+      "last-available-day": 19489,
       "license": "android-sdk-license",
       "name": "extras-google-market_apk_expansion",
       "path": "extras/google/market_apk_expansion",
@@ -1528,6 +1562,7 @@
         }
       ],
       "displayName": "Google Play Licensing Library",
+      "last-available-day": 19489,
       "license": "android-sdk-license",
       "name": "extras-google-market_licensing",
       "path": "extras/google/market_licensing",
@@ -1556,6 +1591,7 @@
         }
       ],
       "displayName": "Android Auto API Simulators",
+      "last-available-day": 19489,
       "license": "android-sdk-license",
       "name": "extras-google-simulators",
       "path": "extras/google/simulators",
@@ -1583,6 +1619,7 @@
         }
       ],
       "displayName": "Google USB Driver",
+      "last-available-day": 19489,
       "license": "android-sdk-license",
       "name": "extras-google-usb_driver",
       "path": "extras/google/usb_driver",
@@ -1610,6 +1647,7 @@
         }
       ],
       "displayName": "Google Web Driver",
+      "last-available-day": 19489,
       "license": "android-sdk-license",
       "name": "extras-google-webdriver",
       "path": "extras/google/webdriver",
@@ -1637,6 +1675,7 @@
         }
       ],
       "displayName": "Solver for ConstraintLayout 1.0.0",
+      "last-available-day": 19489,
       "license": "android-sdk-license",
       "name": "extras-m2repository-com-android-support-constraint-constraint-layout-solver-1.0.0",
       "path": "extras/m2repository/com/android/support/constraint/constraint-layout-solver/1.0.0",
@@ -1664,6 +1703,7 @@
         }
       ],
       "displayName": "com.android.support.constraint:constraint-layout-solver:1.0.0-alpha4",
+      "last-available-day": 19489,
       "license": "android-sdk-license",
       "name": "extras-m2repository-com-android-support-constraint-constraint-layout-solver-1.0.0-alpha4",
       "path": "extras/m2repository/com/android/support/constraint/constraint-layout-solver/1.0.0-alpha4",
@@ -1691,6 +1731,7 @@
         }
       ],
       "displayName": "Solver for ConstraintLayout 1.0.0-alpha8",
+      "last-available-day": 19489,
       "license": "android-sdk-license",
       "name": "extras-m2repository-com-android-support-constraint-constraint-layout-solver-1.0.0-alpha8",
       "path": "extras/m2repository/com/android/support/constraint/constraint-layout-solver/1.0.0-alpha8",
@@ -1718,6 +1759,7 @@
         }
       ],
       "displayName": "Solver for ConstraintLayout 1.0.0-beta1",
+      "last-available-day": 19489,
       "license": "android-sdk-license",
       "name": "extras-m2repository-com-android-support-constraint-constraint-layout-solver-1.0.0-beta1",
       "path": "extras/m2repository/com/android/support/constraint/constraint-layout-solver/1.0.0-beta1",
@@ -1745,6 +1787,7 @@
         }
       ],
       "displayName": "Solver for ConstraintLayout 1.0.0-beta2",
+      "last-available-day": 19489,
       "license": "android-sdk-license",
       "name": "extras-m2repository-com-android-support-constraint-constraint-layout-solver-1.0.0-beta2",
       "path": "extras/m2repository/com/android/support/constraint/constraint-layout-solver/1.0.0-beta2",
@@ -1772,6 +1815,7 @@
         }
       ],
       "displayName": "Solver for ConstraintLayout 1.0.0-beta3",
+      "last-available-day": 19489,
       "license": "android-sdk-license",
       "name": "extras-m2repository-com-android-support-constraint-constraint-layout-solver-1.0.0-beta3",
       "path": "extras/m2repository/com/android/support/constraint/constraint-layout-solver/1.0.0-beta3",
@@ -1799,6 +1843,7 @@
         }
       ],
       "displayName": "Solver for ConstraintLayout 1.0.0-beta4",
+      "last-available-day": 19489,
       "license": "android-sdk-license",
       "name": "extras-m2repository-com-android-support-constraint-constraint-layout-solver-1.0.0-beta4",
       "path": "extras/m2repository/com/android/support/constraint/constraint-layout-solver/1.0.0-beta4",
@@ -1826,6 +1871,7 @@
         }
       ],
       "displayName": "Solver for ConstraintLayout 1.0.0-beta5",
+      "last-available-day": 19489,
       "license": "android-sdk-license",
       "name": "extras-m2repository-com-android-support-constraint-constraint-layout-solver-1.0.0-beta5",
       "path": "extras/m2repository/com/android/support/constraint/constraint-layout-solver/1.0.0-beta5",
@@ -1853,6 +1899,7 @@
         }
       ],
       "displayName": "Solver for ConstraintLayout 1.0.1",
+      "last-available-day": 19489,
       "license": "android-sdk-license",
       "name": "extras-m2repository-com-android-support-constraint-constraint-layout-solver-1.0.1",
       "path": "extras/m2repository/com/android/support/constraint/constraint-layout-solver/1.0.1",
@@ -1880,6 +1927,7 @@
         }
       ],
       "displayName": "Solver for ConstraintLayout 1.0.2",
+      "last-available-day": 19489,
       "license": "android-sdk-license",
       "name": "extras-m2repository-com-android-support-constraint-constraint-layout-solver-1.0.2",
       "path": "extras/m2repository/com/android/support/constraint/constraint-layout-solver/1.0.2",
@@ -1914,6 +1962,7 @@
         }
       },
       "displayName": "ConstraintLayout for Android 1.0.0",
+      "last-available-day": 19489,
       "license": "android-sdk-license",
       "name": "extras-m2repository-com-android-support-constraint-constraint-layout-1.0.0",
       "path": "extras/m2repository/com/android/support/constraint/constraint-layout/1.0.0",
@@ -1948,6 +1997,7 @@
         }
       },
       "displayName": "com.android.support.constraint:constraint-layout:1.0.0-alpha4",
+      "last-available-day": 19489,
       "license": "android-sdk-license",
       "name": "extras-m2repository-com-android-support-constraint-constraint-layout-1.0.0-alpha4",
       "path": "extras/m2repository/com/android/support/constraint/constraint-layout/1.0.0-alpha4",
@@ -1982,6 +2032,7 @@
         }
       },
       "displayName": "ConstraintLayout for Android 1.0.0-alpha8",
+      "last-available-day": 19489,
       "license": "android-sdk-license",
       "name": "extras-m2repository-com-android-support-constraint-constraint-layout-1.0.0-alpha8",
       "path": "extras/m2repository/com/android/support/constraint/constraint-layout/1.0.0-alpha8",
@@ -2016,6 +2067,7 @@
         }
       },
       "displayName": "ConstraintLayout for Android 1.0.0-beta1",
+      "last-available-day": 19489,
       "license": "android-sdk-license",
       "name": "extras-m2repository-com-android-support-constraint-constraint-layout-1.0.0-beta1",
       "path": "extras/m2repository/com/android/support/constraint/constraint-layout/1.0.0-beta1",
@@ -2050,6 +2102,7 @@
         }
       },
       "displayName": "ConstraintLayout for Android 1.0.0-beta2",
+      "last-available-day": 19489,
       "license": "android-sdk-license",
       "name": "extras-m2repository-com-android-support-constraint-constraint-layout-1.0.0-beta2",
       "path": "extras/m2repository/com/android/support/constraint/constraint-layout/1.0.0-beta2",
@@ -2084,6 +2137,7 @@
         }
       },
       "displayName": "ConstraintLayout for Android 1.0.0-beta3",
+      "last-available-day": 19489,
       "license": "android-sdk-license",
       "name": "extras-m2repository-com-android-support-constraint-constraint-layout-1.0.0-beta3",
       "path": "extras/m2repository/com/android/support/constraint/constraint-layout/1.0.0-beta3",
@@ -2118,6 +2172,7 @@
         }
       },
       "displayName": "ConstraintLayout for Android 1.0.0-beta4",
+      "last-available-day": 19489,
       "license": "android-sdk-license",
       "name": "extras-m2repository-com-android-support-constraint-constraint-layout-1.0.0-beta4",
       "path": "extras/m2repository/com/android/support/constraint/constraint-layout/1.0.0-beta4",
@@ -2152,6 +2207,7 @@
         }
       },
       "displayName": "ConstraintLayout for Android 1.0.0-beta5",
+      "last-available-day": 19489,
       "license": "android-sdk-license",
       "name": "extras-m2repository-com-android-support-constraint-constraint-layout-1.0.0-beta5",
       "path": "extras/m2repository/com/android/support/constraint/constraint-layout/1.0.0-beta5",
@@ -2186,6 +2242,7 @@
         }
       },
       "displayName": "ConstraintLayout for Android 1.0.1",
+      "last-available-day": 19489,
       "license": "android-sdk-license",
       "name": "extras-m2repository-com-android-support-constraint-constraint-layout-1.0.1",
       "path": "extras/m2repository/com/android/support/constraint/constraint-layout/1.0.1",
@@ -2220,6 +2277,7 @@
         }
       },
       "displayName": "ConstraintLayout for Android 1.0.2",
+      "last-available-day": 19489,
       "license": "android-sdk-license",
       "name": "extras-m2repository-com-android-support-constraint-constraint-layout-1.0.2",
       "path": "extras/m2repository/com/android/support/constraint/constraint-layout/1.0.2",
@@ -2258,6 +2316,7 @@
             }
           },
           "displayName": "ARM EABI v7a System Image",
+          "last-available-day": 19489,
           "license": "android-sdk-license",
           "name": "system-image-10-default-armeabi-v7a",
           "path": "system-images/android-10/default/armeabi-v7a",
@@ -2295,6 +2354,7 @@
             }
           },
           "displayName": "Intel x86 Atom System Image",
+          "last-available-day": 19489,
           "license": "android-sdk-license",
           "name": "system-image-10-default-x86",
           "path": "system-images/android-10/default/x86",
@@ -2334,6 +2394,7 @@
             }
           },
           "displayName": "Google APIs ARM EABI v7a System Image",
+          "last-available-day": 19489,
           "license": "android-sdk-license",
           "name": "system-image-10-google_apis-armeabi-v7a",
           "path": "system-images/android-10/google_apis/armeabi-v7a",
@@ -2374,6 +2435,7 @@
             }
           },
           "displayName": "Google APIs Intel x86 Atom System Image",
+          "last-available-day": 19489,
           "license": "android-sdk-license",
           "name": "system-image-10-google_apis-x86",
           "path": "system-images/android-10/google_apis/x86",
@@ -2411,6 +2473,7 @@
             }
           ],
           "displayName": "ARM EABI v7a System Image",
+          "last-available-day": 19489,
           "license": "android-sdk-license",
           "name": "system-image-14-default-armeabi-v7a",
           "path": "system-images/android-14/default/armeabi-v7a",
@@ -2452,6 +2515,7 @@
             }
           },
           "displayName": "ARM EABI v7a System Image",
+          "last-available-day": 19489,
           "license": "android-sdk-license",
           "name": "system-image-15-default-armeabi-v7a",
           "path": "system-images/android-15/default/armeabi-v7a",
@@ -2489,6 +2553,7 @@
             }
           },
           "displayName": "Intel x86 Atom System Image",
+          "last-available-day": 19489,
           "license": "android-sdk-license",
           "name": "system-image-15-default-x86",
           "path": "system-images/android-15/default/x86",
@@ -2528,6 +2593,7 @@
             }
           },
           "displayName": "Google APIs ARM EABI v7a System Image",
+          "last-available-day": 19489,
           "license": "android-sdk-license",
           "name": "system-image-15-google_apis-armeabi-v7a",
           "path": "system-images/android-15/google_apis/armeabi-v7a",
@@ -2568,6 +2634,7 @@
             }
           },
           "displayName": "Google APIs Intel x86 Atom System Image",
+          "last-available-day": 19489,
           "license": "android-sdk-license",
           "name": "system-image-15-google_apis-x86",
           "path": "system-images/android-15/google_apis/x86",
@@ -2612,6 +2679,7 @@
             }
           },
           "displayName": "ARM EABI v7a System Image",
+          "last-available-day": 19489,
           "license": "android-sdk-license",
           "name": "system-image-16-default-armeabi-v7a",
           "path": "system-images/android-16/default/armeabi-v7a",
@@ -2642,6 +2710,7 @@
             }
           ],
           "displayName": "MIPS System Image",
+          "last-available-day": 19489,
           "license": "mips-android-sysimage-license",
           "name": "system-image-16-default-mips",
           "path": "system-images/android-16/default/mips",
@@ -2679,6 +2748,7 @@
             }
           },
           "displayName": "Intel x86 Atom System Image",
+          "last-available-day": 19489,
           "license": "android-sdk-license",
           "name": "system-image-16-default-x86",
           "path": "system-images/android-16/default/x86",
@@ -2718,6 +2788,7 @@
             }
           },
           "displayName": "Google APIs ARM EABI v7a System Image",
+          "last-available-day": 19489,
           "license": "android-sdk-license",
           "name": "system-image-16-google_apis-armeabi-v7a",
           "path": "system-images/android-16/google_apis/armeabi-v7a",
@@ -2758,6 +2829,7 @@
             }
           },
           "displayName": "Google APIs Intel x86 Atom System Image",
+          "last-available-day": 19489,
           "license": "android-sdk-license",
           "name": "system-image-16-google_apis-x86",
           "path": "system-images/android-16/google_apis/x86",
@@ -2802,6 +2874,7 @@
             }
           },
           "displayName": "ARM EABI v7a System Image",
+          "last-available-day": 19489,
           "license": "android-sdk-license",
           "name": "system-image-17-default-armeabi-v7a",
           "path": "system-images/android-17/default/armeabi-v7a",
@@ -2832,6 +2905,7 @@
             }
           ],
           "displayName": "MIPS System Image",
+          "last-available-day": 19489,
           "license": "mips-android-sysimage-license",
           "name": "system-image-17-default-mips",
           "path": "system-images/android-17/default/mips",
@@ -2869,6 +2943,7 @@
             }
           },
           "displayName": "Intel x86 Atom System Image",
+          "last-available-day": 19489,
           "license": "android-sdk-license",
           "name": "system-image-17-default-x86",
           "path": "system-images/android-17/default/x86",
@@ -2911,6 +2986,7 @@
             }
           },
           "displayName": "Google APIs ARM EABI v7a System Image",
+          "last-available-day": 19489,
           "license": "android-sdk-license",
           "name": "system-image-17-google_apis-armeabi-v7a",
           "path": "system-images/android-17/google_apis/armeabi-v7a",
@@ -2951,6 +3027,7 @@
             }
           },
           "displayName": "Google APIs Intel x86 Atom System Image",
+          "last-available-day": 19489,
           "license": "android-sdk-license",
           "name": "system-image-17-google_apis-x86",
           "path": "system-images/android-17/google_apis/x86",
@@ -2995,6 +3072,7 @@
             }
           },
           "displayName": "ARM EABI v7a System Image",
+          "last-available-day": 19489,
           "license": "android-sdk-license",
           "name": "system-image-18-default-armeabi-v7a",
           "path": "system-images/android-18/default/armeabi-v7a",
@@ -3032,6 +3110,7 @@
             }
           },
           "displayName": "Intel x86 Atom System Image",
+          "last-available-day": 19489,
           "license": "android-sdk-license",
           "name": "system-image-18-default-x86",
           "path": "system-images/android-18/default/x86",
@@ -3071,6 +3150,7 @@
             }
           },
           "displayName": "Google APIs ARM EABI v7a System Image",
+          "last-available-day": 19489,
           "license": "android-sdk-license",
           "name": "system-image-18-google_apis-armeabi-v7a",
           "path": "system-images/android-18/google_apis/armeabi-v7a",
@@ -3111,6 +3191,7 @@
             }
           },
           "displayName": "Google APIs Intel x86 Atom System Image",
+          "last-available-day": 19489,
           "license": "android-sdk-license",
           "name": "system-image-18-google_apis-x86",
           "path": "system-images/android-18/google_apis/x86",
@@ -3155,6 +3236,7 @@
             }
           },
           "displayName": "ARM EABI v7a System Image",
+          "last-available-day": 19489,
           "license": "android-sdk-license",
           "name": "system-image-19-default-armeabi-v7a",
           "path": "system-images/android-19/default/armeabi-v7a",
@@ -3192,6 +3274,7 @@
             }
           },
           "displayName": "Intel x86 Atom System Image",
+          "last-available-day": 19489,
           "license": "android-sdk-license",
           "name": "system-image-19-default-x86",
           "path": "system-images/android-19/default/x86",
@@ -3231,6 +3314,7 @@
             }
           },
           "displayName": "Google APIs ARM EABI v7a System Image",
+          "last-available-day": 19489,
           "license": "android-sdk-license",
           "name": "system-image-19-google_apis-armeabi-v7a",
           "path": "system-images/android-19/google_apis/armeabi-v7a",
@@ -3271,6 +3355,7 @@
             }
           },
           "displayName": "Google APIs Intel x86 Atom System Image",
+          "last-available-day": 19489,
           "license": "android-sdk-license",
           "name": "system-image-19-google_apis-x86",
           "path": "system-images/android-19/google_apis/x86",
@@ -3308,6 +3393,7 @@
             }
           ],
           "displayName": "Android TV ARM EABI v7a System Image",
+          "last-available-day": 19489,
           "license": "android-sdk-license",
           "name": "system-image-21-android-tv-armeabi-v7a",
           "path": "system-images/android-21/android-tv/armeabi-v7a",
@@ -3337,6 +3423,7 @@
             }
           ],
           "displayName": "Android TV Intel x86 Atom System Image",
+          "last-available-day": 19489,
           "license": "android-sdk-license",
           "name": "system-image-21-android-tv-x86",
           "path": "system-images/android-21/android-tv/x86",
@@ -3368,6 +3455,7 @@
             }
           ],
           "displayName": "ARM 64 v8a System Image",
+          "last-available-day": 19489,
           "license": "android-sdk-license",
           "name": "system-image-21-default-arm64-v8a",
           "path": "system-images/android-21/default/arm64-v8a",
@@ -3405,6 +3493,7 @@
             }
           },
           "displayName": "ARM EABI v7a System Image",
+          "last-available-day": 19489,
           "license": "android-sdk-license",
           "name": "system-image-21-default-armeabi-v7a",
           "path": "system-images/android-21/default/armeabi-v7a",
@@ -3442,6 +3531,7 @@
             }
           },
           "displayName": "Intel x86 Atom System Image",
+          "last-available-day": 19489,
           "license": "android-sdk-license",
           "name": "system-image-21-default-x86",
           "path": "system-images/android-21/default/x86",
@@ -3478,7 +3568,8 @@
               }
             }
           },
-          "displayName": "Intel x86 Atom_64 System Image",
+          "displayName": "Intel x86_64 Atom System Image",
+          "last-available-day": 19489,
           "license": "android-sdk-license",
           "name": "system-image-21-default-x86_64",
           "path": "system-images/android-21/default/x86_64",
@@ -3511,6 +3602,7 @@
             }
           ],
           "displayName": "Google APIs ARM 64 v8a System Image",
+          "last-available-day": 19489,
           "license": "android-sdk-license",
           "name": "system-image-21-google_apis-arm64-v8a",
           "path": "system-images/android-21/google_apis/arm64-v8a",
@@ -3551,6 +3643,7 @@
             }
           },
           "displayName": "Google APIs ARM EABI v7a System Image",
+          "last-available-day": 19489,
           "license": "android-sdk-license",
           "name": "system-image-21-google_apis-armeabi-v7a",
           "path": "system-images/android-21/google_apis/armeabi-v7a",
@@ -3591,6 +3684,7 @@
             }
           },
           "displayName": "Google APIs Intel x86 Atom System Image",
+          "last-available-day": 19489,
           "license": "android-sdk-license",
           "name": "system-image-21-google_apis-x86",
           "path": "system-images/android-21/google_apis/x86",
@@ -3630,7 +3724,8 @@
               }
             }
           },
-          "displayName": "Google APIs Intel x86 Atom_64 System Image",
+          "displayName": "Google APIs Intel x86_64 Atom System Image",
+          "last-available-day": 19489,
           "license": "android-sdk-license",
           "name": "system-image-21-google_apis-x86_64",
           "path": "system-images/android-21/google_apis/x86_64",
@@ -3668,6 +3763,7 @@
             }
           ],
           "displayName": "Android TV Intel x86 Atom System Image",
+          "last-available-day": 19489,
           "license": "android-sdk-license",
           "name": "system-image-22-android-tv-x86",
           "path": "system-images/android-22/android-tv/x86",
@@ -3699,6 +3795,7 @@
             }
           ],
           "displayName": "ARM 64 v8a System Image",
+          "last-available-day": 19489,
           "license": "android-sdk-license",
           "name": "system-image-22-default-arm64-v8a",
           "path": "system-images/android-22/default/arm64-v8a",
@@ -3736,6 +3833,7 @@
             }
           },
           "displayName": "ARM EABI v7a System Image",
+          "last-available-day": 19489,
           "license": "android-sdk-license",
           "name": "system-image-22-default-armeabi-v7a",
           "path": "system-images/android-22/default/armeabi-v7a",
@@ -3773,6 +3871,7 @@
             }
           },
           "displayName": "Intel x86 Atom System Image",
+          "last-available-day": 19489,
           "license": "android-sdk-license",
           "name": "system-image-22-default-x86",
           "path": "system-images/android-22/default/x86",
@@ -3809,7 +3908,8 @@
               }
             }
           },
-          "displayName": "Intel x86 Atom_64 System Image",
+          "displayName": "Intel x86_64 Atom System Image",
+          "last-available-day": 19489,
           "license": "android-sdk-license",
           "name": "system-image-22-default-x86_64",
           "path": "system-images/android-22/default/x86_64",
@@ -3842,6 +3942,7 @@
             }
           ],
           "displayName": "Google APIs ARM 64 v8a System Image",
+          "last-available-day": 19489,
           "license": "android-sdk-license",
           "name": "system-image-22-google_apis-arm64-v8a",
           "path": "system-images/android-22/google_apis/arm64-v8a",
@@ -3882,6 +3983,7 @@
             }
           },
           "displayName": "Google APIs ARM EABI v7a System Image",
+          "last-available-day": 19489,
           "license": "android-sdk-license",
           "name": "system-image-22-google_apis-armeabi-v7a",
           "path": "system-images/android-22/google_apis/armeabi-v7a",
@@ -3922,6 +4024,7 @@
             }
           },
           "displayName": "Google APIs Intel x86 Atom System Image",
+          "last-available-day": 19489,
           "license": "android-sdk-license",
           "name": "system-image-22-google_apis-x86",
           "path": "system-images/android-22/google_apis/x86",
@@ -3961,7 +4064,8 @@
               }
             }
           },
-          "displayName": "Google APIs Intel x86 Atom_64 System Image",
+          "displayName": "Google APIs Intel x86_64 Atom System Image",
+          "last-available-day": 19489,
           "license": "android-sdk-license",
           "name": "system-image-22-google_apis-x86_64",
           "path": "system-images/android-22/google_apis/x86_64",
@@ -3999,6 +4103,7 @@
             }
           ],
           "displayName": "Android TV ARM EABI v7a System Image",
+          "last-available-day": 19489,
           "license": "android-sdk-license",
           "name": "system-image-23-android-tv-armeabi-v7a",
           "path": "system-images/android-23/android-tv/armeabi-v7a",
@@ -4035,6 +4140,7 @@
             }
           },
           "displayName": "Android TV Intel x86 Atom System Image",
+          "last-available-day": 19489,
           "license": "android-sdk-license",
           "name": "system-image-23-android-tv-x86",
           "path": "system-images/android-23/android-tv/x86",
@@ -4066,6 +4172,7 @@
             }
           ],
           "displayName": "ARM 64 v8a System Image",
+          "last-available-day": 19489,
           "license": "android-sdk-license",
           "name": "system-image-23-default-arm64-v8a",
           "path": "system-images/android-23/default/arm64-v8a",
@@ -4103,6 +4210,7 @@
             }
           },
           "displayName": "ARM EABI v7a System Image",
+          "last-available-day": 19489,
           "license": "android-sdk-license",
           "name": "system-image-23-default-armeabi-v7a",
           "path": "system-images/android-23/default/armeabi-v7a",
@@ -4140,6 +4248,7 @@
             }
           },
           "displayName": "Intel x86 Atom System Image",
+          "last-available-day": 19489,
           "license": "android-sdk-license",
           "name": "system-image-23-default-x86",
           "path": "system-images/android-23/default/x86",
@@ -4176,7 +4285,8 @@
               }
             }
           },
-          "displayName": "Intel x86 Atom_64 System Image",
+          "displayName": "Intel x86_64 Atom System Image",
+          "last-available-day": 19489,
           "license": "android-sdk-license",
           "name": "system-image-23-default-x86_64",
           "path": "system-images/android-23/default/x86_64",
@@ -4209,6 +4319,7 @@
             }
           ],
           "displayName": "Google APIs ARM 64 v8a System Image",
+          "last-available-day": 19489,
           "license": "android-sdk-license",
           "name": "system-image-23-google_apis-arm64-v8a",
           "path": "system-images/android-23/google_apis/arm64-v8a",
@@ -4249,6 +4360,7 @@
             }
           },
           "displayName": "Google APIs ARM EABI v7a System Image",
+          "last-available-day": 19489,
           "license": "android-sdk-license",
           "name": "system-image-23-google_apis-armeabi-v7a",
           "path": "system-images/android-23/google_apis/armeabi-v7a",
@@ -4289,6 +4401,7 @@
             }
           },
           "displayName": "Google APIs Intel x86 Atom System Image",
+          "last-available-day": 19489,
           "license": "android-sdk-license",
           "name": "system-image-23-google_apis-x86",
           "path": "system-images/android-23/google_apis/x86",
@@ -4328,7 +4441,8 @@
               }
             }
           },
-          "displayName": "Google APIs Intel x86 Atom_64 System Image",
+          "displayName": "Google APIs Intel x86_64 Atom System Image",
+          "last-available-day": 19489,
           "license": "android-sdk-license",
           "name": "system-image-23-google_apis-x86_64",
           "path": "system-images/android-23/google_apis/x86_64",
@@ -4373,6 +4487,7 @@
             }
           },
           "displayName": "Android TV Intel x86 Atom System Image",
+          "last-available-day": 19489,
           "license": "android-sdk-license",
           "name": "system-image-24-android-tv-x86",
           "path": "system-images/android-24/android-tv/x86",
@@ -4404,6 +4519,7 @@
             }
           ],
           "displayName": "ARM 64 v8a System Image",
+          "last-available-day": 19489,
           "license": "android-sdk-license",
           "name": "system-image-24-default-arm64-v8a",
           "path": "system-images/android-24/default/arm64-v8a",
@@ -4441,6 +4557,7 @@
             }
           },
           "displayName": "ARM EABI v7a System Image",
+          "last-available-day": 19489,
           "license": "android-sdk-license",
           "name": "system-image-24-default-armeabi-v7a",
           "path": "system-images/android-24/default/armeabi-v7a",
@@ -4478,6 +4595,7 @@
             }
           },
           "displayName": "Intel x86 Atom System Image",
+          "last-available-day": 19489,
           "license": "android-sdk-license",
           "name": "system-image-24-default-x86",
           "path": "system-images/android-24/default/x86",
@@ -4514,7 +4632,8 @@
               }
             }
           },
-          "displayName": "Intel x86 Atom_64 System Image",
+          "displayName": "Intel x86_64 Atom System Image",
+          "last-available-day": 19489,
           "license": "android-sdk-license",
           "name": "system-image-24-default-x86_64",
           "path": "system-images/android-24/default/x86_64",
@@ -4554,6 +4673,7 @@
             }
           },
           "displayName": "Google APIs ARM 64 v8a System Image",
+          "last-available-day": 19489,
           "license": "android-sdk-license",
           "name": "system-image-24-google_apis-arm64-v8a",
           "path": "system-images/android-24/google_apis/arm64-v8a",
@@ -4594,6 +4714,7 @@
             }
           },
           "displayName": "Google APIs Intel x86 Atom System Image",
+          "last-available-day": 19489,
           "license": "android-sdk-license",
           "name": "system-image-24-google_apis-x86",
           "path": "system-images/android-24/google_apis/x86",
@@ -4633,7 +4754,8 @@
               }
             }
           },
-          "displayName": "Google APIs Intel x86 Atom_64 System Image",
+          "displayName": "Google APIs Intel x86_64 Atom System Image",
+          "last-available-day": 19489,
           "license": "android-sdk-license",
           "name": "system-image-24-google_apis-x86_64",
           "path": "system-images/android-24/google_apis/x86_64",
@@ -4676,6 +4798,7 @@
             }
           },
           "displayName": "Google Play Intel x86 Atom System Image",
+          "last-available-day": 19489,
           "license": "android-sdk-license",
           "name": "system-image-24-google_apis_playstore-x86",
           "path": "system-images/android-24/google_apis_playstore/x86",
@@ -4720,6 +4843,7 @@
             }
           },
           "displayName": "Android TV Intel x86 Atom System Image",
+          "last-available-day": 19489,
           "license": "android-sdk-license",
           "name": "system-image-25-android-tv-x86",
           "path": "system-images/android-25/android-tv/x86",
@@ -4758,6 +4882,7 @@
             }
           },
           "displayName": "Android Wear ARM EABI v7a System Image",
+          "last-available-day": 19489,
           "license": "android-sdk-license",
           "name": "system-image-25-android-wear-armeabi-v7a",
           "path": "system-images/android-25/android-wear/armeabi-v7a",
@@ -4794,6 +4919,7 @@
             }
           },
           "displayName": "Android Wear Intel x86 Atom System Image",
+          "last-available-day": 19489,
           "license": "android-sdk-license",
           "name": "system-image-25-android-wear-x86",
           "path": "system-images/android-25/android-wear/x86",
@@ -4825,6 +4951,7 @@
             }
           ],
           "displayName": "ARM 64 v8a System Image",
+          "last-available-day": 19489,
           "license": "android-sdk-license",
           "name": "system-image-25-default-arm64-v8a",
           "path": "system-images/android-25/default/arm64-v8a",
@@ -4862,6 +4989,7 @@
             }
           },
           "displayName": "Intel x86 Atom System Image",
+          "last-available-day": 19489,
           "license": "android-sdk-license",
           "name": "system-image-25-default-x86",
           "path": "system-images/android-25/default/x86",
@@ -4898,7 +5026,8 @@
               }
             }
           },
-          "displayName": "Intel x86 Atom_64 System Image",
+          "displayName": "Intel x86_64 Atom System Image",
+          "last-available-day": 19489,
           "license": "android-sdk-license",
           "name": "system-image-25-default-x86_64",
           "path": "system-images/android-25/default/x86_64",
@@ -4931,6 +5060,7 @@
             }
           ],
           "displayName": "Google APIs ARM 64 v8a System Image",
+          "last-available-day": 19489,
           "license": "android-sdk-license",
           "name": "system-image-25-google_apis-arm64-v8a",
           "path": "system-images/android-25/google_apis/arm64-v8a",
@@ -4971,6 +5101,7 @@
             }
           },
           "displayName": "Google APIs ARM EABI v7a System Image",
+          "last-available-day": 19489,
           "license": "android-sdk-license",
           "name": "system-image-25-google_apis-armeabi-v7a",
           "path": "system-images/android-25/google_apis/armeabi-v7a",
@@ -5011,6 +5142,7 @@
             }
           },
           "displayName": "Google APIs Intel x86 Atom System Image",
+          "last-available-day": 19489,
           "license": "android-sdk-license",
           "name": "system-image-25-google_apis-x86",
           "path": "system-images/android-25/google_apis/x86",
@@ -5050,7 +5182,8 @@
               }
             }
           },
-          "displayName": "Google APIs Intel x86 Atom_64 System Image",
+          "displayName": "Google APIs Intel x86_64 Atom System Image",
+          "last-available-day": 19489,
           "license": "android-sdk-license",
           "name": "system-image-25-google_apis-x86_64",
           "path": "system-images/android-25/google_apis/x86_64",
@@ -5093,6 +5226,7 @@
             }
           },
           "displayName": "Google Play Intel x86 Atom System Image",
+          "last-available-day": 19489,
           "license": "android-sdk-license",
           "name": "system-image-25-google_apis_playstore-x86",
           "path": "system-images/android-25/google_apis_playstore/x86",
@@ -5147,6 +5281,7 @@
             }
           },
           "displayName": "Android TV Intel x86 Atom System Image",
+          "last-available-day": 19489,
           "license": "android-sdk-preview-license",
           "name": "system-image-26-android-tv-x86",
           "path": "system-images/android-26/android-tv/x86",
@@ -5185,6 +5320,7 @@
             }
           },
           "displayName": "Android Wear Intel x86 Atom System Image",
+          "last-available-day": 19489,
           "license": "android-sdk-license",
           "name": "system-image-26-android-wear-x86",
           "path": "system-images/android-26/android-wear/x86",
@@ -5210,9 +5346,9 @@
           "archives": [
             {
               "os": "all",
-              "sha1": "c3199baf49790fc65f90f7ce734435d5778f6a30",
-              "size": 328910124,
-              "url": "https://dl.google.com/android/repository/sys-img/android/arm64-v8a-26_r01.zip"
+              "sha1": "12353141d08dd302fbebc03872f0e1ca7357c55f",
+              "size": 330014927,
+              "url": "https://dl.google.com/android/repository/sys-img/android/arm64-v8a-26_r02.zip"
             }
           ],
           "dependencies": {
@@ -5228,12 +5364,13 @@
             }
           },
           "displayName": "ARM 64 v8a System Image",
+          "last-available-day": 19489,
           "license": "android-sdk-license",
           "name": "system-image-26-default-arm64-v8a",
           "path": "system-images/android-26/default/arm64-v8a",
           "revision": "26-default-arm64-v8a",
           "revision-details": {
-            "major:0": "1"
+            "major:0": "2"
           },
           "type-details": {
             "abi:2": "arm64-v8a",
@@ -5264,6 +5401,7 @@
             }
           },
           "displayName": "Intel x86 Atom System Image",
+          "last-available-day": 19489,
           "license": "android-sdk-license",
           "name": "system-image-26-default-x86",
           "path": "system-images/android-26/default/x86",
@@ -5299,7 +5437,8 @@
               }
             }
           },
-          "displayName": "Intel x86 Atom_64 System Image",
+          "displayName": "Intel x86_64 Atom System Image",
+          "last-available-day": 19489,
           "license": "android-sdk-license",
           "name": "system-image-26-default-x86_64",
           "path": "system-images/android-26/default/x86_64",
@@ -5325,9 +5464,9 @@
           "archives": [
             {
               "os": "all",
-              "sha1": "75fe6f36cf0854270876543641da53887961a63b",
-              "size": 732225522,
-              "url": "https://dl.google.com/android/repository/sys-img/google_apis/arm64-v8a-26_r01.zip"
+              "sha1": "307bb9e03b215ebcab5d2a9edd47839009c57c8f",
+              "size": 733341370,
+              "url": "https://dl.google.com/android/repository/sys-img/google_apis/arm64-v8a-26_r02.zip"
             }
           ],
           "dependencies": {
@@ -5343,12 +5482,13 @@
             }
           },
           "displayName": "Google APIs ARM 64 v8a System Image",
+          "last-available-day": 19489,
           "license": "android-sdk-license",
           "name": "system-image-26-google_apis-arm64-v8a",
           "path": "system-images/android-26/google_apis/arm64-v8a",
           "revision": "26-google_apis-arm64-v8a",
           "revision-details": {
-            "major:0": "1"
+            "major:0": "2"
           },
           "type-details": {
             "abi:3": "arm64-v8a",
@@ -5393,6 +5533,7 @@
             }
           },
           "displayName": "Google APIs Intel x86 Atom System Image",
+          "last-available-day": 19489,
           "license": "android-sdk-license",
           "name": "system-image-26-google_apis-x86",
           "path": "system-images/android-26/google_apis/x86",
@@ -5442,7 +5583,8 @@
               }
             }
           },
-          "displayName": "Google APIs Intel x86 Atom_64 System Image",
+          "displayName": "Google APIs Intel x86_64 Atom System Image",
+          "last-available-day": 19489,
           "license": "android-sdk-license",
           "name": "system-image-26-google_apis-x86_64",
           "path": "system-images/android-26/google_apis/x86_64",
@@ -5495,6 +5637,7 @@
             }
           },
           "displayName": "Google Play Intel x86 Atom System Image",
+          "last-available-day": 19489,
           "license": "android-sdk-preview-license",
           "name": "system-image-26-google_apis_playstore-x86",
           "path": "system-images/android-26/google_apis_playstore/x86",
@@ -5539,6 +5682,7 @@
             }
           },
           "displayName": "Android TV Intel x86 Atom System Image",
+          "last-available-day": 19489,
           "license": "android-sdk-preview-license",
           "name": "system-image-27-android-tv-x86",
           "path": "system-images/android-27/android-tv/x86",
@@ -5564,9 +5708,9 @@
           "archives": [
             {
               "os": "all",
-              "sha1": "cb01199edae33ce375c6d8e08aea08911ff0d583",
-              "size": 331796092,
-              "url": "https://dl.google.com/android/repository/sys-img/android/arm64-v8a-27_r01.zip"
+              "sha1": "e014473ac510cc9d8e9b412826332923277fa827",
+              "size": 332173536,
+              "url": "https://dl.google.com/android/repository/sys-img/android/arm64-v8a-27_r02.zip"
             }
           ],
           "dependencies": {
@@ -5582,12 +5726,13 @@
             }
           },
           "displayName": "ARM 64 v8a System Image",
+          "last-available-day": 19489,
           "license": "android-sdk-license",
           "name": "system-image-27-default-arm64-v8a",
           "path": "system-images/android-27/default/arm64-v8a",
           "revision": "27-default-arm64-v8a",
           "revision-details": {
-            "major:0": "1"
+            "major:0": "2"
           },
           "type-details": {
             "abi:2": "arm64-v8a",
@@ -5618,6 +5763,7 @@
             }
           },
           "displayName": "Intel x86 Atom System Image",
+          "last-available-day": 19489,
           "license": "android-sdk-license",
           "name": "system-image-27-default-x86",
           "path": "system-images/android-27/default/x86",
@@ -5653,7 +5799,8 @@
               }
             }
           },
-          "displayName": "Intel x86 Atom_64 System Image",
+          "displayName": "Intel x86_64 Atom System Image",
+          "last-available-day": 19489,
           "license": "android-sdk-license",
           "name": "system-image-27-default-x86_64",
           "path": "system-images/android-27/default/x86_64",
@@ -5679,9 +5826,9 @@
           "archives": [
             {
               "os": "all",
-              "sha1": "a7ae177097205090fee9801349575cea0dd9f606",
-              "size": 730343967,
-              "url": "https://dl.google.com/android/repository/sys-img/google_apis/arm64-v8a-27_r01.zip"
+              "sha1": "e4c06bbee837cd8266774fc4ddd1c70338ab6848",
+              "size": 730720117,
+              "url": "https://dl.google.com/android/repository/sys-img/google_apis/arm64-v8a-27_r02.zip"
             }
           ],
           "dependencies": {
@@ -5697,12 +5844,13 @@
             }
           },
           "displayName": "Google APIs ARM 64 v8a System Image",
+          "last-available-day": 19489,
           "license": "android-sdk-license",
           "name": "system-image-27-google_apis-arm64-v8a",
           "path": "system-images/android-27/google_apis/arm64-v8a",
           "revision": "27-google_apis-arm64-v8a",
           "revision-details": {
-            "major:0": "1"
+            "major:0": "2"
           },
           "type-details": {
             "abi:3": "arm64-v8a",
@@ -5747,6 +5895,7 @@
             }
           },
           "displayName": "Google APIs Intel x86 Atom System Image",
+          "last-available-day": 19489,
           "license": "android-sdk-license",
           "name": "system-image-27-google_apis-x86",
           "path": "system-images/android-27/google_apis/x86",
@@ -5799,6 +5948,7 @@
             }
           },
           "displayName": "Google Play Intel x86 Atom System Image",
+          "last-available-day": 19489,
           "license": "android-sdk-license",
           "name": "system-image-27-google_apis_playstore-x86",
           "path": "system-images/android-27/google_apis_playstore/x86",
@@ -5843,6 +5993,7 @@
             }
           },
           "displayName": "Android TV Intel x86 Atom System Image",
+          "last-available-day": 19489,
           "license": "android-sdk-preview-license",
           "name": "system-image-28-android-tv-x86",
           "path": "system-images/android-28/android-tv/x86",
@@ -5881,6 +6032,7 @@
             }
           },
           "displayName": "Wear OS Intel x86 Atom System Image",
+          "last-available-day": 19489,
           "license": "android-sdk-license",
           "name": "system-image-28-android-wear-x86",
           "path": "system-images/android-28/android-wear/x86",
@@ -5906,9 +6058,9 @@
           "archives": [
             {
               "os": "all",
-              "sha1": "4de0491612ca12097be7deb76af835ebabadefca",
-              "size": 425671679,
-              "url": "https://dl.google.com/android/repository/sys-img/android/arm64-v8a-28_r01.zip"
+              "sha1": "e209114dd0dfc2f4e0d328f5fd7367fec39ee1bd",
+              "size": 426760297,
+              "url": "https://dl.google.com/android/repository/sys-img/android/arm64-v8a-28_r02.zip"
             }
           ],
           "dependencies": {
@@ -5924,12 +6076,13 @@
             }
           },
           "displayName": "ARM 64 v8a System Image",
+          "last-available-day": 19489,
           "license": "android-sdk-license",
           "name": "system-image-28-default-arm64-v8a",
           "path": "system-images/android-28/default/arm64-v8a",
           "revision": "28-default-arm64-v8a",
           "revision-details": {
-            "major:0": "1"
+            "major:0": "2"
           },
           "type-details": {
             "abi:2": "arm64-v8a",
@@ -5953,6 +6106,7 @@
             }
           ],
           "displayName": "Intel x86 Atom System Image",
+          "last-available-day": 19489,
           "license": "android-sdk-preview-license",
           "name": "system-image-28-default-x86",
           "path": "system-images/android-28/default/x86",
@@ -5981,7 +6135,8 @@
               "url": "https://dl.google.com/android/repository/sys-img/android/x86_64-28_r04.zip"
             }
           ],
-          "displayName": "Intel x86 Atom_64 System Image",
+          "displayName": "Intel x86_64 Atom System Image",
+          "last-available-day": 19489,
           "license": "android-sdk-preview-license",
           "name": "system-image-28-default-x86_64",
           "path": "system-images/android-28/default/x86_64",
@@ -6007,9 +6162,9 @@
           "archives": [
             {
               "os": "all",
-              "sha1": "3360092d11284a9f2d7146847932a426c438b372",
-              "size": 856031756,
-              "url": "https://dl.google.com/android/repository/sys-img/google_apis/arm64-v8a-28_r01.zip"
+              "sha1": "28f59164bdb4cb18f1a1060f1880450e06cf4d10",
+              "size": 857120029,
+              "url": "https://dl.google.com/android/repository/sys-img/google_apis/arm64-v8a-28_r02.zip"
             }
           ],
           "dependencies": {
@@ -6025,12 +6180,13 @@
             }
           },
           "displayName": "Google APIs ARM 64 v8a System Image",
-          "license": "android-sdk-arm-dbt-license",
+          "last-available-day": 19489,
+          "license": "android-sdk-license",
           "name": "system-image-28-google_apis-arm64-v8a",
           "path": "system-images/android-28/google_apis/arm64-v8a",
           "revision": "28-google_apis-arm64-v8a",
           "revision-details": {
-            "major:0": "1"
+            "major:0": "2"
           },
           "type-details": {
             "abi:3": "arm64-v8a",
@@ -6075,6 +6231,7 @@
             }
           },
           "displayName": "Google APIs Intel x86 Atom System Image",
+          "last-available-day": 19489,
           "license": "android-sdk-arm-dbt-license",
           "name": "system-image-28-google_apis-x86",
           "path": "system-images/android-28/google_apis/x86",
@@ -6124,7 +6281,8 @@
               }
             }
           },
-          "displayName": "Google APIs Intel x86 Atom_64 System Image",
+          "displayName": "Google APIs Intel x86_64 Atom System Image",
+          "last-available-day": 19489,
           "license": "android-sdk-license",
           "name": "system-image-28-google_apis-x86_64",
           "path": "system-images/android-28/google_apis/x86_64",
@@ -6154,9 +6312,9 @@
           "archives": [
             {
               "os": "all",
-              "sha1": "8901ad796ada9d40272c429427ba628de6919281",
-              "size": 835797733,
-              "url": "https://dl.google.com/android/repository/sys-img/google_apis_playstore/arm64-v8a-28_r01.zip"
+              "sha1": "205a4720befd41be99fcdfb2550fa1680e9a2e18",
+              "size": 836861962,
+              "url": "https://dl.google.com/android/repository/sys-img/google_apis_playstore/arm64-v8a-28_r02.zip"
             }
           ],
           "dependencies": {
@@ -6172,12 +6330,13 @@
             }
           },
           "displayName": "Google ARM64-V8a Play ARM 64 v8a System Image",
+          "last-available-day": 19489,
           "license": "android-sdk-arm-dbt-license",
           "name": "system-image-28-google_apis_playstore-arm64-v8a",
           "path": "system-images/android-28/google_apis_playstore/arm64-v8a",
           "revision": "28-google_apis_playstore-arm64-v8a",
           "revision-details": {
-            "major:0": "1"
+            "major:0": "2"
           },
           "type-details": {
             "abi:3": "arm64-v8a",
@@ -6222,6 +6381,7 @@
             }
           },
           "displayName": "Google Play Intel x86 Atom System Image",
+          "last-available-day": 19489,
           "license": "android-sdk-license",
           "name": "system-image-28-google_apis_playstore-x86",
           "path": "system-images/android-28/google_apis_playstore/x86",
@@ -6271,7 +6431,8 @@
               }
             }
           },
-          "displayName": "Google Play Intel x86 Atom_64 System Image",
+          "displayName": "Google Play Intel x86_64 Atom System Image",
+          "last-available-day": 19489,
           "license": "android-sdk-license",
           "name": "system-image-28-google_apis_playstore-x86_64",
           "path": "system-images/android-28/google_apis_playstore/x86_64",
@@ -6326,6 +6487,7 @@
             }
           },
           "displayName": "Android TV Intel x86 Atom System Image",
+          "last-available-day": 19489,
           "license": "android-sdk-preview-license",
           "name": "system-image-29-android-tv-x86",
           "path": "system-images/android-29/android-tv/x86",
@@ -6357,6 +6519,7 @@
             }
           ],
           "displayName": "ARM 64 v8a System Image",
+          "last-available-day": 19489,
           "license": "android-sdk-license",
           "name": "system-image-29-default-arm64-v8a",
           "path": "system-images/android-29/default/arm64-v8a",
@@ -6410,6 +6573,7 @@
             }
           },
           "displayName": "Intel x86 Atom System Image",
+          "last-available-day": 19489,
           "license": "android-sdk-license",
           "name": "system-image-29-default-x86",
           "path": "system-images/android-29/default/x86",
@@ -6462,7 +6626,8 @@
               }
             }
           },
-          "displayName": "Intel x86 Atom_64 System Image",
+          "displayName": "Intel x86_64 Atom System Image",
+          "last-available-day": 19489,
           "license": "android-sdk-license",
           "name": "system-image-29-default-x86_64",
           "path": "system-images/android-29/default/x86_64",
@@ -6506,6 +6671,7 @@
             }
           },
           "displayName": "Google APIs ARM 64 v8a System Image",
+          "last-available-day": 19489,
           "license": "android-sdk-arm-dbt-license",
           "name": "system-image-29-google_apis-arm64-v8a",
           "path": "system-images/android-29/google_apis/arm64-v8a",
@@ -6551,6 +6717,7 @@
             }
           },
           "displayName": "Google APIs Intel x86 Atom System Image",
+          "last-available-day": 19489,
           "license": "android-sdk-license",
           "name": "system-image-29-google_apis-x86",
           "path": "system-images/android-29/google_apis/x86",
@@ -6595,7 +6762,8 @@
               }
             }
           },
-          "displayName": "Google APIs Intel x86 Atom_64 System Image",
+          "displayName": "Google APIs Intel x86_64 Atom System Image",
+          "last-available-day": 19489,
           "license": "android-sdk-license",
           "name": "system-image-29-google_apis-x86_64",
           "path": "system-images/android-29/google_apis/x86_64",
@@ -6649,6 +6817,7 @@
             }
           },
           "displayName": "Google Play ARM 64 v8a System Image",
+          "last-available-day": 19489,
           "license": "android-sdk-arm-dbt-license",
           "name": "system-image-29-google_apis_playstore-arm64-v8a",
           "path": "system-images/android-29/google_apis_playstore/arm64-v8a",
@@ -6711,6 +6880,7 @@
             }
           },
           "displayName": "Google Play Intel x86 Atom System Image",
+          "last-available-day": 19489,
           "license": "android-sdk-license",
           "name": "system-image-29-google_apis_playstore-x86",
           "path": "system-images/android-29/google_apis_playstore/x86",
@@ -6772,7 +6942,8 @@
               }
             }
           },
-          "displayName": "Google Play Intel x86 Atom_64 System Image",
+          "displayName": "Google Play Intel x86_64 Atom System Image",
+          "last-available-day": 19489,
           "license": "android-sdk-license",
           "name": "system-image-29-google_apis_playstore-x86_64",
           "path": "system-images/android-29/google_apis_playstore/x86_64",
@@ -6827,6 +6998,7 @@
             }
           },
           "displayName": "Android TV Intel x86 Atom System Image",
+          "last-available-day": 19489,
           "license": "android-sdk-preview-license",
           "name": "system-image-30-android-tv-x86",
           "path": "system-images/android-30/android-tv/x86",
@@ -6865,6 +7037,7 @@
             }
           },
           "displayName": "Wear OS 3 ARM 64 v8a System Image",
+          "last-available-day": 19489,
           "license": "android-sdk-license",
           "name": "system-image-30-android-wear-arm64-v8a",
           "path": "system-images/android-30/android-wear/arm64-v8a",
@@ -6901,6 +7074,7 @@
             }
           },
           "displayName": "Wear OS 3 Intel x86 Atom System Image",
+          "last-available-day": 19489,
           "license": "android-sdk-license",
           "name": "system-image-30-android-wear-x86",
           "path": "system-images/android-30/android-wear/x86",
@@ -6932,6 +7106,7 @@
             }
           ],
           "displayName": "ARM 64 v8a System Image",
+          "last-available-day": 19489,
           "license": "android-sdk-license",
           "name": "system-image-30-default-arm64-v8a",
           "path": "system-images/android-30/default/arm64-v8a",
@@ -6955,9 +7130,9 @@
           "archives": [
             {
               "os": "all",
-              "sha1": "e08119b65d2c188ef69f127028eb4c8cc632cd8f",
-              "size": 676379913,
-              "url": "https://dl.google.com/android/repository/sys-img/android/x86_64-30_r10.zip"
+              "sha1": "5e4de3946d46f88856c35efcc4d797b381456347",
+              "size": 676379777,
+              "url": "https://dl.google.com/android/repository/sys-img/android/x86_64-30_r11.zip"
             }
           ],
           "dependencies": {
@@ -6972,13 +7147,14 @@
               }
             }
           },
-          "displayName": "Intel x86 Atom_64 System Image",
+          "displayName": "Intel x86_64 Atom System Image",
+          "last-available-day": 19489,
           "license": "android-sdk-license",
           "name": "system-image-30-default-x86_64",
           "path": "system-images/android-30/default/x86_64",
           "revision": "30-default-x86_64",
           "revision-details": {
-            "major:0": "10"
+            "major:0": "11"
           },
           "type-details": {
             "abi:2": "x86_64",
@@ -7016,6 +7192,7 @@
             }
           },
           "displayName": "Google APIs ARM 64 v8a System Image",
+          "last-available-day": 19489,
           "license": "android-sdk-arm-dbt-license",
           "name": "system-image-30-google_apis-arm64-v8a",
           "path": "system-images/android-30/google_apis/arm64-v8a",
@@ -7066,6 +7243,7 @@
             }
           },
           "displayName": "Google APIs Intel x86 Atom System Image",
+          "last-available-day": 19489,
           "license": "android-sdk-license",
           "name": "system-image-30-google_apis-x86",
           "path": "system-images/android-30/google_apis/x86",
@@ -7093,9 +7271,9 @@
           "archives": [
             {
               "os": "all",
-              "sha1": "8ec579d5fe31804dd80132f1678655bfc015609b",
-              "size": 1438274971,
-              "url": "https://dl.google.com/android/repository/sys-img/google_apis/x86_64-30_r11.zip"
+              "sha1": "efb07cd6268d93d7e2be88883bc9249a00b378b3",
+              "size": 1438275289,
+              "url": "https://dl.google.com/android/repository/sys-img/google_apis/x86_64-30_r12.zip"
             }
           ],
           "dependencies": {
@@ -7115,13 +7293,14 @@
               }
             }
           },
-          "displayName": "Google APIs Intel x86 Atom_64 System Image",
-          "license": "android-sdk-license",
+          "displayName": "Google APIs Intel x86_64 Atom System Image",
+          "last-available-day": 19489,
+          "license": "android-sdk-arm-dbt-license",
           "name": "system-image-30-google_apis-x86_64",
           "path": "system-images/android-30/google_apis/x86_64",
           "revision": "30-google_apis-x86_64",
           "revision-details": {
-            "major:0": "11"
+            "major:0": "12"
           },
           "type-details": {
             "abi:3": "x86_64",
@@ -7169,6 +7348,7 @@
             }
           },
           "displayName": "Google Play ARM 64 v8a System Image",
+          "last-available-day": 19489,
           "license": "android-sdk-arm-dbt-license",
           "name": "system-image-30-google_apis_playstore-arm64-v8a",
           "path": "system-images/android-30/google_apis_playstore/arm64-v8a",
@@ -7231,6 +7411,7 @@
             }
           },
           "displayName": "Google Play Intel x86 Atom System Image",
+          "last-available-day": 19489,
           "license": "android-sdk-license",
           "name": "system-image-30-google_apis_playstore-x86",
           "path": "system-images/android-30/google_apis_playstore/x86",
@@ -7292,7 +7473,8 @@
               }
             }
           },
-          "displayName": "Google Play Intel x86 Atom_64 System Image",
+          "displayName": "Google Play Intel x86_64 Atom System Image",
+          "last-available-day": 19489,
           "license": "android-sdk-arm-dbt-license",
           "name": "system-image-30-google_apis_playstore-x86_64",
           "path": "system-images/android-30/google_apis_playstore/x86_64",
@@ -7347,6 +7529,7 @@
             }
           },
           "displayName": "Android TV ARM 64 v8a System Image",
+          "last-available-day": 19489,
           "license": "android-sdk-license",
           "name": "system-image-31-android-tv-arm64-v8a",
           "path": "system-images/android-31/android-tv/arm64-v8a",
@@ -7393,6 +7576,7 @@
             }
           },
           "displayName": "Android TV Intel x86 Atom System Image",
+          "last-available-day": 19489,
           "license": "android-sdk-license",
           "name": "system-image-31-android-tv-x86",
           "path": "system-images/android-31/android-tv/x86",
@@ -7436,6 +7620,7 @@
             }
           },
           "displayName": "ARM 64 v8a System Image",
+          "last-available-day": 19489,
           "license": "android-sdk-license",
           "name": "system-image-31-default-arm64-v8a",
           "path": "system-images/android-31/default/arm64-v8a",
@@ -7459,9 +7644,9 @@
           "archives": [
             {
               "os": "all",
-              "sha1": "1200d6983af477fd6439f11cc5cabf9866bc4a16",
-              "size": 657244568,
-              "url": "https://dl.google.com/android/repository/sys-img/android/x86_64-31_r03.zip"
+              "sha1": "58bff3cb182c79bbfe3980fe77b87b51b9f7ad71",
+              "size": 657246510,
+              "url": "https://dl.google.com/android/repository/sys-img/android/x86_64-31_r05.zip"
             }
           ],
           "dependencies": {
@@ -7476,13 +7661,14 @@
               }
             }
           },
-          "displayName": "Intel x86 Atom_64 System Image",
+          "displayName": "Intel x86_64 Atom System Image",
+          "last-available-day": 19489,
           "license": "android-sdk-license",
           "name": "system-image-31-default-x86_64",
           "path": "system-images/android-31/default/x86_64",
           "revision": "31-default-x86_64",
           "revision-details": {
-            "major:0": "4"
+            "major:0": "5"
           },
           "type-details": {
             "abi:2": "x86_64",
@@ -7525,6 +7711,7 @@
             }
           },
           "displayName": "Google APIs ARM 64 v8a System Image",
+          "last-available-day": 19489,
           "license": "android-sdk-arm-dbt-license",
           "name": "system-image-31-google_apis-arm64-v8a",
           "path": "system-images/android-31/google_apis/arm64-v8a",
@@ -7552,9 +7739,9 @@
           "archives": [
             {
               "os": "all",
-              "sha1": "05a74ff8509fb76cbfd14b2e3307addad5c4d0df",
-              "size": 1458104208,
-              "url": "https://dl.google.com/android/repository/sys-img/google_apis/x86_64-31_r11.zip"
+              "sha1": "93d3bb0fc37e5cb144eabb0158a98b988d4bb31c",
+              "size": 1470788213,
+              "url": "https://dl.google.com/android/repository/sys-img/google_apis/x86_64-31_r13.zip"
             }
           ],
           "dependencies": {
@@ -7574,13 +7761,14 @@
               }
             }
           },
-          "displayName": "Google APIs Intel x86 Atom_64 System Image",
+          "displayName": "Google APIs Intel x86_64 Atom System Image",
+          "last-available-day": 19489,
           "license": "android-sdk-preview-license",
           "name": "system-image-31-google_apis-x86_64",
           "path": "system-images/android-31/google_apis/x86_64",
           "revision": "31-google_apis-x86_64",
           "revision-details": {
-            "major:0": "11"
+            "major:0": "13"
           },
           "type-details": {
             "abi:3": "x86_64",
@@ -7633,6 +7821,7 @@
             }
           },
           "displayName": "Google Play ARM 64 v8a System Image",
+          "last-available-day": 19489,
           "license": "android-sdk-arm-dbt-license",
           "name": "system-image-31-google_apis_playstore-arm64-v8a",
           "path": "system-images/android-31/google_apis_playstore/arm64-v8a",
@@ -7682,7 +7871,8 @@
               }
             }
           },
-          "displayName": "Google Play Intel x86 Atom_64 System Image",
+          "displayName": "Google Play Intel x86_64 Atom System Image",
+          "last-available-day": 19489,
           "license": "android-sdk-arm-dbt-license",
           "name": "system-image-31-google_apis_playstore-x86_64",
           "path": "system-images/android-31/google_apis_playstore/x86_64",
@@ -7710,13 +7900,13 @@
     },
     "32": {
       "google_apis": {
-        "x86_64": {
+        "arm64-v8a": {
           "archives": [
             {
               "os": "all",
-              "sha1": "9727f570164b062e820d6e62edabc96d125027f6",
-              "size": 1471221547,
-              "url": "https://dl.google.com/android/repository/sys-img/google_apis/x86_64-32_r03.zip"
+              "sha1": "f64546f7cfcd751d89c8b7799d444676b217c623",
+              "size": 1536995320,
+              "url": "https://dl.google.com/android/repository/sys-img/google_apis/arm64-v8a-32_r06.zip"
             }
           ],
           "dependencies": {
@@ -7736,13 +7926,65 @@
               }
             }
           },
-          "displayName": "Google APIs Intel x86 Atom_64 System Image",
+          "displayName": "Google APIs ARM 64 v8a System Image",
+          "last-available-day": 19489,
+          "license": "android-sdk-arm-dbt-license",
+          "name": "system-image-32-google_apis-arm64-v8a",
+          "path": "system-images/android-32/google_apis/arm64-v8a",
+          "revision": "32-google_apis-arm64-v8a",
+          "revision-details": {
+            "major:0": "6"
+          },
+          "type-details": {
+            "abi:3": "arm64-v8a",
+            "api-level:0": "32",
+            "element-attributes": {
+              "xsi:type": "ns12:sysImgDetailsType"
+            },
+            "tag:1": {
+              "display:1": "Google APIs",
+              "id:0": "google_apis"
+            },
+            "vendor:2": {
+              "display:1": "Google Inc.",
+              "id:0": "google"
+            }
+          }
+        },
+        "x86_64": {
+          "archives": [
+            {
+              "os": "all",
+              "sha1": "4b7fb40deefc6e7b5721774ce8f46310c2b434ca",
+              "size": 1511072885,
+              "url": "https://dl.google.com/android/repository/sys-img/google_apis/x86_64-32_r07.zip"
+            }
+          ],
+          "dependencies": {
+            "dependency:0": {
+              "element-attributes": {
+                "path": "patcher;v4"
+              }
+            },
+            "dependency:1": {
+              "element-attributes": {
+                "path": "emulator"
+              },
+              "min-revision:0": {
+                "major:0": "30",
+                "micro:2": "3",
+                "minor:1": "7"
+              }
+            }
+          },
+          "displayName": "Google APIs Intel x86_64 Atom System Image",
+          "last-available-day": 19489,
           "license": "android-sdk-preview-license",
           "name": "system-image-32-google_apis-x86_64",
           "path": "system-images/android-32/google_apis/x86_64",
           "revision": "32-google_apis-x86_64",
           "revision-details": {
-            "major:0": "3"
+            "major:0": "7"
           },
           "type-details": {
             "abi:3": "x86_64",
@@ -7795,6 +8037,7 @@
             }
           },
           "displayName": "Google Play ARM 64 v8a System Image",
+          "last-available-day": 19489,
           "license": "android-sdk-arm-dbt-license",
           "name": "system-image-32-google_apis_playstore-arm64-v8a",
           "path": "system-images/android-32/google_apis_playstore/arm64-v8a",
@@ -7856,7 +8099,8 @@
               }
             }
           },
-          "displayName": "Google Play Intel x86 Atom_64 System Image",
+          "displayName": "Google Play Intel x86_64 Atom System Image",
+          "last-available-day": 19489,
           "license": "android-sdk-preview-license",
           "name": "system-image-32-google_apis_playstore-x86_64",
           "path": "system-images/android-32/google_apis_playstore/x86_64",
@@ -7911,6 +8155,7 @@
             }
           },
           "displayName": "Android TV ARM 64 v8a System Image",
+          "last-available-day": 19489,
           "license": "android-sdk-license",
           "name": "system-image-33-android-tv-arm64-v8a",
           "path": "system-images/android-33/android-tv/arm64-v8a",
@@ -7957,6 +8202,7 @@
             }
           },
           "displayName": "Android TV Intel x86 Atom System Image",
+          "last-available-day": 19489,
           "license": "android-sdk-license",
           "name": "system-image-33-android-tv-x86",
           "path": "system-images/android-33/android-tv/x86",
@@ -7977,14 +8223,90 @@
           }
         }
       },
+      "android-wear": {
+        "arm64-v8a": {
+          "archives": [
+            {
+              "os": "all",
+              "sha1": "d1d540281261cf23895004a18705b62a53928fe6",
+              "size": 976844607,
+              "url": "https://dl.google.com/android/repository/sys-img/android-wear/arm64-v8a-33_r02.zip"
+            }
+          ],
+          "dependencies": {
+            "dependency:0": {
+              "element-attributes": {
+                "path": "patcher;v4"
+              }
+            }
+          },
+          "displayName": "Wear OS 4 - Preview ARM 64 v8a System Image",
+          "last-available-day": 19489,
+          "license": "android-sdk-preview-license",
+          "name": "system-image-33-android-wear-arm64-v8a",
+          "path": "system-images/android-33/android-wear/arm64-v8a",
+          "revision": "33-android-wear-arm64-v8a",
+          "revision-details": {
+            "major:0": "2"
+          },
+          "type-details": {
+            "abi:2": "arm64-v8a",
+            "api-level:0": "33",
+            "element-attributes": {
+              "xsi:type": "ns12:sysImgDetailsType"
+            },
+            "tag:1": {
+              "display:1": "Wear OS 4 - Preview",
+              "id:0": "android-wear"
+            }
+          }
+        },
+        "x86_64": {
+          "archives": [
+            {
+              "os": "all",
+              "sha1": "91f88f49e9484a86f18600fbfdfd281619b5ce79",
+              "size": 1013350511,
+              "url": "https://dl.google.com/android/repository/sys-img/android-wear/x86_64-33_r02.zip"
+            }
+          ],
+          "dependencies": {
+            "dependency:0": {
+              "element-attributes": {
+                "path": "patcher;v4"
+              }
+            }
+          },
+          "displayName": "Wear OS 4 - Preview Intel x86_64 Atom System Image",
+          "last-available-day": 19489,
+          "license": "android-sdk-preview-license",
+          "name": "system-image-33-android-wear-x86_64",
+          "path": "system-images/android-33/android-wear/x86_64",
+          "revision": "33-android-wear-x86_64",
+          "revision-details": {
+            "major:0": "2"
+          },
+          "type-details": {
+            "abi:2": "x86_64",
+            "api-level:0": "33",
+            "element-attributes": {
+              "xsi:type": "ns12:sysImgDetailsType"
+            },
+            "tag:1": {
+              "display:1": "Wear OS 4 - Preview",
+              "id:0": "android-wear"
+            }
+          }
+        }
+      },
       "google_apis": {
         "arm64-v8a": {
           "archives": [
             {
               "os": "all",
-              "sha1": "8e7733de150ad1a912d63f90a11a1de705b5ddcf",
-              "size": 1619645676,
-              "url": "https://dl.google.com/android/repository/sys-img/google_apis/arm64-v8a-33_r08.zip"
+              "sha1": "db779eab0a09e169bc08a5726da026327353e290",
+              "size": 1629964094,
+              "url": "https://dl.google.com/android/repository/sys-img/google_apis/arm64-v8a-33_r09.zip"
             }
           ],
           "dependencies": {
@@ -8005,12 +8327,13 @@
             }
           },
           "displayName": "Google APIs ARM 64 v8a System Image",
+          "last-available-day": 19489,
           "license": "android-sdk-arm-dbt-license",
           "name": "system-image-33-google_apis-arm64-v8a",
           "path": "system-images/android-33/google_apis/arm64-v8a",
           "revision": "33-google_apis-arm64-v8a",
           "revision-details": {
-            "major:0": "8"
+            "major:0": "9"
           },
           "type-details": {
             "abi:3": "arm64-v8a",
@@ -8032,9 +8355,9 @@
           "archives": [
             {
               "os": "all",
-              "sha1": "6f5210b87ca249aa6ea2a25bb6d5598c19fa9372",
-              "size": 1510438727,
-              "url": "https://dl.google.com/android/repository/sys-img/google_apis/x86_64-33_r08.zip"
+              "sha1": "049e63603414c044724ead42232b962b90ee6238",
+              "size": 1545070133,
+              "url": "https://dl.google.com/android/repository/sys-img/google_apis/x86_64-33_r10.zip"
             }
           ],
           "dependencies": {
@@ -8054,13 +8377,14 @@
               }
             }
           },
-          "displayName": "Google APIs Intel x86 Atom_64 System Image",
-          "license": "android-sdk-license",
+          "displayName": "Google APIs Intel x86_64 Atom System Image",
+          "last-available-day": 19489,
+          "license": "android-sdk-arm-dbt-license",
           "name": "system-image-33-google_apis-x86_64",
           "path": "system-images/android-33/google_apis/x86_64",
           "revision": "33-google_apis-x86_64",
           "revision-details": {
-            "major:0": "8"
+            "major:0": "10"
           },
           "type-details": {
             "abi:3": "x86_64",
@@ -8084,15 +8408,15 @@
           "archives": [
             {
               "os": "macosx",
-              "sha1": "831cfe87d12eb5dd9d107ca2dfb203d52ca7b217",
-              "size": 1582091204,
-              "url": "https://dl.google.com/android/repository/sys-img/google_apis_playstore/arm64-v8a-33_r07-darwin.zip"
+              "sha1": "51169278b759ce1f347a235497729bf5b558ecb2",
+              "size": 1475820733,
+              "url": "https://dl.google.com/android/repository/sys-img/google_apis_playstore/arm64-v8a-33_r01-darwin_ext05.zip"
             },
             {
               "os": "linux",
-              "sha1": "831cfe87d12eb5dd9d107ca2dfb203d52ca7b217",
-              "size": 1582091204,
-              "url": "https://dl.google.com/android/repository/sys-img/google_apis_playstore/arm64-v8a-33_r07-linux.zip"
+              "sha1": "51169278b759ce1f347a235497729bf5b558ecb2",
+              "size": 1475820733,
+              "url": "https://dl.google.com/android/repository/sys-img/google_apis_playstore/arm64-v8a-33_r01-linux_ext05.zip"
             }
           ],
           "dependencies": {
@@ -8113,6 +8437,7 @@
             }
           },
           "displayName": "Google Play ARM 64 v8a System Image",
+          "last-available-day": 19489,
           "license": "android-sdk-arm-dbt-license",
           "name": "system-image-33-google_apis_playstore-arm64-v8a",
           "path": "system-images/android-33/google_apis_playstore/arm64-v8a",
@@ -8140,9 +8465,9 @@
           "archives": [
             {
               "os": "all",
-              "sha1": "b7491eecf45556bd96f7b7a80c020b18a8a7df0d",
-              "size": 1481773028,
-              "url": "https://dl.google.com/android/repository/sys-img/google_apis_playstore/x86_64-33_r07.zip"
+              "sha1": "e80584a2c9f8ba863a3fa961efc6d8866650f2eb",
+              "size": 1479931636,
+              "url": "https://dl.google.com/android/repository/sys-img/google_apis_playstore/x86_64-33_r01_ext05.zip"
             }
           ],
           "dependencies": {
@@ -8162,7 +8487,8 @@
               }
             }
           },
-          "displayName": "Google Play Intel x86 Atom_64 System Image",
+          "displayName": "Google Play Intel x86_64 Atom System Image",
+          "last-available-day": 19489,
           "license": "android-sdk-license",
           "name": "system-image-33-google_apis_playstore-x86_64",
           "path": "system-images/android-33/google_apis_playstore/x86_64",
@@ -8194,15 +8520,15 @@
           "archives": [
             {
               "os": "macosx",
-              "sha1": "069cdb5926cef729c8f14897cdc70e47acfe6736",
-              "size": 1489462208,
-              "url": "https://dl.google.com/android/repository/sys-img/google_apis_playstore/arm64-v8a-TiramisuPrivacySandbox_r08-darwin.zip"
+              "sha1": "d4cb5f1b985cb9f6ee093a00a910c5afc1bb0912",
+              "size": 1592946784,
+              "url": "https://dl.google.com/android/repository/sys-img/google_apis_playstore/arm64-v8a-TiramisuPrivacySandbox_r09-darwin.zip"
             },
             {
               "os": "linux",
-              "sha1": "069cdb5926cef729c8f14897cdc70e47acfe6736",
-              "size": 1489462208,
-              "url": "https://dl.google.com/android/repository/sys-img/google_apis_playstore/arm64-v8a-TiramisuPrivacySandbox_r08-linux.zip"
+              "sha1": "d4cb5f1b985cb9f6ee093a00a910c5afc1bb0912",
+              "size": 1592946784,
+              "url": "https://dl.google.com/android/repository/sys-img/google_apis_playstore/arm64-v8a-TiramisuPrivacySandbox_r09-linux.zip"
             }
           ],
           "dependencies": {
@@ -8223,12 +8549,13 @@
             }
           },
           "displayName": "Google Play ARM 64 v8a System Image",
+          "last-available-day": 19489,
           "license": "android-sdk-arm-dbt-license",
           "name": "system-image-TiramisuPrivacySandbox-google_apis_playstore-arm64-v8a",
           "path": "system-images/android-TiramisuPrivacySandbox/google_apis_playstore/arm64-v8a",
           "revision": "TiramisuPrivacySandbox-google_apis_playstore-arm64-v8a",
           "revision-details": {
-            "major:0": "8"
+            "major:0": "9"
           },
           "type-details": {
             "abi:4": "arm64-v8a",
@@ -8251,9 +8578,9 @@
           "archives": [
             {
               "os": "all",
-              "sha1": "7ae1658d066353e9f079afe694bdc17c446c0c88",
-              "size": 1493513570,
-              "url": "https://dl.google.com/android/repository/sys-img/google_apis_playstore/x86_64-TiramisuPrivacySandbox_r08.zip"
+              "sha1": "4893f6e62413e97e2bad5f183319d65d3947a375",
+              "size": 1492912127,
+              "url": "https://dl.google.com/android/repository/sys-img/google_apis_playstore/x86_64-TiramisuPrivacySandbox_r09.zip"
             }
           ],
           "dependencies": {
@@ -8273,18 +8600,239 @@
               }
             }
           },
-          "displayName": "Google Play Intel x86 Atom_64 System Image",
+          "displayName": "Google Play Intel x86_64 Atom System Image",
+          "last-available-day": 19489,
           "license": "android-sdk-preview-license",
           "name": "system-image-TiramisuPrivacySandbox-google_apis_playstore-x86_64",
           "path": "system-images/android-TiramisuPrivacySandbox/google_apis_playstore/x86_64",
           "revision": "TiramisuPrivacySandbox-google_apis_playstore-x86_64",
           "revision-details": {
-            "major:0": "8"
+            "major:0": "9"
           },
           "type-details": {
             "abi:4": "x86_64",
             "api-level:0": "33",
             "codename:1": "TiramisuPrivacySandbox",
+            "element-attributes": {
+              "xsi:type": "ns12:sysImgDetailsType"
+            },
+            "tag:2": {
+              "display:1": "Google Play",
+              "id:0": "google_apis_playstore"
+            },
+            "vendor:3": {
+              "display:1": "Google Inc.",
+              "id:0": "google"
+            }
+          }
+        }
+      }
+    },
+    "UpsideDownCake": {
+      "google_apis": {
+        "arm64-v8a": {
+          "archives": [
+            {
+              "os": "all",
+              "sha1": "2335c0cf2c76cb1883a6d6ee38e6fff99989596f",
+              "size": 1549237055,
+              "url": "https://dl.google.com/android/repository/sys-img/google_apis/arm64-v8a-UpsideDownCake_r04.zip"
+            }
+          ],
+          "dependencies": {
+            "dependency:0": {
+              "element-attributes": {
+                "path": "patcher;v4"
+              }
+            },
+            "dependency:1": {
+              "element-attributes": {
+                "path": "emulator"
+              },
+              "min-revision:0": {
+                "major:0": "32",
+                "micro:2": "8",
+                "minor:1": "1"
+              }
+            }
+          },
+          "displayName": "Google APIs ARM 64 v8a System Image",
+          "last-available-day": 19489,
+          "license": "android-sdk-arm-dbt-license",
+          "name": "system-image-UpsideDownCake-google_apis-arm64-v8a",
+          "path": "system-images/android-UpsideDownCake/google_apis/arm64-v8a",
+          "revision": "UpsideDownCake-google_apis-arm64-v8a",
+          "revision-details": {
+            "major:0": "4"
+          },
+          "type-details": {
+            "abi:4": "arm64-v8a",
+            "api-level:0": "33",
+            "codename:1": "UpsideDownCake",
+            "element-attributes": {
+              "xsi:type": "ns12:sysImgDetailsType"
+            },
+            "tag:2": {
+              "display:1": "Google APIs",
+              "id:0": "google_apis"
+            },
+            "vendor:3": {
+              "display:1": "Google Inc.",
+              "id:0": "google"
+            }
+          }
+        },
+        "x86_64": {
+          "archives": [
+            {
+              "os": "all",
+              "sha1": "15a514144f57865a84abbd6df8e6897c80bb8b88",
+              "size": 1491492723,
+              "url": "https://dl.google.com/android/repository/sys-img/google_apis/x86_64-UpsideDownCake_r04.zip"
+            }
+          ],
+          "dependencies": {
+            "dependency:0": {
+              "element-attributes": {
+                "path": "patcher;v4"
+              }
+            },
+            "dependency:1": {
+              "element-attributes": {
+                "path": "emulator"
+              },
+              "min-revision:0": {
+                "major:0": "32",
+                "micro:2": "8",
+                "minor:1": "1"
+              }
+            }
+          },
+          "displayName": "Google APIs Intel x86_64 Atom System Image",
+          "last-available-day": 19489,
+          "license": "android-sdk-preview-license",
+          "name": "system-image-UpsideDownCake-google_apis-x86_64",
+          "path": "system-images/android-UpsideDownCake/google_apis/x86_64",
+          "revision": "UpsideDownCake-google_apis-x86_64",
+          "revision-details": {
+            "major:0": "4"
+          },
+          "type-details": {
+            "abi:4": "x86_64",
+            "api-level:0": "33",
+            "codename:1": "UpsideDownCake",
+            "element-attributes": {
+              "xsi:type": "ns12:sysImgDetailsType"
+            },
+            "tag:2": {
+              "display:1": "Google APIs",
+              "id:0": "google_apis"
+            },
+            "vendor:3": {
+              "display:1": "Google Inc.",
+              "id:0": "google"
+            }
+          }
+        }
+      },
+      "google_apis_playstore": {
+        "arm64-v8a": {
+          "archives": [
+            {
+              "os": "macosx",
+              "sha1": "b9f7a7d25450e2385a8334af688ab862fc723dba",
+              "size": 1513459071,
+              "url": "https://dl.google.com/android/repository/sys-img/google_apis_playstore/arm64-v8a-UpsideDownCake_r04-darwin.zip"
+            },
+            {
+              "os": "linux",
+              "sha1": "b9f7a7d25450e2385a8334af688ab862fc723dba",
+              "size": 1513459071,
+              "url": "https://dl.google.com/android/repository/sys-img/google_apis_playstore/arm64-v8a-UpsideDownCake_r04-linux.zip"
+            }
+          ],
+          "dependencies": {
+            "dependency:0": {
+              "element-attributes": {
+                "path": "patcher;v4"
+              }
+            },
+            "dependency:1": {
+              "element-attributes": {
+                "path": "emulator"
+              },
+              "min-revision:0": {
+                "major:0": "32",
+                "micro:2": "8",
+                "minor:1": "1"
+              }
+            }
+          },
+          "displayName": "Google Play ARM 64 v8a System Image",
+          "last-available-day": 19489,
+          "license": "android-sdk-arm-dbt-license",
+          "name": "system-image-UpsideDownCake-google_apis_playstore-arm64-v8a",
+          "path": "system-images/android-UpsideDownCake/google_apis_playstore/arm64-v8a",
+          "revision": "UpsideDownCake-google_apis_playstore-arm64-v8a",
+          "revision-details": {
+            "major:0": "4"
+          },
+          "type-details": {
+            "abi:4": "arm64-v8a",
+            "api-level:0": "33",
+            "codename:1": "UpsideDownCake",
+            "element-attributes": {
+              "xsi:type": "ns12:sysImgDetailsType"
+            },
+            "tag:2": {
+              "display:1": "Google Play",
+              "id:0": "google_apis_playstore"
+            },
+            "vendor:3": {
+              "display:1": "Google Inc.",
+              "id:0": "google"
+            }
+          }
+        },
+        "x86_64": {
+          "archives": [
+            {
+              "os": "all",
+              "sha1": "4647cbb1877cca1394b1a4fff52c644e6220d07a",
+              "size": 1464098477,
+              "url": "https://dl.google.com/android/repository/sys-img/google_apis_playstore/x86_64-UpsideDownCake_r04.zip"
+            }
+          ],
+          "dependencies": {
+            "dependency:0": {
+              "element-attributes": {
+                "path": "patcher;v4"
+              }
+            },
+            "dependency:1": {
+              "element-attributes": {
+                "path": "emulator"
+              },
+              "min-revision:0": {
+                "major:0": "32",
+                "micro:2": "8",
+                "minor:1": "1"
+              }
+            }
+          },
+          "displayName": "Google Play Intel x86_64 Atom System Image",
+          "last-available-day": 19489,
+          "license": "android-sdk-preview-license",
+          "name": "system-image-UpsideDownCake-google_apis_playstore-x86_64",
+          "path": "system-images/android-UpsideDownCake/google_apis_playstore/x86_64",
+          "revision": "UpsideDownCake-google_apis_playstore-x86_64",
+          "revision-details": {
+            "major:0": "4"
+          },
+          "type-details": {
+            "abi:4": "x86_64",
+            "api-level:0": "33",
+            "codename:1": "UpsideDownCake",
             "element-attributes": {
               "xsi:type": "ns12:sysImgDetailsType"
             },
@@ -8358,6 +8906,7 @@
           }
         },
         "displayName": "Android SDK Build-Tools 17",
+        "last-available-day": 19489,
         "license": "android-sdk-license",
         "name": "build-tools",
         "obsolete": "true",
@@ -8403,6 +8952,7 @@
           }
         },
         "displayName": "Android SDK Build-Tools 18.0.1",
+        "last-available-day": 19489,
         "license": "android-sdk-license",
         "name": "build-tools",
         "obsolete": "true",
@@ -8448,6 +8998,7 @@
           }
         },
         "displayName": "Android SDK Build-Tools 18.1",
+        "last-available-day": 19489,
         "license": "android-sdk-license",
         "name": "build-tools",
         "obsolete": "true",
@@ -8493,6 +9044,7 @@
           }
         },
         "displayName": "Android SDK Build-Tools 18.1.1",
+        "last-available-day": 19489,
         "license": "android-sdk-license",
         "name": "build-tools",
         "obsolete": "true",
@@ -8538,6 +9090,7 @@
           }
         },
         "displayName": "Android SDK Build-Tools 19",
+        "last-available-day": 19489,
         "license": "android-sdk-license",
         "name": "build-tools",
         "obsolete": "true",
@@ -8583,6 +9136,7 @@
           }
         },
         "displayName": "Android SDK Build-Tools 19.0.1",
+        "last-available-day": 19489,
         "license": "android-sdk-license",
         "name": "build-tools",
         "obsolete": "true",
@@ -8628,6 +9182,7 @@
           }
         },
         "displayName": "Android SDK Build-Tools 19.0.2",
+        "last-available-day": 19489,
         "license": "android-sdk-license",
         "name": "build-tools",
         "obsolete": "true",
@@ -8673,6 +9228,7 @@
           }
         },
         "displayName": "Android SDK Build-Tools 19.0.3",
+        "last-available-day": 19489,
         "license": "android-sdk-license",
         "name": "build-tools",
         "obsolete": "true",
@@ -8718,6 +9274,7 @@
           }
         },
         "displayName": "Android SDK Build-Tools 19.1",
+        "last-available-day": 19489,
         "license": "android-sdk-license",
         "name": "build-tools",
         "path": "build-tools/19.1.0",
@@ -8762,6 +9319,7 @@
           }
         },
         "displayName": "Android SDK Build-Tools 20",
+        "last-available-day": 19489,
         "license": "android-sdk-license",
         "name": "build-tools",
         "path": "build-tools/20.0.0",
@@ -8806,6 +9364,7 @@
           }
         },
         "displayName": "Android SDK Build-Tools 21",
+        "last-available-day": 19489,
         "license": "android-sdk-license",
         "name": "build-tools",
         "obsolete": "true",
@@ -8851,6 +9410,7 @@
           }
         },
         "displayName": "Android SDK Build-Tools 21.0.1",
+        "last-available-day": 19489,
         "license": "android-sdk-license",
         "name": "build-tools",
         "obsolete": "true",
@@ -8896,6 +9456,7 @@
           }
         },
         "displayName": "Android SDK Build-Tools 21.0.2",
+        "last-available-day": 19489,
         "license": "android-sdk-license",
         "name": "build-tools",
         "obsolete": "true",
@@ -8941,6 +9502,7 @@
           }
         },
         "displayName": "Android SDK Build-Tools 21.1",
+        "last-available-day": 19489,
         "license": "android-sdk-license",
         "name": "build-tools",
         "obsolete": "true",
@@ -8986,6 +9548,7 @@
           }
         },
         "displayName": "Android SDK Build-Tools 21.1.1",
+        "last-available-day": 19489,
         "license": "android-sdk-license",
         "name": "build-tools",
         "obsolete": "true",
@@ -9031,6 +9594,7 @@
           }
         },
         "displayName": "Android SDK Build-Tools 21.1.2",
+        "last-available-day": 19489,
         "license": "android-sdk-license",
         "name": "build-tools",
         "path": "build-tools/21.1.2",
@@ -9075,6 +9639,7 @@
           }
         },
         "displayName": "Android SDK Build-Tools 22",
+        "last-available-day": 19489,
         "license": "android-sdk-license",
         "name": "build-tools",
         "obsolete": "true",
@@ -9120,6 +9685,7 @@
           }
         },
         "displayName": "Android SDK Build-Tools 22.0.1",
+        "last-available-day": 19489,
         "license": "android-sdk-license",
         "name": "build-tools",
         "path": "build-tools/22.0.1",
@@ -9164,6 +9730,7 @@
           }
         },
         "displayName": "Android SDK Build-Tools 23",
+        "last-available-day": 19489,
         "license": "android-sdk-license",
         "name": "build-tools",
         "obsolete": "true",
@@ -9209,6 +9776,7 @@
           }
         },
         "displayName": "Android SDK Build-Tools 23.0.1",
+        "last-available-day": 19489,
         "license": "android-sdk-license",
         "name": "build-tools",
         "path": "build-tools/23.0.1",
@@ -9253,6 +9821,7 @@
           }
         },
         "displayName": "Android SDK Build-Tools 23.0.2",
+        "last-available-day": 19489,
         "license": "android-sdk-license",
         "name": "build-tools",
         "path": "build-tools/23.0.2",
@@ -9297,6 +9866,7 @@
           }
         },
         "displayName": "Android SDK Build-Tools 23.0.3",
+        "last-available-day": 19489,
         "license": "android-sdk-license",
         "name": "build-tools",
         "path": "build-tools/23.0.3",
@@ -9341,6 +9911,7 @@
           }
         },
         "displayName": "Android SDK Build-Tools 24",
+        "last-available-day": 19489,
         "license": "android-sdk-license",
         "name": "build-tools",
         "path": "build-tools/24.0.0",
@@ -9385,6 +9956,7 @@
           }
         },
         "displayName": "Android SDK Build-Tools 24.0.1",
+        "last-available-day": 19489,
         "license": "android-sdk-license",
         "name": "build-tools",
         "path": "build-tools/24.0.1",
@@ -9429,6 +10001,7 @@
           }
         },
         "displayName": "Android SDK Build-Tools 24.0.2",
+        "last-available-day": 19489,
         "license": "android-sdk-license",
         "name": "build-tools",
         "path": "build-tools/24.0.2",
@@ -9473,6 +10046,7 @@
           }
         },
         "displayName": "Android SDK Build-Tools 24.0.3",
+        "last-available-day": 19489,
         "license": "android-sdk-license",
         "name": "build-tools",
         "path": "build-tools/24.0.3",
@@ -9517,6 +10091,7 @@
           }
         },
         "displayName": "Android SDK Build-Tools 25",
+        "last-available-day": 19489,
         "license": "android-sdk-license",
         "name": "build-tools",
         "path": "build-tools/25.0.0",
@@ -9561,6 +10136,7 @@
           }
         },
         "displayName": "Android SDK Build-Tools 25.0.1",
+        "last-available-day": 19489,
         "license": "android-sdk-license",
         "name": "build-tools",
         "path": "build-tools/25.0.1",
@@ -9605,6 +10181,7 @@
           }
         },
         "displayName": "Android SDK Build-Tools 25.0.2",
+        "last-available-day": 19489,
         "license": "android-sdk-license",
         "name": "build-tools",
         "path": "build-tools/25.0.2",
@@ -9649,6 +10226,7 @@
           }
         },
         "displayName": "Android SDK Build-Tools 25.0.3",
+        "last-available-day": 19489,
         "license": "android-sdk-license",
         "name": "build-tools",
         "path": "build-tools/25.0.3",
@@ -9693,6 +10271,7 @@
           }
         },
         "displayName": "Android SDK Build-Tools 26",
+        "last-available-day": 19489,
         "license": "android-sdk-license",
         "name": "build-tools",
         "path": "build-tools/26.0.0",
@@ -9737,6 +10316,7 @@
           }
         },
         "displayName": "Android SDK Build-Tools 26.0.1",
+        "last-available-day": 19489,
         "license": "android-sdk-license",
         "name": "build-tools",
         "path": "build-tools/26.0.1",
@@ -9781,6 +10361,7 @@
           }
         },
         "displayName": "Android SDK Build-Tools 26.0.2",
+        "last-available-day": 19489,
         "license": "android-sdk-license",
         "name": "build-tools",
         "path": "build-tools/26.0.2",
@@ -9825,6 +10406,7 @@
           }
         },
         "displayName": "Android SDK Build-Tools 26.0.3",
+        "last-available-day": 19489,
         "license": "android-sdk-license",
         "name": "build-tools",
         "path": "build-tools/26.0.3",
@@ -9869,6 +10451,7 @@
           }
         },
         "displayName": "Android SDK Build-Tools 27",
+        "last-available-day": 19489,
         "license": "android-sdk-license",
         "name": "build-tools",
         "path": "build-tools/27.0.0",
@@ -9913,6 +10496,7 @@
           }
         },
         "displayName": "Android SDK Build-Tools 27.0.1",
+        "last-available-day": 19489,
         "license": "android-sdk-license",
         "name": "build-tools",
         "path": "build-tools/27.0.1",
@@ -9957,6 +10541,7 @@
           }
         },
         "displayName": "Android SDK Build-Tools 27.0.2",
+        "last-available-day": 19489,
         "license": "android-sdk-license",
         "name": "build-tools",
         "path": "build-tools/27.0.2",
@@ -10001,6 +10586,7 @@
           }
         },
         "displayName": "Android SDK Build-Tools 27.0.3",
+        "last-available-day": 19489,
         "license": "android-sdk-license",
         "name": "build-tools",
         "path": "build-tools/27.0.3",
@@ -10045,6 +10631,7 @@
           }
         },
         "displayName": "Android SDK Build-Tools 28",
+        "last-available-day": 19489,
         "license": "android-sdk-license",
         "name": "build-tools",
         "path": "build-tools/28.0.0",
@@ -10089,6 +10676,7 @@
           }
         },
         "displayName": "Android SDK Build-Tools 28-rc1",
+        "last-available-day": 19489,
         "license": "android-sdk-preview-license",
         "name": "build-tools",
         "obsolete": "true",
@@ -10135,6 +10723,7 @@
           }
         },
         "displayName": "Android SDK Build-Tools 28-rc2",
+        "last-available-day": 19489,
         "license": "android-sdk-preview-license",
         "name": "build-tools",
         "obsolete": "true",
@@ -10181,6 +10770,7 @@
           }
         },
         "displayName": "Android SDK Build-Tools 28.0.1",
+        "last-available-day": 19489,
         "license": "android-sdk-license",
         "name": "build-tools",
         "path": "build-tools/28.0.1",
@@ -10225,6 +10815,7 @@
           }
         },
         "displayName": "Android SDK Build-Tools 28.0.2",
+        "last-available-day": 19489,
         "license": "android-sdk-license",
         "name": "build-tools",
         "path": "build-tools/28.0.2",
@@ -10269,6 +10860,7 @@
           }
         },
         "displayName": "Android SDK Build-Tools 28.0.3",
+        "last-available-day": 19489,
         "license": "android-sdk-license",
         "name": "build-tools",
         "path": "build-tools/28.0.3",
@@ -10313,6 +10905,7 @@
           }
         },
         "displayName": "Android SDK Build-Tools 29",
+        "last-available-day": 19489,
         "license": "android-sdk-license",
         "name": "build-tools",
         "path": "build-tools/29.0.0",
@@ -10357,6 +10950,7 @@
           }
         },
         "displayName": "Android SDK Build-Tools 29-rc1",
+        "last-available-day": 19489,
         "license": "android-sdk-preview-license",
         "name": "build-tools",
         "obsolete": "true",
@@ -10403,6 +10997,7 @@
           }
         },
         "displayName": "Android SDK Build-Tools 29-rc2",
+        "last-available-day": 19489,
         "license": "android-sdk-preview-license",
         "name": "build-tools",
         "obsolete": "true",
@@ -10449,6 +11044,7 @@
           }
         },
         "displayName": "Android SDK Build-Tools 29-rc3",
+        "last-available-day": 19489,
         "license": "android-sdk-preview-license",
         "name": "build-tools",
         "obsolete": "true",
@@ -10495,6 +11091,7 @@
           }
         },
         "displayName": "Android SDK Build-Tools 29.0.1",
+        "last-available-day": 19489,
         "license": "android-sdk-license",
         "name": "build-tools",
         "path": "build-tools/29.0.1",
@@ -10539,6 +11136,7 @@
           }
         },
         "displayName": "Android SDK Build-Tools 29.0.2",
+        "last-available-day": 19489,
         "license": "android-sdk-license",
         "name": "build-tools",
         "path": "build-tools/29.0.2",
@@ -10583,6 +11181,7 @@
           }
         },
         "displayName": "Android SDK Build-Tools 29.0.3",
+        "last-available-day": 19489,
         "license": "android-sdk-license",
         "name": "build-tools",
         "path": "build-tools/29.0.3",
@@ -10627,6 +11226,7 @@
           }
         },
         "displayName": "Android SDK Build-Tools 30",
+        "last-available-day": 19489,
         "license": "android-sdk-license",
         "name": "build-tools",
         "path": "build-tools/30.0.0",
@@ -10671,6 +11271,7 @@
           }
         },
         "displayName": "Android SDK Build-Tools 30.0.1",
+        "last-available-day": 19489,
         "license": "android-sdk-license",
         "name": "build-tools",
         "path": "build-tools/30.0.1",
@@ -10715,6 +11316,7 @@
           }
         },
         "displayName": "Android SDK Build-Tools 30.0.2",
+        "last-available-day": 19489,
         "license": "android-sdk-license",
         "name": "build-tools",
         "path": "build-tools/30.0.2",
@@ -10759,6 +11361,7 @@
           }
         },
         "displayName": "Android SDK Build-Tools 30.0.3",
+        "last-available-day": 19489,
         "license": "android-sdk-license",
         "name": "build-tools",
         "path": "build-tools/30.0.3",
@@ -10796,6 +11399,7 @@
           }
         ],
         "displayName": "Android SDK Build-Tools 31",
+        "last-available-day": 19489,
         "license": "android-sdk-license",
         "name": "build-tools",
         "path": "build-tools/31.0.0",
@@ -10833,6 +11437,7 @@
           }
         ],
         "displayName": "Android SDK Build-Tools 32",
+        "last-available-day": 19489,
         "license": "android-sdk-license",
         "name": "build-tools",
         "path": "build-tools/32.0.0",
@@ -10870,6 +11475,7 @@
           }
         ],
         "displayName": "Android SDK Build-Tools 32.1-rc1",
+        "last-available-day": 19489,
         "license": "android-sdk-preview-license",
         "name": "build-tools",
         "path": "build-tools/32.1.0-rc1",
@@ -10908,6 +11514,7 @@
           }
         ],
         "displayName": "Android SDK Build-Tools 33",
+        "last-available-day": 19489,
         "license": "android-sdk-license",
         "name": "build-tools",
         "path": "build-tools/33.0.0",
@@ -10945,6 +11552,7 @@
           }
         ],
         "displayName": "Android SDK Build-Tools 33.0.1",
+        "last-available-day": 19489,
         "license": "android-sdk-license",
         "name": "build-tools",
         "path": "build-tools/33.0.1",
@@ -10953,6 +11561,200 @@
           "major:0": "33",
           "micro:2": "1",
           "minor:1": "0"
+        },
+        "type-details": {
+          "element-attributes": {
+            "xsi:type": "ns5:genericDetailsType"
+          }
+        }
+      },
+      "33.0.2": {
+        "archives": [
+          {
+            "os": "linux",
+            "sha1": "9def17c815f46ac09024ebb674466d39d039255c",
+            "size": 56003588,
+            "url": "https://dl.google.com/android/repository/build-tools_r33.0.2-linux.zip"
+          },
+          {
+            "os": "macosx",
+            "sha1": "482fd9244332cb3e7435f229a22552459b68b3ff",
+            "size": 60013768,
+            "url": "https://dl.google.com/android/repository/build-tools_r33.0.2-macosx.zip"
+          },
+          {
+            "os": "windows",
+            "sha1": "1f33813c884a039f242b386e9127d3a96915066f",
+            "size": 55630250,
+            "url": "https://dl.google.com/android/repository/build-tools_r33.0.2-windows.zip"
+          }
+        ],
+        "displayName": "Android SDK Build-Tools 33.0.2",
+        "last-available-day": 19489,
+        "license": "android-sdk-license",
+        "name": "build-tools",
+        "path": "build-tools/33.0.2",
+        "revision": "33.0.2",
+        "revision-details": {
+          "major:0": "33",
+          "micro:2": "2",
+          "minor:1": "0"
+        },
+        "type-details": {
+          "element-attributes": {
+            "xsi:type": "ns5:genericDetailsType"
+          }
+        }
+      },
+      "34.0.0-rc1": {
+        "archives": [
+          {
+            "os": "linux",
+            "sha1": "fec0a16d0c2fab6576fd58f6aa2e69a561ab1128",
+            "size": 60468599,
+            "url": "https://dl.google.com/android/repository/build-tools_r34-rc1-linux.zip"
+          },
+          {
+            "os": "macosx",
+            "sha1": "1e3847d449ce6124ffbf528db601f3dfab25e77e",
+            "size": 62640488,
+            "url": "https://dl.google.com/android/repository/build-tools_r34-rc1-macosx.zip"
+          },
+          {
+            "os": "windows",
+            "sha1": "73dca92f84827749882bd0ac501c4befdf3ab878",
+            "size": 57791540,
+            "url": "https://dl.google.com/android/repository/build-tools_r34-rc1-windows.zip"
+          }
+        ],
+        "displayName": "Android SDK Build-Tools 34-rc1",
+        "last-available-day": 19489,
+        "license": "android-sdk-preview-license",
+        "name": "build-tools",
+        "path": "build-tools/34.0.0-rc1",
+        "revision": "34.0.0-rc1",
+        "revision-details": {
+          "major:0": "34",
+          "micro:2": "0",
+          "minor:1": "0",
+          "preview:3": "1"
+        },
+        "type-details": {
+          "element-attributes": {
+            "xsi:type": "ns5:genericDetailsType"
+          }
+        }
+      },
+      "34.0.0-rc2": {
+        "archives": [
+          {
+            "os": "linux",
+            "sha1": "bce35f1524d2ea5f6326809dc7accff0ee2fe370",
+            "size": 60835777,
+            "url": "https://dl.google.com/android/repository/build-tools_r34-rc2-linux.zip"
+          },
+          {
+            "os": "macosx",
+            "sha1": "c47d9c9d040567b1b62eefc1a6306b5acebe3a76",
+            "size": 63005203,
+            "url": "https://dl.google.com/android/repository/build-tools_r34-rc2-macosx.zip"
+          },
+          {
+            "os": "windows",
+            "sha1": "60c51d073ac760fdec647b9fecf086d1a35f7841",
+            "size": 58246192,
+            "url": "https://dl.google.com/android/repository/build-tools_r34-rc2-windows.zip"
+          }
+        ],
+        "displayName": "Android SDK Build-Tools 34-rc2",
+        "last-available-day": 19489,
+        "license": "android-sdk-preview-license",
+        "name": "build-tools",
+        "path": "build-tools/34.0.0-rc2",
+        "revision": "34.0.0-rc2",
+        "revision-details": {
+          "major:0": "34",
+          "micro:2": "0",
+          "minor:1": "0",
+          "preview:3": "2"
+        },
+        "type-details": {
+          "element-attributes": {
+            "xsi:type": "ns5:genericDetailsType"
+          }
+        }
+      },
+      "34.0.0-rc3": {
+        "archives": [
+          {
+            "os": "linux",
+            "sha1": "0bcb893e8b009f1da3d538be47c6ae5907884bf6",
+            "size": 61165322,
+            "url": "https://dl.google.com/android/repository/build-tools_r34-rc3-linux.zip"
+          },
+          {
+            "os": "macosx",
+            "sha1": "97db9e5009971021ca18bb62043764b68f756ede",
+            "size": 76497941,
+            "url": "https://dl.google.com/android/repository/build-tools_r34-rc3-macosx.zip"
+          },
+          {
+            "os": "windows",
+            "sha1": "78fa4ca752017c3217786af16c513f44a5042433",
+            "size": 58326432,
+            "url": "https://dl.google.com/android/repository/build-tools_r34-rc3-windows.zip"
+          }
+        ],
+        "displayName": "Android SDK Build-Tools 34-rc3",
+        "last-available-day": 19489,
+        "license": "android-sdk-preview-license",
+        "name": "build-tools",
+        "path": "build-tools/34.0.0-rc3",
+        "revision": "34.0.0-rc3",
+        "revision-details": {
+          "major:0": "34",
+          "micro:2": "0",
+          "minor:1": "0",
+          "preview:3": "3"
+        },
+        "type-details": {
+          "element-attributes": {
+            "xsi:type": "ns5:genericDetailsType"
+          }
+        }
+      },
+      "34.0.0-rc4": {
+        "archives": [
+          {
+            "os": "linux",
+            "sha1": "61f7cfa64786bffbf6c6c9a3d74d025a07239928",
+            "size": 61206867,
+            "url": "https://dl.google.com/android/repository/build-tools_r34-rc4-linux.zip"
+          },
+          {
+            "os": "macosx",
+            "sha1": "522431b33cd7fa1407914a8fa66a27bfe1755cbb",
+            "size": 76553187,
+            "url": "https://dl.google.com/android/repository/build-tools_r34-rc4-macosx.zip"
+          },
+          {
+            "os": "windows",
+            "sha1": "699f1cb99a8de88b1746ce12302d6c2ddce81186",
+            "size": 58219308,
+            "url": "https://dl.google.com/android/repository/build-tools_r34-rc4-windows.zip"
+          }
+        ],
+        "displayName": "Android SDK Build-Tools 34-rc4",
+        "last-available-day": 19489,
+        "license": "android-sdk-preview-license",
+        "name": "build-tools",
+        "path": "build-tools/34.0.0-rc4",
+        "revision": "34.0.0-rc4",
+        "revision-details": {
+          "major:0": "34",
+          "micro:2": "0",
+          "minor:1": "0",
+          "preview:3": "4"
         },
         "type-details": {
           "element-attributes": {
@@ -10984,6 +11786,7 @@
           }
         ],
         "displayName": "CMake 3.10.2.4988404",
+        "last-available-day": 19489,
         "license": "android-sdk-license",
         "name": "cmake",
         "path": "cmake/3.10.2.4988404",
@@ -11021,6 +11824,7 @@
           }
         ],
         "displayName": "CMake 3.18.1",
+        "last-available-day": 19489,
         "license": "android-sdk-license",
         "name": "cmake",
         "path": "cmake/3.18.1",
@@ -11058,6 +11862,7 @@
           }
         ],
         "displayName": "CMake 3.22.1",
+        "last-available-day": 19489,
         "license": "android-sdk-license",
         "name": "cmake",
         "path": "cmake/3.22.1",
@@ -11095,6 +11900,7 @@
           }
         ],
         "displayName": "CMake 3.6.4111459",
+        "last-available-day": 19489,
         "license": "android-sdk-license",
         "name": "cmake",
         "path": "cmake/3.6.4111459",
@@ -11134,6 +11940,7 @@
           }
         ],
         "displayName": "Android SDK Command-line Tools",
+        "last-available-day": 19489,
         "license": "android-sdk-license",
         "name": "cmdline-tools",
         "path": "cmdline-tools/1.0",
@@ -11141,6 +11948,82 @@
         "revision-details": {
           "major:0": "1",
           "minor:1": "0"
+        },
+        "type-details": {
+          "element-attributes": {
+            "xsi:type": "ns5:genericDetailsType"
+          }
+        }
+      },
+      "10.0-rc04": {
+        "archives": [
+          {
+            "os": "linux",
+            "sha1": "fe41906d2ce82df4cde74fe258e0ccdb283de60a",
+            "size": 138718717,
+            "url": "https://dl.google.com/android/repository/commandlinetools-linux-9645777_latest.zip"
+          },
+          {
+            "os": "macosx",
+            "sha1": "021540982a843ae2c9b4e0a5c2034b29681b4f70",
+            "size": 138718701,
+            "url": "https://dl.google.com/android/repository/commandlinetools-mac-9645777_latest.zip"
+          },
+          {
+            "os": "windows",
+            "sha1": "9c3877a2926c1e73af981964b0f4381a6d68fb21",
+            "size": 138694572,
+            "url": "https://dl.google.com/android/repository/commandlinetools-win-9645777_latest.zip"
+          }
+        ],
+        "displayName": "Android SDK Command-line Tools",
+        "last-available-day": 19489,
+        "license": "android-sdk-preview-license",
+        "name": "cmdline-tools",
+        "path": "cmdline-tools/10.0-beta04",
+        "revision": "10.0-rc04",
+        "revision-details": {
+          "major:0": "10",
+          "minor:1": "0",
+          "preview:2": "04"
+        },
+        "type-details": {
+          "element-attributes": {
+            "xsi:type": "ns5:genericDetailsType"
+          }
+        }
+      },
+      "11.0-rc07": {
+        "archives": [
+          {
+            "os": "linux",
+            "sha1": "c43e4fb8567c4625e8daf4cee0a5490f826a5442",
+            "size": 147822296,
+            "url": "https://dl.google.com/android/repository/commandlinetools-linux-9644228_latest.zip"
+          },
+          {
+            "os": "macosx",
+            "sha1": "2c97234849128cb75b0691cf652ab098707c610c",
+            "size": 147822280,
+            "url": "https://dl.google.com/android/repository/commandlinetools-mac-9644228_latest.zip"
+          },
+          {
+            "os": "windows",
+            "sha1": "2bfc8fad022acce100a5b0583def1ca5bc56eff1",
+            "size": 147798151,
+            "url": "https://dl.google.com/android/repository/commandlinetools-win-9644228_latest.zip"
+          }
+        ],
+        "displayName": "Android SDK Command-line Tools",
+        "last-available-day": 19489,
+        "license": "android-sdk-preview-license",
+        "name": "cmdline-tools",
+        "path": "cmdline-tools/11.0-alpha07",
+        "revision": "11.0-rc07",
+        "revision-details": {
+          "major:0": "11",
+          "minor:1": "0",
+          "preview:2": "07"
         },
         "type-details": {
           "element-attributes": {
@@ -11170,6 +12053,7 @@
           }
         ],
         "displayName": "Android SDK Command-line Tools",
+        "last-available-day": 19489,
         "license": "android-sdk-license",
         "name": "cmdline-tools",
         "obsolete": "true",
@@ -11207,6 +12091,7 @@
           }
         ],
         "displayName": "Android SDK Command-line Tools",
+        "last-available-day": 19489,
         "license": "android-sdk-license",
         "name": "cmdline-tools",
         "path": "cmdline-tools/2.1",
@@ -11243,6 +12128,7 @@
           }
         ],
         "displayName": "Android SDK Command-line Tools",
+        "last-available-day": 19489,
         "license": "android-sdk-license",
         "name": "cmdline-tools",
         "path": "cmdline-tools/3.0",
@@ -11279,6 +12165,7 @@
           }
         ],
         "displayName": "Android SDK Command-line Tools",
+        "last-available-day": 19489,
         "license": "android-sdk-license",
         "name": "cmdline-tools",
         "path": "cmdline-tools/4.0",
@@ -11315,6 +12202,7 @@
           }
         ],
         "displayName": "Android SDK Command-line Tools",
+        "last-available-day": 19489,
         "license": "android-sdk-license",
         "name": "cmdline-tools",
         "path": "cmdline-tools/5.0",
@@ -11351,6 +12239,7 @@
           }
         ],
         "displayName": "Android SDK Command-line Tools",
+        "last-available-day": 19489,
         "license": "android-sdk-license",
         "name": "cmdline-tools",
         "path": "cmdline-tools/6.0",
@@ -11387,6 +12276,7 @@
           }
         ],
         "displayName": "Android SDK Command-line Tools",
+        "last-available-day": 19489,
         "license": "android-sdk-license",
         "name": "cmdline-tools",
         "path": "cmdline-tools/7.0",
@@ -11423,12 +12313,50 @@
           }
         ],
         "displayName": "Android SDK Command-line Tools",
+        "last-available-day": 19489,
         "license": "android-sdk-license",
         "name": "cmdline-tools",
         "path": "cmdline-tools/8.0",
         "revision": "8.0",
         "revision-details": {
           "major:0": "8",
+          "minor:1": "0"
+        },
+        "type-details": {
+          "element-attributes": {
+            "xsi:type": "ns5:genericDetailsType"
+          }
+        }
+      },
+      "9.0": {
+        "archives": [
+          {
+            "os": "linux",
+            "sha1": "7f92d6e0783a6d73ade5396fe4cfcb58544ef14b",
+            "size": 133507477,
+            "url": "https://dl.google.com/android/repository/commandlinetools-linux-9477386_latest.zip"
+          },
+          {
+            "os": "macosx",
+            "sha1": "587441bc37d957857c1f654726eb7e04ee9ca3e0",
+            "size": 133507463,
+            "url": "https://dl.google.com/android/repository/commandlinetools-mac-9477386_latest.zip"
+          },
+          {
+            "os": "windows",
+            "sha1": "f8cd24223fee3b4cff857c9435caa72be0d08b70",
+            "size": 133486337,
+            "url": "https://dl.google.com/android/repository/commandlinetools-win-9477386_latest.zip"
+          }
+        ],
+        "displayName": "Android SDK Command-line Tools",
+        "last-available-day": 19489,
+        "license": "android-sdk-license",
+        "name": "cmdline-tools",
+        "path": "cmdline-tools/9.0",
+        "revision": "9.0",
+        "revision-details": {
+          "major:0": "9",
           "minor:1": "0"
         },
         "type-details": {
@@ -11468,6 +12396,7 @@
           }
         },
         "displayName": "Android Emulator",
+        "last-available-day": 19469,
         "license": "android-sdk-license",
         "name": "emulator",
         "path": "emulator",
@@ -11512,6 +12441,7 @@
           }
         },
         "displayName": "Android Emulator",
+        "last-available-day": 19469,
         "license": "android-sdk-license",
         "name": "emulator",
         "path": "emulator",
@@ -11520,6 +12450,96 @@
           "major:0": "31",
           "micro:2": "14",
           "minor:1": "3"
+        },
+        "type-details": {
+          "element-attributes": {
+            "xsi:type": "ns5:genericDetailsType"
+          }
+        }
+      },
+      "32.1.10": {
+        "archives": [
+          {
+            "os": "macosx",
+            "sha1": "518eaa8575a2e5ae7bbb19847e0c25b7968a9e91",
+            "size": 309316195,
+            "url": "https://dl.google.com/android/repository/emulator-darwin_x64-9475343.zip"
+          },
+          {
+            "os": "linux",
+            "sha1": "71ef457eeeee6b55382abf4a5aaab5de7426e383",
+            "size": 270160041,
+            "url": "https://dl.google.com/android/repository/emulator-linux_x64-9475343.zip"
+          },
+          {
+            "os": "windows",
+            "sha1": "a53b8e1026325b48cb722d91deeb128947971b8f",
+            "size": 333004087,
+            "url": "https://dl.google.com/android/repository/emulator-windows_x64-9475343.zip"
+          }
+        ],
+        "dependencies": {
+          "dependency:0": {
+            "element-attributes": {
+              "path": "patcher;v4"
+            }
+          }
+        },
+        "displayName": "Android Emulator",
+        "last-available-day": 19489,
+        "license": "android-sdk-license",
+        "name": "emulator",
+        "path": "emulator",
+        "revision": "32.1.10",
+        "revision-details": {
+          "major:0": "32",
+          "micro:2": "10",
+          "minor:1": "1"
+        },
+        "type-details": {
+          "element-attributes": {
+            "xsi:type": "ns5:genericDetailsType"
+          }
+        }
+      },
+      "32.1.12": {
+        "archives": [
+          {
+            "os": "linux",
+            "sha1": "556fb884d6e72b597bf5c1fa959f59744994fb68",
+            "size": 270165820,
+            "url": "https://dl.google.com/android/repository/emulator-linux_x64-9751036.zip"
+          },
+          {
+            "os": "windows",
+            "sha1": "0ee17dd9b4410d38dc2f6a6227e899d6910b2c55",
+            "size": 332999329,
+            "url": "https://dl.google.com/android/repository/emulator-windows_x64-9751036.zip"
+          },
+          {
+            "os": "macosx",
+            "sha1": "d37d6e301f36d8f0797ca96a3fd6b8ee5f8d46ae",
+            "size": 307219070,
+            "url": "https://dl.google.com/android/repository/emulator-darwin_x64-9751036.zip"
+          }
+        ],
+        "dependencies": {
+          "dependency:0": {
+            "element-attributes": {
+              "path": "patcher;v4"
+            }
+          }
+        },
+        "displayName": "Android Emulator",
+        "last-available-day": 19489,
+        "license": "android-sdk-license",
+        "name": "emulator",
+        "path": "emulator",
+        "revision": "32.1.12",
+        "revision-details": {
+          "major:0": "32",
+          "micro:2": "12",
+          "minor:1": "1"
         },
         "type-details": {
           "element-attributes": {
@@ -11556,6 +12576,7 @@
           }
         },
         "displayName": "Android Emulator",
+        "last-available-day": 19469,
         "license": "android-sdk-preview-license",
         "name": "emulator",
         "path": "emulator",
@@ -11563,6 +12584,141 @@
         "revision-details": {
           "major:0": "32",
           "micro:2": "8",
+          "minor:1": "1"
+        },
+        "type-details": {
+          "element-attributes": {
+            "xsi:type": "ns5:genericDetailsType"
+          }
+        }
+      },
+      "33.1.10": {
+        "archives": [
+          {
+            "os": "macosx",
+            "sha1": "f38b9ec7e9c9ff3b8c4022e7f9baa1d6622634a0",
+            "size": 325272345,
+            "url": "https://dl.google.com/android/repository/emulator-darwin_x64-10078095.zip"
+          },
+          {
+            "os": "linux",
+            "sha1": "e97f77ce116ff8fb13bd8f89a2097cc4ab1dbc67",
+            "size": 180494623,
+            "url": "https://dl.google.com/android/repository/emulator-linux_x64-10078095.zip"
+          },
+          {
+            "os": "windows",
+            "sha1": "8738b20ee568c4e6a84b66b1fa848517db646c47",
+            "size": 354011689,
+            "url": "https://dl.google.com/android/repository/emulator-windows_x64-10078095.zip"
+          }
+        ],
+        "dependencies": {
+          "dependency:0": {
+            "element-attributes": {
+              "path": "patcher;v4"
+            }
+          }
+        },
+        "displayName": "Android Emulator",
+        "last-available-day": 19489,
+        "license": "android-sdk-preview-license",
+        "name": "emulator",
+        "path": "emulator",
+        "revision": "33.1.10",
+        "revision-details": {
+          "major:0": "33",
+          "micro:2": "10",
+          "minor:1": "1"
+        },
+        "type-details": {
+          "element-attributes": {
+            "xsi:type": "ns5:genericDetailsType"
+          }
+        }
+      },
+      "33.1.4": {
+        "archives": [
+          {
+            "os": "macosx",
+            "sha1": "33be82356a352b79b742154f7c71f6f13455f27b",
+            "size": 345831055,
+            "url": "https://dl.google.com/android/repository/emulator-darwin_x64-9936625.zip"
+          },
+          {
+            "os": "linux",
+            "sha1": "cfa28a326b6328e2f3a068ac3030a075471d9df0",
+            "size": 260288819,
+            "url": "https://dl.google.com/android/repository/emulator-linux_x64-9936625.zip"
+          },
+          {
+            "os": "windows",
+            "sha1": "0aab97a7b84853c8f8c7618191dc23416e2a7a4b",
+            "size": 373623936,
+            "url": "https://dl.google.com/android/repository/emulator-windows_x64-9936625.zip"
+          }
+        ],
+        "dependencies": {
+          "dependency:0": {
+            "element-attributes": {
+              "path": "patcher;v4"
+            }
+          }
+        },
+        "displayName": "Android Emulator",
+        "last-available-day": 19469,
+        "license": "android-sdk-preview-license",
+        "name": "emulator",
+        "path": "emulator",
+        "revision": "33.1.4",
+        "revision-details": {
+          "major:0": "33",
+          "micro:2": "4",
+          "minor:1": "1"
+        },
+        "type-details": {
+          "element-attributes": {
+            "xsi:type": "ns5:genericDetailsType"
+          }
+        }
+      },
+      "33.1.6": {
+        "archives": [
+          {
+            "os": "macosx",
+            "sha1": "a31338f160fc5fa7973946d34a0d0ce1a2c0759a",
+            "size": 332134756,
+            "url": "https://dl.google.com/android/repository/emulator-darwin_x64-10047184.zip"
+          },
+          {
+            "os": "linux",
+            "sha1": "9f5c71277f52837d4fb43f72c80103bdf81c0569",
+            "size": 254562719,
+            "url": "https://dl.google.com/android/repository/emulator-linux_x64-10047184.zip"
+          },
+          {
+            "os": "windows",
+            "sha1": "11ba13425c6fcd275f5e1aa95923f736dd2bcb64",
+            "size": 361497029,
+            "url": "https://dl.google.com/android/repository/emulator-windows_x64-10047184.zip"
+          }
+        ],
+        "dependencies": {
+          "dependency:0": {
+            "element-attributes": {
+              "path": "patcher;v4"
+            }
+          }
+        },
+        "displayName": "Android Emulator",
+        "last-available-day": 19489,
+        "license": "android-sdk-preview-license",
+        "name": "emulator",
+        "path": "emulator",
+        "revision": "33.1.6",
+        "revision-details": {
+          "major:0": "33",
+          "micro:2": "6",
           "minor:1": "1"
         },
         "type-details": {
@@ -11595,6 +12751,7 @@
           }
         ],
         "displayName": "Android Auto Desktop Head Unit Emulator",
+        "last-available-day": 19489,
         "license": "android-sdk-license",
         "name": "extras",
         "path": "extras/google/auto",
@@ -11631,6 +12788,7 @@
           }
         ],
         "displayName": "Android Auto Desktop Head Unit Emulator",
+        "last-available-day": 19489,
         "license": "android-sdk-license",
         "name": "extras",
         "path": "extras/google/auto",
@@ -11676,6 +12834,7 @@
           }
         },
         "displayName": "NDK (Side by side) 16.1.4479499",
+        "last-available-day": 19489,
         "license": "android-sdk-license",
         "name": "ndk",
         "path": "ndk/16.1.4479499",
@@ -11720,6 +12879,7 @@
           }
         },
         "displayName": "NDK (Side by side) 17.2.4988734",
+        "last-available-day": 19489,
         "license": "android-sdk-license",
         "name": "ndk",
         "path": "ndk/17.2.4988734",
@@ -11764,6 +12924,7 @@
           }
         },
         "displayName": "NDK (Side by side) 18.1.5063045",
+        "last-available-day": 19489,
         "license": "android-sdk-license",
         "name": "ndk",
         "path": "ndk/18.1.5063045",
@@ -11808,6 +12969,7 @@
           }
         },
         "displayName": "NDK (Side by side) 19.0.5232133",
+        "last-available-day": 19489,
         "license": "android-sdk-license",
         "name": "ndk",
         "obsolete": "true",
@@ -11853,6 +13015,7 @@
           }
         },
         "displayName": "NDK (Side by side) 19.2.5345600",
+        "last-available-day": 19489,
         "license": "android-sdk-license",
         "name": "ndk",
         "path": "ndk/19.2.5345600",
@@ -11897,6 +13060,7 @@
           }
         },
         "displayName": "NDK (Side by side) 20.0.5392854",
+        "last-available-day": 19489,
         "license": "android-sdk-preview-license",
         "name": "ndk",
         "obsolete": "true",
@@ -11943,6 +13107,7 @@
           }
         },
         "displayName": "NDK (Side by side) 20.0.5471264",
+        "last-available-day": 19489,
         "license": "android-sdk-preview-license",
         "name": "ndk",
         "obsolete": "true",
@@ -11989,6 +13154,7 @@
           }
         },
         "displayName": "NDK (Side by side) 20.0.5594570",
+        "last-available-day": 19489,
         "license": "android-sdk-license",
         "name": "ndk",
         "path": "ndk/20.0.5594570",
@@ -12033,6 +13199,7 @@
           }
         },
         "displayName": "NDK (Side by side) 20.1.5948944",
+        "last-available-day": 19489,
         "license": "android-sdk-license",
         "name": "ndk",
         "path": "ndk/20.1.5948944",
@@ -12077,6 +13244,7 @@
           }
         },
         "displayName": "NDK (Side by side) 21.0.6011959",
+        "last-available-day": 19489,
         "license": "android-sdk-preview-license",
         "name": "ndk",
         "path": "ndk/21.0.6011959",
@@ -12122,6 +13290,7 @@
           }
         },
         "displayName": "NDK (Side by side) 21.0.6113669",
+        "last-available-day": 19489,
         "license": "android-sdk-license",
         "name": "ndk",
         "path": "ndk/21.0.6113669",
@@ -12166,6 +13335,7 @@
           }
         },
         "displayName": "NDK (Side by side) 21.1.6210238",
+        "last-available-day": 19489,
         "license": "android-sdk-preview-license",
         "name": "ndk",
         "path": "ndk/21.1.6210238",
@@ -12211,6 +13381,7 @@
           }
         },
         "displayName": "NDK (Side by side) 21.1.6273396",
+        "last-available-day": 19489,
         "license": "android-sdk-preview-license",
         "name": "ndk",
         "path": "ndk/21.1.6273396",
@@ -12256,6 +13427,7 @@
           }
         },
         "displayName": "NDK (Side by side) 21.1.6352462",
+        "last-available-day": 19489,
         "license": "android-sdk-license",
         "name": "ndk",
         "path": "ndk/21.1.6352462",
@@ -12300,6 +13472,7 @@
           }
         },
         "displayName": "NDK (Side by side) 21.1.6363665",
+        "last-available-day": 19489,
         "license": "android-sdk-preview-license",
         "name": "ndk",
         "path": "ndk/21.1.6363665",
@@ -12345,6 +13518,7 @@
           }
         },
         "displayName": "NDK (Side by side) 21.2.6472646",
+        "last-available-day": 19489,
         "license": "android-sdk-license",
         "name": "ndk",
         "path": "ndk/21.2.6472646",
@@ -12389,6 +13563,7 @@
           }
         },
         "displayName": "NDK (Side by side) 21.3.6528147",
+        "last-available-day": 19489,
         "license": "android-sdk-license",
         "name": "ndk",
         "path": "ndk/21.3.6528147",
@@ -12433,6 +13608,7 @@
           }
         },
         "displayName": "NDK (Side by side) 21.4.7075529",
+        "last-available-day": 19489,
         "license": "android-sdk-license",
         "name": "ndk",
         "path": "ndk/21.4.7075529",
@@ -12477,6 +13653,7 @@
           }
         },
         "displayName": "NDK (Side by side) 22.0.6917172",
+        "last-available-day": 19489,
         "license": "android-sdk-preview-license",
         "name": "ndk",
         "path": "ndk/22.0.6917172",
@@ -12522,6 +13699,7 @@
           }
         },
         "displayName": "NDK (Side by side) 22.0.7026061",
+        "last-available-day": 19489,
         "license": "android-sdk-license",
         "name": "ndk",
         "path": "ndk/22.0.7026061",
@@ -12566,6 +13744,7 @@
           }
         },
         "displayName": "NDK (Side by side) 22.1.7171670",
+        "last-available-day": 19489,
         "license": "android-sdk-license",
         "name": "ndk",
         "path": "ndk/22.1.7171670",
@@ -12610,6 +13789,7 @@
           }
         },
         "displayName": "NDK (Side by side) 23.0.7123448",
+        "last-available-day": 19489,
         "license": "android-sdk-preview-license",
         "name": "ndk",
         "path": "ndk/23.0.7123448",
@@ -12655,6 +13835,7 @@
           }
         },
         "displayName": "NDK (Side by side) 23.0.7196353",
+        "last-available-day": 19489,
         "license": "android-sdk-preview-license",
         "name": "ndk",
         "path": "ndk/23.0.7196353",
@@ -12700,6 +13881,7 @@
           }
         },
         "displayName": "NDK (Side by side) 23.0.7272597",
+        "last-available-day": 19489,
         "license": "android-sdk-preview-license",
         "name": "ndk",
         "path": "ndk/23.0.7272597",
@@ -12745,6 +13927,7 @@
           }
         },
         "displayName": "NDK (Side by side) 23.0.7344513",
+        "last-available-day": 19489,
         "license": "android-sdk-preview-license",
         "name": "ndk",
         "path": "ndk/23.0.7344513",
@@ -12790,6 +13973,7 @@
           }
         },
         "displayName": "NDK (Side by side) 23.0.7421159",
+        "last-available-day": 19489,
         "license": "android-sdk-preview-license",
         "name": "ndk",
         "path": "ndk/23.0.7421159",
@@ -12835,6 +14019,7 @@
           }
         },
         "displayName": "NDK (Side by side) 23.0.7530507",
+        "last-available-day": 19489,
         "license": "android-sdk-preview-license",
         "name": "ndk",
         "path": "ndk/23.0.7530507",
@@ -12880,6 +14065,7 @@
           }
         },
         "displayName": "NDK (Side by side) 23.0.7599858",
+        "last-available-day": 19489,
         "license": "android-sdk-license",
         "name": "ndk",
         "path": "ndk/23.0.7599858",
@@ -12924,6 +14110,7 @@
           }
         },
         "displayName": "NDK (Side by side) 23.1.7779620",
+        "last-available-day": 19489,
         "license": "android-sdk-license",
         "name": "ndk",
         "path": "ndk/23.1.7779620",
@@ -12968,6 +14155,7 @@
           }
         },
         "displayName": "NDK (Side by side) 23.2.8568313",
+        "last-available-day": 19489,
         "license": "android-sdk-license",
         "name": "ndk",
         "path": "ndk/23.2.8568313",
@@ -13012,6 +14200,7 @@
           }
         },
         "displayName": "NDK (Side by side) 24.0.7856742",
+        "last-available-day": 19489,
         "license": "android-sdk-preview-license",
         "name": "ndk",
         "path": "ndk/24.0.7856742",
@@ -13057,6 +14246,7 @@
           }
         },
         "displayName": "NDK (Side by side) 24.0.7956693",
+        "last-available-day": 19489,
         "license": "android-sdk-preview-license",
         "name": "ndk",
         "path": "ndk/24.0.7956693",
@@ -13102,6 +14292,7 @@
           }
         },
         "displayName": "NDK (Side by side) 24.0.8079956",
+        "last-available-day": 19489,
         "license": "android-sdk-preview-license",
         "name": "ndk",
         "path": "ndk/24.0.8079956",
@@ -13147,6 +14338,7 @@
           }
         },
         "displayName": "NDK (Side by side) 24.0.8215888",
+        "last-available-day": 19489,
         "license": "android-sdk-license",
         "name": "ndk",
         "path": "ndk/24.0.8215888",
@@ -13191,6 +14383,7 @@
           }
         },
         "displayName": "NDK (Side by side) 25.0.8151533",
+        "last-available-day": 19489,
         "license": "android-sdk-preview-license",
         "name": "ndk",
         "path": "ndk/25.0.8151533",
@@ -13236,6 +14429,7 @@
           }
         },
         "displayName": "NDK (Side by side) 25.0.8221429",
+        "last-available-day": 19489,
         "license": "android-sdk-preview-license",
         "name": "ndk",
         "path": "ndk/25.0.8221429",
@@ -13281,6 +14475,7 @@
           }
         },
         "displayName": "NDK (Side by side) 25.0.8355429",
+        "last-available-day": 19489,
         "license": "android-sdk-preview-license",
         "name": "ndk",
         "path": "ndk/25.0.8355429",
@@ -13326,6 +14521,7 @@
           }
         },
         "displayName": "NDK (Side by side) 25.0.8528842",
+        "last-available-day": 19489,
         "license": "android-sdk-preview-license",
         "name": "ndk",
         "path": "ndk/25.0.8528842",
@@ -13371,6 +14567,7 @@
           }
         },
         "displayName": "NDK (Side by side) 25.0.8775105",
+        "last-available-day": 19489,
         "license": "android-sdk-license",
         "name": "ndk",
         "path": "ndk/25.0.8775105",
@@ -13415,6 +14612,7 @@
           }
         },
         "displayName": "NDK (Side by side) 25.1.8937393",
+        "last-available-day": 19489,
         "license": "android-sdk-license",
         "name": "ndk",
         "path": "ndk/25.1.8937393",
@@ -13423,6 +14621,51 @@
           "major:0": "25",
           "micro:2": "8937393",
           "minor:1": "1"
+        },
+        "type-details": {
+          "element-attributes": {
+            "xsi:type": "ns5:genericDetailsType"
+          }
+        }
+      },
+      "25.2.9519653": {
+        "archives": [
+          {
+            "os": "macosx",
+            "sha1": "75717f3473973c3630e772ec916de380157a593a",
+            "size": 717255580,
+            "url": "https://dl.google.com/android/repository/android-ndk-r25c-darwin.zip"
+          },
+          {
+            "os": "linux",
+            "sha1": "53af80a1cce9144025b81c78c8cd556bff42bd0e",
+            "size": 531118193,
+            "url": "https://dl.google.com/android/repository/android-ndk-r25c-linux.zip"
+          },
+          {
+            "os": "windows",
+            "sha1": "18c4a3cd108916f553b1bedad2672f2c6cd85a10",
+            "size": 467520926,
+            "url": "https://dl.google.com/android/repository/android-ndk-r25c-windows.zip"
+          }
+        ],
+        "dependencies": {
+          "dependency:0": {
+            "element-attributes": {
+              "path": "patcher;v4"
+            }
+          }
+        },
+        "displayName": "NDK (Side by side) 25.2.9519653",
+        "last-available-day": 19489,
+        "license": "android-sdk-license",
+        "name": "ndk",
+        "path": "ndk/25.2.9519653",
+        "revision": "25.2.9519653",
+        "revision-details": {
+          "major:0": "25",
+          "micro:2": "9519653",
+          "minor:1": "2"
         },
         "type-details": {
           "element-attributes": {
@@ -13461,6 +14704,7 @@
           }
         },
         "displayName": "NDK",
+        "last-available-day": 19489,
         "license": "android-sdk-license",
         "name": "ndk-bundle",
         "path": "ndk-bundle",
@@ -13505,6 +14749,7 @@
           }
         },
         "displayName": "NDK",
+        "last-available-day": 19489,
         "license": "android-sdk-license",
         "name": "ndk-bundle",
         "path": "ndk-bundle",
@@ -13549,6 +14794,7 @@
           }
         },
         "displayName": "NDK",
+        "last-available-day": 19489,
         "license": "android-sdk-license",
         "name": "ndk-bundle",
         "path": "ndk-bundle",
@@ -13593,6 +14839,7 @@
           }
         },
         "displayName": "NDK",
+        "last-available-day": 19489,
         "license": "android-sdk-license",
         "name": "ndk-bundle",
         "obsolete": "true",
@@ -13638,6 +14885,7 @@
           }
         },
         "displayName": "NDK",
+        "last-available-day": 19489,
         "license": "android-sdk-license",
         "name": "ndk-bundle",
         "path": "ndk-bundle",
@@ -13682,6 +14930,7 @@
           }
         },
         "displayName": "NDK",
+        "last-available-day": 19489,
         "license": "android-sdk-preview-license",
         "name": "ndk-bundle",
         "obsolete": "true",
@@ -13728,6 +14977,7 @@
           }
         },
         "displayName": "NDK",
+        "last-available-day": 19489,
         "license": "android-sdk-preview-license",
         "name": "ndk-bundle",
         "obsolete": "true",
@@ -13774,6 +15024,7 @@
           }
         },
         "displayName": "NDK",
+        "last-available-day": 19489,
         "license": "android-sdk-license",
         "name": "ndk-bundle",
         "path": "ndk-bundle",
@@ -13818,6 +15069,7 @@
           }
         },
         "displayName": "NDK",
+        "last-available-day": 19489,
         "license": "android-sdk-license",
         "name": "ndk-bundle",
         "path": "ndk-bundle",
@@ -13862,6 +15114,7 @@
           }
         },
         "displayName": "NDK",
+        "last-available-day": 19489,
         "license": "android-sdk-preview-license",
         "name": "ndk-bundle",
         "path": "ndk-bundle",
@@ -13907,6 +15160,7 @@
           }
         },
         "displayName": "NDK",
+        "last-available-day": 19489,
         "license": "android-sdk-license",
         "name": "ndk-bundle",
         "path": "ndk-bundle",
@@ -13951,6 +15205,7 @@
           }
         },
         "displayName": "NDK",
+        "last-available-day": 19489,
         "license": "android-sdk-preview-license",
         "name": "ndk-bundle",
         "path": "ndk-bundle",
@@ -13996,6 +15251,7 @@
           }
         },
         "displayName": "NDK",
+        "last-available-day": 19489,
         "license": "android-sdk-preview-license",
         "name": "ndk-bundle",
         "path": "ndk-bundle",
@@ -14041,6 +15297,7 @@
           }
         },
         "displayName": "NDK",
+        "last-available-day": 19489,
         "license": "android-sdk-license",
         "name": "ndk-bundle",
         "path": "ndk-bundle",
@@ -14085,6 +15342,7 @@
           }
         },
         "displayName": "NDK",
+        "last-available-day": 19489,
         "license": "android-sdk-preview-license",
         "name": "ndk-bundle",
         "path": "ndk-bundle",
@@ -14130,6 +15388,7 @@
           }
         },
         "displayName": "NDK",
+        "last-available-day": 19489,
         "license": "android-sdk-license",
         "name": "ndk-bundle",
         "path": "ndk-bundle",
@@ -14174,6 +15433,7 @@
           }
         },
         "displayName": "NDK",
+        "last-available-day": 19489,
         "license": "android-sdk-license",
         "name": "ndk-bundle",
         "path": "ndk-bundle",
@@ -14218,6 +15478,7 @@
           }
         },
         "displayName": "NDK",
+        "last-available-day": 19489,
         "license": "android-sdk-license",
         "name": "ndk-bundle",
         "path": "ndk-bundle",
@@ -14262,6 +15523,7 @@
           }
         },
         "displayName": "NDK",
+        "last-available-day": 19489,
         "license": "android-sdk-preview-license",
         "name": "ndk-bundle",
         "path": "ndk-bundle",
@@ -14307,6 +15569,7 @@
           }
         },
         "displayName": "NDK",
+        "last-available-day": 19489,
         "license": "android-sdk-license",
         "name": "ndk-bundle",
         "path": "ndk-bundle",
@@ -14351,6 +15614,7 @@
           }
         },
         "displayName": "NDK",
+        "last-available-day": 19489,
         "license": "android-sdk-license",
         "name": "ndk-bundle",
         "path": "ndk-bundle",
@@ -14395,6 +15659,7 @@
           }
         },
         "displayName": "NDK",
+        "last-available-day": 19489,
         "license": "android-sdk-preview-license",
         "name": "ndk-bundle",
         "path": "ndk-bundle",
@@ -14440,6 +15705,7 @@
           }
         },
         "displayName": "NDK",
+        "last-available-day": 19489,
         "license": "android-sdk-preview-license",
         "name": "ndk-bundle",
         "path": "ndk-bundle",
@@ -14485,6 +15751,7 @@
           }
         },
         "displayName": "NDK",
+        "last-available-day": 19489,
         "license": "android-sdk-preview-license",
         "name": "ndk-bundle",
         "path": "ndk-bundle",
@@ -14530,6 +15797,7 @@
           }
         },
         "displayName": "NDK",
+        "last-available-day": 19489,
         "license": "android-sdk-preview-license",
         "name": "ndk-bundle",
         "path": "ndk-bundle",
@@ -14558,6 +15826,7 @@
           }
         ],
         "displayName": "SDK Patch Applier v4",
+        "last-available-day": 19489,
         "license": "android-sdk-license",
         "name": "patcher",
         "path": "patcher/v4",
@@ -14595,6 +15864,7 @@
           }
         ],
         "displayName": "Android SDK Platform-Tools",
+        "last-available-day": 19469,
         "license": "android-sdk-license",
         "name": "platform-tools",
         "path": "platform-tools",
@@ -14602,6 +15872,44 @@
         "revision-details": {
           "major:0": "33",
           "micro:2": "3",
+          "minor:1": "0"
+        },
+        "type-details": {
+          "element-attributes": {
+            "xsi:type": "ns5:genericDetailsType"
+          }
+        }
+      },
+      "34.0.1": {
+        "archives": [
+          {
+            "os": "macosx",
+            "sha1": "40f24dc4f2baf911ccb2a53c14bfb69fb8088c57",
+            "size": 11215880,
+            "url": "https://dl.google.com/android/repository/platform-tools_r34.0.1-darwin.zip"
+          },
+          {
+            "os": "linux",
+            "sha1": "7e8f205a0cfe574ffecb6ec41e6496f5328211fd",
+            "size": 6336109,
+            "url": "https://dl.google.com/android/repository/platform-tools_r34.0.1-linux.zip"
+          },
+          {
+            "os": "windows",
+            "sha1": "3806f15fddb6ffc5ce38efe78df1708be666a9f4",
+            "size": 6079357,
+            "url": "https://dl.google.com/android/repository/platform-tools_r34.0.1-windows.zip"
+          }
+        ],
+        "displayName": "Android SDK Platform-Tools",
+        "last-available-day": 19489,
+        "license": "android-sdk-license",
+        "name": "platform-tools",
+        "path": "platform-tools",
+        "revision": "34.0.1",
+        "revision-details": {
+          "major:0": "34",
+          "micro:2": "1",
           "minor:1": "0"
         },
         "type-details": {
@@ -14622,6 +15930,7 @@
           }
         ],
         "displayName": "Android SDK Platform 10",
+        "last-available-day": 19489,
         "license": "android-sdk-license",
         "name": "platforms",
         "path": "platforms/android-10",
@@ -14653,6 +15962,7 @@
           }
         ],
         "displayName": "Android SDK Platform 11",
+        "last-available-day": 19489,
         "license": "android-sdk-license",
         "name": "platforms",
         "path": "platforms/android-11",
@@ -14684,6 +15994,7 @@
           }
         ],
         "displayName": "Android SDK Platform 12",
+        "last-available-day": 19489,
         "license": "android-sdk-license",
         "name": "platforms",
         "path": "platforms/android-12",
@@ -14715,6 +16026,7 @@
           }
         ],
         "displayName": "Android SDK Platform 13",
+        "last-available-day": 19489,
         "license": "android-sdk-license",
         "name": "platforms",
         "path": "platforms/android-13",
@@ -14746,6 +16058,7 @@
           }
         ],
         "displayName": "Android SDK Platform 14",
+        "last-available-day": 19489,
         "license": "android-sdk-license",
         "name": "platforms",
         "path": "platforms/android-14",
@@ -14777,6 +16090,7 @@
           }
         ],
         "displayName": "Android SDK Platform 15",
+        "last-available-day": 19489,
         "license": "android-sdk-license",
         "name": "platforms",
         "path": "platforms/android-15",
@@ -14808,6 +16122,7 @@
           }
         ],
         "displayName": "Android SDK Platform 16",
+        "last-available-day": 19489,
         "license": "android-sdk-license",
         "name": "platforms",
         "path": "platforms/android-16",
@@ -14839,6 +16154,7 @@
           }
         ],
         "displayName": "Android SDK Platform 17",
+        "last-available-day": 19489,
         "license": "android-sdk-license",
         "name": "platforms",
         "path": "platforms/android-17",
@@ -14870,6 +16186,7 @@
           }
         ],
         "displayName": "Android SDK Platform 18",
+        "last-available-day": 19489,
         "license": "android-sdk-license",
         "name": "platforms",
         "path": "platforms/android-18",
@@ -14901,6 +16218,7 @@
           }
         ],
         "displayName": "Android SDK Platform 19",
+        "last-available-day": 19489,
         "license": "android-sdk-license",
         "name": "platforms",
         "path": "platforms/android-19",
@@ -14944,6 +16262,7 @@
           }
         ],
         "displayName": "Android SDK Platform 2",
+        "last-available-day": 19489,
         "license": "android-sdk-license",
         "name": "platforms",
         "obsolete": "true",
@@ -14976,6 +16295,7 @@
           }
         ],
         "displayName": "Android SDK Platform 20",
+        "last-available-day": 19489,
         "license": "android-sdk-license",
         "name": "platforms",
         "path": "platforms/android-20",
@@ -15007,6 +16327,7 @@
           }
         ],
         "displayName": "Android SDK Platform 21",
+        "last-available-day": 19489,
         "license": "android-sdk-license",
         "name": "platforms",
         "path": "platforms/android-21",
@@ -15038,6 +16359,7 @@
           }
         ],
         "displayName": "Android SDK Platform 22",
+        "last-available-day": 19489,
         "license": "android-sdk-license",
         "name": "platforms",
         "path": "platforms/android-22",
@@ -15069,6 +16391,7 @@
           }
         ],
         "displayName": "Android SDK Platform 23",
+        "last-available-day": 19489,
         "license": "android-sdk-license",
         "name": "platforms",
         "path": "platforms/android-23",
@@ -15100,6 +16423,7 @@
           }
         ],
         "displayName": "Android SDK Platform 24",
+        "last-available-day": 19489,
         "license": "android-sdk-license",
         "name": "platforms",
         "path": "platforms/android-24",
@@ -15131,6 +16455,7 @@
           }
         ],
         "displayName": "Android SDK Platform 25",
+        "last-available-day": 19489,
         "license": "android-sdk-license",
         "name": "platforms",
         "path": "platforms/android-25",
@@ -15162,6 +16487,7 @@
           }
         ],
         "displayName": "Android SDK Platform 26",
+        "last-available-day": 19489,
         "license": "android-sdk-license",
         "name": "platforms",
         "path": "platforms/android-26",
@@ -15193,6 +16519,7 @@
           }
         ],
         "displayName": "Android SDK Platform 27",
+        "last-available-day": 19489,
         "license": "android-sdk-license",
         "name": "platforms",
         "path": "platforms/android-27",
@@ -15224,6 +16551,7 @@
           }
         ],
         "displayName": "Android SDK Platform 28",
+        "last-available-day": 19489,
         "license": "android-sdk-license",
         "name": "platforms",
         "path": "platforms/android-28",
@@ -15255,6 +16583,7 @@
           }
         ],
         "displayName": "Android SDK Platform 29",
+        "last-available-day": 19489,
         "license": "android-sdk-license",
         "name": "platforms",
         "path": "platforms/android-29",
@@ -15298,6 +16627,7 @@
           }
         ],
         "displayName": "Android SDK Platform 3",
+        "last-available-day": 19489,
         "license": "android-sdk-license",
         "name": "platforms",
         "obsolete": "true",
@@ -15330,6 +16660,7 @@
           }
         ],
         "displayName": "Android SDK Platform 30",
+        "last-available-day": 19489,
         "license": "android-sdk-license",
         "name": "platforms",
         "path": "platforms/android-30",
@@ -15361,6 +16692,7 @@
           }
         ],
         "displayName": "Android SDK Platform 31",
+        "last-available-day": 19489,
         "license": "android-sdk-license",
         "name": "platforms",
         "path": "platforms/android-31",
@@ -15392,6 +16724,7 @@
           }
         ],
         "displayName": "Android SDK Platform 32",
+        "last-available-day": 19489,
         "license": "android-sdk-license",
         "name": "platforms",
         "path": "platforms/android-32",
@@ -15422,13 +16755,14 @@
             "url": "https://dl.google.com/android/repository/platform-33_r02.zip"
           }
         ],
-        "displayName": "Android SDK Platform 33",
+        "displayName": "Android SDK Platform 33-ext5",
+        "last-available-day": 19489,
         "license": "android-sdk-license",
         "name": "platforms",
         "path": "platforms/android-33",
         "revision": "33",
         "revision-details": {
-          "major:0": "2"
+          "major:0": "1"
         },
         "type-details": {
           "api-level:0": "33",
@@ -15466,6 +16800,7 @@
           }
         ],
         "displayName": "Android SDK Platform 4",
+        "last-available-day": 19489,
         "license": "android-sdk-license",
         "name": "platforms",
         "obsolete": "true",
@@ -15510,6 +16845,7 @@
           }
         ],
         "displayName": "Android SDK Platform 5",
+        "last-available-day": 19489,
         "license": "android-sdk-license",
         "name": "platforms",
         "obsolete": "true",
@@ -15554,6 +16890,7 @@
           }
         ],
         "displayName": "Android SDK Platform 6",
+        "last-available-day": 19489,
         "license": "android-sdk-license",
         "name": "platforms",
         "obsolete": "true",
@@ -15586,6 +16923,7 @@
           }
         ],
         "displayName": "Android SDK Platform 7",
+        "last-available-day": 19489,
         "license": "android-sdk-license",
         "name": "platforms",
         "path": "platforms/android-7",
@@ -15617,6 +16955,7 @@
           }
         ],
         "displayName": "Android SDK Platform 8",
+        "last-available-day": 19489,
         "license": "android-sdk-license",
         "name": "platforms",
         "path": "platforms/android-8",
@@ -15648,6 +16987,7 @@
           }
         ],
         "displayName": "Android SDK Platform 9",
+        "last-available-day": 19489,
         "license": "android-sdk-license",
         "name": "platforms",
         "path": "platforms/android-9",
@@ -15673,22 +17013,54 @@
         "archives": [
           {
             "os": "all",
-            "sha1": "07f3eb84b8f237e61744967d7aee1225efba25e6",
-            "size": 67975400,
-            "url": "https://dl.google.com/android/repository/platform-TiramisuPrivacySandbox_r08.zip"
+            "sha1": "6bc5e85cd2ea54df4dae036ff20fb0e889a6835e",
+            "size": 67663071,
+            "url": "https://dl.google.com/android/repository/platform-TiramisuPrivacySandbox_r09.zip"
           }
         ],
         "displayName": "Android SDK Platform TiramisuPrivacySandbox",
+        "last-available-day": 19489,
         "license": "android-sdk-license",
         "name": "platforms",
         "path": "platforms/android-TiramisuPrivacySandbox",
         "revision": "TiramisuPrivacySandbox",
         "revision-details": {
-          "major:0": "8"
+          "major:0": "9"
         },
         "type-details": {
           "api-level:0": "33",
           "codename:1": "TiramisuPrivacySandbox",
+          "element-attributes": {
+            "xsi:type": "ns11:platformDetailsType"
+          },
+          "layoutlib:2": {
+            "element-attributes": {
+              "api": "15"
+            }
+          }
+        }
+      },
+      "UpsideDownCake": {
+        "archives": [
+          {
+            "os": "all",
+            "sha1": "a0fe6b17b8ea26c72f4a1feb0234aab6b20fd4be",
+            "size": 63483782,
+            "url": "https://dl.google.com/android/repository/platform-UpsideDownCake_r04.zip"
+          }
+        ],
+        "displayName": "Android SDK Platform UpsideDownCake",
+        "last-available-day": 19489,
+        "license": "android-sdk-license",
+        "name": "platforms",
+        "path": "platforms/android-UpsideDownCake",
+        "revision": "UpsideDownCake",
+        "revision-details": {
+          "major:0": "4"
+        },
+        "type-details": {
+          "api-level:0": "33",
+          "codename:1": "UpsideDownCake",
           "element-attributes": {
             "xsi:type": "ns11:platformDetailsType"
           },
@@ -15723,6 +17095,7 @@
           }
         ],
         "displayName": "Layout Inspector image server for API 31 and T",
+        "last-available-day": 19469,
         "license": "android-sdk-license",
         "name": "skiaparser",
         "path": "skiaparser/3",
@@ -15740,24 +17113,25 @@
         "archives": [
           {
             "os": "linux",
-            "sha1": "36e2c30f7745f4c062129a0fd549d29ab991db41",
-            "size": 6767192,
-            "url": "https://dl.google.com/android/repository/skiaparser-7478287-linux.zip"
+            "sha1": "7fea0f8b5abaaa73b35e7703e54b641d0e60bba1",
+            "size": 6728126,
+            "url": "https://dl.google.com/android/repository/skiaparser-9858946-linux-x64.zip"
           },
           {
             "os": "macosx",
-            "sha1": "04a834a8ab3efd4612300da7cef7f43a6b257468",
-            "size": 7401688,
-            "url": "https://dl.google.com/android/repository/skiaparser-7478287-mac.zip"
+            "sha1": "d08e3a0dab58ad944c837e331f5b2088a7b683eb",
+            "size": 7846286,
+            "url": "https://dl.google.com/android/repository/skiaparser-9858946-mac-x64.zip"
           },
           {
             "os": "windows",
-            "sha1": "567f24512f9d9487a3b948032a136261f5d59c92",
-            "size": 6532776,
-            "url": "https://dl.google.com/android/repository/skiaparser-7478287-win.zip"
+            "sha1": "316c255048f2164a8a3e57692b5b232d2db0963f",
+            "size": 7336670,
+            "url": "https://dl.google.com/android/repository/skiaparser-9858946-win-x64.zip"
           }
         ],
         "displayName": "Layout Inspector image server for API S",
+        "last-available-day": 19489,
         "license": "android-sdk-license",
         "name": "skiaparser",
         "path": "skiaparser/2",
@@ -15793,6 +17167,7 @@
           }
         ],
         "displayName": "Layout Inspector image server for API 29-30",
+        "last-available-day": 19489,
         "license": "android-sdk-license",
         "name": "skiaparser",
         "path": "skiaparser/1",
@@ -15818,6 +17193,7 @@
           }
         ],
         "displayName": "Sources for Android 14",
+        "last-available-day": 19489,
         "license": "android-sdk-license",
         "name": "sources",
         "obsolete": "true",
@@ -15845,6 +17221,7 @@
           }
         ],
         "displayName": "Sources for Android 15",
+        "last-available-day": 19489,
         "license": "android-sdk-license",
         "name": "sources",
         "path": "sources/android-15",
@@ -15871,6 +17248,7 @@
           }
         ],
         "displayName": "Sources for Android 16",
+        "last-available-day": 19489,
         "license": "android-sdk-license",
         "name": "sources",
         "path": "sources/android-16",
@@ -15897,6 +17275,7 @@
           }
         ],
         "displayName": "Sources for Android 17",
+        "last-available-day": 19489,
         "license": "android-sdk-license",
         "name": "sources",
         "path": "sources/android-17",
@@ -15923,6 +17302,7 @@
           }
         ],
         "displayName": "Sources for Android 18",
+        "last-available-day": 19489,
         "license": "android-sdk-license",
         "name": "sources",
         "path": "sources/android-18",
@@ -15949,6 +17329,7 @@
           }
         ],
         "displayName": "Sources for Android 19",
+        "last-available-day": 19489,
         "license": "android-sdk-license",
         "name": "sources",
         "path": "sources/android-19",
@@ -15975,6 +17356,7 @@
           }
         ],
         "displayName": "Sources for Android 20",
+        "last-available-day": 19489,
         "license": "android-sdk-license",
         "name": "sources",
         "path": "sources/android-20",
@@ -16001,6 +17383,7 @@
           }
         ],
         "displayName": "Sources for Android 21",
+        "last-available-day": 19489,
         "license": "android-sdk-license",
         "name": "sources",
         "path": "sources/android-21",
@@ -16027,6 +17410,7 @@
           }
         ],
         "displayName": "Sources for Android 22",
+        "last-available-day": 19489,
         "license": "android-sdk-license",
         "name": "sources",
         "path": "sources/android-22",
@@ -16053,6 +17437,7 @@
           }
         ],
         "displayName": "Sources for Android 23",
+        "last-available-day": 19489,
         "license": "android-sdk-license",
         "name": "sources",
         "path": "sources/android-23",
@@ -16079,6 +17464,7 @@
           }
         ],
         "displayName": "Sources for Android 24",
+        "last-available-day": 19489,
         "license": "android-sdk-license",
         "name": "sources",
         "path": "sources/android-24",
@@ -16105,6 +17491,7 @@
           }
         ],
         "displayName": "Sources for Android 25",
+        "last-available-day": 19489,
         "license": "android-sdk-license",
         "name": "sources",
         "path": "sources/android-25",
@@ -16131,6 +17518,7 @@
           }
         ],
         "displayName": "Sources for Android 26",
+        "last-available-day": 19489,
         "license": "android-sdk-license",
         "name": "sources",
         "path": "sources/android-26",
@@ -16157,6 +17545,7 @@
           }
         ],
         "displayName": "Sources for Android 27",
+        "last-available-day": 19489,
         "license": "android-sdk-license",
         "name": "sources",
         "path": "sources/android-27",
@@ -16183,6 +17572,7 @@
           }
         ],
         "displayName": "Sources for Android 28",
+        "last-available-day": 19489,
         "license": "android-sdk-license",
         "name": "sources",
         "path": "sources/android-28",
@@ -16209,6 +17599,7 @@
           }
         ],
         "displayName": "Sources for Android 29",
+        "last-available-day": 19489,
         "license": "android-sdk-license",
         "name": "sources",
         "path": "sources/android-29",
@@ -16235,6 +17626,7 @@
           }
         ],
         "displayName": "Sources for Android 30",
+        "last-available-day": 19489,
         "license": "android-sdk-license",
         "name": "sources",
         "path": "sources/android-30",
@@ -16261,6 +17653,7 @@
           }
         ],
         "displayName": "Sources for Android 31",
+        "last-available-day": 19489,
         "license": "android-sdk-license",
         "name": "sources",
         "path": "sources/android-31",
@@ -16287,6 +17680,7 @@
           }
         ],
         "displayName": "Sources for Android 32",
+        "last-available-day": 19489,
         "license": "android-sdk-license",
         "name": "sources",
         "path": "sources/android-32",
@@ -16313,6 +17707,7 @@
           }
         ],
         "displayName": "Sources for Android 33",
+        "last-available-day": 19489,
         "license": "android-sdk-license",
         "name": "sources",
         "path": "sources/android-33",
@@ -16373,6 +17768,7 @@
           }
         },
         "displayName": "Android SDK Tools",
+        "last-available-day": 19489,
         "license": "android-sdk-license",
         "name": "tools",
         "obsolete": "true",


### PR DESCRIPTION
###### Description of changes

This PR is solving the problem with different approaches of nixpkgs vs Android SDK to deliver the packages. Android SDK fetches the newest packages, via XML files, and let the user install them, but it'll not remove the packages that are not available in those XML files, so those old packages could co-exist with the new ones, but in our approach in nixpkgs, the user doesn't have access to the old packages, that are not available in the XML files.

With this PR I targeted that problem, also to show this approach in action, **I updated packages** using this new methods.

Therefore, in these changes the `mkrepo.rb` file will receive the old `repo.json` file via `STDIN`, then expire packages that are removed from the XML files more than two years ago, then merge the old JSON with the new ones, the ones that are fetched from the XML files.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [X] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [X] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
