### PR TITLE
wrapGAppsHook: don't add superfluous inputs

### DIFF
--- a/doc/languages-frameworks/gnome.section.md
+++ b/doc/languages-frameworks/gnome.section.md
@@ -100,7 +100,7 @@ preFixup = ''
 
 Fortunately, there is [`wrapGAppsHook`]{#ssec-gnome-hooks-wrapgappshook}. It works in conjunction with other setup hooks that populate environment variables, and it will then wrap all executables in `bin` and `libexec` directories using said variables.
 
-For convenience, it also adds `dconf.lib` for a GIO module implementing a GSettings backend using `dconf`, `gtk3` for GSettings schemas, and `librsvg` for GdkPixbuf loader to the closure. There is also [`wrapGAppsHook4`]{#ssec-gnome-hooks-wrapgappshook4}, which replaces GTK 3 with GTK 4. And in case you are packaging a program without a graphical interface, you might want to use [`wrapGAppsNoGuiHook`]{#ssec-gnome-hooks-wrapgappsnoguihook}, which runs the same script as `wrapGAppsHook` but does not bring `gtk3` and `librsvg` into the closure.
+For convenience, it also adds `dconf.lib` for a GIO module implementing a GSettings backend using `dconf`, `gtk3` for GSettings schemas, and `librsvg` for GdkPixbuf loader to the closure. In case you are packaging a program without a graphical interface, you might want to use [`wrapGAppsNoGuiHook`]{#ssec-gnome-hooks-wrapgappsnoguihook}, which runs the same script as `wrapGAppsHook` but does not bring and `librsvg` into the closure.
 
 - `wrapGAppsHook` itself will add the package’s `share` directory to `XDG_DATA_DIRS`.
 

--- a/pkgs/applications/accessibility/contrast/default.nix
+++ b/pkgs/applications/accessibility/contrast/default.nix
@@ -12,7 +12,7 @@
 , pango
 , pkg-config
 , rustPlatform
-, wrapGAppsHook4
+, wrapGAppsHook
 }:
 
 stdenv.mkDerivation rec {
@@ -43,7 +43,7 @@ stdenv.mkDerivation rec {
     rustPlatform.rust.cargo
     rustPlatform.cargoSetupHook
     rustPlatform.rust.rustc
-    wrapGAppsHook4
+    wrapGAppsHook
   ];
 
   buildInputs = [

--- a/pkgs/applications/audio/alsa-scarlett-gui/default.nix
+++ b/pkgs/applications/audio/alsa-scarlett-gui/default.nix
@@ -4,7 +4,7 @@
 , pkg-config
 , alsa-lib
 , gtk4
-, wrapGAppsHook4
+, wrapGAppsHook
 }:
 
 stdenv.mkDerivation rec {
@@ -22,7 +22,7 @@ stdenv.mkDerivation rec {
 
   makeFlags = [ "DESTDIR=\${out}" "PREFIX=''" ];
   sourceRoot = "source/src";
-  nativeBuildInputs = [ pkg-config wrapGAppsHook4 ];
+  nativeBuildInputs = [ pkg-config wrapGAppsHook ];
   buildInputs = [ gtk4 alsa-lib ];
 
   meta = with lib; {

--- a/pkgs/applications/audio/amberol/default.nix
+++ b/pkgs/applications/audio/amberol/default.nix
@@ -9,7 +9,7 @@
 , pkg-config
 , reuse
 , m4
-, wrapGAppsHook4
+, wrapGAppsHook
 , glib
 , gtk4
 , gst_all_1
@@ -47,7 +47,7 @@ stdenv.mkDerivation rec {
     pkg-config
     reuse
     m4
-    wrapGAppsHook4
+    wrapGAppsHook
   ] ++ (with rustPlatform; [
     cargoSetupHook
     rust.cargo

--- a/pkgs/applications/audio/blanket/default.nix
+++ b/pkgs/applications/audio/blanket/default.nix
@@ -3,7 +3,7 @@
 , meson
 , ninja
 , pkg-config
-, wrapGAppsHook4
+, wrapGAppsHook
 , desktop-file-utils
 , appstream-glib
 , python3Packages
@@ -29,7 +29,7 @@ python3Packages.buildPythonApplication rec {
     meson
     ninja
     pkg-config
-    wrapGAppsHook4
+    wrapGAppsHook
     desktop-file-utils
     gobject-introspection
   ];

--- a/pkgs/applications/audio/cavalier/default.nix
+++ b/pkgs/applications/audio/cavalier/default.nix
@@ -9,7 +9,7 @@
 , gtk4
 , librsvg
 , libadwaita
-, wrapGAppsHook4
+, wrapGAppsHook
 , appstream-glib
 , desktop-file-utils
 , cava
@@ -32,7 +32,7 @@ python3.pkgs.buildPythonApplication rec {
     ninja
     pkg-config
     gobject-introspection
-    wrapGAppsHook4
+    wrapGAppsHook
     appstream-glib
     desktop-file-utils
   ];

--- a/pkgs/applications/audio/eartag/default.nix
+++ b/pkgs/applications/audio/eartag/default.nix
@@ -4,7 +4,7 @@
 , meson
 , ninja
 , pkg-config
-, wrapGAppsHook4
+, wrapGAppsHook
 , libadwaita
 , gettext
 , glib
@@ -45,7 +45,7 @@ python3Packages.buildPythonApplication rec {
     pkg-config
     gettext
     gobject-introspection
-    wrapGAppsHook4
+    wrapGAppsHook
   ] ++ lib.optional stdenv.isDarwin gtk4; # for gtk4-update-icon-cache
 
   buildInputs = [

--- a/pkgs/applications/audio/easyeffects/default.nix
+++ b/pkgs/applications/audio/easyeffects/default.nix
@@ -30,7 +30,7 @@
 , speex
 , speexdsp
 , tbb
-, wrapGAppsHook4
+, wrapGAppsHook
 , zam-plugins
 , zita-convolver
 }:
@@ -52,7 +52,7 @@ stdenv.mkDerivation rec {
     meson
     ninja
     pkg-config
-    wrapGAppsHook4
+    wrapGAppsHook
   ];
 
   buildInputs = [

--- a/pkgs/applications/audio/gtkcord4/default.nix
+++ b/pkgs/applications/audio/gtkcord4/default.nix
@@ -14,7 +14,7 @@
 , pkg-config
 , sound-theme-freedesktop
 , withLibadwaita ? false
-, wrapGAppsHook4
+, wrapGAppsHook
 }:
 
 buildGoModule rec {
@@ -31,7 +31,7 @@ buildGoModule rec {
   nativeBuildInputs = [
     gobject-introspection
     pkg-config
-    wrapGAppsHook4
+    wrapGAppsHook
   ];
 
   buildInputs = [

--- a/pkgs/applications/audio/mousai/default.nix
+++ b/pkgs/applications/audio/mousai/default.nix
@@ -16,7 +16,7 @@
 , ninja
 , pkg-config
 , rustPlatform
-, wrapGAppsHook4
+, wrapGAppsHook
 }:
 
 stdenv.mkDerivation rec {
@@ -42,7 +42,7 @@ stdenv.mkDerivation rec {
     meson
     ninja
     pkg-config
-    wrapGAppsHook4
+    wrapGAppsHook
   ] ++ (with rustPlatform; [
     cargoSetupHook
     rust.cargo

--- a/pkgs/applications/audio/netease-cloud-music-gtk/default.nix
+++ b/pkgs/applications/audio/netease-cloud-music-gtk/default.nix
@@ -10,7 +10,7 @@
 , appstream-glib
 , desktop-file-utils
 , libxml2
-, wrapGAppsHook4
+, wrapGAppsHook
 , openssl
 , dbus
 , libadwaita
@@ -46,7 +46,7 @@ stdenv.mkDerivation rec {
     appstream-glib # appstream-util
     desktop-file-utils # update-desktop-database
     libxml2 # xmllint
-    wrapGAppsHook4
+    wrapGAppsHook
   ] ++ (with rustPlatform; [
     cargoSetupHook
     rust.cargo

--- a/pkgs/applications/audio/shortwave/default.nix
+++ b/pkgs/applications/audio/shortwave/default.nix
@@ -16,7 +16,7 @@
 , pkg-config
 , rustPlatform
 , sqlite
-, wrapGAppsHook4
+, wrapGAppsHook
 , cmake
 , libshumate
 }:
@@ -50,7 +50,7 @@ stdenv.mkDerivation rec {
     rustPlatform.rust.cargo
     rustPlatform.cargoSetupHook
     rustPlatform.rust.rustc
-    wrapGAppsHook4
+    wrapGAppsHook
     cmake
   ];
 

--- a/pkgs/applications/audio/spot/default.nix
+++ b/pkgs/applications/audio/spot/default.nix
@@ -16,7 +16,7 @@
 , openssl
 , alsa-lib
 , libpulseaudio
-, wrapGAppsHook4
+, wrapGAppsHook
 }:
 
 stdenv.mkDerivation rec {
@@ -48,7 +48,7 @@ stdenv.mkDerivation rec {
     rustPlatform.rust.cargo
     rustPlatform.cargoSetupHook
     rustPlatform.rust.rustc
-    wrapGAppsHook4
+    wrapGAppsHook
   ];
 
   buildInputs = [

--- a/pkgs/applications/audio/tagger/default.nix
+++ b/pkgs/applications/audio/tagger/default.nix
@@ -11,7 +11,7 @@
 , glib
 , gtk4
 , libadwaita
-, wrapGAppsHook4
+, wrapGAppsHook
 , desktop-file-utils
 , chromaprint # fpcalc
 }:
@@ -31,7 +31,7 @@ stdenv.mkDerivation rec {
     meson
     ninja
     pkg-config
-    wrapGAppsHook4
+    wrapGAppsHook
     desktop-file-utils
   ];
 

--- a/pkgs/applications/backup/deja-dup/default.nix
+++ b/pkgs/applications/backup/deja-dup/default.nix
@@ -14,7 +14,7 @@
 , libsoup_3
 , libsecret
 , libadwaita
-, wrapGAppsHook4
+, wrapGAppsHook
 , libgpg-error
 , json-glib
 , duplicity
@@ -47,7 +47,7 @@ stdenv.mkDerivation rec {
     gettext
     itstool
     desktop-file-utils
-    wrapGAppsHook4
+    wrapGAppsHook
   ];
 
   buildInputs = [

--- a/pkgs/applications/backup/pika-backup/default.nix
+++ b/pkgs/applications/backup/pika-backup/default.nix
@@ -10,7 +10,7 @@
 , ninja
 , pkg-config
 , python3
-, wrapGAppsHook4
+, wrapGAppsHook
 , borgbackup
 , gtk4
 , libadwaita
@@ -54,7 +54,7 @@ stdenv.mkDerivation rec {
     ninja
     pkg-config
     python3
-    wrapGAppsHook4
+    wrapGAppsHook
   ] ++ (with rustPlatform; [
     cargoSetupHook
     rust.cargo

--- a/pkgs/applications/editors/gnome-builder/default.nix
+++ b/pkgs/applications/editors/gnome-builder/default.nix
@@ -34,7 +34,7 @@
 , vala
 , vte-gtk4
 , webkitgtk_6_0
-, wrapGAppsHook4
+, wrapGAppsHook
 , dbus
 , xvfb-run
 }:
@@ -73,7 +73,7 @@ stdenv.mkDerivation rec {
     pkg-config
     python3
     python3.pkgs.wrapPython
-    wrapGAppsHook4
+    wrapGAppsHook
   ];
 
   buildInputs = [

--- a/pkgs/applications/editors/neovim/neovim-gtk.nix
+++ b/pkgs/applications/editors/neovim/neovim-gtk.nix
@@ -1,7 +1,7 @@
 { lib
 , rustPlatform
 , fetchFromGitHub
-, wrapGAppsHook4
+, wrapGAppsHook
 , pkg-config
 , gdk-pixbuf
 , gtk4
@@ -22,7 +22,7 @@ rustPlatform.buildRustPackage rec {
 
   cargoHash = "sha256-9eZwCOP4xQtFOieqVRBAdXZrXmzdnae6PexGJ/eCyYc=";
 
-  nativeBuildInputs = [ wrapGAppsHook4 pkg-config ];
+  nativeBuildInputs = [ wrapGAppsHook pkg-config ];
 
   buildInputs = [ gdk-pixbuf gtk4 pango vte-gtk4 ];
 

--- a/pkgs/applications/finance/denaro/default.nix
+++ b/pkgs/applications/finance/denaro/default.nix
@@ -7,7 +7,7 @@
 , gtk4
 , libadwaita
 , pkg-config
-, wrapGAppsHook4
+, wrapGAppsHook
 , glib
 , shared-mime-info
 , python3
@@ -39,7 +39,7 @@ buildDotnetModule rec {
 
   nativeBuildInputs = [
     pkg-config
-    wrapGAppsHook4
+    wrapGAppsHook
     glib # For glib-compile-resources
     shared-mime-info # For update-mime-database
     python3

--- a/pkgs/applications/graphics/emblem/default.nix
+++ b/pkgs/applications/graphics/emblem/default.nix
@@ -8,7 +8,7 @@
 , meson
 , ninja
 , pkg-config
-, wrapGAppsHook4
+, wrapGAppsHook
 , gtk4
 , libadwaita
 , libxml2
@@ -42,7 +42,7 @@ stdenv.mkDerivation rec {
     meson
     ninja
     pkg-config
-    wrapGAppsHook4
+    wrapGAppsHook
   ] ++ (with rustPlatform; [
     cargoSetupHook
     rust.cargo

--- a/pkgs/applications/graphics/emulsion-palette/default.nix
+++ b/pkgs/applications/graphics/emulsion-palette/default.nix
@@ -4,7 +4,7 @@
 , meson
 , ninja
 , vala
-, wrapGAppsHook4
+, wrapGAppsHook
 , libadwaita
 , json-glib
 , libgee
@@ -24,7 +24,7 @@ stdenv.mkDerivation rec {
     sha256 = "sha256-xG7yZKbbNao/pzFhdTMof/lw9K12NKZi47YRaEd65ok=";
   };
 
-  nativeBuildInputs = [ meson ninja pkg-config vala wrapGAppsHook4 ];
+  nativeBuildInputs = [ meson ninja pkg-config vala wrapGAppsHook ];
 
   buildInputs = [
     desktop-file-utils

--- a/pkgs/applications/graphics/eyedropper/default.nix
+++ b/pkgs/applications/graphics/eyedropper/default.nix
@@ -8,7 +8,7 @@
 , glib
 , gtk4
 , libadwaita
-, wrapGAppsHook4
+, wrapGAppsHook
 , appstream-glib
 , desktop-file-utils
 }:
@@ -34,7 +34,7 @@ stdenv.mkDerivation rec {
     meson
     ninja
     pkg-config
-    wrapGAppsHook4
+    wrapGAppsHook
     appstream-glib
     desktop-file-utils
   ] ++ (with rustPlatform; [

--- a/pkgs/applications/graphics/gnome-decoder/default.nix
+++ b/pkgs/applications/graphics/gnome-decoder/default.nix
@@ -16,7 +16,7 @@
 , gstreamer
 , gst-plugins-base
 , gst-plugins-bad
-, wrapGAppsHook4
+, wrapGAppsHook
 , appstream-glib
 , desktop-file-utils
 }:
@@ -43,7 +43,7 @@ clangStdenv.mkDerivation rec {
     meson
     ninja
     pkg-config
-    wrapGAppsHook4
+    wrapGAppsHook
     appstream-glib
     desktop-file-utils
   ] ++ (with rustPlatform; [

--- a/pkgs/applications/graphics/gnome-obfuscate/default.nix
+++ b/pkgs/applications/graphics/gnome-obfuscate/default.nix
@@ -8,7 +8,7 @@
 , pkg-config
 , python3
 , rustPlatform
-, wrapGAppsHook4
+, wrapGAppsHook
 
 , appstream-glib
 , desktop-file-utils
@@ -46,7 +46,7 @@ stdenv.mkDerivation rec {
     rustPlatform.cargoSetupHook
     rustPlatform.rust.cargo
     rustPlatform.rust.rustc
-    wrapGAppsHook4
+    wrapGAppsHook
   ];
 
   buildInputs = [

--- a/pkgs/applications/graphics/icon-library/default.nix
+++ b/pkgs/applications/graphics/icon-library/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchurl, fetchpatch, wrapGAppsHook4
+{ lib, stdenv, fetchurl, fetchpatch, wrapGAppsHook
 , cargo, desktop-file-utils, meson, ninja, pkg-config, rustc
 , gdk-pixbuf, glib, gtk4, gtksourceview5, libadwaita, darwin
 }:
@@ -23,7 +23,7 @@ stdenv.mkDerivation rec {
   ];
 
   nativeBuildInputs = [
-    cargo desktop-file-utils meson ninja pkg-config rustc wrapGAppsHook4
+    cargo desktop-file-utils meson ninja pkg-config rustc wrapGAppsHook
   ];
   buildInputs = [
     gdk-pixbuf glib gtk4 gtksourceview5 libadwaita

--- a/pkgs/applications/graphics/identity/default.nix
+++ b/pkgs/applications/graphics/identity/default.nix
@@ -12,7 +12,7 @@
 , pkg-config
 , rustPlatform
 , stdenv
-, wrapGAppsHook4
+, wrapGAppsHook
 }:
 
 stdenv.mkDerivation rec {
@@ -40,7 +40,7 @@ stdenv.mkDerivation rec {
     meson
     ninja
     pkg-config
-    wrapGAppsHook4
+    wrapGAppsHook
   ] ++ (with rustPlatform; [
     cargoSetupHook
     rust.cargo

--- a/pkgs/applications/graphics/image-roll/default.nix
+++ b/pkgs/applications/graphics/image-roll/default.nix
@@ -3,7 +3,7 @@
 , fetchFromGitHub
 , glib
 , pkg-config
-, wrapGAppsHook4
+, wrapGAppsHook
 , gtk4
 }:
 
@@ -20,7 +20,7 @@ rustPlatform.buildRustPackage rec {
 
   cargoSha256 = "sha256-cUE2IZOunR/NIo/qytORRfNqCsf87LfpKA8o/v4Nkhk=";
 
-  nativeBuildInputs = [ glib pkg-config wrapGAppsHook4 ];
+  nativeBuildInputs = [ glib pkg-config wrapGAppsHook ];
 
   buildInputs = [ gtk4 ];
 

--- a/pkgs/applications/graphics/komikku/default.nix
+++ b/pkgs/applications/graphics/komikku/default.nix
@@ -13,7 +13,7 @@
 , ninja
 , pkg-config
 , python3
-, wrapGAppsHook4
+, wrapGAppsHook
 , nix-update-script
 }:
 
@@ -34,7 +34,7 @@ python3.pkgs.buildPythonApplication rec {
     meson
     ninja
     pkg-config
-    wrapGAppsHook4
+    wrapGAppsHook
     gettext
     glib # for glib-compile-resources
     desktop-file-utils

--- a/pkgs/applications/graphics/megapixels/default.nix
+++ b/pkgs/applications/graphics/megapixels/default.nix
@@ -5,7 +5,7 @@
 , meson
 , ninja
 , pkg-config
-, wrapGAppsHook4
+, wrapGAppsHook
 , feedbackd
 , gtk4
 , libepoxy
@@ -43,7 +43,7 @@ stdenv.mkDerivation rec {
     meson
     ninja
     pkg-config
-    wrapGAppsHook4
+    wrapGAppsHook
   ];
 
   buildInputs = [

--- a/pkgs/applications/graphics/paleta/default.nix
+++ b/pkgs/applications/graphics/paleta/default.nix
@@ -5,7 +5,7 @@
 , meson
 , ninja
 , pkg-config
-, wrapGAppsHook4
+, wrapGAppsHook
 , appstream-glib
 , desktop-file-utils
 , glib
@@ -34,7 +34,7 @@ stdenv.mkDerivation rec {
     meson
     ninja
     pkg-config
-    wrapGAppsHook4
+    wrapGAppsHook
     appstream-glib
     desktop-file-utils
   ] ++ (with rustPlatform; [

--- a/pkgs/applications/graphics/rnote/default.nix
+++ b/pkgs/applications/graphics/rnote/default.nix
@@ -18,7 +18,7 @@
 , python3
 , rustPlatform
 , shared-mime-info
-, wrapGAppsHook4
+, wrapGAppsHook
 , AudioUnit
 }:
 
@@ -63,7 +63,7 @@ stdenv.mkDerivation rec {
     rustPlatform.rust.cargo
     rustPlatform.rust.rustc
     shared-mime-info # For update-mime-database
-    wrapGAppsHook4
+    wrapGAppsHook
   ];
 
   dontUseCmakeConfigure = true;

--- a/pkgs/applications/graphics/symbolic-preview/default.nix
+++ b/pkgs/applications/graphics/symbolic-preview/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchurl, wrapGAppsHook4
+{ lib, stdenv, fetchurl, wrapGAppsHook
 , cargo, desktop-file-utils, meson, ninja, pkg-config, rustc
 , glib, gtk4, libadwaita, libxml2
 }:
@@ -13,7 +13,7 @@ stdenv.mkDerivation rec {
   };
 
   nativeBuildInputs = [
-    cargo desktop-file-utils meson ninja pkg-config rustc wrapGAppsHook4
+    cargo desktop-file-utils meson ninja pkg-config rustc wrapGAppsHook
   ];
   buildInputs = [ glib gtk4 libadwaita libxml2 ];
 

--- a/pkgs/applications/graphics/vipsdisp/default.nix
+++ b/pkgs/applications/graphics/vipsdisp/default.nix
@@ -4,7 +4,7 @@
 , meson
 , ninja
 , pkg-config
-, wrapGAppsHook4
+, wrapGAppsHook
 , vips
 , gtk4
 , python3
@@ -30,7 +30,7 @@ stdenv.mkDerivation rec {
     meson
     ninja
     pkg-config
-    wrapGAppsHook4
+    wrapGAppsHook
   ];
 
   buildInputs = [

--- a/pkgs/applications/misc/authenticator/default.nix
+++ b/pkgs/applications/misc/authenticator/default.nix
@@ -7,7 +7,7 @@
 , ninja
 , pkg-config
 , rustPlatform
-, wrapGAppsHook4
+, wrapGAppsHook
 , gdk-pixbuf
 , glib
 , gst_all_1
@@ -44,7 +44,7 @@ stdenv.mkDerivation rec {
     meson
     ninja
     pkg-config
-    wrapGAppsHook4
+    wrapGAppsHook
   ] ++ (with rustPlatform; [
     cargoSetupHook
     rust.cargo

--- a/pkgs/applications/misc/bottles/default.nix
+++ b/pkgs/applications/misc/bottles/default.nix
@@ -7,7 +7,7 @@
 , meson
 , ninja
 , pkg-config
-, wrapGAppsHook4
+, wrapGAppsHook
 , appstream-glib
 , desktop-file-utils
 , librsvg
@@ -54,7 +54,7 @@ python3Packages.buildPythonApplication rec {
     meson
     ninja
     pkg-config
-    wrapGAppsHook4
+    wrapGAppsHook
     gtk4 # gtk4-update-icon-cache
     appstream-glib
     desktop-file-utils

--- a/pkgs/applications/misc/citations/default.nix
+++ b/pkgs/applications/misc/citations/default.nix
@@ -14,7 +14,7 @@
 , rustPlatform
 , stdenv
 , testers
-, wrapGAppsHook4
+, wrapGAppsHook
 }:
 stdenv.mkDerivation (finalAttrs: {
   pname = "citations";
@@ -45,7 +45,7 @@ stdenv.mkDerivation (finalAttrs: {
     rustPlatform.cargoSetupHook
     rustPlatform.rust.cargo
     rustPlatform.rust.rustc
-    wrapGAppsHook4
+    wrapGAppsHook
   ];
 
   buildInputs = [

--- a/pkgs/applications/misc/dialect/default.nix
+++ b/pkgs/applications/misc/dialect/default.nix
@@ -1,6 +1,6 @@
 { lib
 , fetchFromGitHub
-, wrapGAppsHook4
+, wrapGAppsHook
 , python3
 , appstream-glib
 , blueprint-compiler
@@ -39,7 +39,7 @@ python3.pkgs.buildPythonApplication rec {
     meson
     ninja
     pkg-config
-    wrapGAppsHook4
+    wrapGAppsHook
   ];
 
   buildInputs = [

--- a/pkgs/applications/misc/elastic/default.nix
+++ b/pkgs/applications/misc/elastic/default.nix
@@ -10,7 +10,7 @@
 , libadwaita
 , gtksourceview5
 , blueprint-compiler
-, wrapGAppsHook4
+, wrapGAppsHook
 , appstream-glib
 , desktop-file-utils
 , template-glib
@@ -33,7 +33,7 @@ stdenv.mkDerivation rec {
     ninja
     vala
     pkg-config
-    wrapGAppsHook4
+    wrapGAppsHook
     appstream-glib
     desktop-file-utils
     blueprint-compiler

--- a/pkgs/applications/misc/furtherance/default.nix
+++ b/pkgs/applications/misc/furtherance/default.nix
@@ -1,5 +1,5 @@
 { lib, stdenv, fetchFromGitHub, rustPlatform, appstream-glib, desktop-file-utils
-, glib, libadwaita, meson, ninja, pkg-config, wrapGAppsHook4, dbus , gtk4, sqlite }:
+, glib, libadwaita, meson, ninja, pkg-config, wrapGAppsHook, dbus , gtk4, sqlite }:
 
 stdenv.mkDerivation rec {
   pname = "furtherance";
@@ -27,7 +27,7 @@ stdenv.mkDerivation rec {
     rustPlatform.cargoSetupHook
     rustPlatform.rust.cargo
     rustPlatform.rust.rustc
-    wrapGAppsHook4
+    wrapGAppsHook
   ];
 
   buildInputs = [

--- a/pkgs/applications/misc/gnome-extension-manager/default.nix
+++ b/pkgs/applications/misc/gnome-extension-manager/default.nix
@@ -1,7 +1,7 @@
 { stdenv
 , lib
 , fetchFromGitHub
-, wrapGAppsHook4
+, wrapGAppsHook
 , libadwaita
 , meson
 , ninja
@@ -42,7 +42,7 @@ stdenv.mkDerivation rec {
     ninja
     pkg-config
     python3
-    wrapGAppsHook4
+    wrapGAppsHook
   ];
 
   buildInputs = [

--- a/pkgs/applications/misc/gnome-firmware/default.nix
+++ b/pkgs/applications/misc/gnome-firmware/default.nix
@@ -15,7 +15,7 @@
 , pkg-config
 , systemd
 , help2man
-, wrapGAppsHook4
+, wrapGAppsHook
 }:
 
 stdenv.mkDerivation rec {
@@ -38,7 +38,7 @@ stdenv.mkDerivation rec {
     meson
     ninja
     pkg-config
-    wrapGAppsHook4
+    wrapGAppsHook
   ];
 
   buildInputs = [

--- a/pkgs/applications/misc/gnome-frog/default.nix
+++ b/pkgs/applications/misc/gnome-frog/default.nix
@@ -2,7 +2,7 @@
 , lib
 , fetchFromGitHub
 , python3Packages
-, wrapGAppsHook4
+, wrapGAppsHook
 , gtk4
 , meson
 , ninja
@@ -50,7 +50,7 @@ python3Packages.buildPythonApplication rec {
     ninja
     pkg-config
     glib
-    wrapGAppsHook4
+    wrapGAppsHook
     gobject-introspection
   ];
 

--- a/pkgs/applications/misc/gnome-secrets/default.nix
+++ b/pkgs/applications/misc/gnome-secrets/default.nix
@@ -5,7 +5,7 @@
 , gettext
 , fetchFromGitLab
 , python3Packages
-, wrapGAppsHook4
+, wrapGAppsHook
 , gtk4
 , glib
 , gdk-pixbuf
@@ -32,7 +32,7 @@ python3Packages.buildPythonApplication rec {
     ninja
     gettext
     pkg-config
-    wrapGAppsHook4
+    wrapGAppsHook
     desktop-file-utils
     appstream-glib
     gobject-introspection

--- a/pkgs/applications/misc/gradience/default.nix
+++ b/pkgs/applications/misc/gradience/default.nix
@@ -1,7 +1,7 @@
 { stdenv
 , lib
 , fetchFromGitHub
-, wrapGAppsHook4
+, wrapGAppsHook
 , meson
 , ninja
 , pkg-config
@@ -45,7 +45,7 @@ python3Packages.buildPythonApplication rec {
     meson
     ninja
     pkg-config
-    wrapGAppsHook4
+    wrapGAppsHook
     sassc
   ];
 

--- a/pkgs/applications/misc/junction/default.nix
+++ b/pkgs/applications/misc/junction/default.nix
@@ -8,7 +8,7 @@
 , meson
 , ninja
 , pkg-config
-, wrapGAppsHook4
+, wrapGAppsHook
 , gjs
 , gtk4
 , libadwaita
@@ -35,7 +35,7 @@ stdenv.mkDerivation rec {
     meson
     ninja
     pkg-config
-    wrapGAppsHook4
+    wrapGAppsHook
   ];
 
   buildInputs = [

--- a/pkgs/applications/misc/metadata-cleaner/default.nix
+++ b/pkgs/applications/misc/metadata-cleaner/default.nix
@@ -13,7 +13,7 @@
 , ninja
 , pkg-config
 , poppler_gi
-, wrapGAppsHook4
+, wrapGAppsHook
 }:
 
 python3.pkgs.buildPythonApplication rec {
@@ -39,7 +39,7 @@ python3.pkgs.buildPythonApplication rec {
     meson
     ninja
     pkg-config
-    wrapGAppsHook4
+    wrapGAppsHook
   ];
 
   buildInputs = [

--- a/pkgs/applications/misc/notejot/default.nix
+++ b/pkgs/applications/misc/notejot/default.nix
@@ -11,7 +11,7 @@
 , nix-update-script
 , pkg-config
 , vala
-, wrapGAppsHook4
+, wrapGAppsHook
 }:
 
 stdenv.mkDerivation rec {
@@ -31,7 +31,7 @@ stdenv.mkDerivation rec {
     ninja
     pkg-config
     vala
-    wrapGAppsHook4
+    wrapGAppsHook
   ];
 
   buildInputs = [

--- a/pkgs/applications/misc/raider/default.nix
+++ b/pkgs/applications/misc/raider/default.nix
@@ -13,7 +13,7 @@
 , ninja
 , pkg-config
 , stdenv
-, wrapGAppsHook4
+, wrapGAppsHook
 }:
 stdenv.mkDerivation rec {
   pname = "raider";
@@ -34,7 +34,7 @@ stdenv.mkDerivation rec {
     meson
     ninja
     pkg-config
-    wrapGAppsHook4
+    wrapGAppsHook
   ] ++ lib.optionals (!stdenv.buildPlatform.canExecute stdenv.hostPlatform) [
     mesonEmulatorHook
   ];

--- a/pkgs/applications/misc/tuba/default.nix
+++ b/pkgs/applications/misc/tuba/default.nix
@@ -6,7 +6,7 @@
 , ninja
 , python3
 , pkg-config
-, wrapGAppsHook4
+, wrapGAppsHook
 , desktop-file-utils
 , gtk4
 , libadwaita
@@ -38,7 +38,7 @@ stdenv.mkDerivation rec {
     pkg-config
     vala
     python3
-    wrapGAppsHook4
+    wrapGAppsHook
     desktop-file-utils
   ];
 

--- a/pkgs/applications/misc/valent/default.nix
+++ b/pkgs/applications/misc/valent/default.nix
@@ -6,7 +6,7 @@
 , ninja
 , pkg-config
 , vala
-, wrapGAppsHook4
+, wrapGAppsHook
 , evolution-data-server-gtk4
 , glib
 , glib-networking
@@ -38,7 +38,7 @@ stdenv.mkDerivation rec {
     ninja
     pkg-config
     vala
-    wrapGAppsHook4
+    wrapGAppsHook
   ];
 
   buildInputs = [

--- a/pkgs/applications/misc/watchmate/default.nix
+++ b/pkgs/applications/misc/watchmate/default.nix
@@ -7,7 +7,7 @@
 , bluez
 , dbus
 , openssl
-, wrapGAppsHook4
+, wrapGAppsHook
 , glib
 }:
 
@@ -31,7 +31,7 @@ rustPlatform.buildRustPackage rec {
 
   nativeBuildInputs = [
     pkg-config
-    wrapGAppsHook4
+    wrapGAppsHook
     glib
   ];
   buildInputs = [

--- a/pkgs/applications/misc/wordbook/default.nix
+++ b/pkgs/applications/misc/wordbook/default.nix
@@ -10,7 +10,7 @@
 , librsvg
 , espeak-ng
 , gobject-introspection
-, wrapGAppsHook4
+, wrapGAppsHook
 , appstream-glib
 , desktop-file-utils
 }:
@@ -31,7 +31,7 @@ python3.pkgs.buildPythonApplication rec {
     meson
     ninja
     pkg-config
-    wrapGAppsHook4
+    wrapGAppsHook
     appstream-glib
     desktop-file-utils
     gobject-introspection

--- a/pkgs/applications/networking/feedreaders/newsflash/default.nix
+++ b/pkgs/applications/networking/feedreaders/newsflash/default.nix
@@ -5,7 +5,7 @@
 , meson
 , ninja
 , pkg-config
-, wrapGAppsHook4
+, wrapGAppsHook
 , gdk-pixbuf
 , glib
 , gtk4
@@ -57,7 +57,7 @@ stdenv.mkDerivation (finalAttrs: {
     meson
     ninja
     pkg-config
-    wrapGAppsHook4
+    wrapGAppsHook
 
     # Provides setup hook to fix "Unrecognized image file format"
     gdk-pixbuf

--- a/pkgs/applications/networking/giara/default.nix
+++ b/pkgs/applications/networking/giara/default.nix
@@ -6,7 +6,7 @@
 , pkg-config
 , ninja
 , python3
-, wrapGAppsHook4
+, wrapGAppsHook
 , gtk4
 , gdk-pixbuf
 , webkitgtk
@@ -36,7 +36,7 @@ python3.pkgs.buildPythonApplication rec {
     gobject-introspection
     pkg-config
     ninja
-    wrapGAppsHook4
+    wrapGAppsHook
     blueprint-compiler
   ];
 

--- a/pkgs/applications/networking/instant-messengers/flare-signal/default.nix
+++ b/pkgs/applications/networking/instant-messengers/flare-signal/default.nix
@@ -9,7 +9,7 @@
 , libadwaita
 , rustPlatform
 , desktop-file-utils
-, wrapGAppsHook4
+, wrapGAppsHook
 }:
 
 stdenv.mkDerivation rec {
@@ -39,7 +39,7 @@ stdenv.mkDerivation rec {
     meson
     ninja
     pkg-config
-    wrapGAppsHook4
+    wrapGAppsHook
   ] ++ (with rustPlatform; [
     cargoSetupHook
     rust.cargo

--- a/pkgs/applications/networking/instant-messengers/fractal-next/default.nix
+++ b/pkgs/applications/networking/instant-messengers/fractal-next/default.nix
@@ -18,7 +18,7 @@
 , openssl
 , pipewire
 , libshumate
-, wrapGAppsHook4
+, wrapGAppsHook
 }:
 
 stdenv.mkDerivation rec {
@@ -53,7 +53,7 @@ stdenv.mkDerivation rec {
     rustPlatform.rust.rustc
     desktop-file-utils
     appstream-glib
-    wrapGAppsHook4
+    wrapGAppsHook
   ];
 
   buildInputs = [

--- a/pkgs/applications/networking/p2p/fragments/default.nix
+++ b/pkgs/applications/networking/p2p/fragments/default.nix
@@ -16,7 +16,7 @@
 , rustPlatform
 , sqlite
 , transmission
-, wrapGAppsHook4
+, wrapGAppsHook
 }:
 
 let
@@ -55,7 +55,7 @@ in stdenv.mkDerivation rec {
     meson
     ninja
     pkg-config
-    wrapGAppsHook4
+    wrapGAppsHook
   ] ++ (with rustPlatform; [
     cargoSetupHook
     rust.cargo

--- a/pkgs/applications/networking/p2p/torrential/default.nix
+++ b/pkgs/applications/networking/p2p/torrential/default.nix
@@ -8,7 +8,7 @@
 , pkg-config
 , python3
 , vala
-, wrapGAppsHook4
+, wrapGAppsHook
 , curl
 , dht
 , glib
@@ -42,7 +42,7 @@ stdenv.mkDerivation rec {
     pkg-config
     python3
     vala
-    wrapGAppsHook4
+    wrapGAppsHook
   ];
 
   buildInputs = [

--- a/pkgs/applications/networking/sync/celeste/default.nix
+++ b/pkgs/applications/networking/sync/celeste/default.nix
@@ -6,7 +6,7 @@
 , substituteAll
 , fetchpatch
 , pkg-config
-, wrapGAppsHook4
+, wrapGAppsHook
 , cairo
 , gdk-pixbuf
 , glib
@@ -82,7 +82,7 @@ in rustPlatform.buildRustPackage rec {
   nativeBuildInputs = [
     pkg-config
     rustPlatform.bindgenHook
-    wrapGAppsHook4
+    wrapGAppsHook
   ];
 
   buildInputs = [

--- a/pkgs/applications/networking/warp/default.nix
+++ b/pkgs/applications/networking/warp/default.nix
@@ -9,7 +9,7 @@
 , pkg-config
 , python3
 , rustPlatform
-, wrapGAppsHook4
+, wrapGAppsHook
 , glib
 , gtk4
 , libadwaita
@@ -45,7 +45,7 @@ stdenv.mkDerivation rec {
     ninja
     pkg-config
     python3
-    wrapGAppsHook4
+    wrapGAppsHook
   ] ++ (with rustPlatform; [
     cargoSetupHook
     rust.cargo

--- a/pkgs/applications/office/banking/default.nix
+++ b/pkgs/applications/office/banking/default.nix
@@ -9,7 +9,7 @@
 , meson
 , ninja
 , pkg-config
-, wrapGAppsHook4
+, wrapGAppsHook
 , gobject-introspection
 , libadwaita
 , librsvg
@@ -40,7 +40,7 @@ python3.pkgs.buildPythonApplication rec {
     meson
     ninja
     pkg-config
-    wrapGAppsHook4
+    wrapGAppsHook
     gobject-introspection
     gtk4 # for gtk4-update-icon-cache
   ];

--- a/pkgs/applications/office/endeavour/default.nix
+++ b/pkgs/applications/office/endeavour/default.nix
@@ -4,7 +4,7 @@
 , meson
 , ninja
 , pkg-config
-, wrapGAppsHook4
+, wrapGAppsHook
 , gettext
 , gnome
 , glib
@@ -37,7 +37,7 @@ stdenv.mkDerivation rec {
     ninja
     pkg-config
     gettext
-    wrapGAppsHook4
+    wrapGAppsHook
     itstool
   ];
 

--- a/pkgs/applications/office/iotas/default.nix
+++ b/pkgs/applications/office/iotas/default.nix
@@ -5,7 +5,7 @@
 , ninja
 , pkg-config
 , gobject-introspection
-, wrapGAppsHook4
+, wrapGAppsHook
 , appstream-glib
 , desktop-file-utils
 , glib
@@ -35,7 +35,7 @@ python3.pkgs.buildPythonApplication rec {
     ninja
     pkg-config
     gobject-introspection
-    wrapGAppsHook4
+    wrapGAppsHook
     appstream-glib
     desktop-file-utils
   ];

--- a/pkgs/applications/office/karlender/default.nix
+++ b/pkgs/applications/office/karlender/default.nix
@@ -4,7 +4,7 @@
 , pkg-config
 , gtk4
 , libadwaita
-, wrapGAppsHook4
+, wrapGAppsHook
 , glib
 , tzdata
 }:
@@ -24,7 +24,7 @@ rustPlatform.buildRustPackage rec {
 
   nativeBuildInputs = [
     pkg-config
-    wrapGAppsHook4
+    wrapGAppsHook
     glib
   ];
 

--- a/pkgs/applications/office/khronos/default.nix
+++ b/pkgs/applications/office/khronos/default.nix
@@ -12,7 +12,7 @@
 , json-glib
 , libadwaita
 , libgee
-, wrapGAppsHook4
+, wrapGAppsHook
 }:
 
 stdenv.mkDerivation rec {
@@ -32,7 +32,7 @@ stdenv.mkDerivation rec {
     ninja
     vala
     pkg-config
-    wrapGAppsHook4
+    wrapGAppsHook
   ];
 
   buildInputs = [

--- a/pkgs/applications/office/paper-note/default.nix
+++ b/pkgs/applications/office/paper-note/default.nix
@@ -10,7 +10,7 @@
 , libadwaita
 , gtksourceview5
 , blueprint-compiler
-, wrapGAppsHook4
+, wrapGAppsHook
 , appstream-glib
 , desktop-file-utils
 }:
@@ -31,7 +31,7 @@ stdenv.mkDerivation rec {
     ninja
     vala
     pkg-config
-    wrapGAppsHook4
+    wrapGAppsHook
     appstream-glib
     desktop-file-utils
     blueprint-compiler

--- a/pkgs/applications/science/misc/bada-bib/default.nix
+++ b/pkgs/applications/science/misc/bada-bib/default.nix
@@ -15,7 +15,7 @@
 , libxml2
 , pkg-config
 , python3Packages
-, wrapGAppsHook4
+, wrapGAppsHook
 }:
 
 python3Packages.buildPythonApplication rec {
@@ -37,7 +37,7 @@ python3Packages.buildPythonApplication rec {
     meson
     ninja
     pkg-config
-    wrapGAppsHook4
+    wrapGAppsHook
   ];
 
   buildInputs = [

--- a/pkgs/applications/terminal-emulators/gnome-console/default.nix
+++ b/pkgs/applications/terminal-emulators/gnome-console/default.nix
@@ -12,7 +12,7 @@
 , meson
 , ninja
 , pkg-config
-, wrapGAppsHook4
+, wrapGAppsHook
 , nixosTests
 }:
 
@@ -31,7 +31,7 @@ stdenv.mkDerivation rec {
     meson
     ninja
     pkg-config
-    wrapGAppsHook4
+    wrapGAppsHook
   ];
 
   buildInputs = [

--- a/pkgs/applications/video/celluloid/default.nix
+++ b/pkgs/applications/video/celluloid/default.nix
@@ -13,7 +13,7 @@
 , nix-update-script
 , pkg-config
 , python3
-, wrapGAppsHook4
+, wrapGAppsHook
 }:
 
 stdenv.mkDerivation rec {
@@ -34,7 +34,7 @@ stdenv.mkDerivation rec {
     ninja
     pkg-config
     python3
-    wrapGAppsHook4
+    wrapGAppsHook
   ];
 
   buildInputs = [

--- a/pkgs/applications/video/clapper/default.nix
+++ b/pkgs/applications/video/clapper/default.nix
@@ -12,7 +12,7 @@
 , desktop-file-utils
 , makeWrapper
 , shared-mime-info
-, wrapGAppsHook4
+, wrapGAppsHook
 , meson
 , gjs
 , gtk4
@@ -44,7 +44,7 @@ stdenv.mkDerivation rec {
     pkg-config
     python3
     shared-mime-info # for update-mime-database
-    wrapGAppsHook4 # for gsettings
+    wrapGAppsHook # for gsettings
   ];
 
   buildInputs = [

--- a/pkgs/applications/video/kooha/default.nix
+++ b/pkgs/applications/video/kooha/default.nix
@@ -15,7 +15,7 @@
 , pkg-config
 , rustPlatform
 , wayland
-, wrapGAppsHook4
+, wrapGAppsHook
 }:
 
 stdenv.mkDerivation rec {
@@ -44,7 +44,7 @@ stdenv.mkDerivation rec {
     rustPlatform.cargoSetupHook
     rustPlatform.rust.cargo
     rustPlatform.rust.rustc
-    wrapGAppsHook4
+    wrapGAppsHook
   ];
 
   buildInputs = [

--- a/pkgs/applications/video/showmethekey/default.nix
+++ b/pkgs/applications/video/showmethekey/default.nix
@@ -7,7 +7,7 @@
 , json-glib
 , libinput
 , gtk4
-, wrapGAppsHook4
+, wrapGAppsHook
 , libxkbcommon
 , pkg-config
 }:
@@ -27,7 +27,7 @@ stdenv.mkDerivation rec {
     ninja
     json-glib
     pkg-config
-    wrapGAppsHook4
+    wrapGAppsHook
   ];
 
   buildInputs = [

--- a/pkgs/applications/video/video-trimmer/default.nix
+++ b/pkgs/applications/video/video-trimmer/default.nix
@@ -4,7 +4,7 @@
 , rustPlatform
 , pkg-config
 , meson
-, wrapGAppsHook4
+, wrapGAppsHook
 , desktop-file-utils
 , blueprint-compiler
 , ninja
@@ -35,7 +35,7 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [
     pkg-config
     meson
-    wrapGAppsHook4
+    wrapGAppsHook
     desktop-file-utils
     blueprint-compiler
     ninja

--- a/pkgs/applications/virtualization/pods/default.nix
+++ b/pkgs/applications/virtualization/pods/default.nix
@@ -8,7 +8,7 @@
 , ninja
 , pkg-config
 , rustPlatform
-, wrapGAppsHook4
+, wrapGAppsHook
 , gtksourceview5
 , libadwaita
 , libpanel
@@ -44,7 +44,7 @@ stdenv.mkDerivation rec {
     rustPlatform.cargoSetupHook
     rustPlatform.rust.cargo
     rustPlatform.rust.rustc
-    wrapGAppsHook4
+    wrapGAppsHook
   ];
 
   buildInputs = [

--- a/pkgs/build-support/setup-hooks/wrap-gapps-hook/default.nix
+++ b/pkgs/build-support/setup-hooks/wrap-gapps-hook/default.nix
@@ -17,24 +17,15 @@ makeSetupHook {
   propagatedBuildInputs = [
     # We use the wrapProgram function.
     makeWrapper
-  ] ++ lib.optionals isGraphical [
-    # TODO: remove this, packages should depend on GTK explicitly.
-    gtk3
-
-    librsvg
   ];
 
   # depsTargetTargetPropagated will essentially be buildInputs when wrapGAppsHook is placed into nativeBuildInputs
-  # the librsvg and gtk3 above should be removed but kept to not break anything that implicitly depended on its binaries
   depsTargetTargetPropagated = assert (lib.assertMsg (!targetPackages ? raw) "wrapGAppsHook must be in nativeBuildInputs"); lib.optionals isGraphical [
     # librsvg provides a module for gdk-pixbuf to allow rendering
     # SVG icons. Most icon themes are SVG-based and so are some
     # graphics in GTK (e.g. cross for closing window in window title bar)
     # so it is pretty much required for applications using GTK.
     librsvg
-
-    # TODO: remove this, packages should depend on GTK explicitly.
-    gtk3
   ] ++ lib.optionals (!stdenv.isDarwin) [
     # It is highly probable that a program will use GSettings,
     # at minimum through GTK file chooser dialogue.

--- a/pkgs/build-support/setup-hooks/wrap-gapps-hook/default.nix
+++ b/pkgs/build-support/setup-hooks/wrap-gapps-hook/default.nix
@@ -4,7 +4,6 @@
 , makeWrapper
 , gobject-introspection
 , isGraphical ? true
-, gtk3
 , librsvg
 , dconf
 , callPackage

--- a/pkgs/desktops/gnome/apps/ghex/default.nix
+++ b/pkgs/desktops/gnome/apps/ghex/default.nix
@@ -17,7 +17,7 @@
 , atk
 , gobject-introspection
 , vala
-, wrapGAppsHook4
+, wrapGAppsHook
 }:
 
 stdenv.mkDerivation rec {
@@ -41,7 +41,7 @@ stdenv.mkDerivation rec {
     gi-docgen
     gobject-introspection
     vala
-    wrapGAppsHook4
+    wrapGAppsHook
   ];
 
   buildInputs = [

--- a/pkgs/desktops/gnome/apps/gnome-calendar/default.nix
+++ b/pkgs/desktops/gnome/apps/gnome-calendar/default.nix
@@ -4,7 +4,7 @@
 , meson
 , ninja
 , pkg-config
-, wrapGAppsHook4
+, wrapGAppsHook
 , libgweather
 , geoclue2
 , geocode-glib_2
@@ -35,7 +35,7 @@ stdenv.mkDerivation rec {
     pkg-config
     gettext
     libxml2
-    wrapGAppsHook4
+    wrapGAppsHook
   ];
 
   buildInputs = [

--- a/pkgs/desktops/gnome/apps/gnome-characters/default.nix
+++ b/pkgs/desktops/gnome/apps/gnome-characters/default.nix
@@ -9,7 +9,7 @@
 , glib
 , gtk4
 , pango
-, wrapGAppsHook4
+, wrapGAppsHook
 , desktop-file-utils
 , gobject-introspection
 , gjs
@@ -35,7 +35,7 @@ stdenv.mkDerivation rec {
     ninja
     pkg-config
     desktop-file-utils
-    wrapGAppsHook4
+    wrapGAppsHook
   ];
 
 

--- a/pkgs/desktops/gnome/apps/gnome-clocks/default.nix
+++ b/pkgs/desktops/gnome/apps/gnome-clocks/default.nix
@@ -5,7 +5,7 @@
 , ninja
 , gettext
 , pkg-config
-, wrapGAppsHook4
+, wrapGAppsHook
 , itstool
 , desktop-file-utils
 , vala
@@ -41,7 +41,7 @@ stdenv.mkDerivation rec {
     pkg-config
     gettext
     itstool
-    wrapGAppsHook4
+    wrapGAppsHook
     desktop-file-utils
     libxml2
     gobject-introspection # for finding vapi files

--- a/pkgs/desktops/gnome/apps/gnome-logs/default.nix
+++ b/pkgs/desktops/gnome/apps/gnome-logs/default.nix
@@ -9,7 +9,7 @@
 , glib
 , gtk4
 , desktop-file-utils
-, wrapGAppsHook4
+, wrapGAppsHook
 , gettext
 , itstool
 , libadwaita
@@ -46,7 +46,7 @@ stdenv.mkDerivation rec {
     meson
     ninja
     pkg-config
-    wrapGAppsHook4
+    wrapGAppsHook
     gettext
     itstool
     libxml2

--- a/pkgs/desktops/gnome/apps/gnome-maps/default.nix
+++ b/pkgs/desktops/gnome/apps/gnome-maps/default.nix
@@ -14,7 +14,7 @@
 , librest_1_0
 , libgweather
 , geoclue2
-, wrapGAppsHook4
+, wrapGAppsHook
 , desktop-file-utils
 , libshumate
 , libsecret
@@ -41,7 +41,7 @@ stdenv.mkDerivation rec {
     meson
     ninja
     pkg-config
-    wrapGAppsHook4
+    wrapGAppsHook
     gobject-introspection
     # For post install script
     desktop-file-utils

--- a/pkgs/desktops/gnome/apps/gnome-music/default.nix
+++ b/pkgs/desktops/gnome/apps/gnome-music/default.nix
@@ -8,7 +8,7 @@
 , libxml2
 , python3
 , libnotify
-, wrapGAppsHook4
+, wrapGAppsHook
 , libmediaart
 , gobject-introspection
 , gnome-online-accounts
@@ -46,7 +46,7 @@ python3.pkgs.buildPythonApplication rec {
     itstool
     pkg-config
     libxml2
-    wrapGAppsHook4
+    wrapGAppsHook
     desktop-file-utils
     appstream-glib
     gobject-introspection

--- a/pkgs/desktops/gnome/apps/gnome-text-editor/default.nix
+++ b/pkgs/desktops/gnome/apps/gnome-text-editor/default.nix
@@ -8,7 +8,7 @@
 , glib
 , gtksourceview5
 , gsettings-desktop-schemas
-, wrapGAppsHook4
+, wrapGAppsHook
 , ninja
 , gnome
 , cairo
@@ -41,7 +41,7 @@ stdenv.mkDerivation rec {
     ninja
     pkg-config
     python3
-    wrapGAppsHook4
+    wrapGAppsHook
   ];
 
   buildInputs = [

--- a/pkgs/desktops/gnome/apps/gnome-weather/default.nix
+++ b/pkgs/desktops/gnome/apps/gnome-weather/default.nix
@@ -5,7 +5,7 @@
 , gnome
 , gtk4
 , libadwaita
-, wrapGAppsHook4
+, wrapGAppsHook
 , gjs
 , gobject-introspection
 , libgweather
@@ -29,7 +29,7 @@ stdenv.mkDerivation rec {
     pkg-config
     meson
     ninja
-    wrapGAppsHook4
+    wrapGAppsHook
     python3
     gobject-introspection
     gjs

--- a/pkgs/desktops/gnome/apps/polari/default.nix
+++ b/pkgs/desktops/gnome/apps/polari/default.nix
@@ -22,7 +22,7 @@
 , gobject-introspection
 , appstream-glib
 , gnome
-, wrapGAppsHook4
+, wrapGAppsHook
 , telepathy-logger
 , gspell
 , gsettings-desktop-schemas
@@ -55,7 +55,7 @@ stdenv.mkDerivation rec {
     pkg-config
     itstool
     gettext
-    wrapGAppsHook4
+    wrapGAppsHook
     libxml2
     desktop-file-utils
     gobject-introspection

--- a/pkgs/desktops/gnome/core/baobab/default.nix
+++ b/pkgs/desktops/gnome/core/baobab/default.nix
@@ -11,7 +11,7 @@
 , libadwaita
 , glib
 , libxml2
-, wrapGAppsHook4
+, wrapGAppsHook
 , itstool
 , gnome
 }:
@@ -35,7 +35,7 @@ stdenv.mkDerivation rec {
     ninja
     pkg-config
     vala
-    wrapGAppsHook4
+    wrapGAppsHook
     # Prevents “error: Package `libadwaita-1' not found in specified Vala API
     # directories or GObject-Introspection GIR directories” with strictDeps,
     # even though it should only be a runtime dependency.

--- a/pkgs/desktops/gnome/core/epiphany/default.nix
+++ b/pkgs/desktops/gnome/core/epiphany/default.nix
@@ -8,7 +8,7 @@
 , gtk4
 , glib
 , icu
-, wrapGAppsHook4
+, wrapGAppsHook
 , gnome
 , libportal-gtk4
 , libxml2
@@ -50,7 +50,7 @@ stdenv.mkDerivation rec {
     meson
     ninja
     pkg-config
-    wrapGAppsHook4
+    wrapGAppsHook
     buildPackages.glib
     buildPackages.gtk4
   ];

--- a/pkgs/desktops/gnome/core/gnome-bluetooth/default.nix
+++ b/pkgs/desktops/gnome/core/gnome-bluetooth/default.nix
@@ -14,7 +14,7 @@
 , upower
 , itstool
 , libxml2
-, wrapGAppsHook4
+, wrapGAppsHook
 , libnotify
 , gsound
 , gobject-introspection
@@ -44,7 +44,7 @@ stdenv.mkDerivation rec {
     itstool
     pkg-config
     libxml2
-    wrapGAppsHook4
+    wrapGAppsHook
     gobject-introspection
     gtk-doc
     docbook-xsl-nons

--- a/pkgs/desktops/gnome/core/gnome-calculator/default.nix
+++ b/pkgs/desktops/gnome/core/gnome-calculator/default.nix
@@ -11,7 +11,7 @@
 , gtk4
 , glib
 , gtksourceview5
-, wrapGAppsHook4
+, wrapGAppsHook
 , gobject-introspection
 , gnome
 , mpfr
@@ -39,7 +39,7 @@ stdenv.mkDerivation rec {
     vala
     gettext
     itstool
-    wrapGAppsHook4
+    wrapGAppsHook
     gobject-introspection # for finding vapi files
   ];
 

--- a/pkgs/desktops/gnome/core/gnome-contacts/default.nix
+++ b/pkgs/desktops/gnome/core/gnome-contacts/default.nix
@@ -14,7 +14,7 @@
 , gnome-desktop
 , gnome-online-accounts
 , qrencode
-, wrapGAppsHook4
+, wrapGAppsHook
 , folks
 , libxml2
 , gnome
@@ -44,7 +44,7 @@ stdenv.mkDerivation rec {
     docbook-xsl-nons
     docbook_xml_dtd_42
     desktop-file-utils
-    wrapGAppsHook4
+    wrapGAppsHook
   ];
 
   buildInputs = [

--- a/pkgs/desktops/gnome/core/gnome-font-viewer/default.nix
+++ b/pkgs/desktops/gnome/core/gnome-font-viewer/default.nix
@@ -11,7 +11,7 @@
 , gnome-desktop
 , libadwaita
 , fribidi
-, wrapGAppsHook4
+, wrapGAppsHook
 , gnome
 , harfbuzz
 }:
@@ -32,7 +32,7 @@ stdenv.mkDerivation rec {
     ninja
     pkg-config
     gettext
-    wrapGAppsHook4
+    wrapGAppsHook
     libxml2
     glib
   ];

--- a/pkgs/desktops/gnome/core/gnome-initial-setup/default.nix
+++ b/pkgs/desktops/gnome/core/gnome-initial-setup/default.nix
@@ -6,7 +6,7 @@
 , meson
 , ninja
 , pkg-config
-, wrapGAppsHook4
+, wrapGAppsHook
 , gnome
 , accountsservice
 , fontconfig
@@ -58,7 +58,7 @@ stdenv.mkDerivation rec {
     ninja
     pkg-config
     systemd
-    wrapGAppsHook4
+    wrapGAppsHook
   ];
 
   buildInputs = [

--- a/pkgs/desktops/gnome/core/gnome-software/default.nix
+++ b/pkgs/desktops/gnome/core/gnome-software/default.nix
@@ -7,7 +7,7 @@
 , ninja
 , gettext
 , gnome
-, wrapGAppsHook4
+, wrapGAppsHook
 , packagekit
 , ostree
 , glib
@@ -64,7 +64,7 @@ stdenv.mkDerivation rec {
     ninja
     pkg-config
     gettext
-    wrapGAppsHook4
+    wrapGAppsHook
     libxslt
     docbook_xml_dtd_42
     docbook_xml_dtd_43

--- a/pkgs/desktops/gnome/core/gnome-tour/default.nix
+++ b/pkgs/desktops/gnome/core/gnome-tour/default.nix
@@ -11,7 +11,7 @@
 , gdk-pixbuf
 , desktop-file-utils
 , appstream-glib
-, wrapGAppsHook4
+, wrapGAppsHook
 , python3
 , gnome
 , libadwaita
@@ -49,7 +49,7 @@ stdenv.mkDerivation rec {
     python3
     rustPlatform.cargoSetupHook
     rustc
-    wrapGAppsHook4
+    wrapGAppsHook
   ];
 
   buildInputs = [

--- a/pkgs/desktops/gnome/core/mutter/default.nix
+++ b/pkgs/desktops/gnome/core/mutter/default.nix
@@ -52,7 +52,7 @@
 , gnome-settings-daemon
 , xorgserver
 , python3
-, wrapGAppsHook4
+, wrapGAppsHook
 , gi-docgen
 , sysprof
 , libsysprof-capture
@@ -104,7 +104,7 @@ stdenv.mkDerivation (finalAttrs: {
     xvfb-run
     pkg-config
     python3
-    wrapGAppsHook4
+    wrapGAppsHook
     gi-docgen
     xorgserver
   ];

--- a/pkgs/desktops/gnome/core/nautilus/default.nix
+++ b/pkgs/desktops/gnome/core/nautilus/default.nix
@@ -10,7 +10,7 @@
 , gettext
 , libxml2
 , desktop-file-utils
-, wrapGAppsHook4
+, wrapGAppsHook
 , gtk4
 , libadwaita
 , libportal-gtk4
@@ -77,7 +77,7 @@ stdenv.mkDerivation rec {
     pkg-config
     gi-docgen
     docbook-xsl-nons
-    wrapGAppsHook4
+    wrapGAppsHook
   ];
 
   buildInputs = [

--- a/pkgs/desktops/gnome/core/zenity/default.nix
+++ b/pkgs/desktops/gnome/core/zenity/default.nix
@@ -10,7 +10,7 @@
 , gettext
 , libadwaita
 , itstool
-, wrapGAppsHook4
+, wrapGAppsHook
 }:
 
 stdenv.mkDerivation rec {
@@ -29,7 +29,7 @@ stdenv.mkDerivation rec {
     gettext
     itstool
     libxml2
-    wrapGAppsHook4
+    wrapGAppsHook
   ];
 
   buildInputs = [

--- a/pkgs/desktops/gnome/games/gnome-chess/default.nix
+++ b/pkgs/desktops/gnome/games/gnome-chess/default.nix
@@ -6,7 +6,7 @@
 , vala
 , pkg-config
 , desktop-file-utils
-, wrapGAppsHook4
+, wrapGAppsHook
 , gobject-introspection
 , gettext
 , itstool
@@ -37,7 +37,7 @@ stdenv.mkDerivation rec {
     itstool
     libxml2
     desktop-file-utils
-    wrapGAppsHook4
+    wrapGAppsHook
     gobject-introspection
   ];
 

--- a/pkgs/desktops/pantheon/apps/elementary-calculator/default.nix
+++ b/pkgs/desktops/pantheon/apps/elementary-calculator/default.nix
@@ -7,7 +7,7 @@
 , pkg-config
 , python3
 , vala
-, wrapGAppsHook4
+, wrapGAppsHook
 , granite7
 , gtk4
 , libgee
@@ -30,7 +30,7 @@ stdenv.mkDerivation rec {
     pkg-config
     python3
     vala
-    wrapGAppsHook4
+    wrapGAppsHook
   ];
 
   buildInputs = [

--- a/pkgs/desktops/pantheon/apps/elementary-iconbrowser/default.nix
+++ b/pkgs/desktops/pantheon/apps/elementary-iconbrowser/default.nix
@@ -7,7 +7,7 @@
 , pkg-config
 , python3
 , vala
-, wrapGAppsHook4
+, wrapGAppsHook
 , elementary-gtk-theme
 , elementary-icon-theme
 , glib
@@ -33,7 +33,7 @@ stdenv.mkDerivation rec {
     pkg-config
     python3
     vala
-    wrapGAppsHook4
+    wrapGAppsHook
   ];
 
   buildInputs = [

--- a/pkgs/desktops/pantheon/apps/elementary-music/default.nix
+++ b/pkgs/desktops/pantheon/apps/elementary-music/default.nix
@@ -7,7 +7,7 @@
 , pkg-config
 , python3
 , vala
-, wrapGAppsHook4
+, wrapGAppsHook
 , elementary-gtk-theme
 , elementary-icon-theme
 , glib
@@ -33,7 +33,7 @@ stdenv.mkDerivation rec {
     pkg-config
     python3
     vala
-    wrapGAppsHook4
+    wrapGAppsHook
   ];
 
   buildInputs = [

--- a/pkgs/desktops/pantheon/apps/sideload/default.nix
+++ b/pkgs/desktops/pantheon/apps/sideload/default.nix
@@ -14,7 +14,7 @@
 , python3
 , vala
 , libxml2
-, wrapGAppsHook4
+, wrapGAppsHook
 }:
 
 stdenv.mkDerivation rec {
@@ -36,7 +36,7 @@ stdenv.mkDerivation rec {
     pkg-config
     python3
     vala
-    wrapGAppsHook4
+    wrapGAppsHook
   ];
 
   buildInputs = [

--- a/pkgs/desktops/pantheon/desktop/elementary-onboarding/default.nix
+++ b/pkgs/desktops/pantheon/desktop/elementary-onboarding/default.nix
@@ -7,7 +7,7 @@
 , pkg-config
 , python3
 , vala
-, wrapGAppsHook4
+, wrapGAppsHook
 , appcenter
 , elementary-settings-daemon
 , glib
@@ -34,7 +34,7 @@ stdenv.mkDerivation rec {
     pkg-config
     python3
     vala
-    wrapGAppsHook4
+    wrapGAppsHook
   ];
 
   buildInputs = [

--- a/pkgs/desktops/pantheon/desktop/elementary-shortcut-overlay/default.nix
+++ b/pkgs/desktops/pantheon/desktop/elementary-shortcut-overlay/default.nix
@@ -11,7 +11,7 @@
 , glib
 , granite7
 , libgee
-, wrapGAppsHook4
+, wrapGAppsHook
 }:
 
 stdenv.mkDerivation rec {
@@ -31,7 +31,7 @@ stdenv.mkDerivation rec {
     ninja
     pkg-config
     vala
-    wrapGAppsHook4
+    wrapGAppsHook
   ];
 
   buildInputs = [

--- a/pkgs/desktops/pantheon/granite/7/default.nix
+++ b/pkgs/desktops/pantheon/granite/7/default.nix
@@ -13,7 +13,7 @@
 , gettext
 , gsettings-desktop-schemas
 , gobject-introspection
-, wrapGAppsHook4
+, wrapGAppsHook
 }:
 
 stdenv.mkDerivation rec {
@@ -37,7 +37,7 @@ stdenv.mkDerivation rec {
     pkg-config
     python3
     vala
-    wrapGAppsHook4
+    wrapGAppsHook
   ];
 
   propagatedBuildInputs = [

--- a/pkgs/desktops/pantheon/services/xdg-desktop-portal-pantheon/default.nix
+++ b/pkgs/desktops/pantheon/services/xdg-desktop-portal-pantheon/default.nix
@@ -6,7 +6,7 @@
 , ninja
 , pkg-config
 , vala
-, wrapGAppsHook4
+, wrapGAppsHook
 , glib
 , granite7
 , gtk4
@@ -30,7 +30,7 @@ stdenv.mkDerivation rec {
     ninja
     pkg-config
     vala
-    wrapGAppsHook4
+    wrapGAppsHook
   ];
 
   buildInputs = [

--- a/pkgs/development/libraries/gcr/4.nix
+++ b/pkgs/development/libraries/gcr/4.nix
@@ -16,7 +16,7 @@
 , openssh
 , systemd
 , gobject-introspection
-, wrapGAppsHook4
+, wrapGAppsHook
 , vala
 , gi-docgen
 , gnome
@@ -42,7 +42,7 @@ stdenv.mkDerivation rec {
     gettext
     gobject-introspection
     gi-docgen
-    wrapGAppsHook4
+    wrapGAppsHook
     vala
     gi-docgen
     shared-mime-info

--- a/pkgs/development/libraries/gssdp/tools.nix
+++ b/pkgs/development/libraries/gssdp/tools.nix
@@ -4,7 +4,7 @@
 , meson
 , ninja
 , pkg-config
-, wrapGAppsHook4
+, wrapGAppsHook
 , gssdp_1_6
 , gtk4
 , libsoup_3
@@ -27,7 +27,7 @@ stdenv.mkDerivation rec {
     meson
     ninja
     pkg-config
-    wrapGAppsHook4
+    wrapGAppsHook
   ];
 
   buildInputs = [

--- a/pkgs/development/libraries/malcontent/ui.nix
+++ b/pkgs/development/libraries/malcontent/ui.nix
@@ -4,7 +4,7 @@
 , pkg-config
 , gobject-introspection
 , itstool
-, wrapGAppsHook4
+, wrapGAppsHook
 , glib
 , accountsservice
 , dbus
@@ -40,7 +40,7 @@ stdenv.mkDerivation rec {
     gobject-introspection
     itstool
     desktop-file-utils
-    wrapGAppsHook4
+    wrapGAppsHook
   ];
 
   buildInputs = [

--- a/pkgs/development/libraries/xdg-desktop-portal-gnome/default.nix
+++ b/pkgs/development/libraries/xdg-desktop-portal-gnome/default.nix
@@ -4,7 +4,7 @@
 , meson
 , ninja
 , pkg-config
-, wrapGAppsHook4
+, wrapGAppsHook
 , fontconfig
 , glib
 , gsettings-desktop-schemas
@@ -31,7 +31,7 @@ stdenv.mkDerivation rec {
     meson
     ninja
     pkg-config
-    wrapGAppsHook4
+    wrapGAppsHook
   ];
 
   buildInputs = [

--- a/pkgs/development/tools/ashpd-demo/default.nix
+++ b/pkgs/development/tools/ashpd-demo/default.nix
@@ -15,7 +15,7 @@
 , glibc
 , pipewire
 , wayland
-, wrapGAppsHook4
+, wrapGAppsHook
 , desktop-file-utils
 }:
 
@@ -47,7 +47,7 @@ stdenv.mkDerivation rec {
     rustPlatform.rust.cargo
     rustPlatform.cargoSetupHook
     rustPlatform.rust.rustc
-    wrapGAppsHook4
+    wrapGAppsHook
     rustPlatform.bindgenHook
     desktop-file-utils
     glib # for glib-compile-schemas

--- a/pkgs/development/tools/misc/d-spy/default.nix
+++ b/pkgs/development/tools/misc/d-spy/default.nix
@@ -9,7 +9,7 @@
 , meson
 , ninja
 , pkg-config
-, wrapGAppsHook4
+, wrapGAppsHook
 , gnome
 }:
 
@@ -29,7 +29,7 @@ stdenv.mkDerivation rec {
     ninja
     pkg-config
     desktop-file-utils
-    wrapGAppsHook4
+    wrapGAppsHook
     gettext
     glib
   ];

--- a/pkgs/development/tools/profiling/sysprof/default.nix
+++ b/pkgs/development/tools/profiling/sysprof/default.nix
@@ -17,7 +17,7 @@
 , polkit
 , shared-mime-info
 , systemd
-, wrapGAppsHook4
+, wrapGAppsHook
 , gnome
 }:
 
@@ -41,7 +41,7 @@ stdenv.mkDerivation rec {
     ninja
     pkg-config
     shared-mime-info
-    wrapGAppsHook4
+    wrapGAppsHook
   ];
 
   buildInputs = [

--- a/pkgs/tools/filesystems/eiciel/default.nix
+++ b/pkgs/tools/filesystems/eiciel/default.nix
@@ -9,7 +9,7 @@
 , ninja
 , pkg-config
 , itstool
-, wrapGAppsHook4
+, wrapGAppsHook
 , gtk4
 }:
 
@@ -31,7 +31,7 @@ stdenv.mkDerivation rec {
     ninja
     pkg-config
     itstool
-    wrapGAppsHook4
+    wrapGAppsHook
     gtk4
   ];
 

--- a/pkgs/tools/graphics/dippi/default.nix
+++ b/pkgs/tools/graphics/dippi/default.nix
@@ -10,7 +10,7 @@
 , gtk3
 , gtk4
 , libadwaita
-, wrapGAppsHook4
+, wrapGAppsHook
 , appstream-glib
 , desktop-file-utils
 }:
@@ -31,7 +31,7 @@ stdenv.mkDerivation rec {
     ninja
     vala
     pkg-config
-    wrapGAppsHook4
+    wrapGAppsHook
     appstream-glib
     desktop-file-utils
     # For post_install.py

--- a/pkgs/tools/graphics/dynamic-wallpaper/default.nix
+++ b/pkgs/tools/graphics/dynamic-wallpaper/default.nix
@@ -5,7 +5,7 @@
 , ninja
 , pkg-config
 , blueprint-compiler
-, wrapGAppsHook4
+, wrapGAppsHook
 , appstream-glib
 , desktop-file-utils
 , glib
@@ -31,7 +31,7 @@ python3.pkgs.buildPythonApplication rec {
     ninja
     pkg-config
     blueprint-compiler
-    wrapGAppsHook4
+    wrapGAppsHook
     appstream-glib
     desktop-file-utils
   ];

--- a/pkgs/tools/misc/czkawka/default.nix
+++ b/pkgs/tools/misc/czkawka/default.nix
@@ -8,7 +8,7 @@
 , gdk-pixbuf
 , atk
 , gtk4
-, wrapGAppsHook4
+, wrapGAppsHook
 , gobject-introspection
 , xvfb-run
 , testers
@@ -30,7 +30,7 @@ rustPlatform.buildRustPackage rec {
 
   nativeBuildInputs = [
     pkg-config
-    wrapGAppsHook4
+    wrapGAppsHook
     gobject-introspection
   ];
 

--- a/pkgs/tools/networking/iwgtk/default.nix
+++ b/pkgs/tools/networking/iwgtk/default.nix
@@ -5,7 +5,7 @@
 , ninja
 , pkg-config
 , scdoc
-, wrapGAppsHook4
+, wrapGAppsHook
 , gtk4
 , qrencode
 }:
@@ -24,7 +24,7 @@ stdenv.mkDerivation rec {
   # patch systemd service to pass necessary environments and use absolute paths
   patches = [ ./systemd-service.patch ];
 
-  nativeBuildInputs = [ meson ninja pkg-config scdoc wrapGAppsHook4 ];
+  nativeBuildInputs = [ meson ninja pkg-config scdoc wrapGAppsHook ];
 
   buildInputs = [ gtk4 qrencode ];
 

--- a/pkgs/tools/networking/whatip/default.nix
+++ b/pkgs/tools/networking/whatip/default.nix
@@ -10,7 +10,7 @@
 , librsvg
 , blueprint-compiler
 , gobject-introspection
-, wrapGAppsHook4
+, wrapGAppsHook
 , appstream-glib
 , desktop-file-utils
 }:
@@ -34,7 +34,7 @@ python3.pkgs.buildPythonApplication rec {
     ninja
     pkg-config
     blueprint-compiler
-    wrapGAppsHook4
+    wrapGAppsHook
     appstream-glib
     desktop-file-utils
   ];

--- a/pkgs/tools/text/textpieces/default.nix
+++ b/pkgs/tools/text/textpieces/default.nix
@@ -14,7 +14,7 @@
 , blueprint-compiler
 , gtksourceview5
 , gobject-introspection
-, wrapGAppsHook4
+, wrapGAppsHook
 , appstream-glib
 , desktop-file-utils
 }:
@@ -40,7 +40,7 @@ stdenv.mkDerivation rec {
     pythonEnv
     vala
     blueprint-compiler
-    wrapGAppsHook4
+    wrapGAppsHook
     appstream-glib
     desktop-file-utils
   ];

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1198,8 +1198,6 @@ with pkgs;
     makeWrapper = makeBinaryWrapper;
   };
 
-  wrapGAppsHook4 = wrapGAppsHook.override { gtk3 = gtk4; };
-
   wrapGAppsNoGuiHook = wrapGAppsHook.override { isGraphical = false; };
 
   separateDebugInfo = makeSetupHook {


### PR DESCRIPTION
###### Description of changes

As noted in the comments, there's no reason for wrapGAppsHook to propagate gtk3 at all, or librsvg as a native build input.  This also means we can get rid of wrapGAppsHook4, as it's now identical to wrapGAppsHook.

It's finally time to do this, because I noticed the extra gtk build input was breaking cross compilation of gcr_4.

Draft while I search for build regressions.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
