### PR TITLE
wrapFirefox: add extraBuildCommands escape hatch

### DIFF
--- a/pkgs/applications/networking/browsers/firefox/wrapper.nix
+++ b/pkgs/applications/networking/browsers/firefox/wrapper.nix
@@ -41,6 +41,7 @@ let
     ## Following options are needed for extra prefs & policies
     # For more information about anti tracking (german website)
     # visit https://wiki.kairaven.de/open/app/firefox
+    , extraBuildCommands ? ""
     , extraPrefs ? ""
     , extraPrefsFiles ? []
     # For more information about policies visit
@@ -392,6 +393,8 @@ let
         #   END EXTRA PREF CHANGES  #
         #                           #
         #############################
+
+        ${extraBuildCommands}
       '';
 
       preferLocalBuild = true;


### PR DESCRIPTION
###### Description of changes

Adds the `extraBuildCommands` argument to `wrapFirefox`. This allows to write custom wrappers for firefox outside nixpkgs tree, while still utilizing `wrapFirefox` to generate correct `.desktop` files, etc.

An admittedly weird example:

<details>

Setting the `GDK_DPI_SCALE` environment variable that would only affect firefox.
A possible solution before this PR:

<details>

```nix
let pkgs = import <nixpkgs> { };
in

with pkgs;

let
  firefoxGdkDpiScale = 0.9;
  stage0 = firefox-unwrapped;
  stage1 =
    symlinkJoin
      {
        name = "${stage0.name}";
        paths = [ stage0 ];
        nativeBuildInputs = [ makeWrapper ];
        passthru = stage0;
        postBuild = ''
          wrapProgram $out/bin/firefox \
           --set GDK_DPI_SCALE ${toString firefoxGdkDpiScale}
        '';
      };
in
wrapFirefox stage1 { }
```

</details>

```nix

let pkgs = import <nixpkgs> { };
in

with pkgs;

let
  firefoxGdkDpiScale = 0.9;
in
firefox.overrideAttrs (oldAttrs: {
  buildCommand = oldAttrs.buildCommand + ''
    wrapProgram $out/bin/firefox \
     --set GDK_DPI_SCALE ${toString firefoxGdkDpiScale}
  '';
})
```

After this PR:

```nix
with import ./. { };

wrapFirefox firefox-unwrapped {
  extraBuildCommands = ''
    wrapProgram $out/bin/firefox \
      --set GDK_DPI_SCALE 0.75
  '';
}
```

Or just:

```nix
with import ./. { };

firefox.override {
  extraBuildCommands = ''
    wrapProgram $out/bin/firefox \
      --set GDK_DPI_SCALE 0.75
  '';
}
```

</details>

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux

