### PR TITLE
Revert "root: enable root7"

### DIFF
--- a/pkgs/applications/science/misc/root/default.nix
+++ b/pkgs/applications/science/misc/root/default.nix
@@ -191,7 +191,7 @@ stdenv.mkDerivation rec {
     "-Dpythia6=OFF"
     "-Dpythia8=OFF"
     "-Drfio=OFF"
-    "-Droot7=ON"
+    "-Droot7=OFF"
     "-Dsqlite=OFF"
     "-Dssl=ON"
     "-Dtmva=ON"


### PR DESCRIPTION
Reverts NixOS/nixpkgs#226351
Closes: #228616

Apparently it broke darwin builds, and, possibly, enabled C++17 on Linux:
https://github.com/root-project/root/blob/3e712217dfb1eb7e22ecef2b7b38a7fb1f1ea8e2/cmake/modules/RootBuildOptions.cmake#L399-L406

I don't think we should enforce C++17 just yet, hence, a revert.

cc @yipengsun @ShamrockLee