### PR TITLE
auto-cpufreq: actually run as deamon

### DIFF
--- a/nixos/modules/services/hardware/auto-cpufreq.nix
+++ b/nixos/modules/services/hardware/auto-cpufreq.nix
@@ -37,7 +37,7 @@ in {
 
         serviceConfig.ExecStart = [
           ""
-          "${lib.getExe pkgs.auto-cpufreq} --config ${cfgFile}"
+          "${lib.getExe pkgs.auto-cpufreq} --daemon --config ${cfgFile}"
         ];
       };
     };


### PR DESCRIPTION
The upstream service definition uses the (undocumented) --daemon option, which causes the process to stay running and not exit immediately.  So we need to mimic that, as otherwise the service is useless.