### PR TITLE
systemd: assert withUkify -> withEfi

### DIFF
--- a/pkgs/os-specific/linux/systemd/default.nix
+++ b/pkgs/os-specific/linux/systemd/default.nix
@@ -140,6 +140,7 @@ assert withImportd -> withCompression;
 assert withCoredump -> withCompression;
 assert withHomed -> withCryptsetup;
 assert withHomed -> withPam;
+assert withUkify -> withEfi;
 
 let
   wantCurl = withRemote || withImportd;


### PR DESCRIPTION
###### Description of changes

Assert that ukify can only be built if the efi toolchain is present.
