### PR TITLE
haskell.compiler.ghcjs: fix build

### DIFF
--- a/pkgs/development/compilers/ghcjs/8.10/configured-ghcjs-src.nix
+++ b/pkgs/development/compilers/ghcjs/8.10/configured-ghcjs-src.nix
@@ -5,8 +5,7 @@
 , gcc
 , cabal-install
 , runCommand
-, lib
-, stdenv
+, fetchpatch
 
 , ghc
 , happy
@@ -28,7 +27,14 @@ runCommand "configured-ghcjs-src" {
     cabal-install
     gcc
   ];
+
   inherit ghcjsSrc;
+
+  ctimePatch = fetchpatch {
+    name = "ghcjs-base-ctime-64-bit.patch";
+    url = "https://github.com/ghcjs/ghcjs/commit/b7711fbca7c3f43a61f1dba526e6f2a2656ef44c.patch";
+    hash = "sha256-zZ3l8/5gbIGtvu0s2Xl92fEDhkhJ2c2w+5Ql5qkvr3s=";
+  };
 } ''
   export HOME=$(pwd)
   mkdir $HOME/.cabal
@@ -36,6 +42,8 @@ runCommand "configured-ghcjs-src" {
   cp -r "$ghcjsSrc" "$out"
   chmod -R +w "$out"
   cd "$out"
+
+  patch -p1 -i "$ctimePatch"
 
   # TODO: Find a better way to avoid impure version numbers
   sed -i 's/RELEASE=NO/RELEASE=YES/' ghc/configure.ac


### PR DESCRIPTION
Fixes https://github.com/NixOS/nixpkgs/issues/208812

Apply a patch from upstream `ghcjs/ghcjs/ghc-8.10` (not yet present in the obsidiansystems fork we follow) to fix a build failure caused by an emscripten update.

As the patch itself modifies patches that are used during configuration (by `makePackages.sh`), it must be applied in the configured source derivation.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
