### PR TITLE
cudaPackages_12_1: init at 12.1.1; cudnn: don't break cudaPackages

### DIFF
--- a/pkgs/development/compilers/cudatoolkit/redist/extension.nix
+++ b/pkgs/development/compilers/cudatoolkit/redist/extension.nix
@@ -1,7 +1,7 @@
 final: prev: let
 
   inherit (final) callPackage;
-  inherit (prev) cudaVersion lib pkgs;
+  inherit (prev) cudaVersion lib;
 
   ### Cuda Toolkit Redist
 
@@ -14,6 +14,7 @@ final: prev: let
     "11.7" = ./manifests/redistrib_11.7.0.json;
     "11.8" = ./manifests/redistrib_11.8.0.json;
     "12.0" = ./manifests/redistrib_12.0.1.json;
+    "12.1" = ./manifests/redistrib_12.1.1.json;
   };
 
   # Function to build a single cudatoolkit redist package
@@ -23,8 +24,6 @@ final: prev: let
   buildCudaToolkitRedistPackages = { version, manifest }: let
     attrs = lib.filterAttrs (key: value: key != "release_date") (lib.importJSON manifest);
   in lib.mapAttrs buildCudaToolkitRedistPackage attrs;
-
-  redistExists = cudaToolkitRedistManifests ? "${cudaVersion}";
 
   # All cudatoolkit redist packages for the current cuda version
   cudaToolkitRedistPackages = if

--- a/pkgs/development/compilers/cudatoolkit/redist/manifests/redistrib_12.1.1.json
+++ b/pkgs/development/compilers/cudatoolkit/redist/manifests/redistrib_12.1.1.json
@@ -1,0 +1,1127 @@
+{
+    "release_date": "2023-04-19",
+    "cuda_cccl": {
+        "name": "CXX Core Compute Libraries",
+        "license": "CUDA Toolkit",
+        "version": "12.1.109",
+        "linux-x86_64": {
+            "relative_path": "cuda_cccl/linux-x86_64/cuda_cccl-linux-x86_64-12.1.109-archive.tar.xz",
+            "sha256": "b84ef3ec3dc1b4891267be25846f0c3ed7f9fa84154d59eba805402b86991baa",
+            "md5": "7133971e57e54ca78dd4476270c13d56",
+            "size": "1024940"
+        },
+        "linux-ppc64le": {
+            "relative_path": "cuda_cccl/linux-ppc64le/cuda_cccl-linux-ppc64le-12.1.109-archive.tar.xz",
+            "sha256": "54fc03a5d3682e7f09c04d67f8db84a1921b6144838d9e4281584b556e8bdf68",
+            "md5": "1bcbce0bc6c96279637084ff34b12ee3",
+            "size": "1025056"
+        },
+        "linux-sbsa": {
+            "relative_path": "cuda_cccl/linux-sbsa/cuda_cccl-linux-sbsa-12.1.109-archive.tar.xz",
+            "sha256": "bddd9462467f65e1e766998a75b363643e1e99e7ad1640c4e94f5df7d881e757",
+            "md5": "ac9b5a4ee1d8a4321e3f68ea8adab473",
+            "size": "1024688"
+        },
+        "windows-x86_64": {
+            "relative_path": "cuda_cccl/windows-x86_64/cuda_cccl-windows-x86_64-12.1.109-archive.zip",
+            "sha256": "2bf3d61e695abc8c4b5dbb06c6b5286cfd4c27037bb5ea7e6ba232a266b6677b",
+            "md5": "f986f8077feb482e86c64d822d7c777b",
+            "size": "2610919"
+        },
+        "linux-aarch64": {
+            "relative_path": "cuda_cccl/linux-aarch64/cuda_cccl-linux-aarch64-12.1.109-archive.tar.xz",
+            "sha256": "5630dafabf1e3c205661d5caae8e229a17819fd928e24015063196617b8e85f9",
+            "md5": "2a1ed84390a2829a6e772ecf06ffdb4f",
+            "size": "1025192"
+        }
+    },
+    "cuda_compat": {
+        "name": "CUDA compat L4T",
+        "license": "CUDA Toolkit",
+        "version": "12.1.32956252",
+        "linux-aarch64": {
+            "relative_path": "cuda_compat/linux-aarch64/cuda_compat-linux-aarch64-12.1.32956252-archive.tar.xz",
+            "sha256": "ab73e05d9610c79f6f4184fa7f0864f15d5afc99248c053f3189a21808d4c743",
+            "md5": "3ae7a8045bddb5972601073efaa0ae39",
+            "size": "16300032"
+        }
+    },
+    "cuda_cudart": {
+        "name": "CUDA Runtime (cudart)",
+        "license": "CUDA Toolkit",
+        "version": "12.1.105",
+        "linux-x86_64": {
+            "relative_path": "cuda_cudart/linux-x86_64/cuda_cudart-linux-x86_64-12.1.105-archive.tar.xz",
+            "sha256": "6096ec878c8c443258d39c6e9cf2decef127f8aa8da594fdc5a336d047ab6bd9",
+            "md5": "4562908c66430be2baed868c490990b7",
+            "size": "984372"
+        },
+        "linux-ppc64le": {
+            "relative_path": "cuda_cudart/linux-ppc64le/cuda_cudart-linux-ppc64le-12.1.105-archive.tar.xz",
+            "sha256": "5e50478b7b1e4ffde463d2dafb33df8e52748d469257ae53fffc66249ac9d8b9",
+            "md5": "b5d14928bd3b4969410cb78d618da895",
+            "size": "975184"
+        },
+        "linux-sbsa": {
+            "relative_path": "cuda_cudart/linux-sbsa/cuda_cudart-linux-sbsa-12.1.105-archive.tar.xz",
+            "sha256": "4a08376f30c2b3c4274fbd40e546738b59c046beb9766c1d76c5f4d192d2aa2c",
+            "md5": "aa65bdcfe58286bc6678a60ae0a7c02f",
+            "size": "975408"
+        },
+        "windows-x86_64": {
+            "relative_path": "cuda_cudart/windows-x86_64/cuda_cudart-windows-x86_64-12.1.105-archive.zip",
+            "sha256": "99b884fc761a4c8592f819a170947db2dff2cd26fafc350bd4dd3c2b4b9aaf19",
+            "md5": "bbe760196c077c5d94fae5413a2d00d4",
+            "size": "2388734"
+        },
+        "linux-aarch64": {
+            "relative_path": "cuda_cudart/linux-aarch64/cuda_cudart-linux-aarch64-12.1.105-archive.tar.xz",
+            "sha256": "ca7358c878d217b4982df896e726d49146f00396e3687778409bf022b7ce15e1",
+            "md5": "995c7c7e73627521d6557f70afc9e563",
+            "size": "1042344"
+        }
+    },
+    "cuda_cuobjdump": {
+        "name": "cuobjdump",
+        "license": "CUDA Toolkit",
+        "version": "12.1.111",
+        "linux-x86_64": {
+            "relative_path": "cuda_cuobjdump/linux-x86_64/cuda_cuobjdump-linux-x86_64-12.1.111-archive.tar.xz",
+            "sha256": "1098b58dac2be496bf9a2766c9cdc17c20848a0dd42fc7283aa9c669c0afda52",
+            "md5": "94136b6cc6b8584f1c83f5d4654cae3a",
+            "size": "170292"
+        },
+        "linux-ppc64le": {
+            "relative_path": "cuda_cuobjdump/linux-ppc64le/cuda_cuobjdump-linux-ppc64le-12.1.111-archive.tar.xz",
+            "sha256": "9838b259bcc5baae86371a05f336af0f8e5cf8b75b8f7c2532864424e4bf1185",
+            "md5": "136700b759d9ebd4893d356874238d4b",
+            "size": "211324"
+        },
+        "linux-sbsa": {
+            "relative_path": "cuda_cuobjdump/linux-sbsa/cuda_cuobjdump-linux-sbsa-12.1.111-archive.tar.xz",
+            "sha256": "36ebf3301076b41c826df39816cf3db72e08d857191a87f052dceb2edb68993c",
+            "md5": "46ef304ede48c48c099791ad357cf5ee",
+            "size": "178396"
+        },
+        "windows-x86_64": {
+            "relative_path": "cuda_cuobjdump/windows-x86_64/cuda_cuobjdump-windows-x86_64-12.1.111-archive.zip",
+            "sha256": "c4b10ad15fcfd8ae9d8253361026c87db716cf3f6b4ca562f411afe557ca5eec",
+            "md5": "bdaafe80180823df8b706b905b5b7620",
+            "size": "3939463"
+        },
+        "linux-aarch64": {
+            "relative_path": "cuda_cuobjdump/linux-aarch64/cuda_cuobjdump-linux-aarch64-12.1.111-archive.tar.xz",
+            "sha256": "bf03ce708bf5e4b6fd03401c668985fa21bd8bc12259f961b9f4522e2ad11137",
+            "md5": "71538f9f70e44c4debda20da72d78950",
+            "size": "178400"
+        }
+    },
+    "cuda_cupti": {
+        "name": "CUPTI",
+        "license": "CUDA Toolkit",
+        "version": "12.1.105",
+        "linux-x86_64": {
+            "relative_path": "cuda_cupti/linux-x86_64/cuda_cupti-linux-x86_64-12.1.105-archive.tar.xz",
+            "sha256": "397594a200619aa748bdd9e1c95bbf01bfddbb00624940c5ed26e43df1bec363",
+            "md5": "5b3931f56eb0ef25dc17a7be6f87b1df",
+            "size": "19531632"
+        },
+        "linux-ppc64le": {
+            "relative_path": "cuda_cupti/linux-ppc64le/cuda_cupti-linux-ppc64le-12.1.105-archive.tar.xz",
+            "sha256": "197a4ce0e42f41f68fe49ae7d6a7bef9a1f49838785955ef0285a008f6ded365",
+            "md5": "417f9c3232d49810545728ec270115d9",
+            "size": "9890596"
+        },
+        "linux-sbsa": {
+            "relative_path": "cuda_cupti/linux-sbsa/cuda_cupti-linux-sbsa-12.1.105-archive.tar.xz",
+            "sha256": "ead8d9a706b89cd0e4d5243920ccfdf032304187e69f0cc844ec76f7293d4d46",
+            "md5": "e07f6ec79cd468c02b7dc9105ba64ba1",
+            "size": "9823408"
+        },
+        "windows-x86_64": {
+            "relative_path": "cuda_cupti/windows-x86_64/cuda_cupti-windows-x86_64-12.1.105-archive.zip",
+            "sha256": "15d09e7226bc1157c57044af8cc6d01b74847954c856942d93a58f9450f43163",
+            "md5": "3d6be91145958f28a0b7ad57f7f74d26",
+            "size": "13249593"
+        },
+        "linux-aarch64": {
+            "relative_path": "cuda_cupti/linux-aarch64/cuda_cupti-linux-aarch64-12.1.105-archive.tar.xz",
+            "sha256": "7a6d7381bada9a77f723945da77187670b443885be539114ad6fef1fcd9a4792",
+            "md5": "089c04ea2f30089f174a3929a9287b65",
+            "size": "7609012"
+        }
+    },
+    "cuda_cuxxfilt": {
+        "name": "CUDA cuxxfilt (demangler)",
+        "license": "CUDA Toolkit",
+        "version": "12.1.105",
+        "linux-x86_64": {
+            "relative_path": "cuda_cuxxfilt/linux-x86_64/cuda_cuxxfilt-linux-x86_64-12.1.105-archive.tar.xz",
+            "sha256": "1dc4f9cb38d1d9582994bd5656eef4d0536f217ec00ec1ac035a11afdc1b416d",
+            "md5": "8ed4c137c68ab60a6d6f8009b09cb97b",
+            "size": "188412"
+        },
+        "linux-ppc64le": {
+            "relative_path": "cuda_cuxxfilt/linux-ppc64le/cuda_cuxxfilt-linux-ppc64le-12.1.105-archive.tar.xz",
+            "sha256": "3778f811e5e28f899f02a5079af31478227420436ad4db42bb4ae454a8ae7654",
+            "md5": "cd6a267514b84173dc592b65646ff283",
+            "size": "182056"
+        },
+        "linux-sbsa": {
+            "relative_path": "cuda_cuxxfilt/linux-sbsa/cuda_cuxxfilt-linux-sbsa-12.1.105-archive.tar.xz",
+            "sha256": "fa1354301e6c993de2364cb78664e87fca8ddbc571cff28c5fb5a0fc694f7692",
+            "md5": "d2a7c4ef44aee80c2270ced9fd4b84a1",
+            "size": "174336"
+        },
+        "windows-x86_64": {
+            "relative_path": "cuda_cuxxfilt/windows-x86_64/cuda_cuxxfilt-windows-x86_64-12.1.105-archive.zip",
+            "sha256": "db3c55cff2a860b2a6a5e4ae563002bc177657cfc24eee8cf139594d0c1966db",
+            "md5": "331a8f363ec4058080f3367a8c4de8e4",
+            "size": "168665"
+        },
+        "linux-aarch64": {
+            "relative_path": "cuda_cuxxfilt/linux-aarch64/cuda_cuxxfilt-linux-aarch64-12.1.105-archive.tar.xz",
+            "sha256": "7f254d2d23ac5c2644cc12282cda9a88fd2b471a81d4100845f15bd0b5c64b96",
+            "md5": "8c207acf191188ddaed731f12f2121cb",
+            "size": "174444"
+        }
+    },
+    "cuda_demo_suite": {
+        "name": "CUDA Demo Suite",
+        "license": "CUDA Toolkit",
+        "version": "12.1.105",
+        "linux-x86_64": {
+            "relative_path": "cuda_demo_suite/linux-x86_64/cuda_demo_suite-linux-x86_64-12.1.105-archive.tar.xz",
+            "sha256": "17fb34cbfab110c30e1de6bd6eb55b5e60313f4005447d58195261f3032abd1c",
+            "md5": "c58b43c5122590df0306700999843ea8",
+            "size": "4002272"
+        },
+        "windows-x86_64": {
+            "relative_path": "cuda_demo_suite/windows-x86_64/cuda_demo_suite-windows-x86_64-12.1.105-archive.zip",
+            "sha256": "2040fca50af1ea0fc6354d10eec29460c6ad1281707d9a90e769c09c19d57323",
+            "md5": "4da3b6c821850878d0e64be717303b19",
+            "size": "5048732"
+        }
+    },
+    "cuda_documentation": {
+        "name": "CUDA Documentation",
+        "license": "CUDA Toolkit",
+        "version": "12.1.105",
+        "linux-x86_64": {
+            "relative_path": "cuda_documentation/linux-x86_64/cuda_documentation-linux-x86_64-12.1.105-archive.tar.xz",
+            "sha256": "218d2fc583b47d6afa3e8d0c627c9855b444b5a187350f5034c3cda388b1e9d6",
+            "md5": "69cf9cb2267901e4ed10aba0dade705c",
+            "size": "66968"
+        },
+        "linux-ppc64le": {
+            "relative_path": "cuda_documentation/linux-ppc64le/cuda_documentation-linux-ppc64le-12.1.105-archive.tar.xz",
+            "sha256": "1baa62e3d7f6ee21ed59f73debc901a8db8543f455011ebc3c96c7b05da61c1d",
+            "md5": "c3af6d0e92447be67f3a476ab8d6d5ea",
+            "size": "67004"
+        },
+        "linux-sbsa": {
+            "relative_path": "cuda_documentation/linux-sbsa/cuda_documentation-linux-sbsa-12.1.105-archive.tar.xz",
+            "sha256": "85d459c7e6fb6fc0a0eb356b37c791c4287aee083e524800e3f79ad401a6a832",
+            "md5": "524a27c87ac3408985d843396103a7dd",
+            "size": "67008"
+        },
+        "windows-x86_64": {
+            "relative_path": "cuda_documentation/windows-x86_64/cuda_documentation-windows-x86_64-12.1.105-archive.zip",
+            "sha256": "d8cd5cd098fdeafd2fd9b685a1e44d8198c3f0d885a571285a08493c2a12dfb4",
+            "md5": "961aabc26353144b397cec97daa35432",
+            "size": "105380"
+        },
+        "linux-aarch64": {
+            "relative_path": "cuda_documentation/linux-aarch64/cuda_documentation-linux-aarch64-12.1.105-archive.tar.xz",
+            "sha256": "91f29bae1f18b0120e37aa90d3b8232005ee5163b480ecf800cfd42c440d66d2",
+            "md5": "068eb585e84dd2f46661f29ac3bfdbde",
+            "size": "67112"
+        }
+    },
+    "cuda_gdb": {
+        "name": "CUDA GDB",
+        "license": "CUDA Toolkit",
+        "version": "12.1.105",
+        "linux-x86_64": {
+            "relative_path": "cuda_gdb/linux-x86_64/cuda_gdb-linux-x86_64-12.1.105-archive.tar.xz",
+            "sha256": "c4beeae8c5bf76aba1288fb250e1b6da8e3944e7b97a4009203e1bd0a3700508",
+            "md5": "f2775b80ef3e62afc5f2ac6db9305f6f",
+            "size": "65729064"
+        },
+        "linux-ppc64le": {
+            "relative_path": "cuda_gdb/linux-ppc64le/cuda_gdb-linux-ppc64le-12.1.105-archive.tar.xz",
+            "sha256": "7f7a34ed5523f8009fdb254649936349c612928d239442da66b8d5cdaea14fd0",
+            "md5": "937842198afe6ce0a270ab7b014cee0c",
+            "size": "65447760"
+        },
+        "linux-sbsa": {
+            "relative_path": "cuda_gdb/linux-sbsa/cuda_gdb-linux-sbsa-12.1.105-archive.tar.xz",
+            "sha256": "38872097b48fd54717e327c87d8a1074faafa9318b265ffcd154809b2aa33153",
+            "md5": "114d15c7a9f33bc284f4e3009b3f72bd",
+            "size": "65361736"
+        },
+        "linux-aarch64": {
+            "relative_path": "cuda_gdb/linux-aarch64/cuda_gdb-linux-aarch64-12.1.105-archive.tar.xz",
+            "sha256": "5c5acf1aa245e8bff1cf889daa1c8b25b7e0e9ce2b271d1ef2127b207ebe0ced",
+            "md5": "adf1bc7c5197e00e759681005e626fee",
+            "size": "65277972"
+        }
+    },
+    "cuda_nsight": {
+        "name": "Nsight Eclipse Edition Plugin",
+        "license": "CUDA Toolkit",
+        "version": "12.1.105",
+        "linux-x86_64": {
+            "relative_path": "cuda_nsight/linux-x86_64/cuda_nsight-linux-x86_64-12.1.105-archive.tar.xz",
+            "sha256": "76d61e20abbd07e794ab640179d8f86f092c05c418e8ee6d2845ab1626db1655",
+            "md5": "5dcadf51ae2e74ac3e102bf6651f0395",
+            "size": "118607604"
+        },
+        "linux-ppc64le": {
+            "relative_path": "cuda_nsight/linux-ppc64le/cuda_nsight-linux-ppc64le-12.1.105-archive.tar.xz",
+            "sha256": "1b0636867c23e5dd0348ad7b49d9b10a2c831e0cdaac99dce23686a31aebde52",
+            "md5": "e140a6b74c206a6c035cb9b134c3d9b9",
+            "size": "118607596"
+        }
+    },
+    "cuda_nvcc": {
+        "name": "CUDA NVCC",
+        "license": "CUDA Toolkit",
+        "version": "12.1.105",
+        "linux-x86_64": {
+            "relative_path": "cuda_nvcc/linux-x86_64/cuda_nvcc-linux-x86_64-12.1.105-archive.tar.xz",
+            "sha256": "0b85f7eee17788abbd170b0b493c74ce2e9fd5a9604461b99c2c378165e1083b",
+            "md5": "40610a303fa8aa49e3641d2899654a44",
+            "size": "44459684"
+        },
+        "linux-ppc64le": {
+            "relative_path": "cuda_nvcc/linux-ppc64le/cuda_nvcc-linux-ppc64le-12.1.105-archive.tar.xz",
+            "sha256": "e6e2c4c80e44409cd9006c6f1fd56d7c48c4a8bcd2d130f9405bcb7af16660a0",
+            "md5": "b773302b3be16b253de79f8867746769",
+            "size": "41272608"
+        },
+        "linux-sbsa": {
+            "relative_path": "cuda_nvcc/linux-sbsa/cuda_nvcc-linux-sbsa-12.1.105-archive.tar.xz",
+            "sha256": "6e795ec791241e9320ec300657408cbfafbe7e79ceda0da46522cc85ced358f4",
+            "md5": "d7bf2ee4a59943ca0d101d4eff18692d",
+            "size": "40149352"
+        },
+        "windows-x86_64": {
+            "relative_path": "cuda_nvcc/windows-x86_64/cuda_nvcc-windows-x86_64-12.1.105-archive.zip",
+            "sha256": "3b452d704c92e8af6d59247ee842b2ca8c8e37dd04c015eea59c74c265672074",
+            "md5": "99137e9a69b1fe95bdb6f2bb79ff1fd4",
+            "size": "59619440"
+        },
+        "linux-aarch64": {
+            "relative_path": "cuda_nvcc/linux-aarch64/cuda_nvcc-linux-aarch64-12.1.105-archive.tar.xz",
+            "sha256": "16f8614a0478b5d90cf0c9a5aec7c6a28077f8ec11bba09579dc21d05a0e2536",
+            "md5": "7e253d329b35af3ac395313b4e4e0a03",
+            "size": "40137460"
+        }
+    },
+    "cuda_nvdisasm": {
+        "name": "CUDA nvdisasm",
+        "license": "CUDA Toolkit",
+        "version": "12.1.105",
+        "linux-x86_64": {
+            "relative_path": "cuda_nvdisasm/linux-x86_64/cuda_nvdisasm-linux-x86_64-12.1.105-archive.tar.xz",
+            "sha256": "f47cbfd3f139e37da7cfd648e5a4f3d3f2d67a6f1515e8c1f9bb135f1ce6a9e9",
+            "md5": "fbab3080aaaed467883dc2c6a4e36db1",
+            "size": "49869060"
+        },
+        "linux-ppc64le": {
+            "relative_path": "cuda_nvdisasm/linux-ppc64le/cuda_nvdisasm-linux-ppc64le-12.1.105-archive.tar.xz",
+            "sha256": "1c8201b8825f385be4ede895941852b17feff39706b9f950d1ce9502a464b213",
+            "md5": "51d8aaeae0f4dd627482136290296e7d",
+            "size": "49869828"
+        },
+        "linux-sbsa": {
+            "relative_path": "cuda_nvdisasm/linux-sbsa/cuda_nvdisasm-linux-sbsa-12.1.105-archive.tar.xz",
+            "sha256": "9592d0de8a0be49af357b9a7894e073005d9657f3aa23b13b6d665d937d1f90c",
+            "md5": "a2fac2f3dbb6dd35fe52650c5786b941",
+            "size": "49798992"
+        },
+        "windows-x86_64": {
+            "relative_path": "cuda_nvdisasm/windows-x86_64/cuda_nvdisasm-windows-x86_64-12.1.105-archive.zip",
+            "sha256": "32e6b7a9e49ed132fba2968fdf964f019e6a3c34d796c93d37445b5278ba6216",
+            "md5": "cf3c24e497ba4e54d3b18e6ee8895f37",
+            "size": "50121383"
+        },
+        "linux-aarch64": {
+            "relative_path": "cuda_nvdisasm/linux-aarch64/cuda_nvdisasm-linux-aarch64-12.1.105-archive.tar.xz",
+            "sha256": "c239aa158b1081ae8746bf89ac64f502b8a950106bbe59f2485fd7c3420fd35e",
+            "md5": "bc9851b7ccb1cba7b66b9f8d0d2da9b6",
+            "size": "49811684"
+        }
+    },
+    "cuda_nvml_dev": {
+        "name": "CUDA NVML Headers",
+        "license": "CUDA Toolkit",
+        "version": "12.1.105",
+        "linux-x86_64": {
+            "relative_path": "cuda_nvml_dev/linux-x86_64/cuda_nvml_dev-linux-x86_64-12.1.105-archive.tar.xz",
+            "sha256": "20ae775b1c78a107fca1cc52f2cba35f55e5296356fe0678937212f70923d77f",
+            "md5": "f0f7a5d66f2a0865f1af0c761cbf87fd",
+            "size": "80740"
+        },
+        "linux-ppc64le": {
+            "relative_path": "cuda_nvml_dev/linux-ppc64le/cuda_nvml_dev-linux-ppc64le-12.1.105-archive.tar.xz",
+            "sha256": "22e57945f33e4b995d63899993b7a0f07fb512fc8ecb5279d183da726b3550fe",
+            "md5": "02460ca6038b585390f659b6c2323787",
+            "size": "80308"
+        },
+        "linux-sbsa": {
+            "relative_path": "cuda_nvml_dev/linux-sbsa/cuda_nvml_dev-linux-sbsa-12.1.105-archive.tar.xz",
+            "sha256": "c8580a12241b20fc46bdf3acfce09d5395bf5dc665df2db4c2d5e9491326b8cb",
+            "md5": "615a65a9561478b14616777613357c2e",
+            "size": "80840"
+        },
+        "windows-x86_64": {
+            "relative_path": "cuda_nvml_dev/windows-x86_64/cuda_nvml_dev-windows-x86_64-12.1.105-archive.zip",
+            "sha256": "44a500778ecf60988525d1f1b8f32fa224b80d771057bdbe7488cc3c662d6d38",
+            "md5": "521b5f1d6542dad60962037378375727",
+            "size": "112614"
+        },
+        "linux-aarch64": {
+            "relative_path": "cuda_nvml_dev/linux-aarch64/cuda_nvml_dev-linux-aarch64-12.1.105-archive.tar.xz",
+            "sha256": "9dd50f8856d3abcf0dcc00df8d7115922b30464d9ae46d19c93c35b8e5025471",
+            "md5": "b922b83454ef5209f501ff162af02a86",
+            "size": "80828"
+        }
+    },
+    "cuda_nvprof": {
+        "name": "CUDA nvprof",
+        "license": "CUDA Toolkit",
+        "version": "12.1.105",
+        "linux-x86_64": {
+            "relative_path": "cuda_nvprof/linux-x86_64/cuda_nvprof-linux-x86_64-12.1.105-archive.tar.xz",
+            "sha256": "e935e68342597a12b3e1c5adf15cfa497ca633424dbf583d5e38db0cb810e5a3",
+            "md5": "005a24622b25d5b2d8b0f9a6da6c1f98",
+            "size": "2438996"
+        },
+        "linux-ppc64le": {
+            "relative_path": "cuda_nvprof/linux-ppc64le/cuda_nvprof-linux-ppc64le-12.1.105-archive.tar.xz",
+            "sha256": "84490cc8c8b610203c122215f3c2e1fc189d84c6a58e7aba4c82b52fd6e2a9e9",
+            "md5": "ae4a39d501ffc82590a6d0ac4c431734",
+            "size": "2116212"
+        },
+        "windows-x86_64": {
+            "relative_path": "cuda_nvprof/windows-x86_64/cuda_nvprof-windows-x86_64-12.1.105-archive.zip",
+            "sha256": "387d95aa1fcab9d54de34287576ab0ac0455060bdbd297dee82010aea1a20a4e",
+            "md5": "cef902eb145d949db01c2309def9ca22",
+            "size": "1699172"
+        }
+    },
+    "cuda_nvprune": {
+        "name": "CUDA nvprune",
+        "license": "CUDA Toolkit",
+        "version": "12.1.105",
+        "linux-x86_64": {
+            "relative_path": "cuda_nvprune/linux-x86_64/cuda_nvprune-linux-x86_64-12.1.105-archive.tar.xz",
+            "sha256": "aaf3b1f67bb3d6cafc1ea2b9519ec4285a8312be0f44402c7ac292a6a0d23163",
+            "md5": "80a03231204049ee365acb6f3d279ca9",
+            "size": "56112"
+        },
+        "linux-ppc64le": {
+            "relative_path": "cuda_nvprune/linux-ppc64le/cuda_nvprune-linux-ppc64le-12.1.105-archive.tar.xz",
+            "sha256": "f0d9d46ac68030d4f0958c4d3f9de462c0ca93a03c6058de6e46575c2e732259",
+            "md5": "f828bdda82f4c3461594a6ddeb141020",
+            "size": "57072"
+        },
+        "linux-sbsa": {
+            "relative_path": "cuda_nvprune/linux-sbsa/cuda_nvprune-linux-sbsa-12.1.105-archive.tar.xz",
+            "sha256": "0af184fce75a6407cdd7d87e9abc51d6740bacb694c2f22a35ce29b71988de16",
+            "md5": "7cb1b663ee28c6fa132060fd6d118447",
+            "size": "48140"
+        },
+        "windows-x86_64": {
+            "relative_path": "cuda_nvprune/windows-x86_64/cuda_nvprune-windows-x86_64-12.1.105-archive.zip",
+            "sha256": "daf438d2f1f48484428fa06a5d9d72c3f8f1fb6b01c7c38270981ba76ede45dc",
+            "md5": "323903166bd99d6e3e5bc6df85de7932",
+            "size": "145887"
+        },
+        "linux-aarch64": {
+            "relative_path": "cuda_nvprune/linux-aarch64/cuda_nvprune-linux-aarch64-12.1.105-archive.tar.xz",
+            "sha256": "fe522567b7082475f8f2cae12989e9469892d2e7be9d5f65e5112078c781b1c1",
+            "md5": "8ec842811ef6155e97782b50ecc1f6b1",
+            "size": "48264"
+        }
+    },
+    "cuda_nvrtc": {
+        "name": "CUDA NVRTC",
+        "license": "CUDA Toolkit",
+        "version": "12.1.105",
+        "linux-x86_64": {
+            "relative_path": "cuda_nvrtc/linux-x86_64/cuda_nvrtc-linux-x86_64-12.1.105-archive.tar.xz",
+            "sha256": "bb15706aca6760770f0bfb814517f875ab0cfd479bc6b1d5dd7792c5ded8317b",
+            "md5": "370ced2f49edf8abcbfcf73b4dde6407",
+            "size": "30298852"
+        },
+        "linux-ppc64le": {
+            "relative_path": "cuda_nvrtc/linux-ppc64le/cuda_nvrtc-linux-ppc64le-12.1.105-archive.tar.xz",
+            "sha256": "9b931993944a6fe82a996bf765e14360e1f27c6ee2ca77316be6bb2b26e4bc81",
+            "md5": "b7f0f373ec2f04eaa89c328edca80cd1",
+            "size": "27964548"
+        },
+        "linux-sbsa": {
+            "relative_path": "cuda_nvrtc/linux-sbsa/cuda_nvrtc-linux-sbsa-12.1.105-archive.tar.xz",
+            "sha256": "0b42518c99cc31bb45ccbecde0de6f8d60f846dd822656eeeb56e78a91a35f0c",
+            "md5": "74405ecbc39f6712605365a63efe326e",
+            "size": "27947404"
+        },
+        "windows-x86_64": {
+            "relative_path": "cuda_nvrtc/windows-x86_64/cuda_nvrtc-windows-x86_64-12.1.105-archive.zip",
+            "sha256": "7fa294726483b10815305fe1c07c9ceb23e048fc43bb459775eb68dee82d1a8f",
+            "md5": "e810060bf1485e91b388cab3823f9179",
+            "size": "97082567"
+        },
+        "linux-aarch64": {
+            "relative_path": "cuda_nvrtc/linux-aarch64/cuda_nvrtc-linux-aarch64-12.1.105-archive.tar.xz",
+            "sha256": "6160d7f26427e39d5493c42a7f1bde525db813fcd14669f174d944621e3eb72a",
+            "md5": "39e263540f9151bee6919b0724de3a94",
+            "size": "27949992"
+        }
+    },
+    "cuda_nvtx": {
+        "name": "CUDA NVTX",
+        "license": "CUDA Toolkit",
+        "version": "12.1.105",
+        "linux-x86_64": {
+            "relative_path": "cuda_nvtx/linux-x86_64/cuda_nvtx-linux-x86_64-12.1.105-archive.tar.xz",
+            "sha256": "8ca2c72c247bf10ca10653637c60e792a1249cbeecc1d817c4815d98b45cf1c2",
+            "md5": "d9a136e881d34e73d2c8fac20240bbb2",
+            "size": "48392"
+        },
+        "linux-ppc64le": {
+            "relative_path": "cuda_nvtx/linux-ppc64le/cuda_nvtx-linux-ppc64le-12.1.105-archive.tar.xz",
+            "sha256": "61a8522850e0b07f650d72fd9bf5182e06e348f660ef37a7b8fcdf862ea215dc",
+            "md5": "e57f226b073b6b5cf7fcfa93a53b4689",
+            "size": "48384"
+        },
+        "linux-sbsa": {
+            "relative_path": "cuda_nvtx/linux-sbsa/cuda_nvtx-linux-sbsa-12.1.105-archive.tar.xz",
+            "sha256": "cde9802f1c2cc817c6e1d2f516212c4847621b80a204ad7d84fd11b39c386741",
+            "md5": "47262cab870aba1065ae712ba264023d",
+            "size": "48960"
+        },
+        "windows-x86_64": {
+            "relative_path": "cuda_nvtx/windows-x86_64/cuda_nvtx-windows-x86_64-12.1.105-archive.zip",
+            "sha256": "862f9289b193d5d229ebb1a8417eb988a2f318837b35f887e93f74940f7abd1e",
+            "md5": "66378ef4c49f25cf85f88c5f7e9ceae3",
+            "size": "65732"
+        },
+        "linux-aarch64": {
+            "relative_path": "cuda_nvtx/linux-aarch64/cuda_nvtx-linux-aarch64-12.1.105-archive.tar.xz",
+            "sha256": "57aa538cd488794fc29af621af755f51ffdabd39e0536605558a0b7be80d04c9",
+            "md5": "8a4bbd1acc73a2f16e6889cf5b1b78bd",
+            "size": "48900"
+        }
+    },
+    "cuda_nvvp": {
+        "name": "CUDA NVVP",
+        "license": "CUDA Toolkit",
+        "version": "12.1.105",
+        "linux-x86_64": {
+            "relative_path": "cuda_nvvp/linux-x86_64/cuda_nvvp-linux-x86_64-12.1.105-archive.tar.xz",
+            "sha256": "90692b8d390a3e7fd9e3e395b3e41b5b8c245e8359f73e6819da22258eb5c451",
+            "md5": "de39a01d0cc5ddce2b9e574afdc62696",
+            "size": "117590064"
+        },
+        "linux-ppc64le": {
+            "relative_path": "cuda_nvvp/linux-ppc64le/cuda_nvvp-linux-ppc64le-12.1.105-archive.tar.xz",
+            "sha256": "7393407c1902c4ef5d19b9ae80c022a1b7089ff5d5ac0a03baee74d42b32c9f8",
+            "md5": "f20a0d87c73219e3cbca4655531c3090",
+            "size": "117191204"
+        },
+        "windows-x86_64": {
+            "relative_path": "cuda_nvvp/windows-x86_64/cuda_nvvp-windows-x86_64-12.1.105-archive.zip",
+            "sha256": "ecf8a8623e36f376d6353b2cfd6152a3f58946e47a6ba15fd1b062f39165c466",
+            "md5": "36ecadd9342f2ec18603568456a695ea",
+            "size": "120359941"
+        }
+    },
+    "cuda_opencl": {
+        "name": "CUDA OpenCL",
+        "license": "CUDA Toolkit",
+        "version": "12.1.105",
+        "linux-x86_64": {
+            "relative_path": "cuda_opencl/linux-x86_64/cuda_opencl-linux-x86_64-12.1.105-archive.tar.xz",
+            "sha256": "9dbd1f857c93f8785baa0a001def26e56176a4c9550d642dc8f4963791588acc",
+            "md5": "00a8b62612d1402ea8655f6da195da90",
+            "size": "74948"
+        },
+        "windows-x86_64": {
+            "relative_path": "cuda_opencl/windows-x86_64/cuda_opencl-windows-x86_64-12.1.105-archive.zip",
+            "sha256": "f74b45e80e149640edc03ebd6b069848cdde14aa2bea7b72847f9637c2709ba8",
+            "md5": "e88c84b8a2cb5e32ecb2ff5336ddb58c",
+            "size": "111872"
+        }
+    },
+    "cuda_profiler_api": {
+        "name": "CUDA Profiler API",
+        "license": "CUDA Toolkit",
+        "version": "12.1.105",
+        "linux-x86_64": {
+            "relative_path": "cuda_profiler_api/linux-x86_64/cuda_profiler_api-linux-x86_64-12.1.105-archive.tar.xz",
+            "sha256": "3fff6cb6eb0e04f96b0b5fca26d97486cacd1ea6d3d0d2fcf8d2982bf0b3eda0",
+            "md5": "6973dc03ee650bc13a7d9675123f0126",
+            "size": "16044"
+        },
+        "linux-ppc64le": {
+            "relative_path": "cuda_profiler_api/linux-ppc64le/cuda_profiler_api-linux-ppc64le-12.1.105-archive.tar.xz",
+            "sha256": "3fc2cf6556bc3eb8c01044a089c12ae15fcec8a8beb0886b234c0aa61e4b1356",
+            "md5": "facfb6a72b03b048d28330bd38900e0c",
+            "size": "16060"
+        },
+        "linux-sbsa": {
+            "relative_path": "cuda_profiler_api/linux-sbsa/cuda_profiler_api-linux-sbsa-12.1.105-archive.tar.xz",
+            "sha256": "f7e0a26f39e65b8ccdac72ee37b74cd91ca6a02dad5e37eb95d6fb916fdfae2f",
+            "md5": "e065ffa67d6e3d8afda6f1baf74c8a01",
+            "size": "16052"
+        },
+        "windows-x86_64": {
+            "relative_path": "cuda_profiler_api/windows-x86_64/cuda_profiler_api-windows-x86_64-12.1.105-archive.zip",
+            "sha256": "027c91b2bf617a769f97ac381369c2e7d9906df6f10d289e40723212680b854b",
+            "md5": "00552553440481edd0a57936c97581e6",
+            "size": "20085"
+        },
+        "linux-aarch64": {
+            "relative_path": "cuda_profiler_api/linux-aarch64/cuda_profiler_api-linux-aarch64-12.1.105-archive.tar.xz",
+            "sha256": "f95aa99a08cfe543c1e257aa72e0ab1ab1d6aa2392a23a054b75c51160c608ff",
+            "md5": "e2acc123c186ea0bc6685553cad6b381",
+            "size": "16060"
+        }
+    },
+    "cuda_sanitizer_api": {
+        "name": "CUDA Compute Sanitizer API",
+        "license": "CUDA Toolkit",
+        "version": "12.1.105",
+        "linux-x86_64": {
+            "relative_path": "cuda_sanitizer_api/linux-x86_64/cuda_sanitizer_api-linux-x86_64-12.1.105-archive.tar.xz",
+            "sha256": "dfa911da08c37bd521b993bf35c26a9975c4737c77fd8eea92af23be13afa602",
+            "md5": "2b2670d0d0ce84436d34d91b9c6e3569",
+            "size": "8201172"
+        },
+        "linux-ppc64le": {
+            "relative_path": "cuda_sanitizer_api/linux-ppc64le/cuda_sanitizer_api-linux-ppc64le-12.1.105-archive.tar.xz",
+            "sha256": "e38e89cd64d5e63223fee80d8d5f61b5329c42f84a41b27d5348b6824f9be1c2",
+            "md5": "ebf7670de0330f46a595bd9c2ad51ca2",
+            "size": "7504248"
+        },
+        "linux-sbsa": {
+            "relative_path": "cuda_sanitizer_api/linux-sbsa/cuda_sanitizer_api-linux-sbsa-12.1.105-archive.tar.xz",
+            "sha256": "a03f9530b695114c56fdc8ee9fd3cf004697aef7faec9dc025d0985020562687",
+            "md5": "3eeb12d08df90ee42702993de0ba63fe",
+            "size": "6130188"
+        },
+        "windows-x86_64": {
+            "relative_path": "cuda_sanitizer_api/windows-x86_64/cuda_sanitizer_api-windows-x86_64-12.1.105-archive.zip",
+            "sha256": "40d6e1620ed8d2437cc92183ea5758f88e6106ba82260a4c6597a016d98bfec7",
+            "md5": "c707f9b508c213138c72492680c19705",
+            "size": "13778916"
+        },
+        "linux-aarch64": {
+            "relative_path": "cuda_sanitizer_api/linux-aarch64/cuda_sanitizer_api-linux-aarch64-12.1.105-archive.tar.xz",
+            "sha256": "98732b8e98532de8d442e0863054ba7e80e502bb99717b30a5222fc5154e3b06",
+            "md5": "e349cd3718c25ef049ad2da40ba88bd3",
+            "size": "3488580"
+        }
+    },
+    "fabricmanager": {
+        "name": "NVIDIA Fabric Manager",
+        "license": "NVIDIA Driver",
+        "version": "530.30.02",
+        "linux-x86_64": {
+            "relative_path": "fabricmanager/linux-x86_64/fabricmanager-linux-x86_64-530.30.02-archive.tar.xz",
+            "sha256": "8829106dc8f6fbd43555c91bee42b24fd83f03a8866f9832a0d39762e7075e18",
+            "md5": "c09a93d9534e3fb624c99de82992ff75",
+            "size": "1640772"
+        },
+        "linux-sbsa": {
+            "relative_path": "fabricmanager/linux-sbsa/fabricmanager-linux-sbsa-530.30.02-archive.tar.xz",
+            "sha256": "279bcd0d2a0d9bc01a64bfea7b0c307a462c9e89724a3735d9a77a670ab9f56c",
+            "md5": "dc5346ae2383541e954c8b9ffffe131c",
+            "size": "1517396"
+        }
+    },
+    "libcublas": {
+        "name": "CUDA cuBLAS",
+        "license": "CUDA Toolkit",
+        "version": "12.1.3.1",
+        "linux-x86_64": {
+            "relative_path": "libcublas/linux-x86_64/libcublas-linux-x86_64-12.1.3.1-archive.tar.xz",
+            "sha256": "90044d7ad8c44f33cb670c1fe6f2c22246db6c22c2db22c7a172bb61cccb438c",
+            "md5": "620a5e5f4260fc28e551a7814172770d",
+            "size": "486381128"
+        },
+        "linux-ppc64le": {
+            "relative_path": "libcublas/linux-ppc64le/libcublas-linux-ppc64le-12.1.3.1-archive.tar.xz",
+            "sha256": "25f08898e157c2ac2952ff7ce82fa2938580d713494d545a9809ee9aec7cf9f1",
+            "md5": "1099e15913eed6a452edcc074a13fd00",
+            "size": "389886724"
+        },
+        "linux-sbsa": {
+            "relative_path": "libcublas/linux-sbsa/libcublas-linux-sbsa-12.1.3.1-archive.tar.xz",
+            "sha256": "95d01b8185a3e43dad819c10496df17f36c319f0896a45b1a76407ee31d8df78",
+            "md5": "e134c6cfc12390b12699bb41ac0f0b1b",
+            "size": "484671980"
+        },
+        "windows-x86_64": {
+            "relative_path": "libcublas/windows-x86_64/libcublas-windows-x86_64-12.1.3.1-archive.zip",
+            "sha256": "c55de20432e3a2469de8cb3999b829f74441d00384e058b2dcfa1a65d8c280ef",
+            "md5": "297455cb80a983a6c71c37f9153b9684",
+            "size": "433280194"
+        },
+        "linux-aarch64": {
+            "relative_path": "libcublas/linux-aarch64/libcublas-linux-aarch64-12.1.3.1-archive.tar.xz",
+            "sha256": "2e395b3cdf4e492101ecabde4b4ea2d75b6e9d36fcbc37b0e9d78f7fefefffaf",
+            "md5": "f0aa6afface882b17f88228d8a6c4683",
+            "size": "444613724"
+        }
+    },
+    "libcudla": {
+        "name": "cuDLA",
+        "license": "CUDA Toolkit",
+        "version": "12.1.105",
+        "linux-aarch64": {
+            "relative_path": "libcudla/linux-aarch64/libcudla-linux-aarch64-12.1.105-archive.tar.xz",
+            "sha256": "2af462a0130b71b06ea80ece1b53857047f55eb0466dfc7118e9562a6f0ade30",
+            "md5": "bf283975fb5b1971a3b094db73c89891",
+            "size": "38784"
+        }
+    },
+    "libcufft": {
+        "name": "CUDA cuFFT",
+        "license": "CUDA Toolkit",
+        "version": "11.0.2.54",
+        "linux-x86_64": {
+            "relative_path": "libcufft/linux-x86_64/libcufft-linux-x86_64-11.0.2.54-archive.tar.xz",
+            "sha256": "7136c1d42c7d1fbc29db2f401c8d5f169d4b81cff4d017946d3e6f45077e7b14",
+            "md5": "61ebbb5cf403fba1307082713c6adaef",
+            "size": "168580988"
+        },
+        "linux-ppc64le": {
+            "relative_path": "libcufft/linux-ppc64le/libcufft-linux-ppc64le-11.0.2.54-archive.tar.xz",
+            "sha256": "2c7c8c5950de601f400d916095248683401c6d26a3e81497d0db0d129ba6730a",
+            "md5": "e47c320ad1a333cabbce49a732545f24",
+            "size": "168774744"
+        },
+        "linux-sbsa": {
+            "relative_path": "libcufft/linux-sbsa/libcufft-linux-sbsa-11.0.2.54-archive.tar.xz",
+            "sha256": "138ad4dc1d0895a8bf8ed6b32b204dcbda176397a23a044ec76a6785c7452fa4",
+            "md5": "2691db0e505f79a65ce3699a3403d41b",
+            "size": "168136048"
+        },
+        "windows-x86_64": {
+            "relative_path": "libcufft/windows-x86_64/libcufft-windows-x86_64-11.0.2.54-archive.zip",
+            "sha256": "87cd7a4453a873d011210075bfedf76397ca08f29237354277b07076a9e057b3",
+            "md5": "891e19293f838492a24bbf2b3cc13f91",
+            "size": "119758471"
+        },
+        "linux-aarch64": {
+            "relative_path": "libcufft/linux-aarch64/libcufft-linux-aarch64-11.0.2.54-archive.tar.xz",
+            "sha256": "e6bc88cafdf640f2a8483408cf1582297036437746a17c23a86f0341d2ecbe4e",
+            "md5": "897594e0fb8ffca1260845311c34db70",
+            "size": "168766860"
+        }
+    },
+    "libcufile": {
+        "name": "CUDA cuFile",
+        "license": "CUDA Toolkit",
+        "version": "1.6.1.9",
+        "linux-x86_64": {
+            "relative_path": "libcufile/linux-x86_64/libcufile-linux-x86_64-1.6.1.9-archive.tar.xz",
+            "sha256": "c2a635c98aaafff7c7c9daf4c1a60c96c2cbd7b580cff488a26376f42194d9a0",
+            "md5": "f2e84470315651409ab195fbc12f2121",
+            "size": "40933956"
+        },
+        "linux-aarch64": {
+            "relative_path": "libcufile/linux-aarch64/libcufile-linux-aarch64-1.6.1.9-archive.tar.xz",
+            "sha256": "d42d78134a3fd9650867ef6401d7b4367fc788d9537d96045726fc18faa3a943",
+            "md5": "bfa0c27ae0f7922327b12725d3aa985d",
+            "size": "40604524"
+        }
+    },
+    "libcurand": {
+        "name": "CUDA cuRAND",
+        "license": "CUDA Toolkit",
+        "version": "10.3.2.106",
+        "linux-x86_64": {
+            "relative_path": "libcurand/linux-x86_64/libcurand-linux-x86_64-10.3.2.106-archive.tar.xz",
+            "sha256": "9941216fad2d419e6172dbd2ee431d77effe671065c08490782fc286ebb364de",
+            "md5": "bf666aed73b07e8dcc82b114888fa30f",
+            "size": "81957052"
+        },
+        "linux-ppc64le": {
+            "relative_path": "libcurand/linux-ppc64le/libcurand-linux-ppc64le-10.3.2.106-archive.tar.xz",
+            "sha256": "fa3c5424bba7f7ea4bef08278099f2c0cb63eeff80ee51d0fea9965315732817",
+            "md5": "89806fab1c07506392d2e5142301b951",
+            "size": "81998648"
+        },
+        "linux-sbsa": {
+            "relative_path": "libcurand/linux-sbsa/libcurand-linux-sbsa-10.3.2.106-archive.tar.xz",
+            "sha256": "525d997d74b391a3484f9c71e7a6e51a136267b8a2dddbfef1420134f3011827",
+            "md5": "d4caf3b2687f3225459d2239aad88f43",
+            "size": "81945548"
+        },
+        "windows-x86_64": {
+            "relative_path": "libcurand/windows-x86_64/libcurand-windows-x86_64-10.3.2.106-archive.zip",
+            "sha256": "9d899a09c9d227d995b7fd2a4e9f0c16abfe1e0543f41b09ccb05802c9fa107b",
+            "md5": "ad8a371884599e1d98ce06af5a694a2d",
+            "size": "55277946"
+        },
+        "linux-aarch64": {
+            "relative_path": "libcurand/linux-aarch64/libcurand-linux-aarch64-10.3.2.106-archive.tar.xz",
+            "sha256": "43922977f6bbd83329a2b69df06693f4721e0ff66d904eff220984778a1c8553",
+            "md5": "4437cc01b11eb445766b4ae2ab375b6b",
+            "size": "84137248"
+        }
+    },
+    "libcusolver": {
+        "name": "CUDA cuSOLVER",
+        "license": "CUDA Toolkit",
+        "version": "11.4.5.107",
+        "linux-x86_64": {
+            "relative_path": "libcusolver/linux-x86_64/libcusolver-linux-x86_64-11.4.5.107-archive.tar.xz",
+            "sha256": "7169970001e71fbd8ff2678830af9a90edd23d0165f53c829c00a6decfe464f8",
+            "md5": "22f544337bc73be71b201fb8b9bda09b",
+            "size": "122638448"
+        },
+        "linux-ppc64le": {
+            "relative_path": "libcusolver/linux-ppc64le/libcusolver-linux-ppc64le-11.4.5.107-archive.tar.xz",
+            "sha256": "4366b28caf8d44703a491bd654ca2388ad3f122e22fd494396b78707889f538a",
+            "md5": "c70e626d7f9cd07f9f50ac6b0c7bf6e9",
+            "size": "122608296"
+        },
+        "linux-sbsa": {
+            "relative_path": "libcusolver/linux-sbsa/libcusolver-linux-sbsa-11.4.5.107-archive.tar.xz",
+            "sha256": "06bb7bdc008de189117f258ebc4c190392be3950afbcd78b40603ff165bdef74",
+            "md5": "b270531e7da69e9c33a827eb149fdc6c",
+            "size": "121875340"
+        },
+        "windows-x86_64": {
+            "relative_path": "libcusolver/windows-x86_64/libcusolver-windows-x86_64-11.4.5.107-archive.zip",
+            "sha256": "974f0754076678dff903a0f34f50594fa683e54b7ad1ee59b98b86a60a591cdb",
+            "md5": "7998782f61817781f8c9117e9875108f",
+            "size": "120075736"
+        },
+        "linux-aarch64": {
+            "relative_path": "libcusolver/linux-aarch64/libcusolver-linux-aarch64-11.4.5.107-archive.tar.xz",
+            "sha256": "185c2f5733e8f62bc8eef74e35bdd0031f47c48b5fa615d823c92b0c89ea2873",
+            "md5": "100a70e808ea1eebe1652b7d8d7897f1",
+            "size": "132349940"
+        }
+    },
+    "libcusparse": {
+        "name": "CUDA cuSPARSE",
+        "license": "CUDA Toolkit",
+        "version": "12.1.0.106",
+        "linux-x86_64": {
+            "relative_path": "libcusparse/linux-x86_64/libcusparse-linux-x86_64-12.1.0.106-archive.tar.xz",
+            "sha256": "ae1f604d6aa753b156e3072519a29938b74b37b727c7bd78fab73add78f83907",
+            "md5": "f26e877fd4bb52784b751ca1d017207c",
+            "size": "213244220"
+        },
+        "linux-ppc64le": {
+            "relative_path": "libcusparse/linux-ppc64le/libcusparse-linux-ppc64le-12.1.0.106-archive.tar.xz",
+            "sha256": "7b767e2294b6ea89cb0163d7f2d37d7c28973d06e0ea1273a650fd1b6933518e",
+            "md5": "8b9cde1a194d92e2ad33e0bdc5dcebad",
+            "size": "213389568"
+        },
+        "linux-sbsa": {
+            "relative_path": "libcusparse/linux-sbsa/libcusparse-linux-sbsa-12.1.0.106-archive.tar.xz",
+            "sha256": "1cede312d23dd19225cac1124363835127a08d9641f7e2a330056b7c35190703",
+            "md5": "1a39e5c5e22accf3d4c7f7557cf5a5a0",
+            "size": "212898536"
+        },
+        "windows-x86_64": {
+            "relative_path": "libcusparse/windows-x86_64/libcusparse-windows-x86_64-12.1.0.106-archive.zip",
+            "sha256": "882156f87ec1f95938d7b1a35419fbc340e475488dbd45664ef8b8705767c1d2",
+            "md5": "cd2b9f1575ac6d6832426aed78f99a8a",
+            "size": "193245943"
+        },
+        "linux-aarch64": {
+            "relative_path": "libcusparse/linux-aarch64/libcusparse-linux-aarch64-12.1.0.106-archive.tar.xz",
+            "sha256": "334ada7297132db8042cd4275045dfe88b343c83ffd65449d6c7bc8f138fb5ef",
+            "md5": "b6037b1c8de6d9638e308a14f74823c8",
+            "size": "228310912"
+        }
+    },
+    "libnpp": {
+        "name": "CUDA NPP",
+        "license": "CUDA Toolkit",
+        "version": "12.1.0.40",
+        "linux-x86_64": {
+            "relative_path": "libnpp/linux-x86_64/libnpp-linux-x86_64-12.1.0.40-archive.tar.xz",
+            "sha256": "52c42e32c7961ecf8b8eef0e46fca6701928a935d2d918c788038a8d1b448bd1",
+            "md5": "701b8b4eb69d0eb7f3ed63e3965c7822",
+            "size": "183926752"
+        },
+        "linux-ppc64le": {
+            "relative_path": "libnpp/linux-ppc64le/libnpp-linux-ppc64le-12.1.0.40-archive.tar.xz",
+            "sha256": "5eb467e72d4a6c4ce76ded7d26cfbaa3410de78a853660e777ec165c14211c90",
+            "md5": "59c8f4f487dc999d9fc5f64d9b4beaa7",
+            "size": "183959808"
+        },
+        "linux-sbsa": {
+            "relative_path": "libnpp/linux-sbsa/libnpp-linux-sbsa-12.1.0.40-archive.tar.xz",
+            "sha256": "658523dd6d269eb433b30d863c4c9f267941bb8cffc0927db49d35bb0f166cfd",
+            "md5": "a4890024b493df30ed7c00e43a8ad657",
+            "size": "183074132"
+        },
+        "windows-x86_64": {
+            "relative_path": "libnpp/windows-x86_64/libnpp-windows-x86_64-12.1.0.40-archive.zip",
+            "sha256": "36d19f9f0635860f18aa6034359fd661c2a58fe41d891df27b48fb8ac6d42336",
+            "md5": "0250a66b0cda023bd4b0155038792b72",
+            "size": "152885082"
+        },
+        "linux-aarch64": {
+            "relative_path": "libnpp/linux-aarch64/libnpp-linux-aarch64-12.1.0.40-archive.tar.xz",
+            "sha256": "70747c485df1dc434fc76eca56868b45144f7822965f70142972450cf0a40b11",
+            "md5": "4c0eaa97558c733b57ac188baf9d2832",
+            "size": "200270560"
+        }
+    },
+    "libnvidia_nscq": {
+        "name": "NVIDIA NSCQ API",
+        "license": "NVIDIA Driver",
+        "version": "530.30.02",
+        "linux-x86_64": {
+            "relative_path": "libnvidia_nscq/linux-x86_64/libnvidia_nscq-linux-x86_64-530.30.02-archive.tar.xz",
+            "sha256": "92f04a09ad4abea1f3abddd79a93bbea96fe860a0d71ec1cf8a1d0560ed4983f",
+            "md5": "9335a0980c022961a17585579bc47856",
+            "size": "566496"
+        },
+        "linux-sbsa": {
+            "relative_path": "libnvidia_nscq/linux-sbsa/libnvidia_nscq-linux-sbsa-530.30.02-archive.tar.xz",
+            "sha256": "876558b581ab341c5cc70af4482ef022fd93e417563465b403372f5f8fa076d5",
+            "md5": "32c1adeb59c19d98f6199608dbeeab4b",
+            "size": "522780"
+        }
+    },
+    "libnvjitlink": {
+        "name": "NVIDIA compiler library for JIT LTO functionality",
+        "license": "CUDA Toolkit",
+        "version": "12.1.105",
+        "linux-x86_64": {
+            "relative_path": "libnvjitlink/linux-x86_64/libnvjitlink-linux-x86_64-12.1.105-archive.tar.xz",
+            "sha256": "21ee6206cf9509e1c1c31be918b1971da8eb1e7c5492804ecd6750105c7db6b4",
+            "md5": "df8e9e5b969d9b1a7bdf764588896fd2",
+            "size": "25844852"
+        },
+        "linux-ppc64le": {
+            "relative_path": "libnvjitlink/linux-ppc64le/libnvjitlink-linux-ppc64le-12.1.105-archive.tar.xz",
+            "sha256": "4feb6cf35852dc191e3d20d1522374ecbbe9773d70a52fd58e1674642e1b09bf",
+            "md5": "5cb8d20acca552a9cd177670b8688b6c",
+            "size": "23779324"
+        },
+        "linux-sbsa": {
+            "relative_path": "libnvjitlink/linux-sbsa/libnvjitlink-linux-sbsa-12.1.105-archive.tar.xz",
+            "sha256": "0a314ce11a20f097ac844ebe7b8d6ca1cfc00dd1d24624d86b51ad09f41625ed",
+            "md5": "98b01d8a290d04653941e312311047dd",
+            "size": "23712884"
+        },
+        "windows-x86_64": {
+            "relative_path": "libnvjitlink/windows-x86_64/libnvjitlink-windows-x86_64-12.1.105-archive.zip",
+            "sha256": "f89184abc5a1d4a1c12ef202c2524671a3be6d464e0b7d8e9fb67c1a9e714097",
+            "md5": "d2172d6bdfc367275e7c95b7f6b98224",
+            "size": "86687097"
+        },
+        "linux-aarch64": {
+            "relative_path": "libnvjitlink/linux-aarch64/libnvjitlink-linux-aarch64-12.1.105-archive.tar.xz",
+            "sha256": "dfcdecc04bd0d3d30b7605433e23b0ff92d498cd0aeaefa55e3c90f9fc68cb95",
+            "md5": "75cbce40a29b8e91d78f806d38b03b58",
+            "size": "23707576"
+        }
+    },
+    "libnvjpeg": {
+        "name": "CUDA nvJPEG",
+        "license": "CUDA Toolkit",
+        "version": "12.2.0.2",
+        "linux-x86_64": {
+            "relative_path": "libnvjpeg/linux-x86_64/libnvjpeg-linux-x86_64-12.2.0.2-archive.tar.xz",
+            "sha256": "d293267a822c8c87a53cee97cccf49b2eb20c53b99f477328dfa1d7d1c5c7f75",
+            "md5": "ed416e0a36f2ad18eee7ab347366742d",
+            "size": "2514348"
+        },
+        "linux-ppc64le": {
+            "relative_path": "libnvjpeg/linux-ppc64le/libnvjpeg-linux-ppc64le-12.2.0.2-archive.tar.xz",
+            "sha256": "9312eda8337dafa28b4abbca013d1c8bc530de504dd44c0836ba1050929b20fd",
+            "md5": "86ef519a12c8c0203bde1fdcad4c0cd0",
+            "size": "2507988"
+        },
+        "linux-sbsa": {
+            "relative_path": "libnvjpeg/linux-sbsa/libnvjpeg-linux-sbsa-12.2.0.2-archive.tar.xz",
+            "sha256": "54add0d5e2ba36880f47c9a45bdaf9d6b2e41311e40a8d4b933d46f774a6a2fe",
+            "md5": "790aad9c44a0c1d7dc561268751bcb5f",
+            "size": "2340304"
+        },
+        "windows-x86_64": {
+            "relative_path": "libnvjpeg/windows-x86_64/libnvjpeg-windows-x86_64-12.2.0.2-archive.zip",
+            "sha256": "f7e51c1c86298b5ef35d17435234d3ffa8d28e8d10c2439c87bb1875e77f8726",
+            "md5": "7a0ecd4398d55475f39db10c0004214d",
+            "size": "2774956"
+        }
+    },
+    "libnvvm_samples": {
+        "name": "NVVM library samples",
+        "license": "CUDA Toolkit",
+        "version": "12.1.105",
+        "linux-x86_64": {
+            "relative_path": "libnvvm_samples/linux-x86_64/libnvvm_samples-linux-x86_64-12.1.105-archive.tar.xz",
+            "sha256": "b8ca8a3e7e913755eef4f70e15edf0108a684ec6538d84f40a491b60a1568d5e",
+            "md5": "c5ee2fbff8fa2301cbc9b17034030c0e",
+            "size": "28980"
+        },
+        "linux-ppc64le": {
+            "relative_path": "libnvvm_samples/linux-ppc64le/libnvvm_samples-linux-ppc64le-12.1.105-archive.tar.xz",
+            "sha256": "b7e60cf5d037f1763658350c01eb5eb43d8243592a7499bc55de21ad13c9f783",
+            "md5": "e8dfd495ed3a5bee5535453f8d7d13f2",
+            "size": "29008"
+        },
+        "linux-sbsa": {
+            "relative_path": "libnvvm_samples/linux-sbsa/libnvvm_samples-linux-sbsa-12.1.105-archive.tar.xz",
+            "sha256": "41471179b9e5909165928afa36e6806c1ffae1b64d39403c829f8b11e73fa021",
+            "md5": "36eb55edba4b0dc6c6c03d6f6b6cc66c",
+            "size": "28980"
+        },
+        "windows-x86_64": {
+            "relative_path": "libnvvm_samples/windows-x86_64/libnvvm_samples-windows-x86_64-12.1.105-archive.zip",
+            "sha256": "6df8bf51393ac935f0366db9dfbbfce29ccd05e53ebbc6f8e41cdc553d153ee8",
+            "md5": "8b34d002032fbef5d9caa0c8c641815d",
+            "size": "44435"
+        },
+        "linux-aarch64": {
+            "relative_path": "libnvvm_samples/linux-aarch64/libnvvm_samples-linux-aarch64-12.1.105-archive.tar.xz",
+            "sha256": "26563a500a33e92f51a04c96b56e045a87e304212fb399614a22408bf6ffad12",
+            "md5": "9b400d3f8de5b0afdca75e30a8535d04",
+            "size": "29012"
+        }
+    },
+    "nsight_compute": {
+        "name": "Nsight Compute",
+        "license": "NVIDIA SLA",
+        "version": "2023.1.1.4",
+        "linux-x86_64": {
+            "relative_path": "nsight_compute/linux-x86_64/nsight_compute-linux-x86_64-2023.1.1.4-archive.tar.xz",
+            "sha256": "0b19f1fe19e549b217aae3834fea36b0dd56273bf2d6abe682c30916dec83004",
+            "md5": "f1b56347347a8d45bae7521cf070e4c9",
+            "size": "708773752"
+        },
+        "linux-ppc64le": {
+            "relative_path": "nsight_compute/linux-ppc64le/nsight_compute-linux-ppc64le-2023.1.1.4-archive.tar.xz",
+            "sha256": "2dc7ea5c7719550ced4da69e892aae3e97bf03cfdf61a7b70bdf1b4ea6dce227",
+            "md5": "c7f3d83f04a346fb60272c14d1e6c9f7",
+            "size": "181168472"
+        },
+        "linux-sbsa": {
+            "relative_path": "nsight_compute/linux-sbsa/nsight_compute-linux-sbsa-2023.1.1.4-archive.tar.xz",
+            "sha256": "4c93ca3a701a0563e33f1668d85d08a173f5419f2c5170cece2767f4ff322a1b",
+            "md5": "b312e69310f02adaa53221b2c9209916",
+            "size": "344531080"
+        },
+        "windows-x86_64": {
+            "relative_path": "nsight_compute/windows-x86_64/nsight_compute-windows-x86_64-2023.1.1.4-archive.zip",
+            "sha256": "7873643159e97aba86922a6cd26ca9f7451edf6e1e13dbaf5c22e9a16290587b",
+            "md5": "923deaf1a7f14f75391336b17c6c18de",
+            "size": "638766762"
+        },
+        "linux-aarch64": {
+            "relative_path": "nsight_compute/linux-aarch64/nsight_compute-linux-aarch64-2023.1.1.4-archive.tar.xz",
+            "sha256": "a45ba005d765e9467e9f1a6ad6121c5a9efcbdabc284b304ec01c3bda5858eb0",
+            "md5": "10563ea9fad22436b33e9b82915f9f27",
+            "size": "733017452"
+        }
+    },
+    "nsight_systems": {
+        "name": "Nsight Systems",
+        "license": "NVIDIA SLA",
+        "version": "2023.1.2.43",
+        "linux-x86_64": {
+            "relative_path": "nsight_systems/linux-x86_64/nsight_systems-linux-x86_64-2023.1.2.43-archive.tar.xz",
+            "sha256": "db7beae0d1cfd58468a24a682f268828adfb49320e11b3ac2d3b508bce4b2792",
+            "md5": "57f29d05eed0940150c6a1fbcc18ccba",
+            "size": "207237352"
+        },
+        "linux-ppc64le": {
+            "relative_path": "nsight_systems/linux-ppc64le/nsight_systems-linux-ppc64le-2023.1.2.43-archive.tar.xz",
+            "sha256": "8798acb9760a5bb60936e0a209fe3d07835a8c9534a884568f0143bfa5be85f8",
+            "md5": "1113a98ac43d1d3f711a6763c1bc0d66",
+            "size": "60829540"
+        },
+        "linux-sbsa": {
+            "relative_path": "nsight_systems/linux-sbsa/nsight_systems-linux-sbsa-2023.1.2.43-archive.tar.xz",
+            "sha256": "5cd6af8100a17a36a423606f349fe81521982edff3a787486fb97d38bb444883",
+            "md5": "f02c7aa4aa44ece30ade62dcc87bb27b",
+            "size": "195592688"
+        },
+        "windows-x86_64": {
+            "relative_path": "nsight_systems/windows-x86_64/nsight_systems-windows-x86_64-2023.1.2.43-archive.zip",
+            "sha256": "8d70dcca4d105e42d8c7afe37d81b3dabd73ce4111068b04e379c5c4f1f8776f",
+            "md5": "570964242a20a8bfa24f558891f9f27b",
+            "size": "326985615"
+        }
+    },
+    "nsight_vse": {
+        "name": "Nsight Visual Studio Edition (VSE)",
+        "license": "NVIDIA SLA",
+        "version": "2023.1.1.23089",
+        "windows-x86_64": {
+            "relative_path": "nsight_vse/windows-x86_64/nsight_vse-windows-x86_64-2023.1.1.23089-archive.zip",
+            "sha256": "c227d16d9c8c90095ba13290528a4630f5c8d853d0b5555763eb4d21e1a9d2d2",
+            "md5": "03ba47f92340ff97b0d9bf50a8321808",
+            "size": "526974722"
+        }
+    },
+    "nvidia_driver": {
+        "name": "NVIDIA Linux Driver",
+        "license": "NVIDIA Driver",
+        "version": "530.30.02",
+        "linux-x86_64": {
+            "relative_path": "nvidia_driver/linux-x86_64/nvidia_driver-linux-x86_64-530.30.02-archive.tar.xz",
+            "sha256": "db30bba7b44458b2de2e0fb13d335b9eec5886034bde5999dffba23bc4e198ee",
+            "md5": "bfec08e43cc45f45aa07616d9856d2a5",
+            "size": "416508828"
+        },
+        "linux-ppc64le": {
+            "relative_path": "nvidia_driver/linux-ppc64le/nvidia_driver-linux-ppc64le-530.30.02-archive.tar.xz",
+            "sha256": "a5b51d096c36b962c424038bae2279975bc2ccd3caaf7c68fabd67302973b1cc",
+            "md5": "6c8073bc881f177fab52913cd9e95b6e",
+            "size": "98199608"
+        },
+        "linux-sbsa": {
+            "relative_path": "nvidia_driver/linux-sbsa/nvidia_driver-linux-sbsa-530.30.02-archive.tar.xz",
+            "sha256": "a16bfd2ac3cbe16bee5da5c85254a64352cc7bd6a17400db1b65ad692b6ad100",
+            "md5": "1c9513fb5563f4d58507af0d4705a0db",
+            "size": "267452360"
+        }
+    },
+    "nvidia_fs": {
+        "name": "NVIDIA filesystem",
+        "license": "CUDA Toolkit",
+        "version": "2.15.3",
+        "linux-x86_64": {
+            "relative_path": "nvidia_fs/linux-x86_64/nvidia_fs-linux-x86_64-2.15.3-archive.tar.xz",
+            "sha256": "7193562d0c4c1f37ae75d2deedc385bf0bc8d3c580b4e1a3a04dd07011366d6b",
+            "md5": "6d3496b0fb42846df9e77f63ec7b884e",
+            "size": "57576"
+        },
+        "linux-aarch64": {
+            "relative_path": "nvidia_fs/linux-aarch64/nvidia_fs-linux-aarch64-2.15.3-archive.tar.xz",
+            "sha256": "63d80d1bdfdbd1ffaa6bc85f7374752fa47e18dc9e24c1af1ca05ac362f594db",
+            "md5": "dbb45f4bc4cd0c33d1aafc5d602bc945",
+            "size": "57608"
+        }
+    },
+    "visual_studio_integration": {
+        "name": "CUDA Visual Studio Integration",
+        "license": "CUDA Toolkit",
+        "version": "12.1.105",
+        "windows-x86_64": {
+            "relative_path": "visual_studio_integration/windows-x86_64/visual_studio_integration-windows-x86_64-12.1.105-archive.zip",
+            "sha256": "15f513a7ebfa1ad9920f4f1a4adb9949072eb4b3ed6891c65724a72d896734ee",
+            "md5": "236c98bf27739c0f90cc344f1320f86b",
+            "size": "518009"
+        }
+    }
+}

--- a/pkgs/development/compilers/cudatoolkit/versions.toml
+++ b/pkgs/development/compilers/cudatoolkit/versions.toml
@@ -77,3 +77,9 @@ version = "12.0.1"
 url = "https://developer.download.nvidia.com/compute/cuda/12.0.1/local_installers/cuda_12.0.1_525.85.12_linux.run"
 sha256 = "sha256-GyBaBicvFGP0dydv2rkD8/ZmkXwGjlIHOAAeacehh1s="
 gcc = "gcc12"
+
+["12.1"]
+version = "12.1.1"
+url = "https://developer.download.nvidia.com/compute/cuda/12.1.1/local_installers/cuda_12.1.1_530.30.02_linux.run"
+sha256 = "sha256-10Ai1B2AEFMZ36Ib7qObd6W5kZU5wEh6BcqvJEbWpw4="
+gcc = "gcc12"

--- a/pkgs/development/libraries/science/math/cudnn/releases.nix
+++ b/pkgs/development/libraries/science/math/cudnn/releases.nix
@@ -1,3 +1,4 @@
+# NOTE: Check https://docs.nvidia.com/deeplearning/cudnn/archives/index.html for support matrices.
 [
   {
     version = "7.4.2.24";

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6543,6 +6543,7 @@ with pkgs;
   cudaPackages_11 = cudaPackages_11_7;
 
   cudaPackages_12_0 = callPackage ./cuda-packages.nix { cudaVersion = "12.0"; };
+  cudaPackages_12_1 = callPackage ./cuda-packages.nix { cudaVersion = "12.1"; };
   cudaPackages_12 = cudaPackages_12_0;
 
   # TODO: try upgrading once there is a cuDNN release supporting CUDA 12. No


### PR DESCRIPTION
###### Description of changes

Add the 12.1.1 release of `cudatoolkit` and redistributables manifest.

Additionally, fixes a bug where `cudaPackages` was unusable without a supported version of CUDNN, even when CUDNN was not requested.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
