### PR TITLE
onefetch: 2.17.0 -> 2.17.1

### DIFF
--- a/pkgs/tools/misc/onefetch/default.nix
+++ b/pkgs/tools/misc/onefetch/default.nix
@@ -14,16 +14,16 @@
 
 rustPlatform.buildRustPackage rec {
   pname = "onefetch";
-  version = "2.17.0";
+  version = "2.17.1";
 
   src = fetchFromGitHub {
     owner = "o2sh";
     repo = pname;
     rev = version;
-    sha256 = "sha256-5d2u58i5VU+k1iC+bmiyKqe8qNTibryDxXNENxIflEI=";
+    hash = "sha256-mIHaeEnMKOyEeEEkE5OZgQZWwFnm69GZui64iBZkfyo=";
   };
 
-  cargoSha256 = "sha256-PLxccKkJg9LNckAVG2iXU9XB1olAvVZQYRG8R6s+ibU=";
+  cargoHash = "sha256-XFX3J/vgjboEu+xZWTkfo5jmZJkap1u3j9G9ewrzVqc=";
 
   cargoPatches = [
     # enable pkg-config feature of zstd

--- a/pkgs/tools/misc/onefetch/zstd-pkg-config.patch
+++ b/pkgs/tools/misc/onefetch/zstd-pkg-config.patch
@@ -1,14 +1,14 @@
 --- a/Cargo.lock
 +++ b/Cargo.lock
-@@ -2039,6 +2039,7 @@ dependencies = [
-  "tokei",
-  "toml",
+@@ -2498,6 +2498,7 @@ dependencies = [
+  "typetag",
+  "winres",
   "yaml-rust",
 + "zstd",
  ]
  
  [[package]]
-@@ -3286,4 +3287,5 @@ checksum = "9fd07cbbc53846d9145dbffdf6dd09a7a0aa52be46741825f5c97bdd4f73f12b"
+@@ -4052,4 +4053,5 @@ checksum = "9fd07cbbc53846d9145dbffdf6dd09a7a0aa52be46741825f5c97bdd4f73f12b"
  dependencies = [
   "cc",
   "libc",
@@ -16,11 +16,11 @@
  ]
 --- a/Cargo.toml
 +++ b/Cargo.toml
-@@ -58,6 +58,7 @@ time-humanize = { version = "0.1.3", features = ["time"] }
+@@ -49,6 +49,7 @@ time-humanize = { version = "0.1.3", features = ["time"] }
  tokei = "12.1.2"
- toml = "0.5.9"
+ typetag = "0.2"
  yaml-rust = "0.4.5"
 +zstd = { version = "*", features = ["pkg-config"] }
  
- [target.'cfg(windows)'.dependencies]
- enable-ansi-support = "0.1.2"
+ [dev-dependencies]
+ criterion = "0.4.0"


### PR DESCRIPTION
Diff: https://github.com/o2sh/onefetch/compare/2.17.0...2.17.1

Changelog: https://github.com/o2sh/onefetch/blob/v2.17.1/CHANGELOG.md

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
