### PR TITLE
systemd-lock-handler: init at 2.4.1

### DIFF
--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -1120,6 +1120,7 @@
   ./services/system/saslauthd.nix
   ./services/system/self-deploy.nix
   ./services/system/systembus-notify.nix
+  ./services/system/systemd-lock-handler
   ./services/system/uptimed.nix
   ./services/torrent/deluge.nix
   ./services/torrent/flexget.nix

--- a/nixos/modules/services/system/systemd-lock-handler/default.nix
+++ b/nixos/modules/services/system/systemd-lock-handler/default.nix
@@ -1,0 +1,33 @@
+{
+  config,
+  pkgs,
+  lib,
+  ...
+}:
+with lib; let
+  cfg = config.services.systemd-lock-handler;
+in {
+  options.services.systemd-lock-handler = {
+    enable = mkEnableOption (lib.mdDoc "systemd-lock-handler");
+    package = mkOption {
+      default = pkgs.systemd-lock-handler;
+      defaultText = literalExpression "pkgs.systemd-lock-handler";
+      type = types.package;
+      description = lib.mdDoc "systemd-lock-handler package to use.";
+    };
+    config = mkIf cfg.enable {
+      systemd.user.services.systemd-lock-handler = {
+        description = "Logind lock event to systemd target translation";
+        wantedBy = [ "default.target" ];
+        serviceConfig = {
+          Documentation = "https://sr.ht/~whynothugo/systemd-lock-handler";
+          Slice = [ "session.slice" ];
+          ExecStart = "${cfg.package}/bin/systemd-lock-handler";
+          Type = "notify";
+          Restart = "on-failure";
+          RestartSec = "10s";
+        };
+      };
+    };
+  };
+}

--- a/pkgs/os-specific/linux/systemd-lock-handler/default.nix
+++ b/pkgs/os-specific/linux/systemd-lock-handler/default.nix
@@ -1,0 +1,25 @@
+{ lib
+, buildGoModule
+, fetchFromSourcehut
+}:
+
+buildGoModule rec {
+  pname = "systemd-lock-handler";
+  version = "2.4.1";
+
+  src = fetchFromSourcehut {
+    owner = "~whynothugo";
+    repo = "systemd-lock-handler";
+    rev = "v${version}";
+    hash = "sha256-dkOgdDGwinCvv+pO6wqykhG0J/cRtUb7uOSpIFDReoQ=";
+  };
+
+  vendorHash = "sha256-dWzojV3tDA5lLdpAQNC9NaADGyvV7dNOS3x8mfgNNtA=";
+
+  meta = with lib; {
+    description = "A systemd helper to handle lock events in systemd";
+    homepage = "https://git.sr.ht/~whynothugo/systemd-lock-handler";
+    license = licenses.isc;
+    maintainers = with maintainers; [ matthewcroughan ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -27382,6 +27382,8 @@ with pkgs;
 
   systemd-wait = callPackage ../os-specific/linux/systemd-wait { };
 
+  systemd-lock-handler = callPackage ../os-specific/linux/systemd-lock-handler { };
+
   sysvinit = callPackage ../os-specific/linux/sysvinit { };
 
   sysvtools = sysvinit.override {


### PR DESCRIPTION
###### Description of changes

Adds [systemd-lock-handler](https://git.sr.ht/~whynothugo/systemd-lock-handler) to Nixpkgs

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
