### PR TITLE
nixos/swww: init at 0.7.3

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -1604,6 +1604,15 @@
     githubId = 9315;
     name = "Zhong Jianxin";
   };
+  b3nj5m1n = {
+    name = "Benjamin";
+    email = "b3nj4m1n@gmx.net";
+    github = "b3nj5m1n";
+    githubId = 47924309;
+    keys = [{
+      fingerprint = "9F7D 2083 BB22 0CEE B720  E068 309D 4C86 8984 9C5B";
+    }];
+  };
   b4dm4n = {
     email = "fabianm88@gmail.com";
     github = "B4dM4n";

--- a/nixos/doc/manual/release-notes/rl-2305.section.md
+++ b/nixos/doc/manual/release-notes/rl-2305.section.md
@@ -53,6 +53,8 @@ In addition to numerous new and upgraded packages, this release has the followin
 
 - [hyprland](https://github.com/hyprwm/hyprland), a dynamic tiling Wayland compositor that doesn't sacrifice on its looks. Available as [programs.hyprland](#opt-programs.hyprland.enable).
 
+- [swww](https://github.com/Horus645/swww/), a wayland wallpaper daemon. Available as [services.swww](#opt-services.swww.enable).
+
 - [minipro](https://gitlab.com/DavidGriffith/minipro/), an open source program for controlling the MiniPRO TL866xx series of chip programmers. Available as [programs.minipro](options.html#opt-programs.minipro.enable).
 
 - [stevenblack-blocklist](https://github.com/StevenBlack/hosts), A unified hosts file with base extensions for blocking unwanted websites. Available as [networking.stevenblack](options.html#opt-networking.stevenblack.enable).

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -1139,6 +1139,7 @@
   ./services/video/unifi-video.nix
   ./services/video/v4l2-relayd.nix
   ./services/wayland/cage.nix
+  ./services/wayland/swww.nix
   ./services/web-apps/akkoma.nix
   ./services/web-apps/alps.nix
   ./services/web-apps/atlassian/confluence.nix

--- a/nixos/modules/services/wayland/swww.nix
+++ b/nixos/modules/services/wayland/swww.nix
@@ -1,0 +1,29 @@
+{ config, pkgs, lib, ... }:
+
+with lib;
+
+let
+  cfg = config.services.swww;
+in
+{
+  options.services.swww.enable = mkEnableOption (lib.mdDoc "wallpaper daemon");
+
+  config = mkIf cfg.enable {
+    systemd.user.services."swww" = {
+      enable = true;
+      description = "wallpaper daemon";
+      after = [ "graphical-session.target" ];
+      requires = [ "graphical-session.target" ];
+      wantedBy = [ "graphical-session.target" ];
+      serviceConfig = {
+        Type = "notify";
+        ExecStart = "${pkgs.swww}/bin/swww init --no-daemon";
+        NotifyAccess = "all";
+      };
+      path = [ pkgs.swww ];
+    };
+  };
+
+  meta.maintainers = with lib.maintainers; [ b3nj5m1n ];
+
+}


### PR DESCRIPTION
###### Description of changes

This adds a systemd service for the [swww](https://github.com/Horus645/swww/) wallpaper daemon.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [x] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
