### PR TITLE
openslp: Mark known vulnerable

### DIFF
--- a/pkgs/applications/kde/kio-extras.nix
+++ b/pkgs/applications/kde/kio-extras.nix
@@ -3,7 +3,7 @@
   exiv2, kactivities, kactivities-stats, karchive, kbookmarks, kconfig, kconfigwidgets,
   kcoreaddons, kdbusaddons, kdsoap, kguiaddons, kdnssd, kiconthemes, ki18n, kio,
   khtml, kpty, syntax-highlighting, libmtp, libssh, openexr, libtirpc,
-  ilmbase, openslp, phonon, qtsvg, samba, solid, gperf, taglib
+  ilmbase, phonon, qtsvg, samba, solid, gperf, taglib
 }:
 
 mkDerivation {
@@ -16,7 +16,7 @@ mkDerivation {
   buildInputs = [
     exiv2 kactivities kactivities-stats karchive kbookmarks kconfig kconfigwidgets kcoreaddons
     kdbusaddons kdsoap kguiaddons kdnssd kiconthemes ki18n kio khtml
-    kpty syntax-highlighting libmtp libssh openexr libtirpc openslp
+    kpty syntax-highlighting libmtp libssh openexr libtirpc
     phonon qtsvg samba solid gperf taglib
   ];
 

--- a/pkgs/development/libraries/openslp/default.nix
+++ b/pkgs/development/libraries/openslp/default.nix
@@ -32,6 +32,9 @@ stdenv.mkDerivation rec {
     platforms = platforms.all;
     # never built on aarch64-darwin since first introduction in nixpkgs
     broken = stdenv.isDarwin && stdenv.isAarch64;
+    knownVulnerabilities = [
+      "CVE-2023-29552: UDP Reflection Attack with ampliciation factor of up to 2200"
+    ];
   };
 
 }


### PR DESCRIPTION
CVE-2023-29552 affects the [SLP protocol](https://en.wikipedia.org/wiki/Service_Location_Protocol) as implemented in the openslp library. The only consumer was kio-extras, but only because we didn't prune the dependency years ago. 

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
