### PR TITLE
nixos/qemu-vm: fix diskless VMs

### DIFF
--- a/nixos/modules/virtualisation/qemu-vm.nix
+++ b/nixos/modules/virtualisation/qemu-vm.nix
@@ -264,7 +264,7 @@ let
   suggestedRootDevice = {
     "efi_bootloading_with_default_fs" = "${cfg.bootLoaderDevice}2";
     "legacy_bootloading_with_default_fs" = "${cfg.bootLoaderDevice}1";
-    "direct_boot_with_default_fs" = cfg.bootLoaderDevice;
+    "direct_boot_with_default_fs" = lookupDriveDeviceName "root" cfg.qemu.drives;
     # This will enforce a NixOS module type checking error
     # to ask explicitly the user to set a rootDevice.
     # As it will look like `rootDevice = lib.mkDefault null;` after
@@ -336,14 +336,14 @@ in
 
     virtualisation.bootLoaderDevice =
       mkOption {
-        type = types.path;
-        default = lookupDriveDeviceName "root" cfg.qemu.drives;
-        defaultText = literalExpression ''lookupDriveDeviceName "root" cfg.qemu.drives'';
+        type = types.nullOr types.path;
+        default = if cfg.useBootLoader then lookupDriveDeviceName "root" cfg.qemu.drives else null;
+        defaultText = literalExpression ''if cfg.useBootLoader then lookupDriveDeviceName "root" cfg.qemu.drives else null;'';
         example = "/dev/vda";
         description =
           lib.mdDoc ''
             The disk to be used for the boot filesystem.
-            By default, it is the same disk as the root filesystem.
+            By default, it is the same disk as the root filesystem if you use a bootloader, otherwise it's null.
           '';
         };
 
@@ -836,6 +836,16 @@ in
                 Invalid virtualisation.forwardPorts.<entry ${toString i}>.guest.address:
                   The address must be in the default VLAN (10.0.2.0/24).
               '';
+            }
+          { assertion = cfg.useBootLoader -> cfg.diskImage != null;
+            message =
+              ''
+                Currently, bootloaders cannot be used with a tmpfs disk image.
+                It would require some rework in the boot configuration mechanism
+                to detect the proper boot partition in UEFI scenarios for example.
+
+                If you are interested into this feature, please open an issue or open a pull request.
+              '';
           }
         ]));
 
@@ -863,7 +873,8 @@ in
     # legacy and UEFI. In order to avoid this, we have to put "nodev" to force UEFI-only installs.
     # Otherwise, we set the proper bootloader device for this.
     # FIXME: make a sense of this mess wrt to multiple ESP present in the system, probably use boot.efiSysMountpoint?
-    boot.loader.grub.device = mkVMOverride (if cfg.useEFIBoot then "nodev" else cfg.bootLoaderDevice);
+    boot.loader.grub.enable = cfg.useBootLoader;
+    boot.loader.grub.device = mkIf cfg.useBootLoader (mkVMOverride (if cfg.useEFIBoot then "nodev" else cfg.bootLoaderDevice));
     boot.loader.grub.gfxmodeBios = with cfg.resolution; "${toString x}x${toString y}";
     virtualisation.rootDevice = mkDefault suggestedRootDevice;
 
@@ -871,13 +882,13 @@ in
 
     boot.loader.supportsInitrdSecrets = mkIf (!cfg.useBootLoader) (mkVMOverride false);
 
-    boot.initrd.extraUtilsCommands = lib.mkIf (cfg.useDefaultFilesystems && !config.boot.initrd.systemd.enable)
+    boot.initrd.extraUtilsCommands = lib.mkIf (cfg.useDefaultFilesystems && !config.boot.initrd.systemd.enable && cfg.diskImage != null)
       ''
         # We need mke2fs in the initrd.
         copy_bin_and_libs ${pkgs.e2fsprogs}/bin/mke2fs
       '';
 
-    boot.initrd.postDeviceCommands = lib.mkIf (cfg.useDefaultFilesystems && !config.boot.initrd.systemd.enable)
+    boot.initrd.postDeviceCommands = lib.mkIf (cfg.useDefaultFilesystems && !config.boot.initrd.systemd.enable && cfg.diskImage != null)
       ''
         # If the disk image appears to be empty, run mke2fs to
         # initialise.


### PR DESCRIPTION
###### Description of changes

Previously, it was possible to run with a tmpfs / with `virtualisation.diskImage = null;`, this was likely broken by my changes in 4b4e4c3ef930c6106918d27a933de1b6965eff2c.

It is reintroduced by disabling properly the bootloader for now, as it is complicated to make it work with.


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
