### PR TITLE
googleearth-pro: Avoid dragging in stdenv

### DIFF
--- a/pkgs/applications/misc/googleearth-pro/default.nix
+++ b/pkgs/applications/misc/googleearth-pro/default.nix
@@ -71,16 +71,17 @@ mkDerivation rec {
 
   unpackPhase = ''
     # deb file contains a setuid binary, so 'dpkg -x' doesn't work here
-    dpkg --fsys-tarfile ${src} | tar --extract
+    mkdir deb
+    dpkg --fsys-tarfile ${src} | tar --extract -C deb
   '';
 
   installPhase =''
     runHook preInstall
 
     mkdir $out
-    mv usr/* $out/
-    rmdir usr
-    mv * $out/
+    mv deb/usr/* $out/
+    rmdir deb/usr
+    mv deb/* $out/
     rm $out/bin/google-earth-pro $out/opt/google/earth/pro/googleearth
 
     # patch and link googleearth binary


### PR DESCRIPTION
I noticed that my system closure contained duplicate of various packages, and traced it back to `googleearth-pro`. It included a `env-vars` file created by `stdenv` which pulled in lots of build tools, and it seems it was copied in `installPhase` by accident. By only copying the directories from the upstream package, the number of paths in the closure is reduced noticably:

```diff
~/build/nixpkgs $ diff -u <(nix-store --query -R result-before|wc -l) <(nix-store --query -R result|wc -l)
--- /dev/fd/63	2023-04-23 14:31:22.653577750 +0200
+++ /dev/fd/62	2023-04-23 14:31:22.654577714 +0200
@@ -1 +1 @@
-396
+256
$ du -sch $(nix-store -qR result-before) | grep total
1.5G    total
$ du -sch $(nix-store -qR result) | grep total
894M    total
```

@friedelino @SCOTT-HAMILTON

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
