### PR TITLE
python38Packages.cryptography: fix build with libxcrypt

### DIFF
--- a/pkgs/development/python-modules/cryptography/default.nix
+++ b/pkgs/development/python-modules/cryptography/default.nix
@@ -18,6 +18,7 @@
 , pythonOlder
 , pretend
 , libiconv
+, libxcrypt
 , iso8601
 , py
 , pytz
@@ -56,7 +57,8 @@ buildPythonPackage rec {
   ] ++ (with rustPlatform; [ rust.cargo rust.rustc ]);
 
   buildInputs = [ openssl ]
-    ++ lib.optionals stdenv.isDarwin [ Security libiconv ];
+    ++ lib.optionals stdenv.isDarwin [ Security libiconv ]
+    ++ lib.optionals (pythonOlder "3.9") [ libxcrypt ];
 
   propagatedBuildInputs = lib.optionals (!isPyPy) [
     cffi


### PR DESCRIPTION
###### Description of changes

This fixes the build of `python38Packages.cryptography`:

```
The following warnings were emitted during compilation:

warning: In file included from /build/cryptography-40.0.1/src/rust/target/release/build/cryptography-rust-46be46709bffef16/out/_openssl.c:57:
warning: /nix/store/1mdmddvxmb16ap5vgv6ifv6m0xkhf04i-python3-3.8.16/include/python3.8/Python.h:44:10: fatal error: crypt.h: No such file or directory
warning:    44 | #include <crypt.h>
warning:       |          ^~~~~~~~~
warning: compilation terminated.

error: failed to run custom build command for `cryptography-rust v0.1.0 (/build/cryptography-40.0.1/src/rust)`
```

`python38Packages.cryptography` is used by something in `grab-site`'s dependencies (grab-site is stuck on Python 3.8 at the moment).

Similar to https://github.com/NixOS/nixpkgs/pull/198045 https://github.com/NixOS/nixpkgs/pull/225731

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

cc @mweinelt

cc maintainer @SuperSandro2000 