### PR TITLE
jami: 20230313.0 -> 20230323.0

### DIFF
--- a/pkgs/applications/networking/instant-messengers/jami/default.nix
+++ b/pkgs/applications/networking/instant-messengers/jami/default.nix
@@ -5,7 +5,7 @@
 , gitUpdater
 , ffmpeg_5
 
-# for daemon
+  # for daemon
 , autoreconfHook
 , perl # for pod2man
 , alsa-lib
@@ -33,7 +33,7 @@
 , webrtc-audio-processing
 , zlib
 
-# for client
+  # for client
 , cmake
 , networkmanager # for libnm
 , python3
@@ -46,16 +46,17 @@
 , qrencode
 , qtmultimedia
 , qtnetworkauth
+, qtpositioning
 , qtsvg
 , qtwebengine
 , qtwebchannel
 , withWebengine ? true
 
-# for pjsip
+  # for pjsip
 , fetchFromGitHub
 , pjsip
 
-# for opendht
+  # for opendht
 , opendht
 }:
 
@@ -64,14 +65,14 @@ let
 in
 stdenv.mkDerivation rec {
   pname = "jami";
-  version = "20230313.0";
+  version = "20230323.0";
 
   src = fetchFromGitLab {
     domain = "git.jami.net";
     owner = "savoirfairelinux";
     repo = "jami-client-qt";
     rev = "stable/${version}";
-    hash = "sha256-3kZ4nn6x1xsXWybyuaY9W07tEM6LFvLL4QtDRPRmob4=";
+    hash = "sha256-X8iIT8UtI2Vq0Ne5e2ahSPN4g7QLZGnq3SZV/NY+1pY=";
     fetchSubmodules = true;
   };
 
@@ -169,6 +170,7 @@ stdenv.mkDerivation rec {
     qtnetworkauth
     qtdeclarative
     qtmultimedia
+    qtpositioning
     qtsvg
     qtwebchannel
   ] ++ lib.optionals withWebengine [


### PR DESCRIPTION
###### Description of changes
qtpositioning is needed when withWebengine is false.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
