### PR TITLE
[22.11] python3Packages.sqlparse: apply patch for CVE-2023-30608

### DIFF
--- a/pkgs/development/python-modules/sqlparse/CVE-2023-30608.patch
+++ b/pkgs/development/python-modules/sqlparse/CVE-2023-30608.patch
@@ -1,0 +1,48 @@
+From 7e85934218a8251e856a3f47021f5e3c7f03808c Mon Sep 17 00:00:00 2001
+From: Andi Albrecht <albrecht.andi@gmail.com>
+Date: Mon, 20 Mar 2023 08:33:46 +0100
+Subject: [PATCH] Remove unnecessary parts in regex for bad escaping.
+
+The regex tried to deal with situations where escaping in the
+SQL to be parsed was suspicious.
+
+(cherry picked from commit c457abd5f097dd13fb21543381e7cfafe7d31cfb)
+---
+ sqlparse/keywords.py | 4 ++--
+ tests/test_split.py  | 4 ++--
+ 2 files changed, 4 insertions(+), 4 deletions(-)
+
+diff --git a/sqlparse/keywords.py b/sqlparse/keywords.py
+index 6850628..4e97477 100644
+--- a/sqlparse/keywords.py
++++ b/sqlparse/keywords.py
+@@ -66,9 +66,9 @@ SQL_REGEX = {
+         (r'(?![_A-ZÀ-Ü])-?(\d+(\.\d*)|\.\d+)(?![_A-ZÀ-Ü])',
+          tokens.Number.Float),
+         (r'(?![_A-ZÀ-Ü])-?\d+(?![_A-ZÀ-Ü])', tokens.Number.Integer),
+-        (r"'(''|\\\\|\\'|[^'])*'", tokens.String.Single),
++        (r"'(''|\\'|[^'])*'", tokens.String.Single),
+         # not a real string literal in ANSI SQL:
+-        (r'"(""|\\\\|\\"|[^"])*"', tokens.String.Symbol),
++        (r'"(""|\\"|[^"])*"', tokens.String.Symbol),
+         (r'(""|".*?[^\\]")', tokens.String.Symbol),
+         # sqlite names can be escaped with [square brackets]. left bracket
+         # cannot be preceded by word character or a right bracket --
+diff --git a/tests/test_split.py b/tests/test_split.py
+index a9d7576..e79750e 100644
+--- a/tests/test_split.py
++++ b/tests/test_split.py
+@@ -18,8 +18,8 @@ def test_split_semicolon():
+ 
+ 
+ def test_split_backslash():
+-    stmts = sqlparse.parse(r"select '\\'; select '\''; select '\\\'';")
+-    assert len(stmts) == 3
++    stmts = sqlparse.parse("select '\'; select '\'';")
++    assert len(stmts) == 2
+ 
+ 
+ @pytest.mark.parametrize('fn', ['function.sql',
+-- 
+2.40.1
+

--- a/pkgs/development/python-modules/sqlparse/default.nix
+++ b/pkgs/development/python-modules/sqlparse/default.nix
@@ -17,6 +17,10 @@ buildPythonPackage rec {
     sha256 = "0c00730c74263a94e5a9919ade150dfc3b19c574389985446148402998287dae";
   };
 
+  patches = [
+    ./CVE-2023-30608.patch
+  ];
+
   nativeBuildInputs = [ installShellFiles ];
 
   checkInputs = [ pytestCheckHook ];


### PR DESCRIPTION
###### Description of changes

https://github.com/advisories/GHSA-rrm6-wvj7-cwh2

PR for `master`: #228680

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
