### PR TITLE
firefox-unwrapped: 112.0.1 -> 112.0.2

### DIFF
--- a/pkgs/applications/networking/browsers/firefox-bin/release_sources.nix
+++ b/pkgs/applications/networking/browsers/firefox-bin/release_sources.nix
@@ -1,1005 +1,1005 @@
 {
-  version = "112.0.1";
+  version = "112.0.2";
   sources = [
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.1/linux-x86_64/ach/firefox-112.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.2/linux-x86_64/ach/firefox-112.0.2.tar.bz2";
       locale = "ach";
       arch = "linux-x86_64";
-      sha256 = "36fd6c7580b7c52be08eeec0cdb078847d85150db5a7589b6170b87680352aee";
+      sha256 = "4a32600dad771995ad6c347174b85f8f186da8ddd5223255c80d5f1a88bba375";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.1/linux-x86_64/af/firefox-112.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.2/linux-x86_64/af/firefox-112.0.2.tar.bz2";
       locale = "af";
       arch = "linux-x86_64";
-      sha256 = "faadb7dbb35eb85dd5afd2b1fae89a317efbc57d47c55bddf5913633f3a94f5a";
+      sha256 = "ab23aed01c5e1ca7afcf09494ed11066625c9be3d3e386d68745e7e3a7d24b42";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.1/linux-x86_64/an/firefox-112.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.2/linux-x86_64/an/firefox-112.0.2.tar.bz2";
       locale = "an";
       arch = "linux-x86_64";
-      sha256 = "413cc005f597c80e45e21238e6d1efc6b7ea9601a414f17f7a9de649ae100838";
+      sha256 = "7a3c5919771eb1fb5ff5238339de9bc19139011293125c64216572b5ffecf28a";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.1/linux-x86_64/ar/firefox-112.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.2/linux-x86_64/ar/firefox-112.0.2.tar.bz2";
       locale = "ar";
       arch = "linux-x86_64";
-      sha256 = "ea1da8a30f29b34444140ded31282fbb22376954d5ee2a6a7545d2eddb19edd8";
+      sha256 = "077af6c198cbcf37bd128cb4a6831868c8b472663246cb46adb89588a4451851";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.1/linux-x86_64/ast/firefox-112.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.2/linux-x86_64/ast/firefox-112.0.2.tar.bz2";
       locale = "ast";
       arch = "linux-x86_64";
-      sha256 = "441d682a09325f46cead74d300b4f27200af97b4315fd2990d1fa33ba93412c5";
+      sha256 = "494c7cc952ecd0d349b7e5626233ffbdfd541ad0efd7f502198f76d6eadee33d";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.1/linux-x86_64/az/firefox-112.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.2/linux-x86_64/az/firefox-112.0.2.tar.bz2";
       locale = "az";
       arch = "linux-x86_64";
-      sha256 = "24440875e36dcba8c5d4e125715d2d8c61bab534739ff5a4e0c9e41419c3a05a";
+      sha256 = "87519f82b780e04a8fc4c41d0ab248562c3d6b6d6941d9a50b0f1d7ae1335367";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.1/linux-x86_64/be/firefox-112.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.2/linux-x86_64/be/firefox-112.0.2.tar.bz2";
       locale = "be";
       arch = "linux-x86_64";
-      sha256 = "5b3e6c637256f9d54e414a56807f8c3e5dcad75e839b97bb26c4ed8391538e53";
+      sha256 = "f65bf7ea0d9dfa5be6da26dd762e862dc562688f506a65c05d5d344693ef7325";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.1/linux-x86_64/bg/firefox-112.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.2/linux-x86_64/bg/firefox-112.0.2.tar.bz2";
       locale = "bg";
       arch = "linux-x86_64";
-      sha256 = "cb132442599cc876435aeb99ce3d366ecabe583f66ac50b964fc6d34039b7a06";
+      sha256 = "fdee1836538fbfcb9f5409a132a3ba13a0c6cbd56be5f5839c5a6aa10f21fb78";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.1/linux-x86_64/bn/firefox-112.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.2/linux-x86_64/bn/firefox-112.0.2.tar.bz2";
       locale = "bn";
       arch = "linux-x86_64";
-      sha256 = "8ffa2b5e01300ef62a980d504b9d5c61c17c71e36bc267694d7de6594227f86e";
+      sha256 = "b305faf020b19eb6c7967b2e1c5b1b8ecd026ea49d8387fbd1a7304e7fe4eec3";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.1/linux-x86_64/br/firefox-112.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.2/linux-x86_64/br/firefox-112.0.2.tar.bz2";
       locale = "br";
       arch = "linux-x86_64";
-      sha256 = "ee830d98b21fc9cc74a181c2c3cdb61692a83450df7dd35b7777591fa17cbd16";
+      sha256 = "f373e63caeb791e7f6394e9339daf7e5604a5e8603f0b04bc138b3c9660198a0";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.1/linux-x86_64/bs/firefox-112.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.2/linux-x86_64/bs/firefox-112.0.2.tar.bz2";
       locale = "bs";
       arch = "linux-x86_64";
-      sha256 = "1728f28b2b36feaf09eaf6b1750a2b9bd23e03bbf72b9fc7836e4c2ded27d120";
+      sha256 = "d1889939bce050c63a769c2d67666361d78b2d87210fcaedeb41b0ad13fc8e38";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.1/linux-x86_64/ca-valencia/firefox-112.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.2/linux-x86_64/ca-valencia/firefox-112.0.2.tar.bz2";
       locale = "ca-valencia";
       arch = "linux-x86_64";
-      sha256 = "c9cb9c84d03593a2f95071fe4e720fe23b8a70284c9f6b4225f3d501672b0800";
+      sha256 = "9092a32d66cf883b574d0532ccf7398468d4940186f3bb31fc6add6154430f51";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.1/linux-x86_64/ca/firefox-112.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.2/linux-x86_64/ca/firefox-112.0.2.tar.bz2";
       locale = "ca";
       arch = "linux-x86_64";
-      sha256 = "633d527b4d9e4ff77474ac9e401290d1f700243588c963e96490a36ff1a9fd92";
+      sha256 = "d7bb4dec533ba1824692e13dcfcf8b0dc2831d3c6556e8a2122285599227994e";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.1/linux-x86_64/cak/firefox-112.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.2/linux-x86_64/cak/firefox-112.0.2.tar.bz2";
       locale = "cak";
       arch = "linux-x86_64";
-      sha256 = "a7228264a85d64f8aa7a585452a7ff452535bf23faa4fde823a1d161c9234a19";
+      sha256 = "89ebad425295cf88f6a33b238e98eaf593afd7459d6db3f75cc1f50cf3354273";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.1/linux-x86_64/cs/firefox-112.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.2/linux-x86_64/cs/firefox-112.0.2.tar.bz2";
       locale = "cs";
       arch = "linux-x86_64";
-      sha256 = "133263691738d5a03950bc909ed50b5379c56ab118b43ab1ebf874cf67c448ac";
+      sha256 = "4a6d64263f1503cc35c36b2077bd64adbe9d2e7de4223a64c1eeb5eaf2e939a0";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.1/linux-x86_64/cy/firefox-112.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.2/linux-x86_64/cy/firefox-112.0.2.tar.bz2";
       locale = "cy";
       arch = "linux-x86_64";
-      sha256 = "ac0b70542cb73d62f76619daaa435ec433e766af5922947113239e6d2ba9dcc2";
+      sha256 = "d07924a243ce699dc200fdaedc57cf197126b3f31da78fd9b65ff8b24483729a";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.1/linux-x86_64/da/firefox-112.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.2/linux-x86_64/da/firefox-112.0.2.tar.bz2";
       locale = "da";
       arch = "linux-x86_64";
-      sha256 = "71167831d1cd3836ef54f8fc0e42ffee0a22116c1f9b512a5a9f4ef6eb94dd6f";
+      sha256 = "401d14c70aaa14ded17b5f1f4ea1d5ebc4a1dffba349aadc730e3a226e78f1c2";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.1/linux-x86_64/de/firefox-112.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.2/linux-x86_64/de/firefox-112.0.2.tar.bz2";
       locale = "de";
       arch = "linux-x86_64";
-      sha256 = "c01cf989f29d637504de219af4905769318b93aee07ad2b02ec56b678a733ab6";
+      sha256 = "0b8785f1b6320878bd4a870adeb93512331fdd9ef86150ad8aaef0440c5fc0b4";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.1/linux-x86_64/dsb/firefox-112.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.2/linux-x86_64/dsb/firefox-112.0.2.tar.bz2";
       locale = "dsb";
       arch = "linux-x86_64";
-      sha256 = "6c442c04e8899cc11055839bfe946a4cf5710fa07daefb858f67e63a749006cf";
+      sha256 = "d8324ff9c74be9bf6e20ba76f67d7ceaed2f6e551331873f4d1564f84eae18b6";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.1/linux-x86_64/el/firefox-112.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.2/linux-x86_64/el/firefox-112.0.2.tar.bz2";
       locale = "el";
       arch = "linux-x86_64";
-      sha256 = "c8d02a7659d65f47fe95a3528246631ac502c972d9cae5efac34d41175300902";
+      sha256 = "ec2b6ab8258c6b7c09524e5c1d6b7204d82aecf7b0daf13cee23f8a9c53995dc";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.1/linux-x86_64/en-CA/firefox-112.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.2/linux-x86_64/en-CA/firefox-112.0.2.tar.bz2";
       locale = "en-CA";
       arch = "linux-x86_64";
-      sha256 = "69e5c206ff03eef0a2da0b8dafebbb5b7fc75ed83c56915974587ae2bf13c314";
+      sha256 = "733933a42d4488689aab752954895d9ebf0f6c8bca3600816b2d97f047d7a0c6";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.1/linux-x86_64/en-GB/firefox-112.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.2/linux-x86_64/en-GB/firefox-112.0.2.tar.bz2";
       locale = "en-GB";
       arch = "linux-x86_64";
-      sha256 = "8b0111486226ba15b1a145914647ae05c0c3c25280c2d15de2c10e5928eb0926";
+      sha256 = "7e2014255101bcc88ad490eca8f8d6c7206e5463ce2570630f4d9c7829afc1d1";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.1/linux-x86_64/en-US/firefox-112.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.2/linux-x86_64/en-US/firefox-112.0.2.tar.bz2";
       locale = "en-US";
       arch = "linux-x86_64";
-      sha256 = "6ae1a778523203660d1c300dfca88c14e2ea012e417a31238f6b312cfc3902f1";
+      sha256 = "dd91e070aa5c6fa2e174cd4dcfaf4794791e6ccacc2a6a8ad8ecb5b6a51cf6bd";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.1/linux-x86_64/eo/firefox-112.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.2/linux-x86_64/eo/firefox-112.0.2.tar.bz2";
       locale = "eo";
       arch = "linux-x86_64";
-      sha256 = "b8882e0c5d01432ab35b18e2dd6de92432964366671887d6171020018a87af2e";
+      sha256 = "0fd41889e888e9ac017485f3883d21cc855ec45642879c4e7c38320de31674e3";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.1/linux-x86_64/es-AR/firefox-112.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.2/linux-x86_64/es-AR/firefox-112.0.2.tar.bz2";
       locale = "es-AR";
       arch = "linux-x86_64";
-      sha256 = "fad8033a87c95d50d7959ef7d74186b832a93ae0be590f5d2122651c7f8a8421";
+      sha256 = "28cf2a097b222dd13f51eac35cb9d9ff500fd7a43003cedbf63cc3bad30bd013";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.1/linux-x86_64/es-CL/firefox-112.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.2/linux-x86_64/es-CL/firefox-112.0.2.tar.bz2";
       locale = "es-CL";
       arch = "linux-x86_64";
-      sha256 = "53a70c208fe9599f709bb706f1cfc4dba73c1165ae0308cff42f0bab89f27d68";
+      sha256 = "948eed7a7575d7c6624508abd734e2db897c4b1277f91bf9543d9a286bc9051d";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.1/linux-x86_64/es-ES/firefox-112.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.2/linux-x86_64/es-ES/firefox-112.0.2.tar.bz2";
       locale = "es-ES";
       arch = "linux-x86_64";
-      sha256 = "a36a7cfd3214b40566e76086dd0554c264bbe58044e170f3a5529a57bf45a96b";
+      sha256 = "3de6cdfa93914bc8da328100fc04313a4863a4c9c10eed3c9792ca3eba6a817b";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.1/linux-x86_64/es-MX/firefox-112.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.2/linux-x86_64/es-MX/firefox-112.0.2.tar.bz2";
       locale = "es-MX";
       arch = "linux-x86_64";
-      sha256 = "408aa0cdf4199ee4bcedf5167739582bffd4779a55eef529ddb1e55dc5312b08";
+      sha256 = "cac850a48979e1b96112ec144520728804d61f18e9f615a2e1a0738b8cd92765";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.1/linux-x86_64/et/firefox-112.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.2/linux-x86_64/et/firefox-112.0.2.tar.bz2";
       locale = "et";
       arch = "linux-x86_64";
-      sha256 = "17c4dbb7f5833a3ad954891d2f73eadcd464812500e75a11be93142920b1ff8e";
+      sha256 = "645ada14230634143a8bc338f8595596ffb6de4f448efde826ecb6e7d7e07ca8";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.1/linux-x86_64/eu/firefox-112.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.2/linux-x86_64/eu/firefox-112.0.2.tar.bz2";
       locale = "eu";
       arch = "linux-x86_64";
-      sha256 = "0db77714cef6bb365f7757d4d9d2c3f9cb8f422a0b1b1f1742e9bb0e69f9ad03";
+      sha256 = "8212ef486ec59000dee4bcd62d61e55cd375381b5119c688980910f6ab27426b";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.1/linux-x86_64/fa/firefox-112.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.2/linux-x86_64/fa/firefox-112.0.2.tar.bz2";
       locale = "fa";
       arch = "linux-x86_64";
-      sha256 = "16ef1cff8506f6c2b51fd511416e87095929824f86f9efa48b4e4908f7fff39a";
+      sha256 = "83886a65a04e7a32d3c479e953e228ce08b3e8b62b1074f07286e46e7265790b";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.1/linux-x86_64/ff/firefox-112.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.2/linux-x86_64/ff/firefox-112.0.2.tar.bz2";
       locale = "ff";
       arch = "linux-x86_64";
-      sha256 = "0d62047ad33735aa46f745af59baf77ed7fe5f52acad40f08b26a9a477dee9d6";
+      sha256 = "e06797ab1e0c263ca31d1b5c1cd8b4e38823efc053f2be2e7467679fcb22e073";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.1/linux-x86_64/fi/firefox-112.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.2/linux-x86_64/fi/firefox-112.0.2.tar.bz2";
       locale = "fi";
       arch = "linux-x86_64";
-      sha256 = "e0f3cac06f7a949ab17e60599fcadce7c3953df5f079fb88ef7bf2288c57bd3b";
+      sha256 = "b14d6bdf063177efa85eb6813c21f91ca0a6139b38aed501e65cc584a68e15ea";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.1/linux-x86_64/fr/firefox-112.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.2/linux-x86_64/fr/firefox-112.0.2.tar.bz2";
       locale = "fr";
       arch = "linux-x86_64";
-      sha256 = "c764c8a45e7ba5c2d2843a9abc875cc69e6854d51ff1971574581a96eba46f00";
+      sha256 = "9729e6f1baf38fde3382869572fb073beeab30f8a9a837643cbc69b63a45f463";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.1/linux-x86_64/fur/firefox-112.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.2/linux-x86_64/fur/firefox-112.0.2.tar.bz2";
       locale = "fur";
       arch = "linux-x86_64";
-      sha256 = "25bdd7f2ef2082f78fa5791c96991bb5c0a8b8d2e9dea084d8657a1296c47bd8";
+      sha256 = "ac8f33ecf4e7ee66bb7c428052f853793d426f1fe169805f231412e28aa6404a";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.1/linux-x86_64/fy-NL/firefox-112.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.2/linux-x86_64/fy-NL/firefox-112.0.2.tar.bz2";
       locale = "fy-NL";
       arch = "linux-x86_64";
-      sha256 = "4bea0e611c5574c481ffc1f6c31ab085225536856f7de8100a75d31651530b89";
+      sha256 = "103cd7396ef8c64df1f84db958d12688fbb90f95e56c0be05590f7d9b8a2348d";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.1/linux-x86_64/ga-IE/firefox-112.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.2/linux-x86_64/ga-IE/firefox-112.0.2.tar.bz2";
       locale = "ga-IE";
       arch = "linux-x86_64";
-      sha256 = "90e6f28e3aed2288731b3b9e7066b4603846b2ef848a23cfa6d821478879b146";
+      sha256 = "9a04c66d62dcb51c573f9b14b48a064a1fd2725ca20f4518af6de2517e7054fc";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.1/linux-x86_64/gd/firefox-112.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.2/linux-x86_64/gd/firefox-112.0.2.tar.bz2";
       locale = "gd";
       arch = "linux-x86_64";
-      sha256 = "3b3fb7d17b4091eca185833f8f486b17b8fe3b9c3ecad316dccb0779aadb4490";
+      sha256 = "2a8e057a49f39610ae4ed5c0cec5feacb435680194070b4e0ea5c64ca2328933";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.1/linux-x86_64/gl/firefox-112.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.2/linux-x86_64/gl/firefox-112.0.2.tar.bz2";
       locale = "gl";
       arch = "linux-x86_64";
-      sha256 = "dde97c135fba0ce84e1e517a77821a7c9cde34ac02230ab23879982c2bc4de77";
+      sha256 = "a354febd40bbdc0dfa8d03306336f43a919f8e393fc984edc2a8a32fd7e06500";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.1/linux-x86_64/gn/firefox-112.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.2/linux-x86_64/gn/firefox-112.0.2.tar.bz2";
       locale = "gn";
       arch = "linux-x86_64";
-      sha256 = "be096c4bd208c339c1882aa22d5ca94139cc6605691a114ff8f2de397946be2f";
+      sha256 = "fdcb1f427ad40ff9559090dad581f5039e768627dbbad1fda99624d4bb51d8d1";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.1/linux-x86_64/gu-IN/firefox-112.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.2/linux-x86_64/gu-IN/firefox-112.0.2.tar.bz2";
       locale = "gu-IN";
       arch = "linux-x86_64";
-      sha256 = "62c3d524526543f0ea6ef1b5013b3dd2316590eb8f9b2a68184c68e24cd20e43";
+      sha256 = "c8b946ba9cf2c56d6dca6d9c10a67602f4fad80969858a7c7b906bdda7fdf6f0";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.1/linux-x86_64/he/firefox-112.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.2/linux-x86_64/he/firefox-112.0.2.tar.bz2";
       locale = "he";
       arch = "linux-x86_64";
-      sha256 = "5f626f9004889bafbb11a6bce604481f0e8b1e445b372d8159d210798c67cc20";
+      sha256 = "9990a04b86f765d79e00890780c7fcf2ec3fd61573ef7f341f156c1c48cd467f";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.1/linux-x86_64/hi-IN/firefox-112.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.2/linux-x86_64/hi-IN/firefox-112.0.2.tar.bz2";
       locale = "hi-IN";
       arch = "linux-x86_64";
-      sha256 = "465bcef608d516b88a5c6a6e0c833f77e871250ccd937f2ff200aa88152a8acf";
+      sha256 = "f3a2c58f7192abbd4690711255035186498b1a8c499afbc9c2dcceaa61fc0b2b";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.1/linux-x86_64/hr/firefox-112.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.2/linux-x86_64/hr/firefox-112.0.2.tar.bz2";
       locale = "hr";
       arch = "linux-x86_64";
-      sha256 = "5dec945d595e193c1971a179224d3f68b3df23b5c0a587375a77afce4d9e0055";
+      sha256 = "26dded9c117143aafdf502896a11197b028ca978701830f1c84acf258ab307c9";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.1/linux-x86_64/hsb/firefox-112.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.2/linux-x86_64/hsb/firefox-112.0.2.tar.bz2";
       locale = "hsb";
       arch = "linux-x86_64";
-      sha256 = "a6db8e61d45a20bbb6797757eccc1150ac8f7d3a24561ff86f7a68b57183a051";
+      sha256 = "caf295576ac3d579a1b88cae94e46934cd4c83ff89658b5876e7af217ee31681";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.1/linux-x86_64/hu/firefox-112.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.2/linux-x86_64/hu/firefox-112.0.2.tar.bz2";
       locale = "hu";
       arch = "linux-x86_64";
-      sha256 = "5d1e84ffe73b3d91d1d2527a8dd08fdbd7f0df50cdbeeefcf9139b0ac359ebde";
+      sha256 = "89e89b13c7dd676ca4cc739ddceab1184c68e70f12292795d91142813058e279";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.1/linux-x86_64/hy-AM/firefox-112.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.2/linux-x86_64/hy-AM/firefox-112.0.2.tar.bz2";
       locale = "hy-AM";
       arch = "linux-x86_64";
-      sha256 = "07988bd5220f474ca1b6ca06a7a30f057b3ac93e07dccb2d969d938c74d92388";
+      sha256 = "6c3819149739a866dd231707daaf6819da49e26d5941f556b24f0cf29be8c35c";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.1/linux-x86_64/ia/firefox-112.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.2/linux-x86_64/ia/firefox-112.0.2.tar.bz2";
       locale = "ia";
       arch = "linux-x86_64";
-      sha256 = "dd4193ab35b05a767575f332398c1952020dbe698f583e08eeb3012e35ec386e";
+      sha256 = "10965794c2075e5a9e5cac21eb9a6dd4e12e1cc55d2bae846a5c7ce2de9159d2";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.1/linux-x86_64/id/firefox-112.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.2/linux-x86_64/id/firefox-112.0.2.tar.bz2";
       locale = "id";
       arch = "linux-x86_64";
-      sha256 = "1b9cb6b5889b32cf5d906a4d85521b8fdc98f74d1ed13ac77a8252bfe7ff84d9";
+      sha256 = "a91f75dee13ca425fc7abde7696c26ebfdf0db98b339015ad2a5db8d2254742f";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.1/linux-x86_64/is/firefox-112.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.2/linux-x86_64/is/firefox-112.0.2.tar.bz2";
       locale = "is";
       arch = "linux-x86_64";
-      sha256 = "a4b0d7918a259ba34df259366d1db65e7ae1c47feea4e9fb6047c0051eccf52f";
+      sha256 = "365946180b375dea606db48a6929264a2e151f53d413ffc0ecf8e3845c0d962f";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.1/linux-x86_64/it/firefox-112.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.2/linux-x86_64/it/firefox-112.0.2.tar.bz2";
       locale = "it";
       arch = "linux-x86_64";
-      sha256 = "e9a5fb694a2b26ee05059340b4d6698261d1b9440e2a838ffa8eed3fab7a967c";
+      sha256 = "57feb62a6d3e9b5be052988109724c870d8a7e0f5dc88f08a57dc853b1c42a9f";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.1/linux-x86_64/ja/firefox-112.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.2/linux-x86_64/ja/firefox-112.0.2.tar.bz2";
       locale = "ja";
       arch = "linux-x86_64";
-      sha256 = "9ed9888d19d21024306163a155df7c49188212e308e1aa4981273fb5f06e2a88";
+      sha256 = "b5a47f6a9995789049b717b45ef489da1ddd19532d69d69b887b7a33a9b582dd";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.1/linux-x86_64/ka/firefox-112.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.2/linux-x86_64/ka/firefox-112.0.2.tar.bz2";
       locale = "ka";
       arch = "linux-x86_64";
-      sha256 = "7b573603e74a833fbdcad554b27d006f01a0d6019e94338e6fead0c0be1c56b2";
+      sha256 = "8cee5bfe910d8297aba0c41ebf82f0df957a4bbf2add068fdf39dbfd91abd480";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.1/linux-x86_64/kab/firefox-112.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.2/linux-x86_64/kab/firefox-112.0.2.tar.bz2";
       locale = "kab";
       arch = "linux-x86_64";
-      sha256 = "a98b7b01aa07c27075d44d593870fa52dc124103b52e77f30cfaec12f755c194";
+      sha256 = "c6045ff1ccf44319be689de1564b27d4986ae97e944d54d730551adef6124ced";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.1/linux-x86_64/kk/firefox-112.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.2/linux-x86_64/kk/firefox-112.0.2.tar.bz2";
       locale = "kk";
       arch = "linux-x86_64";
-      sha256 = "74a496d781fea2e845876871bd731d98fa6f30c4b083e19eadc2762c8cd3644f";
+      sha256 = "5f18181e89268c4556d3d2d299aed3283fa82edec3ebfcab40df3baa494b1697";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.1/linux-x86_64/km/firefox-112.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.2/linux-x86_64/km/firefox-112.0.2.tar.bz2";
       locale = "km";
       arch = "linux-x86_64";
-      sha256 = "a0b5a577323ae6f20d0bbfb0022c502e9c3228ea0e252cce19bc88df64cb22fb";
+      sha256 = "3909f25efcfac4a4663c93a95f1590f55cee54681f8f4110647040f911b6cdba";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.1/linux-x86_64/kn/firefox-112.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.2/linux-x86_64/kn/firefox-112.0.2.tar.bz2";
       locale = "kn";
       arch = "linux-x86_64";
-      sha256 = "05c03016b5782ff7b07610cc3e438a9657b226d9150f5335a3fd34906348dc8f";
+      sha256 = "b6a5512beb535eba8a3a58c3807ab1c02af73850f030bf013cc08df07649cdee";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.1/linux-x86_64/ko/firefox-112.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.2/linux-x86_64/ko/firefox-112.0.2.tar.bz2";
       locale = "ko";
       arch = "linux-x86_64";
-      sha256 = "9da58cde61b0f0e2208dc01b4de216732786460e8d6fa82533b682bb4d678614";
+      sha256 = "f8235d477c82154ef6bfabfd172b5a13451b3970e4beec8cc6500184ada1af60";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.1/linux-x86_64/lij/firefox-112.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.2/linux-x86_64/lij/firefox-112.0.2.tar.bz2";
       locale = "lij";
       arch = "linux-x86_64";
-      sha256 = "85202a3383a179b471d5020469af49fb52e154e4f71cd00833fe7137240c8149";
+      sha256 = "169d029ae526ea51e5812e116f7266ce51fc4c622c693b976e2a874ea4ef857a";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.1/linux-x86_64/lt/firefox-112.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.2/linux-x86_64/lt/firefox-112.0.2.tar.bz2";
       locale = "lt";
       arch = "linux-x86_64";
-      sha256 = "fbcf75e4b55d6eb423f3d94e363e68d0ca1e33f3e199c4ea4d26f0cfd0b3e4f5";
+      sha256 = "6e65530f552c9c267f5b3cc31f301118d5474aa539b33f46bbaff27f62b9f016";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.1/linux-x86_64/lv/firefox-112.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.2/linux-x86_64/lv/firefox-112.0.2.tar.bz2";
       locale = "lv";
       arch = "linux-x86_64";
-      sha256 = "d41068cd02315dec5daac3c6dfe37ef7eb9c0f2ebafb9d9f223cc287b8d22115";
+      sha256 = "46325094def40a1d9589c7fa49484bacac27277cdf754b7cacaae203b5940bcb";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.1/linux-x86_64/mk/firefox-112.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.2/linux-x86_64/mk/firefox-112.0.2.tar.bz2";
       locale = "mk";
       arch = "linux-x86_64";
-      sha256 = "ec654f8c5d676506b134c5ba4069c7fe1bea15db644808b191d6474f45c75783";
+      sha256 = "033756b122d219ce79b667f405d54fe1c0eccd1532f43d42bde1c8b928d3ddb1";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.1/linux-x86_64/mr/firefox-112.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.2/linux-x86_64/mr/firefox-112.0.2.tar.bz2";
       locale = "mr";
       arch = "linux-x86_64";
-      sha256 = "b4f0d9ff4b887b7d2fb657b107547caf834804e695872a422570211d4eeff089";
+      sha256 = "71f23b05b692eb12c834ef356a868e455bdfdb3bf6ed641eb4b6565b4d2fdcc6";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.1/linux-x86_64/ms/firefox-112.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.2/linux-x86_64/ms/firefox-112.0.2.tar.bz2";
       locale = "ms";
       arch = "linux-x86_64";
-      sha256 = "3bcae3c3c59484e7196bf8b7122da9a75f1f5657f68cc8125cd3e37c77f85ebf";
+      sha256 = "0e224bb6d7341a17656c57bce4c8f753708deee18fa0f31877938702c3a2d61d";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.1/linux-x86_64/my/firefox-112.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.2/linux-x86_64/my/firefox-112.0.2.tar.bz2";
       locale = "my";
       arch = "linux-x86_64";
-      sha256 = "dc07314c65084877c8c89035b1f821eea79993dcc5b55ecb304754ba6ea6808b";
+      sha256 = "9eb954ee63bf6e4c8b6ef3fe1eaf8e91eeaa546b78ea4b1e518a1400865d94bd";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.1/linux-x86_64/nb-NO/firefox-112.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.2/linux-x86_64/nb-NO/firefox-112.0.2.tar.bz2";
       locale = "nb-NO";
       arch = "linux-x86_64";
-      sha256 = "df4b24e54cd19b30a2d0de40e6efac30ff7a7a4a5542c9f6dd4c63b1f9359af5";
+      sha256 = "ca2368edf9441d1fdb4d580926b7af8f1330f99bff62f0d2ce8cc669cd10e85e";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.1/linux-x86_64/ne-NP/firefox-112.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.2/linux-x86_64/ne-NP/firefox-112.0.2.tar.bz2";
       locale = "ne-NP";
       arch = "linux-x86_64";
-      sha256 = "ff641ab36ed7c353609c346a66a9a7e5e5ff4f18a789a00d3c22c23bacc2a8a8";
+      sha256 = "324ec07ac0a4694388b392e051e60d4fbed9df5b5a4e16e8b5362f3d35aae2fd";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.1/linux-x86_64/nl/firefox-112.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.2/linux-x86_64/nl/firefox-112.0.2.tar.bz2";
       locale = "nl";
       arch = "linux-x86_64";
-      sha256 = "b3161e91e62415101daef2620d747e67cafc649518007da34e16da0a46a881ef";
+      sha256 = "1abafd5ed255a8c73ef9c1ec1bdd52f4f5d7f1fc305e55bff279d681d48f9266";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.1/linux-x86_64/nn-NO/firefox-112.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.2/linux-x86_64/nn-NO/firefox-112.0.2.tar.bz2";
       locale = "nn-NO";
       arch = "linux-x86_64";
-      sha256 = "3b298aa6a1957e160d162f36eaf8af2e5f0c36af80dd7d047f50774b9f7d1d09";
+      sha256 = "1d821b71811a9ff6359ecd91695d92ddf4c84c7480e70ddc5a5bcb9b4e038d74";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.1/linux-x86_64/oc/firefox-112.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.2/linux-x86_64/oc/firefox-112.0.2.tar.bz2";
       locale = "oc";
       arch = "linux-x86_64";
-      sha256 = "ce50933b0f8e672f1552973791312ef337b71e374c4327ea7bcee7f30da43baf";
+      sha256 = "f249b854be5e54abd6218be95110aa94694054adaddd31b6c932d29b51cd9681";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.1/linux-x86_64/pa-IN/firefox-112.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.2/linux-x86_64/pa-IN/firefox-112.0.2.tar.bz2";
       locale = "pa-IN";
       arch = "linux-x86_64";
-      sha256 = "8b01acea823d687303fa21f6502a2e6b4ab1a6f3ad3a6e4b3a7e2a0ea0ee55c1";
+      sha256 = "8575d4e60c478e6129be7e56ad537eced9ca5f50b22fcad976a6574486cdc67e";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.1/linux-x86_64/pl/firefox-112.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.2/linux-x86_64/pl/firefox-112.0.2.tar.bz2";
       locale = "pl";
       arch = "linux-x86_64";
-      sha256 = "9d2018e146acac6440bc12ea8c6c410ea7c11e7e18cda5e8f72f33813d5dbd87";
+      sha256 = "6d822d6de184aa269dcf6c6d868fcffde563081321e861285a48ab471fb9759d";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.1/linux-x86_64/pt-BR/firefox-112.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.2/linux-x86_64/pt-BR/firefox-112.0.2.tar.bz2";
       locale = "pt-BR";
       arch = "linux-x86_64";
-      sha256 = "0c4b8b4871c4a2a8374f6cdb5c3c8f8986285d4e0a105797e025608298765253";
+      sha256 = "1856751bbc497a734508db1717ca7ee82c67af3e6adfdbfe7dfc44e80f0536e8";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.1/linux-x86_64/pt-PT/firefox-112.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.2/linux-x86_64/pt-PT/firefox-112.0.2.tar.bz2";
       locale = "pt-PT";
       arch = "linux-x86_64";
-      sha256 = "6e227a07bf2d909763a22f8bf5c2e2b74b39651881685d00bc64bd4fea7d939f";
+      sha256 = "b98aa8e3a2b3cf760723228406c21d9407a13be5f5e5785c7271aa3952261f94";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.1/linux-x86_64/rm/firefox-112.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.2/linux-x86_64/rm/firefox-112.0.2.tar.bz2";
       locale = "rm";
       arch = "linux-x86_64";
-      sha256 = "28878ce52ccf14a6745d5e2b57155d20ac966a345822d1d95006fdeaae12a2a7";
+      sha256 = "8a5ae33a54647c02c18e01acd5b1a15076d8f9afbc324643f985912f7e724f7f";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.1/linux-x86_64/ro/firefox-112.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.2/linux-x86_64/ro/firefox-112.0.2.tar.bz2";
       locale = "ro";
       arch = "linux-x86_64";
-      sha256 = "dd0b021cd9cd6f903d9b253309658da187485f57db7b1ae6e466c186ee49d8b7";
+      sha256 = "8396ac479024eef5631a54e58807118e0fa9cedb863303876c67d16a126a80c0";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.1/linux-x86_64/ru/firefox-112.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.2/linux-x86_64/ru/firefox-112.0.2.tar.bz2";
       locale = "ru";
       arch = "linux-x86_64";
-      sha256 = "6b0564a7139628b15df935f4a1add5263ca67e686b0558ec70f305258bdc4054";
+      sha256 = "ffbf56b7677b5a2f8d3d712eb029aa92e196201157634ad45f7eee32329df4e4";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.1/linux-x86_64/sc/firefox-112.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.2/linux-x86_64/sc/firefox-112.0.2.tar.bz2";
       locale = "sc";
       arch = "linux-x86_64";
-      sha256 = "db9e37d5202a44542ea7fb62a946c858eac6716625c63d190a34d0fda7a7b955";
+      sha256 = "16beacb5eecedcf911bb4a7b70d47f396e68b495842f60e7cb90a7581499f05b";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.1/linux-x86_64/sco/firefox-112.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.2/linux-x86_64/sco/firefox-112.0.2.tar.bz2";
       locale = "sco";
       arch = "linux-x86_64";
-      sha256 = "f35499b1b27fa69934a2c9fbc030a15884966c6f7b38e3d07abdfe7d8af8ba28";
+      sha256 = "41349269d84c88543f343c9ffcc003d89650584e7e01a618a38e7aa7455162ff";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.1/linux-x86_64/si/firefox-112.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.2/linux-x86_64/si/firefox-112.0.2.tar.bz2";
       locale = "si";
       arch = "linux-x86_64";
-      sha256 = "cd90b1bcb2e0c59420f33728b63530f282bebe61cea80e5817dc8eb8abe77d52";
+      sha256 = "4e1d451b9e1dfe6e9a3783dbbab627da7337da28b419fb20b4530f8ab667e01b";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.1/linux-x86_64/sk/firefox-112.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.2/linux-x86_64/sk/firefox-112.0.2.tar.bz2";
       locale = "sk";
       arch = "linux-x86_64";
-      sha256 = "3d34d6502191d06f207c57b8cd15cd33b6cb93533bb962498c240be8b6d8a989";
+      sha256 = "474535436e42a5e0db7c4ff066a066633e9d27f912018a7d297fb2155b271e17";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.1/linux-x86_64/sl/firefox-112.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.2/linux-x86_64/sl/firefox-112.0.2.tar.bz2";
       locale = "sl";
       arch = "linux-x86_64";
-      sha256 = "32a5359344d8580d551d38a03d691eae56c0f868cd1e5810bcf116043cd19f97";
+      sha256 = "e9470ab915fec42daec4a790d9c6c6dba5bb3c322bd4dd86d3275b875a1076bd";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.1/linux-x86_64/son/firefox-112.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.2/linux-x86_64/son/firefox-112.0.2.tar.bz2";
       locale = "son";
       arch = "linux-x86_64";
-      sha256 = "7ac2c8a8218687638bc3ba9f14b72015020d25cc6a28e192705bd5dfdca83b60";
+      sha256 = "d46566118297c0699de1809dfda3a322ff64fa966218aa0e869b81a473a94fc9";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.1/linux-x86_64/sq/firefox-112.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.2/linux-x86_64/sq/firefox-112.0.2.tar.bz2";
       locale = "sq";
       arch = "linux-x86_64";
-      sha256 = "6cefb5b63772879cc83a8113afa682499222f0c58b736bca9049699f76ba4403";
+      sha256 = "84c87224e4fbda73e953b88a37607722daaf47a8330d2fedaa08bf55a5a4f7c7";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.1/linux-x86_64/sr/firefox-112.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.2/linux-x86_64/sr/firefox-112.0.2.tar.bz2";
       locale = "sr";
       arch = "linux-x86_64";
-      sha256 = "73a3ef123e3c65f251557cdcad39197684ef258bc9d79973568d8e50641bd6b4";
+      sha256 = "aacceca53b7a5bf79be03992741ce67b8a902a2684e9354452d4f56618a51f2f";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.1/linux-x86_64/sv-SE/firefox-112.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.2/linux-x86_64/sv-SE/firefox-112.0.2.tar.bz2";
       locale = "sv-SE";
       arch = "linux-x86_64";
-      sha256 = "6182cdf106563fd8016765a08169dae772641b7badf581b4f1cd71d22d66a739";
+      sha256 = "76142e5423922ae3b75946dce3b2a902f3fab70339c07d9a4815d668e23a9821";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.1/linux-x86_64/szl/firefox-112.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.2/linux-x86_64/szl/firefox-112.0.2.tar.bz2";
       locale = "szl";
       arch = "linux-x86_64";
-      sha256 = "808d255d36dc65c0126a62e6acc54231bd4bcc6e171a2ac017f1746607b9c981";
+      sha256 = "dbd0a963fa7a674f3aa3fc2f22bf35c3f2d9a9efab49800ef259cb914b82b819";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.1/linux-x86_64/ta/firefox-112.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.2/linux-x86_64/ta/firefox-112.0.2.tar.bz2";
       locale = "ta";
       arch = "linux-x86_64";
-      sha256 = "32389f9702b9f2e1dc87c40d6ab64da59c42ae7d0471c56d8f66c8187ddc2fc4";
+      sha256 = "08a6f42e20932a906e7eb365b75c8536536fdff50db5ad702ff687345401a7a7";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.1/linux-x86_64/te/firefox-112.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.2/linux-x86_64/te/firefox-112.0.2.tar.bz2";
       locale = "te";
       arch = "linux-x86_64";
-      sha256 = "3a0ebea6051d8e495c8bdce885b6880198bae4f72c5c4991611d9f9b58054921";
+      sha256 = "c82225dc13a4dd9feceda5552677cf80734785e04b5281140bb0245f3df47784";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.1/linux-x86_64/th/firefox-112.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.2/linux-x86_64/th/firefox-112.0.2.tar.bz2";
       locale = "th";
       arch = "linux-x86_64";
-      sha256 = "c3987449dc9f22b149c193aab7f618129e6f3f82df87753f21b93a579f4a8c46";
+      sha256 = "42c8282d65f1aa74b3c1508040650a0c5a5890d378e35d4bc5c301843569e02f";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.1/linux-x86_64/tl/firefox-112.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.2/linux-x86_64/tl/firefox-112.0.2.tar.bz2";
       locale = "tl";
       arch = "linux-x86_64";
-      sha256 = "f69a1d00396fca338b1ef37fc98566c1f977fd41103950a05bec22f88eca9708";
+      sha256 = "3c877d0a2fb95e25361d2936096a7c47b56062f05db8505b2848d8f4d6be3795";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.1/linux-x86_64/tr/firefox-112.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.2/linux-x86_64/tr/firefox-112.0.2.tar.bz2";
       locale = "tr";
       arch = "linux-x86_64";
-      sha256 = "ccdee7f762fae29a3a6f52a50aa3104965fac7c8ea6d0c0be7029dec33d59f48";
+      sha256 = "c8f105b999bdb235c6f90d5cdcba94d615f03c0fbab08d850043b8e38677af65";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.1/linux-x86_64/trs/firefox-112.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.2/linux-x86_64/trs/firefox-112.0.2.tar.bz2";
       locale = "trs";
       arch = "linux-x86_64";
-      sha256 = "9ddbd803a3188c69c90b0a62b295cbbef3357f3cd3074080bf6f4d6eb87b94d3";
+      sha256 = "01f0f20141d982dbc6db2c49c3456cba85bdec92e967c9e22b467320a927463c";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.1/linux-x86_64/uk/firefox-112.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.2/linux-x86_64/uk/firefox-112.0.2.tar.bz2";
       locale = "uk";
       arch = "linux-x86_64";
-      sha256 = "5409d308337224d5c76a7f20d99d6bae87b0535aa9ba3c56abaac677543dd04e";
+      sha256 = "99a1fbbd80e2b74004ea492f6bc8fcff2c11fe3a393dfec69644f6f2d7a6eb09";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.1/linux-x86_64/ur/firefox-112.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.2/linux-x86_64/ur/firefox-112.0.2.tar.bz2";
       locale = "ur";
       arch = "linux-x86_64";
-      sha256 = "a2aa8fbaef5f1814128a3d39a4780bbb8aa20ab7970f10ecd51165e21e0fbb4d";
+      sha256 = "5f6a004c96b55842566a37c9b7bb63e7b384ec8da9d4032fc02f61eb7995a717";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.1/linux-x86_64/uz/firefox-112.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.2/linux-x86_64/uz/firefox-112.0.2.tar.bz2";
       locale = "uz";
       arch = "linux-x86_64";
-      sha256 = "55230fd3cde7e5dab7309b7dcfd7688feb332ec3c8370001ba925076c3200bbf";
+      sha256 = "6681c59607a6dcdf51e95d802c68cd2eee3cee8935b7a0b493fddd3c32205e16";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.1/linux-x86_64/vi/firefox-112.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.2/linux-x86_64/vi/firefox-112.0.2.tar.bz2";
       locale = "vi";
       arch = "linux-x86_64";
-      sha256 = "f7a8ecf5eeac44aa6ca156d131ebd05a268ce5e92ff0c88c208c3981a658ef78";
+      sha256 = "457590c34d1b207414192f8a1f2b54884dac2c5cfe8999aaf135ac58eb0dc731";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.1/linux-x86_64/xh/firefox-112.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.2/linux-x86_64/xh/firefox-112.0.2.tar.bz2";
       locale = "xh";
       arch = "linux-x86_64";
-      sha256 = "e52862f470202fa07f370a8912023edbf2a5350f1aa7ce5351afa335fc194bc4";
+      sha256 = "d2fafd74b04ba3cdf2de360f9f6d7e19da576d81139010fe3d80a19055a3a326";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.1/linux-x86_64/zh-CN/firefox-112.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.2/linux-x86_64/zh-CN/firefox-112.0.2.tar.bz2";
       locale = "zh-CN";
       arch = "linux-x86_64";
-      sha256 = "03e0a67ed68413022cb5452e68f1dde9480ec71cfd6726be604cbc54581ce84c";
+      sha256 = "30062a56f9b7cce01adc683896d921a568ced738a7bc089f679df85820d62441";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.1/linux-x86_64/zh-TW/firefox-112.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.2/linux-x86_64/zh-TW/firefox-112.0.2.tar.bz2";
       locale = "zh-TW";
       arch = "linux-x86_64";
-      sha256 = "f4e54e3ef22307cb52c26059cd7d862ce7c45c24e6c7cc365f3b0e45f84afeea";
+      sha256 = "ac6ff13f68590aff1d7ec0e88c147ba86bd2074d98ba6586dd4f2a3a448ff38f";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.1/linux-i686/ach/firefox-112.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.2/linux-i686/ach/firefox-112.0.2.tar.bz2";
       locale = "ach";
       arch = "linux-i686";
-      sha256 = "68d790bffa6415c57274d39e1ca04ccafd55c78720b659beaa696746c8a196a4";
+      sha256 = "8e5894479c8c2670ca2ca8aa2067f319e7609d2d15eb19ab6c47eedc3af02ebf";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.1/linux-i686/af/firefox-112.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.2/linux-i686/af/firefox-112.0.2.tar.bz2";
       locale = "af";
       arch = "linux-i686";
-      sha256 = "db827c1ece4fa12b217fb7c41af6064cd286c1f73c3deda8f370cc24294829f7";
+      sha256 = "4be87cd20eae2e2e0481fee449a56db8d22fb4ebe356a7ca04db2911b025d152";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.1/linux-i686/an/firefox-112.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.2/linux-i686/an/firefox-112.0.2.tar.bz2";
       locale = "an";
       arch = "linux-i686";
-      sha256 = "8e43a3008913bbbb33578ffe6725e5cfcc191484d66e9b4ccb80fb4bd1e1822c";
+      sha256 = "34c8db9bca3f337a6f081c99299fd6b07c3d69352e1032882922d380531fcc49";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.1/linux-i686/ar/firefox-112.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.2/linux-i686/ar/firefox-112.0.2.tar.bz2";
       locale = "ar";
       arch = "linux-i686";
-      sha256 = "639cda8d39adf8618b316ed30768306c60b5a2f03c8aacc4e8196b9050f7bc5d";
+      sha256 = "0441a66c9e246804cded5f6db9456e5d31dee3984c59b2b4b01540f92713dcf8";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.1/linux-i686/ast/firefox-112.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.2/linux-i686/ast/firefox-112.0.2.tar.bz2";
       locale = "ast";
       arch = "linux-i686";
-      sha256 = "76e1b0b2d93728304eca8dd25c6d8b589afd054ab1b1b1ac0ddaf4c20982962b";
+      sha256 = "32089836ebcb905c17a10c7f9b02a209064c4db693c29d962bc0067ada617b1c";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.1/linux-i686/az/firefox-112.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.2/linux-i686/az/firefox-112.0.2.tar.bz2";
       locale = "az";
       arch = "linux-i686";
-      sha256 = "7ce308bcfb41db1149425cb73b3298ea98735c871c46077bec33a9c74d876ac7";
+      sha256 = "50b29941e2185e0793587952009571b067e8e60a298388b7024fc4648e5d03aa";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.1/linux-i686/be/firefox-112.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.2/linux-i686/be/firefox-112.0.2.tar.bz2";
       locale = "be";
       arch = "linux-i686";
-      sha256 = "fde37924c46e1a0d1f7dfe17187abf1756e7f02a5ace60b239acfdca11f9a5b4";
+      sha256 = "c4848f7e1a5f50a6814d57f17a5834bc7b1286e988cc52196182291ab9aa2d7b";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.1/linux-i686/bg/firefox-112.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.2/linux-i686/bg/firefox-112.0.2.tar.bz2";
       locale = "bg";
       arch = "linux-i686";
-      sha256 = "8b99e80e883aa1d24612978e085adb0d0d6fb00bc71817e48cdf95bd407eab3e";
+      sha256 = "0ae7bbb8b682b363878577ef92d146f36b48884b2deaedcbf6bc57da434758ee";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.1/linux-i686/bn/firefox-112.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.2/linux-i686/bn/firefox-112.0.2.tar.bz2";
       locale = "bn";
       arch = "linux-i686";
-      sha256 = "82e31e51ecd8d478eef65f437e07d695745bd03d02ee90379364c17506cac7fa";
+      sha256 = "e5e0640cd37e4e9d115e7f67d0a90b08e34a0146356bfcd67214cb7dcfae3c9c";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.1/linux-i686/br/firefox-112.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.2/linux-i686/br/firefox-112.0.2.tar.bz2";
       locale = "br";
       arch = "linux-i686";
-      sha256 = "23a8d61abb4001186847a43b13cf497f9872b8aba5119e515ef4fc5862220410";
+      sha256 = "f5e5149cd30fce3dd992ab09157f3975eb4823bb9f0b7a0662cbde28c64baecf";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.1/linux-i686/bs/firefox-112.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.2/linux-i686/bs/firefox-112.0.2.tar.bz2";
       locale = "bs";
       arch = "linux-i686";
-      sha256 = "149c6fcba2165f9c16f2df471aa345c75b7effe9d7d34e011a1c59bd4a24992a";
+      sha256 = "29f609bcba5ef2fde4bd796eeae9155b9ced42da97203f527ebfa1ea038e8d81";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.1/linux-i686/ca-valencia/firefox-112.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.2/linux-i686/ca-valencia/firefox-112.0.2.tar.bz2";
       locale = "ca-valencia";
       arch = "linux-i686";
-      sha256 = "567e3cf76f645820a1b10cae5c1b38967c0348fbf65eda45eeb9fe2fa4d901d8";
+      sha256 = "9b732ef026044892b33f5e4059e4b86ae670ed202b31735b8a26b7c86d935f80";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.1/linux-i686/ca/firefox-112.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.2/linux-i686/ca/firefox-112.0.2.tar.bz2";
       locale = "ca";
       arch = "linux-i686";
-      sha256 = "db7bee1e3fe1be75d7fb92a242d7a436902f5fe86b8aa4c7fa25dfe61f3faac2";
+      sha256 = "5e8b8ce7f063212e92bd1a23ac22a9e74642e6c69c51f2e123ba1b0756f1b95c";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.1/linux-i686/cak/firefox-112.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.2/linux-i686/cak/firefox-112.0.2.tar.bz2";
       locale = "cak";
       arch = "linux-i686";
-      sha256 = "4eb2cd9f324777fcb8be0af9840eea4d01084921c270278605a4d9e90f69ab41";
+      sha256 = "596c1aea0b6a6634be8de4e334a2186111b6a3370cf428b6ab24c6707a588442";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.1/linux-i686/cs/firefox-112.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.2/linux-i686/cs/firefox-112.0.2.tar.bz2";
       locale = "cs";
       arch = "linux-i686";
-      sha256 = "d5acd46ffe1c44b8e150cc392c06de3b9886dc996942c82593a326692897c8b0";
+      sha256 = "fa53d85a8a7ca5af00fedbb527de4c0c4386b4c62ed7c7f3a76f9c189123954b";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.1/linux-i686/cy/firefox-112.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.2/linux-i686/cy/firefox-112.0.2.tar.bz2";
       locale = "cy";
       arch = "linux-i686";
-      sha256 = "d086fddb56c18a8189ca6c66c353e76d2e99853c88847675b2b69362741c41a7";
+      sha256 = "18ee47aa148012d2d5528db5829feebbec941568221731c38f191485ca57ec0a";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.1/linux-i686/da/firefox-112.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.2/linux-i686/da/firefox-112.0.2.tar.bz2";
       locale = "da";
       arch = "linux-i686";
-      sha256 = "b8c6e563c98a1a7e0c583bc3463d501dfa7d5b3f9e5bfdf026fad1f20e94b4b4";
+      sha256 = "0c17d62a5edbddbff5bdb5ec7efd2ea32fc0e19ba7767500d0f21d15d6aa3d14";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.1/linux-i686/de/firefox-112.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.2/linux-i686/de/firefox-112.0.2.tar.bz2";
       locale = "de";
       arch = "linux-i686";
-      sha256 = "8be83652fd8872ece97120f21abc66ef17332900696aea65350d9c36f51aef20";
+      sha256 = "cb9b72b06c83a0eedf83704ff01aa6a7ae8b15a39118cdec4c6abeca6b59fc8e";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.1/linux-i686/dsb/firefox-112.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.2/linux-i686/dsb/firefox-112.0.2.tar.bz2";
       locale = "dsb";
       arch = "linux-i686";
-      sha256 = "0b7c5bf0808b4cdb24767aca38983db2769a9dc17182b05f05767f5bdb1510a7";
+      sha256 = "ece81a97a047b520aa912db9ca372a8e9550cbd1f0c8996cdf3f686068edcdf3";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.1/linux-i686/el/firefox-112.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.2/linux-i686/el/firefox-112.0.2.tar.bz2";
       locale = "el";
       arch = "linux-i686";
-      sha256 = "564fc0fc6cf469254a55756142a7bd221f7e8f5a2a65a7af7884442d405cdcc3";
+      sha256 = "35076bd574b638a871f3a0a70a87b7a0b6f56b3eea8653d2888cdb4fa1fc52df";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.1/linux-i686/en-CA/firefox-112.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.2/linux-i686/en-CA/firefox-112.0.2.tar.bz2";
       locale = "en-CA";
       arch = "linux-i686";
-      sha256 = "8fe5513b1cd1e4735ead8f7232bfa95e709a7f09e15c998ffcc57e866f0e0177";
+      sha256 = "38ed101fbb4a68915c6e11eed1576c0312fcb1ec7c45264fb929f5019fa30340";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.1/linux-i686/en-GB/firefox-112.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.2/linux-i686/en-GB/firefox-112.0.2.tar.bz2";
       locale = "en-GB";
       arch = "linux-i686";
-      sha256 = "6d7614935cd1cb93e8dbb843e5725d263655d0042fbcde4656fb90899fc4923e";
+      sha256 = "06f5012d8e6ede5eeab23dfdf8eb06e20410514e13e7872ffe6b77c5bd6cf25d";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.1/linux-i686/en-US/firefox-112.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.2/linux-i686/en-US/firefox-112.0.2.tar.bz2";
       locale = "en-US";
       arch = "linux-i686";
-      sha256 = "7c30ab48a4cc32e6358d6dd29e34274453b1db998cb52cfc5e2108ebf1f9ba41";
+      sha256 = "b3b6537de3f8c2606d6cd119a4158c1e30ad21cd0936e9887fffe398cfa264cc";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.1/linux-i686/eo/firefox-112.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.2/linux-i686/eo/firefox-112.0.2.tar.bz2";
       locale = "eo";
       arch = "linux-i686";
-      sha256 = "d0c603545d9e36cc43a0dcf5013d29c2557f7b31fc4c551fe482d5e53b76e7f9";
+      sha256 = "8eec80b82de6279eda4d1a4b740c7be1eb4c3278efd9d1ddb35235775527ac72";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.1/linux-i686/es-AR/firefox-112.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.2/linux-i686/es-AR/firefox-112.0.2.tar.bz2";
       locale = "es-AR";
       arch = "linux-i686";
-      sha256 = "2b3e80b83fe78178074a784c6800ceea0ef449ec0fca0919855c0cfb0d8f3eb8";
+      sha256 = "226a16beaea00f60292f4ca1275967aa266f30b0f9afd7fc7f8ef20b28db409d";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.1/linux-i686/es-CL/firefox-112.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.2/linux-i686/es-CL/firefox-112.0.2.tar.bz2";
       locale = "es-CL";
       arch = "linux-i686";
-      sha256 = "fa46c867f8daef7b4aebf3c9968f12b26aa5ead295baa5da991730bfd022907d";
+      sha256 = "e08c2d0452fb24aa7ebff8bb937df400d18a84f6cb19e80884fc1fa5daf41590";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.1/linux-i686/es-ES/firefox-112.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.2/linux-i686/es-ES/firefox-112.0.2.tar.bz2";
       locale = "es-ES";
       arch = "linux-i686";
-      sha256 = "a6c24fef469e0b7e4b8bab3ad7127c569e0c2e0c38c5cbf344dc70ada34016b8";
+      sha256 = "eefb4f5342e102b90b6350d3dc091c6286459aa69938a0e9d57b1e4624beb41b";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.1/linux-i686/es-MX/firefox-112.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.2/linux-i686/es-MX/firefox-112.0.2.tar.bz2";
       locale = "es-MX";
       arch = "linux-i686";
-      sha256 = "372403d23deac3dfb397bb3c5da5b10e58c60656b9c5d9126d06435c07b86282";
+      sha256 = "bd7424bd23b4dedfc007e15c13e250030194b4b4efee75f52ed87ef0b7059b6e";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.1/linux-i686/et/firefox-112.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.2/linux-i686/et/firefox-112.0.2.tar.bz2";
       locale = "et";
       arch = "linux-i686";
-      sha256 = "586efc4af3e4c10e13394967d880e4132e9739da259a505df84488ed069bdb55";
+      sha256 = "66d1f747f3545aacc89e26f062052dafd48ad3bec8e8285f86764198ee325fe8";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.1/linux-i686/eu/firefox-112.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.2/linux-i686/eu/firefox-112.0.2.tar.bz2";
       locale = "eu";
       arch = "linux-i686";
-      sha256 = "ea16876186a0666cbf4783a114ae32c60d5279e9c0aee9db5ab7404a8ed94ff8";
+      sha256 = "0cc51370fd7640ee7b9b319b5a6ea211b6fe1b5a8aa8dc36e75f7da25e8c4b98";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.1/linux-i686/fa/firefox-112.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.2/linux-i686/fa/firefox-112.0.2.tar.bz2";
       locale = "fa";
       arch = "linux-i686";
-      sha256 = "44189a301db4defe04160de90fd4722003b062460c44ccb54466044641eadfa6";
+      sha256 = "550cccf8b9ab72e9d9d0a37edd836c9c0c6a397c54a58bc23aacca2567055d01";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.1/linux-i686/ff/firefox-112.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.2/linux-i686/ff/firefox-112.0.2.tar.bz2";
       locale = "ff";
       arch = "linux-i686";
-      sha256 = "6d61ac3ec8652416cbf32449658da95eecd8ea84fbb0fe5ddac4fc8c9ced964e";
+      sha256 = "402e4bdff0865524ceb5c295c157d7387f22682a29ac16718239af485f1f0384";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.1/linux-i686/fi/firefox-112.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.2/linux-i686/fi/firefox-112.0.2.tar.bz2";
       locale = "fi";
       arch = "linux-i686";
-      sha256 = "09e3ae90365f38d5fe7859c24c6bee640fd0aee3f2283d9cf1cc5840ac9fa70a";
+      sha256 = "9f49648a46043fbbd22ec1b73b73452bdac23bb046c1bd4951f17b847c403ee9";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.1/linux-i686/fr/firefox-112.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.2/linux-i686/fr/firefox-112.0.2.tar.bz2";
       locale = "fr";
       arch = "linux-i686";
-      sha256 = "a037725177bd002cb06ff82548efe8e48b99095362c1ed443101dfe00f0c2e87";
+      sha256 = "ab17b387391556820d9ebdf4dc28bbc90e3e644d5364ab48faf49e0b378c1b5c";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.1/linux-i686/fur/firefox-112.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.2/linux-i686/fur/firefox-112.0.2.tar.bz2";
       locale = "fur";
       arch = "linux-i686";
-      sha256 = "fbfb3357784a0609260e42ef8011f354e3e9312607d116d324bbffa410607f01";
+      sha256 = "b1420357530394c326a85f06c0b66cf1a7f1f92aed13b7e04fcf49f9e492033a";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.1/linux-i686/fy-NL/firefox-112.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.2/linux-i686/fy-NL/firefox-112.0.2.tar.bz2";
       locale = "fy-NL";
       arch = "linux-i686";
-      sha256 = "1a7348fd973379cb6b639f4651d704267cba9eea65484672858a7e6f55739cde";
+      sha256 = "1758f2ce57166b97182c02904970eedc00cb8c5195f7872f7edbc63f0443d184";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.1/linux-i686/ga-IE/firefox-112.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.2/linux-i686/ga-IE/firefox-112.0.2.tar.bz2";
       locale = "ga-IE";
       arch = "linux-i686";
-      sha256 = "01b7652d854d25745378e612f71e9aacef07d18318f14658a17d491a25724a62";
+      sha256 = "05f0ce176ef1ed1df62e56e57ca78c2da4181769213c62a84dfd1486bd6c0291";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.1/linux-i686/gd/firefox-112.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.2/linux-i686/gd/firefox-112.0.2.tar.bz2";
       locale = "gd";
       arch = "linux-i686";
-      sha256 = "33bb06317e98eb560bff3599f57aa76b3d686549b32237200c12374fbb95cb7a";
+      sha256 = "c71cf775a36b2e40512fbb514d18f7d1e5734bb2bf9ce3753fa992178c71cc84";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.1/linux-i686/gl/firefox-112.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.2/linux-i686/gl/firefox-112.0.2.tar.bz2";
       locale = "gl";
       arch = "linux-i686";
-      sha256 = "8ea125896e735709ac7ae1f5ef29740dd7db3eb08de10ee0b5a25e005e1bb1e1";
+      sha256 = "527a3b3175a70e4309194ed8ec12d2735dfa51c6830a62f7ca202553f85038ff";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.1/linux-i686/gn/firefox-112.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.2/linux-i686/gn/firefox-112.0.2.tar.bz2";
       locale = "gn";
       arch = "linux-i686";
-      sha256 = "f3e546720ac549e6b4c94bceba5c8fa66ef0af771268052fd114141397c5f518";
+      sha256 = "125222a06c0b25f0187907cc66d04a15638d8f162544dfa53af3bc85a0922396";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.1/linux-i686/gu-IN/firefox-112.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.2/linux-i686/gu-IN/firefox-112.0.2.tar.bz2";
       locale = "gu-IN";
       arch = "linux-i686";
-      sha256 = "e5a671e30fefd9a669b4f6d86b958887320dec0f450a302069ce944327d2b0b9";
+      sha256 = "49a051e5a95b0738c7f5e97ddd3679ad062c83d80395d71fd7e5a9988577db16";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.1/linux-i686/he/firefox-112.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.2/linux-i686/he/firefox-112.0.2.tar.bz2";
       locale = "he";
       arch = "linux-i686";
-      sha256 = "ecbea24231080df03d6a884589d1a48f5cdbc61eb9f53111507e438a1442972e";
+      sha256 = "f0e992f6b27a99f67a252fbd67fbe1511230467c3b2ede7b0d3395c4bebe040b";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.1/linux-i686/hi-IN/firefox-112.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.2/linux-i686/hi-IN/firefox-112.0.2.tar.bz2";
       locale = "hi-IN";
       arch = "linux-i686";
-      sha256 = "9ad861c0dfcc7cdf08129948b04a1ff22dbc84c67b0b085621fa11f9b733691a";
+      sha256 = "d4639508f927056cace33d0d1adbdbad13852f05b00ff5b439bbd956c7cb5f67";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.1/linux-i686/hr/firefox-112.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.2/linux-i686/hr/firefox-112.0.2.tar.bz2";
       locale = "hr";
       arch = "linux-i686";
-      sha256 = "66a15a6321789612a15e1f897ba69146a0f48640a452b92e98ee50bc2fc5bee1";
+      sha256 = "29cd33f9d173a416e9e8a825ec1b6b7656eb429475befb3debed0f9319c4f9ae";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.1/linux-i686/hsb/firefox-112.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.2/linux-i686/hsb/firefox-112.0.2.tar.bz2";
       locale = "hsb";
       arch = "linux-i686";
-      sha256 = "5e0a10c8abc026543ec9aee297b0246af5726fbc19c8c3defe3816cff96a5306";
+      sha256 = "da044123db5f309920f49075d6b2c2d379423094f79cd82ff857cb8e55a80634";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.1/linux-i686/hu/firefox-112.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.2/linux-i686/hu/firefox-112.0.2.tar.bz2";
       locale = "hu";
       arch = "linux-i686";
-      sha256 = "35dfc59a336d1d4c977f393cda08df4aac2ea4b570cb347234b04e36e60ccd7a";
+      sha256 = "4212ff43a627d29a081effc62cd8a44db79f266c1f2a9f64fb610cea7930b7d5";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.1/linux-i686/hy-AM/firefox-112.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.2/linux-i686/hy-AM/firefox-112.0.2.tar.bz2";
       locale = "hy-AM";
       arch = "linux-i686";
-      sha256 = "a44666a2855563a2437a3a5b317858b5d97608c1d84a366e6fc9ca7d500fd908";
+      sha256 = "fefa97627dfd5e368057ad40be7ac15a397e2915f82f4dbaafccfcbacf0d96f5";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.1/linux-i686/ia/firefox-112.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.2/linux-i686/ia/firefox-112.0.2.tar.bz2";
       locale = "ia";
       arch = "linux-i686";
-      sha256 = "578824cc54bf08eebb5391f7195e0e668684103d57913c73f34323e48fc9b997";
+      sha256 = "4fd80715413cb0eeb63c615764b287ca126f2cc09014f4dfd213f2f7be81b64e";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.1/linux-i686/id/firefox-112.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.2/linux-i686/id/firefox-112.0.2.tar.bz2";
       locale = "id";
       arch = "linux-i686";
-      sha256 = "ec9d5f75f85a97e88fa16eca1e5d365b20453594f23bc7ce6b0accd64a06cd2a";
+      sha256 = "e43da18d58eeb275888988471307004ea7efbf6ccd88c6e03dc16e5bfa548e08";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.1/linux-i686/is/firefox-112.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.2/linux-i686/is/firefox-112.0.2.tar.bz2";
       locale = "is";
       arch = "linux-i686";
-      sha256 = "c11658c067c6ec8ed7f2cf34c74587b6500a3f96d0d48647105d6218b39dbffa";
+      sha256 = "a2ba240444cbc96d56b6d4a851da6f80b783f9fd74ab0b89a672f88173b33a0f";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.1/linux-i686/it/firefox-112.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.2/linux-i686/it/firefox-112.0.2.tar.bz2";
       locale = "it";
       arch = "linux-i686";
-      sha256 = "0cd5cb70fc40956caed930ca51c01c539159a35a7a5ad5cbf9257a3e12bb9845";
+      sha256 = "4f908a9c9386c214301ea3cd6e8298d7aea9ef94ec8c92062bcf6a98ff7d5c7d";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.1/linux-i686/ja/firefox-112.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.2/linux-i686/ja/firefox-112.0.2.tar.bz2";
       locale = "ja";
       arch = "linux-i686";
-      sha256 = "56a73fddb5a0d2d2160e68bcfab172e81f572a2db3981b43b330292057b0e671";
+      sha256 = "c69b6cf1fde3d7a76f258732f9aaa558e1315ec0dd83bd3f2a6af02c88d05bef";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.1/linux-i686/ka/firefox-112.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.2/linux-i686/ka/firefox-112.0.2.tar.bz2";
       locale = "ka";
       arch = "linux-i686";
-      sha256 = "57bc43faf0e2610fb0e58c5e7e323e7909a9834dcac1bb6b1b3803c0ffe88ab4";
+      sha256 = "6c1fb4069bece39160c3d8de030c8d8d8e7f698784199aeff9b86cb5d6af3803";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.1/linux-i686/kab/firefox-112.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.2/linux-i686/kab/firefox-112.0.2.tar.bz2";
       locale = "kab";
       arch = "linux-i686";
-      sha256 = "48eca6ab0e3dc3d187f2f296b48f5ddf85481f3c0a14614778fee21d0356ab5c";
+      sha256 = "e14bbc22e6f922714109db165cec4f8dcd9c4a3672b37519e3df7e0e9fedcfe5";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.1/linux-i686/kk/firefox-112.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.2/linux-i686/kk/firefox-112.0.2.tar.bz2";
       locale = "kk";
       arch = "linux-i686";
-      sha256 = "0e8693939975ef607d1d955b994e047e43018be58654f25436233c8686241baf";
+      sha256 = "92c694a35a19cede811364ad0bad3cdb33a62de8a6effe742a5c57ba865ac5be";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.1/linux-i686/km/firefox-112.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.2/linux-i686/km/firefox-112.0.2.tar.bz2";
       locale = "km";
       arch = "linux-i686";
-      sha256 = "453b984e1709b99947d1e4ef4509c89f73de9041d231c62755674f976599b1ac";
+      sha256 = "2e4f6f21b44e8a2812961bd2e625bfd8b070816ea3640cee163d177dfe090498";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.1/linux-i686/kn/firefox-112.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.2/linux-i686/kn/firefox-112.0.2.tar.bz2";
       locale = "kn";
       arch = "linux-i686";
-      sha256 = "a25556c0340257300b205c4ffc4e0f6f59d8dd151a415452e501f041ba868278";
+      sha256 = "ec99d9517002fa62cdc210c57fd9ef3a38faf35fd3ce34c24910b42673b67133";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.1/linux-i686/ko/firefox-112.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.2/linux-i686/ko/firefox-112.0.2.tar.bz2";
       locale = "ko";
       arch = "linux-i686";
-      sha256 = "3fd45baeafaee0f24639388337c659073c19f6892e7ce02a458521fb50fb021f";
+      sha256 = "3fb1d5ba4c8f6b3824c72c561e45834054113f70ccd8087ff8c9a957ee9dce4f";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.1/linux-i686/lij/firefox-112.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.2/linux-i686/lij/firefox-112.0.2.tar.bz2";
       locale = "lij";
       arch = "linux-i686";
-      sha256 = "74d12bfbb8b64d95c583a4d18e3ddeb7c47589206d9e01093e536af83b3c2263";
+      sha256 = "d8225a7dfb4f93faff92f853fef3001c737a83328ea51618aaa4f8aab44fb902";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.1/linux-i686/lt/firefox-112.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.2/linux-i686/lt/firefox-112.0.2.tar.bz2";
       locale = "lt";
       arch = "linux-i686";
-      sha256 = "935a06e6c9418796b262bf11c2bf10e02c799866f9a71cfb1b287387a1e7d429";
+      sha256 = "631230b71052285b7d58b272839fdfb6b86457690c3036094faa50f11cad0ae4";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.1/linux-i686/lv/firefox-112.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.2/linux-i686/lv/firefox-112.0.2.tar.bz2";
       locale = "lv";
       arch = "linux-i686";
-      sha256 = "37ba1df6e5300cab332f66e1872ebfd03210a9405b2a6a696c04cb5973e8aa3e";
+      sha256 = "31a76eed0cddd4bb7ba24c063d0936d4f0e36e3efc18f8f0e504bd1bc3542f99";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.1/linux-i686/mk/firefox-112.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.2/linux-i686/mk/firefox-112.0.2.tar.bz2";
       locale = "mk";
       arch = "linux-i686";
-      sha256 = "846f8905382d8ecd621ecb4476364d13a83cc9759f3c6d6fa532f52d868f5081";
+      sha256 = "d2987264002bb665866507da3e6df5a04d72834c98f89a996cd24ab968b0a4a3";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.1/linux-i686/mr/firefox-112.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.2/linux-i686/mr/firefox-112.0.2.tar.bz2";
       locale = "mr";
       arch = "linux-i686";
-      sha256 = "eb182cf3e62502d7978e8321a43dcf7ce83b2f8871494206b89b36063ee87f9e";
+      sha256 = "d39f7668e6548de3e5a33265ea5ee6b99d801a97aff7e2cc12f054ac6042655f";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.1/linux-i686/ms/firefox-112.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.2/linux-i686/ms/firefox-112.0.2.tar.bz2";
       locale = "ms";
       arch = "linux-i686";
-      sha256 = "ca659d6e58ad5bbda6f5029358ee8d8e2434490ceb315ee9c92777892976eb35";
+      sha256 = "1d9d5aef69d76136d0b02313277bc79069f7ad778ff700430fc91481dfb9a2ca";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.1/linux-i686/my/firefox-112.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.2/linux-i686/my/firefox-112.0.2.tar.bz2";
       locale = "my";
       arch = "linux-i686";
-      sha256 = "a3656a0dceaab329a1b66d2559307c95582da97599f0f24afbd1a2f3ac3d8978";
+      sha256 = "5ce8128deacde8fcd65f0dc40919cc1a47f2699258be3b19c3cddc6766df8185";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.1/linux-i686/nb-NO/firefox-112.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.2/linux-i686/nb-NO/firefox-112.0.2.tar.bz2";
       locale = "nb-NO";
       arch = "linux-i686";
-      sha256 = "79696194984f1789a2e0b1b0ccaddae490077bacaa96184adf4f8d298b75b47b";
+      sha256 = "b6ab5e4dc4566b9e7a2147b487cbe6cac2661168d2d2a9af19fdb8054d3fea6b";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.1/linux-i686/ne-NP/firefox-112.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.2/linux-i686/ne-NP/firefox-112.0.2.tar.bz2";
       locale = "ne-NP";
       arch = "linux-i686";
-      sha256 = "bdcd39bd3d0c0441044f7f1d7ed2dea1d07fc550778e6071ec03d159b30db413";
+      sha256 = "0b738935a8b514fa94137713a64b3343747af647f92c89a8650300e74fe06c3f";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.1/linux-i686/nl/firefox-112.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.2/linux-i686/nl/firefox-112.0.2.tar.bz2";
       locale = "nl";
       arch = "linux-i686";
-      sha256 = "b0e14bad355f3a63a37fae0dc74eb3f974c5a923261ac42dea9d30485ebe61c6";
+      sha256 = "43bea3aaf6394e346d5a7a94fa9b6d272eadbd24ca4c905e5ec19d24070f5763";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.1/linux-i686/nn-NO/firefox-112.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.2/linux-i686/nn-NO/firefox-112.0.2.tar.bz2";
       locale = "nn-NO";
       arch = "linux-i686";
-      sha256 = "2cd11da894f7f3ee53ceb1138ceda8542b4b143341cbcd624a4f9bc808d520ad";
+      sha256 = "21bbb6ea695b81932168ce7ed16b14a3204b5cbd8cd4963544dedf02d1aab10e";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.1/linux-i686/oc/firefox-112.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.2/linux-i686/oc/firefox-112.0.2.tar.bz2";
       locale = "oc";
       arch = "linux-i686";
-      sha256 = "7435492bd6079d7e76cdb4a41f070b42ee4c080d3e891f05a21942046d33d76d";
+      sha256 = "91bbc293db4e4397c0502d38fcb9c5fbadeb7834ffab87e337bd33b96afe9911";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.1/linux-i686/pa-IN/firefox-112.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.2/linux-i686/pa-IN/firefox-112.0.2.tar.bz2";
       locale = "pa-IN";
       arch = "linux-i686";
-      sha256 = "93c90602e511aac82efa2da0fb4c3043bfadcfa27cb87a39108c803639d52b3e";
+      sha256 = "03b9d04b28df436bdab3d792f15e5a59f30073c50f9f1697d0062c6defcd0f4c";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.1/linux-i686/pl/firefox-112.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.2/linux-i686/pl/firefox-112.0.2.tar.bz2";
       locale = "pl";
       arch = "linux-i686";
-      sha256 = "a75bfe0ec38e782c939348a34e6acf23598338c3350278f096ab73354c43f3c4";
+      sha256 = "84b532132fcc5e832d71a97de46f14fb2ae8a0855bcb88b98b77c73a22a9d742";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.1/linux-i686/pt-BR/firefox-112.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.2/linux-i686/pt-BR/firefox-112.0.2.tar.bz2";
       locale = "pt-BR";
       arch = "linux-i686";
-      sha256 = "67b17c53ec8618064d0fefc0b5a61ee8911f714396fc19b0931fcd242c8d117e";
+      sha256 = "346524c9dd078c68227e681afd0344b1574623a88abb025dbadd7ecfad4759c9";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.1/linux-i686/pt-PT/firefox-112.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.2/linux-i686/pt-PT/firefox-112.0.2.tar.bz2";
       locale = "pt-PT";
       arch = "linux-i686";
-      sha256 = "e4e412aab7cd1e938be7c5e689bee63499a9b44b5e4efa2fafa58d5bb2c12c2a";
+      sha256 = "e14516096e990defff67deb73aaae9448b4a14ce660829aa7c392d9a45b3891f";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.1/linux-i686/rm/firefox-112.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.2/linux-i686/rm/firefox-112.0.2.tar.bz2";
       locale = "rm";
       arch = "linux-i686";
-      sha256 = "b86be0830e26e01302f1f99ed9c5acc9a43757d340361dc137267c9b95feeff9";
+      sha256 = "7c6e7381e963eb9d7100c1d380df759107d5baf4f4862177986adb2068844ac5";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.1/linux-i686/ro/firefox-112.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.2/linux-i686/ro/firefox-112.0.2.tar.bz2";
       locale = "ro";
       arch = "linux-i686";
-      sha256 = "ad830ca7e0c7f0b53031fc85d8884beb6beabedc38dbe570f06324fa4acb0bc6";
+      sha256 = "6b9d0dd1256f50088706d1c695d08d92a970f5b1ad6e536647e4b917ed3758d5";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.1/linux-i686/ru/firefox-112.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.2/linux-i686/ru/firefox-112.0.2.tar.bz2";
       locale = "ru";
       arch = "linux-i686";
-      sha256 = "9c2778b094dbebe800f8f590d1df5202b1632616d0f78ba94d8db31726ad8b83";
+      sha256 = "52e4449fac2a97b5db5ca525edc664e0fb25519df4472e8f820b4233c33411ae";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.1/linux-i686/sc/firefox-112.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.2/linux-i686/sc/firefox-112.0.2.tar.bz2";
       locale = "sc";
       arch = "linux-i686";
-      sha256 = "4799ac43e8a0d44412e8ff2c50982d494d039430eb1175bd98dda95399b8aadf";
+      sha256 = "3b011a7316737f53219e942cdb62938d961826e284246294097a4505e8ebeb71";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.1/linux-i686/sco/firefox-112.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.2/linux-i686/sco/firefox-112.0.2.tar.bz2";
       locale = "sco";
       arch = "linux-i686";
-      sha256 = "135ef70b894fb2ce564c9e8070b65f605b199382b109faa2f2519f9ebbf9c0f9";
+      sha256 = "37d7f80776a35165ec071e8dff8d390db5a11e5f8f11814b9c7c0fc3d18fbb24";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.1/linux-i686/si/firefox-112.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.2/linux-i686/si/firefox-112.0.2.tar.bz2";
       locale = "si";
       arch = "linux-i686";
-      sha256 = "52329952a8075a05a248a49d69a5c5ceb41778d6c68b76e5a334b1ebff3d4a1d";
+      sha256 = "3acf9722a50c1baa35bafd323876882999b353c9b3b39a38ea8085d44cc27694";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.1/linux-i686/sk/firefox-112.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.2/linux-i686/sk/firefox-112.0.2.tar.bz2";
       locale = "sk";
       arch = "linux-i686";
-      sha256 = "1b3073d92b6eacabf8c26efa58e00c6895332f560f4be93a57fba4666f328751";
+      sha256 = "c2571e8d25564675ee4c11126e3a8dee278b11ba4be1f333c4a0feb83d78f3a6";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.1/linux-i686/sl/firefox-112.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.2/linux-i686/sl/firefox-112.0.2.tar.bz2";
       locale = "sl";
       arch = "linux-i686";
-      sha256 = "4ec9e44b3defcd7b79f60a4304123f228bbbfc4ad615548ef5183366d730c335";
+      sha256 = "d12738c69e586a45bb45339b4c5e4dbe9812eb161517479d5e09c1d84ac8e6b8";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.1/linux-i686/son/firefox-112.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.2/linux-i686/son/firefox-112.0.2.tar.bz2";
       locale = "son";
       arch = "linux-i686";
-      sha256 = "1da86784e9dc41d4d2c6b05d35da1a2f96bd133b87b759719768bf085fa07dc4";
+      sha256 = "dbde4f4fb12d2c76ec6ebb478f23e23914af66f417960ee1459ad7d5af85a306";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.1/linux-i686/sq/firefox-112.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.2/linux-i686/sq/firefox-112.0.2.tar.bz2";
       locale = "sq";
       arch = "linux-i686";
-      sha256 = "06525d8421cc412c8e5ec2c6cb47d91665b9d0e8d622c09b2fb70b21ad0a724c";
+      sha256 = "a588d5a5328794397d4b2b85800343f86f5e7219f1419e9c9cfc1102e686cec0";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.1/linux-i686/sr/firefox-112.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.2/linux-i686/sr/firefox-112.0.2.tar.bz2";
       locale = "sr";
       arch = "linux-i686";
-      sha256 = "358dcc70895bdfd935419b755711dc7001a56866746a0340b534192e58de7948";
+      sha256 = "bb2539149ab918bb256946dbb1c229b161ace148c6bcf1882329460f5c37b62d";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.1/linux-i686/sv-SE/firefox-112.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.2/linux-i686/sv-SE/firefox-112.0.2.tar.bz2";
       locale = "sv-SE";
       arch = "linux-i686";
-      sha256 = "91a7e6eaa15b846a6d7f942249b783e51fad059cd13932726ae8a2bfe154b746";
+      sha256 = "af57326935c3b392d80ee6148d02caf3c371adb0e1feb509c992e38394a0285c";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.1/linux-i686/szl/firefox-112.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.2/linux-i686/szl/firefox-112.0.2.tar.bz2";
       locale = "szl";
       arch = "linux-i686";
-      sha256 = "8127eeba4f40a5a1a4c7a85bdb343ac360bcdf2f14721423196f7803c8648bc5";
+      sha256 = "79a565f7d7954385f0bd2d24004a9915611c23659bf6da928817cb876b1b2130";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.1/linux-i686/ta/firefox-112.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.2/linux-i686/ta/firefox-112.0.2.tar.bz2";
       locale = "ta";
       arch = "linux-i686";
-      sha256 = "337ddde6c133d2fd2a4e5850605586ffdf78a4038aa54f291584d522efd06faf";
+      sha256 = "92c515d9e7686579833c211662022fc81b9342f3b69672454ca7f88ae40912c5";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.1/linux-i686/te/firefox-112.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.2/linux-i686/te/firefox-112.0.2.tar.bz2";
       locale = "te";
       arch = "linux-i686";
-      sha256 = "602edab53a94b72761f1fcf805621e2871633540e43212602ba85381ca7a0093";
+      sha256 = "3e1e2280e586ec818d21213e83ef09cff59d85802b40d297d24937312c9b0f36";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.1/linux-i686/th/firefox-112.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.2/linux-i686/th/firefox-112.0.2.tar.bz2";
       locale = "th";
       arch = "linux-i686";
-      sha256 = "541593a4e696e85281942f57a0276da033c47a1ab2782820f8c77c97d10ab74b";
+      sha256 = "c5f564feeca7ee1ed94749cbc5864bc1ed2905a995d11f3551c7ec8d2be82d16";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.1/linux-i686/tl/firefox-112.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.2/linux-i686/tl/firefox-112.0.2.tar.bz2";
       locale = "tl";
       arch = "linux-i686";
-      sha256 = "6d5a977aa0e651bb8a3c1868b4639472c203e791d0cba0ce34ac556ea18a0e27";
+      sha256 = "32ccb86053d91355cb937af203297051cf32ef09085199924ac62374f3b5a43c";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.1/linux-i686/tr/firefox-112.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.2/linux-i686/tr/firefox-112.0.2.tar.bz2";
       locale = "tr";
       arch = "linux-i686";
-      sha256 = "2c94db9856cf6dfaa810fe6397185959a8d78222d3cc8e8968906cbe864b3ae4";
+      sha256 = "0b97e08b5852bf2ed2ed19098e850fc7670772a797c21bec561ff2bed55b3679";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.1/linux-i686/trs/firefox-112.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.2/linux-i686/trs/firefox-112.0.2.tar.bz2";
       locale = "trs";
       arch = "linux-i686";
-      sha256 = "21742ee25642a258df95f7aa2dc92f422546408e8084071b42792d90b0cb6713";
+      sha256 = "01a7242176bfd92ca3aad41305f5eac96d191c6cc8790981e4dbf4f0ad0792ce";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.1/linux-i686/uk/firefox-112.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.2/linux-i686/uk/firefox-112.0.2.tar.bz2";
       locale = "uk";
       arch = "linux-i686";
-      sha256 = "6f93c32705ce3b72db574c36c318fcf69c91423eaf41b70d144b91f6a71b91d1";
+      sha256 = "4b4a9642cf069bca7c5f01d76c2c8503530f37810cc09fe72ad73f213c96e78b";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.1/linux-i686/ur/firefox-112.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.2/linux-i686/ur/firefox-112.0.2.tar.bz2";
       locale = "ur";
       arch = "linux-i686";
-      sha256 = "8ccea04fb8a753fcf0b7c4a1a2c941e630438ed74b077714355d816c09e5c537";
+      sha256 = "47a4e99ec6dd1d262b21e432485c2bef3ef112971fdecbb01cab5715a868bccb";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.1/linux-i686/uz/firefox-112.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.2/linux-i686/uz/firefox-112.0.2.tar.bz2";
       locale = "uz";
       arch = "linux-i686";
-      sha256 = "707fb054e342b449c79a86788096d25ca61f965ce31f862d8779135d5eed888e";
+      sha256 = "4ea75c2774cb552b962df7aa851bf7ae102dfb1de72637143784ba52e21e8d08";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.1/linux-i686/vi/firefox-112.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.2/linux-i686/vi/firefox-112.0.2.tar.bz2";
       locale = "vi";
       arch = "linux-i686";
-      sha256 = "4019556dd8c934548c0ea646d5c6d3dc557c9bbe4382a30375fd03f564eb034c";
+      sha256 = "6fba17093fa1146955e614e49faa9aba235a1b9cc071e2622e6fd2f089049fd6";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.1/linux-i686/xh/firefox-112.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.2/linux-i686/xh/firefox-112.0.2.tar.bz2";
       locale = "xh";
       arch = "linux-i686";
-      sha256 = "712d9a1f97b649aa3776a7d80fc38b71c204689afff6e0f49f13a4fcda786092";
+      sha256 = "bf02cdb2d591dec4fb86b548fc17d6e7d1a7e147b4a8aec0eb5282227f82b575";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.1/linux-i686/zh-CN/firefox-112.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.2/linux-i686/zh-CN/firefox-112.0.2.tar.bz2";
       locale = "zh-CN";
       arch = "linux-i686";
-      sha256 = "59a5c6cbeaae82e0debe411685b1f5b44bd59acf965c93af52c21a715600522b";
+      sha256 = "2dd64475a0ea10963d04be835e1ce45a7f89a3dbd9f838b7913dd64a93197629";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.1/linux-i686/zh-TW/firefox-112.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/112.0.2/linux-i686/zh-TW/firefox-112.0.2.tar.bz2";
       locale = "zh-TW";
       arch = "linux-i686";
-      sha256 = "85fe472a78190083dae4e3f275636ef1b8f5518f6d3fda04fe352c0cb702c490";
+      sha256 = "a72f3dd7664de9f976e5f3c7fc8ab5d1ae4a3a9fa1e2d548d2059e76d3a8d53d";
     }
     ];
 }

--- a/pkgs/applications/networking/browsers/firefox/packages.nix
+++ b/pkgs/applications/networking/browsers/firefox/packages.nix
@@ -3,10 +3,10 @@
 rec {
   firefox = buildMozillaMach rec {
     pname = "firefox";
-    version = "112.0.1";
+    version = "112.0.2";
     src = fetchurl {
       url = "mirror://mozilla/firefox/releases/${version}/source/firefox-${version}.source.tar.xz";
-      sha512 = "23a5cd9c1f165275d8ca7465bebce86018441c72292421f4ed56d7ad8ada9402dc8d22a08467d9d0ef3ef8c62338006dfa3bcbddf12cb8a59eafa0bd7d0cda50";
+      sha512 = "2cd7adeb6c9a39ad4c5366982e0e58382d7f205e6f2cee02b8ec2867034d1c0c884eeeb870a35db35cba60fa9c84aea73f8c77cfd9f36b5146dde06464aaabd1";
     };
 
     meta = {


### PR DESCRIPTION
https://www.mozilla.org/en-US/firefox/112.0.2/releasenotes/

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
