### PR TITLE
xcodeenv: use __noChroot to avoid permission errors

### DIFF
--- a/pkgs/development/mobile/xcodeenv/compose-xcodewrapper.nix
+++ b/pkgs/development/mobile/xcodeenv/compose-xcodewrapper.nix
@@ -8,6 +8,8 @@ assert stdenv.isDarwin;
 stdenv.mkDerivation {
   pname = "xcode-wrapper${lib.optionalString allowHigher "-plus"}";
   inherit version;
+  # Fails in sandbox. Use `--option sandbox relaxed` or `--option sandbox false`.
+  __noChroot = true;
   buildCommand = ''
     mkdir -p $out/bin
     cd $out/bin


### PR DESCRIPTION
###### Description of changes
When `sandbox=relaxed` is used this derivation fails with: `xcodebuild: Operation not permitted`
```
> /nix/store/yyy-stdenv-darwin/setup: line 1391: /nix/store/xxx-xcode-wrapper-14.3/bin/xcodebuild: Operation not permitted
> We require xcodebuild version: 14.3
```

###### Things done

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).