### PR TITLE
pcsx-redux: init at 0093bea292920f1d1c3eb7515026b4153fe2e926

### DIFF
--- a/pkgs/applications/emulators/pcsx-redux/default.nix
+++ b/pkgs/applications/emulators/pcsx-redux/default.nix
@@ -1,0 +1,76 @@
+{ stdenv
+, lib
+, fetchFromGitHub
+, zlib
+, pkg-config
+, libuv
+, curl
+, ffmpeg
+, glfw
+, capstone
+, freetype
+, libX11
+, imagemagick
+, libpulseaudio
+, alsa-lib
+}:
+
+stdenv.mkDerivation rec {
+  pname = "pcsx-redux";
+  version = "unstable-2023-04-18";
+
+  src = fetchFromGitHub {
+    owner = "grumpycoders";
+    repo = "pcsx-redux";
+    fetchSubmodules = true;
+    rev = "0093bea292920f1d1c3eb7515026b4153fe2e926";
+    hash = "sha256-Mwg4jAve0nLuODV/8JO4t5akswi3/qRU/Q5UihJnbps=";
+  };
+
+  nativeBuildInputs = [ pkg-config ];
+
+  buildInputs = [
+    imagemagick
+    libX11
+    freetype
+    capstone
+    glfw
+    ffmpeg
+    curl
+    libuv
+    zlib
+  ];
+
+  # A dependency in third_party (miniaudio) tries to load audio backends on
+  # demand, by querying dynamic libraries at runtime. Patch the paths to point
+  # at ALSA and PulseAudio backends so that it has a chance of finding them, say
+  # on NixOS. There are more backends, such as OSS and JACK. I guess we can add
+  # these on demand in the future.
+  postPatch = lib.optionalString stdenv.isLinux ''
+    substituteInPlace third_party/miniaudio/miniaudio.h \
+      --replace 'libasound.so' '${alsa-lib}/lib/libasound.so'
+    substituteInPlace third_party/miniaudio/extras/miniaudio_split/miniaudio.c \
+      --replace 'libasound.so' '${alsa-lib}/lib/libasound.so'
+    substituteInPlace third_party/miniaudio/miniaudio.h \
+      --replace 'libpulse.so' '${libpulseaudio}/lib/libpulse.so'
+    substituteInPlace third_party/miniaudio/extras/miniaudio_split/miniaudio.c \
+      --replace 'libpulse.so' '${libpulseaudio}/lib/libpulse.so'
+  '';
+
+  # Fails with -Wformat-security: https://github.com/grumpycoders/pcsx-redux/issues/1250
+  hardeningDisable = [ "format" ];
+
+  # DESTDIR defauts to /usr/local. Yeah, I know that we're not supposed to set
+  # this (https://github.com/NixOS/nixpkgs/issues/65718) but I think we have to
+  # because this repo doesn't use configure (so no --prefix) nor does it leave
+  # DESTDIR unset.
+  makeFlags = [ "DESTDIR=$(out)" ];
+
+  meta = with lib; {
+    description = "This is yet another fork of the Playstation emulator, PCSX";
+    maintainers = with maintainers; [ fuuzetsu ];
+
+    license = licenses.gpl2Only;
+    platforms = platforms.x86_64;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2290,6 +2290,8 @@ with pkgs;
 
   pcsxr = callPackage ../applications/emulators/pcsxr { };
 
+  pcsx-redux = callPackage ../applications/emulators/pcsx-redux { };
+
   ppsspp = callPackage ../applications/emulators/ppsspp { };
 
   ppsspp-sdl = ppsspp;


### PR DESCRIPTION
###### Description of changes

Added new PSX emulator.

Runs well, except the sound which doesn't work for me (NixOS). I will address with follow-up commits when I figure it out.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
