### PR TITLE
livecaptions: init at 0.4.0

### DIFF
--- a/pkgs/applications/misc/livecaptions/default.nix
+++ b/pkgs/applications/misc/livecaptions/default.nix
@@ -1,0 +1,76 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  fetchurl,
+  meson,
+  ninja,
+  pkg-config,
+  cmake,
+  desktop-file-utils,
+  wrapGAppsHook4,
+  onnxruntime,
+  libadwaita,
+  libpulseaudio,
+  xorg,
+}: let
+  aprilAsr = fetchFromGitHub {
+    name = "april-asr";
+    owner = "abb128";
+    repo = "april-asr";
+    rev = "c2f138c674cad58e2708ecaddc95cc72e7f85549";
+    sha256 = "hZe2iss3BGdzeTM5FCp9wp6LaDOjtGJrZS5vB5F6uLg=";
+  };
+
+  aprilModel = fetchurl {
+    name = "aprilv0_en-us.april";
+    url = "https://april.sapples.net/aprilv0_en-us.april";
+    sha256 = "9aMPiI55d2mxt94UPAXSySoXAsJjtbcdYv0gKM7eVic=";
+  };
+in
+  stdenv.mkDerivation rec {
+    pname = "livecaptions";
+    version = "0.4.0";
+
+    src = fetchFromGitHub {
+      owner = "abb128";
+      repo = "LiveCaptions";
+      rev = "v${version}";
+      hash = "sha256-RepuvqNPHRGENupPG5ezadn6f7FxEUYFDi4+DpNanuA=";
+    };
+
+    nativeBuildInputs = [
+      meson
+      ninja
+      pkg-config
+      cmake
+      desktop-file-utils # update-desktop-database
+      wrapGAppsHook4
+    ];
+
+    buildInputs = [
+      onnxruntime
+      libadwaita
+      libpulseaudio
+      xorg.libX11
+    ];
+
+    postUnpack = ''
+      rm -r source/subprojects/april-asr
+      ln -sf ${aprilAsr} source/subprojects/april-asr
+    '';
+
+    preFixup = ''
+      gappsWrapperArgs+=(
+        --set APRIL_MODEL_PATH ${aprilModel}
+      )
+    '';
+
+    meta = with lib; {
+      description = "Linux Desktop application that provides live captioning";
+      homepage = "https://github.com/abb128/LiveCaptions";
+      license = licenses.gpl3Plus;
+      platforms = platforms.linux;
+      maintainers = with maintainers; [Scrumplex];
+    };
+  }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1033,6 +1033,8 @@ with pkgs;
 
   libredirect = callPackage ../build-support/libredirect { };
 
+  livecaptions = callPackage ../applications/misc/livecaptions { };
+
   madonctl = callPackage ../applications/misc/madonctl { };
 
   copyDesktopItems = makeSetupHook {


### PR DESCRIPTION
###### Description of changes

[LiveCaptions](https://github.com/abb128/LiveCaptions) is a desktop application that provides live captioning, similar to the feature on Android distributions with the same name.

This package also bundles the default model recommended by upstream here: https://abb128.github.io/april-asr/models.html

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
