### PR TITLE
rustPlatform.importCargoLock: fix [package] section handling

### DIFF
--- a/pkgs/build-support/rust/import-cargo-lock.nix
+++ b/pkgs/build-support/rust/import-cargo-lock.nix
@@ -108,7 +108,7 @@ let
 
   # Replaces values inherited by workspace members.
   replaceWorkspaceValues = writers.writePython3 "replace-workspace-values"
-    { libraries = with python3Packages; [ tomli tomli-w ]; flakeIgnore = [ "E501" ]; }
+    { libraries = with python3Packages; [ tomli tomli-w ]; flakeIgnore = [ "E501" "W503" ]; }
     (builtins.readFile ./replace-workspace-values.py);
 
   # Fetch and unpack a crate.

--- a/pkgs/build-support/rust/replace-workspace-values.py
+++ b/pkgs/build-support/rust/replace-workspace-values.py
@@ -18,7 +18,11 @@ def load_file(path: str) -> dict[str, Any]:
 def replace_key(
     workspace_manifest: dict[str, Any], table: dict[str, Any], section: str, key: str
 ) -> bool:
-    if "workspace" in table[key] and table[key]["workspace"] is True:
+    if (
+        isinstance(table[key], dict)
+        and "workspace" in table[key]
+        and table[key]["workspace"] is True
+    ):
         print("replacing " + key)
 
         replaced = table[key]

--- a/pkgs/build-support/rust/test/import-cargo-lock/default.nix
+++ b/pkgs/build-support/rust/test/import-cargo-lock/default.nix
@@ -14,7 +14,7 @@
   v1 = callPackage ./v1 { };
   gitDependencyWorkspaceInheritance = callPackage ./git-dependency-workspace-inheritance {
     replaceWorkspaceValues = writers.writePython3 "replace-workspace-values"
-      { libraries = with python3Packages; [ tomli tomli-w ]; flakeIgnore = [ "E501" ]; }
+      { libraries = with python3Packages; [ tomli tomli-w ]; flakeIgnore = [ "E501" "W503" ]; }
       (builtins.readFile ../../replace-workspace-values.py);
   };
 }

--- a/pkgs/build-support/rust/test/import-cargo-lock/git-dependency-workspace-inheritance/crate.toml
+++ b/pkgs/build-support/rust/test/import-cargo-lock/git-dependency-workspace-inheritance/crate.toml
@@ -1,5 +1,12 @@
 [package]
+name = "im_using_workspaces"
 version = { workspace = true }
+publish = false
+keywords = [
+    "workspace",
+    "other_thing",
+    "third_thing",
+]
 
 [dependencies]
 foo = { workspace = true, features = ["cat"] }

--- a/pkgs/build-support/rust/test/import-cargo-lock/git-dependency-workspace-inheritance/want.toml
+++ b/pkgs/build-support/rust/test/import-cargo-lock/git-dependency-workspace-inheritance/want.toml
@@ -1,5 +1,12 @@
 [package]
+name = "im_using_workspaces"
 version = "1.0.0"
+publish = false
+keywords = [
+    "workspace",
+    "other_thing",
+    "third_thing",
+]
 
 [dependencies]
 bar = "1.0.0"


### PR DESCRIPTION
###### Description of changes

An issue [came up on Matrix](https://matrix.to/#/%23dev%3Anixos.org/%24Pu4NDTNI7fpcoYmHnYD92DssmtrqI26Vv8qOjQnSknc?via=nixos.org&via=matrix.org&via=nixos.dev), where a build was breaking on [this line in a Cargo.toml](https://github.com/AdrianEddy/wgpu/blob/fdc4469051ca058b3ba95a23e280ade41565bdcc/wgpu/Cargo.toml#L22).

This breaks because the value here is a boolean, and the `in` operator works on iterables. It has incidentally worked for string values, since Python strings *are* iterables, but more properly we should only check TOML subtables/Python dicts.

I manually ran replace-workspace-values.py on the package in question, and it seems to work, and the person who originally mentioned this says it also works for them, but I haven't tested beyond that.

###### Things done
- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
