### PR TITLE
darwin.darling: rename to darwin.darling-sandbox to avoid confusion with darling

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2305.section.md
+++ b/nixos/doc/manual/release-notes/rl-2305.section.md
@@ -145,6 +145,8 @@ In addition to numerous new and upgraded packages, this release has the followin
 
 - `nushell` has been updated to at least version 0.77.0, which includes potential breaking changes in aliases. The old aliases are now available as `old-alias` but it is recommended you migrate to the new format. See [Reworked aliases](https://www.nushell.sh/blog/2023-03-14-nushell_0_77.html#reworked-aliases-breaking-changes-kubouch).
 
+- The `darwin.darling` package has been renamed to `darwing.darling-sandbox` to distinguish from [Darling](https://github.com/darlinghq/darling), a Darwin emulation layer for Linux. The name `darwin-sandbox` emphasize that it is compiled from the sandbox part of Darling, and is meant to be run directly on Darwin instead of on Linux.
+
 - `keepassx` and `keepassx2` have been removed, due to upstream [stopping development](https://www.keepassx.org/index.html%3Fp=636.html). Consider [KeePassXC](https://keepassxc.org) as a maintained alternative.
 
 - The [services.kubo.settings](#opt-services.kubo.settings) option is now no longer stateful. If you changed any of the options in [services.kubo.settings](#opt-services.kubo.settings) in the past and then removed them from your NixOS configuration again, those changes are still in your Kubo configuration file but will now be reset to the default. If you're unsure, you may want to make a backup of your configuration file (probably /var/lib/ipfs/config) and compare after the update.

--- a/pkgs/os-specific/darwin/apple-source-releases/Libsystem/default.nix
+++ b/pkgs/os-specific/darwin/apple-source-releases/Libsystem/default.nix
@@ -2,7 +2,7 @@
 , appleDerivation', xnu, Libc, Libm, libdispatch, Libinfo
 , dyld, Csu, architecture, libclosure, CarbonHeaders, ncurses, CommonCrypto
 , copyfile, removefile, libresolvHeaders, libresolv, Libnotify, libplatform, libpthread
-, mDNSResponder, launchd, libutilHeaders, hfsHeaders, darling, darwin-stubs
+, mDNSResponder, launchd, libutilHeaders, hfsHeaders, darling-sandbox, darwin-stubs
 , headersOnly ? false
 , withLibresolv ? !headersOnly
 }:
@@ -41,9 +41,9 @@ appleDerivation' stdenv {
 
     mkdir -p $out/include/os
 
-    cp ${darling.src}/src/libc/os/activity.h $out/include/os
-    cp ${darling.src}/src/libc/os/log.h $out/include/os
-    cp ${darling.src}/src/duct/include/os/trace.h $out/include/os
+    cp ${darling-sandbox.src}/src/libc/os/activity.h $out/include/os
+    cp ${darling-sandbox.src}/src/libc/os/log.h $out/include/os
+    cp ${darling-sandbox.src}/src/duct/include/os/trace.h $out/include/os
 
     cat <<EOF > $out/include/os/availability.h
     #ifndef __OS_AVAILABILITY__

--- a/pkgs/os-specific/darwin/apple-source-releases/Security/default.nix
+++ b/pkgs/os-specific/darwin/apple-source-releases/Security/default.nix
@@ -2,7 +2,7 @@
 
 appleDerivation {
   nativeBuildInputs = [ xcbuildHook dtrace ];
-  # buildInputs = [ Foundation xpc darling ];
+  # buildInputs = [ Foundation xpc darling-sandbox ];
   buildInputs = [ xpc xnu ];
 
   xcbuildFlags = [ "-target" "Security_frameworks_osx" ];

--- a/pkgs/os-specific/darwin/apple-source-releases/dtrace/default.nix
+++ b/pkgs/os-specific/darwin/apple-source-releases/dtrace/default.nix
@@ -1,9 +1,9 @@
 { appleDerivation, xcbuildHook, CoreSymbolication, apple_sdk
-, xnu, bison, flex, darling, stdenv, fixDarwinDylibNames }:
+, xnu, bison, flex, darling-sandbox, stdenv, fixDarwinDylibNames }:
 
 appleDerivation {
   nativeBuildInputs = [ xcbuildHook flex bison fixDarwinDylibNames ];
-  buildInputs = [ CoreSymbolication apple_sdk.frameworks.CoreSymbolication darling xnu ];
+  buildInputs = [ CoreSymbolication apple_sdk.frameworks.CoreSymbolication darling-sandbox xnu ];
   # -fcommon: workaround build failure on -fno-common toolchains:
   #   duplicate symbol '_kCSRegionMachHeaderName' in: libproc.o dt_module_apple.o
   env.NIX_CFLAGS_COMPILE = "-DCTF_OLD_VERSIONS -DPRIVATE -DYYDEBUG=1 -I${xnu}/Library/Frameworks/System.framework/Headers -Wno-error=implicit-function-declaration -fcommon";

--- a/pkgs/os-specific/darwin/darling-sandbox/default.nix
+++ b/pkgs/os-specific/darwin/darling-sandbox/default.nix
@@ -1,7 +1,7 @@
 {stdenv, lib, fetchzip}:
 
 stdenv.mkDerivation rec {
-  pname = "darling";
+  pname = "darling-sandbox";
   name = pname;
 
   src = fetchzip {
@@ -45,7 +45,7 @@ stdenv.mkDerivation rec {
   meta = with lib; {
     maintainers = with maintainers; [ matthewbauer ];
     license = licenses.gpl3;
-    description = "Darwin/macOS emulation layer for Linux";
+    description = "The sandbox part of Darling, a Darwin/macOS emulation layer for Linux";
     platforms = platforms.darwin;
   };
 }

--- a/pkgs/top-level/darwin-packages.nix
+++ b/pkgs/top-level/darwin-packages.nix
@@ -216,7 +216,7 @@ impure-cmds // appleSourcePackages // chooseLibs // {
   # As the name says, this is broken, but I don't want to lose it since it's a direction we want to go in
   # libdispatch-broken = callPackage ../os-specific/darwin/swift-corelibs/libdispatch.nix { };
 
-  darling = callPackage ../os-specific/darwin/darling/default.nix { };
+  darling-sandbox = callPackage ../os-specific/darwin/darling-sandbox/default.nix { };
 
   libtapi = callPackage ../os-specific/darwin/libtapi {};
 


### PR DESCRIPTION
###### Description of changes

This PR renames `darwing.darling` to `darwing.darling-sandbox`, since it only packages "the sandbox part" of Darling and is meant to be executed directly on Darwin instead of on Linux.

See also #227765 for the progress of `darling` packaging.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux (All packages under `pkgs.darwin` evaluates successfully)
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [X] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage) (done on Linux, which is actually not that helpful.)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
