### PR TITLE
python3Packages.python-lsp-ruff: init at 1.4.0

### DIFF
--- a/pkgs/development/python-modules/python-lsp-ruff/default.nix
+++ b/pkgs/development/python-modules/python-lsp-ruff/default.nix
@@ -1,0 +1,45 @@
+{ lib
+, pythonOlder
+, buildPythonPackage
+, fetchPypi
+, ruff
+, lsprotocol
+, python-lsp-server
+, tomli
+}:
+
+buildPythonPackage rec {
+  pname = "python-lsp-ruff";
+  version = "1.4.0";
+  format = "pyproject";
+  disabled = pythonOlder "3.7";
+
+  src = fetchPypi {
+    inherit version;
+    pname = "python-lsp-ruff";
+    sha256 = "sha256-TqTeQc/lT5DcPcJbZXbEiUGbYjFP8idpzdSZlXD59Y4=";
+  };
+
+  postPatch = ''
+    # ruff binary is used directly, the ruff python package is not needed
+    sed -i '/"ruff>=/d' pyproject.toml
+    sed -i 's|sys.executable, "-m", "ruff"|"${ruff}/bin/ruff"|' pylsp_ruff/plugin.py
+  '';
+
+  propagatedBuildInputs = [
+    lsprotocol
+    python-lsp-server
+  ] ++ lib.optionals (pythonOlder "3.11") [
+    tomli
+  ];
+
+  doCheck = true;
+
+  meta = with lib; {
+    homepage = "https://github.com/python-lsp/python-lsp-ruff";
+    description = "Ruff linting plugin for pylsp";
+    changelog = "https://github.com/python-lsp/python-lsp-ruff/releases/tag/v${version}";
+    license = licenses.mit;
+    maintainers = with maintainers; [ linsui ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -9603,6 +9603,8 @@ self: super: with self; {
 
   python-lsp-jsonrpc = callPackage ../development/python-modules/python-lsp-jsonrpc { };
 
+  python-lsp-ruff = callPackage ../development/python-modules/python-lsp-ruff { };
+
   python-lsp-server = callPackage ../development/python-modules/python-lsp-server { };
 
   python-ly = callPackage ../development/python-modules/python-ly { };


### PR DESCRIPTION
###### Description of changes

A plugin of python-lsp-server for ruff.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
