### PR TITLE
yatas: 1.3.3 -> 1.5.1

### DIFF
--- a/pkgs/tools/security/yatas/default.nix
+++ b/pkgs/tools/security/yatas/default.nix
@@ -5,16 +5,16 @@
 
 buildGoModule rec {
   pname = "yatas";
-  version = "1.3.3";
+  version = "1.5.1";
 
   src = fetchFromGitHub {
     owner = "padok-team";
     repo = "YATAS";
     rev = "refs/tags/v${version}";
-    hash = "sha256-BjcqEO+rDEjPttGgTH07XyQKLcs/O+FarKTWjqXWQOo=";
+    hash = "sha256-gw4aZ7SLUz5WLUb1z4zDtI6Ca0tEWhE5wobp5NRvjkg=";
   };
 
-  vendorHash = "sha256-QOFt9h4Hdt+Mx82yw4mjAoyUXHeprvjRoLYLBnihwJo=";
+  vendorHash = "sha256-zp5EVJe5Q6o6C0CZ8u+oEFEOy0NU5SgVN+cSc6A/jZ4=";
 
   meta = with lib; {
     description = "Tool to audit AWS infrastructure for misconfiguration or potential security issues";


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
With master version I had:
```
$ nix --init
$ nix --install
/tmp/yatas-tmp-196840224
{0xc000002480}
2023/04/24 13:58:56 [DEBUG] Downloaded to /tmp/yatas-tmp-196840224
2023/04/24 13:58:56 [DEBUG] file found in zip: yatas-aws
2023/04/24 13:58:57 [DEBUG] Installed /home/teto/.yatas.d/plugins/github.com/padok-team/yatas-aws/latest/yatas-aws successfully
New version available for plugin aws : 1.8.1
panic: unexpected EOF

goroutine 1 [running]:
github.com/padok-team/yatas/plugins/commons.(*YatasRPC).Run(0xc000126898, 0xc00012d2f4?)
	github.com/padok-team/yatas/plugins/commons/commons.go:23 +0xdf
github.com/padok-team/yatas/plugins/manager.RunPlugin({{0xc00012d2f4, 0x3}, 0x1, {0xc000176540, 0x1f}, {0x0, 0x0}, {0xc00012d320, 0x6}, {0xc000176660, ...}, ...}, ...)
	github.com/padok-team/yatas/plugins/manager/manager.go:69 +0x69d
github.com/padok-team/yatas/internal/cli.runChecksPlugins(0xc00017a600, 0xc000187e00)
	github.com/padok-team/yatas/internal/cli/cli.go:43 +0x225
github.com/padok-team/yatas/internal/cli.Execute()
	github.com/padok-team/yatas/internal/cli/cli.go:130 +0x11d
main.run()
	github.com/padok-team/yatas/main.go:52 +0x7a
main.main()
	github.com/padok-team/yatas/main.go:14 +0x19
```

It now works.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
