### PR TITLE
mutter, gnome-shell: 44.0 → 44.1

### DIFF
--- a/pkgs/desktops/gnome/core/gnome-shell/default.nix
+++ b/pkgs/desktops/gnome/core/gnome-shell/default.nix
@@ -67,13 +67,13 @@ let
 in
 stdenv.mkDerivation rec {
   pname = "gnome-shell";
-  version = "44.0";
+  version = "44.1";
 
   outputs = [ "out" "devdoc" ];
 
   src = fetchurl {
     url = "mirror://gnome/sources/gnome-shell/${lib.versions.major version}/${pname}-${version}.tar.xz";
-    sha256 = "MxCtwd1OIQmY1Z84cbwx9+BJFUKNnO2IwqZrKwXWwAo=";
+    sha256 = "C/vkOU0mdiUVTQjQFGe9vZnoFXUS/I30XVwC3bdVHKY=";
   };
 
   patches = [
@@ -103,14 +103,6 @@ stdenv.mkDerivation rec {
     (fetchpatch {
       url = "https://src.fedoraproject.org/rpms/gnome-shell/raw/9a647c460b651aaec0b8a21f046cc289c1999416/f/0001-gdm-Work-around-failing-fingerprint-auth.patch";
       sha256 = "pFvZli3TilUt6YwdZztpB8Xq7O60XfuWUuPMMVSpqLw=";
-    })
-
-    # Logout/reboot/poweroff timeout leaves the session in a broken state
-    # https://gitlab.gnome.org/GNOME/gnome-shell/-/issues/6506
-    # Should be part of 44.1
-    (fetchpatch {
-      url = "https://gitlab.gnome.org/GNOME/gnome-shell/-/commit/5766d4111ac065b37417bedcc1b998ab6bee5514.patch";
-      sha256 = "d9oEzRnVbaFeCaBFhfLnW/Z8FzyQ7J8L7eAQe91133k=";
     })
   ];
 
@@ -194,13 +186,6 @@ stdenv.mkDerivation rec {
     # We can generate it ourselves.
     rm -f man/gnome-shell.1
     rm data/theme/gnome-shell.css
-
-    # Build fails with -Dgtk_doc=true
-    # https://gitlab.gnome.org/GNOME/gnome-shell/-/issues/6486
-    # element include: XInclude error : could not load xxx, and no fallback was found
-    substituteInPlace docs/reference/shell/shell-docs.sgml \
-      --replace '<xi:include href="xml/shell-embedded-window.xml"/>' ' ' \
-      --replace '<xi:include href="xml/shell-gtk-embed.xml"/>' ' '
   '';
 
   postInstall = ''

--- a/pkgs/desktops/gnome/core/mutter/43/default.nix
+++ b/pkgs/desktops/gnome/core/mutter/43/default.nix
@@ -45,6 +45,7 @@
 , libcap_ng
 , egl-wayland
 , graphene
+, wayland
 , wayland-protocols
 }:
 
@@ -137,6 +138,7 @@ stdenv.mkDerivation (finalAttrs: {
     libsysprof-capture
     xkeyboard_config
     xwayland
+    wayland
     wayland-protocols
   ];
 

--- a/pkgs/desktops/gnome/core/mutter/default.nix
+++ b/pkgs/desktops/gnome/core/mutter/default.nix
@@ -60,18 +60,19 @@
 , libcap_ng
 , egl-wayland
 , graphene
+, wayland
 , wayland-protocols
 }:
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "mutter";
-  version = "44.0";
+  version = "44.1";
 
   outputs = [ "out" "dev" "man" "devdoc" ];
 
   src = fetchurl {
     url = "mirror://gnome/sources/mutter/${lib.versions.major finalAttrs.version}/mutter-${finalAttrs.version}.tar.xz";
-    sha256 = "chSwfhNYnvfB31U8ftEaAnmOQ62mwiiRP056Zm7vusQ=";
+    sha256 = "lzrq+rQvBvk0oJlPyEh4lYzbTSdmpMhnpczcVH3VcFY=";
   };
 
   mesonFlags = [
@@ -134,6 +135,7 @@ stdenv.mkDerivation (finalAttrs: {
     sysprof # for D-Bus interfaces
     libsysprof-capture
     xwayland
+    wayland
     wayland-protocols
   ] ++ [
     # X11 client


### PR DESCRIPTION
###### Description of changes

- https://github.com/GNOME/mutter/compare/44.0...44.1
- https://github.com/GNOME/gnome-shell/compare/44.0...44.1

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Confirmed the focus [issue](https://gitlab.gnome.org/GNOME/mutter/-/issues/2690) is not fixed and we still need `machine.send_key("esc")`
- [x] Browsed the issue tracker for [mutter](https://gitlab.gnome.org/GNOME/mutter/-/issues), [gnome-shell](https://gitlab.gnome.org/GNOME/gnome-shell/-/issues)
- [x] Browsed the commits made after release for [mutter](https://gitlab.gnome.org/GNOME/mutter/-/commits/main), [gnome-shell](https://gitlab.gnome.org/GNOME/gnome-shell/-/commits/gnome-44/)
- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
