### PR TITLE
openvswitch: 3.0.3 -> 3.1.1, openvswitch-lts: 2.17.5 -> 2.17.6

### DIFF
--- a/pkgs/os-specific/linux/openvswitch/default.nix
+++ b/pkgs/os-specific/linux/openvswitch/default.nix
@@ -1,4 +1,4 @@
 import ./generic.nix {
-  version = "3.0.3";
-  hash = "sha256-9QZlCnbx8s7737WD80NBIQLxcKvFXG/4dWd5Jrm9lGM=";
+  version = "3.1.1";
+  hash = "sha256-YEiRg6RNO5WlUiQHIhfF9tN6oRvhKnV2JRDO25Ok4gQ=";
 }

--- a/pkgs/os-specific/linux/openvswitch/generic.nix
+++ b/pkgs/os-specific/linux/openvswitch/generic.nix
@@ -93,6 +93,9 @@ in stdenv.mkDerivation rec {
   '';
 
   doCheck = true;
+  preCheck = ''
+    patchShebangs tests/
+  '';
 
   nativeCheckInputs = [
     iproute2

--- a/pkgs/os-specific/linux/openvswitch/lts.nix
+++ b/pkgs/os-specific/linux/openvswitch/lts.nix
@@ -1,4 +1,4 @@
 import ./generic.nix {
-  version = "2.17.5";
-  hash = "sha256-Woye+zUikjdGWIp8pRDBC7CsUrnInfJ23byGcxFtwQY=";
+  version = "2.17.6";
+  hash = "sha256-dNqvK+c0iuXdQBe6RbjaxlNB8Vn0+0paecVC/tQQENk=";
 }


### PR DESCRIPTION
###### Description of changes
https://nvd.nist.gov/vuln/detail/CVE-2023-1668
https://www.openwall.com/lists/oss-security/2023/04/06/1

This needs a backport but not an auto-backport - for stable we can keep `openvswitch` on the 3.0 series.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
