### PR TITLE
cereal: 1.3.0 -> 1.3.2

### DIFF
--- a/pkgs/development/libraries/cereal/default.nix
+++ b/pkgs/development/libraries/cereal/default.nix
@@ -1,7 +1,7 @@
-{ lib, stdenv, fetchFromGitHub, fetchpatch, cmake }:
+{ lib, stdenv, fetchFromGitHub, cmake }:
 stdenv.mkDerivation rec {
   pname = "cereal";
-  version = "1.3.0";
+  version = "1.3.2";
 
   nativeBuildInputs = [ cmake ];
 
@@ -9,20 +9,8 @@ stdenv.mkDerivation rec {
     owner = "USCiLab";
     repo = "cereal";
     rev = "v${version}";
-    sha256 = "0hc8wh9dwpc1w1zf5lfss4vg5hmgpblqxbrpp1rggicpx9ar831p";
+    hash = "sha256-HapnwM5oSNKuqoKm5x7+i2zt0sny8z8CePwobz1ITQs=";
   };
-
-  patches = [
-    # https://nvd.nist.gov/vuln/detail/CVE-2020-11105
-    # serialized std::shared_ptr variables cannot always be expected to
-    # serialize back into their original values. This can have any number of
-    # consequences, depending on the context within which this manifests.
-    (fetchpatch {
-      name = "CVE-2020-11105.patch";
-      url = "https://github.com/USCiLab/cereal/commit/f27c12d491955c94583512603bf32c4568f20929.patch";
-      sha256 = "CIkbJ7bAN0MXBhTXQdoQKXUmY60/wQvsdn99FaWt31w=";
-    })
-  ];
 
   cmakeFlags = [ "-DJUST_INSTALL_CEREAL=yes" ];
 


### PR DESCRIPTION
###### Description of changes

This allow us to drop the patch for CVE-2020-11105.

https://github.com/USCiLab/cereal/releases/tag/v1.3.2
https://github.com/USCiLab/cereal/releases/tag/v1.3.1
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage) (partial build only, `bpftrace`, `domoticz` and  `openmvg-unstable` appears OK)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
