### PR TITLE
texlive: unpack and expose useful tlpkg/ content; run postaction scripts

### DIFF
--- a/pkgs/tools/typesetting/tex/texlive/combine.nix
+++ b/pkgs/tools/typesetting/tex/texlive/combine.nix
@@ -248,6 +248,17 @@ in (buildEnv {
     done
     }
   '' +
+  # texlive postactions (see TeXLive::TLUtils::_do_postaction_script)
+  (lib.concatMapStrings (pkg: ''
+    postaction='${pkg.postactionScript}'
+    case "$postaction" in
+      *.pl) postInterp=perl ;;
+      *.texlua) postInterp=texlua ;;
+      *) postInterp= ;;
+    esac
+    echo "postaction install script for ${pkg.pname}: ''${postInterp:+$postInterp }$postaction install $TEXMFROOT"
+    $postInterp "$TEXMFROOT/$postaction" install "$TEXMFROOT"
+  '') (lib.filter (pkg: pkg ? postactionScript) pkgList.tlpkg)) +
   # texlive post-install actions
   ''
     ln -sf "$TEXMFDIST"/scripts/texlive/updmap.pl "$out"/bin/updmap

--- a/pkgs/tools/typesetting/tex/texlive/combine.nix
+++ b/pkgs/tools/typesetting/tex/texlive/combine.nix
@@ -15,13 +15,15 @@ let
     ];
   };
   pkgList = rec {
-    all = lib.filter pkgFilter (combinePkgs (lib.attrValues pkgSet));
+    combined = combinePkgs (lib.attrValues pkgSet);
+    all = lib.filter pkgFilter combined;
     splitBin = builtins.partition (p: p.tlType == "bin") all;
     bin = splitBin.right
       ++ lib.optional
           (lib.any (p: p.tlType == "run" && p.pname == "pdfcrop") splitBin.wrong)
           (lib.getBin ghostscript);
     nonbin = splitBin.wrong;
+    tlpkg = lib.filter (pkg: pkg.tlType == "tlpkg") combined;
 
     # extra interpreters needed for shebangs, based on 2015 schemes "medium" and "tetex"
     # (omitted tk needed in pname == "epspdf", bin/epspdftk)
@@ -35,11 +37,8 @@ let
 
   name = "texlive-${extraName}-${bin.texliveYear}${extraVersion}";
 
-  texmfroot = (buildEnv {
-    name = "${name}-texmfroot";
-
-    # the 'non-relocated' packages must live in $TEXMFROOT/texmf-dist (e.g. fmtutil, updmap look for perl modules there)
-    extraPrefix = "/texmf-dist";
+  texmfdist = (buildEnv {
+    name = "${name}-texmfdist";
 
     # remove fake derivations (without 'outPath') to avoid undesired build dependencies
     paths = lib.catAttrs "outPath" pkgList.nonbin;
@@ -48,16 +47,32 @@ let
 
     postBuild = # generate ls-R database
     ''
-      perl -I "${bin.core.out}/share/texmf-dist/scripts/texlive" \
-        -- "$out/texmf-dist/scripts/texlive/mktexlsr.pl" --sort "$out"/texmf-dist
+      perl "$out/scripts/texlive/mktexlsr.pl" --sort "$out"
     '';
   }).overrideAttrs (_: { allowSubstitutes = true; });
+
+  tlpkg = (buildEnv {
+    name = "${name}-tlpkg";
+
+    # remove fake derivations (without 'outPath') to avoid undesired build dependencies
+    paths = lib.catAttrs "outPath" pkgList.tlpkg;
+  }).overrideAttrs (_: { allowSubstitutes = true; });
+
+  # the 'non-relocated' packages must live in $TEXMFROOT/texmf-dist
+  # and sometimes look into $TEXMFROOT/tlpkg (notably fmtutil, updmap look for perl modules in both)
+  texmfroot = runCommand "${name}-texmfroot" {
+    inherit texmfdist tlpkg;
+  } ''
+    mkdir -p "$out"
+    ln -s "$texmfdist" "$out"/texmf-dist
+    ln -s "$tlpkg" "$out"/tlpkg
+  '';
 
   # expose info and man pages in usual /share/{info,man} location
   doc = buildEnv {
     name = "${name}-doc";
 
-    paths = [ (texmfroot.outPath + "/texmf-dist/doc") ];
+    paths = [ (texmfdist.outPath + "/doc") ];
     extraPrefix = "/share";
 
     pathsToLink = [
@@ -76,6 +91,9 @@ in (buildEnv {
   paths = lib.catAttrs "outPath" pkgList.bin ++ [ doc ];
   pathsToLink = [
     "/"
+    "/share/texmf-var/scripts"
+    "/share/texmf-var/tex/generic/config"
+    "/share/texmf-var/web2c"
     "/bin" # ensure these are writeable directories
   ];
 
@@ -91,9 +109,8 @@ in (buildEnv {
 
   postBuild = ''
     TEXMFROOT="${texmfroot}"
-    TEXMFDIST="${texmfroot}/texmf-dist"
+    TEXMFDIST="${texmfdist}"
     export PATH="$out/bin:$PATH"
-    export PERL5LIB="${bin.core.out}/share/texmf-dist/scripts/texlive" # modules otherwise found in tlpkg/ of texlive.infra
     TEXMFSYSCONFIG="$out/share/texmf-config"
     TEXMFSYSVAR="$out/share/texmf-var"
     export TEXMFCNF="$TEXMFSYSVAR/web2c"
@@ -199,7 +216,6 @@ in (buildEnv {
       rm "$link"
       makeWrapper "$target" "$link" \
         --prefix PATH : "${gnused}/bin:${gnugrep}/bin:${coreutils}/bin:$out/bin:${perl}/bin" \
-        --prefix PERL5LIB : "$PERL5LIB" \
         --set-default TEXMFCNF "$TEXMFCNF" \
         --set-default FONTCONFIG_FILE "${
           # neccessary for XeTeX to find the fonts distributed with texlive
@@ -235,13 +251,15 @@ in (buildEnv {
   # texlive post-install actions
   ''
     ln -sf "$TEXMFDIST"/scripts/texlive/updmap.pl "$out"/bin/updmap
+    ln -sf "$TEXMFDIST"/scripts/texlive/fmtutil.pl "$out"/bin/fmtutil
   '' +
     # now hack to preserve "$0" for mktexfmt
   ''
-    cp "$TEXMFDIST"/scripts/texlive/fmtutil.pl "$out/bin/fmtutil"
-    patchShebangs "$out/bin/fmtutil"
-    ln -sf fmtutil "$out/bin/mktexfmt"
-
+    cp "$TEXMFDIST"/scripts/texlive/fmtutil.pl "$TEXMFSYSVAR"/scripts/mktexfmt
+    ln -sf "$TEXMFSYSVAR"/scripts/mktexfmt "$out"/bin/mktexfmt
+  '' +
+    # generate formats
+  ''
     texlinks "$out/bin" && wrapBin
 
     # many formats still ignore SOURCE_DATE_EPOCH even when FORCE_SOURCE_DATE=1
@@ -250,7 +268,7 @@ in (buildEnv {
     # https://salsa.debian.org/live-team/live-build/-/blob/master/examples/hooks/reproducible/2006-reproducible-texlive-binaries-fmt-files.hook.chroot#L52
     # note that calling faketime and fmtutil is fragile (faketime uses LD_PRELOAD, fmtutil calls /bin/sh, causing potential glibc issues on non-NixOS)
     # so we patch fmtutil to use faketime, rather than calling faketime fmtutil
-    substitute "$out/bin/fmtutil" fmtutil \
+    substitute "$TEXMFDIST"/scripts/texlive/fmtutil.pl fmtutil \
       --replace 'my $cmdline = "$eng -ini ' 'my $cmdline = "faketime -f '"'"'\@1980-01-01 00:00:00 x0.001'"'"' $eng -ini '
     FORCE_SOURCE_DATE=1 TZ= perl fmtutil --sys --all | grep '^fmtutil' # too verbose
     #texlinks "$out/bin" && wrapBin # do we need to regenerate format links?
@@ -280,7 +298,6 @@ in (buildEnv {
     #  * ./bin/repstopdf needs to be a symlink to be processed by wrapBin
   ''
     if [[ -e "$out"/bin/epstopdf ]]; then
-      mkdir -p "$TEXMFSYSVAR/scripts"
       cp "$out"/bin/epstopdf "$TEXMFSYSVAR"/scripts/repstopdf
       ln -s "$TEXMFSYSVAR"/scripts/repstopdf "$out"/bin/repstopdf
     fi

--- a/pkgs/tools/typesetting/tex/texlive/default.nix
+++ b/pkgs/tools/typesetting/tex/texlive/default.nix
@@ -178,6 +178,8 @@ let
           } // lib.optionalAttrs (tlType == "run") {
             hasFormats = args.hasFormats or false;
             hasHyphens = args.hasHyphens or false;
+          } // lib.optionalAttrs (tlType == "tlpkg" && args ? postactionScript) {
+            postactionScript = args.postactionScript;
           };
         } // lib.optionalAttrs (fixedHash != null) {
           outputHash = fixedHash;

--- a/pkgs/tools/typesetting/tex/texlive/default.nix
+++ b/pkgs/tools/typesetting/tex/texlive/default.nix
@@ -23,7 +23,7 @@ let
 
   # function for creating a working environment from a set of TL packages
   combine = import ./combine.nix {
-    inherit bin combinePkgs buildEnv lib makeWrapper writeText
+    inherit bin combinePkgs buildEnv lib makeWrapper writeText runCommand
       stdenv python3 ruby perl gnused gnugrep coreutils libfaketime makeFontsConf;
     ghostscript = ghostscript_headless;
   };
@@ -39,9 +39,8 @@ let
     overridden = orig // {
       # overrides of texlive.tlpdb
 
-      texlive-msg-translations = orig.texlive-msg-translations // {
-        hasRunfiles = false; # only *.po for tlmgr
-      };
+      # only *.po for tlmgr
+      texlive-msg-translations = builtins.removeAttrs orig.texlive-msg-translations [ "hasTlpkg" ];
 
       xdvi = orig.xdvi // { # it seems to need it to transform fonts
         deps = (orig.xdvi.deps or []) ++  [ "metafont" ];
@@ -82,8 +81,6 @@ let
     }; # overrides
 
     in lib.mapAttrs mkTLPkg overridden;
-    # TODO: texlive.infra for web2c config?
-
 
   # create a TeX package: an attribute set { pkgs = [ ... ]; ... } where pkgs is a list of derivations
   mkTLPkg = pname: attrs:
@@ -91,12 +88,12 @@ let
       version = attrs.version or (toString attrs.revision);
       mkPkgV = tlType: let
         pkg = attrs // {
-          sha512 = attrs.sha512.${tlType};
+          sha512 = attrs.sha512.${if tlType == "tlpkg" then "run" else tlType};
           inherit pname tlType version;
         };
         in mkPkg pkg;
     in {
-      # TL pkg contains lists of packages: runtime files, docs, sources, binaries
+      # TL pkg contains lists of packages: runtime files, docs, sources, tlpkg, binaries
       pkgs =
         # tarball of a collection/scheme itself only contains a tlobj file
         [( if (attrs.hasRunfiles or false) then mkPkgV "run"
@@ -111,6 +108,7 @@ let
         )]
         ++ lib.optional (attrs.sha512 ? doc) (mkPkgV "doc")
         ++ lib.optional (attrs.sha512 ? source) (mkPkgV "source")
+        ++ lib.optional (attrs.hasTlpkg or false) (mkPkgV "tlpkg")
         ++ lib.optional (bin ? ${pname})
             ( bin.${pname} // { tlType = "bin"; } );
     };
@@ -161,8 +159,8 @@ let
   mkPkg = { pname, tlType, revision, version, sha512, postUnpack ? "", stripPrefix ? 1, ... }@args:
     let
       # the basename used by upstream (without ".tar.xz" suffix)
-      urlName = pname + lib.optionalString (tlType != "run") ".${tlType}";
-      tlName = urlName + "-${version}";
+      urlName = pname + lib.optionalString (tlType != "run" && tlType != "tlpkg") ".${tlType}";
+      tlName = urlName + lib.optionalString (tlType == "tlpkg") ".tlpkg" + "-${version}";
       fixedHash = fixedHashes.${tlName} or null; # be graceful about missing hashes
 
       urls = args.urls or (if args ? url then [ args.url ] else
@@ -171,7 +169,7 @@ let
     in runCommand "texlive-${tlName}"
       ( {
           src = fetchurl { inherit urls sha512; };
-          inherit stripPrefix;
+          inherit stripPrefix tlType;
           # metadata for texlive.combine
           passthru = {
             inherit pname tlType version;
@@ -189,9 +187,16 @@ let
       )
       ( ''
           mkdir "$out"
-          tar -xf "$src" \
-          --strip-components="$stripPrefix" \
-          -C "$out" --anchored --exclude=tlpkg --keep-old-files
+          if [[ "$tlType"  == "tlpkg" ]]; then
+            tar -xf "$src" \
+              --strip-components=1 \
+              -C "$out" --anchored --exclude=tlpkg/tlpobj --exclude=tlpkg/installer --exclude=tlpkg/gpg --keep-old-files \
+              tlpkg
+          else
+            tar -xf "$src" \
+              --strip-components="$stripPrefix" \
+              -C "$out" --anchored --exclude=tlpkg --keep-old-files
+          fi
         '' + postUnpack
       );
 

--- a/pkgs/tools/typesetting/tex/texlive/fixedHashes.nix
+++ b/pkgs/tools/typesetting/tex/texlive/fixedHashes.nix
@@ -1,4 +1,7 @@
 {
+"texlive.infra-63645"="127ff11k8hamywgvvb4apbg1ra64ig7sghg0qqn8c913mqgxf844";
+"texlive.infra.doc-63645"="1c9xqbbbn2h7v76kp7bhjwk1g3zzykgdrkrslrzrrhs9x7laicl4";
+"texlive.infra.tlpkg-63645"="135cgamyq6dnffa7r8xvyr8krx65gqdgy88v3wwprqwz4dfhvzpi";
 "amsfonts-3.04"="0l3ypclhv5qdpcpy29xwda2m3cjfn5l996agas6yhpdr2m58q211";
 "amsfonts.doc-3.04"="1v7chx5rvvqmcf7j35qi55wxwxkbfkbv34b15yrgn6bflniziicm";
 "amsfonts.source-3.04"="064gndy9lnmsq2srw5hh97sbdk8gk0qv9zzki00ms3c6rzhd9sjl";
@@ -12,6 +15,7 @@
 "colorprofiles.doc-20181105"="152vrbm5km4ymj5h41x8cjyypj06g4xq3vyvmgakai9qz270dvyz";
 "dvipdfmx-61101"="0i83g2476bp3zfgdvg11kmls969ip36z1d4w592946547ar2akmv";
 "dvipdfmx.doc-61101"="04zmlbpiclcd6bsxzq2xcssrbnla9wxvw4fx4p52lkija91qv848";
+"dvipdfmx.tlpkg-61101"="1b9wcx70n7dip0yhp7sh3j4g0rkwg03w6hr2mav07219kp0bw75k";
 "glyphlist-54074"="12nmmyh77vr2622lzi11nm1z1k2bxs7jz018yl4rwjlpg0sxg1ja";
 "dvips-62387"="0k89qqz9zx5zh13azpjndfzszgl85hq4513kaayf4k3spy9fn5yw";
 "dvips.doc-62387"="0cf5rdlg25lvyk7vzhyxnwfbgb5ngm8z4kzvj2y0hhq9jz9szpyj";
@@ -65,8 +69,10 @@
 "texlive-en.doc-65770"="05i4ggfi558frkjhxrrkjzd3x8ff1zm2qk056a23v736a5hg9y2m";
 "texlive-scripts-66570"="0hl1vjr4hr7q7s2pvizicmabb185df5rl84cjsz0ki7vai5mh7pq";
 "texlive-scripts.doc-66570"="0zvji7w8zvykmy97yim0yx0m05pazg0f60bbls0lb3mnx7rx8imj";
+"texlive-scripts.tlpkg-66570"="0sjjj9z1dhilhpc8pq4154czrb79z9cm044jvn75kxcjv6v5l2m5";
 "tlshell-62795"="06zjawsk91jknic542k9gw74pdfb1lv2iil09rpv9fw2i58lxsg9";
 "tlshell.doc-62795"="1h5mk09sakbmgsppl9fnry28xnzqya3bmp3r1nkzg44cv7kl98vz";
+"tlshell.tlpkg-62795"="0zvpmmf9dnjz64adb4dn615qyd1d09hqj2kvm898009697r20lh7";
 "aaai-named-52470"="1xs2iki0v1mh0kbqjxnv9r24bcfmgj6myfw7h368h8g0s1n8d5v6";
 "aichej-15878"="1pr92pq3yjsrbax6ah01cqg7131fp2rkqqjnxwcrm4119z2ic0gf";
 "ajl-34016"="1xkrvy06lw4ngj94zybs14ysal2pg7g71h864gq9bjw0zwq2yjzs";
@@ -847,6 +853,7 @@
 "stmaryrd.source-22027"="1wmn7bwahn28lwipkpsla74wn3a018808rmh7yvxdkbxfbzcwqcz";
 "xetex-62387"="09124rd2k40dihk4c1pidkd44rvhv1b0ain1bfk5ry1032ky7wly";
 "xetex.doc-62387"="1zj2mwi7rlibadwy42f1jkgzni6wvz01rwd5d7w48x00sjxhckxj";
+"xetex.tlpkg-62387"="01xia61wywddd2aa8xv703z1fb6sz4n13gvpbk7kync4dmki8v48";
 "xetexconfig-45845"="1253njshiwdayzq0xir9cmbi8syhjb3sc4pyrw9p6kzyqvckkcxm";
 "context-account-47085"="1j1rvgcznn8c637dayxpdagpwjq6fbn52sjmrb0wn4gd4b4q3nk8";
 "context-account.doc-47085"="0lfx6aa235jx7sz27qh0328n68ra3z2bw3dsh5p2wzkg1wxbaa6g";
@@ -2888,6 +2895,7 @@
 "gentombow.doc-64333"="0vqfamrsy4r1wqly1196cq2w69wydzzw09y3jg5llvyh95a6dp0i";
 "haranoaji-20230223"="1vfk6bh62pkmf961qlj1f0gv4yggp6sadjr141h8905wf5980m46";
 "haranoaji.doc-20230223"="1phy7r81z2wykymzsscvgk0211w1lwjjn946mpzdw97vskx1v2f3";
+"haranoaji.tlpkg-20230223"="0l9jczs7kyml3i79idyzxsmla443zaxl5fm2k7dmg5qpc30kzmaw";
 "haranoaji-extra-20230223"="0j34fizmxvalvw4vssx9fm8ik2lg0nhv1saq9xbrd1pymjkavnv8";
 "haranoaji-extra.doc-20230223"="0izf929g5fwzgyb9piagjjjn87rq4dj6qy3j873q4cflqd9avdns";
 "ieejtran-0.19"="07y254kl5wanv7d2jyzhwlf5z6n542217f5n7gdyrm4jryzhb0ly";
@@ -2935,9 +2943,11 @@
 "ptex-fontmaps-20210625.0"="0f6cijbr26jjnba7g5ffyh8pb0aihdfv094yyxhrp2wlf93ca4jg";
 "ptex-fontmaps.doc-20210625.0"="00lx6cv5sb039k3wzjsq92q9x6a2q6l96khmj6rc0l06xva4j6am";
 "ptex-fontmaps.source-20210625.0"="046jbs402n7g7dyd1akqwx382rkn9m7cs6qr6nz1cpd7c56kfb9n";
+"ptex-fontmaps.tlpkg-20210625.0"="0znid3c8bpw7acfi4hj14gabs44ywfmcz88x8vya1vzs9mzsiqbj";
 "ptex-manual.doc-62915"="0zwmig2h7ma853lqnl845mxw6512x663y16q9vdd93ci5k94dlf1";
 "ptex2pdf-20200520.0"="0s4b60gc0wg4wgxczzr2h1xlic0rk23a9wvfy76vysqzlsfmh0xl";
 "ptex2pdf.doc-20200520.0"="0ky2zh6a5d6w2aq8k9wg7p3cvp8l4wihfjlz3sir3ggj1rx2x6j4";
+"ptex2pdf.tlpkg-20200520.0"="0413ifnbmmp6awmpbfa6vm31lfqzxhli49dfd5gnw8r8ny5k1jhy";
 "pxbase-1.4"="0nlnlzpbd2dd397lxxg97pgaagfyb00ygrd6dz0v3gkmpwllnkvf";
 "pxbase.doc-1.4"="1kjkqsbrsiwzz6szjm2irz6ijy9q5xnjimdhhv52xk0j46hyiphf";
 "pxchfon-1.9a"="1g1xxx5imyhpblbvwpb86fw3as6mfcxq7ay2vjjn8ydixmx30pnz";

--- a/pkgs/tools/typesetting/tex/texlive/tl2nix.sed
+++ b/pkgs/tools/typesetting/tex/texlive/tl2nix.sed
@@ -66,6 +66,9 @@ $a}
     s/^.*\n//          # remove saved lines, resume processing
   }
 
+  # extract postaction scripts (right now, at most one per package, so a string suffices)
+  s/^postaction script file=(.*)$/  postactionScript = "\1";/p
+
   # extract hyphenation patterns and formats
   # (this may create duplicate lines, use uniq to remove them)
   /^execute\sAddHyphen/i\  hasHyphens = true;

--- a/pkgs/tools/typesetting/tex/texlive/tl2nix.sed
+++ b/pkgs/tools/typesetting/tex/texlive/tl2nix.sed
@@ -15,10 +15,10 @@ $a}
 
 # form an attrmap per package
 # ignore packages whose name contains "." (such as binaries)
-/^name ([^.]+)$/,/^$/{
+:next-package
+/^name ([^.]+|texlive\.infra)$/,/^$/{
   # quote package names, as some start with a number :-/
   s/^name (.*)$/"\1" = {/p
-  /^$/,1i};
 
   # extract revision
   s/^revision ([0-9]*)$/  revision = \1;/p
@@ -27,7 +27,6 @@ $a}
   s/^containerchecksum (.*)/  sha512.run = "\1";/p
   s/^doccontainerchecksum (.*)/  sha512.doc = "\1";/p
   s/^srccontainerchecksum (.*)/  sha512.source = "\1";/p
-  /^runfiles /i\  hasRunfiles = true;
 
   # number of path components to strip, defaulting to 1 ("texmf-dist/")
   /^relocated 1/i\  stripPrefix = 0;
@@ -44,16 +43,37 @@ $a}
     # loop through following depend lines
     :next
       h ; N     # save & read next line
-      s/\ndepend (.+)\.(.+)$//
-      s/\ndepend (.+)$/\n    "\1"/
+      s/\ndepend ([^.]+|texlive\.infra)$/\n    "\1"/
+      s/\ndepend (.+)$//
       t next    # loop if the previous lines matched
 
     x; s/$/\n  ];/p ; x     # print saved deps
     s/^.*\n//   # remove deps, resume processing
   }
 
+  # detect presence of notable files
+  /^runfiles /{
+    s/^runfiles .*$//  # ignore the first line
+    :next-file
+      h ; N            # save to hold space & read next line
+      s!\n (.+)$! \1!  # save file name
+      t next-file      # loop if the previous lines matched
+
+    x                  # work on saved lines in hold space
+    / (RELOC|texmf-dist)\//i\  hasRunfiles = true;
+    / tlpkg\//i\  hasTlpkg = true;
+    x                  # restore pattern space
+    s/^.*\n//          # remove saved lines, resume processing
+  }
+
   # extract hyphenation patterns and formats
   # (this may create duplicate lines, use uniq to remove them)
   /^execute\sAddHyphen/i\  hasHyphens = true;
   /^execute\sAddFormat/i\  hasFormats = true;
+
+  # close attrmap
+  /^$/{
+    i};
+    b next-package
+  }
 }

--- a/pkgs/tools/typesetting/tex/texlive/tlpdb.nix
+++ b/pkgs/tools/typesetting/tex/texlive/tlpdb.nix
@@ -13966,6 +13966,7 @@
   deps = [
     "glyphlist"
   ];
+  postactionScript = "tlpkg/tlpostcode/dvipdfmx.pl";
   sha512.run = "6dd78f4b5cabb51c3bd9988fa46bf90a5a79b3d3293257a4c563a8a76a5a03eb167ce3ec0d4ce6ed05412a551eb201f2379a50a97ac5355ebe833f7b34cee4b4";
   sha512.doc = "00dce9b36eefd1788bbe455b2e5104efd9afc8bd891aeafb2cd9bdee406eeb25ab520e42e614e9d2363eb6a7273232bc3c4805bacd82a22099c5ffc438e852cb";
   hasRunfiles = true;
@@ -18806,6 +18807,7 @@
 };
 "haranoaji" = {
   revision = 66119;
+  postactionScript = "tlpkg/tlpostcode/haranoaji-tlpost.pl";
   sha512.run = "96100a78ab4292a4dc656fb70e2973f75ece3964f3a0d85d9f9153b7052ea90c14f074b195d31e46465dc52ea0516541a16981239abf552861dbca16fac3ab1d";
   sha512.doc = "bb4161c95b760c9c103f086c134d7f7528dafd92f82623dd95322ea644b86c35e2baef05170c3c67a7f1c4905dc8a5fd40108db1c65074b558eec69f0e3c6910";
   hasRunfiles = true;
@@ -31282,6 +31284,7 @@
 };
 "ptex-fontmaps" = {
   revision = 59711;
+  postactionScript = "tlpkg/tlpostcode/ptex-fontmaps-tlpost.pl";
   sha512.run = "16afa97812d830b2b98f657f67ef690da420afe63ccf6f002131101f3ce9a03ff6e5170db1b316e9db521e4cdf89c7aedf26c57be162bf1c5b48fa4226e5e029";
   sha512.doc = "affd6dde30276fa680a0d99d0a51650ee95260535dff717801d61ccb8165c5526047e46ad6478367a439e9a84721500128062b8cb6a1f33a25a65fadae4547f1";
   sha512.source = "eb450119b3897f9e8374d29a3a9512819a05263d5829c81d56dc00dd35995133d1a3cfcadc59ce2aea52ac8b5bc195d27446f159356e63b433e235d1098e93b5";
@@ -31304,6 +31307,7 @@
 };
 "ptex2pdf" = {
   revision = 64072;
+  postactionScript = "tlpkg/tlpostcode/ptex2pdf-tlpost.pl";
   sha512.run = "1893a49eb389914d7a9247dece7f67d9d6af05efca77801130726d6422b1a0150b56f29d3f133f433d70989f6ffcc2b44d209cd044c84ee0833c2f77b87f3e46";
   sha512.doc = "f193b44004b487d93f025b34b72a17cbaf4111b1a6e1ceb4ac1b69c6c07aa4dce46cde510cbd01fb71fb08c06f7bbb415a4a8051de5861f1f586b756060f386f";
   hasRunfiles = true;
@@ -39929,6 +39933,7 @@
     "xetexconfig"
   ];
   hasFormats = true;
+  postactionScript = "tlpkg/tlpostcode/xetex.pl";
   sha512.run = "e9f0aebda0a7fb36e2cbce4dd49e965335438c4ebf2d41eb8e19eabe29617239dd67e7e3433a8c75fd40f072a2c6753a7d0762afd34fca4130929e51888aaabf";
   sha512.doc = "31f03ee1ae00bc7883109ab7b7374feedc384d86b491873e90797658eae12299dd60b95edc1c86f1faa61a0b7a952cca23993e991863b37e49c27afd6c21c034";
   hasRunfiles = true;

--- a/pkgs/tools/typesetting/tex/texlive/tlpdb.nix
+++ b/pkgs/tools/typesetting/tex/texlive/tlpdb.nix
@@ -6349,6 +6349,7 @@
     "texlive-en"
     "texlive-msg-translations"
     "texlive-scripts"
+    "texlive.infra"
     "tlshell"
     "unicode-data"
     "xdvi"
@@ -13968,6 +13969,7 @@
   sha512.run = "6dd78f4b5cabb51c3bd9988fa46bf90a5a79b3d3293257a4c563a8a76a5a03eb167ce3ec0d4ce6ed05412a551eb201f2379a50a97ac5355ebe833f7b34cee4b4";
   sha512.doc = "00dce9b36eefd1788bbe455b2e5104efd9afc8bd891aeafb2cd9bdee406eeb25ab520e42e614e9d2363eb6a7273232bc3c4805bacd82a22099c5ffc438e852cb";
   hasRunfiles = true;
+  hasTlpkg = true;
 };
 "dvipng" = {
   revision = 62517;
@@ -18807,6 +18809,7 @@
   sha512.run = "96100a78ab4292a4dc656fb70e2973f75ece3964f3a0d85d9f9153b7052ea90c14f074b195d31e46465dc52ea0516541a16981239abf552861dbca16fac3ab1d";
   sha512.doc = "bb4161c95b760c9c103f086c134d7f7528dafd92f82623dd95322ea644b86c35e2baef05170c3c67a7f1c4905dc8a5fd40108db1c65074b558eec69f0e3c6910";
   hasRunfiles = true;
+  hasTlpkg = true;
   version = "20230223";
 };
 "haranoaji-extra" = {
@@ -31283,6 +31286,7 @@
   sha512.doc = "affd6dde30276fa680a0d99d0a51650ee95260535dff717801d61ccb8165c5526047e46ad6478367a439e9a84721500128062b8cb6a1f33a25a65fadae4547f1";
   sha512.source = "eb450119b3897f9e8374d29a3a9512819a05263d5829c81d56dc00dd35995133d1a3cfcadc59ce2aea52ac8b5bc195d27446f159356e63b433e235d1098e93b5";
   hasRunfiles = true;
+  hasTlpkg = true;
   version = "20210625.0";
 };
 "ptex-fonts" = {
@@ -31303,6 +31307,7 @@
   sha512.run = "1893a49eb389914d7a9247dece7f67d9d6af05efca77801130726d6422b1a0150b56f29d3f133f433d70989f6ffcc2b44d209cd044c84ee0833c2f77b87f3e46";
   sha512.doc = "f193b44004b487d93f025b34b72a17cbaf4111b1a6e1ceb4ac1b69c6c07aa4dce46cde510cbd01fb71fb08c06f7bbb415a4a8051de5861f1f586b756060f386f";
   hasRunfiles = true;
+  hasTlpkg = true;
   version = "20200520.0";
 };
 "ptext" = {
@@ -32946,6 +32951,7 @@
     "hyphen-base"
     "kpathsea"
     "texlive-scripts"
+    "texlive.infra"
   ];
   sha512.run = "f3e449bf0b34deb9ae776685f386245c4ca9644f2175ae51e9c62faa00e3cfac30fa2aa07fbd83b15b21d487ca368c09a18742d2434047783350698ced3b20b9";
 };
@@ -36160,7 +36166,7 @@
 "texlive-msg-translations" = {
   revision = 65889;
   sha512.run = "03c0445d0cb0bb3722a691fd94b93c7fe9d046dbf5945ecadcce17a2333878ffc542f0b7f263ae09bd0537a68c1a59d6c04b873ce8cdc6c8b57f7ded5b6681f9";
-  hasRunfiles = true;
+  hasTlpkg = true;
 };
 "texlive-pl" = {
   revision = 62841;
@@ -36179,6 +36185,7 @@
   sha512.run = "3dbb2007ae7b80862265d6196f77a9d796f02f6914871f4dad094f8419040fe7064daf6ecf5dd611b5764dd4148d034a97d82aa22671199e8a3dc79373859c67";
   sha512.doc = "6976ba00c8ee50664aaa1f762231f297f01548a94d6a632b386845e7fa43b20b63342d58874e87869a73a9c23bba358f762f5cc3814690f870c6216679471a89";
   hasRunfiles = true;
+  hasTlpkg = true;
 };
 "texlive-scripts-extra" = {
   revision = 62517;
@@ -36197,6 +36204,13 @@
   stripPrefix = 0;
   sha512.run = "1a7e43528c2dac5c623943b1b268b99f0db6a4876f50c5386a8ea160b8b5e066604d34c0a53cee25cc3f839eb7f4be177e3d98ed51c83c77df6293c77a02e0ab";
   sha512.doc = "534c505455c5f9c73803c140a340df2882a97516e15f52c5b65695b7c626404336a0e4f6190155b5bda1b9a86d7f4d44ac294bccec791ec6701e56d13c00d71d";
+};
+"texlive.infra" = {
+  revision = 63645;
+  sha512.run = "cbc7e70f3b4d451a51f06ed640b37ce28b8ea32f0dad75b32e54856e1051934d32125f2428b074a69503fb24c943c5eded58d77168d606891ea8209bbf852c65";
+  sha512.doc = "37f37bfd17988a8897312581efcf05aff76af6fd2c30867c65e0a4445ddc1f7fb90bb86984999d5fc942159bccf5c2a188e5b552702405405c902c97ae4828ff";
+  hasRunfiles = true;
+  hasTlpkg = true;
 };
 "texliveonfly" = {
   revision = 55777;
@@ -37393,6 +37407,7 @@
   sha512.run = "285fffbc63ac1b87b1ad143d043ace7ed1f52f48c4e03a9fc78c9ff6adeb2062af0ce9b5245b77349528ca18c0fe6ee8ad44b794adb24ae62f00e4a18501d7c7";
   sha512.doc = "73962fa94f7ca3a78b6149a44b72c39096fb54263660ccb6c0bcc024023dfef665c5132b9cb78953c92ec8b7d161581294e32b0ab26c9e0e2e9eadc16aa9ff72";
   hasRunfiles = true;
+  hasTlpkg = true;
 };
 "to-be-determined" = {
   revision = 64882;
@@ -39917,6 +39932,7 @@
   sha512.run = "e9f0aebda0a7fb36e2cbce4dd49e965335438c4ebf2d41eb8e19eabe29617239dd67e7e3433a8c75fd40f072a2c6753a7d0762afd34fca4130929e51888aaabf";
   sha512.doc = "31f03ee1ae00bc7883109ab7b7374feedc384d86b491873e90797658eae12299dd60b95edc1c86f1faa61a0b7a952cca23993e991863b37e49c27afd6c21c034";
   hasRunfiles = true;
+  hasTlpkg = true;
 };
 "xetex-devanagari" = {
   revision = 34296;


### PR DESCRIPTION
###### Description of changes
Bring `texlive` closer to a native install by exposing the content of the `tlpkg/` folder of some (just 8) packages, including `texlive.infra` that was previously absent, and by running the `postaction` scripts which the TeX Live installer would normally do.

We do not need to set `PERL5LIB` anymore, nor we need `${bin.core}/share/texmf-dist` (to the point that we could delete it altogether).

Edit: updated description.

###### Things done
- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [X] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [X] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).