### PR TITLE
serf: patch for openssl_3

### DIFF
--- a/pkgs/development/libraries/serf/default.nix
+++ b/pkgs/development/libraries/serf/default.nix
@@ -1,5 +1,6 @@
 { lib, stdenv, fetchurl, apr, scons, openssl, aprutil, zlib, libkrb5
-, pkg-config, libiconv }:
+, pkg-config, libiconv
+, fetchpatch }:
 
 stdenv.mkDerivation rec {
   pname = "serf";
@@ -14,7 +15,18 @@ stdenv.mkDerivation rec {
   buildInputs = [ apr openssl aprutil zlib libiconv ]
     ++ lib.optional (!stdenv.isCygwin) libkrb5;
 
-  patches = [ ./scons.patch ];
+  patches = [
+    ./scons.patch
+    # https://issues.apache.org/jira/projects/SERF/issues/SERF-198
+    (fetchpatch {
+      url = "https://issues.apache.org/jira/secure/attachment/13019945/serf.patch";
+      hash = "sha256-3djDGG30R/gq74KJL8OJ/upMh1zDpqtwGylRzN0lXpY=";
+    })
+    (fetchpatch {
+      url = "https://src.fedoraproject.org/rpms/libserf/raw/rawhide/f/libserf-1.3.9-errgetfunc.patch";
+      hash = "sha256-FQJvXOIZ0iItvbbcu4kR88j74M7fOi7C/0NN3o1/ub4=";
+    })
+  ];
 
   prefixKey = "PREFIX=";
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -23647,10 +23647,7 @@ with pkgs;
 
   serd = callPackage ../development/libraries/serd { };
 
-  serf = callPackage ../development/libraries/serf {
-    openssl = openssl_1_1;
-    aprutil = aprutil.override { openssl = openssl_1_1; };
-  };
+  serf = callPackage ../development/libraries/serf { };
 
   sfsexp = callPackage ../development/libraries/sfsexp { };
 
@@ -33964,7 +33961,6 @@ with pkgs;
     sublime-merge-dev;
 
   inherit (callPackages ../applications/version-management/subversion {
-    openssl = openssl_1_1;
     sasl = cyrus_sasl;
     inherit (darwin.apple_sdk.frameworks) CoreServices Security;
   }) subversion;


### PR DESCRIPTION
###### Description of changes
also affects subversion

See #210452

###### Things done
- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).