### PR TITLE
python3Packages.pytest-ansible: 2.2.4 -> 3.0.0

### DIFF
--- a/pkgs/development/python-modules/pytest-ansible/default.nix
+++ b/pkgs/development/python-modules/pytest-ansible/default.nix
@@ -1,46 +1,46 @@
 { lib
 , buildPythonPackage
 , fetchFromGitHub
-, ansible
-, pytest
-, mock
+, ansible-core
+, coreutils
+, coverage
+, pytestCheckHook
 }:
 
 buildPythonPackage rec {
   pname = "pytest-ansible";
-  version = "2.2.4";
+  version = "3.0.0";
 
   src = fetchFromGitHub {
     owner = "ansible";
-    repo = "pytest-ansible";
+    repo = pname;
     rev = "v${version}";
-    sha256 = "0vr015msciwzz20zplxalfmfx5hbg8rkf8vwjdg3z12fba8z8ks4";
+    sha256 = "sha256-kxOp7ScpIIzEbM4VQa+3ByHzkPS8pzdYq82rggF9Fpk=";
   };
 
-  patchPhase = ''
-    sed -i "s/'setuptools-markdown'//g" setup.py
+  postPatch = ''
+    substituteInPlace tests/conftest.py inventory --replace '/usr/bin/env' '${coreutils}/bin/env'
   '';
 
-  buildInputs = [ pytest ];
+  nativeCheckInputs =  [ pytestCheckHook coverage ];
+  propagatedBuildInputs = [ ansible-core ];
 
-  # requires pandoc < 2.0
-  # buildInputs = [ setuptools-markdown ];
-  nativeCheckInputs =  [ mock ];
-  propagatedBuildInputs = [ ansible ];
+  format = "pyproject";
 
-  # tests not included with release, even on github
-  doCheck = false;
-
-  checkPhase = ''
-    HOME=$TMPDIR pytest tests/
-  '';
+  preCheck = "export HOME=$TMPDIR";
+  pytestFlagsArray = [ "tests/" ];
+  disabledTests = [
+    # Host unreachable in the inventory
+    "test_become"
+    # [Errno -3] Temporary failure in name resolution
+    "test_connection_failure_v2"
+    "test_connection_failure_extra_inventory_v2"
+  ];
 
   meta = with lib; {
     homepage = "https://github.com/jlaska/pytest-ansible";
     description = "Plugin for py.test to simplify calling ansible modules from tests or fixtures";
     license = licenses.mit;
     maintainers = [ maintainers.costrouc ];
-    # https://github.com/ansible-community/pytest-ansible/blob/v2.2.4/setup.py#L124
-    broken = lib.versionAtLeast ansible.version "2.10";
   };
 }

--- a/pkgs/development/python-modules/pytest-ansible/default.nix
+++ b/pkgs/development/python-modules/pytest-ansible/default.nix
@@ -4,31 +4,51 @@
 , ansible-core
 , coreutils
 , coverage
+, pytest
 , pytestCheckHook
+, pythonOlder
 }:
 
 buildPythonPackage rec {
   pname = "pytest-ansible";
   version = "3.0.0";
+  format = "pyproject";
+
+  disabled = pythonOlder "3.9";
 
   src = fetchFromGitHub {
     owner = "ansible";
     repo = pname;
-    rev = "v${version}";
-    sha256 = "sha256-kxOp7ScpIIzEbM4VQa+3ByHzkPS8pzdYq82rggF9Fpk=";
+    rev = "refs/tags/v${version}";
+    hash = "sha256-kxOp7ScpIIzEbM4VQa+3ByHzkPS8pzdYq82rggF9Fpk=";
   };
 
   postPatch = ''
-    substituteInPlace tests/conftest.py inventory --replace '/usr/bin/env' '${coreutils}/bin/env'
+    substituteInPlace tests/conftest.py inventory \
+      --replace '/usr/bin/env' '${coreutils}/bin/env'
   '';
 
-  nativeCheckInputs =  [ pytestCheckHook coverage ];
-  propagatedBuildInputs = [ ansible-core ];
+  buildInputs = [
+    pytest
+  ];
 
-  format = "pyproject";
+  propagatedBuildInputs = [
+    ansible-core
+  ];
 
-  preCheck = "export HOME=$TMPDIR";
-  pytestFlagsArray = [ "tests/" ];
+  nativeCheckInputs = [
+    coverage
+    pytestCheckHook
+  ];
+
+  preCheck = ''
+    export HOME=$TMPDIR
+  '';
+
+  pytestFlagsArray = [
+    "tests/"
+  ];
+
   disabledTests = [
     # Host unreachable in the inventory
     "test_become"
@@ -37,10 +57,15 @@ buildPythonPackage rec {
     "test_connection_failure_extra_inventory_v2"
   ];
 
+  pythonImportsCheck = [
+    "pytest_ansible"
+  ];
+
   meta = with lib; {
-    homepage = "https://github.com/jlaska/pytest-ansible";
     description = "Plugin for py.test to simplify calling ansible modules from tests or fixtures";
+    homepage = "https://github.com/jlaska/pytest-ansible";
+    changelog = "https://github.com/ansible-community/pytest-ansible/releases/tag/v${version}";
     license = licenses.mit;
-    maintainers = [ maintainers.costrouc ];
+    maintainers = with maintainers; [ costrouc ];
   };
 }


### PR DESCRIPTION
Found this revdeps is broken on master while reviewing: https://github.com/NixOS/nixpkgs/pull/220183

`python39Packages.pytest-ansible` should be fixed but a deps is failing check so it can't be built.
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
