### PR TITLE
elixir-ls: 0.13.0 -> 0.14.5

### DIFF
--- a/pkgs/development/beam-modules/elixir-ls/pin.json
+++ b/pkgs/development/beam-modules/elixir-ls/pin.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.13.0",
-  "sha256": "sha256-eUAlnEKhoJ3j2Ii2EBL620jv3aGeMJcWoMMG+vWIdm4=",
-  "depsSha256": "sha256-fAt9BpEE9truGWpor0BttVd9aNZlgQ6UTorIEcJ82wM="
+  "version": "0.14.5",
+  "sha256": "sha256-F0c1vyeie8sf11SHfDKb8v1DZ5No3Rr3PPj3jMg0veg=",
+  "depsSha256": "sha256-/lKZ9Ns32A/elJTez72mH2tZ7ujwEX9p4FIKHpfGq78="
 }


### PR DESCRIPTION
First Pull Request, sorry for mistakes !

Link to changelog: https://github.com/elixir-lsp/elixir-ls/blob/master/CHANGELOG.md

###### Description of changes

v0.14.5: 21 April 2023
Fixes
Fixed regression in debugger not respecting MIX_ENV and MIX_TARGET
Silence output from dialyxir making client disconnect from the server on elixir < 1.14
Avoid serializing PID to JSON
v0.14.4: 20 April 2023
Fixes
Fixed invalid encoding of messages with unicode strings. This should resolve issues when starting the server in in non-ASCII path
v0.14.3: 17 April 2023
Fixes
Fixed compatibility with elixir 1.12 and 1.13 [Maciej Szlosarczyk](https://github.com/maciej-szlosarczyk)
v0.14.2: 15 April 2023
Fixes
Print correct version
v0.14.1: 14 April 2023
Fixes
Reorder startup sequence to avert mix crash
v0.14.0: 14 April 2023
Improvements
Numerous improvements to variable tracking. This should make navigation to variable definition and references work correctly [Samuel Hełdak](https://github.com/sheldak)
Doctests can now be run via Test UI [Carl-Foster](https://github.com/Carl-Foster)
Fixed completions of records defined in the same file
Fixed support for alias __MODULE__
Silent crashes in dialyzer fixed
Document symbol provider now does not crash on incomplete typespec
Debugger now properly tracks running processes. Previously UI was not updated when new processes start or running not monitored processes exit
Debugger now respects MIX_TARGET environment variable
Undefined function diagnostics no longer emitted from mix.exs dependencies. Elixir mix swallows those warnings since 1.10
Builds now use --all-warnings flag on mix compile. This should result in more predictable diagnostics in umbrella apps.
Completion provider returns typespecs for struct properties in documentation if struct module defines type t()
Debugger now returns type of breakpoint in the hit event as required by DAP
Fixed crash when elixir-ls is run in a directory without mix.exs
References provider now can find references to elixir modules. Previously modules were found only when a function or macro from that module was called
Typespecs from behaviour module are used on callback implementations in completions, hover and specification providers
@after_verify attribute added in elixir 1.14 is recognized as builtin
Fixed edge cases when private def would overshadow a public one
Quoted expressions are now skipped when code AST is analyzed. There is low chance anything useful can be extracted from them
Submodule implicit alias behavior is now correctly implemented. This should improve quality in various providers
Fixed crash in references provider when reference does not have a line (e.g. in phoenix live views)
Refactorings
Mix Formatter now properly formats elixir-ls code from the top directory
Major refactoring of elixir-ls server driven by [Steve Cohen](https://github.com/scohen) is under way. It's not yet complete and can be tested by enabling experimental server. Thanks to others involved ([Scott Ming](https://github.com/scottming), [Samuel Hełdak](https://github.com/sheldak))
Language server now runs with consolidated protocols. Consolidation is disabled on each build with --no-protocol-consolidation flag on mix compile. This should make the server faster. The side effect is more protocol consolidation warnings printed to the console on elixir < 1.14.
Deprecations
This is the last release supporting elixir 1.12

###### Things done


- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
