### PR TITLE
nixos/security/ca: Increased description-verbosity

### DIFF
--- a/nixos/modules/security/ca.nix
+++ b/nixos/modules/security/ca.nix
@@ -24,11 +24,11 @@ in
       default = [];
       example = literalExpression ''[ "''${pkgs.cacert}/etc/ssl/certs/ca-bundle.crt" ]'';
       description = lib.mdDoc ''
-        A list of files containing trusted root certificates in PEM
-        format. These are concatenated to form
-        {file}`/etc/ssl/certs/ca-certificates.crt`, which is
-        used by many programs that use OpenSSL, such as
-        {command}`curl` and {command}`git`.
+        A list of files containing trusted root certificates in PEM format.
+        These are concatenated with the certificates of the Mozilla Trust Store and
+        those listed in {option}`security.pki.certificates`
+        to form  {file}`/etc/ssl/certs/ca-certificates.crt`,
+        which is used by many programs that use OpenSSL, such as {command}`curl` and {command}`git`.
       '';
     };
 
@@ -49,6 +49,9 @@ in
       '';
       description = lib.mdDoc ''
         A list of trusted root certificates in PEM format.
+        These are concatenated with the certificates of the Mozilla Trust Store and
+        those listed in {option}`security.pki.certificateFiles`
+        to form  {file}`/etc/ssl/certs/ca-certificates.crt`,
       '';
     };
 
@@ -61,10 +64,10 @@ in
         "Certification Authority of WoSign G2"
       ];
       description = lib.mdDoc ''
-        A list of blacklisted CA certificate names that won't be imported from
-        the Mozilla Trust Store into
-        {file}`/etc/ssl/certs/ca-certificates.crt`. Use the
-        names from that file.
+        A list of blacklisted CA certificate names that will not be imported from the Mozilla Trust Store into
+        {file}`/etc/ssl/certs/ca-certificates.crt`.
+        Use the names from that file.
+        Additionally to those listed here, the root certificates by TrustCor are always blacklisted.
       '';
     };
 


### PR DESCRIPTION
###### Description of changes

Added the info, that additionally the certificates listed in certificates and certificateFiles, those of the Mozilla Trust Store are used as well. Additionally to the names of certificate listed in caCertificateBlacklist, pkgs.cacert also blacklists the root certificates by TrustCor.

###### Things done
nothing…because this is only an insignificant change of some descriptions. I just checked that there is no syntax-error.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
