### PR TITLE
aaaaxy: 1.3.457 -> 1.3.524

### DIFF
--- a/nixos/tests/aaaaxy.nix
+++ b/nixos/tests/aaaaxy.nix
@@ -3,14 +3,16 @@
   meta.maintainers = with lib.maintainers; [ Luflosi ];
 
   nodes.machine = {
-    hardware.opengl.enable = true;
+    imports = [
+      ./common/x11.nix
+    ];
   };
 
   # This starts the game from a known state, feeds it a prerecorded set of button presses
   # and then checks if the final game state is identical to the expected state.
   # This is also what AAAAXY's CI system does and serves as a good sanity check.
   testScript = ''
-    machine.wait_for_unit("basic.target")
+    machine.wait_for_x()
 
     machine.succeed(
       # benchmark.dem needs to be in a mutable directory,
@@ -18,7 +20,6 @@
       "mkdir -p '/tmp/aaaaxy/assets/demos/'",
       "ln -s '${pkgs.aaaaxy.testing_infra}/assets/demos/benchmark.dem' '/tmp/aaaaxy/assets/demos/'",
       """
-        '${pkgs.xvfb-run}/bin/xvfb-run' \
         '${pkgs.aaaaxy.testing_infra}/scripts/regression-test-demo.sh' \
         'aaaaxy' 'on track for Any%, All Paths and No Teleports' \
         '${pkgs.aaaaxy}/bin/aaaaxy' '/tmp/aaaaxy/assets/demos/benchmark.dem'

--- a/pkgs/games/aaaaxy/default.nix
+++ b/pkgs/games/aaaaxy/default.nix
@@ -17,17 +17,17 @@
 
 buildGoModule rec {
   pname = "aaaaxy";
-  version = "1.3.457";
+  version = "1.3.524";
 
   src = fetchFromGitHub {
     owner = "divVerent";
     repo = pname;
     rev = "v${version}";
-    hash = "sha256-PN/Gt2iDOWsbKspyWYKjnX98xF6NQuGVFjlEg3ZZpio=";
+    hash = "sha256-9g0wTvG6XSKI7e3RP6e3RoYyvE5UjOYxI5hVINI9Fq8=";
     fetchSubmodules = true;
   };
 
-  vendorHash = "sha256-vI8EyZgjJA89UmqoDuh/H+qQzAKO9pyqpmA8hci9cco=";
+  vendorHash = "sha256-slvBpweXRLsDegJDQ0ysZ0pugx5fdOOnD/OxWUfUnno=";
 
   buildInputs = [
     alsa-lib


### PR DESCRIPTION
###### Description of changes
https://github.com/divVerent/aaaaxy/releases/tag/v1.3.469
https://github.com/divVerent/aaaaxy/releases/tag/v1.3.511
https://github.com/divVerent/aaaaxy/releases/tag/v1.3.524
~~I'm marking this as a draft until I figure out why the NixOS test no longer works.~~
I managed to fix the test thanks to a helpful comment in #228094.

Closes #230260.

ZHF: #230712

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).