### PR TITLE
obs-studio-plugins.obs-scale-to-sound: init at 1.2.2

### DIFF
--- a/pkgs/applications/video/obs-studio/plugins/default.nix
+++ b/pkgs/applications/video/obs-studio/plugins/default.nix
@@ -32,6 +32,7 @@
 
   obs-pipewire-audio-capture = callPackage ./obs-pipewire-audio-capture.nix { };
 
+  obs-scale-to-sound = qt6Packages.callPackage ./obs-scale-to-sound.nix { };
   obs-source-clone = callPackage ./obs-source-clone.nix { };
 
   obs-source-record = callPackage ./obs-source-record.nix { };

--- a/pkgs/applications/video/obs-studio/plugins/obs-scale-to-sound.nix
+++ b/pkgs/applications/video/obs-studio/plugins/obs-scale-to-sound.nix
@@ -4,10 +4,15 @@
 , cmake
 , qtbase
 , xorg
+, curl
+, procps
 , libxkbcommon
 , libxkbfile
 , obs-studio
 , pkg-config
+, opencv
+, websocketpp
+, asio
 }:
 
 stdenv.mkDerivation rec {
@@ -25,15 +30,15 @@ stdenv.mkDerivation rec {
 
   buildInputs = [
     obs-studio qtbase xorg.libX11 xorg.libXau xorg.libXdmcp xorg.libXtst xorg.libXext
-    xorg.libXi xorg.libXt xorg.libXinerama libxkbcommon libxkbfile
+    xorg.libXi xorg.libXt xorg.libXinerama xorg.libXScrnSaver procps curl opencv websocketpp asio libxkbcommon libxkbfile
   ];
   dontWrapQtApps = true;
 
-  #postInstall = ''
-  #  mkdir $out/lib $out/share
-  #  mv $out/obs-plugins/64bit $out/lib/obs-plugins
-  #  mv $out/data $out/share/obs
-  #'';
+  postInstall = ''
+    mkdir $out/lib $out/share
+    mv $out/obs-plugins/64bit $out/lib/obs-plugins
+    mv $out/data $out/share/obs
+  '';
 
   meta = {
     description = "A plugin for OBS Studio that adds a filter which makes a source scale based on the audio levels of any audio source you choose";

--- a/pkgs/applications/video/obs-studio/plugins/obs-scale-to-sound.nix
+++ b/pkgs/applications/video/obs-studio/plugins/obs-scale-to-sound.nix
@@ -1,0 +1,45 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, cmake
+, qtbase
+, xorg
+, libxkbcommon
+, libxkbfile
+, obs-studio
+, pkg-config
+}:
+
+stdenv.mkDerivation rec {
+  pname = "obs-scale-to-sound";
+  version = "1.2.2";
+
+  src = fetchFromGitHub {
+    owner = "dimtpap";
+    repo = "obs-scale-to-sound";
+    rev = version;
+    sha256 = "04k7f7v756vdsan95g73cc29lrs61jis738v37a3ihi3ivps3ma3";
+  };
+
+  nativeBuildInputs = [ cmake pkg-config ];
+
+  buildInputs = [
+    obs-studio qtbase xorg.libX11 xorg.libXau xorg.libXdmcp xorg.libXtst xorg.libXext
+    xorg.libXi xorg.libXt xorg.libXinerama libxkbcommon libxkbfile
+  ];
+  dontWrapQtApps = true;
+
+  #postInstall = ''
+  #  mkdir $out/lib $out/share
+  #  mv $out/obs-plugins/64bit $out/lib/obs-plugins
+  #  mv $out/data $out/share/obs
+  #'';
+
+  meta = {
+    description = "A plugin for OBS Studio that adds a filter which makes a source scale based on the audio levels of any audio source you choose";
+    homepage = "https://github.com/dimtpap/obs-scale-to-sound";
+    maintainers = with lib.maintainers; [ takov751 ];
+    license = lib.licenses.gpl2Plus;
+    platforms = lib.platforms.linux;
+  };
+}


### PR DESCRIPTION
###### Description of changes
A plugin for OBS Studio that adds a filter which makes a source scale based on the audio levels of any audio source you choose

https://github.com/dimtpap/obs-scale-to-sound



```

├── lib
│   └── obs-plugins
│       ├── advanced-scene-switcher-lib.so -> advanced-scene-switcher-lib.so.1
│       ├── advanced-scene-switcher-lib.so.1
│       ├── advanced-scene-switcher.so
│       └── adv-ss-plugins
│           └── advanced-scene-switcher-opencv.so
├── obs-plugins
└── share
    └── obs
        └── obs-plugins
            └── advanced-scene-switcher
                ├── locale
                │   ├── de-DE.ini
                │   ├── en-US.ini
                │   ├── es-ES.ini
                │   ├── ru-RU.ini
                │   ├── tr-TR.ini
                │   └── zh-CN.ini
                └── res
                    ├── cascadeClassifiers
                    │   ├── haarcascade_eye_tree_eyeglasses.xml
                    │   ├── haarcascade_eye.xml
                    │   ├── haarcascade_frontalface_alt2.xml
                    │   ├── haarcascade_frontalface_alt_tree.xml
                    │   ├── haarcascade_frontalface_alt.xml
                    │   ├── haarcascade_frontalface_default.xml
                    │   ├── haarcascade_fullbody.xml
                    │   ├── haarcascade_lefteye_2splits.xml
                    │   ├── haarcascade_lowerbody.xml
                    │   ├── haarcascade_profileface.xml
                    │   ├── haarcascade_righteye_2splits.xml
                    │   └── haarcascade_upperbody.xml
                    └── time.svg
```
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
