### PR TITLE
rosie: unstable-2020-01-11 -> 1.3.0

### DIFF
--- a/pkgs/tools/text/rosie/default.nix
+++ b/pkgs/tools/text/rosie/default.nix
@@ -7,12 +7,12 @@
 
 stdenv.mkDerivation rec {
   pname = "rosie";
-  version = "unstable-2020-01-11";
+  version = "1.3.0";
 
   src = fetchgit {
     url = "https://gitlab.com/rosie-pattern-language/rosie";
-    rev = "670e9027563609ba2ea31e14e2621a1302742795";
-    sha256 = "0jc512dbn62a1fniknhbp6q0xa1p7xi3hn5v60is8sy9jgi3afxv";
+    rev = "9303e04ae2cffabdda6ccc4e2a351a47218615ff";
+    sha256 = "1smh760baf43hr56p6rh4khz3shyzda5lqva4ffxwchl7yy7r82j";
     fetchSubmodules = true;
   };
 
@@ -23,16 +23,30 @@ stdenv.mkDerivation rec {
 
   preConfigure = ''
     patchShebangs src/build_info.sh
+    # rosie is ran as part of `make check`,
+    # and so needs to be patched in preConfigure.
+    patchShebangs rosie
     # Part of the same Makefile target which calls git to update submodules
     ln -s src submodules/lua/include
+    # ldconfig is irrelevant, disable it inside `make installforce`.
+    sed -iE 's/ldconfig/echo skippin ldconfig/' Makefile
+    sed -iE '/ld.so.conf.d/d' Makefile
+  '';
+
+  preInstall = lib.optionalString stdenv.isDarwin ''
+    install_name_tool -add_rpath $out/lib build/bin/rosie
+    install_name_tool -id $out/lib/librosie.dylib build/lib/librosie.dylib
   '';
 
   postInstall = ''
     mkdir -p $out/share/emacs/site-lisp $out/share/vim-plugins $out/share/nvim
-    mv $out/lib/rosie/extra/extra/emacs/* $out/share/emacs/site-lisp/
-    mv $out/lib/rosie/extra/extra/vim $out/share/vim-plugins/rosie
+    mv $out/lib/rosie/extra/emacs/* $out/share/emacs/site-lisp/
+    mv $out/lib/rosie/extra/vim $out/share/vim-plugins/rosie
     ln -s $out/share/vim-plugins/rosie $out/share/nvim/site
   '';
+
+  # librosie.so is dlopen'ed , so we disable ELF patching to preserve RUNPATH .
+  dontPatchELF = true;
 
   makeFlags = [ "DESTDIR=${placeholder "out"}" ];
 


### PR DESCRIPTION
###### Description of changes

unstable-2020-01-11 seems to be between 1.2.1 and 1.2.2 , based on https://gitlab.com/rosie-pattern-language/rosie/-/blob/670e9027563609ba2ea31e14e2621a1302742795/CHANGELOG . There has been no breaking changes since, according to https://gitlab.com/rosie-pattern-language/rosie/-/blob/v1.3.0/CHANGELOG?ref_type=tags .

###### Things done

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
