### PR TITLE
prometheus-fronius-exporter: init at 0.10.0

### DIFF
--- a/nixos/modules/services/monitoring/prometheus/exporters.nix
+++ b/nixos/modules/services/monitoring/prometheus/exporters.nix
@@ -35,6 +35,7 @@ let
     "dovecot"
     "fastly"
     "fritzbox"
+    "fronius"
     "graphite"
     "influxdb"
     "ipmi"

--- a/nixos/modules/services/monitoring/prometheus/exporters/fronius.nix
+++ b/nixos/modules/services/monitoring/prometheus/exporters/fronius.nix
@@ -1,0 +1,79 @@
+{ config, lib, pkgs, options }:
+
+with lib;
+
+let
+  cfg = config.services.prometheus.exporters.fronius;
+in
+{
+  port = 8080;
+  extraOpts = {
+    symo = {
+      url = mkOption {
+        type = types.str;
+        description = lib.mdDoc ''
+          Target base URL of Fronius Symo device. (default "http://symo.ip.or.hostname")
+        '';
+      };
+      enable-archive = mkOption {
+        type = types.bool;
+        description = lib.mdDoc ''
+          Enable/disable scraping of archive data (default true), at least one of archive/power-flow has to be enabled
+        '';
+        default = true;
+      };
+      enable-power-flow = mkOption {
+        type = types.bool;
+        description = lib.mdDoc ''
+          Enable/disable scraping of power flow data (default true), at least one of archive/power-flow has to be enabled
+        '';
+        default = true;
+      };
+      header = mkOption {
+        type = types.nullOr types.str;
+        description = lib.mdDoc ''
+          List of "key: value" headers to append to the requests going to Fronius Symo. Example: --symo.header "authorization=Basic <base64>".
+        '';
+        default = null;
+      };
+      timeout = mkOption {
+        type = types.nullOr types.str;
+        description = lib.mdDoc ''
+          Timeout in seconds when collecting metrics from Fronius Symo. Should not be larger than the scrape interval. (default 5)
+        '';
+        default = "5s";
+      };
+    };
+    log.level = mkOption {
+      type = types.nullOr types.str;
+      description = lib.mdDoc ''
+        Logging level. (default "info")
+      '';
+      default = "info";
+    };
+  };
+  serviceOpts = {
+    serviceConfig = {
+      Environment = [
+        ## IP Address to bind to listen for Prometheus scrapes.
+        "BIND_ADDR=${cfg.listenAddress}:${toString cfg.port}"
+        ## Target URL of Fronius Symo device.
+        "SYMO__URL=${cfg.symo.url}"
+        ## Enable/disable scraping of archive data
+        "SYMO__ENABLE_ARCHIVE=${lib.boolToString cfg.symo.enable-archive}"
+        ## Enable/disable scraping of power flow data
+        "SYMO__ENABLE_POWER_FLOW=${lib.boolToString cfg.symo.enable-power-flow}"
+      ]
+        ## Comma-separated List of "key: value" headers to append to the requests going to Fronius Symo. Example: "authorization=Basic <base64>".
+        ++ lib.optional (cfg.symo.header != null) "SYMO__HEADER=${cfg.symo.header}"
+        ## Logging level.
+        ++ lib.optional (cfg.log.level != null) "LOG__LEVEL=${cfg.log.level}"
+        ## Timeout in seconds when collecting metrics from Fronius Symo. Should not be larger than the scrape interval.
+        ++ lib.optional (cfg.symo.timeout != null) "SYMO__TIMEOUT=${cfg.symo.timeout}"
+      ;
+      ExecStart = ''
+        ${pkgs.prometheus-fronius-exporter}/bin/fronius-exporter
+      '';
+    };
+  };
+}

--- a/nixos/tests/prometheus-exporters.nix
+++ b/nixos/tests/prometheus-exporters.nix
@@ -284,6 +284,20 @@ let
       '';
     };
 
+    fronius = {
+      exporterConfig = {
+        enable = true;
+        symo.url = "http://localhost";
+      };
+      exporterTest = ''
+        wait_for_unit("prometheus-fronius-exporter.service")
+        wait_for_open_port(8080)
+        wait_until_succeeds(
+            "curl -sSf 'localhost:8080/metrics' | grep 'fronius_scrape_error_count'"
+        )
+      '';
+    };
+
     graphite = {
       exporterConfig = {
         enable = true;

--- a/pkgs/servers/monitoring/prometheus/fronius-exporter.nix
+++ b/pkgs/servers/monitoring/prometheus/fronius-exporter.nix
@@ -1,0 +1,26 @@
+{ lib, buildGoModule, fetchFromGitHub, nixosTests }:
+
+buildGoModule rec {
+  pname = "fronius-exporter";
+  version = "0.10.0";
+
+  src = fetchFromGitHub {
+    owner = "ccremer";
+    repo = pname;
+    rev = "v${version}";
+    hash = "sha256-BRCs7FNoZZLk7uvRNgPEJBhof1C+GCM4Pqb8HHZoZGY=";
+  };
+
+  vendorHash = "sha256-yNZk0Lb0mduhqVvG4+5Z+bV/ssQh8ujhjBvBDgToBho=";
+
+  passthru.tests = { inherit (nixosTests.prometheus-exporters) fronius; };
+
+  meta = with lib; {
+    description = "Fronius Symo Photovoltaics exporter for prometheus";
+    homepage = "https://github.com/ccremer/fronius-exporter";
+    license = licenses.asl20;
+    maintainers = with maintainers; [
+      _0x4A6F
+    ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -26195,6 +26195,7 @@ with pkgs;
   prometheus-fastly-exporter = callPackage ../servers/monitoring/prometheus/fastly-exporter.nix { };
   prometheus-flow-exporter = callPackage ../servers/monitoring/prometheus/flow-exporter.nix { };
   prometheus-fritzbox-exporter = callPackage ../servers/monitoring/prometheus/fritzbox-exporter.nix { };
+  prometheus-fronius-exporter = callPackage ../servers/monitoring/prometheus/fronius-exporter.nix { };
   prometheus-gitlab-ci-pipelines-exporter = callPackage ../servers/monitoring/prometheus/gitlab-ci-pipelines-exporter.nix { };
   prometheus-graphite-exporter = callPackage ../servers/monitoring/prometheus/graphite-exporter.nix { };
   prometheus-haproxy-exporter = callPackage ../servers/monitoring/prometheus/haproxy-exporter.nix { };


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
Add [fronius-exporter](https://github.com/ccremer/fronius-exporter/) to nixpkgs.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
