### PR TITLE
python: don't use keep for hooks, so they will be spliced

### DIFF
--- a/pkgs/development/interpreters/python/hooks/default.nix
+++ b/pkgs/development/interpreters/python/hooks/default.nix
@@ -237,9 +237,7 @@ in {
       propagatedBuildInputs = [ wheel ];
     } ./wheel-unpack-hook.sh) {};
 
-  wrapPython = callPackage ../wrap-python.nix {
-    inherit (pkgs.buildPackages) makeWrapper;
-  };
+  wrapPython = callPackage ../wrap-python.nix { };
 
   sphinxHook = callPackage ({ makePythonHook, installShellFiles }:
     makePythonHook {

--- a/pkgs/development/interpreters/python/hooks/default.nix
+++ b/pkgs/development/interpreters/python/hooks/default.nix
@@ -3,7 +3,7 @@ self: dontUse: with self;
 let
   inherit (python) pythonOnBuildForHost;
   inherit (pkgs) runCommand;
-  pythonInterpreter = pythonOnBuildForHost.interpreter;
+  pythonInterpreter = python.interpreter;
   pythonSitePackages = python.sitePackages;
   pythonCheckInterpreter = python.interpreter;
   setuppy = ../run_setup.py;
@@ -74,7 +74,7 @@ in {
         inherit pythonOnBuildForHost;
       };
     } ./pypa-build-hook.sh) {
-      inherit (pythonOnBuildForHost.pkgs) build;
+      inherit build;
     };
 
   pipInstallHook = callPackage ({ makePythonHook, pip }:
@@ -94,7 +94,7 @@ in {
         inherit pythonInterpreter pythonSitePackages;
       };
     } ./pypa-install-hook.sh) {
-      inherit (pythonOnBuildForHost.pkgs) installer;
+      inherit installer;
     };
 
   pytestCheckHook = callPackage ({ makePythonHook, pytest }:
@@ -242,9 +242,9 @@ in {
   sphinxHook = callPackage ({ makePythonHook, installShellFiles }:
     makePythonHook {
       name = "python${python.pythonVersion}-sphinx-hook";
-      propagatedBuildInputs = [ pythonOnBuildForHost.pkgs.sphinx installShellFiles ];
+      propagatedBuildInputs = [ sphinx installShellFiles ];
       substitutions = {
-        sphinxBuild = "${pythonOnBuildForHost.pkgs.sphinx}/bin/sphinx-build";
+        sphinxBuild = "${sphinx}/bin/sphinx-build";
       };
     } ./sphinx-hook.sh) {};
 }

--- a/pkgs/development/interpreters/python/mk-python-derivation.nix
+++ b/pkgs/development/interpreters/python/mk-python-derivation.nix
@@ -262,7 +262,7 @@ let
       setuptoolsBuildHook
     ] ++ optionals (format' == "pyproject") [(
       if isBootstrapPackage then
-        pypaBuildHook.override {
+        python.pythonOnBuildForHost.pkgs.pypaBuildHook.override {
           inherit (python.pythonOnBuildForHost.pkgs.bootstrap) build;
           wheel = null;
         }
@@ -270,7 +270,7 @@ let
         pypaBuildHook
     ) (
       if isBootstrapPackage then
-        pythonRuntimeDepsCheckHook.override {
+        python.pythonOnBuildForHost.pkgs.pythonRuntimeDepsCheckHook.override {
           inherit (python.pythonOnBuildForHost.pkgs.bootstrap) packaging;
         }
       else
@@ -281,7 +281,7 @@ let
       eggUnpackHook eggBuildHook eggInstallHook
     ] ++ optionals (format' != "other") [(
       if isBootstrapInstallPackage then
-        pypaInstallHook.override {
+        python.pythonOnBuildForHost.pkgs.pypaInstallHook.override {
           inherit (python.pythonOnBuildForHost.pkgs.bootstrap) installer;
         }
       else

--- a/pkgs/development/interpreters/python/mk-python-derivation.nix
+++ b/pkgs/development/interpreters/python/mk-python-derivation.nix
@@ -26,7 +26,7 @@
 , eggUnpackHook
 , eggBuildHook
 , eggInstallHook
-}:
+}@things:
 
 let
   inherit (builtins) unsafeGetAttrPos;
@@ -324,7 +324,7 @@ let
 
     outputs = outputs ++ optional withDistOutput "dist";
 
-    inherit passthru;
+    passthru = { inherit things; } // passthru;
 
     meta = {
       # default to python's platforms

--- a/pkgs/development/interpreters/python/passthrufun.nix
+++ b/pkgs/development/interpreters/python/passthrufun.nix
@@ -47,7 +47,7 @@
         selfTargetTarget = pythonOnTargetForTarget.pkgs or {}; # There is no Python TargetTarget.
       };
       hooks = import ./hooks/default.nix;
-      keep = self: { inherit (self) wrapPython; };
+      keep = _: { };
       optionalExtensions = cond: as: lib.optionals cond as;
       pythonExtension = import ../../../top-level/python-packages.nix;
       python2Extension = import ../../../top-level/python2-packages.nix;

--- a/pkgs/development/interpreters/python/passthrufun.nix
+++ b/pkgs/development/interpreters/python/passthrufun.nix
@@ -47,7 +47,7 @@
         selfTargetTarget = pythonOnTargetForTarget.pkgs or {}; # There is no Python TargetTarget.
       };
       hooks = import ./hooks/default.nix;
-      keep = self: hooks self {};
+      keep = self: { inherit (self) wrapPython; };
       optionalExtensions = cond: as: lib.optionals cond as;
       pythonExtension = import ../../../top-level/python-packages.nix;
       python2Extension = import ../../../top-level/python2-packages.nix;

--- a/pkgs/development/interpreters/python/wrap-python.nix
+++ b/pkgs/development/interpreters/python/wrap-python.nix
@@ -9,7 +9,7 @@ makePythonHook {
       substitutions.sitePackages = python.sitePackages;
       substitutions.executable = python.interpreter;
       substitutions.python = python.pythonOnBuildForHost;
-      substitutions.pythonHost = python.__spliced.targetTarget or python;
+      substitutions.pythonHost = python.__spliced.hostHost or python;
       substitutions.magicalSedExpression = let
         # Looks weird? Of course, it's between single quoted shell strings.
         # NOTE: Order DOES matter here, so single character quotes need to be

--- a/pkgs/development/interpreters/python/wrap-python.nix
+++ b/pkgs/development/interpreters/python/wrap-python.nix
@@ -1,15 +1,33 @@
 { lib
 , python
 , makePythonHook
-, makeWrapper }:
+, makeWrapper
+, stdenv
+, targetPackages
+}:
 
 makePythonHook {
       name = "wrap-python-hook";
       propagatedBuildInputs = [ makeWrapper ];
       substitutions.sitePackages = python.sitePackages;
       substitutions.executable = python.interpreter;
-      substitutions.python = python.pythonOnBuildForHost;
-      substitutions.pythonHost = python.__spliced.hostHost or python;
+      substitutions.python = python;
+      #substitutions.pythonHost =
+      #if ((targetPackages.stdenv.buildPlatform != targetPackages.stdenv.targetPlatform) && (targetPackages.stdenv.hostPlatform == targetPackages.stdenv.targetPlatform))
+      #  then python.__spliced.hostHost
+      #else if (stdenv.buildPlatform != (stdenv.hostPlatform == stdenv.targetPlatform))
+      #  then python
+      #else if (stdenv.hostPlatform != stdenv.targetPlatform)
+      #  then python.__spliced.hostHost
+      #else throw "don't reach";
+      substitutions.pythonHost =
+      if ((targetPackages.stdenv.buildPlatform != targetPackages.stdenv.targetPlatform) && (targetPackages.stdenv.hostPlatform == targetPackages.stdenv.targetPlatform))
+        then python.__spliced.hostHost
+      else python;
+      passthru = {
+        python1 = python;
+        targetstdenv = targetPackages.stdenv;
+      };
       substitutions.magicalSedExpression = let
         # Looks weird? Of course, it's between single quoted shell strings.
         # NOTE: Order DOES matter here, so single character quotes need to be

--- a/pkgs/development/interpreters/python/wrap-python.nix
+++ b/pkgs/development/interpreters/python/wrap-python.nix
@@ -9,7 +9,7 @@ makePythonHook {
       substitutions.sitePackages = python.sitePackages;
       substitutions.executable = python.interpreter;
       substitutions.python = python.pythonOnBuildForHost;
-      substitutions.pythonHost = python.__spliced.hostHost or python;
+      substitutions.pythonHost = python.__spliced.targetTarget or python;
       substitutions.magicalSedExpression = let
         # Looks weird? Of course, it's between single quoted shell strings.
         # NOTE: Order DOES matter here, so single character quotes need to be

--- a/pkgs/development/interpreters/python/wrap-python.nix
+++ b/pkgs/development/interpreters/python/wrap-python.nix
@@ -9,7 +9,7 @@ makePythonHook {
       substitutions.sitePackages = python.sitePackages;
       substitutions.executable = python.interpreter;
       substitutions.python = python.pythonOnBuildForHost;
-      substitutions.pythonHost = python;
+      substitutions.pythonHost = python.__spliced.hostHost or python;
       substitutions.magicalSedExpression = let
         # Looks weird? Of course, it's between single quoted shell strings.
         # NOTE: Order DOES matter here, so single character quotes need to be

--- a/pkgs/misc/flashfocus/default.nix
+++ b/pkgs/misc/flashfocus/default.nix
@@ -38,6 +38,10 @@ python3Packages.buildPythonApplication rec {
   # Tests require access to a X session
   doCheck = false;
 
+  preFixup = ''
+    set -x
+  '';
+
   pythonImportsCheck = [ "flashfocus" ];
 
   passthru.updateScript = nix-update-script { };


### PR DESCRIPTION
See https://github.com/NixOS/nixpkgs/issues/211340 for prerequisite 


The wrapPython weirdness is to fix
```
error: output '/nix/store/li07bad6s9brxx7cf8j408631nca39ka-python3.10-chardet-5.1.0-aarch64-unknown-linux-gnu' is not allowed to refer to the following paths:
         /nix/store/fdqpyj613dr0v1l1lrzqhzay7sk4xg87-python3-3.10.10
```

ericson said in https://github.com/NixOS/nixpkgs/pull/104201#discussion_r527041018 that the reason they were in keep was to not splice them but before the commit which broke hook splicing (33d12e5) everything appeared to be working correctly when cross-compiling


###### Description of changes

experimenting with hook splicing fix @amjoseph-nixpkgs 

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
