### PR TITLE
pkgs.formats: wrap lib.generators.toINIWithGlobalSection in pkgs.formats.ini

### DIFF
--- a/pkgs/pkgs-lib/formats.nix
+++ b/pkgs/pkgs-lib/formats.nix
@@ -122,9 +122,26 @@ rec {
         else
           singleIniAtom;
 
+      iniSection = attrsOf iniAtom // { description = "section of an INI file (attrset of " + iniAtom.description + ")"; };
+      iniSections = attrsOf iniSection // { description = "sections of an INI file (attrset of " + iniSection.description + ")"; };
+
+      globalIni = { ... }: {
+        options = {
+          sections = lib.mkOption {
+            type = iniSections;
+            default = {};
+            description = iniSections.description;
+          };
+          globalSection = lib.mkOption {
+            type = iniSection;
+            default = {};
+            description = "global section of an INI file (" + iniSection.description + ")";
+          };
+        };
+      };
     in
-      if withGlobalSection then attrsOf (attrsOf (either iniAtom (attrsOf iniAtom)))
-      else attrsOf (attrsOf iniAtom);
+      if withGlobalSection then types.submodule globalIni
+      else iniSections;
 
     generate = name: value:
       let

--- a/pkgs/pkgs-lib/tests/formats.nix
+++ b/pkgs/pkgs-lib/tests/formats.nix
@@ -147,6 +147,78 @@ in runBuildTests {
     '';
   };
 
+  testIniWithGlobalSection = {
+    drv = evalFormat formats.ini { withGlobalSection = true; } {
+      globalSection.xyzzy = true;
+      sections.foo = {
+        bool = true;
+        float = 3.14159;
+      };
+    };
+    expected = ''
+      xyzzy=true
+
+      [foo]
+      bool=true
+      float=3.141590
+    '';
+  };
+
+  testIniWithGlobalSectionListToValue = {
+    drv = evalFormat formats.ini {
+      withGlobalSection = true;
+      listToValue = concatMapStringsSep ", " (generators.mkValueStringDefault {});
+    } {
+      globalSection = {
+        xyzzy = true;
+        bar = [ null true "test" 1.2 10 ];
+      };
+      sections.foo = {
+        bool = true;
+        float = 3.14159;
+        baz = [ 0 0.1 null ];
+      };
+    };
+    expected = ''
+      bar=null, true, test, 1.200000, 10
+      xyzzy=true
+
+      [foo]
+      baz=0, 0.100000, null
+      bool=true
+      float=3.141590
+    '';
+  };
+
+  testIniWithGlobalSectionDuplicateKeys = {
+    drv = evalFormat formats.ini { withGlobalSection = true; listsAsDuplicateKeys = true; } {
+      globalSection = {
+        xyzzy = true;
+        bar = [ null true "test" 1.2 10 ];
+      };
+      sections.foo = {
+        bool = true;
+        float = 3.14159;
+        baz = [ 0 0.1 null ];
+      };
+    };
+    expected = ''
+      bar=null
+      bar=true
+      bar=test
+      bar=1.200000
+      bar=10
+      xyzzy=true
+
+      [foo]
+      baz=0
+      baz=0.100000
+      baz=null
+      bool=true
+      float=3.141590
+    '';
+  };
+
   testKeyValueAtoms = {
     drv = evalFormat formats.keyValue {} {
       bool = true;


### PR DESCRIPTION
###### Description of changes
This is my attempt to wrap `lib.generators.toINIWithGlobalSection` with `pkgs.formats.ini`. I am a relatively new contributor, please give changes a close reading.

```
fmt = pkgs.formats.ini { withGlobalSection = true; }
fmt.generate "foobar.ini" { sections.sec.val = true; globalSection.address = "127.0.0.1"; }
```

produces

```
address=127.0.0.1

[sec]
val=true
```

The `listToValue` functionality is adapted to both `sections` and `globalSection` attributes.

```
fmt = pkgs.formats.ini { listToValue = x: head x; withGlobalSection = true; }
fmt.generate "foobar.ini" { sections.a.b = [ 1 2 ]; globalSection.address = "127.0.0.1"; }
```

produces

```
address=127.0.0.1

[a]
b=1
```

I leave it to the module writer to pump the correct attribute of a `settings` option in the config into `globalSection`.

For example,

```
{ config, lib, pkgs, ... }:

with lib;

let
  cfg = config.services.myservice;
  settingsFormat = pkgs.formats.ini { withGlobalSection = true; };
  myserviceConf = settingsFormat.generate "myservice.conf" {
    globalSection = if hasAttr "global" cfg.settings then cfg.settings.global else { };
    sections = removeAttrs cfg.settings [ "global" ];
  };
in {

  options = {
    services.myservice = {
      enable = mkEnableOption (lib.mdDoc "myservice");
      settings = lib.mkOption {
        type = lib.types.submodule {
          freeformType = settingsFormat.type;
        };
        default = { };
        description = lib.mdDoc ''
          Configuration for myservice
        '';
      };
    };
  };

  config = mkIf cfg.enable { };

}
```

Example config:

```
{
  boot.loader.grub.device = "/dev/sda";
  fileSystems."/".device = "/dev/sda1";
  system.stateVersion = "22.11";
  services.logrotate.checkConfig = false;
  services.myservice = {
    enable = true;
    settings.global.ipv6 = true;
    settings.foobar.enabled = true;
  };
  documentation.enable = false;
}
```

###### Things done
* Built on platform(s)
  
  * [x]  x86_64-linux
  * [ ]  aarch64-linux
  * [ ]  x86_64-darwin
  * [ ]  aarch64-darwin
* [ ]  For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
* [x]  Tested, as applicable:
  
  * [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  * and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  * or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  * made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
* [ ]  Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
* [ ]  Tested basic functionality of all binary files (usually in `./result/bin/`)
* [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  
  * [ ]  (Package updates) Added a release notes entry if the change is major or breaking
  * [ ]  (Module updates) Added a release notes entry if the change is significant
  * [ ]  (Module addition) Added a release notes entry if adding a new NixOS module
  * [ ]  (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
* [ ]  Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
