### PR TITLE
discourse: 3.1.0.beta2 -> 3.1.0.beta4, discourseAllPlugins: update all

### DIFF
--- a/nixos/modules/services/web-apps/discourse.nix
+++ b/nixos/modules/services/web-apps/discourse.nix
@@ -651,6 +651,9 @@ in
       preload_link_header = false;
       redirect_avatar_requests = false;
       pg_force_readonly_mode = false;
+      dns_query_timeout_secs = null;
+      regex_timeout_seconds = 2;
+      allow_impersonation = true;
     };
 
     services.redis.servers.discourse =

--- a/pkgs/misc/dart-sass-embedded/default.nix
+++ b/pkgs/misc/dart-sass-embedded/default.nix
@@ -1,0 +1,49 @@
+{ lib
+, stdenvNoCC
+, fetchurl
+, autoPatchelfHook
+}:
+
+stdenvNoCC.mkDerivation rec {
+  pname = "dart-sass-embedded";
+  version = "1.62.1";
+
+  dontConfigure = true;
+  dontBuild = true;
+
+  nativeBuildInputs = lib.optional stdenvNoCC.hostPlatform.isLinux autoPatchelfHook;
+
+  src = let base = "https://github.com/sass/dart-sass-embedded/releases/download/${version}/sass_embedded-${version}"; in
+    fetchurl {
+      "x86_64-linux" = {
+        url = "${base}-linux-x64.tar.gz";
+        hash = "sha256-NXTadacyKlOQNGSLj/hP8syhYuuSTXK2Y9cYzTk28HU=";
+      };
+      "aarch64-linux" = {
+        url = "${base}-linux-arm64.tar.gz";
+        hash = "sha256-DX29U1AjmqVhKFgzP+71vsdoMjQ13IS93PZ1JLOA7bA=";
+      };
+      "x86_64-darwin" = {
+        url = "${base}-macos-x64.tar.gz";
+        hash = "sha256-0oyb9YBKoPNaWFLbIUZOJc5yK11uDYyAKKW4urkmRJQ=";
+      };
+      "aarch64-darwin" = {
+        url = "${base}-macos-arm64.tar.gz";
+        hash = "sha256-dkBcdVbxolK8xXYaOHot0s9FxGmfhMNAEoZqo+2LRfk=";
+      };
+    }."${stdenvNoCC.hostPlatform.system}" or (throw "Unsupported system ${stdenvNoCC.hostPlatform.system}");
+
+  installPhase = ''
+    mkdir -p $out/bin
+    cp -r * $out
+    ln -s $out/dart-sass-embedded $out/bin/dart-sass-embedded
+  '';
+
+  meta = with lib; {
+    description = "A wrapper for Dart Sass that implements the compiler side of the Embedded Sass protocol";
+    homepage = "https://github.com/sass/dart-sass-embedded";
+    changelog = "https://github.com/sass/dart-sass-embedded/blob/${version}/CHANGELOG.md";
+    license = licenses.mit;
+    maintainers = with maintainers; [ shyim ];
+  };
+}

--- a/pkgs/servers/web-apps/discourse/asserts_patch-package_from_path.patch
+++ b/pkgs/servers/web-apps/discourse/asserts_patch-package_from_path.patch
@@ -1,0 +1,13 @@
+diff --git a/app/assets/javascripts/discourse/package.json b/app/assets/javascripts/discourse/package.json
+index 9e4533d2..e57f8a5f 100644
+--- a/app/assets/javascripts/discourse/package.json
++++ b/app/assets/javascripts/discourse/package.json
+@@ -14,7 +14,7 @@
+     "build": "ember build",
+     "start": "ember serve",
+     "test": "ember test",
+-    "postinstall": "yarn --silent --cwd .. patch-package"
++    "postinstall": "patch-package"
+   },
+   "dependencies": {
+     "@babel/core": "^7.21.4",

--- a/pkgs/servers/web-apps/discourse/default.nix
+++ b/pkgs/servers/web-apps/discourse/default.nix
@@ -8,7 +8,7 @@
 , bundlerEnv
 , callPackage
 
-, ruby_3_1
+, ruby_3_2
 , replace
 , gzip
 , gnutar
@@ -38,21 +38,22 @@
 , fixup_yarn_lock
 , nodePackages
 , nodejs_16
+, dart-sass-embedded
 
 , plugins ? []
 }@args:
 
 let
-  version = "3.1.0.beta2";
+  version = "3.1.0.beta4";
 
   src = fetchFromGitHub {
     owner = "discourse";
     repo = "discourse";
     rev = "v${version}";
-    sha256 = "sha256-wkNTm5/QyujPcMUrnc6eWmjhrRQAthhmejmjpy6zmbE=";
+    sha256 = "sha256-22GXFYPjPYL20amR4xFB4L/dCp32H4Z3uf0GLGEghUE=";
   };
 
-  ruby = ruby_3_1;
+  ruby = ruby_3_2;
 
   runtimeDeps = [
     # For backups, themes and assets
@@ -186,6 +187,20 @@ let
               cp $(readlink -f ${libpsl}/lib/libpsl.so) vendor/libpsl.x86_64.so
             '';
           };
+          sass-embedded = gems.sass-embedded // {
+            dontBuild = false;
+            # `sass-embedded` depends on `dart-sass-embedded` and tries to
+            # fetch that as `.tar.gz` from GitHub releases. That `.tar.gz`
+            # can also be specified via `SASS_EMBEDDED`. But instead of
+            # compressing our `dart-sass-embedded` just to decompress it
+            # again, we simply patch the Rakefile to symlink that path.
+            patches = [
+              ./rubyEnv/sass-embedded-static.patch
+            ];
+            postPatch = ''
+              export SASS_EMBEDDED=${dart-sass-embedded}
+            '';
+          };
         };
 
     groups = [
@@ -199,7 +214,7 @@ let
 
     yarnOfflineCache = fetchYarnDeps {
       yarnLock = src + "/app/assets/javascripts/yarn.lock";
-      sha256 = "0ryc4p5s35mzg1p71z98x5fvr5fpldmgghdi1viha4ckbpv153lw";
+      sha256 = "0a20kns4irdpzzx2dvdjbi0m3s754gp737q08z5nlcnffxqvykrk";
     };
 
     nativeBuildInputs = runtimeDeps ++ [
@@ -207,6 +222,7 @@ let
       redis
       nodePackages.uglify-js
       nodePackages.terser
+      nodePackages.patch-package
       yarn
       nodejs_16
     ];
@@ -226,6 +242,12 @@ let
       # Fix the rake command used to recursively execute itself in the
       # assets precompilation task.
       ./assets_rake_command.patch
+
+      # `app/assets/javascripts/discourse/package.json`'s postinstall
+      # hook tries to call `../node_modules/.bin/patch-package`, which
+      # hasn't been `patchShebangs`-ed yet. So instead we just use
+      # `patch-package` from `nativeBuildInputs`.
+      ./asserts_patch-package_from_path.patch
     ];
 
     # We have to set up an environment that is close enough to

--- a/pkgs/servers/web-apps/discourse/plugins/discourse-assign/default.nix
+++ b/pkgs/servers/web-apps/discourse/plugins/discourse-assign/default.nix
@@ -5,8 +5,8 @@ mkDiscoursePlugin {
   src = fetchFromGitHub {
     owner = "discourse";
     repo = "discourse-assign";
-    rev = "c6e6a883f66670e5cfc1eb973af8ac5b7c20f815";
-    sha256 = "sha256-OwNV+ZNogUgd6ZKdXwUqoMqcZKc4jbf276rHIYQzjYc=";
+    rev = "a655a009fade4671e4a2d38f0a0f7ce89d201d80";
+    sha256 = "sha256-HCwId3/7NRuToLFyJrOVaAiSxysB7XNZp9BUndSJzlY=";
   };
   meta = with lib; {
     homepage = "https://github.com/discourse/discourse-docs";

--- a/pkgs/servers/web-apps/discourse/plugins/discourse-calendar/Gemfile.lock
+++ b/pkgs/servers/web-apps/discourse/plugins/discourse-calendar/Gemfile.lock
@@ -1,15 +1,15 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    activesupport (7.0.4.2)
+    activesupport (7.0.4.3)
       concurrent-ruby (~> 1.0, >= 1.0.2)
       i18n (>= 1.6, < 2)
       minitest (>= 5.1)
       tzinfo (~> 2.0)
-    concurrent-ruby (1.2.0)
-    i18n (1.12.0)
+    concurrent-ruby (1.2.2)
+    i18n (1.13.0)
       concurrent-ruby (~> 1.0)
-    minitest (5.17.0)
+    minitest (5.18.0)
     rrule (0.4.4)
       activesupport (>= 2.3)
     tzinfo (2.0.6)
@@ -22,4 +22,4 @@ DEPENDENCIES
   rrule (= 0.4.4)
 
 BUNDLED WITH
-   2.4.6
+   2.4.10

--- a/pkgs/servers/web-apps/discourse/plugins/discourse-calendar/default.nix
+++ b/pkgs/servers/web-apps/discourse/plugins/discourse-calendar/default.nix
@@ -6,8 +6,8 @@ mkDiscoursePlugin {
   src = fetchFromGitHub {
     owner = "discourse";
     repo = "discourse-calendar";
-    rev = "b71d4979370dcbd6f193b2ac5cfa0267f8a19fed";
-    sha256 = "sha256-XGybZqoM0nX8acLo3iwo+zD+zA4pz/ekLOnmDRNIVSo=";
+    rev = "d85e8e288d69788e0c3202bb3dab9c3450a98914";
+    sha256 = "sha256-mSn2gGidH4iSZ0fhf3UPh9pwMQurK0YGW2OAtdEWFBQ=";
   };
   meta = with lib; {
     homepage = "https://github.com/discourse/discourse-calendar";

--- a/pkgs/servers/web-apps/discourse/plugins/discourse-calendar/gemset.nix
+++ b/pkgs/servers/web-apps/discourse/plugins/discourse-calendar/gemset.nix
@@ -5,20 +5,20 @@
     platforms = [];
     source = {
       remotes = ["https://rubygems.org"];
-      sha256 = "0dmywys50074vj5rivpx188b00qimlc4jn84xzqlialrgp3ckq5f";
+      sha256 = "15m0b1im6i401ab51vzr7f8nk8kys1qa0snnl741y3sir3xd07jp";
       type = "gem";
     };
-    version = "7.0.4.2";
+    version = "7.0.4.3";
   };
   concurrent-ruby = {
     groups = ["default"];
     platforms = [];
     source = {
       remotes = ["https://rubygems.org"];
-      sha256 = "1qnsflsbjj38im8xq35g0vihlz96h09wjn2dad5g543l3vvrkrx5";
+      sha256 = "0krcwb6mn0iklajwngwsg850nk8k9b35dhmc2qkbdqvmifdi2y9q";
       type = "gem";
     };
-    version = "1.2.0";
+    version = "1.2.2";
   };
   i18n = {
     dependencies = ["concurrent-ruby"];
@@ -26,20 +26,20 @@
     platforms = [];
     source = {
       remotes = ["https://rubygems.org"];
-      sha256 = "1vdcchz7jli1p0gnc669a7bj3q1fv09y9ppf0y3k0vb1jwdwrqwi";
+      sha256 = "1yk33slipi3i1kydzrrchbi7cgisaxym6pgwlzx7ir8vjk6wl90x";
       type = "gem";
     };
-    version = "1.12.0";
+    version = "1.13.0";
   };
   minitest = {
     groups = ["default"];
     platforms = [];
     source = {
       remotes = ["https://rubygems.org"];
-      sha256 = "1kjy67qajw4rnkbjs5jyk7kc3lyhz5613fwj1i8f6ppdk4zampy0";
+      sha256 = "0ic7i5z88zcaqnpzprf7saimq2f6sad57g5mkkqsrqrcd6h3mx06";
       type = "gem";
     };
-    version = "5.17.0";
+    version = "5.18.0";
   };
   rrule = {
     dependencies = ["activesupport"];

--- a/pkgs/servers/web-apps/discourse/plugins/discourse-canned-replies/default.nix
+++ b/pkgs/servers/web-apps/discourse/plugins/discourse-canned-replies/default.nix
@@ -5,8 +5,8 @@ mkDiscoursePlugin {
   src = fetchFromGitHub {
     owner = "discourse";
     repo = "discourse-canned-replies";
-    rev = "b30b20d43ba5cbbb1ff1476bb43e97d5b8a807e8";
-    sha256 = "sha256-XROYSqGy4Z39VAlMXCbx9d+kivpknN98Kn/HhoC4ndQ=";
+    rev = "5a2d9a11ef3f07fc781acd83770bafc14eca2c1b";
+    sha256 = "sha256-R6CmL1hqqybc/I3oAzr3xZ4WThPWQirMjlXkF82xmIk=";
   };
   meta = with lib; {
     homepage = "https://github.com/discourse/discourse-canned-replies";

--- a/pkgs/servers/web-apps/discourse/plugins/discourse-chat-integration/default.nix
+++ b/pkgs/servers/web-apps/discourse/plugins/discourse-chat-integration/default.nix
@@ -5,8 +5,8 @@ mkDiscoursePlugin {
   src = fetchFromGitHub {
     owner = "discourse";
     repo = "discourse-chat-integration";
-    rev = "0522ad64143c9aedb27e00b642e82cad1273c83b";
-    sha256 = "sha256-GsoDVZkmKEX8+HwwQXptmmRuykTDqkbsL4WbFsL/PSo=";
+    rev = "9647c7afc0df42b8e2b5ae585afaf51f107fa195";
+    sha256 = "sha256-lP404OJvEEQVKIQTBMca7zb/YxQ6HXcPG1jMKpEB3iA=";
   };
   meta = with lib; {
     homepage = "https://github.com/discourse/discourse-chat-integration";

--- a/pkgs/servers/web-apps/discourse/plugins/discourse-data-explorer/default.nix
+++ b/pkgs/servers/web-apps/discourse/plugins/discourse-data-explorer/default.nix
@@ -5,8 +5,8 @@ mkDiscoursePlugin {
   src = fetchFromGitHub {
     owner = "discourse";
     repo = "discourse-data-explorer";
-    rev = "556d12ac507b140d1ed9d307cad58fa8e1d8cfdd";
-    sha256 = "sha256-fcO/j506kIydnipx6VsuMkj4Wb2MmPCo3LSrj9Fnczc=";
+    rev = "f99b3af7ed4a21474f35223e83013ee3e8ad7002";
+    sha256 = "sha256-3bBKBSc/+yF9ogNj3J6HXM3ynoAoUZeHhZOOhTfbxDw=";
   };
   meta = with lib; {
     homepage = "https://github.com/discourse/discourse-data-explorer";

--- a/pkgs/servers/web-apps/discourse/plugins/discourse-docs/default.nix
+++ b/pkgs/servers/web-apps/discourse/plugins/discourse-docs/default.nix
@@ -5,8 +5,8 @@ mkDiscoursePlugin {
   src = fetchFromGitHub {
     owner = "discourse";
     repo = "discourse-docs";
-    rev = "bf1c4574a61b053c136e2b181ba2fedb6c16f838";
-    sha256 = "sha256-voo3Q+e/Ud1Hg+SdHlvRsxoacFnPOQXwWu/g6n5cR3Y=";
+    rev = "0b4d2f3691048b6e0e257a1ac9ed01f66f662ba8";
+    sha256 = "sha256-HeIUCTbMNpuo6zeaDClsGrUOz4m0L+4UK7AwPsrKIHY=";
   };
   meta = with lib; {
     homepage = "https://github.com/discourse/discourse-docs";

--- a/pkgs/servers/web-apps/discourse/plugins/discourse-github/Gemfile.lock
+++ b/pkgs/servers/web-apps/discourse/plugins/discourse-github/Gemfile.lock
@@ -1,7 +1,7 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    addressable (2.8.1)
+    addressable (2.8.4)
       public_suffix (>= 2.0.2, < 6.0)
     faraday (2.7.4)
       faraday-net_http (>= 2.0, < 3.1)
@@ -24,4 +24,4 @@ DEPENDENCIES
   sawyer (= 0.9.2)
 
 BUNDLED WITH
-   2.4.6
+   2.4.10

--- a/pkgs/servers/web-apps/discourse/plugins/discourse-github/default.nix
+++ b/pkgs/servers/web-apps/discourse/plugins/discourse-github/default.nix
@@ -6,8 +6,8 @@ mkDiscoursePlugin {
   src = fetchFromGitHub {
     owner = "discourse";
     repo = "discourse-github";
-    rev = "148f28c1089288c9527fab1dcb88f13a5a5b0d10";
-    sha256 = "sha256-u91X+YFoKE0lP4RnNWX2XzNrJvlOQPbuZzFqBEVf84w=";
+    rev = "77e336a1b4ea08e2bb8a010d30146e4844afb3f3";
+    sha256 = "sha256-VHuf4ymT+W676RAuA3WPQl9QXLdQz4s8vP9EC8XAwW0=";
   };
   meta = with lib; {
     homepage = "https://github.com/discourse/discourse-github";

--- a/pkgs/servers/web-apps/discourse/plugins/discourse-github/gemset.nix
+++ b/pkgs/servers/web-apps/discourse/plugins/discourse-github/gemset.nix
@@ -5,10 +5,10 @@
     platforms = [];
     source = {
       remotes = ["https://rubygems.org"];
-      sha256 = "1ypdmpdn20hxp5vwxz3zc04r5xcwqc25qszdlg41h8ghdqbllwmw";
+      sha256 = "15s8van7r2ad3dq6i03l3z4hqnvxcq75a3h72kxvf9an53sqma20";
       type = "gem";
     };
-    version = "2.8.1";
+    version = "2.8.4";
   };
   faraday = {
     dependencies = ["faraday-net_http" "ruby2_keywords"];

--- a/pkgs/servers/web-apps/discourse/plugins/discourse-ldap-auth/Gemfile.lock
+++ b/pkgs/servers/web-apps/discourse/plugins/discourse-ldap-auth/Gemfile.lock
@@ -12,7 +12,7 @@ GEM
       pyu-ruby-sasl (~> 0.0.3.2)
       rubyntlm (~> 0.3.4)
     pyu-ruby-sasl (0.0.3.3)
-    rack (2.2.6.2)
+    rack (2.2.7)
     rubyntlm (0.3.4)
 
 PLATFORMS
@@ -25,4 +25,4 @@ DEPENDENCIES
   rubyntlm (= 0.3.4)
 
 BUNDLED WITH
-   2.4.6
+   2.4.10

--- a/pkgs/servers/web-apps/discourse/plugins/discourse-ldap-auth/default.nix
+++ b/pkgs/servers/web-apps/discourse/plugins/discourse-ldap-auth/default.nix
@@ -6,8 +6,8 @@ mkDiscoursePlugin {
   src = fetchFromGitHub {
     owner = "jonmbake";
     repo = "discourse-ldap-auth";
-    rev = "2f7a04b9fbeda0c8ab5c70e9012e4914ede9a707";
-    sha256 = "sha256-zBug9PHgvRsdQjvfWE5Bylm+0Ot+jBHFrbux7+Kn72c=";
+    rev = "edcf06957090e8d978a89fe7b07a6ba56fe35214";
+    sha256 = "sha256-VxBBip8QEXDQGDOsU5cXjUZe2HThJn20BPsNr33KhKI=";
   };
   meta = with lib; {
     homepage = "https://github.com/jonmbake/discourse-ldap-auth";

--- a/pkgs/servers/web-apps/discourse/plugins/discourse-ldap-auth/gemset.nix
+++ b/pkgs/servers/web-apps/discourse/plugins/discourse-ldap-auth/gemset.nix
@@ -56,10 +56,10 @@
     platforms = [];
     source = {
       remotes = ["https://rubygems.org"];
-      sha256 = "0qvp6h2abmlsl4sqjsvac03cr2mxq6143gbx4kq52rpazp021qsb";
+      sha256 = "16w217k9z02c4hqizym8dkj6bqmmzx4qdvqpnskgzf174a5pwdxk";
       type = "gem";
     };
-    version = "2.2.6.2";
+    version = "2.2.7";
   };
   rubyntlm = {
     groups = ["default"];

--- a/pkgs/servers/web-apps/discourse/plugins/discourse-openid-connect/default.nix
+++ b/pkgs/servers/web-apps/discourse/plugins/discourse-openid-connect/default.nix
@@ -6,8 +6,8 @@ mkDiscoursePlugin {
   src = fetchFromGitHub {
     owner = "discourse";
     repo = "discourse-openid-connect";
-    rev = "fd552d5eee75ba5710ce92bcd2fa7457ec98bcab";
-    sha256 = "sha256-+58QfVvA6BqI/5AfdI4RiSSMzWHvAJMxPvDS2r5FieU=";
+    rev = "a16d5edd386f4099064753a4eed72ecb9c1bb1a8";
+    sha256 = "sha256-9Fuu/UFmU4Gpkm5cRKOgDK0bt7nD545X18wtue+IrN8=";
   };
   meta = with lib; {
     homepage = "https://github.com/discourse/discourse-openid-connect";

--- a/pkgs/servers/web-apps/discourse/plugins/discourse-prometheus/Gemfile.lock
+++ b/pkgs/servers/web-apps/discourse/plugins/discourse-prometheus/Gemfile.lock
@@ -13,4 +13,4 @@ DEPENDENCIES
   webrick (= 1.7.0)
 
 BUNDLED WITH
-   2.4.6
+   2.4.10

--- a/pkgs/servers/web-apps/discourse/plugins/discourse-prometheus/default.nix
+++ b/pkgs/servers/web-apps/discourse/plugins/discourse-prometheus/default.nix
@@ -6,8 +6,8 @@
   src = fetchFromGitHub {
     owner = "discourse";
     repo = "discourse-prometheus";
-    rev = "78324fbaa8cfa3040ee7e01ac793ad2515b6c004";
-    sha256 = "sha256-xzI6gzRztLuEzFHlMi3iXZP9bRRMsRHRQEBrwqyzpdk=";
+    rev = "802cb5aa89838ecb3078dbe21b70d87b1675d89e";
+    sha256 = "sha256-tgujK/k/7l/9dAFna5sfUpgP0PVfjk+aGRbqZ70lmRw=";
   };
 
   patches = [

--- a/pkgs/servers/web-apps/discourse/plugins/discourse-reactions/default.nix
+++ b/pkgs/servers/web-apps/discourse/plugins/discourse-reactions/default.nix
@@ -5,8 +5,8 @@ mkDiscoursePlugin {
   src = fetchFromGitHub {
     owner = "discourse";
     repo = "discourse-reactions";
-    rev = "aba16d53d15ceca9ae18595ae85defbd10fe0256";
-    sha256 = "sha256-mGyMQGNa5Q2hMQkdIsa1JArA6cqSK+FmGSDJFZxS/go=";
+    rev = "01aca15b2774c088f3673118e92e9469f37d2fb6";
+    sha256 = "sha256-txQ1G2pBcl4bMBwv3vTs9dwBGKp2uEBvK7BuqQ1O8xg=";
   };
   meta = with lib; {
     homepage = "https://github.com/discourse/discourse-reactions";

--- a/pkgs/servers/web-apps/discourse/plugins/discourse-saved-searches/default.nix
+++ b/pkgs/servers/web-apps/discourse/plugins/discourse-saved-searches/default.nix
@@ -5,8 +5,8 @@ mkDiscoursePlugin {
   src = fetchFromGitHub {
     owner = "discourse";
     repo = "discourse-saved-searches";
-    rev = "d0b568efe6f829617a5bb85793f0ec1d697f2a96";
-    sha256 = "sha256-455ovBExE2+vuZOc0bESAbhtTOXqkMrQ//mVSIitLig=";
+    rev = "5c6d1b6c186c5c96bb92bd6de62d3bc2da6a5b68";
+    sha256 = "sha256-Z9wWwf9gH/Iainxx089J4eT7MpQeHpFXgTU40p/IcYY=";
   };
   meta = with lib; {
     homepage = "https://github.com/discourse/discourse-saved-searches";

--- a/pkgs/servers/web-apps/discourse/plugins/discourse-solved/default.nix
+++ b/pkgs/servers/web-apps/discourse/plugins/discourse-solved/default.nix
@@ -5,8 +5,8 @@ mkDiscoursePlugin {
   src = fetchFromGitHub {
     owner = "discourse";
     repo = "discourse-solved";
-    rev = "8580f96fdf64abf8b22fa4b28d67a4cb0d72fc42";
-    sha256 = "sha256-YpUybEXQuPeDxxdX9dMNw4h6Mh/zNUaiR3bwzck5Urg=";
+    rev = "29a991e60f3ca3bb44d382d675e4458794a683f3";
+    sha256 = "sha256-6flXuGA7SdIlGLYzyY5AXzQF/cEs39XfeptoBia8SHw=";
   };
   meta = with lib; {
     homepage = "https://github.com/discourse/discourse-solved";

--- a/pkgs/servers/web-apps/discourse/plugins/discourse-spoiler-alert/default.nix
+++ b/pkgs/servers/web-apps/discourse/plugins/discourse-spoiler-alert/default.nix
@@ -5,8 +5,8 @@ mkDiscoursePlugin {
   src = fetchFromGitHub {
     owner = "discourse";
     repo = "discourse-spoiler-alert";
-    rev = "a5fdb9096d638ac4a2a3f8ea6b02b6cb04c667d8";
-    sha256 = "sha256-S2Xtd/csB1YI85OA+2UO+OgF5u75Oi2YgIukQNOTQjk=";
+    rev = "0ee68da1fe1d029685a373df7fc874fcd2e50991";
+    sha256 = "sha256-z+0RL7HAJ92TyI1z2DBpirYN7IWzV7iGejs8Howo2+s=";
   };
   meta = with lib; {
     homepage = "https://github.com/discourse/discourse-spoiler-alert";

--- a/pkgs/servers/web-apps/discourse/plugins/discourse-voting/default.nix
+++ b/pkgs/servers/web-apps/discourse/plugins/discourse-voting/default.nix
@@ -5,8 +5,8 @@ mkDiscoursePlugin {
   src = fetchFromGitHub {
     owner = "discourse";
     repo = "discourse-voting";
-    rev = "54e134c9b4dfeeb7585ff2c2a782990308733d8b";
-    sha256 = "sha256-0V+4G2XxUjL424DChFIFjCKm2zWaTAXOSiB9Ic8/lF0=";
+    rev = "d9cab9664263e75d46533fb83586ce88cb2b6cfe";
+    sha256 = "sha256-cKbsc2ZPXaU4CAzM+oqwbs93l3NMrOGw4IBZLVZIDyw=";
   };
   meta = with lib; {
     homepage = "https://github.com/discourse/discourse-voting";

--- a/pkgs/servers/web-apps/discourse/plugins/discourse-yearly-review/default.nix
+++ b/pkgs/servers/web-apps/discourse/plugins/discourse-yearly-review/default.nix
@@ -5,8 +5,8 @@ mkDiscoursePlugin {
   src = fetchFromGitHub {
     owner = "discourse";
     repo = "discourse-yearly-review";
-    rev = "cb9a2df92788b0a285a595d4acf1749620f62974";
-    sha256 = "sha256-Hu61ULEXUxb/cjH7Z47hpBchyUTkz0QqunWoW8mSVQg=";
+    rev = "af7e294d04ca7b0c64dd604d19a553500accee51";
+    sha256 = "sha256-ioUJqLe/sUDKKa106hGY4OhwOgC+96YFQ4Lqr/CFF7Y=";
   };
   meta = with lib; {
     homepage = "https://github.com/discourse/discourse-yearly-review";

--- a/pkgs/servers/web-apps/discourse/rubyEnv/Gemfile
+++ b/pkgs/servers/web-apps/discourse/rubyEnv/Gemfile
@@ -18,7 +18,7 @@ else
   # this allows us to include the bits of rails we use without pieces we do not.
   #
   # To issue a rails update bump the version number here
-  rails_version = "7.0.4.1"
+  rails_version = "7.0.4.3"
   gem "actionmailer", rails_version
   gem "actionpack", rails_version
   gem "actionview", rails_version
@@ -41,7 +41,7 @@ gem "actionview_precompiler", require: false
 
 gem "discourse-seed-fu"
 
-gem "mail", git: "https://github.com/discourse/mail.git"
+gem "mail"
 gem "mini_mime"
 gem "mini_suffix"
 
@@ -70,8 +70,6 @@ gem "message_bus"
 gem "rails_multisite"
 
 gem "fast_xs", platform: :ruby
-
-gem "xorcist"
 
 gem "fastimage"
 
@@ -105,7 +103,7 @@ gem "pg"
 gem "mini_sql"
 gem "pry-rails", require: false
 gem "pry-byebug", require: false
-gem "r2", require: false
+gem "rtlcss", require: false
 gem "rake"
 
 gem "thor", require: false
@@ -180,6 +178,7 @@ group :development do
   gem "better_errors", platform: :mri, require: !!ENV["BETTER_ERRORS"]
   gem "binding_of_caller"
   gem "yaml-lint"
+  gem "yard"
 end
 
 if ENV["ALLOW_DEV_POPULATE"] == "1"
@@ -229,10 +228,9 @@ gem "logstash-event", require: false
 gem "logstash-logger", require: false
 gem "logster"
 
-# NOTE: later versions of sassc are causing a segfault, possibly dependent on processer architecture
-# and until resolved should be locked at 2.0.1
-gem "sassc", "2.0.1", require: false
-gem "sassc-rails"
+# These are forks of sassc and sassc-rails with dart-sass support
+gem "dartsass-ruby"
+gem "dartsass-sprockets"
 
 gem "rotp", require: false
 
@@ -279,3 +277,5 @@ gem "webrick", require: false
 
 # Workaround until Ruby ships with cgi version 0.3.6 or higher.
 gem "cgi", ">= 0.3.6", require: false
+
+gem "tzinfo-data"

--- a/pkgs/servers/web-apps/discourse/rubyEnv/Gemfile.lock
+++ b/pkgs/servers/web-apps/discourse/rubyEnv/Gemfile.lock
@@ -1,11 +1,4 @@
 GIT
-  remote: https://github.com/discourse/mail.git
-  revision: 5b700fc95ee66378e0cf2559abc73c8bc3062a4b
-  specs:
-    mail (2.8.0.edge)
-      mini_mime (>= 0.1.1)
-
-GIT
   remote: https://github.com/rails/sprockets
   revision: f4d3dae71ef29c44b75a49cfbf8032cce07b423a
   branch: 3.x
@@ -17,25 +10,25 @@ GIT
 GEM
   remote: https://rubygems.org/
   specs:
-    actionmailer (7.0.4.1)
-      actionpack (= 7.0.4.1)
-      actionview (= 7.0.4.1)
-      activejob (= 7.0.4.1)
-      activesupport (= 7.0.4.1)
+    actionmailer (7.0.4.3)
+      actionpack (= 7.0.4.3)
+      actionview (= 7.0.4.3)
+      activejob (= 7.0.4.3)
+      activesupport (= 7.0.4.3)
       mail (~> 2.5, >= 2.5.4)
       net-imap
       net-pop
       net-smtp
       rails-dom-testing (~> 2.0)
-    actionpack (7.0.4.1)
-      actionview (= 7.0.4.1)
-      activesupport (= 7.0.4.1)
+    actionpack (7.0.4.3)
+      actionview (= 7.0.4.3)
+      activesupport (= 7.0.4.3)
       rack (~> 2.0, >= 2.2.0)
       rack-test (>= 0.6.3)
       rails-dom-testing (~> 2.0)
       rails-html-sanitizer (~> 1.0, >= 1.2.0)
-    actionview (7.0.4.1)
-      activesupport (= 7.0.4.1)
+    actionview (7.0.4.3)
+      activesupport (= 7.0.4.3)
       builder (~> 3.1)
       erubi (~> 1.4)
       rails-dom-testing (~> 2.0)
@@ -44,20 +37,20 @@ GEM
       actionview (>= 6.0.a)
     active_model_serializers (0.8.4)
       activemodel (>= 3.0)
-    activejob (7.0.4.1)
-      activesupport (= 7.0.4.1)
+    activejob (7.0.4.3)
+      activesupport (= 7.0.4.3)
       globalid (>= 0.3.6)
-    activemodel (7.0.4.1)
-      activesupport (= 7.0.4.1)
-    activerecord (7.0.4.1)
-      activemodel (= 7.0.4.1)
-      activesupport (= 7.0.4.1)
-    activesupport (7.0.4.1)
+    activemodel (7.0.4.3)
+      activesupport (= 7.0.4.3)
+    activerecord (7.0.4.3)
+      activemodel (= 7.0.4.3)
+      activesupport (= 7.0.4.3)
+    activesupport (7.0.4.3)
       concurrent-ruby (~> 1.0, >= 1.0.2)
       i18n (>= 1.6, < 2)
       minitest (>= 5.1)
       tzinfo (~> 2.0)
-    addressable (2.8.1)
+    addressable (2.8.4)
       public_suffix (>= 2.0.2, < 6.0)
     annotate (3.2.0)
       activerecord (>= 3.2, < 8.0)
@@ -88,14 +81,14 @@ GEM
       rack (>= 0.9.0)
     binding_of_caller (1.0.0)
       debug_inspector (>= 0.0.1)
-    bootsnap (1.15.0)
+    bootsnap (1.16.0)
       msgpack (~> 1.2)
     builder (3.2.4)
     bullet (7.0.7)
       activesupport (>= 3.0.0)
       uniform_notifier (~> 1.11)
     byebug (11.1.3)
-    capybara (3.38.0)
+    capybara (3.39.0)
       addressable
       matrix
       mini_mime (>= 0.1.3)
@@ -110,8 +103,8 @@ GEM
     chunky_png (1.4.0)
     coderay (1.1.3)
     colored2 (3.1.2)
-    concurrent-ruby (1.2.0)
-    connection_pool (2.3.0)
+    concurrent-ruby (1.2.2)
+    connection_pool (2.4.0)
     cose (1.3.0)
       cbor (~> 0.5.9)
       openssl-signature_algorithm (~> 1.0)
@@ -121,6 +114,14 @@ GEM
     crass (1.0.6)
     css_parser (1.14.0)
       addressable
+    dartsass-ruby (3.0.1)
+      sass-embedded (~> 1.54)
+    dartsass-sprockets (3.0.0)
+      dartsass-ruby (~> 3.0)
+      railties (>= 4.0.0)
+      sprockets (> 3.0)
+      sprockets-rails
+      tilt
     date (3.3.3)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
@@ -138,7 +139,7 @@ GEM
       regexp_parser (~> 2.2)
     email_reply_trimmer (0.1.13)
     erubi (1.12.0)
-    excon (0.97.2)
+    excon (0.99.0)
     execjs (2.8.1)
     exifr (1.3.10)
     fabrication (2.30.0)
@@ -149,7 +150,7 @@ GEM
       faraday-net_http (>= 2.0, < 3.1)
       ruby2_keywords (>= 0.0.4)
     faraday-net_http (3.0.2)
-    faraday-retry (2.0.0)
+    faraday-retry (2.1.0)
       faraday (~> 2.0)
     fast_blank (1.0.1)
     fast_xs (0.8.0)
@@ -157,8 +158,9 @@ GEM
     ffi (1.15.5)
     fspath (3.1.2)
     gc_tracer (1.5.1)
-    globalid (1.0.1)
+    globalid (1.1.0)
       activesupport (>= 5.0)
+    google-protobuf (3.22.3)
     guess_html_encoding (0.0.11)
     hana (1.3.7)
     hashdiff (1.0.1)
@@ -169,7 +171,7 @@ GEM
     http_accept_language (2.1.1)
     i18n (1.12.0)
       concurrent-ruby (~> 1.0)
-    image_optim (0.31.2)
+    image_optim (0.31.3)
       exifr (~> 1.2, >= 1.2.2)
       fspath (~> 3.0)
       image_size (>= 1.5, < 4)
@@ -186,7 +188,7 @@ GEM
       hana (~> 1.3)
       regexp_parser (~> 2.0)
       uri_template (~> 0.7)
-    jwt (2.6.0)
+    jwt (2.7.0)
     kgio (2.11.4)
     libv8-node (16.10.0.0)
     listen (3.8.0)
@@ -201,12 +203,17 @@ GEM
     logstash-event (1.2.02)
     logstash-logger (0.26.1)
       logstash-event (~> 1.2)
-    logster (2.11.3)
-    loofah (2.19.1)
+    logster (2.12.2)
+    loofah (2.20.0)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
     lru_redux (1.1.0)
     lz4-ruby (0.3.3)
+    mail (2.8.1)
+      mini_mime (>= 0.1.1)
+      net-imap
+      net-pop
+      net-smtp
     matrix (0.4.2)
     maxminddb (0.1.22)
     memory_profiler (1.0.1)
@@ -222,10 +229,10 @@ GEM
     mini_sql (1.4.0)
     mini_suffix (0.3.3)
       ffi (~> 1.9)
-    minitest (5.17.0)
+    minitest (5.18.0)
     mocha (2.0.2)
       ruby2_keywords (>= 0.0.5)
-    msgpack (1.6.0)
+    msgpack (1.7.0)
     multi_json (1.15.0)
     multi_xml (0.6.0)
     mustache (1.1.1)
@@ -240,8 +247,8 @@ GEM
       timeout
     net-smtp (0.3.3)
       net-protocol
-    nio4r (2.5.8)
-    nokogiri (1.14.0)
+    nio4r (2.5.9)
+    nokogiri (1.14.3)
       mini_portile2 (~> 2.8.0)
       racc (~> 1.4)
     oauth (1.1.0)
@@ -279,17 +286,17 @@ GEM
     omniauth-twitter (1.4.0)
       omniauth-oauth (~> 1.1)
       rack
-    openssl (3.0.2)
-    openssl-signature_algorithm (1.2.1)
-      openssl (> 2.0, < 3.1)
+    openssl (3.1.0)
+    openssl-signature_algorithm (1.3.0)
+      openssl (> 2.0)
     optimist (3.0.1)
     parallel (1.22.1)
-    parallel_tests (4.1.0)
+    parallel_tests (4.2.0)
       parallel
-    parser (3.2.0.0)
+    parser (3.2.2.0)
       ast (~> 2.4.1)
-    pg (1.4.5)
-    prettier_print (1.2.0)
+    pg (1.4.6)
+    prettier_print (1.2.1)
     progress (3.6.0)
     pry (0.14.2)
       coderay (~> 1.1)
@@ -300,38 +307,37 @@ GEM
     pry-rails (0.3.9)
       pry (>= 0.10.4)
     public_suffix (5.0.1)
-    puma (6.0.2)
+    puma (6.2.1)
       nio4r (~> 2.0)
-    r2 (0.2.7)
     racc (1.6.2)
-    rack (2.2.6.2)
-    rack-mini-profiler (3.0.0)
+    rack (2.2.6.4)
+    rack-mini-profiler (3.1.0)
       rack (>= 1.2.0)
-    rack-protection (3.0.5)
+    rack-protection (3.0.6)
       rack
-    rack-test (2.0.2)
+    rack-test (2.1.0)
       rack (>= 1.3)
     rails-dom-testing (2.0.3)
       activesupport (>= 4.2.0)
       nokogiri (>= 1.6)
     rails-html-sanitizer (1.5.0)
       loofah (~> 2.19, >= 2.19.1)
-    rails_failover (0.8.1)
+    rails_failover (1.0.0)
       activerecord (> 6.0, < 7.1)
       concurrent-ruby
       railties (> 6.0, < 7.1)
     rails_multisite (4.0.1)
       activerecord (> 5.0, < 7.1)
       railties (> 5.0, < 7.1)
-    railties (7.0.4.1)
-      actionpack (= 7.0.4.1)
-      activesupport (= 7.0.4.1)
+    railties (7.0.4.3)
+      actionpack (= 7.0.4.3)
+      activesupport (= 7.0.4.3)
       method_source
       rake (>= 12.2)
       thor (~> 1.0)
       zeitwerk (~> 2.5)
     rainbow (3.1.1)
-    raindrops (0.20.0)
+    raindrops (0.20.1)
     rake (13.0.6)
     rb-fsevent (0.11.2)
     rb-inotify (0.10.1)
@@ -341,10 +347,10 @@ GEM
       msgpack (>= 0.4.3)
       optimist (>= 3.0.0)
     rchardet (1.8.0)
-    redis (4.8.0)
+    redis (4.8.1)
     redis-namespace (1.10.0)
       redis (>= 4)
-    regexp_parser (2.6.2)
+    regexp_parser (2.8.0)
     request_store (1.5.1)
       rack (>= 1.4)
     rexml (3.2.5)
@@ -358,7 +364,7 @@ GEM
       rspec-core (~> 3.12.0)
       rspec-expectations (~> 3.12.0)
       rspec-mocks (~> 3.12.0)
-    rspec-core (3.12.0)
+    rspec-core (3.12.1)
       rspec-support (~> 3.12.0)
     rspec-expectations (3.12.2)
       diff-lcs (>= 1.2.0, < 2.0)
@@ -366,7 +372,7 @@ GEM
     rspec-html-matchers (0.10.0)
       nokogiri (~> 1)
       rspec (>= 3.0.0.a)
-    rspec-mocks (3.12.3)
+    rspec-mocks (3.12.5)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.12.0)
     rspec-rails (6.0.1)
@@ -385,46 +391,42 @@ GEM
       json-schema (>= 2.2, < 4.0)
       railties (>= 3.1, < 7.1)
       rspec-core (>= 2.14)
-    rubocop (1.44.0)
+    rtlcss (0.2.0)
+      mini_racer (~> 0.6.3)
+    rubocop (1.50.2)
       json (~> 2.3)
       parallel (~> 1.10)
       parser (>= 3.2.0.0)
       rainbow (>= 2.2.2, < 4.0)
       regexp_parser (>= 1.8, < 3.0)
       rexml (>= 3.2.5, < 4.0)
-      rubocop-ast (>= 1.24.1, < 2.0)
+      rubocop-ast (>= 1.28.0, < 2.0)
       ruby-progressbar (~> 1.7)
       unicode-display_width (>= 2.4.0, < 3.0)
-    rubocop-ast (1.24.1)
-      parser (>= 3.1.1.0)
-    rubocop-capybara (2.17.0)
+    rubocop-ast (1.28.0)
+      parser (>= 3.2.1.0)
+    rubocop-capybara (2.17.1)
       rubocop (~> 1.41)
-    rubocop-discourse (3.0.3)
+    rubocop-discourse (3.2.0)
       rubocop (>= 1.1.0)
       rubocop-rspec (>= 2.0.0)
-    rubocop-rspec (2.18.1)
+    rubocop-rspec (2.19.0)
       rubocop (~> 1.33)
       rubocop-capybara (~> 2.17)
-    ruby-prof (1.4.5)
-    ruby-progressbar (1.11.0)
+    ruby-prof (1.6.1)
+    ruby-progressbar (1.13.0)
     ruby-readability (0.7.0)
       guess_html_encoding (>= 0.0.4)
       nokogiri (>= 1.6.0)
     ruby2_keywords (0.0.5)
     rubyzip (2.3.2)
-    sanitize (6.0.0)
+    sanitize (6.0.1)
       crass (~> 1.0.2)
       nokogiri (>= 1.12.0)
-    sassc (2.0.1)
-      ffi (~> 1.9)
-      rake
-    sassc-rails (2.1.2)
-      railties (>= 4.0.0)
-      sassc (>= 2.0)
-      sprockets (> 3.0)
-      sprockets-rails
-      tilt
-    selenium-webdriver (4.8.0)
+    sass-embedded (1.62.0)
+      google-protobuf (~> 3.21)
+      rake (>= 10.0.0)
+    selenium-webdriver (4.8.6)
       rexml (~> 3.2, >= 3.2.5)
       rubyzip (>= 1.2.2, < 3.0)
       websocket (~> 1.0)
@@ -448,16 +450,18 @@ GEM
       activesupport (>= 5.2)
       sprockets (>= 3.0.0)
     sshkey (2.0.0)
-    stackprof (0.2.23)
-    syntax_tree (5.2.0)
+    stackprof (0.2.25)
+    syntax_tree (6.1.1)
       prettier_print (>= 1.2.0)
     syntax_tree-disable_ternary (1.0.0)
-    test-prof (1.1.0)
+    test-prof (1.2.1)
     thor (1.2.1)
-    tilt (2.0.11)
-    timeout (0.3.1)
-    tzinfo (2.0.5)
+    tilt (2.1.0)
+    timeout (0.3.2)
+    tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
+    tzinfo-data (1.2023.3)
+      tzinfo (>= 1.0.0)
     uglifier (4.2.0)
       execjs (>= 0.3.0, < 3)
     unf (0.1.4)
@@ -468,9 +472,9 @@ GEM
       kgio (~> 2.6)
       raindrops (~> 0.7)
     uniform_notifier (1.16.0)
-    uri (0.12.0)
+    uri (0.12.1)
     uri_template (0.7.0)
-    version_gem (1.1.1)
+    version_gem (1.1.2)
     web-push (3.0.0)
       hkdf (~> 1.0)
       jwt (~> 2.0)
@@ -485,24 +489,24 @@ GEM
       hashdiff (>= 0.4.0, < 2.0.0)
     webrick (1.7.0)
     websocket (1.2.9)
-    xorcist (1.1.3)
     xpath (3.2.0)
       nokogiri (~> 1.8)
     yaml-lint (0.1.2)
-    zeitwerk (2.6.6)
+    yard (0.9.34)
+    zeitwerk (2.6.7)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
-  actionmailer (= 7.0.4.1)
-  actionpack (= 7.0.4.1)
-  actionview (= 7.0.4.1)
+  actionmailer (= 7.0.4.3)
+  actionpack (= 7.0.4.3)
+  actionview (= 7.0.4.3)
   actionview_precompiler
   active_model_serializers (~> 0.8.3)
-  activemodel (= 7.0.4.1)
-  activerecord (= 7.0.4.1)
-  activesupport (= 7.0.4.1)
+  activemodel (= 7.0.4.3)
+  activerecord (= 7.0.4.3)
+  activesupport (= 7.0.4.3)
   addressable
   annotate
   aws-sdk-s3
@@ -520,6 +524,8 @@ DEPENDENCIES
   cose
   cppjieba_rb
   css_parser
+  dartsass-ruby
+  dartsass-sprockets
   diffy
   digest
   discourse-fonts
@@ -551,7 +557,7 @@ DEPENDENCIES
   loofah
   lru_redux
   lz4-ruby
-  mail!
+  mail
   maxminddb
   memory_profiler
   message_bus
@@ -581,13 +587,12 @@ DEPENDENCIES
   pry-byebug
   pry-rails
   puma
-  r2
   rack
   rack-mini-profiler
   rack-protection
   rails_failover
   rails_multisite
-  railties (= 7.0.4.1)
+  railties (= 7.0.4.3)
   rake
   rb-fsevent
   rbtrace
@@ -602,13 +607,12 @@ DEPENDENCIES
   rspec-rails
   rss
   rswag-specs
+  rtlcss
   rubocop-discourse
   ruby-prof
   ruby-readability
   rubyzip
   sanitize
-  sassc (= 2.0.1)
-  sassc-rails
   selenium-webdriver
   shoulda-matchers
   sidekiq
@@ -621,6 +625,7 @@ DEPENDENCIES
   syntax_tree-disable_ternary
   test-prof
   thor
+  tzinfo-data
   uglifier
   unf
   unicorn
@@ -628,8 +633,8 @@ DEPENDENCIES
   webdrivers
   webmock
   webrick
-  xorcist
   yaml-lint
+  yard
 
 BUNDLED WITH
-   2.4.6
+   2.4.10

--- a/pkgs/servers/web-apps/discourse/rubyEnv/gemset.nix
+++ b/pkgs/servers/web-apps/discourse/rubyEnv/gemset.nix
@@ -5,10 +5,10 @@
     platforms = [];
     source = {
       remotes = ["https://rubygems.org"];
-      sha256 = "1v4ra6jx4bynzj3im6fjbyyy1h6582qg72r6i42myls84z75qsxk";
+      sha256 = "112ga1x7y5l0fmammlwajzqxp0fbg1ciw7f6ad9a55wrb0n3hk3y";
       type = "gem";
     };
-    version = "7.0.4.1";
+    version = "7.0.4.3";
   };
   actionpack = {
     dependencies = ["actionview" "activesupport" "rack" "rack-test" "rails-dom-testing" "rails-html-sanitizer"];
@@ -16,10 +16,10 @@
     platforms = [];
     source = {
       remotes = ["https://rubygems.org"];
-      sha256 = "1g823r92w9c1si2mxd82mibdva1fyw0ccin0dc2bpbszk6zfyxrh";
+      sha256 = "1cb0hqkfkc0b9s7swvi4nf64c24i3ma1gv09anr8a81k56s0rwxd";
       type = "gem";
     };
-    version = "7.0.4.1";
+    version = "7.0.4.3";
   };
   actionview = {
     dependencies = ["activesupport" "builder" "erubi" "rails-dom-testing" "rails-html-sanitizer"];
@@ -27,10 +27,10 @@
     platforms = [];
     source = {
       remotes = ["https://rubygems.org"];
-      sha256 = "1pfnbkq1hzzxzrnc0m1dd0l2cad6x041dfv3ndrkk5llcjarphx2";
+      sha256 = "1h9027sqzfcbc84dnzw8nxjyg15zrk1y2fc0468wg1xi9nmyw96z";
       type = "gem";
     };
-    version = "7.0.4.1";
+    version = "7.0.4.3";
   };
   actionview_precompiler = {
     dependencies = ["actionview"];
@@ -60,10 +60,10 @@
     platforms = [];
     source = {
       remotes = ["https://rubygems.org"];
-      sha256 = "0yrjvd2w3l6fd5s984hn885dwcxj078ggfbbr1cpynjnqxrvvm6f";
+      sha256 = "08xawfj8lkxlfwnmx3f7324w126rli6mqdx9j6ybz2ks9vxz0x3w";
       type = "gem";
     };
-    version = "7.0.4.1";
+    version = "7.0.4.3";
   };
   activemodel = {
     dependencies = ["activesupport"];
@@ -71,10 +71,10 @@
     platforms = [];
     source = {
       remotes = ["https://rubygems.org"];
-      sha256 = "0y1v2jy4cwi6dkd9yr399kw53smaiyiqx7bsnljwmsz98g125sdw";
+      sha256 = "0ymhsxgdb68zgf4zp07g2bymmpgn0b9r38avn9pagz1p5zy1ql9v";
       type = "gem";
     };
-    version = "7.0.4.1";
+    version = "7.0.4.3";
   };
   activerecord = {
     dependencies = ["activemodel" "activesupport"];
@@ -82,10 +82,10 @@
     platforms = [];
     source = {
       remotes = ["https://rubygems.org"];
-      sha256 = "1c3wvrym6ib2a6ljc4n572gsrr46hazp7f0zijm8jdc8zp3yx5vi";
+      sha256 = "01wb98i2zsbb4jcb4i6z72vb05wiks4hv9chc66h1rsxrv0zi4dv";
       type = "gem";
     };
-    version = "7.0.4.1";
+    version = "7.0.4.3";
   };
   activesupport = {
     dependencies = ["concurrent-ruby" "i18n" "minitest" "tzinfo"];
@@ -93,10 +93,10 @@
     platforms = [];
     source = {
       remotes = ["https://rubygems.org"];
-      sha256 = "1j0ms94ng1hsxb37aar5j3n4mabjqvjkcl70adjrqib7grriyq7b";
+      sha256 = "15m0b1im6i401ab51vzr7f8nk8kys1qa0snnl741y3sir3xd07jp";
       type = "gem";
     };
-    version = "7.0.4.1";
+    version = "7.0.4.3";
   };
   addressable = {
     dependencies = ["public_suffix"];
@@ -104,10 +104,10 @@
     platforms = [];
     source = {
       remotes = ["https://rubygems.org"];
-      sha256 = "1ypdmpdn20hxp5vwxz3zc04r5xcwqc25qszdlg41h8ghdqbllwmw";
+      sha256 = "15s8van7r2ad3dq6i03l3z4hqnvxcq75a3h72kxvf9an53sqma20";
       type = "gem";
     };
-    version = "2.8.1";
+    version = "2.8.4";
   };
   annotate = {
     dependencies = ["activerecord" "rake"];
@@ -241,10 +241,10 @@
     }];
     source = {
       remotes = ["https://rubygems.org"];
-      sha256 = "1ln89f9ypzincd5hqgmzd5vvfgf7fgir56v1spsri40ma88vnipj";
+      sha256 = "1vcg52gwl64xhhal6kwk1pc01y1klzdlnv1awyk89kb91z010x7q";
       type = "gem";
     };
-    version = "1.15.0";
+    version = "1.16.0";
   };
   builder = {
     groups = ["default" "development" "test"];
@@ -287,10 +287,10 @@
     platforms = [];
     source = {
       remotes = ["https://rubygems.org"];
-      sha256 = "123198zk2ak8mziwa5jc3ckgpmsg08zn064n3aywnqm9s1bwjv3v";
+      sha256 = "06b4nlhirsq8ny17s8zgz7qyvl9v41rixj1xkviiiwxlnjz982d3";
       type = "gem";
     };
-    version = "3.38.0";
+    version = "3.39.0";
   };
   cbor = {
     groups = ["default"];
@@ -361,20 +361,20 @@
     platforms = [];
     source = {
       remotes = ["https://rubygems.org"];
-      sha256 = "1qnsflsbjj38im8xq35g0vihlz96h09wjn2dad5g543l3vvrkrx5";
+      sha256 = "0krcwb6mn0iklajwngwsg850nk8k9b35dhmc2qkbdqvmifdi2y9q";
       type = "gem";
     };
-    version = "1.2.0";
+    version = "1.2.2";
   };
   connection_pool = {
     groups = ["default"];
     platforms = [];
     source = {
       remotes = ["https://rubygems.org"];
-      sha256 = "1nj4r58m5cpfdsijj6gjfs3yzcnxq2halagjk07wjcrgj6z8ayb7";
+      sha256 = "0dndngqvkm2ih3wqn5ilf9980c1cc57lqn5lywx3myalzpilq05z";
       type = "gem";
     };
-    version = "2.3.0";
+    version = "2.4.0";
   };
   cose = {
     dependencies = ["cbor" "openssl-signature_algorithm"];
@@ -428,6 +428,28 @@
       type = "gem";
     };
     version = "1.14.0";
+  };
+  dartsass-ruby = {
+    dependencies = ["sass-embedded"];
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0z3gdsnyvdjgn9gwia72irqgxq04i8hv9pv60yqkd4h5nk9rx4p6";
+      type = "gem";
+    };
+    version = "3.0.1";
+  };
+  dartsass-sprockets = {
+    dependencies = ["dartsass-ruby" "railties" "sprockets" "sprockets-rails" "tilt"];
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "1842k5i96iiz264wzzqar2m3whs2caf0d8yhbsr6qdbi4j5pzmcx";
+      type = "gem";
+    };
+    version = "3.0.0";
   };
   date = {
     groups = ["default"];
@@ -561,10 +583,10 @@
     platforms = [];
     source = {
       remotes = ["https://rubygems.org"];
-      sha256 = "17prxavwwskpv7dfl3npl0pgqiqg99rrmakqj1n4m5hl69jqz8y4";
+      sha256 = "0j826kfvzn7nc5pv950n270r0sx1702k988ad11cdlav3dcxxw09";
       type = "gem";
     };
-    version = "0.97.2";
+    version = "0.99.0";
   };
   execjs = {
     groups = ["assets" "default"];
@@ -644,10 +666,10 @@
     platforms = [];
     source = {
       remotes = ["https://rubygems.org"];
-      sha256 = "07bn75d784ndj9ljqk19ff6217hkqqmxjlnjx5b9v36k2nnj9kys";
+      sha256 = "1zz0w4jpfa6h1wlirfcs9hzvlpijnd1nnmjq94w5yv50585p279n";
       type = "gem";
     };
-    version = "2.0.0";
+    version = "2.1.0";
   };
   fast_blank = {
     groups = ["default"];
@@ -735,10 +757,20 @@
     platforms = [];
     source = {
       remotes = ["https://rubygems.org"];
-      sha256 = "040bxzfd7mz1p6z4bc9vk5yrf762hdllvf98hmk848fq28xc5dsk";
+      sha256 = "0kqm5ndzaybpnpxqiqkc41k4ksyxl41ln8qqr6kb130cdxsf2dxk";
       type = "gem";
     };
-    version = "1.0.1";
+    version = "1.1.0";
+  };
+  google-protobuf = {
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "1xcg53yz44cqhcpb85w3ay80kvnniy0v441c9p08wb6zzia2mnq9";
+      type = "gem";
+    };
+    version = "3.22.3";
   };
   guess_html_encoding = {
     groups = ["default"];
@@ -837,10 +869,10 @@
     platforms = [];
     source = {
       remotes = ["https://rubygems.org"];
-      sha256 = "0acrqj9g8x39lz3z9li52wwc98d0csqarc7bv6jcfd0fp6h9zykb";
+      sha256 = "02iw1plldayr1l8bdw2gshq0h083h0fxwji1m1nfhzikz917c07p";
       type = "gem";
     };
-    version = "0.31.2";
+    version = "0.31.3";
   };
   image_size = {
     groups = ["default"];
@@ -909,10 +941,10 @@
     platforms = [];
     source = {
       remotes = ["https://rubygems.org"];
-      sha256 = "1x8zp1a2pnngxh7631s0kn0r665qkwzfp16kifmp93r4zj6ci8v8";
+      sha256 = "09yj3z5snhaawh2z1w45yyihzmh57m6m7dp8ra8gxavhj5kbiq5p";
       type = "gem";
     };
-    version = "2.6.0";
+    version = "2.7.0";
   };
   kgio = {
     groups = ["default"];
@@ -998,10 +1030,10 @@
     platforms = [];
     source = {
       remotes = ["https://rubygems.org"];
-      sha256 = "01n1ynk2xa94za8hhqy3xzfwhm24zhh3x5yllziyz3zjxxrj7fxc";
+      sha256 = "18yqcf756rzxdq5pw2qrximfryv15ib7rv2g622wjig7zhvk8wx4";
       type = "gem";
     };
-    version = "2.11.3";
+    version = "2.12.2";
   };
   loofah = {
     dependencies = ["crass" "nokogiri"];
@@ -1009,10 +1041,10 @@
     platforms = [];
     source = {
       remotes = ["https://rubygems.org"];
-      sha256 = "08qhzck271anrx9y6qa6mh8hwwdzsgwld8q0000rcd7yvvpnjr3c";
+      sha256 = "1mi4ia13fisc97fzd8xcd9wkjdki7zfbmdn1xkdzplicir68gyp8";
       type = "gem";
     };
-    version = "2.19.1";
+    version = "2.20.0";
   };
   lru_redux = {
     groups = ["default"];
@@ -1041,17 +1073,15 @@
     version = "0.3.3";
   };
   mail = {
-    dependencies = ["mini_mime"];
+    dependencies = ["mini_mime" "net-imap" "net-pop" "net-smtp"];
     groups = ["default"];
     platforms = [];
     source = {
-      fetchSubmodules = false;
-      rev = "5b700fc95ee66378e0cf2559abc73c8bc3062a4b";
-      sha256 = "0j084s1gsdwiqvm4jdayi0x4rsdrazqv8z8wkz28v7zmaymw18lz";
-      type = "git";
-      url = "https://github.com/discourse/mail.git";
+      remotes = ["https://rubygems.org"];
+      sha256 = "1bf9pysw1jfgynv692hhaycfxa8ckay1gjw5hz3madrbrynryfzc";
+      type = "gem";
     };
-    version = "2.8.0.edge";
+    version = "2.8.1";
   };
   matrix = {
     groups = ["default" "test"];
@@ -1176,10 +1206,10 @@
     platforms = [];
     source = {
       remotes = ["https://rubygems.org"];
-      sha256 = "1kjy67qajw4rnkbjs5jyk7kc3lyhz5613fwj1i8f6ppdk4zampy0";
+      sha256 = "0ic7i5z88zcaqnpzprf7saimq2f6sad57g5mkkqsrqrcd6h3mx06";
       type = "gem";
     };
-    version = "5.17.0";
+    version = "5.18.0";
   };
   mocha = {
     dependencies = ["ruby2_keywords"];
@@ -1201,10 +1231,10 @@
     }];
     source = {
       remotes = ["https://rubygems.org"];
-      sha256 = "1q03pb0vq8388s431nbxabsfxnch6p304c8vnjlk0zzpcv713yr3";
+      sha256 = "172ky0r1jfcm3xyg067pia7k1lhc15vw9svv93max120gcdbrvji";
       type = "gem";
     };
-    version = "1.6.0";
+    version = "1.7.0";
   };
   multi_json = {
     groups = ["default"];
@@ -1296,10 +1326,10 @@
     platforms = [];
     source = {
       remotes = ["https://rubygems.org"];
-      sha256 = "0xk64wghkscs6bv2n22853k2nh39d131c6rfpnlw12mbjnnv9v1v";
+      sha256 = "0w9978zwjf1qhy3amkivab0f9syz6a7k0xgydjidaf7xc831d78f";
       type = "gem";
     };
-    version = "2.5.8";
+    version = "2.5.9";
   };
   nokogiri = {
     dependencies = ["mini_portile2" "racc"];
@@ -1307,10 +1337,10 @@
     platforms = [];
     source = {
       remotes = ["https://rubygems.org"];
-      sha256 = "1fqld4wnamj7awdr1lwdifpylqdrrg5adm8xj2jl9sc5ms3nxjjm";
+      sha256 = "0fnw0z8zl8b5k35g9m5hhc1g4s6ajzjinhyxnqjrx7l7p07fw71v";
       type = "gem";
     };
-    version = "1.14.0";
+    version = "1.14.3";
   };
   oauth = {
     dependencies = ["oauth-tty" "snaky_hash" "version_gem"];
@@ -1437,10 +1467,10 @@
     platforms = [];
     source = {
       remotes = ["https://rubygems.org"];
-      sha256 = "0mcg47zz4w902cq6c8cdj62npawgwq68sfh7n7aqy7vm3pgvls9h";
+      sha256 = "0c649921vg2l939z5cc3jwd8p1v49099pdhxfk7sb9qqx5wi5873";
       type = "gem";
     };
-    version = "3.0.2";
+    version = "3.1.0";
   };
   openssl-signature_algorithm = {
     dependencies = ["openssl"];
@@ -1448,10 +1478,10 @@
     platforms = [];
     source = {
       remotes = ["https://rubygems.org"];
-      sha256 = "0rwjga70kbg0rmwgksb2if34ndh9cy0fgrimkx3hjz9c68ssvpxg";
+      sha256 = "103yjl68wqhl5kxaciir5jdnyi7iv9yckishdr52s5knh9g0pd53";
       type = "gem";
     };
-    version = "1.2.1";
+    version = "1.3.0";
   };
   optimist = {
     groups = ["default"];
@@ -1483,10 +1513,10 @@
     platforms = [];
     source = {
       remotes = ["https://rubygems.org"];
-      sha256 = "1p0y8cgdmfwyg7plwlsjf9afshm81wj9ah8nprmpfrv28adg3vn6";
+      sha256 = "11lf8vsh6kxzp7k3xzkxdmb31b01phaz5z8a7sjpq9hh6ab30k8l";
       type = "gem";
     };
-    version = "4.1.0";
+    version = "4.2.0";
   };
   parser = {
     dependencies = ["ast"];
@@ -1494,30 +1524,30 @@
     platforms = [];
     source = {
       remotes = ["https://rubygems.org"];
-      sha256 = "0zk8mdyr0322r11d63rcp5jhz4lakxilhvyvdv0ql5dw4lb83623";
+      sha256 = "0s5afi89p76k8vpwiqvh343pm5l23ijqlpszhz65afym3zpkxhzx";
       type = "gem";
     };
-    version = "3.2.0.0";
+    version = "3.2.2.0";
   };
   pg = {
     groups = ["default"];
     platforms = [];
     source = {
       remotes = ["https://rubygems.org"];
-      sha256 = "1wd6nl81nbdwck04hccsm7wf23ghpi8yddd9j4rbwyvyj0sbsff1";
+      sha256 = "07m6lxljabw9kyww5k5lgsxsznsm1v5l14r1la09gqka9b5kv3yr";
       type = "gem";
     };
-    version = "1.4.5";
+    version = "1.4.6";
   };
   prettier_print = {
     groups = ["default" "development" "test"];
     platforms = [];
     source = {
       remotes = ["https://rubygems.org"];
-      sha256 = "1bbw4czjr2ch6m57rgjib5a35hx3g18975vwzm2iwq13pvdj9hzk";
+      sha256 = "1ybgks9862zmlx71zd4j20ky86fsrp6j6m0az4hzzb1zyaskha57";
       type = "gem";
     };
-    version = "1.2.0";
+    version = "1.2.1";
   };
   progress = {
     groups = ["default"];
@@ -1578,20 +1608,10 @@
     platforms = [];
     source = {
       remotes = ["https://rubygems.org"];
-      sha256 = "15hj8r6wp23k187ajmp13kldk53ygm84q4caq7nlndrn8jlcsps0";
+      sha256 = "0qqd5lb3mamh53ssx0xavmspg4blhq6hd1kipksw20bq71xcklf5";
       type = "gem";
     };
-    version = "6.0.2";
-  };
-  r2 = {
-    groups = ["default"];
-    platforms = [];
-    source = {
-      remotes = ["https://rubygems.org"];
-      sha256 = "0wk0p55zp3l96xy5ps28b33dn5z0jwsjl74bwfdn6z81pzjs5sfk";
-      type = "gem";
-    };
-    version = "0.2.7";
+    version = "6.2.1";
   };
   racc = {
     groups = ["default" "development" "test"];
@@ -1612,10 +1632,10 @@
     }];
     source = {
       remotes = ["https://rubygems.org"];
-      sha256 = "0qvp6h2abmlsl4sqjsvac03cr2mxq6143gbx4kq52rpazp021qsb";
+      sha256 = "1qgwkcb8kxns8d5187cxjaxf18b7dmg9gh6cr9c1125m0bj2pnfk";
       type = "gem";
     };
-    version = "2.2.6.2";
+    version = "2.2.6.4";
   };
   rack-mini-profiler = {
     dependencies = ["rack"];
@@ -1623,10 +1643,10 @@
     platforms = [];
     source = {
       remotes = ["https://rubygems.org"];
-      sha256 = "121fqk18x1bd52c2bkz8wkvv9nkgpqphj5aycnb7lkf67jkwic0h";
+      sha256 = "13dhpp1iljhqp9c8akmp6gjhx47qf83w12ns4bif26ldkignpam1";
       type = "gem";
     };
-    version = "3.0.0";
+    version = "3.1.0";
   };
   rack-protection = {
     dependencies = ["rack"];
@@ -1634,10 +1654,10 @@
     platforms = [];
     source = {
       remotes = ["https://rubygems.org"];
-      sha256 = "1a12m1mv8dc0g90fs1myvis8vsgr427k1arg1q4a9qlfw6fqyhis";
+      sha256 = "1kpm67az1wxlg76h620in2r7agfyhv177ps268j5ggsanzddzih8";
       type = "gem";
     };
-    version = "3.0.5";
+    version = "3.0.6";
   };
   rack-test = {
     dependencies = ["rack"];
@@ -1645,10 +1665,10 @@
     platforms = [];
     source = {
       remotes = ["https://rubygems.org"];
-      sha256 = "0rjl709krgf499dhjdapg580l2qaj9d91pwzk8ck8fpnazlx1bdd";
+      sha256 = "1ysx29gk9k14a14zsp5a8czys140wacvp91fja8xcja0j1hzqq8c";
       type = "gem";
     };
-    version = "2.0.2";
+    version = "2.1.0";
   };
   rails-dom-testing = {
     dependencies = ["activesupport" "nokogiri"];
@@ -1678,10 +1698,10 @@
     platforms = [];
     source = {
       remotes = ["https://rubygems.org"];
-      sha256 = "145m778yylgrjl2q7zfkq35l5sibyynlx6pyp176ifm146gbf9wf";
+      sha256 = "1j0zi64m9njfgk4xs4invqlimkgiy4fsivfmbpz33bg0w5yyzazi";
       type = "gem";
     };
-    version = "0.8.1";
+    version = "1.0.0";
   };
   rails_multisite = {
     dependencies = ["activerecord" "railties"];
@@ -1700,10 +1720,10 @@
     platforms = [];
     source = {
       remotes = ["https://rubygems.org"];
-      sha256 = "0q8as8yq6ni256fc6bmcqmdch1bksbhsg5lmaqmi4bpi33f06g01";
+      sha256 = "0w6pib1s0kmfnhjvxwh48flz7w4gy8y961n821w8by7d1g83vjwq";
       type = "gem";
     };
-    version = "7.0.4.1";
+    version = "7.0.4.3";
   };
   rainbow = {
     groups = ["default" "development" "test"];
@@ -1726,10 +1746,10 @@
     }];
     source = {
       remotes = ["https://rubygems.org"];
-      sha256 = "0wb2x51parf6v78w0cic90m33bdc92y5h8rj4wqs75dhw1b69hc7";
+      sha256 = "0c27mcglrj928zkm4d2spj9yh2xkkka8ns5s6bidkwild3zvj3ma";
       type = "gem";
     };
-    version = "0.20.0";
+    version = "0.20.1";
   };
   rake = {
     groups = ["default" "development" "test"];
@@ -1792,10 +1812,10 @@
     platforms = [];
     source = {
       remotes = ["https://rubygems.org"];
-      sha256 = "0i4a8hxxcxci3n8hhlm9a8wa7a9m58r6sjvh4749v7362i8cy010";
+      sha256 = "0fikjg6j12ka6hh36dxzhfkpqqmilzjfzcdf59iwkzsgd63f0ziq";
       type = "gem";
     };
-    version = "4.8.0";
+    version = "4.8.1";
   };
   redis-namespace = {
     dependencies = ["redis"];
@@ -1813,10 +1833,10 @@
     platforms = [];
     source = {
       remotes = ["https://rubygems.org"];
-      sha256 = "0zjg29w5zvar7by1kqck3zilbdzm5iz3jp5d1zn3970krskfazh2";
+      sha256 = "17xizkw5ryw8hhq64iqxmzdrrdxpc5lhkqc1fgm1aj0zsk1r2950";
       type = "gem";
     };
-    version = "2.6.2";
+    version = "2.8.0";
   };
   request_store = {
     dependencies = ["rack"];
@@ -1897,10 +1917,10 @@
     platforms = [];
     source = {
       remotes = ["https://rubygems.org"];
-      sha256 = "1ibb81slc35q5yp276sixp3yrvj9q92wlmi1glbnwlk6g49z8rn4";
+      sha256 = "0da45cvllbv39sdbsl65vp5djb2xf5m10mxc9jm7rsqyyxjw4h1f";
       type = "gem";
     };
-    version = "3.12.0";
+    version = "3.12.1";
   };
   rspec-expectations = {
     dependencies = ["diff-lcs" "rspec-support"];
@@ -1930,10 +1950,10 @@
     platforms = [];
     source = {
       remotes = ["https://rubygems.org"];
-      sha256 = "0sq2cc9pm5gq411y7iwfvzbmgv3g91lyf7y7cqn1lr3yf1v122nc";
+      sha256 = "1hfm17xakfvwya236graj6c2arr4sb9zasp35q5fykhyz8mhs0w2";
       type = "gem";
     };
-    version = "3.12.3";
+    version = "3.12.5";
   };
   rspec-rails = {
     dependencies = ["actionpack" "activesupport" "railties" "rspec-core" "rspec-expectations" "rspec-mocks" "rspec-support"];
@@ -1978,16 +1998,27 @@
     };
     version = "2.8.0";
   };
+  rtlcss = {
+    dependencies = ["mini_racer"];
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0nnc1qdr4vdr91406ga1nnw5xk27ii2yzk325ixrf2qca3zl213k";
+      type = "gem";
+    };
+    version = "0.2.0";
+  };
   rubocop = {
     dependencies = ["json" "parallel" "parser" "rainbow" "regexp_parser" "rexml" "rubocop-ast" "ruby-progressbar" "unicode-display_width"];
     groups = ["default" "development" "test"];
     platforms = [];
     source = {
       remotes = ["https://rubygems.org"];
-      sha256 = "0a2j57r6pvngqlzkmww031gs5isax3nsr9n7cbfpqnh34ljh2lk1";
+      sha256 = "0l46lw5gfj3mcm982wpmx7br4rs466gyislv0hfwcsk8dxhv1zkw";
       type = "gem";
     };
-    version = "1.44.0";
+    version = "1.50.2";
   };
   rubocop-ast = {
     dependencies = ["parser"];
@@ -1995,10 +2026,10 @@
     platforms = [];
     source = {
       remotes = ["https://rubygems.org"];
-      sha256 = "1pdzabz95hv3z5sfbkfqa8bdybsfl13gv7rjb32v3ss8klq99lbd";
+      sha256 = "0n2gsafg6p7nr1z8i1hkvp2qqkkbg842ba183dnl0h08xd9ms6q5";
       type = "gem";
     };
-    version = "1.24.1";
+    version = "1.28.0";
   };
   rubocop-capybara = {
     dependencies = ["rubocop"];
@@ -2006,10 +2037,10 @@
     platforms = [];
     source = {
       remotes = ["https://rubygems.org"];
-      sha256 = "1h4qcjkz0365qlhi7y1ni94qj14k397cad566zygm20p15ypbp5v";
+      sha256 = "1pz52ml0qbxgcjlmp8y0wsq8xy398n6ypkbrwfaa8zb0v7pscj6n";
       type = "gem";
     };
-    version = "2.17.0";
+    version = "2.17.1";
   };
   rubocop-discourse = {
     dependencies = ["rubocop" "rubocop-rspec"];
@@ -2017,10 +2048,10 @@
     platforms = [];
     source = {
       remotes = ["https://rubygems.org"];
-      sha256 = "0m6jqyh44vfibqcnxi0xz69xgrbf8vpps90h6al5qdbibm9dmajd";
+      sha256 = "1jfpi8wd6gxd626kp27n20ja1yj68478dqbc1fiyzj4mr8nw8nsl";
       type = "gem";
     };
-    version = "3.0.3";
+    version = "3.2.0";
   };
   rubocop-rspec = {
     dependencies = ["rubocop" "rubocop-capybara"];
@@ -2028,10 +2059,10 @@
     platforms = [];
     source = {
       remotes = ["https://rubygems.org"];
-      sha256 = "1vmmin3ymgq7bhv2hl4pd0zpwawy709p816axc4vi67w61b4bij1";
+      sha256 = "1k8yh0nzlz0g8igmj5smnxq71qmi2b005nkl25wkpjkwvzn2wfdx";
       type = "gem";
     };
-    version = "2.18.1";
+    version = "2.19.0";
   };
   ruby-prof = {
     groups = ["development"];
@@ -2042,20 +2073,20 @@
     }];
     source = {
       remotes = ["https://rubygems.org"];
-      sha256 = "09n13bzm1p956z318xx1v7ikqdp2i971v7p3kwf3170axz368ccy";
+      sha256 = "106i9m62a20xaipp3vsq4rsnggddfgdvb8xqhvi264slvmac85zq";
       type = "gem";
     };
-    version = "1.4.5";
+    version = "1.6.1";
   };
   ruby-progressbar = {
     groups = ["default" "development" "test"];
     platforms = [];
     source = {
       remotes = ["https://rubygems.org"];
-      sha256 = "02nmaw7yx9kl7rbaan5pl8x5nn0y4j5954mzrkzi9i3dhsrps4nc";
+      sha256 = "0cwvyb7j47m7wihpfaq7rc47zwwx9k4v7iqd9s1xch5nm53rrz40";
       type = "gem";
     };
-    version = "1.11.0";
+    version = "1.13.0";
   };
   ruby-readability = {
     dependencies = ["guess_html_encoding" "nokogiri"];
@@ -2094,32 +2125,21 @@
     platforms = [];
     source = {
       remotes = ["https://rubygems.org"];
-      sha256 = "1zq8pxmsd1abw18zz6mazsm2jfpwmbgdxbpawb7bmwvkb2c5yyc1";
+      sha256 = "1ga8yzc9zj45m92ycwnzhzahkwvc3dp3lym5m3f3880hs4jhh7l3";
       type = "gem";
     };
-    version = "6.0.0";
+    version = "6.0.1";
   };
-  sassc = {
-    dependencies = ["ffi" "rake"];
+  sass-embedded = {
+    dependencies = ["google-protobuf" "rake"];
     groups = ["default"];
     platforms = [];
     source = {
       remotes = ["https://rubygems.org"];
-      sha256 = "1sr4825rlwsrl7xrsm0sgalcpf5zgp4i56dbi3qxfa9lhs8r6zh4";
+      sha256 = "1fprlazlld0yr4g8aq9qh4lxjxpvzl2s3fp8f9ydwsrchzj95rbh";
       type = "gem";
     };
-    version = "2.0.1";
-  };
-  sassc-rails = {
-    dependencies = ["railties" "sassc" "sprockets" "sprockets-rails" "tilt"];
-    groups = ["default"];
-    platforms = [];
-    source = {
-      remotes = ["https://rubygems.org"];
-      sha256 = "1d9djmwn36a5m8a83bpycs48g8kh1n2xkyvghn7dr6zwh4wdyksz";
-      type = "gem";
-    };
-    version = "2.1.2";
+    version = "1.62.0";
   };
   selenium-webdriver = {
     dependencies = ["rexml" "rubyzip" "websocket"];
@@ -2127,10 +2147,10 @@
     platforms = [];
     source = {
       remotes = ["https://rubygems.org"];
-      sha256 = "1dkcyq2hfvf4wdj7q5cqqlka1dw6gz28dckxf4r17jmd53ymwg28";
+      sha256 = "1hfaz3srv9c420jkmhr19fmdisnjylwpwyjsr8fsw2ggw35ryhrz";
       type = "gem";
     };
-    version = "4.8.0";
+    version = "4.8.6";
   };
   shoulda-matchers = {
     dependencies = ["activesupport"];
@@ -2239,10 +2259,10 @@
     }];
     source = {
       remotes = ["https://rubygems.org"];
-      sha256 = "02r3a3ny27ljj19bzmxscw2vlmk7sw1p4ppbl2i69g17khi0p4sw";
+      sha256 = "0bhdgfb0pmw9mav1kw9fn0ka012sa0i3h5ppvqssw5xq48nhxnr8";
       type = "gem";
     };
-    version = "0.2.23";
+    version = "0.2.25";
   };
   syntax_tree = {
     dependencies = ["prettier_print"];
@@ -2250,10 +2270,10 @@
     platforms = [];
     source = {
       remotes = ["https://rubygems.org"];
-      sha256 = "1sqjjz3ja2563p4dgw46wfx0knpcp176gfvx8gfmkv8h166qnkqg";
+      sha256 = "162m5xhbiq315bncp49ziddws537dv09pqsgrzsrmhhsymhgy0zb";
       type = "gem";
     };
-    version = "5.2.0";
+    version = "6.1.1";
   };
   syntax_tree-disable_ternary = {
     groups = ["development" "test"];
@@ -2270,10 +2290,10 @@
     platforms = [];
     source = {
       remotes = ["https://rubygems.org"];
-      sha256 = "15fcfjplc1zqahrha6rxgwnmjlyp41qkj4369fbxdfp0iaxb15pg";
+      sha256 = "09phq7jxfgamv03kjcgibw0f6w3g3mlb9yapji3bxh7cbjvwk2pa";
       type = "gem";
     };
-    version = "1.1.0";
+    version = "1.2.1";
   };
   thor = {
     groups = ["default" "development" "test"];
@@ -2290,20 +2310,20 @@
     platforms = [];
     source = {
       remotes = ["https://rubygems.org"];
-      sha256 = "186nfbcsk0l4l86gvng1fw6jq6p6s7rc0caxr23b3pnbfb20y63v";
+      sha256 = "1qmhi6d9przjzhsyk9g5pq2j75c656msh6xzprqd2mxgphf23jxs";
       type = "gem";
     };
-    version = "2.0.11";
+    version = "2.1.0";
   };
   timeout = {
     groups = ["default"];
     platforms = [];
     source = {
       remotes = ["https://rubygems.org"];
-      sha256 = "0lnh0kr7f43m1cjzc2jvggfsl1rzsaj2rd3pn6vp7mcqliymzaza";
+      sha256 = "1pfddf51n5fnj4f9ggwj3wbf23ynj0nbxlxqpz12y1gvl9g7d6r6";
       type = "gem";
     };
-    version = "0.3.1";
+    version = "0.3.2";
   };
   tzinfo = {
     dependencies = ["concurrent-ruby"];
@@ -2311,10 +2331,21 @@
     platforms = [];
     source = {
       remotes = ["https://rubygems.org"];
-      sha256 = "0rx114mpqnw2k4h98vc0rs0x0bmf0img84yh8mkkjkal07cjydf5";
+      sha256 = "16w2g84dzaf3z13gxyzlzbf748kylk5bdgg3n1ipvkvvqy685bwd";
       type = "gem";
     };
-    version = "2.0.5";
+    version = "2.0.6";
+  };
+  tzinfo-data = {
+    dependencies = ["tzinfo"];
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0m2d0gpsgqnv29j5h2d6g57g0rayvd460b8s2vjr8sn46bqf89m5";
+      type = "gem";
+    };
+    version = "1.2023.3";
   };
   uglifier = {
     dependencies = ["execjs"];
@@ -2390,10 +2421,10 @@
     platforms = [];
     source = {
       remotes = ["https://rubygems.org"];
-      sha256 = "11c4n5rri8d45c47krpg76n98mqh36l0kp2qrkb4dxnkp4flay6y";
+      sha256 = "1vigw7nfszfqgikr6n574k9bfh0rvs74z8xq46rz2zsm8249l8cc";
       type = "gem";
     };
-    version = "0.12.0";
+    version = "0.12.1";
   };
   uri_template = {
     groups = ["default"];
@@ -2410,10 +2441,10 @@
     platforms = [];
     source = {
       remotes = ["https://rubygems.org"];
-      sha256 = "0v2vj7q1rk3wd7hdqa3i1d4hq7sfcgf55qc70g6dsichsbgacb9w";
+      sha256 = "1dza601x34ln5yvmyaj42gnbij9pifx12frp5vak6n19q9j941r0";
       type = "gem";
     };
-    version = "1.1.1";
+    version = "1.1.2";
   };
   web-push = {
     dependencies = ["hkdf" "jwt" "openssl"];
@@ -2468,16 +2499,6 @@
     };
     version = "1.2.9";
   };
-  xorcist = {
-    groups = ["default"];
-    platforms = [];
-    source = {
-      remotes = ["https://rubygems.org"];
-      sha256 = "1dbbiy8xlcfvn9ais37xfb5rci4liwakkmxzbkp72wmvlgcrf339";
-      type = "gem";
-    };
-    version = "1.1.3";
-  };
   xpath = {
     dependencies = ["nokogiri"];
     groups = ["default" "test"];
@@ -2499,14 +2520,24 @@
     };
     version = "0.1.2";
   };
+  yard = {
+    groups = ["development"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "013yrnwx1zhzhn1fnc19zck22a1qgimsaglp2iwgf5bz9l8h93js";
+      type = "gem";
+    };
+    version = "0.9.34";
+  };
   zeitwerk = {
     groups = ["default" "development" "test"];
     platforms = [];
     source = {
       remotes = ["https://rubygems.org"];
-      sha256 = "09pqhdi6q4sqv0p1gnjpbcy4az0yv8hrpykjngdgh9qiqd87nfdv";
+      sha256 = "028ld9qmgdllxrl7d0qkl65s58wb1n3gv8yjs28g43a8b1hplxk1";
       type = "gem";
     };
-    version = "2.6.6";
+    version = "2.6.7";
   };
 }

--- a/pkgs/servers/web-apps/discourse/rubyEnv/sass-embedded-static.patch
+++ b/pkgs/servers/web-apps/discourse/rubyEnv/sass-embedded-static.patch
@@ -1,0 +1,21 @@
+diff --git a/ext/sass/Rakefile b/ext/sass/Rakefile
+index 77ced01..1e60ab0 100644
+--- a/ext/sass/Rakefile
++++ b/ext/sass/Rakefile
+@@ -18,15 +18,7 @@ file 'protoc.exe' do |t|
+ end
+ 
+ file 'sass_embedded' do |t|
+-  archive = fetch(ENV.fetch(t.name.upcase) { Configuration.default_sass_embedded })
+-  unarchive archive
+-  rm archive
+-
+-  if ENV.key?('NIX_BINTOOLS')
+-    sh 'patchelf',
+-       '--set-interpreter', File.read("#{ENV.fetch('NIX_BINTOOLS')}/nix-support/dynamic-linker").chomp,
+-       (['sass_embedded/src/dart', 'sass_embedded/dart-sass-embedded'].find { |exe| File.exist?(exe) })
+-  end
++  symlink(ENV.fetch(t.name.upcase), 'sass_embedded')
+ end
+ 
+ file 'embedded.rb' => %w[sass_embedded] do |t|

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -16632,6 +16632,8 @@ with pkgs;
     inherit (darwin.apple_sdk.frameworks) Security;
   };
 
+  dart-sass-embedded = callPackage ../misc/dart-sass-embedded { };
+
   clojupyter = callPackage ../applications/editors/jupyter-kernels/clojupyter {
     jre = jre8;
   };


### PR DESCRIPTION
###### Description of changes

Closes #228426
Depends on #227286 (should get merged first, cc @shyim)

https://github.com/NixOS/nixpkgs/issues/228426#issuecomment-1524755784 has lots of details, most of which I will repeat here.

3.1.0.beta4: https://meta.discourse.org/t/3-1-0-beta4-new-notifications-menu-chat-and-sidebar-improvements-security-fixes-and-more/262044
3.1.0.beta3: https://meta.discourse.org/t/3-1-0-beta3-search-optimizations-resizable-chat-drawer-new-api-scopes-and-more/258274
diff: https://github.com/discourse/discourse/compare/v3.1.0.beta2..v3.1.0.beta4

---

Discourse bumped the minimum Ruby version from v3.1 to v3.2.

---

`sass-embedded` has been added as dependency, which in turn depends on `dart-sass-embedded` -- the reason why this PR depends on #227286.

I originally used `export SASS_EMBEDDED=${dart-sass-embedded.src}` instead of a full-blown patch (see #228426).
But this only really worked because `dart-sass-embedded` can't be built from source yet and because there is an additional nix-specific patch in the Rakefile:
https://github.com/ntkme/sass-embedded-host-ruby/blob/v1.62.0/ext/sass/Rakefile#L20-L30

I didn't expect that, and I kinda feel sorry for @ntkme who seems to receive quite a bunch of issues by nix-users.

v1.62.1 (which Discourse isn't using yet) has an even more complex nix/guix-specific handling :exploding_head:  https://github.com/ntkme/sass-embedded-host-ruby/commit/985f4e2cade4c5cbe4e7cfb2a9d3289c6993bd94 

I eventually settled on a different approach, the one currently present in this PR, which allows us to use `dart-sass-embedded` (`.out`) instead of `dart-sass-embedded.src` by patching the `Rakefile` to use a symlink instead of unpacking the release archive. 

---

And the final change (but I am lazy and simply copy-paste my comment):

```
# `app/assets/javascripts/discourse/package.json`'s postinstall
# hook tries to call `../node_modules/.bin/patch-package`, which
# hasn't been `patchShebangs`-ed yet. So instead we just use
# `patch-package` from `nativeBuildInputs`.
./asserts_patch-package_from_path.patch
```

---

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).