### PR TITLE
nixos/doas: add options for sudo shim 

### DIFF
--- a/nixos/modules/security/doas.nix
+++ b/nixos/modules/security/doas.nix
@@ -4,8 +4,6 @@ with lib;
 let
   cfg = config.security.doas;
 
-  inherit (pkgs) doas;
-
   mkUsrString = user: toString user;
 
   mkGrpString = group: ":${toString group}";
@@ -50,14 +48,9 @@ in
 
   options.security.doas = {
 
-    enable = mkOption {
-      type = with types; bool;
-      default = false;
-      description = lib.mdDoc ''
-        Whether to enable the {command}`doas` command, which allows
-        non-root users to execute commands as root.
-      '';
-    };
+    enable = mkEnableOption (mdDoc "{command}`doas` command, which allows non-root users to excute commands as root");
+
+    package = mkPackageOptionMD pkgs "doas" {};
 
     wheelNeedsPassword = mkOption {
       type = with types; bool;
@@ -249,11 +242,11 @@ in
       { setuid = true;
         owner = "root";
         group = "root";
-        source = "${doas}/bin/doas";
+        source = "${cfg.package}/bin/doas";
       };
 
     environment.systemPackages = [
-      doas
+      cfg.package
     ];
 
     security.pam.services.doas = {

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -216,6 +216,7 @@ in {
   dnscrypt-wrapper = handleTestOn ["x86_64-linux"] ./dnscrypt-wrapper {};
   dnsdist = handleTest ./dnsdist.nix {};
   doas = handleTest ./doas.nix {};
+  doas-sudo-shim = handleTest ./doas-sudo-shim.nix {};
   docker = handleTestOn ["aarch64-linux" "x86_64-linux"] ./docker.nix {};
   docker-rootless = handleTestOn ["aarch64-linux" "x86_64-linux"] ./docker-rootless.nix {};
   docker-registry = handleTest ./docker-registry.nix {};

--- a/nixos/tests/doas-sudo-shim.nix
+++ b/nixos/tests/doas-sudo-shim.nix
@@ -1,0 +1,31 @@
+# Some tests to ensure doas-sudo-shim is working properly.
+
+import ./make-test-python.nix (
+  { lib, ... }: with lib; {
+    name = "doas-sudo-shim";
+    meta.maintainers = with maintainers; [ dsuetin ];
+
+    nodes.machine = {
+      users.users = {
+        test0 = { isNormalUser = true; extraGroups = [ "wheel" ]; };
+        test1 = { isNormalUser = true; };
+      };
+
+      security.sudo.enable = false;
+
+      security.doas = {
+        enable = true;
+        sudoShim.enable = true;
+        wheelNeedsPassword = false;
+      };
+    };
+
+    testScript = ''
+      with subtest("doas-sudo-shim should work without any options"):
+          machine.succeed("[ $(su test0 -c 'sudo whoami') = 'root' ]")
+
+      with subtest("doas-sudo-shim should work with user option"):
+          machine.succeed("[ $(su test0 -c 'sudo -u test1 whoami') = 'test1' ]")
+    '';
+  }
+)

--- a/pkgs/tools/security/doas-sudo-shim/default.nix
+++ b/pkgs/tools/security/doas-sudo-shim/default.nix
@@ -10,6 +10,7 @@
 , bash
 , makeBinaryWrapper
 , doas-sudo-shim
+, nixosTests
 }:
 
 stdenv.mkDerivation rec {
@@ -41,6 +42,8 @@ stdenv.mkDerivation rec {
       ${doas-sudo-shim}/bin/sudo -h > $out
       grep -q "Execute a command as another user using doas(1)" $out
     '';
+
+    inherit (nixosTests) doas-sudo-shim;
   };
 
   meta = with lib; {

--- a/pkgs/tools/security/doas/default.nix
+++ b/pkgs/tools/security/doas/default.nix
@@ -4,6 +4,7 @@
 , bison
 , pam
 , libxcrypt
+, nixosTests
 
 , withPAM ? true
 , withTimestamp ? true
@@ -47,6 +48,10 @@ stdenv.mkDerivation rec {
   buildInputs = [ ]
     ++ lib.optional withPAM pam
     ++ lib.optional (!withPAM) libxcrypt;
+
+  passthru.tests = {
+    inherit (nixosTests) doas;
+  };
 
   meta = with lib; {
     description = "Executes the given command as another user";


### PR DESCRIPTION
###### Description of changes

Added submodule to `doas` for sudo shim, like `programs.neovim.vimAlias`, but using a shim package which can map `--login` and `--shell` options in sudo style. Useful when running scripts which have dependency on sudo command.

Also added tests and linked them back to package test. Since due to lack of security wrappers it is hard to test in package itself. But with NixOS tests it's possible. Useful for future package updates.

Also added package option, but that's minor.

There are multiple changes in this PR, but the main one is submodule. Others are minor, but if required can split into separate PRs, but put them out sequentially to avoid rebasing too much.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
