### PR TITLE
lua.lib: use toLua in generateLuarocksConfig

### DIFF
--- a/pkgs/development/lua-modules/lib.nix
+++ b/pkgs/development/lua-modules/lib.nix
@@ -1,5 +1,6 @@
 { pkgs, lib, lua }:
 let
+  inherit (lib.generators) toLua;
   requiredLuaModules = drvs: with lib; let
     modules =  filter hasLuaModule drvs;
   in unique ([lua] ++ modules ++ concatLists (catAttrs "requiredLuaModules" modules));
@@ -89,58 +90,50 @@ rec {
     , rocksSubdir
     }: let
       rocksTrees = lib.imap0
-        (i: dep: "{ name = [[dep-${toString i}]], root = '${dep}', rocks_dir = '${dep}/${dep.rocksSubdir}' }")
+        (i: dep: { name = "dep-${toString i}"; root = "${dep}"; rocks_dir = "${dep}/${dep.rocksSubdir}"; })
         requiredLuaRocks;
 
       # Explicitly point luarocks to the relevant locations for multiple-output
       # derivations that are external dependencies, to work around an issue it has
       # (https://github.com/luarocks/luarocks/issues/766)
-      depVariables = lib.concatMap ({name, dep}: [
-        "${name}_INCDIR='${lib.getDev dep}/include';"
-        "${name}_LIBDIR='${lib.getLib dep}/lib';"
-        "${name}_BINDIR='${lib.getBin dep}/bin';"
-      ]) externalDeps';
+      depVariables = zipAttrsWithLast (lib.lists.map ({name, dep}: {
+        "${name}_INCDIR" = "${lib.getDev dep}/include";
+        "${name}_LIBDIR" = "${lib.getLib dep}/lib";
+        "${name}_BINDIR" = "${lib.getBin dep}/bin";
+      }) externalDeps');
+      zipAttrsWithLast = lib.attrsets.zipAttrsWith (name: lib.lists.last);
 
       # example externalDeps': [ { name = "CRYPTO"; dep = pkgs.openssl; } ]
       externalDeps' = lib.filter (dep: !lib.isDerivation dep) externalDeps;
 
       externalDepsDirs = map
-        (x: "'${builtins.toString x}'")
+        (x: builtins.toString x)
         (lib.filter (lib.isDerivation) externalDeps);
-
-      extraVariablesStr = lib.concatStringsSep "\n "
-        (lib.mapAttrsToList (k: v: "${k}='${v}';") extraVariables);
   in ''
     local_cache = ""
     -- To prevent collisions when creating environments, we install the rock
     -- files into per-package subdirectories
-    rocks_subdir = '${rocksSubdir}'
+    rocks_subdir = ${toLua {} rocksSubdir}
     -- first tree is the default target where new rocks are installed,
     -- any other trees in the list are treated as additional sources of installed rocks for matching dependencies.
-    rocks_trees = {
-      {name = "current", root = '${placeholder "out"}', rocks_dir = "current" },
-      ${lib.concatStringsSep "\n, " rocksTrees}
-    }
+    rocks_trees = ${toLua {} (
+      [{name = "current"; root = "${placeholder "out"}"; rocks_dir = "current"; }] ++
+      rocksTrees
+    )}
   '' + lib.optionalString lua.pkgs.isLuaJIT ''
     -- Luajit provides some additional functionality built-in; this exposes
     -- that to luarock's dependency system
-    rocks_provided = {
-      jit='${lua.luaversion}-1';
-      ffi='${lua.luaversion}-1';
-      luaffi='${lua.luaversion}-1';
-      bit='${lua.luaversion}-1';
-    }
+    rocks_provided = ${toLua {} {
+      jit = "${lua.luaversion}-1";
+      ffi = "${lua.luaversion}-1";
+      luaffi = "${lua.luaversion}-1";
+      bit = "${lua.luaversion}-1";
+    }}
   '' + ''
     -- For single-output external dependencies
-    external_deps_dirs = {
-      ${lib.concatStringsSep "\n, " externalDepsDirs}
-    }
-    variables = {
-      -- Some needed machinery to handle multiple-output external dependencies,
-      -- as per https://github.com/luarocks/luarocks/issues/766
-      ${lib.optionalString (lib.length depVariables > 0) ''
-        ${lib.concatStringsSep "\n  " depVariables}''}
-      ${extraVariablesStr}
-    }
+    external_deps_dirs = ${toLua {} externalDepsDirs}
+    -- Some needed machinery to handle multiple-output external dependencies,
+    -- as per https://github.com/luarocks/luarocks/issues/766
+    variables = ${toLua {} (depVariables // extraVariables)}
   '';
 }

--- a/pkgs/development/lua-modules/lib.nix
+++ b/pkgs/development/lua-modules/lib.nix
@@ -109,31 +109,31 @@ rec {
       externalDepsDirs = map
         (x: builtins.toString x)
         (lib.filter (lib.isDerivation) externalDeps);
-  in ''
-    local_cache = ""
-    -- To prevent collisions when creating environments, we install the rock
-    -- files into per-package subdirectories
-    rocks_subdir = ${toLua {} rocksSubdir}
-    -- first tree is the default target where new rocks are installed,
-    -- any other trees in the list are treated as additional sources of installed rocks for matching dependencies.
-    rocks_trees = ${toLua {} (
+  in toLua { asBindings = true; } ({
+    local_cache = "";
+    # To prevent collisions when creating environments, we install the rock
+    # files into per-package subdirectories
+    rocks_subdir = rocksSubdir;
+    # first tree is the default target where new rocks are installed,
+    # any other trees in the list are treated as additional sources of installed rocks for matching dependencies.
+    rocks_trees = (
       [{name = "current"; root = "${placeholder "out"}"; rocks_dir = "current"; }] ++
       rocksTrees
-    )}
-  '' + lib.optionalString lua.pkgs.isLuaJIT ''
-    -- Luajit provides some additional functionality built-in; this exposes
-    -- that to luarock's dependency system
-    rocks_provided = ${toLua {} {
+    );
+  } // lib.optionalAttrs lua.pkgs.isLuaJIT {
+    # Luajit provides some additional functionality built-in; this exposes
+    # that to luarock's dependency system
+    rocks_provided = {
       jit = "${lua.luaversion}-1";
       ffi = "${lua.luaversion}-1";
       luaffi = "${lua.luaversion}-1";
       bit = "${lua.luaversion}-1";
-    }}
-  '' + ''
-    -- For single-output external dependencies
-    external_deps_dirs = ${toLua {} externalDepsDirs}
-    -- Some needed machinery to handle multiple-output external dependencies,
-    -- as per https://github.com/luarocks/luarocks/issues/766
-    variables = ${toLua {} (depVariables // extraVariables)}
-  '';
+    };
+  } // {
+    # For single-output external dependencies
+    external_deps_dirs = externalDepsDirs;
+    # Some needed machinery to handle multiple-output external dependencies,
+    # as per https://github.com/luarocks/luarocks/issues/766
+    variables = (depVariables // extraVariables);
+  });
 }


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
This is follow-up for suggestion in #225496 from @teto about re-factoring `generateLuarocksConfig` to start using newly introduced `toLua` generator.

Commit for this PR is 3e60fd2ef657ea12d03fc8d587a8d9d2e0f9c48c . Other one is for previous PR.


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).


---
For `luaPackages.cqueues` generated `luarocks-config.lua` now looks like:
```
local_cache = ""
-- To prevent collisions when creating environments, we install the rock
-- files into per-package subdirectories
rocks_subdir = "cqueues-20200726-0-rocks"
-- first tree is the default target where new rocks are installed,
-- any other trees in the list are treated as additional sources of installed rocks for matching dependencies.
rocks_trees = {
  {
    ["name"] = "current",
    ["rocks_dir"] = "current",
    ["root"] = "/nix/store/2nzpqnv48b931ylxbd8y9hba5dqr6jrm-lua20200726.52-cqueues-20200726-0"
  }
}
-- For single-output external dependencies
external_deps_dirs = {
  "/nix/store/yrb14jdd2wh1xrzz4vlbsdn21vkvimsd-wrap-lua-hook",
  "/nix/store/kp355cm1wyv8dbx6rq79n823iarrq061-luarocks-3.9.1",
  "/nix/store/pi7ca6hpy4g82l96f9d8yk2k69q9wr0l-lua-5.2.4",
  "/nix/store/ggsmy3rwsr6q6ri45ck3jdqnz9cf6dm6-openssl-3.0.8-dev"
}
-- Some needed machinery to handle multiple-output external dependencies,
-- as per https://github.com/luarocks/luarocks/issues/766
variables = {
  ["CRYPTO_BINDIR"] = "/nix/store/05qna7girdhnzx38jkhr4yyh7gmnizv3-openssl-3.0.8-bin/bin",
  ["CRYPTO_INCDIR"] = "/nix/store/ggsmy3rwsr6q6ri45ck3jdqnz9cf6dm6-openssl-3.0.8-dev/include",
  ["CRYPTO_LIBDIR"] = "/nix/store/s8vg2h8xzqmjd72f3g3p1jqy2lbbapc6-openssl-3.0.8/lib",
  ["OPENSSL_BINDIR"] = "/nix/store/05qna7girdhnzx38jkhr4yyh7gmnizv3-openssl-3.0.8-bin/bin",
  ["OPENSSL_INCDIR"] = "/nix/store/ggsmy3rwsr6q6ri45ck3jdqnz9cf6dm6-openssl-3.0.8-dev/include",
  ["OPENSSL_LIBDIR"] = "/nix/store/s8vg2h8xzqmjd72f3g3p1jqy2lbbapc6-openssl-3.0.8/lib"
}



```
After `nix build .\#luaPackages.cqueues` can see in output of `ldd result/**/*.so`:
```
	linux-vdso.so.1 (0x00007fff591f4000)
	libssl.so.3 => /nix/store/s8vg2h8xzqmjd72f3g3p1jqy2lbbapc6-openssl-3.0.8/lib/libssl.so.3 (0x00007f1b3dbc8000)
	libcrypto.so.3 => /nix/store/s8vg2h8xzqmjd72f3g3p1jqy2lbbapc6-openssl-3.0.8/lib/libcrypto.so.3 (0x00007f1b3d74b000)
	libpthread.so.0 => /nix/store/8xk4yl1r3n6kbyn05qhan7nbag7npymx-glibc-2.35-224/lib/libpthread.so.0 (0x00007f1b3d746000)
	libdl.so.2 => /nix/store/8xk4yl1r3n6kbyn05qhan7nbag7npymx-glibc-2.35-224/lib/libdl.so.2 (0x00007f1b3d741000)
	librt.so.1 => /nix/store/8xk4yl1r3n6kbyn05qhan7nbag7npymx-glibc-2.35-224/lib/librt.so.1 (0x00007f1b3d73c000)
	libm.so.6 => /nix/store/8xk4yl1r3n6kbyn05qhan7nbag7npymx-glibc-2.35-224/lib/libm.so.6 (0x00007f1b3d65a000)
	libc.so.6 => /nix/store/8xk4yl1r3n6kbyn05qhan7nbag7npymx-glibc-2.35-224/lib/libc.so.6 (0x00007f1b3d451000)
	/nix/store/4nlgxhb09sdr51nc9hdm8az5b08vzkgx-glibc-2.35-163/lib64/ld-linux-x86-64.so.2 (0x00007f1b3dccb000)
```
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
