### PR TITLE
sitespeed-io: init at 27.3.1

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2311.section.md
+++ b/nixos/doc/manual/release-notes/rl-2311.section.md
@@ -12,6 +12,8 @@
 
 - [river](https://github.com/riverwm/river), A dynamic tiling wayland compositor. Available as [programs.river](#opt-programs.river.enable).
 
+- [sitespeed-io](https://sitespeed.io), a tool that can generate metrics (timings, diagnostics) for websites. Available as [services.sitespeed-io](#opt-services.sitespeed-io.enable).
+
 ## Backward Incompatibilities {#sec-release-23.11-incompatibilities}
 
 - The latest version of `clonehero` now stores custom content in `~/.clonehero`. See the [migration instructions](https://clonehero.net/2022/11/29/v23-to-v1-migration-instructions.html). Typically, these content files would exist along side the binary, but the previous build used a wrapper script that would store them in `~/.config/unity3d/srylain Inc_/Clone Hero`.

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -1009,6 +1009,7 @@
   ./services/networking/shorewall.nix
   ./services/networking/shorewall6.nix
   ./services/networking/shout.nix
+  ./services/networking/sitespeed-io.nix
   ./services/networking/skydns.nix
   ./services/networking/smartdns.nix
   ./services/networking/smokeping.nix

--- a/nixos/modules/services/networking/sitespeed-io.nix
+++ b/nixos/modules/services/networking/sitespeed-io.nix
@@ -1,0 +1,122 @@
+{ lib, config, pkgs, ... }:
+let
+  cfg = config.services.sitespeed-io;
+  format = pkgs.formats.json { };
+in
+{
+  options.services.sitespeed-io = {
+    enable = lib.mkEnableOption (lib.mdDoc "Sitespeed.io");
+
+    user = lib.mkOption {
+      type = lib.types.str;
+      default = "sitespeed-io";
+      description = lib.mdDoc "User account under which sitespeed-io runs.";
+    };
+
+    package = lib.mkOption {
+      type = lib.types.package;
+      default = pkgs.sitespeed-io;
+      defaultText = "pkgs.sitespeed-io";
+      description = lib.mdDoc "Sitespeed.io package to use.";
+    };
+
+    dataDir = lib.mkOption {
+      default = "/var/lib/sitespeed-io";
+      type = lib.types.str;
+      description = lib.mdDoc "The base sitespeed-io data directory.";
+    };
+
+    period = lib.mkOption {
+      type = lib.types.str;
+      default = "hourly";
+      description = lib.mdDoc ''
+        Systemd calendar expression when to run. See {manpage}`systemd.time(7)`.
+      '';
+    };
+
+    runs = lib.mkOption {
+      default = [ ];
+      description = lib.mdDoc ''
+        A list of run configurations. The service will call sitespeed-io once
+        for every run listed here. This lets you examine different websites
+        with different sitespeed-io settings.
+      '';
+      type = lib.types.listOf (lib.types.submodule {
+        options = {
+          urls = lib.mkOption {
+            type = with lib.types; listOf str;
+            default = [];
+            description = lib.mdDoc ''
+              URLs the service should monitor.
+            '';
+          };
+
+          settings = lib.mkOption {
+            type = lib.types.submodule {
+              freeformType = format.type;
+              options = { };
+            };
+            default = { };
+            description = lib.mdDoc ''
+              Configuration for sitespeed-io, see
+              <https://www.sitespeed.io/documentation/sitespeed.io/configuration/>
+              for available options. The value here will be directly transformed to
+              JSON and passed as `--config` to the program.
+            '';
+          };
+
+          extraArgs = lib.mkOption {
+            type = with lib.types; listOf str;
+            default = [];
+            description = lib.mdDoc ''
+              Extra command line arguments to pass to the program.
+            '';
+          };
+        };
+      });
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    assertions = [
+    {
+      assertion = cfg.runs != [];
+      message = "At least one run must be configured.";
+    }
+    {
+      assertion = lib.all (run: run.urls != []) cfg.runs;
+      message = "All runs must have at least one url configured.";
+    }
+  ];
+
+    systemd.services.sitespeed-io = {
+      description = "Check website status";
+      startAt = cfg.period;
+      serviceConfig = {
+        WorkingDirectory = cfg.dataDir;
+        User = cfg.user;
+      };
+      preStart = "chmod u+w -R ${cfg.dataDir}"; # Make sure things are writable
+      script = (lib.concatMapStrings (run: ''
+        ${lib.getExe cfg.package} \
+          --config ${format.generate "sitespeed.json" run.settings} \
+          ${lib.escapeShellArgs run.extraArgs} \
+          ${builtins.toFile "urls.txt" (lib.concatLines run.urls)} &
+      '') cfg.runs) +
+      ''
+        wait
+      '';
+    };
+
+    users = {
+      extraUsers.${cfg.user} = {
+        isSystemUser = true;
+        group = cfg.user;
+        home = cfg.dataDir;
+        createHome = true;
+        homeMode = "755";
+      };
+      extraGroups.${cfg.user} = { };
+    };
+  };
+}

--- a/pkgs/tools/networking/sitespeed-io/default.nix
+++ b/pkgs/tools/networking/sitespeed-io/default.nix
@@ -1,0 +1,91 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, buildNpmPackage
+, makeWrapper
+, coreutils
+, ffmpeg-headless
+, imagemagick_light
+, procps
+, python3
+, xorg
+
+# chromedriver is more efficient than geckodriver, but is available on less platforms.
+
+, withChromium ? (lib.elem stdenv.hostPlatform.system chromedriver.meta.platforms)
+, chromedriver
+, chromium
+
+, withFirefox ? (lib.elem stdenv.hostPlatform.system geckodriver.meta.platforms)
+, geckodriver
+, firefox
+}:
+assert (!withFirefox && !withChromium) -> throw "Either `withFirefox` or `withChromium` must be enabled.";
+buildNpmPackage rec {
+  pname = "sitespeed-io";
+  version = "27.3.1";
+
+  src = fetchFromGitHub {
+    owner = "sitespeedio";
+    repo = "sitespeed.io";
+    rev = "v${version}";
+    hash = "sha256-Z4U4ZIw5Du/VSHIsGKdgu7wRv/6XVh/nMFDs8aYwkOQ=";
+  };
+
+  postPatch = ''
+    ln -s npm-shrinkwrap.json package-lock.json
+  '';
+
+  # Don't try to download the browser drivers
+  CHROMEDRIVER_SKIP_DOWNLOAD = true;
+  GECKODRIVER_SKIP_DOWNLOAD = true;
+  EDGEDRIVER_SKIP_DOWNLOAD = true;
+
+  nativeBuildInputs = [ python3 makeWrapper ];
+
+  dontNpmBuild = true;
+  npmInstallFlags = [ "--omit=dev" ];
+  npmDepsHash = "sha256-Z9SSIPF/QPDsv4DexiqJAAXhY/QvnWqnauih6DT7I8o=";
+
+  postInstall = ''
+    mv $out/bin/sitespeed{.,-}io
+    mv $out/bin/sitespeed{.,-}io-wpr
+  '';
+
+  postFixup =
+    let
+      chromiumArgs = lib.concatStringsSep " " [
+        "--browsertime.chrome.chromedriverPath=${lib.getExe chromedriver}"
+        "--browsertime.chrome.binaryPath=${lib.getExe chromium}"
+      ];
+      firefoxArgs = lib.concatStringsSep " " [
+        "--browsertime.firefox.geckodriverPath=${lib.getExe geckodriver}"
+        "--browsertime.firefox.binaryPath=${lib.getExe firefox}"
+        # Firefox crashes if the profile template dir is not writable
+        "--browsertime.firefox.profileTemplate=$(mktemp -d)"
+      ];
+    in
+    ''
+      wrapProgram $out/bin/sitespeed-io \
+        --set PATH ${lib.makeBinPath ([
+          (python3.withPackages (p: [p.numpy p.opencv4 p.pyssim]))
+          ffmpeg-headless
+          imagemagick_light
+          xorg.xorgserver
+          procps
+          coreutils
+        ])} \
+        ${lib.optionalString withChromium "--add-flags '${chromiumArgs}'"} \
+        ${lib.optionalString withFirefox "--add-flags '${firefoxArgs}'"} \
+        ${lib.optionalString (!withFirefox && withChromium) "--add-flags '-b chrome'"} \
+        ${lib.optionalString (withFirefox && !withChromium) "--add-flags '-b firefox'"}
+    '';
+
+  meta = with lib; {
+    description = "An open source tool that helps you monitor, analyze and optimize your website speed and performance";
+    homepage = "https://sitespeed.io";
+    license = licenses.mit;
+    maintainers = with maintainers; [ misterio77 ];
+    platforms = lib.unique (geckodriver.meta.platforms ++ chromedriver.meta.platforms);
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1709,6 +1709,8 @@ with pkgs;
 
   simple-dlna-browser = callPackage ../tools/networking/simple-dlna-browser { };
 
+  sitespeed-io = callPackage ../tools/networking/sitespeed-io { };
+
   sorted-grep = callPackage ../tools/text/sorted-grep { };
 
   smbmap = callPackage ../tools/security/smbmap { };


### PR DESCRIPTION
###### Description of changes

Packages sitespeed.io, a tool that can generate metrics (timings, diagnostics) for websites.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [x] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
