### PR TITLE
vim: Fix install phase parallelism and harden against future failures

### DIFF
--- a/pkgs/applications/editors/vim/default.nix
+++ b/pkgs/applications/editors/vim/default.nix
@@ -50,6 +50,15 @@ stdenv.mkDerivation {
     ln -s $out/bin/vim $out/bin/vi
     mkdir -p $out/share/vim
     cp "${vimrc}" $out/share/vim/vimrc
+
+    # Prevent bugs in the upstream makefile from silently failing and missing outputs.
+    # Some of those are build-time requirements for other packages.
+    for tool in ex xxd vi view vimdiff; do
+      if [ ! -e "$out/bin/$tool" ]; then
+        echo "ERROR: install phase did not install '$tool'."
+        exit 1
+      fi
+    done
   '';
 
   __impureHostDeps = [ "/dev/ptmx" ];

--- a/pkgs/applications/editors/vim/default.nix
+++ b/pkgs/applications/editors/vim/default.nix
@@ -15,7 +15,7 @@ in
 stdenv.mkDerivation {
   pname = "vim";
 
-  inherit (common) version src postPatch hardeningDisable enableParallelBuilding meta;
+  inherit (common) version src postPatch hardeningDisable enableParallelBuilding enableParallelInstalling meta;
 
   nativeBuildInputs = [ gettext pkg-config ];
   buildInputs = [ ncurses bash gawk ]


### PR DESCRIPTION
###### Description of changes

- https://github.com/NixOS/nixpkgs/commit/fd1afd335926c668c761115a4c882eb5f4b24ede#commitcomment-110127655
- https://github.com/NixOS/nixpkgs/issues/227660

Our current build of `vim` has a not-exactly-reproducible issue where some tools may not end-up being installed. Those tools are used as build-time dependencies in other packages.

```
cd /nix/store/12jh1klrixvqilis5ywqsgqr6nkvrbh1-vim-9.0.1441/bin; ln -s vim ex
cd /nix/store/12jh1klrixvqilis5ywqsgqr6nkvrbh1-vim-9.0.1441/bin; ln -s vim view
cd /nix/store/12jh1klrixvqilis5ywqsgqr6nkvrbh1-vim-9.0.1441/bin; ln -s vim rvim
/nix/store/zlf0f88vj30sc7567b80l52d19pbdmy2-bash-5.2-p15/bin/bash: line 1: cd: /nix/store/12jh1klrixvqilis5ywqsgqr6nkvrbh1-vim-9.0.1441/bin: No such file or directory
/nix/store/zlf0f88vj30sc7567b80l52d19pbdmy2-bash-5.2-p15/bin/bash: line 1: cd: /nix/store/12jh1klrixvqilis5ywqsgqr6nkvrbh1-vim-9.0.1441/bin: No such file or directory
/nix/store/zlf0f88vj30sc7567b80l52d19pbdmy2-bash-5.2-p15/bin/bash: line 1: cd: /nix/store/12jh1klrixvqilis5ywqsgqr6nkvrbh1-vim-9.0.1441/bin: No such file or directory
```

— https://hydra.nixos.org/build/215173431/nixlog/1

There are two changes in this PR:

 - Make fd1afd335926c668c761115a4c882eb5f4b24ede actually take effect (cc @vcunat)
 - Prevent future builds from being successful when the build is actually bad.

When attempting to reproduce the issue, I had to use this, or else on my `-j16` system issues wouldn't reproduce.

```diff
diff --git a/pkgs/applications/editors/vim/common.nix b/pkgs/applications/editors/vim/common.nix
index e946139e6e8..77861ca1f28 100644
--- a/pkgs/applications/editors/vim/common.nix
+++ b/pkgs/applications/editors/vim/common.nix
@@ -1,6 +1,6 @@
 { lib, fetchFromGitHub }:
 rec {
-  version = "9.0.1441";
+  version = "9.0.1441+${toString builtins.currentTime}";
 
   src = fetchFromGitHub {
     owner = "vim";
diff --git a/pkgs/applications/editors/vim/default.nix b/pkgs/applications/editors/vim/default.nix
index 4dacccafe74..bbbc65ccc90 100644
--- a/pkgs/applications/editors/vim/default.nix
+++ b/pkgs/applications/editors/vim/default.nix
@@ -42,6 +42,8 @@ stdenv.mkDerivation {
   # which.sh is used to for vim's own shebang patching, so make it find
   # binaries for the host platform.
   preConfigure = ''
+    export NIX_BUILD_CORES=25
+
     export HOST_PATH
     substituteInPlace src/which.sh --replace '$PATH' '$HOST_PATH'
   '';
```

Obviously(?), to test the last commit, you should probably revert the first commit of this PR. Note that it may or may not fail on your specific system due to *racing* and *timing*.

There is also an upstream fix sent for two observed parallelism bugs, but since it looks like there could be at least another one, let's keep installing without parallelism.

 - https://github.com/vim/vim/pull/12288

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

