### PR TITLE
wasmserve: init at 1.0.0

### DIFF
--- a/pkgs/development/tools/wasmserve/default.nix
+++ b/pkgs/development/tools/wasmserve/default.nix
@@ -1,0 +1,25 @@
+{ buildGoModule
+, lib
+, fetchFromGitHub
+}:
+
+buildGoModule rec {
+  pname = "wasmserve";
+  version = "1.0.0";
+
+  src = fetchFromGitHub {
+    owner = "hajimehoshi";
+    repo = "wasmserve";
+    rev = "v${version}";
+    hash = "sha256-KlCbUre6yIorE1ZM++Rto8vgwVGsC1wZj1xCd3AwQy0=";
+  };
+
+  vendorHash = null;
+
+  meta = with lib; {
+    description = "An HTTP server for testing Wasm";
+    homepage = "https://github.com/hajimehoshi/wasmserve";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ kirillrdy ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -14162,6 +14162,8 @@ with pkgs;
 
   wasmi = callPackage ../development/tools/wasmi { };
 
+  wasmserve = callPackage ../development/tools/wasmserve {};
+
   welkin = callPackage ../tools/graphics/welkin { };
 
   wemux = callPackage ../tools/misc/wemux { };


### PR DESCRIPTION
###### Description of changes

https://github.com/hajimehoshi/wasmserve
is just simple wasm server for golang wasm apps, somewhat similar to trunk from rust world.

I used it now and then and maybe its useful to others.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
