### PR TITLE
pythonPackages.hasPythonModule: Deprecate calling with non-derivation

### DIFF
--- a/pkgs/development/interpreters/python/python-packages-base.nix
+++ b/pkgs/development/interpreters/python/python-packages-base.nix
@@ -47,9 +47,20 @@ let
   buildSetupcfg = import ../../../build-support/build-setupcfg lib self;
 
   # Check whether a derivation provides a Python module.
-  hasPythonModule = drv: drv?pythonModule && drv.pythonModule == python;
+  # hasPythonModule :: derivation -> bool
+  hasPythonModule = drv:
+    let
+      isDrv = lib.isDerivation drv;
+      result = drv?pythonModule && drv.pythonModule == python;
+    in
+      lib.warnIfNot
+        isDrv
+        "Calling hasPythonModule with a ${builtins.typeOf drv} instead of a deprecation is deprecated"
+        result;
 
   # Get list of required Python modules given a list of derivations.
+  #
+  # requiredPythonModules :: [ derivation ] -> [ derivation ]
   requiredPythonModules = drvs: let
     modules = lib.filter hasPythonModule drvs;
   in lib.unique ([python] ++ modules ++ lib.concatLists (lib.catAttrs "requiredPythonModules" modules));

--- a/pkgs/development/interpreters/python/python-packages-base.nix
+++ b/pkgs/development/interpreters/python/python-packages-base.nix
@@ -55,7 +55,7 @@ let
     in
       lib.warnIfNot
         isDrv
-        "Calling hasPythonModule with a ${builtins.typeOf drv} instead of a deprecation is deprecated"
+        "Calling hasPythonModule with a ${builtins.typeOf drv} instead of a derivation is not supported"
         result;
 
   # Get list of required Python modules given a list of derivations.


### PR DESCRIPTION
###### Description of changes

This adds a warning when hasPythonModule is called with a value that is not a derivation.

This happens if the `buildEnv.override { extraLibs = [ ... ]; }` list includes non-derivations, such as nested lists (and so also affects any callers of this, like `python.withPackages`).

This provides a warning about an easy mistake to make, where a list of Python module derivations is nested inside the top-level list.  This case currently passes silently and just doesn't add any of the nested derivations to the environment.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
