### PR TITLE
nixos/qemu-vm: introduce `virtualisation.useDefaultPartitionTable`

### DIFF
--- a/nixos/modules/virtualisation/qemu-vm.nix
+++ b/nixos/modules/virtualisation/qemu-vm.nix
@@ -55,11 +55,6 @@ let
 
   };
 
-  selectPartitionTableLayout = { useEFIBoot, useDefaultFilesystems }:
-  if useDefaultFilesystems then
-    if useEFIBoot then "efi" else "legacy"
-  else "none";
-
   driveCmdline = idx: { file, driveExtraOpts, deviceExtraOpts, ... }:
     let
       drvId = "drive${toString idx}";
@@ -213,6 +208,8 @@ let
 
   regInfo = pkgs.closureInfo { rootPaths = config.virtualisation.additionalPaths; };
 
+  selectPartitionTableLayout = { useEFIBoot, useDefaultPartitionTable }: if useDefaultPartitionTable then (if useEFIBoot then "efi" else "legacy") else "none";
+
   # System image is akin to a complete NixOS install with
   # a boot partition and root partition.
   systemImage = import ../../lib/make-disk-image.nix {
@@ -220,7 +217,7 @@ let
     additionalPaths = [ regInfo ];
     format = "qcow2";
     onlyNixStore = false;
-    partitionTableType = selectPartitionTableLayout { inherit (cfg) useDefaultFilesystems useEFIBoot; };
+    partitionTableType = selectPartitionTableLayout { inherit (cfg) useDefaultPartitionTable useEFIBoot; };
     # Bootloader should be installed on the system image only if we are booting through bootloaders.
     # Though, if a user is not using our default filesystems, it is possible to not have any ESP
     # or a strange partition table that's incompatible with GRUB configuration.
@@ -802,12 +799,27 @@ in
         default = true;
         description =
           lib.mdDoc ''
-            If enabled, the boot disk of the virtual machine will be
+            If enabled, the system disk of the virtual machine will be
             formatted and mounted with the default filesystems for
             testing. Swap devices and LUKS will be disabled.
 
             If disabled, a root filesystem has to be specified and
             formatted (for example in the initial ramdisk).
+          '';
+        };
+
+    virtualisation.useDefaultPartitionTable =
+      mkOption {
+        type = types.bool;
+        default = true;
+        description =
+          lib.mdDoc ''
+            If enabled, the partition table of the system disk for the virtual machine
+            will be initialized according to your boot configuration.
+            e.g. GPT for UEFI, MBR for BIOS.
+
+            If disabled, UEFI cannot be used as we have no way to determine if you are passing
+            a GPT partition table for the bootloader installation phase.
           '';
       };
 
@@ -853,6 +865,21 @@ in
               ''
                 Invalid virtualisation.forwardPorts.<entry ${toString i}>.guest.address:
                   The address must be in the default VLAN (10.0.2.0/24).
+              '';
+          }
+          { assertion = cfg.useDefaultFilesystems -> cfg.useDefaultPartitionTable;
+            message =
+              ''
+                You cannot use a non-default partition table with the default filesystems.
+              '';
+          }
+          {
+            assertion = !cfg.useDefaultPartitionTable -> !cfg.useEFIBoot;
+            message =
+              ''
+                You cannot use UEFI with a non-default partition table.
+                This is a limitation of the NixOS module, please open an issue explaining your needs
+                if you run into this.
               '';
           }
         ]));


### PR DESCRIPTION
###### Description of changes

Usually, some people want to run with defaultFilesystems = false; but want to change only the partitions, not the partition table.

This option makes it possible.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
