### PR TITLE
androidenv: raise a much nicer error message

### DIFF
--- a/pkgs/development/mobile/androidenv/compose-android-packages.nix
+++ b/pkgs/development/mobile/androidenv/compose-android-packages.nix
@@ -116,6 +116,7 @@ rec {
   deployAndroidPackages = callPackage ./deploy-androidpackages.nix {
     inherit stdenv lib mkLicenses;
   };
+
   deployAndroidPackage = ({package, os ? null, buildInputs ? [], patchInstructions ? "", meta ? {}, ...}@args:
     let
       extraParams = removeAttrs args [ "package" "os" "buildInputs" "patchInstructions" ];
@@ -127,15 +128,25 @@ rec {
     } // extraParams
   ));
 
+  # put a much nicer error message that includes the available options.
+  check-version = packages: package: version:
+    if lib.hasAttrByPath [ package version ] packages then
+      packages.${package}.${version}
+    else
+      throw ''
+        The version ${version} is missing in package ${package}.
+        The only available versions are ${builtins.concatStringsSep ", " (builtins.attrNames packages.${package})}.
+      '';
+
   platform-tools = callPackage ./platform-tools.nix {
     inherit deployAndroidPackage;
     os = if stdenv.system == "aarch64-darwin" then "macosx" else os; # "macosx" is a universal binary here
-    package = packages.platform-tools.${platformToolsVersion};
+    package = check-version packages "platform-tools" platformToolsVersion;
   };
 
   tools = callPackage ./tools.nix {
     inherit deployAndroidPackage os;
-    package = packages.tools.${toolsVersion};
+    package = check-version packages "tools" toolsVersion;
 
     postInstall = ''
       ${linkPlugin { name = "platform-tools"; plugin = platform-tools; }}
@@ -152,7 +163,7 @@ rec {
   build-tools = map (version:
     callPackage ./build-tools.nix {
       inherit deployAndroidPackage os;
-      package = packages.build-tools.${version};
+      package = check-version packages "build-tools" version;
 
       postInstall = ''
         ${linkPlugin { name = "tools"; plugin = tools; check = toolsVersion != null; }}
@@ -162,7 +173,7 @@ rec {
 
   emulator = callPackage ./emulator.nix {
     inherit deployAndroidPackage os;
-    package = packages.emulator.${emulatorVersion};
+    package = check-version packages "emulator" emulatorVersion;
 
     postInstall = ''
       ${linkSystemImages { images = system-images; check = includeSystemImages; }}
@@ -172,14 +183,14 @@ rec {
   platforms = map (version:
     deployAndroidPackage {
       inherit os;
-      package = packages.platforms.${version};
+      package = check-version packages "platforms" version;
     }
   ) platformVersions;
 
   sources = map (version:
     deployAndroidPackage {
       inherit os;
-      package = packages.sources.${version};
+      package = check-version packages "sources" version;
     }
   ) platformVersions;
 
@@ -223,7 +234,7 @@ rec {
   cmake = map (version:
     callPackage ./cmake.nix {
       inherit deployAndroidPackage os;
-      package = packages.cmake.${version};
+      package = check-version packages "cmake" version;
     }
   ) cmakeVersions;
 
@@ -243,14 +254,14 @@ rec {
   google-apis = map (version:
     deployAndroidPackage {
       inherit os;
-      package = addons.addons.${version}.google_apis;
+      package = (check-version addons "addons" version).google_apis;
     }
   ) (builtins.filter (platformVersion: platformVersion < "26") platformVersions); # API level 26 and higher include Google APIs by default
 
   google-tv-addons = map (version:
     deployAndroidPackage {
       inherit os;
-      package = addons.addons.${version}.google_tv_addon;
+      package = (check-version addons "addons" version).google_tv_addon;
     }
   ) platformVersions;
 
@@ -320,7 +331,7 @@ rec {
   '' else callPackage ./cmdline-tools.nix {
     inherit deployAndroidPackage os cmdLineToolsVersion;
 
-    package = packages.cmdline-tools.${cmdLineToolsVersion};
+    package = check-version packages "cmdline-tools" cmdLineToolsVersion;
 
     postInstall = ''
       # Symlink all requested plugins


### PR DESCRIPTION
###### Description of changes

A problem I faced multiple times when I wanted to update a package is that when I try a wrong version, the error message is not showing me all available versions for that package.

This PR is trying to solve this problem by listing the available versions.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [X] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [X] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
