### PR TITLE
pcb2gcode: 2.4.0 -> 2.5.0, gerbv: 2.7.0 -> 2.9.6, switch to the maintained fork

### DIFF
--- a/pkgs/applications/science/electronics/gerbv/default.nix
+++ b/pkgs/applications/science/electronics/gerbv/default.nix
@@ -1,34 +1,29 @@
-{ lib, stdenv, fetchurl, fetchpatch, pkg-config, gettext, libtool, automake, autoconf, cairo, gtk2-x11, autoreconfHook }:
+{ lib, stdenv, fetchFromGitHub, pkg-config, gettext, libtool, automake, autoconf, cairo, gtk2-x11, autoreconfHook }:
 
 stdenv.mkDerivation rec {
   pname = "gerbv";
-  version = "2.7.0";
+  version = "2.9.6";
 
-  src = fetchurl {
-    url = "mirror://sourceforge/gerbv/${pname}-${version}.tar.gz";
-    sha256 = "sha256-xe6AjEIwzmvjrRCrY8VHCYOG1DAicE3iXduTeOYgU7Q=";
+  src = fetchFromGitHub {
+    owner = "gerbv";
+    repo = pname;
+    rev = "v${version}";
+    hash = "sha256-HNhrnXOBlzfO/roWzTsg0RcJPb0c7RuJepankB5zNts=";
   };
 
-  patches = [
-    # Pull patch pending upstream inclusion for -fno-common toolchains:
-    #  https://sourceforge.net/p/gerbv/patches/84/
-    (fetchpatch {
-      name = "fnoc-mmon.patch";
-      url = "https://sourceforge.net/p/gerbv/patches/84/attachment/0001-gerbv-fix-build-on-gcc-10-fno-common.patch";
-      sha256 = "1avfbkqhxl7wxn1z19y30ilkwvdgpdkzhzawrs5y3damxmqq8ggk";
-    })
-  ];
+  postPatch = ''
+    sed -i '/AC_INIT/s/m4_esyscmd.*/${version}])/' configure.ac
+  '';
 
   nativeBuildInputs = [ autoreconfHook pkg-config automake autoconf ];
   buildInputs = [ gettext libtool cairo gtk2-x11 ];
 
   configureFlags = ["--disable-update-desktop-database"];
 
-  env.NIX_CFLAGS_COMPILE = "-Wno-format-security";
-
   meta = with lib; {
     description = "A Gerber (RS-274X) viewer";
-    homepage = "http://gerbv.geda-project.org/";
+    homepage = "https://gerbv.github.io/";
+    changelog = "https://github.com/gerbv/gerbv/releases/tag/v${version}";
     maintainers = with maintainers; [ mog ];
     platforms = platforms.unix;
     license = licenses.gpl2;

--- a/pkgs/tools/misc/pcb2gcode/default.nix
+++ b/pkgs/tools/misc/pcb2gcode/default.nix
@@ -9,28 +9,18 @@
 , gerbv
 , librsvg
 , bash
-, fetchpatch
 }:
 
 stdenv.mkDerivation rec {
   pname = "pcb2gcode";
-  version = "2.4.0";
+  version = "2.5.0";
 
   src = fetchFromGitHub {
     owner = "pcb2gcode";
     repo = "pcb2gcode";
     rev = "v${version}";
-    sha256 = "sha256-3VQlYtSi6yWWNuxTlBzvBtkM5hAss47xat+sEW+P79E=";
+    hash = "sha256-c5YabBqZn6ilIkF3lifTsYyLZMsZN21jDj1hNu0PRAc=";
   };
-
-  patches = [
-    # the patch below is part of upstream mainline, we can remove this
-    # when they make their next release
-    (fetchpatch {
-      url = "https://github.com/pcb2gcode/pcb2gcode/commit/01cd18a6d859ab1aac6c532c99be9109f083448d.patch";
-      sha256 = "sha256-5hl8KsDxSWMzXS3oRG0fBfHFq0IpZ//sU8lfY9Yp8L0=";
-    })
-  ];
 
   nativeBuildInputs = [ autoreconfHook pkg-config ];
 


### PR DESCRIPTION
###### Description of changes

The pcb2gcode upgrade was done because it is needed to support gerbv 2.9.6.

pcb2gcode: 2.4.0 -> 2.5.0

Changelog:
https://github.com/pcb2gcode/pcb2gcode/releases/tag/v2.5.0

gerbv: 2.7.0 -> 2.9.6, switch to the maintained fork

The current 2.7.0 has a bunch of known vulnerabilities
(CVE-2021-40391, CVE-2021-40393, CVE-2021-40394, CVE-2021-40400, CVE-2021-40401, CVE-2021-40402 and CVE-2021-40403)
and is not maintained upstream.

A forked repository exists and is maintained. Debian/Ubuntu, Fedora and Homebrew have switched to it.

Changelogs:
https://github.com/gerbv/gerbv/releases/tag/v2.9.6
https://github.com/gerbv/gerbv/releases/tag/v2.9.5
https://github.com/gerbv/gerbv/releases/tag/v2.9.4
https://github.com/gerbv/gerbv/releases/tag/v2.9.3
https://github.com/gerbv/gerbv/releases/tag/v2.9.2
https://github.com/gerbv/gerbv/releases/tag/v2.9.1
https://github.com/gerbv/gerbv/releases/tag/v2.9.0
https://github.com/gerbv/gerbv/releases/tag/v2.8.2

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
