### PR TITLE
makeFontsConf: add darwin system fonts

### DIFF
--- a/pkgs/development/libraries/fontconfig/make-fonts-conf.nix
+++ b/pkgs/development/libraries/fontconfig/make-fonts-conf.nix
@@ -1,11 +1,13 @@
-{ runCommand, libxslt, fontconfig, dejavu_fonts, fontDirectories }:
+{ runCommand, stdenv, lib, libxslt, fontconfig, dejavu_fonts, fontDirectories }:
 
 runCommand "fonts.conf"
   {
     nativeBuildInputs = [ libxslt ];
     buildInputs = [ fontconfig ];
     # Add a default font for non-nixos systems, <1MB and in nixos defaults.
-    fontDirectories = fontDirectories ++ [ dejavu_fonts.minimal ];
+    fontDirectories = fontDirectories ++ [ dejavu_fonts.minimal ]
+      # further non-nixos fonts on darwin
+      ++ lib.optionals stdenv.isDarwin [ "/System/Library/Fonts" "/Library/Fonts" "~/Library/Fonts" ];
   }
   ''
     xsltproc --stringparam fontDirectories "$fontDirectories" \


### PR DESCRIPTION
###### Description of changes
Add further non-NixOS system font folders on macOS (idea mentioned in https://github.com/NixOS/nixpkgs/pull/228196#issuecomment-1524078415).

###### Things done

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [X] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).