### PR TITLE
obs-studio-plugins.obs-transition-table: init at 0.2.6

### DIFF
--- a/pkgs/applications/video/obs-studio/plugins/default.nix
+++ b/pkgs/applications/video/obs-studio/plugins/default.nix
@@ -38,6 +38,8 @@
 
   obs-teleport = callPackage ./obs-teleport { };
 
+  obs-transition-table = qt6Packages.callPackage ./obs-transition-table.nix { };
+
   obs-vaapi = callPackage ./obs-vaapi { };
 
   obs-vkcapture = callPackage ./obs-vkcapture.nix {

--- a/pkgs/applications/video/obs-studio/plugins/obs-transition-table.nix
+++ b/pkgs/applications/video/obs-studio/plugins/obs-transition-table.nix
@@ -1,0 +1,40 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, cmake
+, obs-studio
+, qtbase
+}:
+
+stdenv.mkDerivation rec {
+  pname = "obs-transition-table";
+  version = "0.2.6";
+
+  src = fetchFromGitHub {
+    owner = "exeldro";
+    repo = "obs-transition-table";
+    rev = version;
+    sha256 = "sha256-Is2XWMPhqd/rd6cXc40eSZTvSRpbroTBzM4SPfHOWPg=";
+  };
+
+  nativeBuildInputs = [ cmake ];
+  buildInputs = [ obs-studio qtbase ];
+
+  cmakeFlags = [
+    "-DBUILD_OUT_OF_TREE=On"
+  ];
+
+  dontWrapQtApps = true;
+
+  postInstall = ''
+    rm -rf $out/obs-plugins $out/data
+  '';
+
+  meta = with lib; {
+    description = "Plugin for OBS Studio to add a Transition Table to the tools menu.";
+    homepage = "https://github.com/exeldro/obs-transition-table";
+    maintainers = with maintainers; [ flexiondotorg ];
+    license = licenses.gpl2Plus;
+    platforms = [ "x86_64-linux" "i686-linux" ];
+  };
+}


### PR DESCRIPTION
###### Description of changes

Plugin for OBS Studio to add a Transition Table to the tools menu: https://github.com/exeldro/obs-transition-table

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

Result of `nixpkgs-review` run on x86_64-linux [1](https://github.com/Mic92/nixpkgs-review)
<details>
  <summary>1 package built:</summary>
  <ul>
    <li>obs-studio-plugins.obs-transition-table</li>
  </ul>
</details>

```
 result
├──  lib
│  └──  obs-plugins
│     └──  transition-table.so
└──  share
   └──  obs
      └──  obs-plugins
         └──  transition-table
            └──  locale
               ├──  en-US.ini
               ├──  es-ES.ini
               ├──  nl-NL.ini
               ├──  pt-BR.ini
               └──  zh-CN.ini
```