### PR TITLE
luksroot: fix issue when yubikey is detached during boot process

### DIFF
--- a/nixos/modules/system/boot/luksroot.nix
+++ b/nixos/modules/system/boot/luksroot.nix
@@ -351,6 +351,12 @@ let
 
         new_response="$(ykchalresp -${toString dev.yubikey.slot} -x $new_challenge 2>/dev/null)"
 
+        if [ -z "$new_response" ]; then
+            echo "Warning: Unable to generate new challenge response, current challenge persists!"
+            umount /crypt-storage
+            return
+        fi
+
         if [ ! -z "$k_user" ]; then
             new_k_luks="$(echo -n $k_user | pbkdf2-sha512 ${toString dev.yubikey.keyLength} $new_iterations $new_response | rbtohex)"
         else


### PR DESCRIPTION
Fixes #228141, which describes an issue where detaching Yubikey during the boot process causes cryptsetup to write empty passphrase instead of the challenge-response salt stored on the boot drive.

###### Description of changes

#228141 contains detailed description of the issue. Basically when using `boot.initrd.luks.devices.<name>.yubikey.storage.path` there's a multiple second long process, between Yubikey calls. If the key is removed between these two calls, multiple variables are left empty due to failing calls, finally resulting in `luksChangeKey` writing empty passphrase to the device, which breaks expected functionality of `luksroot`. This fix simply checks for the returned variable from the second call, making sure that it has been populated before continuing. If the variable is empty, a warning message is displayed that the salt hasn't been rotated.

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
