### PR TITLE
fix: sec17.27.1.2.1 python38 -> python39

### DIFF
--- a/doc/languages-frameworks/python.section.md
+++ b/doc/languages-frameworks/python.section.md
@@ -412,7 +412,7 @@ with import <nixpkgs> {};
       };
     };
 
-  in python38.withPackages (ps: [ps.numpy my_toolz])
+  in python39.withPackages (ps: [ps.numpy my_toolz])
 ).env
 ```
 


### PR DESCRIPTION
###### Description of changes

Nixpkgs Manual change in Languages and Frameworks: Python section 17.27.1.2.1. The given example:
```nix
with import <nixpkgs> {};

( let
    my_toolz = python39.pkgs.buildPythonPackage rec {
      pname = "toolz";
      version = "0.10.0";

      src = python39.pkgs.fetchPypi {
        inherit pname version;
        sha256 = "08fdd5ef7c96480ad11c12d472de21acd32359996f69a5259299b540feba4560";
      };

      doCheck = false;

      meta = {
        homepage = "https://github.com/pytoolz/toolz/";
        description = "List processing tools and functional utilities";
      };
    };

  in python38.withPackages (ps: [ps.numpy my_toolz])
).env
```

does not actually include python v3.8 with the module `toolz` because of different python versions. To resolve this, either the version of python with package needs to be altered to the same as `my_toolz` or `my_toolz` needs to be the same as python with packages.

In the change, I decided to change to `python39.withPackages` as it both more up-to-date and more in line with the other parts of the documentation.

###### Things done

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

It was only a small documentation change so I didn't both building or testing. I can if you really would like me to though.
