### PR TITLE
xen: mark EOL ≤ 4.15, add known CVEs in nixpkgs

### DIFF
--- a/pkgs/applications/virtualization/xen/generic.nix
+++ b/pkgs/applications/virtualization/xen/generic.nix
@@ -244,10 +244,21 @@ stdenv.mkDerivation (rec {
                     + "\nIncludes:\n"
                     + withXenfiles (name: x: "* ${name}: ${x.meta.description or "(No description)"}.");
     platforms = [ "x86_64-linux" ];
-    maintainers = with lib.maintainers; [ eelco oxij ];
+    maintainers = [ ];
     license = lib.licenses.gpl2;
+    knownVulnerabilities = [
+      # https://www.openwall.com/lists/oss-security/2023/03/21/1
+      # Affects 3.2 (at *least*) - 4.17
+      "CVE-2022-42332"
+      # https://www.openwall.com/lists/oss-security/2023/03/21/2
+      # Affects 4.11 - 4.17
+      "CVE-2022-42333"
+      "CVE-2022-42334"
+      # https://www.openwall.com/lists/oss-security/2023/03/21/3
+      # Affects 4.15 - 4.17
+      "CVE-2022-42331"
     # https://xenbits.xen.org/docs/unstable/support-matrix.html
-    knownVulnerabilities = lib.optionals (lib.versionOlder version "4.13") [
+    ] ++ lib.optionals (lib.versionOlder version "4.15") [
       "This version of Xen has reached its end of life. See https://xenbits.xen.org/docs/unstable/support-matrix.html"
     ];
   } // (config.meta or {});


### PR DESCRIPTION
###### Description of changes

Currently, Xen is very unmaintained, as this is a particularly complex piece of software that touts itself as secure, we are not doing a service to Xen by packaging unsecure piece of their software.

Let's be brutally honest about the state of things in nixpkgs.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
