### PR TITLE
gotktrix: unstable-2022-09-29 -> unstable-2023-04-05

### DIFF
--- a/pkgs/applications/networking/instant-messengers/gotktrix/default.nix
+++ b/pkgs/applications/networking/instant-messengers/gotktrix/default.nix
@@ -5,21 +5,20 @@
 , glib
 , gobject-introspection
 , pkg-config
-, go
 }:
 
 buildGoModule rec {
   pname = "gotktrix";
-  version = "unstable-2022-09-29";
+  version = "unstable-2023-04-05";
 
   src = fetchFromGitHub {
     owner = "diamondburned";
     repo = pname;
-    rev = "3d9e8ac4810f7cb9d9ead7b4b13ffa6f5da8927f"; # compound
-    sha256 = "sha256-VIV4vSntu3oCIE23f5fiYj8cxcKY1n4M4Xkf0MGhvxI=";
+    rev = "a8f876a383cc34dac18edddbe22be2dd494b8d0c"; # compound
+    hash = "sha256-BuiA9UajdMhSrEfaXdu5DZlVhC4GVUdUpQDLMvKGrEk=";
   };
 
-  vendorSha256 = "sha256-R55tfTJL/bgNWTgmuBFRxIQleKS9zeDqvfez2VyzqjI=";
+  vendorHash = "sha256-oo/j6i7slXILqyvj/EHojsyCZzJMGd10PTZaLvI1xoc=";
 
   buildInputs = [
     gtk4


### PR DESCRIPTION
###### Description of changes

Fixes launching failure

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).