### PR TITLE
haskellPackages.mkDerivation: New `intermediates` output

### DIFF
--- a/doc/languages-frameworks/dhall.section.md
+++ b/doc/languages-frameworks/dhall.section.md
@@ -307,12 +307,12 @@ $ nix-env --install --attr haskellPackages.dhall-nixpkgs
 
 $ nix-env --install --attr nix-prefetch-git  # Used by dhall-to-nixpkgs
 
-$ dhall-to-nixpkgs github https://github.com/Gabriel439/dhall-semver.git
+$ dhall-to-nixpkgs github https://github.com/Gabriella439/dhall-semver.git
 { buildDhallGitHubPackage, Prelude }:
   buildDhallGitHubPackage {
     name = "dhall-semver";
     githubBase = "github.com";
-    owner = "Gabriel439";
+    owner = "Gabriella439";
     repo = "dhall-semver";
     rev = "2d44ae605302ce5dc6c657a1216887fbb96392a4";
     fetchSubmodules = false;

--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -5524,17 +5524,17 @@
     githubId = 606000;
     name = "Gabriel Adomnicai";
   };
-  Gabriel439 = {
-    email = "Gabriel439@gmail.com";
-    github = "Gabriella439";
-    githubId = 1313787;
-    name = "Gabriel Gonzalez";
-  };
   GabrielDougherty = {
     email = "contact@gabrieldougherty.com";
     github = "GabrielDougherty";
     githubId = 10541219;
     name = "Gabriel Dougherty";
+  };
+  Gabriella439 = {
+    email = "GenuineGabriella@gmail.com";
+    github = "Gabriella439";
+    githubId = 1313787;
+    name = "Gabriella Gonzalez";
   };
   gador = {
     email = "florian.brandes@posteo.de";

--- a/maintainers/team-list.nix
+++ b/maintainers/team-list.nix
@@ -556,6 +556,15 @@ with lib.maintainers; {
     shortName = "Minimal Bootstrap";
   };
 
+  mercury = {
+    members = [
+      _9999years
+      Gabriella439
+    ];
+    scope = "mercury.com engineers working on Haskell.";
+    shortName = "Mercury";
+  };
+
   mobile = {
     members = [
       samueldr

--- a/maintainers/team-list.nix
+++ b/maintainers/team-list.nix
@@ -561,8 +561,8 @@ with lib.maintainers; {
       _9999years
       Gabriella439
     ];
-    scope = "mercury.com engineers working on Haskell.";
-    shortName = "Mercury";
+    scope = "Group registry for packages maintained by Mercury";
+    shortName = "Mercury Employees";
   };
 
   mobile = {

--- a/maintainers/team-list.nix
+++ b/maintainers/team-list.nix
@@ -213,7 +213,7 @@ with lib.maintainers; {
 
   dhall = {
     members = [
-      Gabriel439
+      Gabriella439
       ehmry
     ];
     scope = "Maintain Dhall and related packages.";

--- a/pkgs/development/haskell-modules/configuration-hackage2nix/main.yaml
+++ b/pkgs/development/haskell-modules/configuration-hackage2nix/main.yaml
@@ -202,7 +202,7 @@ package-maintainers:
     - vulkan-utils
   erictapen:
     - hakyll
-  Gabriel439:
+  Gabriella439:
     - annah
     - bench
     - break

--- a/pkgs/development/haskell-modules/generic-builder.nix
+++ b/pkgs/development/haskell-modules/generic-builder.nix
@@ -31,6 +31,7 @@ in
 , doBenchmark ? false
 , doHoogle ? true
 , doHaddockQuickjump ? doHoogle && lib.versionAtLeast ghc.version "8.6"
+, doInstallIntermediates ? false
 , editedCabalFile ? null
 # aarch64 outputs otherwise exceed 2GB limit
 , enableLibraryProfiling ? !(ghc.isGhcjs or stdenv.targetPlatform.isAarch64 or false)
@@ -84,6 +85,7 @@ in
 , enableSeparateBinOutput ? false
 , enableSeparateDataOutput ? false
 , enableSeparateDocOutput ? doHaddock
+, enableSeparateIntermediatesOutput ? false
 , # Don't fail at configure time if there are multiple versions of the
   # same package in the (recursive) dependencies of the package being
   # built. Will delay failures, if any, to compile time.
@@ -93,6 +95,10 @@ in
   # This can make it slightly faster to load this library into GHCi, but takes
   # extra disk space and compile time.
   enableLibraryForGhci ? false
+  # Set this to a previous build of this same package to reuse the intermediate
+  # build products from that prior build as a starting point for accelerating
+  # this build
+, previousIntermediates ? null
 } @ args:
 
 assert editedCabalFile != null -> revision != null;
@@ -240,6 +246,8 @@ let
     "--ghc-options=-haddock"
   ];
 
+  postPhases = optional doInstallIntermediates [ "installIntermediatesPhase" ];
+
   setupCompileFlags = [
     (optionalString (!coreSetup) "-${nativePackageDbFlag}=$setupPackageConfDir")
     (optionalString enableParallelBuilding (parallelBuildingFlags))
@@ -316,7 +324,9 @@ stdenv.mkDerivation ({
   outputs = [ "out" ]
          ++ (optional enableSeparateDataOutput "data")
          ++ (optional enableSeparateDocOutput "doc")
-         ++ (optional enableSeparateBinOutput "bin");
+         ++ (optional enableSeparateBinOutput "bin")
+         ++ (optional enableSeparateIntermediatesOutput "intermediates");
+
   setOutputFlags = false;
 
   pos = builtins.unsafeGetAttrPos "pname" args;
@@ -393,7 +403,13 @@ stdenv.mkDerivation ({
   # only use the links hack if we're actually building dylibs. otherwise, the
   # "dynamic-library-dirs" point to nonexistent paths, and the ln command becomes
   # "ln -s $out/lib/links", which tries to recreate the links dir and fails
-  + (optionalString (stdenv.isDarwin && (enableSharedLibraries || enableSharedExecutables)) ''
+  #
+  # Note: We need to disable this work-around when using intermediate build
+  # products from a prior build because otherwise Nix will change permissions on
+  # the `$out/lib/links` directory to read-only when the build is done after the
+  # dist directory has already been exported, which triggers an unnecessary
+  # rebuild of modules included in the exported dist directory.
+  + (optionalString (stdenv.isDarwin && (enableSharedLibraries || enableSharedExecutables) && !enableSeparateIntermediatesOutput) ''
     # Work around a limit in the macOS Sierra linker on the number of paths
     # referenced by any one dynamic library:
     #
@@ -471,11 +487,22 @@ stdenv.mkDerivation ({
     runHook postConfigure
   '';
 
-  buildPhase = ''
-    runHook preBuild
-    ${setupCommand} build ${buildTarget}${crossCabalFlagsString}${buildFlagsString}
-    runHook postBuild
-  '';
+  buildPhase =
+      ''
+      runHook preBuild
+      ''
+    + lib.optionalString (previousIntermediates != null)
+        ''
+        mkdir -p dist;
+        rm -r dist/build
+        cp -r ${previousIntermediates}/dist/build dist/build
+        find dist/build -exec chmod u+w {} +
+        find dist/build -exec touch -d '1970-01-01T00:00:00Z' {} +
+        ''
+    + ''
+      ${setupCommand} build ${buildTarget}${crossCabalFlagsString}${buildFlagsString}
+      runHook postBuild
+      '';
 
   inherit doCheck;
 
@@ -556,6 +583,14 @@ stdenv.mkDerivation ({
     ${optionalString enableSeparateDataOutput "mkdir -p $data"}
 
     runHook postInstall
+  '';
+
+  ${if doInstallIntermediates then "installIntermediatesPhase" else null} = ''
+    runHook preInstallIntermediates
+    installIntermediatesDir=${if enableSeparateIntermediatesOutput then "$intermediates" else "$out"}
+    mkdir -p $installIntermediatesDir/dist
+    cp -r dist/build $installIntermediatesDir/dist
+    runHook postInstallIntermediates
   '';
 
   passthru = passthru // rec {
@@ -719,6 +754,7 @@ stdenv.mkDerivation ({
 // optionalAttrs (args ? preFixup)               { inherit preFixup; }
 // optionalAttrs (args ? postFixup)              { inherit postFixup; }
 // optionalAttrs (args ? dontStrip)              { inherit dontStrip; }
+// optionalAttrs (postPhases != [])              { inherit postPhases; }
 // optionalAttrs (stdenv.buildPlatform.libc == "glibc"){ LOCALE_ARCHIVE = "${glibcLocales}/lib/locale/locale-archive"; }
 )
 )

--- a/pkgs/development/haskell-modules/generic-builder.nix
+++ b/pkgs/development/haskell-modules/generic-builder.nix
@@ -314,6 +314,8 @@ let
       continue
     fi
   '';
+
+  intermediatesDir = "share/haskell/${ghc.version}/${pname}-${version}/dist";
 in lib.fix (drv:
 
 assert allPkgconfigDepends != [] -> pkg-config != null;
@@ -495,7 +497,7 @@ stdenv.mkDerivation ({
         ''
         mkdir -p dist;
         rm -r dist/build
-        cp -r ${previousIntermediates}/dist/build dist/build
+        cp -r ${previousIntermediates}/${intermediatesDir}/build dist/build
         find dist/build -exec chmod u+w {} +
         find dist/build -exec touch -d '1970-01-01T00:00:00Z' {} +
         ''
@@ -587,9 +589,10 @@ stdenv.mkDerivation ({
 
   ${if doInstallIntermediates then "installIntermediatesPhase" else null} = ''
     runHook preInstallIntermediates
-    installIntermediatesDir=${if enableSeparateIntermediatesOutput then "$intermediates" else "$out"}
-    mkdir -p $installIntermediatesDir/dist
-    cp -r dist/build $installIntermediatesDir/dist
+    intermediatesOutput=${if enableSeparateIntermediatesOutput then "$intermediates" else "$out"}
+    installIntermediatesDir="$intermediatesOutput/${intermediatesDir}"
+    mkdir -p "$installIntermediatesDir"
+    cp -r dist/build "$installIntermediatesDir"
     runHook postInstallIntermediates
   '';
 

--- a/pkgs/test/haskell/default.nix
+++ b/pkgs/test/haskell/default.nix
@@ -6,4 +6,5 @@ lib.recurseIntoAttrs {
   documentationTarball = callPackage ./documentationTarball { };
   setBuildTarget = callPackage ./setBuildTarget { };
   writers = callPackage ./writers { };
+  incremental = callPackage ./incremental { };
 }

--- a/pkgs/test/haskell/incremental/default.nix
+++ b/pkgs/test/haskell/incremental/default.nix
@@ -1,0 +1,35 @@
+# Demonstration of incremental builds for Haskell. Useful for speeding up CI.
+#
+# See: https://www.haskellforall.com/2022/12/nixpkgs-support-for-incremental-haskell.html
+# See: https://felixspringer.xyz/homepage/blog/incrementalHaskellBuildsWithNix
+
+{ haskell, lib }:
+
+let
+  inherit (haskell.lib.compose) overrideCabal;
+
+  # Incremental builds work with GHC >=9.4.
+  turtle = haskell.packages.ghc944.turtle;
+
+  # This will do a full build of `turtle`, while writing the intermediate build products
+  # (compiled modules, etc.) to the `intermediates` output.
+  turtle-full-build-with-incremental-output = overrideCabal (drv: {
+    doInstallIntermediates = true;
+    enableSeparateIntermediatesOutput = true;
+  }) turtle;
+
+  # This will do an incremental build of `turtle` by copying the previously
+  # compiled modules and intermediate build products into the source tree
+  # before running the build.
+  #
+  # GHC will then naturally pick up and reuse these products, making this build
+  # complete much more quickly than the previous one.
+  turtle-incremental-build = overrideCabal (drv: {
+    previousIntermediates = turtle-full-build-with-incremental-output.intermediates;
+  }) turtle;
+in
+  turtle-incremental-build.overrideAttrs (old: {
+    meta = {
+      maintainers = lib.teams.mercury.members;
+    };
+  })


### PR DESCRIPTION
This adds a new `intermediates` output that can be used to accelerate a Haskell build by importing build products exported from a prior similar build.

The motivation for this is explained by the following post:

https://www.haskellforall.com/2022/12/nixpkgs-support-for-incremental-haskell.html

This is a subset of the changes from #204020 that I believe are safe to merge while waiting for https://github.com/NixOS/nix/pull/7362 to be reviewed.  I've incorporated outstanding feedback from the last PR into this one.

I structured this to be a hash-preserving changes for Haskell packages that don't use the feature, so this won't trigger unnecessary rebuilds or breakage.

This is a redo of #213817 since that inadvertently subscribed too many people to the pull request discussion.

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->