### PR TITLE
WIP: transitive-unsupported-packages.nix

### DIFF
--- a/maintainers/scripts/haskell/transitive-unsupported-packages.nix
+++ b/maintainers/scripts/haskell/transitive-unsupported-packages.nix
@@ -1,0 +1,25 @@
+let
+  nixpkgs = import ../../..;
+  inherit (nixpkgs { system = "x86_64-linux"; }) pkgs lib;
+  getEvaluating = x:
+    builtins.attrNames (
+      lib.filterAttrs (
+        _: v: (builtins.tryEval (v.outPath or null)).success && lib.isDerivation v && !v.meta.broken
+      ) x
+    );
+  evaluatingOn-default = getEvaluating pkgs.haskellPackages;
+  evaluatingOn-aarch64-darwin = getEvaluating (nixpkgs { system = "aarch64-darwin"; }).haskellPackages;
+  evaluatingOn-x86_64-darwin = getEvaluating (nixpkgs { system = "x86_64-darwin"; }).haskellPackages;
+  evaluatingOn-aarch64-linux = getEvaluating (nixpkgs { system = "aarch64-linux"; }).haskellPackages;
+  unsupported-aarch64 = lib.subtractLists (evaluatingOn-aarch64-darwin ++ evaluatingOn-aarch64-linux) evaluatingOn-x86_64-darwin;
+  unsupported-darwin = lib.subtractLists (evaluatingOn-aarch64-darwin ++ evaluatingOn-x86_64-darwin) evaluatingOn-aarch64-linux;
+  only-default = lib.subtractLists (evaluatingOn-aarch64-darwin ++ evaluatingOn-x86_64-darwin ++ evaluatingOn-aarch64-linux) evaluatingOn-default;
+in
+''
+  noarm:
+  ${lib.concatMapStringsSep "\n" (x: " - ${x}") unsupported-aarch64}
+  nodarwin:
+  ${lib.concatMapStringsSep "\n" (x: " - ${x}") unsupported-darwin}
+  noeverything:
+  ${lib.concatMapStringsSep "\n" (x: " - ${x}") only-default}
+''


### PR DESCRIPTION
###### Description of changes

This is analogous to the transitive-broken file, but this is currently not very useful because the hackage2nix config has no support to deal with this.
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
