### PR TITLE
tauri-mobile: init at unstable-2023-04-25

### DIFF
--- a/pkgs/development/tools/rust/tauri-mobile/default.nix
+++ b/pkgs/development/tools/rust/tauri-mobile/default.nix
@@ -1,0 +1,54 @@
+{ lib
+, stdenv
+, rustPlatform
+, fetchFromGitHub
+, pkg-config
+, openssl
+, git
+, darwin
+, makeWrapper
+}:
+
+let
+  inherit (darwin.apple_sdk.frameworks) CoreServices;
+  pname = "tauri-mobile";
+  version = "unstable-2023-04-25";
+in
+rustPlatform.buildRustPackage {
+  inherit pname version;
+  src = fetchFromGitHub {
+    owner = "tauri-apps";
+    repo = pname;
+    rev = "c2abaf54135bf65b1165a38d3b1d84e8d57f5d6c";
+    sha256 = "sha256-WHyiswe64tkNhhgmHquv9YPLQAU1yTJ/KglTqEPBcOM=";
+  };
+
+  # Manually specify the sourceRoot since this crate depends on other crates in the workspace. Relevant info at
+  # https://discourse.nixos.org/t/difficulty-using-buildrustpackage-with-a-src-containing-multiple-cargo-workspaces/10202
+  # sourceRoot = "source/tooling/cli";
+
+  cargoHash = "sha256-Kc1BikwUYSpPShRtAPbHCdfVzo6zwjiO3QeqRkO+WhY=";
+
+  preBuild = ''
+    export HOME=$(mktemp -d)
+  '';
+
+  buildInputs = [ openssl ] ++ lib.optionals stdenv.isDarwin [ CoreServices ];
+  nativeBuildInputs = [ pkg-config git makeWrapper ];
+
+  preInstall = ''
+    mkdir -p $out/share/
+    # the directory created in the build process is .tauri-mobile, a hidden directory
+    shopt -s dotglob
+    for temp_dir in $HOME/*; do
+      cp -R $temp_dir $out/share
+    done
+  '';
+
+  meta = with lib; {
+    description = "Rust on mobile made easy! ";
+    homepage = "https://tauri.app/";
+    license = with licenses; [ asl20 /* or */ mit ];
+    maintainers = with maintainers; [ happysalada ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -16229,6 +16229,7 @@ with pkgs;
   cargo-unused-features = callPackage ../development/tools/rust/cargo-unused-features { };
 
   cargo-tauri = callPackage ../development/tools/rust/cargo-tauri { };
+  tauri-mobile = callPackage ../development/tools/rust/tauri-mobile { };
 
   cargo-valgrind = callPackage ../development/tools/rust/cargo-valgrind { };
   cargo-vet = callPackage ../development/tools/rust/cargo-vet {


### PR DESCRIPTION
###### Description of changes

I'm using unstable here since the cargo lock was fixed after the release was made.
The install process populates the home directory, I've open an issue asking them to be able to define the directory with an env var. Not sure before then how we can really get access to that. I've put that directory in share in the meanwhile it contains the commit info and some templates.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [X] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
