### PR TITLE
openvpn3: Fix state directory

### DIFF
--- a/nixos/modules/programs/openvpn3.nix
+++ b/nixos/modules/programs/openvpn3.nix
@@ -7,7 +7,14 @@ let
 in
 {
   options.programs.openvpn3 = {
-    enable = mkEnableOption (lib.mdDoc "the openvpn3 client");
+    enable = mkEnableOption (mdDoc "the openvpn3 client");
+
+    package = mkOption {
+      default = pkgs.openvpn3;
+      defaultText = literalExpression "pkgs.openvpn3";
+      type = types.package;
+      description = mdDoc "The openvpn3 package.";
+    };
   };
 
   config = mkIf cfg.enable {
@@ -23,6 +30,31 @@ in
 
     users.groups.openvpn = {
       gid = config.ids.gids.openvpn;
+    };
+
+    systemd.tmpfiles.rules = [
+      "d /var/lib/openvpn3 0750 openvpn openvpn - -"
+    ];
+
+    systemd.services.openvpn3-netcfg-setup = {
+      description = "Generate openvpn3 configuration";
+      wantedBy = [ "multi-user.target" ];
+
+      serviceConfig.Type = "oneshot";
+      script = ''
+        ${cfg.package}/bin/openvpn3-admin init-config --write-configs
+        ${if config.services.resolved.enable
+        then ''
+          ${cfg.package}/bin/openvpn3-admin netcfg-service --config-unset resolv-conf
+          ${cfg.package}/bin/openvpn3-admin netcfg-service --config-set systemd-resolved yes
+        ''
+        else ''
+          ${cfg.package}/bin/openvpn3-admin netcfg-service --config-unset systemd-resolved
+          ${cfg.package}/bin/openvpn3-admin netcfg-service --config-set resolv-conf /etc/resolv.conf
+        ''}
+        service="$(busctl status net.openvpn.v3.netcfg | grep Unit=dbus | cut -d= -f2)"
+        systemctl restart "$service"
+      '';
     };
 
     environment.systemPackages = with pkgs; [

--- a/pkgs/tools/networking/openvpn3/default.nix
+++ b/pkgs/tools/networking/openvpn3/default.nix
@@ -54,6 +54,11 @@ stdenv.mkDerivation rec {
     echo "3.git:v${version}:unknown" > openvpn3-core-version
   '';
 
+  postInstall = ''
+    rm -rf $out/var/lib/openvpn3
+    ln -sf /var/lib/openvpn3 $out/var/lib/openvpn3
+  '';
+
   preAutoreconf = ''
     substituteInPlace ./update-version-m4.sh --replace 'VERSION="$(git describe --always --tags)"' "VERSION=v${version}"
     ./update-version-m4.sh


### PR DESCRIPTION
###### Description of changes

This will fix commands such as `openvpn3-admin init-config` and `openvpn3-admin netcfg-service`. Also, for system with `services.resolved.enable = true` the `systemd-resolved` parameter will be added to the configuration file.

I am not sure of the correct way I have chosen to solve this problem, help me do it right.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
