### PR TITLE
rust-hypervisor-firmware: fix build

### DIFF
--- a/pkgs/applications/virtualization/rust-hypervisor-firmware/default.nix
+++ b/pkgs/applications/virtualization/rust-hypervisor-firmware/default.nix
@@ -41,6 +41,9 @@ rustPlatform.buildRustPackage rec {
 
   cargoSha256 = "sha256-edi6/Md6KebKM3wHArZe1htUCg0/BqMVZKA4xEH25GI=";
 
+  # lld: error: unknown argument '-Wl,--undefined=AUDITABLE_VERSION_INFO'
+  auditable = false;
+
   RUSTC_BOOTSTRAP = 1;
 
   nativeBuildInputs = [

--- a/pkgs/development/compilers/rust/cargo-auditable-cargo-wrapper.nix
+++ b/pkgs/development/compilers/rust/cargo-auditable-cargo-wrapper.nix
@@ -1,6 +1,7 @@
-{ lib, writeShellScriptBin, cargo, cargo-auditable }:
+{ lib, buildPackages, writeScriptBin, cargo, cargo-auditable }:
 
-(writeShellScriptBin "cargo" ''
+(writeScriptBin "cargo" ''
+  #!${buildPackages.runtimeShell} -e
   export PATH="${lib.makeBinPath [ cargo cargo-auditable ]}:$PATH"
   CARGO_AUDITABLE_IGNORE_UNSUPPORTED=1 exec cargo auditable "$@"
 '') // {


### PR DESCRIPTION
###### Description of changes

Fixes the build of rust-hypervisor-firmware. I still had to fix cargo-auditable-cargo-wrapper because that was depending on a bash from the target though it runs on the build platform.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
