### PR TITLE
quaternion: 0.0.95.1 -> 0.0.95.81

### DIFF
--- a/pkgs/applications/networking/instant-messengers/quaternion/default.nix
+++ b/pkgs/applications/networking/instant-messengers/quaternion/default.nix
@@ -1,37 +1,40 @@
-{ mkDerivation
-, stdenv
+{ stdenv
 , lib
 , fetchFromGitHub
 , cmake
-, qtquickcontrols
+, wrapQtAppsHook
+, qtbase
 , qtquickcontrols2
 , qtkeychain
 , qtmultimedia
 , qttools
 , libquotient
 , libsecret
+, olm
 }:
 
-mkDerivation rec {
+stdenv.mkDerivation {
   pname = "quaternion";
-  version = "0.0.95.1";
+  version = "0.0.95.81";
 
   src = fetchFromGitHub {
     owner = "QMatrixClient";
     repo = "Quaternion";
-    rev = version;
-    sha256 = "sha256-6FLj/hVY13WO7sMgHCHV57eMJu39cwQHXQX7m0lmv4I=";
+    rev = "5f639d8c84ed1475057b2cb3f7d0cb0abe77203b";
+    hash = "sha256-/1fich97oqSSDpfOjaYghYzHfu3MDrh77nanbIN/v/w=";
   };
 
   buildInputs = [
-    qtmultimedia
-    qtquickcontrols2
-    qtkeychain
     libquotient
     libsecret
+    olm
+    qtbase
+    qtkeychain
+    qtmultimedia
+    qtquickcontrols2
   ];
 
-  nativeBuildInputs = [ cmake qttools ];
+  nativeBuildInputs = [ cmake qttools wrapQtAppsHook ];
 
   postInstall =
     if stdenv.isDarwin then ''

--- a/pkgs/development/libraries/libquotient/default.nix
+++ b/pkgs/development/libraries/libquotient/default.nix
@@ -1,17 +1,17 @@
-{ mkDerivation, lib, fetchFromGitHub, cmake, olm, openssl, qtmultimedia, qtkeychain }:
+{ stdenv, lib, fetchFromGitHub, cmake, olm, openssl, qtbase, qtmultimedia, qtkeychain }:
 
-mkDerivation rec {
+stdenv.mkDerivation rec {
   pname = "libquotient";
-  version = "0.7.1";
+  version = "0.7.2";
 
   src = fetchFromGitHub {
     owner = "quotient-im";
     repo = "libQuotient";
     rev = version;
-    hash = "sha256-3xnv1dcyeX3Kl5EH2Tlf6nXobLG1zXsFmYstnvmSAXA=";
+    hash = "sha256-Lq404O2VjZ8vlXOW+rhsvWDvZsNd3APNbv6AadQCjhk=";
   };
 
-  buildInputs = [ olm openssl qtmultimedia qtkeychain ];
+  buildInputs = [ olm openssl qtbase qtmultimedia qtkeychain ];
 
   nativeBuildInputs = [ cmake ];
 
@@ -25,6 +25,8 @@ mkDerivation rec {
       --replace '$'{prefix}/@CMAKE_INSTALL_LIBDIR@ @CMAKE_INSTALL_FULL_LIBDIR@ \
       --replace '$'{prefix}/@CMAKE_INSTALL_INCLUDEDIR@ @CMAKE_INSTALL_FULL_INCLUDEDIR@
   '';
+
+  dontWrapQtApps = true;
 
   meta = with lib; {
     description = "A Qt5/Qt6 library to write cross-platform clients for Matrix";

--- a/pkgs/development/libraries/qtkeychain/default.nix
+++ b/pkgs/development/libraries/qtkeychain/default.nix
@@ -1,11 +1,18 @@
-{ lib, stdenv, fetchFromGitHub, cmake, pkg-config, qtbase, qttools
-, CoreFoundation, Security
+{ lib
+, stdenv
+, fetchFromGitHub
+, cmake
+, pkg-config
+, qtbase
+, qttools
+, CoreFoundation
+, Security
 , libsecret
 }:
 
 stdenv.mkDerivation rec {
   pname = "qtkeychain";
-  version = "0.12.0";            # verify after nix-build with `grep -R "set(PACKAGE_VERSION " result/`
+  version = "0.12.0";
 
   src = fetchFromGitHub {
     owner = "frankosterfeld";
@@ -18,7 +25,10 @@ stdenv.mkDerivation rec {
 
   patches = [ ./0002-Fix-install-name-Darwin.patch ];
 
-  cmakeFlags = [ "-DQT_TRANSLATIONS_DIR=share/qt/translations" ];
+  cmakeFlags = [
+    "-DBUILD_WITH_QT6=${if lib.versions.major qtbase.version == "6" then "ON" else "OFF"}"
+    "-DQT_TRANSLATIONS_DIR=share/qt/translations"
+  ];
 
   nativeBuildInputs = [ cmake ]
     ++ lib.optionals (!stdenv.isDarwin) [ pkg-config ] # for finding libsecret
@@ -27,9 +37,22 @@ stdenv.mkDerivation rec {
   buildInputs = lib.optionals (!stdenv.isDarwin) [ libsecret ]
     ++ [ qtbase qttools ]
     ++ lib.optionals stdenv.isDarwin [
-      CoreFoundation Security
-    ]
-  ;
+    CoreFoundation
+    Security
+  ];
+
+  doInstallCheck = true;
+
+  # we previously had a note in here saying to run this check manually, so we might as
+  # well do it automatically. It seems like a perfectly valid sanity check, but I
+  # have no idea *why* we might need it
+  installCheckPhase = ''
+    runHook preInstallCheck
+
+    grep --quiet -R 'set(PACKAGE_VERSION "${version}"' .
+
+    runHook postInstallCheck
+  '';
 
   meta = {
     description = "Platform-independent Qt API for storing passwords securely";

--- a/pkgs/top-level/qt6-packages.nix
+++ b/pkgs/top-level/qt6-packages.nix
@@ -31,6 +31,10 @@ in
 
   inherit (kdeFrameworks) kcoreaddons;
 
+  qtkeychain = callPackage ../development/libraries/qtkeychain {
+    inherit (pkgs.darwin.apple_sdk.frameworks) CoreFoundation Security;
+  };
+
   qtpbfimageplugin = callPackage ../development/libraries/qtpbfimageplugin { };
 
   quazip = callPackage ../development/libraries/quazip { };


### PR DESCRIPTION
###### Description of changes

upstream update with a few minor related changes to prep building for qt6.

- qt6Packages.qtkeychain: allow building with qt6
- libquotient: 0.7.1 -> 0.7.2
- quaternion: 0.0.95.1 -> 0.0.95.81

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [X] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
