### PR TITLE
can-utils: 20170830 -> 2023.03

### DIFF
--- a/pkgs/os-specific/linux/can-utils/default.nix
+++ b/pkgs/os-specific/linux/can-utils/default.nix
@@ -26,6 +26,6 @@ stdenv.mkDerivation {
     homepage = "https://github.com/linux-can/can-utils";
     license = licenses.gpl2Plus;
     platforms = platforms.linux;
-    maintainers = [ maintainers.bjornfor ];
+    maintainers = with maintainers; [ bjornfor Luflosi ];
   };
 }

--- a/pkgs/os-specific/linux/can-utils/default.nix
+++ b/pkgs/os-specific/linux/can-utils/default.nix
@@ -1,25 +1,17 @@
 { lib, stdenv, fetchFromGitHub }:
 
-stdenv.mkDerivation {
+stdenv.mkDerivation rec {
   pname = "can-utils";
-  # There are no releases (source archives or git tags), so use the date of the
-  # latest commit in git master as version number.
-  version = "20170830";
+  version = "2023.03";
 
   src = fetchFromGitHub {
     owner = "linux-can";
     repo = "can-utils";
-    rev = "5b518a0a5fa56856f804372a6b99b518dedb5386";
-    sha256 = "1ygzp8rjr8f1gs48mb1pz7psdgbfhlvr6kjdnmzbsqcml06zvrpr";
+    rev = "v${version}";
+    hash = "sha256-FaopviBJOmO0lXoJcdKNdtsoaJ8JrFEJGyO1aNBv+Pg=";
   };
 
-  # Fixup build with newer Linux headers.
-  postPatch = ''
-    sed '1i#include <linux/sockios.h>' -i \
-      slcanpty.c cansniffer.c canlogserver.c isotpdump.c isotpsniffer.c isotpperf.c
-  '';
-
-  preConfigure = ''makeFlagsArray+=(PREFIX="$out")'';
+  makeFlags = [ "PREFIX=$(out)" ];
 
   meta = with lib; {
     description = "CAN userspace utilities and tools (for use with Linux SocketCAN)";


### PR DESCRIPTION
###### Description of changes
https://github.com/linux-can/can-utils/releases/tag/v2023.03

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).