### PR TITLE
linuxPackages.ax99100: fix build with Linux >= 6.2

### DIFF
--- a/pkgs/os-specific/linux/ax99100/default.nix
+++ b/pkgs/os-specific/linux/ax99100/default.nix
@@ -26,7 +26,9 @@ stdenv.mkDerivation
   patches = [
     ./kernel-5.18-pci_free_consistent-pci_alloc_consistent.patch
     ./kernel-6.1-set_termios-const-ktermios.patch
-  ];
+  ] ++ (lib.optional (lib.versionAtLeast kernel.version "6.2") [
+    ./kernel-6.2-fix-pointer-type.patch
+  ]);
 
   patchFlags = [ "-p0" ];
 

--- a/pkgs/os-specific/linux/ax99100/kernel-6.2-fix-pointer-type.patch
+++ b/pkgs/os-specific/linux/ax99100/kernel-6.2-fix-pointer-type.patch
@@ -1,0 +1,11 @@
+--- ax99100_spi.c
++++ ax99100_spi.c
+@@ -76,7 +76,7 @@ int spi_suspend_count;
+ static unsigned int spi_major = 241;
+ static unsigned int spi_min_count = 0;
+ /* device Class */
+-static char *ax_devnode(struct device *dev, umode_t *mode)
++static char *ax_devnode(const struct device *dev, umode_t *mode)
+ {
+ 	return kasprintf(GFP_KERNEL, "%s", dev_name(dev));
+ }


### PR DESCRIPTION
###### Description of changes

The device class definition was changed to require a `const` pointer, so this driver needs to be patched as well.

https://github.com/torvalds/linux/commit/ff62b8e6588fb07bedda7423622c140c4edd66a7

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
