### PR TITLE
Arianna

### DIFF
--- a/pkgs/applications/misc/arianna/default.nix
+++ b/pkgs/applications/misc/arianna/default.nix
@@ -1,0 +1,59 @@
+{ lib
+, mkDerivation
+, fetchFromGitLab
+, cmake
+, extra-cmake-modules
+, pkg-config
+, baloo
+, kfilemetadata
+, kirigami2
+, kirigami-addons
+, kquickcharts
+, plasma-framework
+, qqc2-desktop-style
+, qtbase
+, qtquickcontrols2
+, qtwebsockets
+, qtwebengine
+}:
+
+mkDerivation rec {
+  pname = "arianna";
+  version = "1.0.0";
+
+  src = fetchFromGitLab {
+    domain = "invent.kde.org";
+    owner = "graphics";
+    repo = "arianna";
+    rev = "v${version}";
+    hash = "sha256-X3PDGWsQ8Alj5fisZC1tTHQDLPmjtiLw0X9gMvh5KFI=";
+  };
+
+  nativeBuildInputs = [
+    cmake
+    extra-cmake-modules
+    pkg-config
+  ];
+
+  buildInputs = [
+    baloo
+    kfilemetadata
+    kirigami2
+    kirigami-addons
+    kquickcharts
+    plasma-framework
+    qqc2-desktop-style
+    qtbase
+    qtquickcontrols2
+    qtwebsockets
+    qtwebengine
+  ];
+
+  meta = with lib; {
+    description = "An Epub Reader for Plasma and Plasma Mobile";
+    homepage = "https://invent.kde.org/graphics/arianna";
+    license = licenses.gpl3Plus;
+    platforms = platforms.unix;
+    maintainers = with maintainers; [ Thra11 ];
+  };
+}

--- a/pkgs/development/libraries/kirigami-addons/default.nix
+++ b/pkgs/development/libraries/kirigami-addons/default.nix
@@ -12,14 +12,14 @@
 
 mkDerivation rec {
   pname = "kirigami-addons";
-  version = "0.7.2";
+  version = "0.8.0";
 
   src = fetchFromGitLab {
     domain = "invent.kde.org";
     owner = "libraries";
     repo = pname;
     rev = "v${version}";
-    sha256 = "sha256-2s9ShwYd2hOb18WRA2nLst6Q4UBHvFL+g7Grpjclz9I=";
+    hash = "sha256-ObbpM1gVVFhOIHOla5YS8YYe+JoPgdZ8kJ356wLTJq4=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -28916,6 +28916,8 @@ with pkgs;
 
   argo-rollouts = callPackage ../applications/networking/cluster/argo-rollouts { };
 
+  arianna = libsForQt5.callPackage ../applications/misc/arianna { };
+
   ario = callPackage ../applications/audio/ario { };
 
   arion = callPackage ../applications/virtualization/arion { };


### PR DESCRIPTION
###### Description of changes

Package a new plasma / plasma mobile epub reader application, Arianna. Requries kirigami-addons 0.8.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
