### PR TITLE
amazon-ec2-utils: Fix shebang not being patched

### DIFF
--- a/pkgs/tools/admin/amazon-ec2-utils/default.nix
+++ b/pkgs/tools/admin/amazon-ec2-utils/default.nix
@@ -5,6 +5,7 @@
 , gawk
 , python3
 , installShellFiles
+, bash
 }:
 stdenv.mkDerivation rec {
   pname = "amazon-ec2-utils";
@@ -22,6 +23,7 @@ stdenv.mkDerivation rec {
   strictDeps = true;
   buildInputs = [
     python3
+    bash
   ];
   nativeBuildInputs = [
     installShellFiles


### PR DESCRIPTION
###### Description of changes

Fixes #228878


###### Things done

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [X] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [X] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
