### PR TITLE
texlive: fix texlive fonts for xetex

### DIFF
--- a/pkgs/test/texlive/default.nix
+++ b/pkgs/test/texlive/default.nix
@@ -11,11 +11,11 @@
     diff -u "''${nixpkgsTlpdbNix}" "''${tlpdbNix}" | tee "$out/tlpdb.nix.patch"
   '';
 
-  luaotfload-fonts = runCommand "texlive-test-lualatex" {
+  opentype-fonts = runCommand "texlive-test-opentype" {
     nativeBuildInputs = [
       (with texlive; combine { inherit scheme-medium libertinus-fonts; })
     ];
-    input = builtins.toFile "lualatex-testfile.tex" ''
+    input = builtins.toFile "opentype-testfile.tex" ''
       \documentclass{article}
       \usepackage{fontspec}
       \setmainfont{Libertinus Serif}
@@ -26,7 +26,13 @@
   }
   ''
     export HOME="$(mktemp -d)"
+    # We use the same testfile to test two completely different
+    # font discovery mechanisms, both of which were once broken:
+    #  - lualatex uses its own luaotfload script (#220228)
+    #  - xelatex uses fontconfig (#228196)
+    # both of the following two commands need to succeed.
     lualatex -halt-on-error "$input"
+    xelatex -halt-on-error "$input"
     echo success > $out
   '';
 

--- a/pkgs/tools/typesetting/tex/texlive/combine.nix
+++ b/pkgs/tools/typesetting/tex/texlive/combine.nix
@@ -196,7 +196,11 @@ in (buildEnv {
       makeWrapper "$target" "$link" \
         --prefix PATH : "${gnused}/bin:${gnugrep}/bin:${coreutils}/bin:$out/bin:${perl}/bin" \
         --prefix PERL5LIB : "$PERL5LIB" \
-        --set-default TEXMFCNF "$TEXMFCNF"
+        --set-default TEXMFCNF "$TEXMFCNF" \
+        --set-default FONTCONFIG_FILE "${
+          # neccessary for XeTeX to find the fonts distributed with texlive
+          makeFontsConf { fontDirectories = [ "${texmfroot}/texmf-dist/fonts" ]; }
+        }"
 
       # avoid using non-nix shebang in $target by calling interpreter
       if [[ "$(head -c 2 "$target")" = "#!" ]]; then
@@ -311,5 +315,3 @@ in (buildEnv {
   ''
   ;
 }).overrideAttrs (_: { allowSubstitutes = true; })
-# TODO: make TeX fonts visible by fontconfig: it should be enough to install an appropriate file
-#       similarly, deal with xe(la)tex font visibility?

--- a/pkgs/tools/typesetting/tex/texlive/combine.nix
+++ b/pkgs/tools/typesetting/tex/texlive/combine.nix
@@ -82,8 +82,12 @@ in (buildEnv {
   nativeBuildInputs = [ makeWrapper libfaketime perl bin.texlinks ];
   buildInputs = pkgList.extraInputs;
 
-  # This is set primarily to help find-tarballs.nix to do its job
-  passthru.packages = pkgList.all;
+  passthru = {
+    # This is set primarily to help find-tarballs.nix to do its job
+    packages = pkgList.all;
+    # useful for inclusion in the `fonts.fonts` nixos option or for use in devshells
+    fonts = "${texmfroot}/texmf-dist/fonts";
+  };
 
   postBuild = ''
     TEXMFROOT="${texmfroot}"

--- a/pkgs/tools/typesetting/tex/texlive/default.nix
+++ b/pkgs/tools/typesetting/tex/texlive/default.nix
@@ -5,7 +5,7 @@
 { stdenv, lib, fetchurl, runCommand, writeText, buildEnv
 , callPackage, ghostscript_headless, harfbuzz
 , makeWrapper, python3, ruby, perl, gnused, gnugrep, coreutils
-, libfaketime
+, libfaketime, makeFontsConf
 , useFixedHashes ? true
 , recurseIntoAttrs
 }:
@@ -24,7 +24,7 @@ let
   # function for creating a working environment from a set of TL packages
   combine = import ./combine.nix {
     inherit bin combinePkgs buildEnv lib makeWrapper writeText
-      stdenv python3 ruby perl gnused gnugrep coreutils libfaketime;
+      stdenv python3 ruby perl gnused gnugrep coreutils libfaketime makeFontsConf;
     ghostscript = ghostscript_headless;
   };
 


### PR DESCRIPTION
###### Description of changes
XeTeX relies on the system's font managent tooling to locate fonts. This means that XeTeX was unable to find the fonts distributed with texlive as these weren't installed in paths searched by the system's font configuration.

This PR fixes this ~~for linux~~ by wrapping xetex such that the `FONTCONFIG_FILE` environment value is set to a suitable fontconfig file generated by `makeFontsConf`. This file is almost identical to the one from the fontconfig package and 
`/etc/fonts/fonts.conf ` on NixOS -- it only adds the texlive font directories. In particular this means that all the actual
configuration files in /`etc/fonts/conf.d` are still included and there also is a `/usr/share/fonts` font directory entry for use with non-NixOS linuxes, so it's unlikely that this breaks someone's setup.

~~Darwin remains broken since XeTeX doesn't use fontconfig there.~~

This also exposes texlive's font directory as a passthru-attribute, which makes adding texlive's fonts to the `fonts.fonts.` nixos-option (or symlinking the directory to `~/Library/fonts` on MacOS with home-manager) a lot easier.

As the wrapper uses `--set-default`, devShells can easily override the font directories to add more fonts. For example in the shell
```nix
{ pkgs ? import <nixpkgs> {} }:
let
  texlive = pkgs.texlive.combined.scheme-full;
  systemfontdirs = with pkgs; map toString [ comic-mono crimson ];
in pkgs.mkShell {
    nativeBuildInputs = [ texlive ];
    # used by xetex and mtx-fonts (context)
    FONTCONFIG_FILE = pkgs.makeFontsConf { fontDirectories = systemfontdirs ++ [ texlive.fonts ]; };
    # used by luaotfload (lualatex)
    OSFONTDIR = pkgs.lib.concatStringsSep "//:" systemfontdirs;
}
```
the document
```tex
\documentclass{article}
\usepackage{mwe,fontspec}
\begin{document}
\fontspec{Crimson} \blindtext % "system" font
\fontspec{STIX Two Text} \blindtext % texlive font
\end{document}
```
compiles with both `lualatex` and `xelatex`. (It's a bit unfortunate that luaotfload hardcodes the fontconfig location to `/etc/fonts/fonts.conf` and `/usr/local/etc/fonts/fonts.conf`, so a separate environment variable has to be used, but at least it works).

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
