### PR TITLE
fontbakery: init at 0.10.40

### DIFF
--- a/pkgs/by-name/op/opentype-sanitizer/package.nix
+++ b/pkgs/by-name/op/opentype-sanitizer/package.nix
@@ -1,0 +1,44 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, freetype
+, gtest
+, lz4
+, meson
+, ninja
+, pkg-config
+, woff2
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "opentype-sanitizer";
+  version = "9.1.0";
+
+  src = fetchFromGitHub {
+    owner = "khaledhosny";
+    repo = "ots";
+    rev = "v${finalAttrs.version}";
+    hash = "sha256-gsNMPNPcfHyOgjJnIrJ5tLYHbCfIfTowEhcaGOUPb2Q=";
+  };
+
+  buildInputs = [
+    freetype
+    gtest
+    lz4
+    woff2
+  ];
+  nativeBuildInputs = [
+    meson
+    ninja
+    pkg-config
+  ];
+
+  doCheck = true;
+
+  meta = with lib; {
+    description = "Sanitizing parser for OpenType fonts";
+    homepage = "https://github.com/khaledhosny/ots";
+    license = licenses.bsd3;
+    maintainers = with maintainers; [ danc86 ];
+  };
+})

--- a/pkgs/development/python-modules/axisregistry/default.nix
+++ b/pkgs/development/python-modules/axisregistry/default.nix
@@ -1,0 +1,46 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, fonttools
+, protobuf
+, pythonRelaxDepsHook
+, pytestCheckHook
+, setuptools-scm
+}:
+
+buildPythonPackage rec {
+  pname = "axisregistry";
+  version = "0.4.5";
+
+  src = fetchPypi {
+    inherit pname version;
+    hash = "sha256-elQUcl6Zh/3xXLduFKbiXZ6uQsDE8C6M3QnTEwaJlaA=";
+  };
+
+  propagatedBuildInputs = [
+    fonttools
+    protobuf
+  ];
+  nativeBuildInputs = [
+    pythonRelaxDepsHook
+    setuptools-scm
+  ];
+
+  doCheck = true;
+  nativeCheckInputs = [
+    pytestCheckHook
+  ];
+
+  # Relax the dependency on protobuf 3. Other packages in the Google Fonts
+  # ecosystem have begun upgrading from protobuf 3 to protobuf 4,
+  # so we need to use protobuf 4 here as well to avoid a conflict
+  # in the closure of fontbakery. It seems to be compatible enough.
+  pythonRelaxDeps = [ "protobuf" ];
+
+  meta = with lib; {
+    description = "Google Fonts registry of OpenType variation axis tags";
+    homepage = "https://github.com/googlefonts/axisregistry";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ danc86 ];
+  };
+}

--- a/pkgs/development/python-modules/babelfont/default.nix
+++ b/pkgs/development/python-modules/babelfont/default.nix
@@ -1,0 +1,55 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, cu2qu
+, defcon
+, fontfeatures
+, fonttools
+, glyphslib
+, openstep-plist
+, orjson
+, poetry-core
+, pytestCheckHook
+, ufoLib2
+}:
+
+buildPythonPackage rec {
+  pname = "babelfont";
+  version = "3.0.1";
+
+  # PyPI source tarballs omit tests, fetch from Github instead
+  src = fetchFromGitHub {
+    owner = "simoncozens";
+    repo = pname;
+    rev = "v${version}";
+    hash = "sha256-1DHcJDVaCgIAODyf5UUrXej8x3ySD4+6/KtxuF2yFV4=";
+  };
+
+  pyproject = true;
+
+  propagatedBuildInputs = [
+    cu2qu
+    fontfeatures
+    fonttools
+    glyphslib
+    openstep-plist
+    orjson
+    ufoLib2
+  ];
+  nativeBuildInputs = [
+    poetry-core
+  ];
+
+  doCheck = true;
+  nativeCheckInputs = [
+    defcon
+    pytestCheckHook
+  ];
+
+  meta = with lib; {
+    description = "Python library to load, examine, and save fonts in a variety of formats";
+    homepage = "https://github.com/simoncozens/babelfont";
+    license = licenses.bsd3;
+    maintainers = with maintainers; [ danc86 ];
+  };
+}

--- a/pkgs/development/python-modules/beziers/default.nix
+++ b/pkgs/development/python-modules/beziers/default.nix
@@ -1,0 +1,40 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, dotmap
+, matplotlib
+, pyclipper
+, unittestCheckHook
+}:
+
+buildPythonPackage rec {
+  pname = "beziers";
+  version = "0.5.0";
+
+  # PyPI doesn't have a proper source tarball, fetch from Github instead
+  src = fetchFromGitHub {
+    owner = "simoncozens";
+    repo = "beziers.py";
+    rev = "v${version}";
+    hash = "sha256-4014u7s47Tfdpa2Q9hKAoHg7Ebcs1/DVW5TpEmoh2bc=";
+  };
+
+  propagatedBuildInputs = [
+    pyclipper
+  ];
+
+  doCheck = true;
+  nativeCheckInputs = [
+    dotmap
+    matplotlib
+    unittestCheckHook
+  ];
+  unittestFlagsArray = [ "-s" "test" "-v" ];
+
+  meta = with lib; {
+    description = "Python library for manipulating Bezier curves and paths in fonts";
+    homepage = "https://github.com/simoncozens/beziers.py";
+    license = licenses.mit;
+    maintainers = with maintainers; [ danc86 ];
+  };
+}

--- a/pkgs/development/python-modules/collidoscope/default.nix
+++ b/pkgs/development/python-modules/collidoscope/default.nix
@@ -1,0 +1,43 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, babelfont
+, kurbopy
+, fonttools
+, skia-pathops
+, tqdm
+, uharfbuzz
+, unittestCheckHook
+}:
+
+buildPythonPackage rec {
+  pname = "collidoscope";
+  version = "0.6.5";
+
+  src = fetchPypi {
+    inherit pname version;
+    hash = "sha256-D7MzJ8FZjA/NSXCqCJQ9a02FPPi3t4W0q65wRIDcfSA=";
+  };
+
+  propagatedBuildInputs = [
+    babelfont
+    kurbopy
+    fonttools
+    skia-pathops
+    tqdm
+    uharfbuzz
+  ];
+
+  doCheck = true;
+  nativeCheckInputs = [
+    unittestCheckHook
+  ];
+  unittestFlagsArray = [ "-s" "test" "-v" ];
+
+  meta = with lib; {
+    description = "Python library to detect glyph collisions in fonts";
+    homepage = "https://github.com/googlefonts/collidoscope";
+    license = licenses.mit;
+    maintainers = with maintainers; [ danc86 ];
+  };
+}

--- a/pkgs/development/python-modules/commandlines/default.nix
+++ b/pkgs/development/python-modules/commandlines/default.nix
@@ -1,0 +1,31 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, pytestCheckHook
+}:
+
+buildPythonPackage rec {
+  pname = "commandlines";
+  version = "0.4.1";
+
+  # PyPI source tarballs omit tests, fetch from Github instead
+  src = fetchFromGitHub {
+    owner = "chrissimpkins";
+    repo = "commandlines";
+    rev = "v${version}";
+    hash = "sha256-x3iUeOTAaTKNW5Y5foMPMJcWVxu52uYZoY3Hhe3UvQ4=";
+  };
+
+  doCheck = true;
+  nativeCheckInputs = [
+    pytestCheckHook
+  ];
+
+  meta = with lib; {
+    description = "Python library for command line argument parsing";
+    homepage = "https://github.com/chrissimpkins/commandlines";
+    license = licenses.mit;
+    maintainers = with maintainers; [ danc86 ];
+  };
+}
+

--- a/pkgs/development/python-modules/dehinter/default.nix
+++ b/pkgs/development/python-modules/dehinter/default.nix
@@ -1,0 +1,36 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, fonttools
+, pytestCheckHook
+}:
+
+buildPythonPackage rec {
+  pname = "dehinter";
+  version = "4.0.0";
+
+  # PyPI source tarballs omit tests, fetch from Github instead
+  src = fetchFromGitHub {
+    owner = "source-foundry";
+    repo = "dehinter";
+    rev = "v${version}";
+    hash = "sha256-l988SW6OWKXzJK0WGAJZR/QDFvgnSir+5TwMMvFcOxg=";
+  };
+
+  propagatedBuildInputs = [
+    fonttools
+  ];
+
+  doCheck = true;
+  nativeCheckInputs = [
+    pytestCheckHook
+  ];
+
+  meta = with lib; {
+    description = "Utility for removing hinting data from TrueType and OpenType fonts";
+    homepage = "https://github.com/source-foundry/dehinter";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ danc86 ];
+  };
+}
+

--- a/pkgs/development/python-modules/font-v/default.nix
+++ b/pkgs/development/python-modules/font-v/default.nix
@@ -1,0 +1,53 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, fonttools
+, git
+, gitpython
+, pytestCheckHook
+}:
+
+buildPythonPackage rec {
+  pname = "font-v";
+  version = "2.1.0";
+
+  # PyPI source tarballs omit tests, fetch from Github instead
+  src = fetchFromGitHub {
+    owner = "source-foundry";
+    repo = "font-v";
+    rev = "v${version}";
+    hash = "sha256-ceASyYcNul5aWPAPGajCQrqsQ3bN1sE+nMbCbj7f35w=";
+  };
+
+  propagatedBuildInputs = [
+    fonttools
+    gitpython
+  ];
+
+  doCheck = true;
+  nativeCheckInputs = [
+    git
+    pytestCheckHook
+  ];
+  preCheck = ''
+    # Many tests assume they are running from a git checkout, although they
+    # don't care which one. Create a dummy git repo to satisfy the tests:
+    git init -b main
+    git config user.email test@example.invalid
+    git config user.name Test
+    git commit --allow-empty --message 'Dummy commit for tests'
+  '';
+  disabledTests = [
+    # These tests assume they are actually running from a font-v git checkout,
+    # so just skip them:
+    "test_utilities_get_gitrootpath_function"
+  ];
+
+  meta = with lib; {
+    description = "Python utility for manipulating font version headers";
+    homepage = "https://github.com/source-foundry/font-v";
+    license = licenses.mit;
+    maintainers = with maintainers; [ danc86 ];
+  };
+}
+

--- a/pkgs/development/python-modules/fontbakery/default.nix
+++ b/pkgs/development/python-modules/fontbakery/default.nix
@@ -1,0 +1,146 @@
+{ lib
+, buildPythonPackage
+, callPackage
+, fetchpatch
+, fetchPypi
+, axisregistry
+, babelfont
+, beautifulsoup4
+, beziers
+, cmarkgfm
+, collidoscope
+, defcon
+, dehinter
+, fonttools
+, font-v
+, freetype-py
+, gflanguages
+, git
+, glyphsets
+, lxml
+, installShellFiles
+, munkres
+, opentypespec
+, ots-python
+, packaging
+, pip-api
+, protobuf
+, pytestCheckHook
+, pytest-xdist
+, pythonRelaxDepsHook
+, pyyaml
+, requests
+, requests-mock
+, rich
+, setuptools-scm
+, shaperglot
+, stringbrewer
+, toml
+, unicodedata2
+, ufo2ft
+, ufolint
+, vharfbuzz
+}:
+
+buildPythonPackage rec {
+  pname = "fontbakery";
+  version = "0.10.4";
+
+  src = fetchPypi {
+    inherit pname version;
+    hash = "sha256-Ye/TMGvURxSU2yoohwYbSo5RvrmbHKdMnFNj2lUvtMk=";
+  };
+
+  patches = [
+    # Mock HTTP requests in tests (note we still have to skip some below)
+    # https://github.com/googlefonts/fontbakery/pull/4124
+    (fetchpatch {
+      url = "https://github.com/fonttools/fontbakery/pull/4124.patch";
+      hash = "sha256-NXuC2+TtxpHYMdd0t+cF0FJ3lrh4exP5yxspEasKKd0=";
+    })
+  ];
+
+  propagatedBuildInputs = [
+    axisregistry
+    babelfont
+    beautifulsoup4
+    beziers
+    cmarkgfm
+    collidoscope
+    defcon
+    dehinter
+    fonttools
+    font-v
+    freetype-py
+    gflanguages
+    glyphsets
+    lxml
+    munkres
+    ots-python
+    opentypespec
+    packaging
+    pip-api
+    protobuf
+    pyyaml
+    requests
+    rich
+    shaperglot
+    stringbrewer
+    toml
+    ufolint
+    unicodedata2
+    vharfbuzz
+    ufo2ft
+  ];
+  nativeBuildInputs = [
+    installShellFiles
+    pythonRelaxDepsHook
+    setuptools-scm
+  ];
+
+  pythonRelaxDeps = [
+    "collidoscope"
+    "protobuf"
+    "vharfbuzz"
+  ];
+
+  doCheck = true;
+  nativeCheckInputs = [
+    git
+    pytestCheckHook
+    pytest-xdist
+    requests-mock
+    ufolint
+  ];
+  preCheck = ''
+    # Let the tests invoke 'fontbakery' command.
+    export PATH="$out/bin:$PATH"
+    # font-v tests assume they are running from a git checkout, although they
+    # don't care which one. Create a dummy git repo to satisfy the tests:
+    git init -b main
+    git config user.email test@example.invalid
+    git config user.name Test
+    git commit --allow-empty --message 'Dummy commit for tests'
+  '';
+  disabledTests = [
+    # These require network access:
+    "test_check_vertical_metrics_regressions"
+    "test_check_cjk_vertical_metrics_regressions"
+    "test_check_fontbakery_version_live_apis"
+  ];
+
+  postInstall = ''
+    installShellCompletion --bash --name fontbakery \
+      snippets/fontbakery.bash-completion
+  '';
+
+  passthru.tests.simple = callPackage ./tests.nix { };
+
+  meta = with lib; {
+    description = "Tool for checking the quality of font projects";
+    homepage = "https://github.com/googlefonts/fontbakery";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ danc86 ];
+  };
+}
+

--- a/pkgs/development/python-modules/fontbakery/tests.nix
+++ b/pkgs/development/python-modules/fontbakery/tests.nix
@@ -1,0 +1,22 @@
+{ runCommand
+, fontbakery
+}:
+
+let
+  inherit (fontbakery) pname version src;
+in
+
+runCommand "${pname}-tests" { meta.timeout = 5; } ''
+  # Check the version matches what we packaged.
+  ${fontbakery}/bin/fontbakery --version | grep -q "${version}"
+
+  # Can it list its own subcommands?
+  ${fontbakery}/bin/fontbakery --list-subcommands >>$out
+
+  # Unpack src to get some test fonts.
+  tar -xzf ${src} --strip-components=1 ${pname}-${version}/data/test
+
+  # Run some font checks.
+  ${fontbakery}/bin/fontbakery check-ufo-sources --no-progress --no-colors data/test/test.ufo >>$out
+  # TODO add more
+''

--- a/pkgs/development/python-modules/fontfeatures/default.nix
+++ b/pkgs/development/python-modules/fontfeatures/default.nix
@@ -1,0 +1,50 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, fetchpatch
+, beziers
+, fonttools
+, fs
+, glyphtools
+, lxml
+, pytestCheckHook
+, youseedee
+}:
+
+buildPythonPackage rec {
+  pname = "fontfeatures";
+  version = "1.8.0";
+
+  src = fetchPypi {
+    pname = "fontFeatures";
+    inherit version;
+    hash = "sha256-XLJD91IyUUjeSqdhWFfIqv9yISPcbU4bgRvXETSHOiY=";
+  };
+
+  propagatedBuildInputs = [
+    beziers
+    fonttools
+    fs
+    glyphtools
+    lxml
+    youseedee
+  ];
+
+  doCheck = true;
+  nativeCheckInputs = [
+    pytestCheckHook
+  ];
+  disabledTestPaths = [
+    # These tests require babelfont but we have to leave it out and skip them
+    # to break the cyclic dependency with babelfont.
+    "tests/test_shaping_generic.py"
+    "tests/test_shaping_harfbuzz.py"
+  ];
+
+  meta = with lib; {
+    description = "Python library for compiling OpenType font features";
+    homepage = "https://github.com/simoncozens/fontFeatures";
+    license = licenses.bsd3;
+    maintainers = with maintainers; [ danc86 ];
+  };
+}

--- a/pkgs/development/python-modules/gflanguages/default.nix
+++ b/pkgs/development/python-modules/gflanguages/default.nix
@@ -1,0 +1,48 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, protobuf
+, setuptools-scm
+, pythonRelaxDepsHook
+, pytestCheckHook
+, uharfbuzz
+, youseedee
+}:
+
+buildPythonPackage rec {
+  pname = "gflanguages";
+  version = "0.5.10";
+
+  src = fetchPypi {
+    inherit pname version;
+    hash = "sha256-JVeI7TlJjbKCa+gGmjylbNiEhX3qmpbLXiH3VpFqgXc=";
+  };
+
+  propagatedBuildInputs = [
+    protobuf
+  ];
+  nativeBuildInputs = [
+    setuptools-scm
+  ];
+
+  doCheck = true;
+  nativeCheckInputs = [
+    pythonRelaxDepsHook
+    pytestCheckHook
+    uharfbuzz
+    youseedee
+  ];
+
+  # Relax the dependency on protobuf 3. Other packages in the Google Fonts
+  # ecosystem have begun upgrading from protobuf 3 to protobuf 4,
+  # so we need to use protobuf 4 here as well to avoid a conflict
+  # in the closure of fontbakery. It seems to be compatible enough.
+  pythonRelaxDeps = [ "protobuf" ];
+
+  meta = with lib; {
+    description = "Python library for Google Fonts language metadata";
+    homepage = "https://github.com/googlefonts/lang";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ danc86 ];
+  };
+}

--- a/pkgs/development/python-modules/glyphsets/0001-relax-setuptools-scm-dep.patch
+++ b/pkgs/development/python-modules/glyphsets/0001-relax-setuptools-scm-dep.patch
@@ -1,0 +1,22 @@
+From de2e02a41b11a708d58dfd1e24d335b8882dd7bd Mon Sep 17 00:00:00 2001
+From: Dan Callaghan <djc@djc.id.au>
+Date: Sun, 23 Apr 2023 12:15:47 +1000
+Subject: [PATCH] relax setuptools-scm dep
+
+
+diff --git a/setup.py b/setup.py
+index 2c122a7..42f9b61 100644
+--- a/setup.py
++++ b/setup.py
+@@ -55,7 +55,7 @@
+         'Programming Language :: Python :: 3'
+     ],
+     python_requires=">=3.7",
+-    setup_requires=['setuptools_scm>=4,<6.1'],
++    setup_requires=['setuptools_scm'],
+     install_requires=[
+         'setuptools',
+         'FontTools[ufo]',
+-- 
+2.38.4
+

--- a/pkgs/development/python-modules/glyphsets/default.nix
+++ b/pkgs/development/python-modules/glyphsets/default.nix
@@ -1,0 +1,55 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, defcon
+, fonttools
+, glyphslib
+, pytestCheckHook
+, setuptools
+, setuptools-scm
+, unicodedata2
+}:
+
+buildPythonPackage rec {
+  pname = "glyphsets";
+  version = "0.6.5";
+
+  src = fetchPypi {
+    inherit pname version;
+    hash = "sha256-Zp4VLJ9h6lkz7KOM7LWKAj7UX1KziLobzeT9Dosv5UU=";
+  };
+
+  patches = [
+    # Upstream has a needlessly strict version range for setuptools_scm, our
+    # setuptools-scm is newer. We can't use pythonRelaxDepsHook for this
+    # because it's in setup_requires which means we'll fail the requirement
+    # before pythonRelaxDepsHook can run.
+    ./0001-relax-setuptools-scm-dep.patch
+  ];
+
+  propagatedBuildInputs = [
+    defcon
+    fonttools
+    glyphslib
+    setuptools
+    unicodedata2
+  ];
+  nativeBuildInputs = [
+    setuptools-scm
+  ];
+
+  doCheck = true;
+  nativeCheckInputs = [
+    pytestCheckHook
+  ];
+  preCheck = ''
+    export PATH="$out/bin:$PATH"
+  '';
+
+  meta = with lib; {
+    description = "Google Fonts glyph set metadata";
+    homepage = "https://github.com/googlefonts/glyphsets";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ danc86 ];
+  };
+}

--- a/pkgs/development/python-modules/glyphtools/default.nix
+++ b/pkgs/development/python-modules/glyphtools/default.nix
@@ -1,0 +1,39 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, beziers
+, glyphslib
+, numpy
+, setuptoolsCheckHook
+}:
+
+buildPythonPackage rec {
+  pname = "glyphtools";
+  version = "0.8.0";
+
+  src = fetchPypi {
+    inherit pname version;
+    hash = "sha256-PXwXHWMJbsi6ZtN+daaXAnlw3gV5DFAhyRxdBa7UP+M=";
+  };
+
+  propagatedBuildInputs = [
+    beziers
+    glyphslib
+    numpy
+  ];
+
+  # A unit test suite does exist, but it only contains a dummy test that
+  # doesn't test anything. It does import the module though so we still run it.
+  doCheck = true;
+  nativeCheckInputs = [
+    # Upstream apparently prefers the deprecated setuptools 'test' command.
+    setuptoolsCheckHook
+  ];
+
+  meta = with lib; {
+    description = "Python library for extracting information from font glyphs";
+    homepage = "https://github.com/simoncozens/glyphtools";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ danc86 ];
+  };
+}

--- a/pkgs/development/python-modules/kurbopy/default.nix
+++ b/pkgs/development/python-modules/kurbopy/default.nix
@@ -1,0 +1,53 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, fonttools
+, pytestCheckHook
+, python
+, rustPlatform
+, unzip
+}:
+
+buildPythonPackage rec {
+  pname = "kurbopy";
+  version = "0.10.40";
+
+  src = fetchPypi {
+    inherit pname version;
+    hash = "sha256-dhpcDi20Na6SDbRxrC8N3SWdN1J/CWJgCUI3scJX/6s=";
+  };
+
+  propagatedBuildInputs = [
+    fonttools
+  ];
+  nativeBuildInputs = [
+    rustPlatform.cargoSetupHook
+    rustPlatform.maturinBuildHook
+  ];
+
+  cargoDeps = rustPlatform.fetchCargoTarball {
+    inherit src;
+    name = "${pname}-${version}";
+    hash = "sha256-V3LeT0dqkfft1ftc+azwvuSzzdUJ7/wAp31fN7te9RQ=";
+  };
+
+  doCheck = true;
+  nativeCheckInputs = [
+    pytestCheckHook
+  ];
+  preCheck = ''
+    # pytestCheckHook puts . at the front of Python's sys.path, due to:
+    # https://github.com/NixOS/nixpkgs/issues/255262
+    # So we need to prevent pytest from trying to import kurbopy from
+    # ./kurbopy, which contains the sources but not the newly built module.
+    # We want it to import kurbopy from the nix store via $PYTHONPATH instead.
+    rm -r kurbopy
+  '';
+
+  meta = with lib; {
+    description = "Python wrapper around the Rust kurbo library for 2D curve manipulation";
+    homepage = "https://github.com/simoncozens/kurbopy";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ danc86 ];
+  };
+}

--- a/pkgs/development/python-modules/opentypespec/default.nix
+++ b/pkgs/development/python-modules/opentypespec/default.nix
@@ -1,0 +1,29 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, unittestCheckHook
+}:
+
+buildPythonPackage rec {
+  pname = "opentypespec";
+  version = "1.9.1";
+
+  src = fetchPypi {
+    inherit pname version;
+    hash = "sha256-fOEHmtlCkFhn1jyIA+CsHIfud7x3PPb7UWQsnrVyDqY=";
+  };
+
+  doCheck = true;
+  nativeCheckInputs = [
+    unittestCheckHook
+  ];
+  unittestFlagsArray = [ "-s" "test" "-v" ];
+
+  meta = with lib; {
+    description = "Python library for OpenType specification metadata";
+    homepage = "https://github.com/simoncozens/opentypespec-py";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ danc86 ];
+  };
+}
+

--- a/pkgs/development/python-modules/ots-python/0001-use-packaged-ots.patch
+++ b/pkgs/development/python-modules/ots-python/0001-use-packaged-ots.patch
@@ -1,0 +1,34 @@
+From 6ba3b97253cf540fdf4b36672f290def72386096 Mon Sep 17 00:00:00 2001
+From: Dan Callaghan <djc@djc.id.au>
+Date: Sun, 23 Apr 2023 21:26:53 +1000
+Subject: [PATCH] use packaged ots
+
+
+diff --git a/setup.py b/setup.py
+index 6c3ccae..ca021da 100755
+--- a/setup.py
++++ b/setup.py
+@@ -248,7 +248,6 @@ def run(self):
+     platforms=["posix", "nt"],
+     package_dir={"": "src/python"},
+     packages=find_packages("src/python"),
+-    ext_modules=[ots_sanitize],
+     zip_safe=False,
+     cmdclass=cmdclass,
+     setup_requires=["setuptools_scm"],
+diff --git a/src/python/ots/__init__.py b/src/python/ots/__init__.py
+index 5fc1724..db9d21e 100644
+--- a/src/python/ots/__init__.py
++++ b/src/python/ots/__init__.py
+@@ -3,7 +3,7 @@
+ import sys
+ import os
+ 
+-OTS_SANITIZE = os.path.join(os.path.dirname(__file__), "ots-sanitize")
++OTS_SANITIZE = "@ots_sanitize@"
+ 
+ __all__ = ["sanitize", "OTSError", "CalledProcessError"]
+ 
+-- 
+2.38.4
+

--- a/pkgs/development/python-modules/ots-python/default.nix
+++ b/pkgs/development/python-modules/ots-python/default.nix
@@ -1,0 +1,48 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, substituteAll
+, opentype-sanitizer
+, setuptools-scm
+, pytestCheckHook
+}:
+
+buildPythonPackage rec {
+  pname = "ots-python";
+  version = "9.1.0";
+
+  src = fetchPypi {
+    pname = "opentype-sanitizer";
+    inherit version;
+    hash = "sha256-1Zdd+eRECimZl8L8CCkm7pCjN0TafSsc5i2Y6/oH88I=";
+  };
+
+  patches = [
+    # Invoke ots-sanitize from the opentype-sanitizer package instead of
+    # downloading precompiled binaries from the internet.
+    # (nixpkgs-specific, not upstreamable)
+    (substituteAll {
+      src = ./0001-use-packaged-ots.patch;
+      ots_sanitize = "${opentype-sanitizer}/bin/ots-sanitize";
+    })
+  ];
+
+  propagatedBuildInputs = [
+    opentype-sanitizer
+  ];
+  nativeBuildInputs = [
+    setuptools-scm
+  ];
+
+  doCheck = true;
+  nativeCheckInputs = [
+    pytestCheckHook
+  ];
+
+  meta = with lib; {
+    description = "Python wrapper for ots (OpenType Sanitizer)";
+    homepage = "https://github.com/googlefonts/ots-python";
+    license = licenses.bsd3;
+    maintainers = with maintainers; [ danc86 ];
+  };
+}

--- a/pkgs/development/python-modules/rstr/default.nix
+++ b/pkgs/development/python-modules/rstr/default.nix
@@ -1,0 +1,37 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, setuptools
+, setuptools-scm
+, unittestCheckHook
+}:
+
+buildPythonPackage rec {
+  pname = "rstr";
+  version = "3.2.2";
+
+  src = fetchPypi {
+    inherit pname version;
+    hash = "sha256-xKVk1N+0Ry2THRRcQ9HPGteMJFkhQud1W4hmF57qwBI=";
+  };
+
+  pyproject = true;
+
+  nativeBuildInputs = [
+    setuptools
+    setuptools-scm
+  ];
+
+  doCheck = true;
+  nativeCheckInputs = [
+    unittestCheckHook
+  ];
+
+  meta = with lib; {
+    description = "Python library to generate random strings";
+    homepage = "https://github.com/leapfrogonline/rstr";
+    license = licenses.bsd3;
+    maintainers = with maintainers; [ danc86 ];
+  };
+}
+

--- a/pkgs/development/python-modules/shaperglot/default.nix
+++ b/pkgs/development/python-modules/shaperglot/default.nix
@@ -1,0 +1,55 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, gflanguages
+, num2words
+, poetry-core
+, protobuf
+, pytestCheckHook
+, strictyaml
+, termcolor
+, ufo2ft
+, vharfbuzz
+, youseedee
+}:
+
+buildPythonPackage rec {
+  pname = "shaperglot";
+  version = "0.3.1";
+
+  # PyPI source tarballs omit tests, fetch from Github instead
+  src = fetchFromGitHub {
+    owner = "googlefonts";
+    repo = "shaperglot";
+    rev = "v${version}";
+    hash = "sha256-29MzD42rgh+7n/0kjqKGDxXPnUEvj/xxEIKWZg03pxw=";
+  };
+
+  pyproject = true;
+
+  propagatedBuildInputs = [
+    gflanguages
+    num2words
+    protobuf
+    strictyaml
+    termcolor
+    ufo2ft
+    vharfbuzz
+    youseedee
+  ];
+  nativeBuildInputs = [
+    poetry-core
+  ];
+
+  doCheck = true;
+  nativeCheckInputs = [
+    pytestCheckHook
+  ];
+
+  meta = with lib; {
+    description = "Tool to test OpenType fonts for language support";
+    homepage = "https://github.com/googlefonts/shaperglot";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ danc86 ];
+  };
+}

--- a/pkgs/development/python-modules/sre-yield/default.nix
+++ b/pkgs/development/python-modules/sre-yield/default.nix
@@ -1,0 +1,34 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, setuptools
+, unittestCheckHook
+}:
+
+buildPythonPackage rec {
+  pname = "sre-yield";
+  version = "1.2";
+
+  src = fetchPypi {
+    pname = "sre_yield";
+    inherit version;
+    hash = "sha256-6U8aKjy6//4dzRXB1U5AGhUX4FKqZMfTFk+I3HYde4o=";
+  };
+
+  nativeBuildInputs = [
+    setuptools
+  ];
+
+  doCheck = true;
+  nativeCheckInputs = [
+    unittestCheckHook
+  ];
+
+  meta = with lib; {
+    description = "Python library to efficiently generate all values that can match a given regular expression";
+    homepage = "https://github.com/sre-yield/sre-yield";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ danc86 ];
+  };
+}
+

--- a/pkgs/development/python-modules/stringbrewer/default.nix
+++ b/pkgs/development/python-modules/stringbrewer/default.nix
@@ -1,0 +1,37 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, rstr
+, sre-yield
+, pythonImportsCheckHook
+}:
+
+buildPythonPackage rec {
+  pname = "stringbrewer";
+  version = "0.0.1";
+
+  src = fetchPypi {
+    inherit pname version;
+    hash = "sha256-wtETgi+Tk1ALJzzIM6Ic5zkDbALGL0cELg8X75uepkk=";
+  };
+
+  propagatedBuildInputs = [
+    rstr
+    sre-yield
+  ];
+  nativeBuildInputs = [
+    pythonImportsCheckHook
+  ];
+
+  # Package has no tests
+  doCheck = false;
+  pythonImportsCheck = [ "stringbrewer" ];
+
+  meta = with lib; {
+    description = "Python library to generate random strings matching a pattern";
+    homepage = "https://github.com/simoncozens/stringbrewer";
+    license = licenses.mit;
+    maintainers = with maintainers; [ danc86 ];
+  };
+}
+

--- a/pkgs/development/python-modules/ufolint/default.nix
+++ b/pkgs/development/python-modules/ufolint/default.nix
@@ -1,0 +1,40 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, commandlines
+, fonttools
+, fs
+, pytestCheckHook
+}:
+
+buildPythonPackage rec {
+  pname = "ufolint";
+  version = "1.2.0";
+
+  # PyPI source tarballs omit tests, fetch from Github instead
+  src = fetchFromGitHub {
+    owner = "source-foundry";
+    repo = "ufolint";
+    rev = "v${version}";
+    hash = "sha256-sv8WbnDd2LFHkwNsB9FO04OlLhemdzwjq0tC9+Fd6/M=";
+  };
+
+  propagatedBuildInputs = [
+    commandlines
+    fs
+    fonttools
+  ];
+
+  doCheck = true;
+  nativeBuildInputs = [
+    pytestCheckHook
+  ];
+
+  meta = with lib; {
+    description = "Linter for Unified Font Object (UFO) source code";
+    homepage = "https://github.com/source-foundry/ufolint";
+    license = licenses.mit;
+    maintainers = with maintainers; [ danc86 ];
+  };
+}
+

--- a/pkgs/development/python-modules/vharfbuzz/default.nix
+++ b/pkgs/development/python-modules/vharfbuzz/default.nix
@@ -1,0 +1,37 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, fonttools
+, pythonImportsCheckHook
+, uharfbuzz
+}:
+
+buildPythonPackage rec {
+  pname = "vharfbuzz";
+  version = "0.2.0";
+
+  src = fetchPypi {
+    inherit pname version;
+    hash = "sha256-uDX2fYqxV4wmAAIMfA3dBohWmq1N0VurSTEFOjSRpmY=";
+  };
+
+  propagatedBuildInputs = [
+    fonttools
+    uharfbuzz
+  ];
+  nativeBuildInputs = [
+    pythonImportsCheckHook
+  ];
+
+  # Package has no tests.
+  doCheck = false;
+  pythonImportsCheck = [ "vharfbuzz" ];
+
+  meta = with lib; {
+    description = "Utility for removing hinting data from TrueType and OpenType fonts";
+    homepage = "https://github.com/source-foundry/dehinter";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ danc86 ];
+  };
+}
+

--- a/pkgs/development/python-modules/youseedee/0001-use-packaged-unicode-data.patch
+++ b/pkgs/development/python-modules/youseedee/0001-use-packaged-unicode-data.patch
@@ -1,0 +1,25 @@
+From 9013d36cfe7b2958eb18ce373f49193b66a0bbf6 Mon Sep 17 00:00:00 2001
+From: Dan Callaghan <djc@djc.id.au>
+Date: Sun, 23 Apr 2023 16:14:55 +1000
+Subject: [PATCH] use packaged unicode data
+
+
+diff --git a/lib/youseedee/__init__.py b/lib/youseedee/__init__.py
+index 4424ef1..9a72f52 100644
+--- a/lib/youseedee/__init__.py
++++ b/lib/youseedee/__init__.py
+@@ -11,10 +11,7 @@
+ UCD_URL = "https://unicode.org/Public/UCD/latest/ucd/UCD.zip"
+ 
+ def ucd_dir():
+-  ucddir = os.path.expanduser("~/.youseedee")
+-  if not os.path.isdir(ucddir):
+-    os.mkdir(ucddir)
+-  return ucddir
++  return "@ucd_dir@"
+ 
+ def ensure_files():
+   if os.path.isfile(os.path.join(ucd_dir(), "UnicodeData.txt")):
+-- 
+2.38.4
+

--- a/pkgs/development/python-modules/youseedee/default.nix
+++ b/pkgs/development/python-modules/youseedee/default.nix
@@ -1,0 +1,45 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, substituteAll
+, requests
+, unicode-character-database
+}:
+
+buildPythonPackage rec {
+  pname = "youseedee";
+  version = "0.4.1";
+
+  src = fetchPypi {
+    inherit pname version;
+    hash = "sha256-fdI4CBUSMbdKW0qg4y22wjWI6bhotgDkQdFMc9X00as=";
+  };
+
+  patches = [
+    # Load data files from the unicode-character-database package instead of
+    # downloading them from the internet. (nixpkgs-specific, not upstreamable)
+    (substituteAll {
+      src = ./0001-use-packaged-unicode-data.patch;
+      ucd_dir = "${unicode-character-database}/share/unicode";
+    })
+  ];
+
+  propagatedBuildInputs = [
+    requests
+  ];
+
+  doCheck = true;
+  # Package has no unit tests, but we can check an example as per README.rst:
+  checkPhase = ''
+    runHook preCheck
+    python -m youseedee 0x078A | grep -q "'Block': 'Thaana'"
+    runHook postCheck
+  '';
+
+  meta = with lib; {
+    description = "Python library for querying the Unicode Character Database";
+    homepage = "https://github.com/simoncozens/youseedee";
+    license = licenses.mit;
+    maintainers = with maintainers; [ danc86 ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2094,6 +2094,8 @@ with pkgs;
 
   ttchat = callPackage ../tools/misc/ttchat { };
 
+  ufolint = with python3Packages; toPythonApplication ufolint;
+
   ukmm = callPackage ../tools/games/ukmm { };
 
   unflac = callPackage ../tools/audio/unflac { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1766,6 +1766,8 @@ with pkgs;
 
   davinci-resolve-studio = callPackage ../applications/video/davinci-resolve { studioVariant = true; };
 
+  dehinter = with python3Packages; toPythonApplication dehinter;
+
   dolbybcsoftwaredecode = callPackage ../applications/audio/dolbybcsoftwaredecode { };
 
   donkey = callPackage ../tools/security/donkey { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2028,6 +2028,8 @@ with pkgs;
 
   sgrep = callPackage ../tools/text/sgrep { };
 
+  shaperglot = with python3Packages; toPythonApplication shaperglot;
+
   shell-genie = callPackage  ../applications/misc/shell-genie { };
 
   sloth = callPackage ../tools/misc/sloth { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1806,6 +1806,8 @@ with pkgs;
 
   ethq = callPackage ../os-specific/linux/ethq { };
 
+  font-v = with python3Packages; toPythonApplication font-v;
+
   weidu = callPackage ../tools/games/weidu { };
 
   weylus = callPackage ../applications/graphics/weylus  {

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1810,6 +1810,8 @@ with pkgs;
 
   font-v = with python3Packages; toPythonApplication font-v;
 
+  fontbakery = with python3Packages; toPythonApplication fontbakery;
+
   weidu = callPackage ../tools/games/weidu { };
 
   weylus = callPackage ../applications/graphics/weylus  {

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2252,6 +2252,8 @@ self: super: with self; {
 
   comm = callPackage ../development/python-modules/comm { };
 
+  commandlines = callPackage ../development/python-modules/commandlines { };
+
   commandparse = callPackage ../development/python-modules/commandparse { };
 
   commentjson = callPackage ../development/python-modules/commentjson { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -12553,6 +12553,8 @@ self: super: with self; {
 
   rstcheck-core = callPackage ../development/python-modules/rstcheck-core { };
 
+  rstr = callPackage ../development/python-modules/rstr { };
+
   rtmidi-python = callPackage ../development/python-modules/rtmidi-python {
     inherit (pkgs.darwin.apple_sdk.frameworks) CoreAudio CoreMIDI CoreServices;
   };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -4204,6 +4204,8 @@ self: super: with self; {
 
   glyphslib = callPackage ../development/python-modules/glyphslib { };
 
+  glyphtools = callPackage ../development/python-modules/glyphtools { };
+
   foobot-async = callPackage ../development/python-modules/foobot-async { };
 
   foolscap = callPackage ../development/python-modules/foolscap { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2216,6 +2216,8 @@ self: super: with self; {
 
   collections-extended = callPackage ../development/python-modules/collections-extended { };
 
+  collidoscope = callPackage ../development/python-modules/collidoscope { };
+
   colorama = callPackage ../development/python-modules/colorama { };
 
   colorcet = callPackage ../development/python-modules/colorcet { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2736,6 +2736,8 @@ self: super: with self; {
 
   defusedxml = callPackage ../development/python-modules/defusedxml { };
 
+  dehinter = callPackage ../development/python-modules/dehinter { };
+
   deid = callPackage ../development/python-modules/deid { };
 
   delegator-py = callPackage ../development/python-modules/delegator-py { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -4198,6 +4198,8 @@ self: super: with self; {
 
   openstep-plist = callPackage ../development/python-modules/openstep-plist { };
 
+  glyphsets = callPackage ../development/python-modules/glyphsets { };
+
   glyphslib = callPackage ../development/python-modules/glyphslib { };
 
   foobot-async = callPackage ../development/python-modules/foobot-async { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -13499,6 +13499,8 @@ self: super: with self; {
 
   squarify = callPackage ../development/python-modules/squarify { };
 
+  sre-yield = callPackage ../development/python-modules/sre-yield { };
+
   srp = callPackage ../development/python-modules/srp { };
 
   srpenergy = callPackage ../development/python-modules/srpenergy { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -12919,6 +12919,8 @@ self: super: with self; {
 
   shapely = callPackage ../development/python-modules/shapely { };
 
+  shaperglot = callPackage ../development/python-modules/shaperglot { };
+
   sharedmem = callPackage ../development/python-modules/sharedmem { };
 
   sharkiq = callPackage ../development/python-modules/sharkiq { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -8735,6 +8735,8 @@ self: super: with self; {
 
   ossfs = callPackage ../development/python-modules/ossfs { };
 
+  ots-python = callPackage ../development/python-modules/ots-python { };
+
   outcome = callPackage ../development/python-modules/outcome { };
 
   ovh = callPackage ../development/python-modules/ovh { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1422,6 +1422,8 @@ self: super: with self; {
 
   betterproto = callPackage ../development/python-modules/betterproto { };
 
+  beziers = callPackage ../development/python-modules/beziers { };
+
   bibtexparser = callPackage ../development/python-modules/bibtexparser { };
 
   bidict = callPackage ../development/python-modules/bidict { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1253,6 +1253,8 @@ self: super: with self; {
 
   babelfish = callPackage ../development/python-modules/babelfish { };
 
+  babelfont = callPackage ../development/python-modules/babelfont { };
+
   babelgladeextractor = callPackage ../development/python-modules/babelgladeextractor { };
 
   bambi = callPackage ../development/python-modules/bambi { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -8641,6 +8641,8 @@ self: super: with self; {
 
   opentsne = callPackage ../development/python-modules/opentsne { };
 
+  opentypespec = callPackage ../development/python-modules/opentypespec { };
+
   openvino = callPackage ../development/python-modules/openvino {
     openvino-native = pkgs.openvino.override {
       inherit python;

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -4177,6 +4177,8 @@ self: super: with self; {
 
   fontawesomefree = callPackage ../development/python-modules/fontawesomefree { };
 
+  fontbakery = callPackage ../development/python-modules/fontbakery { };
+
   fontfeatures = callPackage ../development/python-modules/fontfeatures { };
 
   fontforge = toPythonModule (pkgs.fontforge.override {

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -16075,6 +16075,8 @@ self: super: with self; {
 
   youless-api = callPackage ../development/python-modules/youless-api { };
 
+  youseedee = callPackage ../development/python-modules/youseedee { };
+
   youtube-dl = callPackage ../tools/misc/youtube-dl { };
 
   youtube-dl-light = callPackage ../tools/misc/youtube-dl {

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -4169,6 +4169,8 @@ self: super: with self; {
 
   fontawesomefree = callPackage ../development/python-modules/fontawesomefree { };
 
+  fontfeatures = callPackage ../development/python-modules/fontfeatures { };
+
   fontforge = toPythonModule (pkgs.fontforge.override {
     withPython = true;
     inherit python;

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -6058,6 +6058,8 @@ self: super: with self; {
 
   kubernetes = callPackage ../development/python-modules/kubernetes { };
 
+  kurbopy = callPackage ../development/python-modules/kurbopy { };
+
   l18n = callPackage ../development/python-modules/l18n { };
 
   labelbox = callPackage ../development/python-modules/labelbox { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -4477,6 +4477,8 @@ self: super: with self; {
 
   gflags = callPackage ../development/python-modules/gflags { };
 
+  gflanguages = callPackage ../development/python-modules/gflanguages { };
+
   ghapi = callPackage ../development/python-modules/ghapi { };
 
   ghdiff = callPackage ../development/python-modules/ghdiff { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -15569,6 +15569,8 @@ self: super: with self; {
 
   vg = callPackage ../development/python-modules/vg { };
 
+  vharfbuzz = callPackage ../development/python-modules/vharfbuzz { };
+
   videocr = callPackage ../development/python-modules/videocr { };
 
   vidstab = callPackage ../development/python-modules/vidstab { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -999,6 +999,8 @@ self: super: with self; {
 
   axis = callPackage ../development/python-modules/axis { };
 
+  axisregistry = callPackage ../development/python-modules/axisregistry { };
+
   azure-appconfiguration = callPackage ../development/python-modules/azure-appconfiguration { };
 
   azure-applicationinsights = callPackage ../development/python-modules/azure-applicationinsights { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -4192,6 +4192,8 @@ self: super: with self; {
 
   fontmake = callPackage ../development/python-modules/fontmake { };
 
+  font-v = callPackage ../development/python-modules/font-v { };
+
   skia-pathops = callPackage ../development/python-modules/skia-pathops {
     inherit (pkgs.darwin.apple_sdk.frameworks) ApplicationServices OpenGL;
   };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -15307,6 +15307,8 @@ self: super: with self; {
 
   ufoLib2 = callPackage ../development/python-modules/ufoLib2 { };
 
+  ufolint = callPackage ../development/python-modules/ufolint { };
+
   ufonormalizer = callPackage ../development/python-modules/ufonormalizer { };
 
   ufoprocessor = callPackage ../development/python-modules/ufoprocessor { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -13621,6 +13621,8 @@ self: super: with self; {
 
   strictyaml = callPackage ../development/python-modules/strictyaml { };
 
+  stringbrewer = callPackage ../development/python-modules/stringbrewer { };
+
   stringcase = callPackage ../development/python-modules/stringcase { };
 
   stringly = callPackage ../development/python-modules/stringly { };


### PR DESCRIPTION
###### Description of changes

[Font Bakery](https://github.com/googlefonts/fontbakery) is a command-line tool for checking the quality of font projects.

It's used for example in the build process for the Inter font family.

This PR also includes a number of new Python packages which are dependencies of fontbakery.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- ~[ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))~
- [x] Tested, as applicable:
  - ~[NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))~
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - ~or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)~
  - ~made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages~
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - ~[ ] (Package updates) Added a release notes entry if the change is major or breaking~
  - ~[ ] (Module updates) Added a release notes entry if the change is significant~
  - ~[ ] (Module addition) Added a release notes entry if adding a new NixOS module~
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
