### PR TITLE
nixos/tests/netboot: repair testing

### DIFF
--- a/nixos/modules/installer/netboot/netboot.nix
+++ b/nixos/modules/installer/netboot/netboot.nix
@@ -123,8 +123,7 @@ with lib;
 
     # Create the initrd
     system.build.netbootRamdisk = pkgs.makeInitrdNG {
-      inherit (config.boot.initrd) compressor;
-      prepend = [ "${config.system.build.initialRamdisk}/initrd" ];
+      prepend = [ "${config.system.build.initialRamdisk}/${config.system.boot.loader.initrdFile}" ];
 
       contents =
         [ { object = config.system.build.squashfsStore;
@@ -137,8 +136,8 @@ with lib;
       #!ipxe
       # Use the cmdline variable to allow the user to specify custom kernel params
       # when chainloading this script from other iPXE scripts like netboot.xyz
-      kernel ${pkgs.stdenv.hostPlatform.linux-kernel.target} init=${config.system.build.toplevel}/init initrd=initrd ${toString config.boot.kernelParams} ''${cmdline}
-      initrd initrd
+      kernel ${pkgs.stdenv.hostPlatform.linux-kernel.target} init=${config.system.build.toplevel}/init initrd=${config.system.boot.loader.initrdFile} ${toString config.boot.kernelParams} ''${cmdline}
+      initrd ${config.system.boot.loader.initrdFile}
       boot
     '';
 
@@ -152,7 +151,7 @@ with lib;
       fi
       SCRIPT_DIR=$( cd -- "$( dirname -- "''${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
       kexec --load ''${SCRIPT_DIR}/bzImage \
-        --initrd=''${SCRIPT_DIR}/initrd.gz \
+        --initrd=''${SCRIPT_DIR}/${config.system.boot.loader.initrdFile} \
         --command-line "init=${config.system.build.toplevel}/init ${toString config.boot.kernelParams}"
       kexec -e
     '';
@@ -160,8 +159,8 @@ with lib;
     # A tree containing initrd.gz, bzImage and a kexec-boot script.
     system.build.kexecTree = pkgs.linkFarm "kexec-tree" [
       {
-        name = "initrd.gz";
-        path = "${config.system.build.netbootRamdisk}/initrd";
+        name = "${config.system.boot.loader.initrdFile}";
+        path = "${config.system.build.netbootRamdisk}/${config.system.boot.loader.initrdFile}";
       }
       {
         name = "bzImage";

--- a/nixos/modules/virtualisation/qemu-vm.nix
+++ b/nixos/modules/virtualisation/qemu-vm.nix
@@ -1192,7 +1192,7 @@ in
     # value for the `fileSystems' attribute should be disregarded (since those
     # filesystems don't necessarily exist in the VM). You can disable this
     # override by setting `virtualisation.fileSystems = lib.mkForce { };`.
-    fileSystems = lib.mkIf (cfg.fileSystems != { }) (mkVMOverride cfg.fileSystems);
+    fileSystems = lib.mkIf (cfg.fileSystems != { }) (lib.mapAttrs (n: v: mkVMOverride v) cfg.fileSystems);
 
     virtualisation.fileSystems = let
       mkSharedDir = tag: share:

--- a/nixos/tests/boot.nix
+++ b/nixos/tests/boot.nix
@@ -104,6 +104,15 @@ in {
       bios = uefiBinary;
     };
 
+    directNetboot = makeTest {
+      name = "directboot-netboot";
+      nodes.machine = {
+        imports = [ ../modules/installer/netboot/netboot-minimal.nix ];
+        virtualisation.memorySize = 4096;
+      };
+      testScript = "machine.fail('stat /dev/vda')";
+    };
+
     uefiNetboot = makeNetbootTest "uefi" {
       bios = uefiBinary;
       # Custom ROM is needed for EFI PXE boot. I failed to understand exactly why, because QEMU should still use iPXE for EFI.


### PR DESCRIPTION
###### Description of changes

This repairs netboot testing, performs some cleanup to move to modern QEMU test infrastructure.

Depends on #228047.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
