### PR TITLE
termbook: init at 1.4.6

### DIFF
--- a/pkgs/tools/text/termbook/default.nix
+++ b/pkgs/tools/text/termbook/default.nix
@@ -1,0 +1,22 @@
+{ lib, stdenv, fetchFromGitHub, rustPlatform }:
+
+rustPlatform.buildRustPackage rec {
+  pname = "termbook";
+  version = "1.4.6";
+
+  src = fetchFromGitHub {
+    owner = "Byron";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "sha256-Bo3DI0cMXIfP7ZVr8MAW/Tmv+4mEJBIQyLvRfVBDG8c=";
+  };
+
+  cargoSha256 = "sha256-+LQriLzLYt+mG2qoQeD9/Ay51TKMZpklLH72qrcSV0U=";
+
+  meta = with lib; {
+    description = "A runner for `mdbooks` to keep your documentation tested.";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ phaer ];
+    homepage = "https://github.com/Byron/termbook/";
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -13544,6 +13544,8 @@ with pkgs;
 
   xteve = callPackage ../servers/xteve { };
 
+  termbook = callPackage ../tools/text/termbook { };
+
   testdisk = libsForQt5.callPackage ../tools/system/testdisk { };
 
   testdisk-qt = testdisk.override { enableQt = true; };


### PR DESCRIPTION
###### Description of changes

Adds termbook, a runner for `mdbooks` to keep your documentation tested. It's a standalone application, that uses `mdbook` as a crate, so we let rustPlatform handle that instead of depending on nixpkgs `mdbook`.

Could be that it needs `darwin.apple_sdk.frameworks.CoreServices` as *some* other `mdbook`-related packages do, but I personally can't test on darwin due to lack of a machine.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
