### PR TITLE
rpm: 4.18.0 -> 4.18.1

### DIFF
--- a/pkgs/tools/package-management/rpm/default.nix
+++ b/pkgs/tools/package-management/rpm/default.nix
@@ -1,22 +1,22 @@
 { stdenv, lib
-, pkg-config, autoreconfHook
+, pkg-config, autoreconfHook, pandoc
 , fetchurl, cpio, zlib, bzip2, file, elfutils, libbfd, libgcrypt, libarchive, nspr, nss, popt, db, xz, python, lua, llvmPackages
 , sqlite, zstd, libcap
 }:
 
 stdenv.mkDerivation rec {
   pname = "rpm";
-  version = "4.18.0";
+  version = "4.18.1";
 
   src = fetchurl {
     url = "https://ftp.osuosl.org/pub/rpm/releases/rpm-${lib.versions.majorMinor version}.x/rpm-${version}.tar.bz2";
-    hash = "sha256-KhcVLXGHqzDt8sL7WGRjvfY4jee1g3SAlVZZ5ekFRVQ=";
+    hash = "sha256-N/O0LAlmlB4q0/EP3jY5gkplkdBxl7qP0IacoHeeH1Y=";
   };
 
   outputs = [ "out" "dev" "man" ];
   separateDebugInfo = true;
 
-  nativeBuildInputs = [ autoreconfHook pkg-config ];
+  nativeBuildInputs = [ autoreconfHook pkg-config pandoc ];
   buildInputs = [ cpio zlib zstd bzip2 file libarchive libgcrypt nspr nss db xz python lua sqlite ]
                 ++ lib.optional stdenv.cc.isClang llvmPackages.openmp
                 ++ lib.optional stdenv.isLinux libcap;


### PR DESCRIPTION
###### Description of changes

Release notes:
https://rpm.org/wiki/Releases/4.18.1
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

No new build failures.


Result of `nixpkgs-review` run on x86_64-linux [1](https://github.com/Mic92/nixpkgs-review)
<details>
  <summary>6 packages failed to build:</summary>
  <ul>
    <li>clmagma</li>
    <li>febio</li>
    <li>hqplayer-desktop</li>
    <li>hqplayerd</li>
    <li>lattice-diamond</li>
    <li>nice-dcv-client</li>
  </ul>
</details>
<details>
  <summary>93 packages built:</summary>
  <ul>
    <li>aliza</li>
    <li>apkg</li>
    <li>apkg.dist</li>
    <li>bluejeans-gui</li>
    <li>clair</li>
    <li>createrepo_c</li>
    <li>dell-530cdn</li>
    <li>diffoscope</li>
    <li>diffoscope.dist</li>
    <li>diffoscope.man</li>
    <li>diffoscopeMinimal</li>
    <li>diffoscopeMinimal.dist</li>
    <li>diffoscopeMinimal.man</li>
    <li>doodle</li>
    <li>drawio</li>
    <li>drawio-headless</li>
    <li>dsseries</li>
    <li>dtrx</li>
    <li>dtrx.dist</li>
    <li>epkowa</li>
    <li>epm</li>
    <li>epson-201106w</li>
    <li>epson-201401w</li>
    <li>epson-workforce-635-nx625-series</li>
    <li>epson_201207w</li>
    <li>flatpak-builder</li>
    <li>flatpak-builder.doc</li>
    <li>flatpak-builder.installedTests</li>
    <li>flatpak-builder.man</li>
    <li>gnunet</li>
    <li>gnunet-gtk</li>
    <li>gutenprintBin</li>
    <li>hpmyroom</li>
    <li>hydra_unstable</li>
    <li>intel-ocl</li>
    <li>libdnf</li>
    <li>libextractor</li>
    <li>libmodulemd</li>
    <li>libmodulemd.bin</li>
    <li>libmodulemd.dev</li>
    <li>libmodulemd.devdoc</li>
    <li>libmodulemd.man</li>
    <li>libmodulemd.py (python310Packages.libmodulemd ,python310Packages.libmodulemd.bin ,python310Packages.libmodulemd.dev ,python310Packages.libmodulemd.devdoc ,python310Packages.libmodulemd.man ,python310Packages.libmodulemd.py)</li>
    <li>libsolv</li>
    <li>megacli</li>
    <li>microdnf</li>
    <li>micromamba</li>
    <li>mkl</li>
    <li>pandoc-drawio-filter</li>
    <li>pandoc-drawio-filter.dist</li>
    <li>perccli</li>
    <li>perl534Packages.RPM2</li>
    <li>perl534Packages.RPM2.devdoc</li>
    <li>perl536Packages.RPM2</li>
    <li>perl536Packages.RPM2.devdoc</li>
    <li>postscript-lexmark</li>
    <li>python310Packages.mkdocs-drawio-exporter</li>
    <li>python310Packages.mkdocs-drawio-exporter.dist</li>
    <li>python310Packages.mkl-service</li>
    <li>python310Packages.mkl-service.dist</li>
    <li>python310Packages.osc</li>
    <li>python310Packages.osc.dist</li>
    <li>rpm (python310Packages.rpm)</li>
    <li>rpm.debug (python310Packages.rpm.debug)</li>
    <li>rpm.dev (python310Packages.rpm.dev)</li>
    <li>rpm.man (python310Packages.rpm.man)</li>
    <li>python311Packages.libmodulemd (python311Packages.libmodulemd.bin ,python311Packages.libmodulemd.dev ,python311Packages.libmodulemd.devdoc ,python311Packages.libmodulemd.man ,python311Packages.libmodulemd.py)</li>
    <li>python311Packages.mkdocs-drawio-exporter</li>
    <li>python311Packages.mkdocs-drawio-exporter.dist</li>
    <li>python311Packages.mkl-service</li>
    <li>python311Packages.mkl-service.dist</li>
    <li>python311Packages.osc</li>
    <li>python311Packages.osc.dist</li>
    <li>python311Packages.rpm</li>
    <li>python311Packages.rpm.debug</li>
    <li>python311Packages.rpm.dev</li>
    <li>python311Packages.rpm.man</li>
    <li>realvnc-vnc-viewer</li>
    <li>rpm-ostree</li>
    <li>rpm-ostree.dev</li>
    <li>rpm-ostree.devdoc</li>
    <li>rpm-ostree.man</li>
    <li>rpmextract</li>
    <li>scaleft</li>
    <li>snowsql</li>
    <li>storcli</li>
    <li>taler-exchange</li>
    <li>taler-merchant</li>
    <li>tsm-client</li>
    <li>tsm-client-withGui</li>
    <li>utsushi-networkscan</li>
    <li>vk-messenger</li>
    <li>yandex-disk</li>
  </ul>
</details>