### PR TITLE
python310Packages.edalize: 0.4.1 -> 0.5.0 

### DIFF
--- a/pkgs/development/python-modules/edalize/default.nix
+++ b/pkgs/development/python-modules/edalize/default.nix
@@ -5,6 +5,7 @@
 , jinja2
 , pandas
 , pytestCheckHook
+, pythonOlder
 , which
 , yosys
 }:
@@ -12,6 +13,9 @@
 buildPythonPackage rec {
   pname = "edalize";
   version = "0.4.1";
+  format = "setuptools";
+
+  disabled = pythonOlder "3.7";
 
   src = fetchFromGitHub {
     owner = "olofk";
@@ -26,7 +30,9 @@ buildPythonPackage rec {
     patchShebangs tests/mock_commands/vsim
   '';
 
-  propagatedBuildInputs = [ jinja2 ];
+  propagatedBuildInputs = [
+    jinja2
+  ];
 
   nativeCheckInputs = [
     pytestCheckHook
@@ -35,7 +41,9 @@ buildPythonPackage rec {
     yosys
   ];
 
-  pythonImportsCheck = [ "edalize" ];
+  pythonImportsCheck = [
+    "edalize"
+  ];
 
   disabledTestPaths = [
     "tests/test_questa_formal.py"

--- a/pkgs/development/python-modules/edalize/default.nix
+++ b/pkgs/development/python-modules/edalize/default.nix
@@ -67,7 +67,8 @@ buildPythonPackage rec {
   meta = with lib; {
     description = "Abstraction library for interfacing EDA tools";
     homepage = "https://github.com/olofk/edalize";
+    changelog = "https://github.com/olofk/edalize/releases/tag/v${version}";
     license = licenses.bsd2;
-    maintainers = [ maintainers.astro ];
+    maintainers = with maintainers; [ astro ];
   };
 }

--- a/pkgs/development/python-modules/edalize/default.nix
+++ b/pkgs/development/python-modules/edalize/default.nix
@@ -4,6 +4,7 @@
 , coreutils
 , jinja2
 , pandas
+, pyparsing
 , pytestCheckHook
 , pythonOlder
 , which
@@ -12,7 +13,7 @@
 
 buildPythonPackage rec {
   pname = "edalize";
-  version = "0.4.1";
+  version = "0.5.0";
   format = "setuptools";
 
   disabled = pythonOlder "3.7";
@@ -21,7 +22,7 @@ buildPythonPackage rec {
     owner = "olofk";
     repo = pname;
     rev = "refs/tags/v${version}";
-    hash = "sha256-h6b0mdAUR4NsN2SpnLu5OgS9Fy9ZRitG+5Sbon1jlUM=";
+    hash = "sha256-jsrJr/iuezh9/KL0PykWB1XKev4Wr5QeDh0ZWNMZSp8=";
   };
 
   postPatch = ''
@@ -34,12 +35,18 @@ buildPythonPackage rec {
     jinja2
   ];
 
+  passthru.optional-dependencies = {
+    reporting = [
+      pandas
+      pyparsing
+    ];
+  };
+
   nativeCheckInputs = [
     pytestCheckHook
-    pandas
     which
     yosys
-  ];
+  ] ++ lib.flatten (builtins.attrValues passthru.optional-dependencies);
 
   pythonImportsCheck = [
     "edalize"


### PR DESCRIPTION
Diff: https://github.com/olofk/edalize/compare/refs/tags/v0.4.1...v0.5.0

Changelog: https://github.com/olofk/edalize/releases/tag/v0.5.0

###### Description of changes
Fix build (https://hydra.nixos.org/build/217517947)
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
