### PR TITLE
lib/versions: dateFormat init

### DIFF
--- a/lib/default.nix
+++ b/lib/default.nix
@@ -160,6 +160,6 @@ let
       fakeHash fakeSha256 fakeSha512
       nixType imap;
     inherit (self.versions)
-      splitVersion;
+      splitVersion dateFormat;
   });
 in lib

--- a/lib/tests/misc.nix
+++ b/lib/tests/misc.nix
@@ -158,6 +158,11 @@ runTests {
     expected = "a\nb\nc\n";
   };
 
+  testDateFormat = {
+    expr = dateFormat "19700101";
+    expected = "1970-01-01";
+  };
+
   testSplitStringsSimple = {
     expr = strings.splitString "." "a.b.c.d";
     expected = [ "a" "b" "c" "d" ];

--- a/lib/versions.nix
+++ b/lib/versions.nix
@@ -61,4 +61,17 @@ rec {
     versionSuffix = lib.removePrefix numericVersion version;
   in lib.concatStringsSep "." (lib.take n (lib.splitVersion numericVersion ++ lib.genList (_: "0") n)) + versionSuffix;
 
+  /* Format date from YYYYMMDD to YYYY-MM-DD. This is usually used with a flake's input lastModifiedDate value.
+
+     Type: dateFormat :: String -> String
+
+     Example:
+       dateFormat "19700101"
+       => "1970-01-01"
+       dateFormat self.lastModifiedDate # (20230426163528)
+       => "2023-04-26"
+  */
+  dateFormat = d:
+    assert lib.assertMsg ((builtins.stringLength d) >= 8) "versions.dateFormat: date string length must be at least 8 characters long!";
+    builtins.concatStringsSep "-" (builtins.match "([0-9]{4})([0-9]{2})([0-9]{2})[0-9]*" d);
 }


### PR DESCRIPTION
###### Description of changes

closes: https://github.com/NixOS/nix/issues/8163 (I think it makes more sense for it to be in nixpkgs than as a builtin.)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
