### PR TITLE
darling: init at unstable-2023-05-02

### DIFF
--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -153,6 +153,7 @@
   ./programs/cnping.nix
   ./programs/command-not-found/command-not-found.nix
   ./programs/criu.nix
+  ./programs/darling.nix
   ./programs/dconf.nix
   ./programs/digitalbitbox/default.nix
   ./programs/dmrconfig.nix

--- a/nixos/modules/programs/darling.nix
+++ b/nixos/modules/programs/darling.nix
@@ -1,0 +1,21 @@
+{ config, lib, pkgs, ... }:
+
+let
+  cfg = config.programs.darling;
+in {
+  options = {
+    programs.darling = {
+      enable = lib.mkEnableOption (lib.mdDoc "Darling, a Darwin/macOS compatibility layer for Linux");
+      package = lib.mkPackageOptionMD pkgs "darling" {};
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    security.wrappers.darling = {
+      source = lib.getExe cfg.package;
+      owner = "root";
+      group = "root";
+      setuid = true;
+    };
+  };
+}

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -171,6 +171,7 @@ in {
   cups-pdf = handleTest ./cups-pdf.nix {};
   custom-ca = handleTest ./custom-ca.nix {};
   croc = handleTest ./croc.nix {};
+  darling = handleTest ./darling.nix {};
   deepin = handleTest ./deepin.nix {};
   deluge = handleTest ./deluge.nix {};
   dendrite = handleTest ./matrix/dendrite.nix {};

--- a/nixos/tests/darling.nix
+++ b/nixos/tests/darling.nix
@@ -1,0 +1,44 @@
+import ./make-test-python.nix ({ pkgs, lib, ... }:
+
+let
+  # Well, we _can_ cross-compile from Linux :)
+  hello = pkgs.runCommand "hello" {
+    sdk = "${pkgs.darling.sdk}/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk";
+    nativeBuildInputs = with pkgs.llvmPackages_latest; [ clang-unwrapped lld ];
+    src = pkgs.writeText "hello.c" ''
+      #include <stdio.h>
+      int main() {
+        printf("Hello, Darling!\n");
+        return 0;
+      }
+    '';
+  } ''
+    clang \
+      -target x86_64-apple-darwin \
+      -fuse-ld=lld \
+      -nostdinc -nostdlib \
+      -mmacosx-version-min=10.15 \
+      --sysroot $sdk \
+      -isystem $sdk/usr/include \
+      -L $sdk/usr/lib -lSystem \
+      $src -o $out
+  '';
+in
+{
+  name = "darling";
+
+  meta.maintainers = with lib.maintainers; [ zhaofengli ];
+
+  nodes.machine = {
+    programs.darling.enable = true;
+  };
+
+  testScript = ''
+    start_all()
+
+    # Darling holds stdout until the server is shutdown
+    machine.succeed("darling ${hello} >hello.out")
+    machine.succeed("grep Hello hello.out")
+    machine.succeed("darling shutdown")
+  '';
+})

--- a/pkgs/applications/emulators/darling/default.nix
+++ b/pkgs/applications/emulators/darling/default.nix
@@ -1,0 +1,197 @@
+{ clangStdenv
+, lib
+, runCommandWith
+, writeShellScript
+, fetchFromGitHub
+, fetchpatch
+
+, freetype
+, libjpeg
+, libpng
+, libtiff
+, giflib
+, libX11
+, libXext
+, libXrandr
+, libXcursor
+, libxkbfile
+, cairo
+, libglvnd
+, fontconfig
+, dbus
+, libGLU
+, fuse
+, ffmpeg
+, pulseaudio
+
+, makeWrapper
+, python2
+, python3
+, cmake
+, ninja
+, pkg-config
+, bison
+, flex
+
+, libbsd
+, openssl
+
+, xdg-user-dirs
+
+, addOpenGLRunpath
+
+# Whether to pre-compile Python 2 bytecode for performance.
+, compilePy2Bytecode ? false
+}:
+let
+  stdenv = clangStdenv;
+
+  # The build system invokes clang to compile Darwin executables.
+  # In this case, our cc-wrapper must not be used.
+  ccWrapperBypass = runCommandWith {
+    inherit stdenv;
+    name = "cc-wrapper-bypass";
+    runLocal = false;
+    derivationArgs = {
+      template = writeShellScript "template" ''
+        for (( i=1; i<=$#; i++)); do
+          j=$((i+1))
+          if [[ "''${!i}" == "-target" && "''${!j}" == *"darwin"* ]]; then
+            # their flags must take precedence
+            exec @unwrapped@ "$@" $NIX_CFLAGS_COMPILE
+          fi
+        done
+        exec @wrapped@ "$@"
+      '';
+    };
+  } ''
+    unwrapped_bin=${stdenv.cc.cc}/bin
+    wrapped_bin=${stdenv.cc}/bin
+
+    mkdir -p $out/bin
+
+    unwrapped=$unwrapped_bin/$CC wrapped=$wrapped_bin/$CC \
+      substituteAll $template $out/bin/$CC
+    unwrapped=$unwrapped_bin/$CXX wrapped=$wrapped_bin/$CXX \
+      substituteAll $template $out/bin/$CXX
+
+    chmod +x $out/bin/$CC $out/bin/$CXX
+  '';
+
+  wrappedLibs = [
+    # To find all of them: rg -w wrap_elf
+
+    # src/native/CMakeLists.txt
+    freetype
+    libjpeg
+    libpng
+    libtiff
+    giflib
+    libX11
+    libXext
+    libXrandr
+    libXcursor
+    libxkbfile
+    cairo
+    libglvnd
+    fontconfig
+    dbus
+    libGLU
+
+    # src/external/darling-dmg/CMakeLists.txt
+    fuse
+
+    # src/CoreAudio/CMakeLists.txt
+    ffmpeg
+    pulseaudio
+  ];
+in stdenv.mkDerivation {
+  pname = "darling";
+  version = "unstable-2023-05-02";
+
+  src = fetchFromGitHub {
+    owner = "darlinghq";
+    repo = "darling";
+    rev = "557e7e9dece394a3f623825679474457e5b64fd0";
+    fetchSubmodules = true;
+    hash = "sha256-SOoLaV7wg33qRHPQXkdMvrY++CvoG85kwd6IU6DkYa0=";
+  };
+
+
+  postPatch = ''
+    # We have to be careful - Patching everything indiscriminately
+    # would affect Darwin scripts as well
+    chmod +x src/external/bootstrap_cmds/migcom.tproj/mig.sh
+    patchShebangs \
+      src/external/bootstrap_cmds/migcom.tproj/mig.sh \
+      src/external/darlingserver/scripts \
+      src/external/openssl_certificates/scripts
+
+    substituteInPlace src/startup/CMakeLists.txt --replace SETUID ""
+    substituteInPlace src/external/basic_cmds/CMakeLists.txt --replace SETGID ""
+  '';
+
+  nativeBuildInputs = [
+    bison
+    ccWrapperBypass
+    cmake
+    flex
+    makeWrapper
+    ninja
+    pkg-config
+    python3
+  ]
+  ++ lib.optional compilePy2Bytecode python2;
+  buildInputs = wrappedLibs ++ [
+    libbsd
+    openssl
+    stdenv.cc.libc.linuxHeaders
+  ];
+
+  # Breaks valid paths like
+  # Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include
+  dontFixCmake = true;
+
+  # src/external/objc4 forces OBJC_IS_DEBUG_BUILD=1, which conflicts with NDEBUG
+  # TODO: Fix in a better way
+  cmakeBuildType = " ";
+
+  cmakeFlags = [
+    "-DTARGET_i386=OFF"
+    "-DCOMPILE_PY2_BYTECODE=${if compilePy2Bytecode then "ON" else "OFF"}"
+    "-DDARLINGSERVER_XDG_USER_DIR_CMD=${xdg-user-dirs}/bin/xdg-user-dir"
+  ];
+
+  env.NIX_CFLAGS_COMPILE = "-Wno-macro-redefined -Wno-unused-command-line-argument";
+
+  # Linux .so's are dlopen'd by wrapgen during the build
+  env.LD_LIBRARY_PATH = lib.makeLibraryPath wrappedLibs;
+
+  # Breaks shebangs of Darwin scripts
+  dontPatchShebangs = true;
+
+  postFixup = ''
+    echo "Checking for references to $NIX_STORE in Darling root..."
+
+    set +e
+    grep -r --exclude=mldr "$NIX_STORE" $out/libexec/darling
+    ret=$?
+    set -e
+
+    if [[ $ret == 0 ]]; then
+      echo "Found references to $NIX_STORE in Darling root (see above)"
+      exit 1
+    fi
+
+    patchelf --add-rpath "${lib.makeLibraryPath wrappedLibs}:${addOpenGLRunpath.driverLink}/lib" \
+      $out/libexec/darling/usr/libexec/darling/mldr
+  '';
+
+  meta = with lib; {
+    description = "Open-source Darwin/macOS emulation layer for Linux";
+    homepage = "https://www.darlinghq.org";
+    license = licenses.gpl3Plus;
+    maintainers = with maintainers; [ zhaofengli ];
+    platforms = [ "x86_64-linux" ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -493,6 +493,8 @@ with pkgs;
 
   dae = callPackage ../tools/networking/dae { };
 
+  darling = callPackage ../applications/emulators/darling { };
+
   databricks-sql-cli = python3Packages.callPackage ../applications/misc/databricks-sql-cli { };
 
   dhallDirectoryToNix = callPackage ../build-support/dhall/directory-to-nix.nix { };


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

This PR adds [Darling](https://github.com/darlinghq/darling) which is a Darwin/macOS emulation layer for Linux.

Patches applied:

- https://github.com/darlinghq/darling/pull/1355: Fixes the incorrect assumption during ELF parsing in the wrapper generator
- https://github.com/darlinghq/darling/pull/1356: Makes pre-compiling Python 2 bytecode optional, at the cost of performance
- https://github.com/darlinghq/darling/pull/1358: Removes libsystem_m.dylib's reference to the store
- https://github.com/darlinghq/darling-nano/pull/1: Fixes incorrect sysconfdir for nano
- https://github.com/darlinghq/darlingserver/pull/10: Allows overriding the path to xdg-user-dir

Fixes #38628.

## Installing

Set `programs.darling.enable = true;` in your NixOS config. This will install the setuid wrapper necessary to start Darling. Then, run `darling shell`.

## Stuff To Try

See also https://docs.darlinghq.org/what-to-try.html

```console
$ uname -a
Darwin host 19.6.0 Darwin Kernel Version 19.6.0 x86_64

# You can also use a real copy of Xcode (I haven't tried)
$ xcode-select --install
[...]

# Compile some code
$ clang hello.c

# Install Nix (does not fully work yet - more below)
$ curl -LO "https://github.com/zhaofengli/nix-on-darling/releases/download/initial-hack/nixos-system-x86_64-darwin.tar.xz"
[...]
$ tar xpf nixos-system-x86_64-darwin.tar.xz -C /
[...]
$ bootstrap-nix
Bootstrapping Nix...
installing 'nix-2.13.3'
building '/nix/store/ja3kqp1qwz66iqbkg50wzj264rppcnmg-user-environment.drv'...
installing 'nss-cacert-3.86'
building '/nix/store/27fw1kpgngj3q29ndphb30dw1vkhaxdz-user-environment.drv'...
Run the following command to make Nix work in the current shell:
. '/nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh'

$ . /nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh

$ nix-instantiate --eval -E 'builtins.currentSystem'
"x86_64-darwin"

# Try other stuff
$ nix run nixpkgs#neofetch
                    c.'          zhaofeng@host 
                 ,xNMM.          -------------- 
               .OMMMMo           OS: macOS Catalina 10.15 Darling x86_64   
               lMM"              Kernel: 19.6.0 
     .;loddo:.  .olloddol;.      Uptime: 86 days, 4 hours, 9 mins 
   cKMMMMMMMMMMNWMMMMMMMMMM0:    Shell: fish /nix/store/jawzvjj5x2iwv8zmz0905ix2v62a9h3r-neofetch- 
 .KMMMMMMMMMMMMMMMMMMMMMMMWd.    DE: Aqua 
 XMMMMMMMMMMMMMMMMMMMMMMMX.      WM: Quartz Compositor 
;MMMMMMMMMMMMMMMMMMMMMMMM:       WM Theme: Blue (Print: Entry, AppleInterfaceStyle, Does Not Exist 
:MMMMMMMMMMMMMMMMMMMMMMMM:       Terminal: shellspawn 
.MMMMMMMMMMMMMMMMMMMMMMMMX.      Memory: 27141MiB / 32034MiB 
 kMMMMMMMMMMMMMMMMMMMMMMMMWd.
 'XMMMMMMMMMMMMMMMMMMMMMMMMMMk                           
  'XMMMMMMMMMMMMMMMMMMMMMMMMK.                           
    kMMMMMMMMMMMMMMMMMMMMMMd
     ;KMMMMMMMWXXWMMMMMMMk.
       "cooc*"    "*coo'"
```

## Nix

The official Nix install script does not work on Darling due to its attempts to modify partitions and users on the system. Nix also has trouble [clearing file attributes](https://github.com/NixOS/nix/blob/7474a90db69813d051ab1bef35c7d0ab958d9ccd/src/libstore/local-store.cc#L607-L615) in the emulated filesystem.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
