### PR TITLE
obs-studio-plugins.obs-shaderfilter: init at v1.22

### DIFF
--- a/pkgs/applications/video/obs-studio/plugins/default.nix
+++ b/pkgs/applications/video/obs-studio/plugins/default.nix
@@ -32,6 +32,8 @@
 
   obs-pipewire-audio-capture = callPackage ./obs-pipewire-audio-capture.nix { };
 
+  obs-shaderfilter = qt6Packages.callPackage ./obs-shaderfilter.nix { };
+
   obs-source-clone = callPackage ./obs-source-clone.nix { };
 
   obs-source-record = callPackage ./obs-source-record.nix { };

--- a/pkgs/applications/video/obs-studio/plugins/obs-shaderfilter.nix
+++ b/pkgs/applications/video/obs-studio/plugins/obs-shaderfilter.nix
@@ -1,0 +1,41 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, cmake
+, obs-studio
+, qtbase
+}:
+
+stdenv.mkDerivation rec {
+  pname = "obs-shaderfilter";
+  version = "v1.22";
+
+  src = fetchFromGitHub {
+    owner = "exeldro";
+    repo = "obs-shaderfilter";
+    rev = version;
+    sha256 = "sha256-CqqYzGRhlHO8Zva+so8uo9+EIlzTfoFVl3NzZMsE7Xc=";
+  };
+
+  nativeBuildInputs = [ cmake ];
+  buildInputs = [ obs-studio qtbase ];
+
+  cmakeFlags = [
+    "-DBUILD_OUT_OF_TREE=On"
+  ];
+
+  dontWrapQtApps = true;
+
+  postInstall = ''
+    rm -rf $out/obs-plugins
+    mv $out/data $out/share/obs
+  '';
+
+  meta = with lib; {
+    description = "OBS Studio filter for applying an arbitrary shader to a source.";
+    homepage = "https://github.com/exeldro/obs-shaderfilter";
+    maintainers = with maintainers; [ flexiondotorg ];
+    license = licenses.gpl2Plus;
+    platforms = [ "x86_64-linux" "i686-linux" ];
+  };
+}


### PR DESCRIPTION
###### Description of changes

OBS Studio filter for applying an arbitrary shader to a source: https://github.com/exeldro/obs-shaderfilter

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

Result of `nixpkgs-review` run on x86_64-linux [1](https://github.com/Mic92/nixpkgs-review)
<details>
  <summary>1 package built:</summary>
  <ul>
    <li>obs-studio-plugins.obs-shaderfilter</li>
  </ul>
</details>

```
 result
├──  lib
│  └──  obs-plugins
│     └──  obs-shaderfilter.so
└──  share
   └──  obs
      ├──  data
      │  └──  obs-plugins
      │     └──  obs-shaderfilter
      │        ├──  examples
      │        │  ├──  Add.shader
      │        │  ├──  alpha-gaming-bent-camera.shader
      │        │  ├──  alpha_border.shader
      │        │  ├──  animated_path.effect
      │        │  ├──  animated_texture.effect
      │        │  ├──  ascii.shader
      │        │  ├──  aspect_ratio.shader
      │        │  ├──  background_removal.effect
      │        │  ├──  blend_opacity.shader
      │        │  ├──  blink.shader
      │        │  ├──  bloom.shader
      │        │  ├──  border.shader
      │        │  ├──  box-blur.shader
      │        │  ├──  bt601tobt709.shader
      │        │  ├──  bt709tobt601.shader
      │        │  ├──  BulgePinch.shader
      │        │  ├──  burn.shader
      │        │  ├──  cartoon.effect
      │        │  ├──  cell_shaded.shader
      │        │  ├──  Chroma+UV-Distortion.shader
      │        │  ├──  chromatic-aberration.shader
      │        │  ├──  chromatic-aberration_blackbg.shader
      │        │  ├──  circle.shader
      │        │  ├──  color-depth.shader
      │        │  ├──  color_grade_filter.shader
      │        │  ├──  corner-pin.shader
      │        │  ├──  corner_pin.shader
      │        │  ├──  cut_rect_per_corner.shader
      │        │  ├──  cylinder.shader
      │        │  ├──  darken.shader
      │        │  ├──  divide_rotate.shader
      │        │  ├──  doodle.effect
      │        │  ├──  drawings.shader
      │        │  ├──  drop_shadow.shader
      │        │  ├──  drunk.shader
      │        │  ├──  edge_detection.shader
      │        │  ├──  embers.effect
      │        │  ├──  emboss.shader
      │        │  ├──  emboss_color.shader
      │        │  ├──  exeldro-bent-camera.shader
      │        │  ├──  filter_template.effect
      │        │  ├──  filter_template.shader
      │        │  ├──  fire-3.effect
      │        │  ├──  fire.shader
      │        │  ├──  fisheye-xy.shader
      │        │  ├──  fisheye.shader
      │        │  ├──  frosted_glass.shader
      │        │  ├──  gamma_correction.shader
      │        │  ├──  gaussian-blur-advanced.shader
      │        │  ├──  gaussian-blur-simple.shader
      │        │  ├──  gaussian-blur.effect
      │        │  ├──  gaussian-example.effect
      │        │  ├──  gaussian-simple.shader
      │        │  ├──  glass.shader
      │        │  ├──  glitch.shader
      │        │  ├──  glitch_analog.effect
      │        │  ├──  glitch_analog.shader
      │        │  ├──  glow.shader
      │        │  ├──  gradient.shader
      │        │  ├──  heat-wave-simple.shader
      │        │  ├──  hexagon.shader
      │        │  ├──  Invert.shader
      │        │  ├──  Luminance.shader
      │        │  ├──  luminance2.shader
      │        │  ├──  luminance_alpha.effect
      │        │  ├──  matrix.effect
      │        │  ├──  multiply.shader
      │        │  ├──  night_sky.shader
      │        │  ├──  perlin_noise.shader
      │        │  ├──  pie-chart.shader
      │        │  ├──  pixelation.effect
      │        │  ├──  pixelation.shader
      │        │  ├──  pulse.effect
      │        │  ├──  rainbow.shader
      │        │  ├──  rectangular_drop_shadow.shader
      │        │  ├──  remove_partial_pixels.shader
      │        │  ├──  repeat.effect
      │        │  ├──  repeat_texture.effect
      │        │  ├──  rgb_color_wheel.shader
      │        │  ├──  ripple.shader
      │        │  ├──  rotatoe.effect
      │        │  ├──  rounded_rect.shader
      │        │  ├──  rounded_rect2.shader
      │        │  ├──  rounded_rect_per_corner.shader
      │        │  ├──  rounded_rect_per_side.shader
      │        │  ├──  rounded_stroke.shader
      │        │  ├──  rounded_stroke_gradient.shader
      │        │  ├──  scan_line.shader
      │        │  ├──  seasick.shader
      │        │  ├──  selective_color.shader
      │        │  ├──  shake.effect
      │        │  ├──  shine.shader
      │        │  ├──  simple_gradient.shader
      │        │  ├──  simplex_noise.shader
      │        │  ├──  spotlight.shader
      │        │  ├──  Swirl.shader
      │        │  ├──  twist.shader
      │        │  ├──  two-pass-drop-shadow.effect
      │        │  ├──  VCR.shader
      │        │  ├──  VHS.shader
      │        │  ├──  vignetting.shader
      │        │  ├──  ZigZag.shader
      │        │  ├──  zoom.shader
      │        │  └──  zoom_blur.shader
      │        ├──  locale
      │        │  └──  en-US.ini
      │        └──  textures
      │           ├──  blank.png
      │           ├──  burngradient.png
      │           ├──  burngradient_small.png
      │           ├──  canvas.png
      │           ├──  giraffe.png
      │           ├──  Rainbow-a.png
      │           ├──  Rainbow-a2.png
      │           ├──  Rainbow-b.png
      │           ├──  Rainbow-c.png
      │           ├──  Rainbow.png
      │           ├──  Rainbow2.png
      │           ├──  TileableLinearApertureGrille15Wide8And5d5Spacing.png
      │           ├──  TileableLinearApertureGrille15Wide8And5d5SpacingResizeTo64.png
      │           ├──  TileableLinearShadowMask.png
      │           ├──  TileableLinearShadowMaskEDP.png
      │           ├──  TileableLinearShadowMaskEDPResizeTo64.png
      │           ├──  TileableLinearShadowMaskResizeTo64.png
      │           ├──  TileableLinearSlotMaskTall15Wide9And4d5Horizontal9d14VerticalSpacing.png
      │           └──  TileableLinearSlotMaskTall15Wide9And4d5Horizontal9d14VerticalSpacingResizeTo64.png
      └──  obs-plugins
         └──  obs-shaderfilter
            └──  locale
               └──  en-US.ini
```