### PR TITLE
gtkcord4: 0.0.9 -> 0.0.10

### DIFF
--- a/pkgs/applications/audio/gtkcord4/default.nix
+++ b/pkgs/applications/audio/gtkcord4/default.nix
@@ -63,6 +63,6 @@ buildGoModule rec {
     description = "GTK4 Discord client in Go, attempt #4.";
     homepage = "https://github.com/diamondburned/gtkcord4";
     license = licenses.gpl3Only;
-    maintainers = with maintainers; [ hmenke urandom ];
+    maintainers = with maintainers; [ hmenke urandom aleksana ];
   };
 }

--- a/pkgs/applications/audio/gtkcord4/default.nix
+++ b/pkgs/applications/audio/gtkcord4/default.nix
@@ -13,19 +13,18 @@
 , pango
 , pkg-config
 , sound-theme-freedesktop
-, withLibadwaita ? false
 , wrapGAppsHook4
 }:
 
 buildGoModule rec {
   pname = "gtkcord4";
-  version = "0.0.9";
+  version = "0.0.10";
 
   src = fetchFromGitHub {
     owner = "diamondburned";
     repo = pname;
     rev = "v${version}";
-    hash = "sha256-55mS+hrhLLRkhgih5lvdM9Xka+WKg2iliFm6TYF6n3w=";
+    hash = "sha256-WrKZRRJAbEzcCRcFUTa7PxahQ3YADhfWaKlB4uJjVk0=";
   };
 
   nativeBuildInputs = [
@@ -49,11 +48,8 @@ buildGoModule rec {
     gst_all_1.gstreamer
     libcanberra-gtk3
     sound-theme-freedesktop
-  ] ++ lib.optionals withLibadwaita [
     libadwaita
   ];
-
-  tags = lib.optionals withLibadwaita [ "libadwaita" ];
 
   postInstall = ''
     install -D -m 444 -t $out/share/applications nix/xyz.diamondb.gtkcord4.desktop
@@ -61,7 +57,7 @@ buildGoModule rec {
     install -D -m 444 internal/icons/png/logo.png $out/share/icons/hicolor/256x256/apps/gtkcord4.png
   '';
 
-  vendorHash = "sha256-IQpokMeo46vZIdVA1F7JILXCN9bUqTMOCa/SQ0JSjaM=";
+  vendorHash = "sha256-8Xnu3WjaaWMRkqmnQCxSc/SD65XFMIY0xamWDx4jZbw=";
 
   meta = with lib; {
     description = "GTK4 Discord client in Go, attempt #4.";


### PR DESCRIPTION
###### Description of changes

breaking change: `withLibadwaita` no longer optional. See https://github.com/diamondburned/gtkcord4/releases/tag/v0.0.10

(Actually it is also broken in the last release, because the author changed the flag from `libadwaita` to `nolibadwaita` two months ago)

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
