### PR TITLE
phpExtensions.relay: init at 0.6.3

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -15527,6 +15527,12 @@
     github = "TilCreator";
     githubId = 18621411;
   };
+  tillkruss = {
+    name = "Till Krüss";
+    email = "till@kruss.io";
+    github = "tillkruss";
+    githubId = 665029;
+  };
   tilpner = {
     email = "till@hoeppner.ws";
     github = "tilpner";

--- a/pkgs/development/php-packages/relay/default.nix
+++ b/pkgs/development/php-packages/relay/default.nix
@@ -1,0 +1,113 @@
+{ stdenv
+, lib
+, fetchurl
+, php
+, openssl
+, openssl_1_1
+, zstd
+, lz4
+, autoPatchelfHook
+}:
+
+let
+  version = "0.6.3";
+  system = stdenv.hostPlatform.system;
+  phpVersion = lib.versions.majorMinor php.version;
+  variation = {
+    "aarch64-darwin" = {
+      platform = "darwin-arm64";
+      hashes = {
+        "8.0" = "00a7pyf9na7hjifkmp2482c7sh086w72zniqgr4cz2rhz7hnqp7p";
+        "8.1" = "0mg6nsllycgjxxinn8s30y9sk06g40vk8blnpx0askjw5zdsf5y7";
+        "8.2" = "0qmcbrj6jaxczv25rdgfjrj9nwq4vb2faw7kzlyxrvvzb5pyn9dm";
+        "8.3" = "1hqjy5y4q3alxvrj7xksaf7vvmz8p51bgzxbvmzdx6jnl63dix33";
+      };
+    };
+    "aarch64-linux" = {
+      platform = "debian-aarch64+libssl3";
+      hashes = {
+        "8.0" = "19zzw4324z096b6bph1686r30i4i2kwmlmmcqmb33lqkr9b9n5ag";
+        "8.1" = "0j6wpwy8d67pqij4v8m2xwydfddzr7nn4c3lyrssp8llbn4ghwpn";
+        "8.2" = "1nbajvi5zk6z8qr32l86p65f1zxv12kald56pg8k7bj4axlj2pmy";
+        "8.3" = "1sn638g2636m6s3lv2cclza9lzmzgqxamcga7jz3ijhn2ja6znbv";
+      };
+    };
+    "x86_64-darwin" = {
+      platform = "darwin-x86-64";
+      hashes = {
+        "8.0" = "13q6va9lxgfyx86xw20iqjz4s9r9xms74ywb2hgqrhs5mjnazzz4";
+        "8.1" = "1ncih5bf0jcylpl0nj8hi50kcwb4nl1g0ql359dgg9gp8s1b4hmw";
+        "8.2" = "150difm3vg0g2pl5hb5cci4jzybd7jcd7prjdv3rmwsi91gsydlv";
+        # 8.3 for this platform does not exist
+      };
+    };
+    "x86_64-linux" = {
+      platform = "debian-x86-64+libssl3";
+      hashes = {
+        "8.0" = "1qvd5r591kp7qf9pkymz78s8llzs1vxjwqhwy9rvma21hh6gd8ld";
+        "8.1" = "0fm9ppgx7qaggid134qnl9jkq5h97dac2ax21f1f1d0k8f5blmc2";
+        "8.2" = "0g2yqwfrigf047dqkrvfcj318lvgp38zy522ry484mrgq7iqwvb8";
+        "8.3" = "06mi3yr7k1a9icdljzl76xvrw6xqnvwiavgzx2g487s097mycjp4";
+      };
+    };
+  }.${system} or (throw "Unsupported platform for relay: ${system}");
+in
+stdenv.mkDerivation (finalAttrs: {
+  inherit version;
+  pname = "relay";
+  extensionName = "relay";
+
+  src = fetchurl {
+    url = "https://builds.r2.relay.so/v${finalAttrs.version}/relay-v${finalAttrs.version}-php"
+      + phpVersion + "-" + variation.platform + ".tar.gz";
+    sha256 = variation.hashes.${phpVersion} or (throw "Unsupported PHP version for relay ${phpVersion} on ${system}");
+  };
+  nativeBuildInputs = lib.optionals (!stdenv.isDarwin) [
+    autoPatchelfHook
+  ];
+  buildInputs = lib.optionals (!stdenv.isDarwin) [
+    openssl
+    zstd
+    lz4
+  ];
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/lib/php/extensions
+    cp relay-pkg.so $out/lib/php/extensions/relay.so
+    chmod +w $out/lib/php/extensions/relay.so
+  '' + (if stdenv.isDarwin then
+    let
+      args = lib.strings.concatMapStrings
+        (v: " -change /Users/administrator/dev/relay-dev/relay-deps/build/arm64/lib/${v.name}"
+          + " ${lib.strings.makeLibraryPath [ v.value ]}/${v.name}")
+        (with lib.attrsets; [
+          (nameValuePair "libssl.1.1.dylib" openssl_1_1)
+          (nameValuePair "libcrypto.1.1.dylib" openssl_1_1)
+          (nameValuePair "libzstd.1.dylib" zstd)
+          (nameValuePair "liblz4.1.dylib" lz4)
+        ]);
+    in
+    # fixDarwinDylibNames can't be used here because we need to completely remap .dylibs, not just add absolute paths
+    ''
+      install_name_tool${args} $out/lib/php/extensions/relay.so
+    ''
+  else
+    "") + ''
+    # Random UUID that's required by the extension. Can be anything, but must be different from default.
+    sed -i "s/00000000-0000-0000-0000-000000000000/aced680f-30e9-40cc-a868-390ead14ba0c/" $out/lib/php/extensions/relay.so
+    chmod -w $out/lib/php/extensions/relay.so
+
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    description = "Next-generation Redis extension for PHP";
+    changelog = "https://github.com/cachewerk/relay/releases/tag/v${version}";
+    homepage = "https://relay.so/";
+    sourceProvenance = [ sourceTypes.binaryNativeCode ];
+    license = licenses.unfree;
+    maintainers = with maintainers; [ tillkruss ostrolucky ];
+    platforms = [ "x86_64-linux" "aarch64-linux" "x86_64-darwin" "aarch64-darwin" ];
+  };
+})

--- a/pkgs/top-level/php-packages.nix
+++ b/pkgs/top-level/php-packages.nix
@@ -282,6 +282,8 @@ lib.makeScope pkgs.newScope (self: with self; {
 
     redis = callPackage ../development/php-packages/redis { };
 
+    relay = callPackage ../development/php-packages/relay  { inherit php; };
+
     smbclient = callPackage ../development/php-packages/smbclient { };
 
     snuffleupagus = callPackage ../development/php-packages/snuffleupagus { };


### PR DESCRIPTION
###### Description of changes

Adding an https://relay.so/, which is a new Redis extension for PHP. There are no sources for this package available, because it has commercial tier. Its founder is @tillkruss and after talking to him I am adding him to maintainers, which he agreed with. I'll tell him to comment here as a proof.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
