### PR TITLE
linux-wifi-hotspot: Fix desktop file path

### DIFF
--- a/pkgs/os-specific/linux/linux-wifi-hotspot/default.nix
+++ b/pkgs/os-specific/linux/linux-wifi-hotspot/default.nix
@@ -57,6 +57,8 @@ stdenv.mkDerivation rec {
       --replace "/usr" "$out"
     substituteInPlace ./src/desktop/wifihotspot.desktop \
       --replace "/usr" "$out"
+    substituteInPlace ./src/scripts/policies/polkit.policy \
+      --replace "/usr" "$out"
   '';
 
   makeFlags = [

--- a/pkgs/os-specific/linux/linux-wifi-hotspot/default.nix
+++ b/pkgs/os-specific/linux/linux-wifi-hotspot/default.nix
@@ -55,6 +55,8 @@ stdenv.mkDerivation rec {
       --replace "etc" "$out/etc"
     substituteInPlace ./src/scripts/wihotspot \
       --replace "/usr" "$out"
+    substituteInPlace ./src/desktop/wifihotspot.desktop \
+      --replace "/usr" "$out"
   '';
 
   makeFlags = [


### PR DESCRIPTION
###### Description of changes

- Patch correct binary path in desktop file. Fixes https://github.com/NixOS/nixpkgs/issues/228119 
- Patch correct binary in polkit rule. Fixes https://github.com/NixOS/nixpkgs/issues/228120

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
