### PR TITLE
Upgrade Nexus from 3.45.0-01 to 3.52.0-01

### DIFF
--- a/pkgs/development/tools/repository-managers/nexus/default.nix
+++ b/pkgs/development/tools/repository-managers/nexus/default.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation rec {
   pname = "nexus";
-  version = "3.45.0-01";
+  version = "3.52.0-01";
 
   src = fetchurl {
-    url = "https://sonatype-download.global.ssl.fastly.net/nexus/3/nexus-${version}-unix.tar.gz";
-    hash = "sha256-ISTORslFPgFt0kEKK17fpBXi3yAMwgm6qDnk33V2wa0=";
+    url = "https://download.sonatype.com/nexus/3/nexus-${version}-unix.tar.gz";
+    hash = "sha256-+Hdmuy7WBtUIjEBZyLgE3a3+L/lANHiy1VRBJ2s686U=";
   };
 
   preferLocalBuild = true;
@@ -19,6 +19,7 @@ stdenv.mkDerivation rec {
 
   postPatch = ''
     substituteInPlace bin/nexus.vmoptions \
+      --replace ../sonatype-work /var/lib/sonatype-work \
       --replace etc/karaf $out/etc/karaf \
       --replace =. =$out
   '';
@@ -40,7 +41,7 @@ stdenv.mkDerivation rec {
 
   meta = with lib; {
     description = "Repository manager for binary software components";
-    homepage = "http://www.sonatype.org/nexus";
+    homepage = "https://www.sonatype.com/products/sonatype-nexus-oss";
     sourceProvenance = with sourceTypes; [ binaryBytecode ];
     license = licenses.epl10;
     platforms = platforms.all;


### PR DESCRIPTION
###### Description of changes

- Upgrade the `nexus` package from `3.45.0-01` to `3.52.0-01` ([release notes](https://help.sonatype.com/repomanager3/product-information/release-notes/2023-release-notes/sonatype-nexus-repository-3.52.0-release-notes))
  - Switch the URL to the one listed in the [public documentation](https://help.sonatype.com/repomanager3/product-information/download)
- Partially fix a bug with the `postPatch` behavior modifying `bin/nexus.vmoptions` (detailed in the specific commit and discussed further below)
- Update the URL for the `meta.homepage`, since the old one no longer resolves

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

## Discussion of the change to `/var/lib/sonatype-work`

---

Currently, the `bin/nexus.vmoptions` file contains several instances of `../sonatype-work`. The intent of this appears to be to enable a user to download the tgz, unpack it, and run from that folder directly ([documented here](https://help.sonatype.com/repomanager3/installation-and-upgrades/directories)). This would already be a problem, as the nix store is not intended to contain writable data folders.

The existing package attempts to make relative paths absolute with the `--replace =. =$out` line. However, the result is that the `<jvm_option>=../sonatype-work/<subfolder>` paths end up something like `<jvm_option>=/<nix>/<store>/<path>/./sonatype-work/<subfolder>`, which does not exist.

The NixOS module avoids this problem by defining its own equivalent of `nexus.vmoptions` and overriding it through the `VM_OPTS_FILE` environment variable, so it is unaffected by this change.

Adding this change sets the data folder to be the same as the default for the NixOS module. This does not result in a working package by itself, but does enable the user to get it in a working state by creating that directory.

I attempted to research if there was an existing pattern for how NixOS prefers handling packages like this that expect to have a writable data folder. Since it is a server application that's likely to be run as a service, using the XDG folder specification didn't make sense to me. I found [this forum thread](https://discourse.nixos.org/t/where-to-put-a-packages-variable-data/14391), which seemed to be a second indicate that `/var/lib/<folder>/` was an acceptable pattern. If there is a different approach that is preferred, let me know and I will make whatever changes that are appropriate.