### PR TITLE
[22.11] cinnamon.warpinator: 1.2.15 -> 1.4.5

### DIFF
--- a/pkgs/desktops/cinnamon/warpinator/CVE-2023-29380.patch
+++ b/pkgs/desktops/cinnamon/warpinator/CVE-2023-29380.patch
@@ -1,0 +1,212 @@
+From a7f280b679bf52a52ecb9f47c9dbcc8e78de0894 Mon Sep 17 00:00:00 2001
+From: Michael Webster <miketwebster@gmail.com>
+Date: Wed, 22 Feb 2023 14:33:48 -0500
+Subject: [PATCH] Improve incoming file path validation.
+
+- Refactor test.
+- Check top_dir_basenames when processing initial request, and
+  immediately fail the transfer if necessary.
+- Check individual files during transfer as before.
+
+These are less important when using landlock/bubblewrap but will
+provide better explanations for any issues than 'read only
+filesystem'.
+---
+ src/ops.py       | 12 +++++++++++
+ src/remote.py    | 13 ++++++++++++
+ src/transfers.py | 55 ++++++++++++++++++++++++++++++++----------------
+ src/util.py      | 24 +++++++++++++++++++++
+ 4 files changed, 86 insertions(+), 18 deletions(-)
+
+diff --git a/src/ops.py b/src/ops.py
+index db5b925..00c5da0 100644
+--- a/src/ops.py
++++ b/src/ops.py
+@@ -2,6 +2,7 @@
+ 
+ import gettext
+ import logging
++from pathlib import Path
+ 
+ from gi.repository import GObject, GLib, Gio
+ 
+@@ -228,6 +229,17 @@ class ReceiveOp(CommonOp):
+         self.size_string = GLib.format_size(self.total_size)
+         logging.debug("Op: details: %d files, with a size of %s" % (self.total_count, self.size_string))
+ 
++        # Check that toplevels are valid, safe. This is done immediately to prevent some sort of runaway
++        # free-space check.
++        for top_dir in self.top_dir_basenames:
++            try:
++                util.test_resolved_path_safety(top_dir)
++            except ReceiveError as e:
++                self.set_error(e)
++                self.status = OpStatus.FAILED_UNRECOVERABLE
++                self.emit_initial_setup_complete()
++                return
++
+         self.have_space = util.have_free_space(self.total_size)
+         self.existing = util.files_exist(self.top_dir_basenames)
+         self.update_ui_info()
+diff --git a/src/remote.py b/src/remote.py
+index 2203d81..5d38347 100644
+--- a/src/remote.py
++++ b/src/remote.py
+@@ -457,6 +457,10 @@ class RemoteMachine(GObject.Object):
+         def report_receive_error(error):
+             op.file_iterator = None
+ 
++            # Get rid of any toplevel file/folder if the transfer stops prematurely,
++            # so it or its children
++            receiver.clean_current_top_dir_file()
++
+             if error is None:
+                 return
+ 
+@@ -476,6 +480,8 @@ class RemoteMachine(GObject.Object):
+             op.stop_transfer()
+ 
+         try:
++            receiver.clean_existing_files()
++
+             for data in op.file_iterator:
+                 receiver.receive_data(data)
+ 
+@@ -581,6 +587,13 @@ class RemoteMachine(GObject.Object):
+         op.connect("active", lambda op: set_busy())
+ 
+         self.emit_ops_changed()
++
++        # For now, only bad base filenames cause this (failed util.test_resolved_path_safety())
++        # We let it get this far so the UI has something to show the user.
++        if op.status == OpStatus.FAILED_UNRECOVERABLE:
++            op.decline_transfer_request()
++            return
++
+         self.check_for_autostart(op)
+ 
+     @util._idle
+diff --git a/src/transfers.py b/src/transfers.py
+index 13ce8c3..e3b1888 100644
+--- a/src/transfers.py
++++ b/src/transfers.py
+@@ -184,23 +184,45 @@ class FileReceiver(GObject.Object):
+         self.remaining_files = op.total_count
+         self.remaining_bytes = op.total_size
+ 
+-        for name in op.top_dir_basenames:
+-            try:
+-                path = os.path.join(self.save_path, name)
+-                if os.path.isdir(path): # file not found is ok
+-                    shutil.rmtree(path)
+-                else:
+-                    os.remove(path)
+-            except FileNotFoundError:
+-                pass
+-            except Exception as e:
+-                logging.warning("Problem removing existing files.  Transfer may not succeed: %s" % e)
+-
+         # We write files top-down.  If we're preserving permissions and we receive
+         # a folder in some hierarchy that is not writable, we won't be able to create
+         # anything inside it.
+         self.folder_permission_change_list = []
+ 
++    def clean_existing_files(self):
++        logging.debug("Removing any existing files matching the pending transfer")
++        for name in self.op.top_dir_basenames:
++            path = Path(os.path.join(self.save_path, name))
++            self.rm_any(path)
++
++    def clean_current_top_dir_file(self):
++        if self.current_path is not None:
++            current = Path(self.current_path)
++            save = Path(self.save_path)
++
++            try:
++                relative = current.relative_to(save)
++                util.test_resolved_path_safety(relative.as_posix())
++            except (ValueError, ReceiveError) as e:
++                logging.critical("Partial file or directory from aborted transfer is invalid: %s" % str(e))
++                return
++
++            abs_top_dir = save.joinpath(relative.parts[0])
++            logging.debug("Removing partial file or directory: %s" % abs_top_dir)
++
++            self.rm_any(abs_top_dir)
++
++    def rm_any(self, path):
++        try:
++            try:
++                os.remove(path)
++            except IsADirectoryError:
++                shutil.rmtree(path)
++        except FileNotFoundError:
++            pass
++        except Exception as e:
++            logging.warning("Problem removing existing files: %s" % e)
++
+     def receive_data(self, s):
+         save_path = prefs.get_save_path()
+ 
+@@ -212,16 +234,13 @@ class FileReceiver(GObject.Object):
+             self.current_type = s.file_type
+             self.current_mtime = s.time.mtime
+             self.current_mtime_usec = s.time.mtime_usec
++            if not s.relative_path.startswith(tuple(self.op.top_dir_basenames)):
++                raise ReceiveError("File path is not descended from a valid toplevel directory: %s" % s.relative_path)
+         if self.remaining_files == 0:
+             raise Exception(_("File count exceeds original request size"))
+ 
+         if not self.current_gfile:
+-            # Check for valid path (pathlib.Path resolves both relative and symbolically-linked paths)
+-            test_path = Path(path).resolve()
+-            try:
+-                test_path.relative_to(self.save_path_obj)
+-            except ValueError:
+-                raise ReceiveError(_("Resolved path is not valid: %s -> %s") % (path, str(test_path)), fatal=True)
++            util.test_resolved_path_safety(s.relative_path)
+ 
+             self.current_gfile = Gio.File.new_for_path(path)
+ 
+diff --git a/src/util.py b/src/util.py
+index ddb0bfd..b6cb929 100644
+--- a/src/util.py
++++ b/src/util.py
+@@ -5,6 +5,7 @@ import gettext
+ import math
+ import logging
+ import os
++from pathlib import Path
+ import socket
+ import traceback
+ from concurrent.futures import ThreadPoolExecutor
+@@ -241,6 +242,29 @@ def open_save_folder(filename=None):
+ def verify_save_folder(transient_for=None):
+     return os.access(prefs.get_save_path(), os.R_OK | os.W_OK)
+ 
++def test_resolved_path_safety(relative_path):
++    # Check for valid path (pathlib.Path resolves both relative and symbolically-linked paths)
++    base = Path(prefs.get_save_path())
++    unresolved = base.joinpath(relative_path)
++
++    try:
++        resolved = unresolved.resolve()
++
++        # Not outside the base folder (raises ValueError)
++        relative = resolved.relative_to(base)
++
++        # Not the base folder (../Warpinator.. )
++        try:
++            if resolved.samefile(base):
++                raise ValueError()
++        except OSError:
++            # resolved doesn't exist, so it can't be the same
++            pass
++    except RuntimeError as e:
++        raise ReceiveError("Could not resolve path '%s': %s" % str(e))
++    except ValueError:
++        raise ReceiveError("Resolved path is not valid child of the save folder: %s -> %s" % (unresolved, str(resolved)), fatal=True)
++
+ def save_folder_is_native_fs():
+     file = Gio.File.new_for_path(prefs.get_save_path())
+     return file.is_native()

--- a/pkgs/desktops/cinnamon/warpinator/default.nix
+++ b/pkgs/desktops/cinnamon/warpinator/default.nix
@@ -15,7 +15,7 @@
 
 python3.pkgs.buildPythonApplication rec  {
   pname = "warpinator";
-  version = "1.4.2";
+  version = "1.4.3";
 
   format = "other";
 
@@ -23,7 +23,7 @@ python3.pkgs.buildPythonApplication rec  {
     owner = "linuxmint";
     repo = pname;
     rev = version;
-    hash = "sha256-aiHlBeWGYqSaqvRtwL7smqt4iueIKzQoDawdFSCn6eg=";
+    hash = "sha256-blsDOAdfu0N6I+6ZvycL+BIIsZPIjwYm+sJnbZtHJE8=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/desktops/cinnamon/warpinator/default.nix
+++ b/pkgs/desktops/cinnamon/warpinator/default.nix
@@ -15,7 +15,7 @@
 
 python3.pkgs.buildPythonApplication rec  {
   pname = "warpinator";
-  version = "1.4.3";
+  version = "1.4.4";
 
   format = "other";
 
@@ -23,7 +23,7 @@ python3.pkgs.buildPythonApplication rec  {
     owner = "linuxmint";
     repo = pname;
     rev = version;
-    hash = "sha256-blsDOAdfu0N6I+6ZvycL+BIIsZPIjwYm+sJnbZtHJE8=";
+    hash = "sha256-oHJOwdCvHnPalTHb5E3mNDYBaR9ZvlV1F6ux7nejBlc=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/desktops/cinnamon/warpinator/default.nix
+++ b/pkgs/desktops/cinnamon/warpinator/default.nix
@@ -15,7 +15,7 @@
 
 python3.pkgs.buildPythonApplication rec  {
   pname = "warpinator";
-  version = "1.4.4";
+  version = "1.4.5";
 
   format = "other";
 
@@ -23,7 +23,7 @@ python3.pkgs.buildPythonApplication rec  {
     owner = "linuxmint";
     repo = pname;
     rev = version;
-    hash = "sha256-oHJOwdCvHnPalTHb5E3mNDYBaR9ZvlV1F6ux7nejBlc=";
+    hash = "sha256-5mMV4WinpFR9ihgoQsgIXre0VpBdg9S8GjSkx+7ocLg=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/desktops/cinnamon/warpinator/default.nix
+++ b/pkgs/desktops/cinnamon/warpinator/default.nix
@@ -15,7 +15,7 @@
 
 python3.pkgs.buildPythonApplication rec  {
   pname = "warpinator";
-  version = "1.4.1";
+  version = "1.4.2";
 
   format = "other";
 
@@ -23,7 +23,7 @@ python3.pkgs.buildPythonApplication rec  {
     owner = "linuxmint";
     repo = pname;
     rev = version;
-    hash = "sha256-gZ19WVolm8uoDZcX3OgLGkB8nFUPZIwCmKGQop9/xJ8=";
+    hash = "sha256-aiHlBeWGYqSaqvRtwL7smqt4iueIKzQoDawdFSCn6eg=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/desktops/cinnamon/warpinator/default.nix
+++ b/pkgs/desktops/cinnamon/warpinator/default.nix
@@ -15,7 +15,7 @@
 
 python3.pkgs.buildPythonApplication rec  {
   pname = "warpinator";
-  version = "1.2.15";
+  version = "1.4.1";
 
   format = "other";
 
@@ -23,7 +23,7 @@ python3.pkgs.buildPythonApplication rec  {
     owner = "linuxmint";
     repo = pname;
     rev = version;
-    hash = "sha256-WLeJTSf8906CjvJvBWnmFRVV1ngOuIK0V/3qZ82Bx7s=";
+    hash = "sha256-gZ19WVolm8uoDZcX3OgLGkB8nFUPZIwCmKGQop9/xJ8=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/desktops/cinnamon/warpinator/default.nix
+++ b/pkgs/desktops/cinnamon/warpinator/default.nix
@@ -26,6 +26,12 @@ python3.pkgs.buildPythonApplication rec  {
     hash = "sha256-5mMV4WinpFR9ihgoQsgIXre0VpBdg9S8GjSkx+7ocLg=";
   };
 
+  patches = [
+    # See https://www.openwall.com/lists/oss-security/2023/04/26/1. Manually adjusted from
+    # https://github.com/linuxmint/warpinator/commit/9aae768522b7bbb09c836419893802a02221d663.
+    ./CVE-2023-29380.patch
+  ];
+
   nativeBuildInputs = [
     meson
     ninja


### PR DESCRIPTION
###### Description of changes

unstable will have 1.6.1 - #228083

We can probably just have 1.6.1 in 22.11 since the only new feature (new isolation methods) in 1.6.x are [mentioned](https://www.openwall.com/lists/oss-security/2023/04/26/1) in the CVE as well. But probably when linuxmint [ship it to linuxmint users](http://packages.linuxmint.com/search.php?release=any&section=any&keyword=warpinator) :upside_down_face:


<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
