### PR TITLE
python310Packages.pillow: 9.4.0 -> 9.5.0

### DIFF
--- a/pkgs/development/python-modules/pillow/default.nix
+++ b/pkgs/development/python-modules/pillow/default.nix
@@ -4,6 +4,7 @@
 , pythonOlder
 , fetchPypi
 , isPyPy
+, fetchpatch
 , defusedxml, olefile, freetype, libjpeg, zlib, libtiff, libwebp, libxcrypt, tcl, lcms2, tk, libX11
 , libxcb, openjpeg, libimagequant, pyroma, numpy, pytestCheckHook
 # for passthru.tests
@@ -12,7 +13,7 @@
 
 import ./generic.nix (rec {
   pname = "pillow";
-  version = "9.4.0";
+  version = "9.5.0";
   format = "setuptools";
 
   disabled = pythonOlder "3.7";
@@ -20,8 +21,32 @@ import ./generic.nix (rec {
   src = fetchPypi {
     pname = "Pillow";
     inherit version;
-    hash = "sha256-ocLXeARI65P7zDeJvzkWqlcg2ULjeUX0BWaAMX8c0j4=";
+    hash = "sha256-v1SEedM2cm16Ds6252fhefveN4M65CeUYCYxoHDWMPE=";
   };
+
+  # Reverts 04cf5e2cfc5dc1676efd9f5c8d605ddfccb0f9ee, which prevents pillow from
+  # finding zlib. This has been fixed upstream, so this patch can be removed on
+  # next pillow update.
+  patches = [
+    (fetchpatch {
+      name = "revert-multiple-paths-in-pkgconfig1.patch";
+      url = "https://github.com/python-pillow/pillow/commit/17a0a2ee3eeb9df6e9fcf894d204911c7e6e4eef.patch";
+      sha256 = "sha256-wAJfCYhBmXaVcVMwNBTk7kCpuJucAmetJTWtL155Ybc=";
+      revert = true;
+    })
+    (fetchpatch {
+      name = "revert-multiple-paths-in-pkgconfig2.patch";
+      url = "https://github.com/python-pillow/pillow/commit/a0492f796876c2a9b8ba445d72c771b84eff93a5.patch";
+      sha256 = "sha256-vCBRczrl9v5QWrYkt85Nb06+ZXKt9GxTxg3djn4/m2o=";
+      revert = true;
+    })
+    (fetchpatch {
+      name = "revert-multiple-paths-in-pkgconfig3.patch";
+      url = "https://github.com/python-pillow/pillow/commit/04cf5e2cfc5dc1676efd9f5c8d605ddfccb0f9ee.patch";
+      sha256 = "sha256-7uvNEUk6fBCBkwcqg6njhsAJGla11diz8KY966zsxew";
+      revert = true;
+    })
+  ];
 
   passthru.tests = {
     inherit imageio matplotlib pilkit pydicom reportlab;


### PR DESCRIPTION
###### Description of changes

Pillow changelog: https://github.com/python-pillow/Pillow/blob/main/CHANGES.rst#950-2023-04-01

Note that this MR reverts an upstream commit (04cf5e2cfc5dc1676efd9f5c8d605ddfccb0f9ee) as it prevents pillow from finding its native dependencies during the build. We should probably try to fix the underlying issue, but I'm having trouble understanding what the patch even does.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).