### PR TITLE
haskellPackages.hspec*_2_11_0: update references to be hspec*_2_11_0_1

### DIFF
--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -61,15 +61,15 @@ self: super: {
           # not solvable short of recompiling GHC. Instead of adding
           # allowInconsistentDependencies for all reverse dependencies of hspec-core,
           # just upgrade to an hspec version without the offending dependency.
-          hspec-core = cself.hspec-core_2_11_0;
-          hspec-discover = cself.hspec-discover_2_11_0;
-          hspec = cself.hspec_2_11_0;
+          hspec-core = cself.hspec-core_2_11_0_1;
+          hspec-discover = cself.hspec-discover_2_11_0_1;
+          hspec = cself.hspec_2_11_0_1;
 
           # hspec-discover and hspec-core depend on hspec-meta for testing which
           # we need to avoid since it depends on ghc as well. Since hspec*_2_10*
           # are overridden to take the versioned attributes as inputs, we need
           # to make sure to override the versioned attribute with this fix.
-          hspec-discover_2_11_0 = dontCheck csuper.hspec-discover_2_11_0;
+          hspec-discover_2_11_0_1 = dontCheck csuper.hspec-discover_2_11_0_1;
 
           # Prevent dependency on doctest which causes an inconsistent dependency
           # due to depending on ghc which depends on directory etc.
@@ -1005,12 +1005,12 @@ self: super: {
     testHaskellDepends = drv.testHaskellDepends or [] ++ [ self.hspec-meta_2_10_5 ];
     testToolDepends = drv.testToolDepends or [] ++ [ pkgs.git ];
   }) (super.sensei.override {
-    hspec = self.hspec_2_11_0;
+    hspec = self.hspec_2_11_0_1;
     hspec-wai = self.hspec-wai.override {
-      hspec = self.hspec_2_11_0;
+      hspec = self.hspec_2_11_0_1;
     };
     hspec-contrib = self.hspec-contrib.override {
-      hspec-core = self.hspec-core_2_11_0;
+      hspec-core = self.hspec-core_2_11_0_1;
     };
     fsnotify = self.fsnotify_0_4_1_0;
   });
@@ -1674,16 +1674,16 @@ self: super: {
   servant-openapi3 = dontCheck super.servant-openapi3;
 
   # Give hspec 2.10.* correct dependency versions without overrideScope
-  hspec_2_11_0 = doDistribute (super.hspec_2_11_0.override {
-    hspec-discover = self.hspec-discover_2_11_0;
-    hspec-core = self.hspec-core_2_11_0;
+  hspec_2_11_0_1 = doDistribute (super.hspec_2_11_0_1.override {
+    hspec-discover = self.hspec-discover_2_11_0_1;
+    hspec-core = self.hspec-core_2_11_0_1;
   });
-  hspec-discover_2_11_0 = doDistribute (super.hspec-discover_2_11_0.override {
+  hspec-discover_2_11_0_1 = doDistribute (super.hspec-discover_2_11_0_1.override {
     hspec-meta = self.hspec-meta_2_10_5;
   });
-  # Need to disable tests to prevent an infinite recursion if hspec-core_2_11_0
+  # Need to disable tests to prevent an infinite recursion if hspec-core_2_11_0_1
   # is overlayed to hspec-core.
-  hspec-core_2_11_0 = doDistribute (dontCheck (super.hspec-core_2_11_0.override {
+  hspec-core_2_11_0_1 = doDistribute (dontCheck (super.hspec-core_2_11_0_1.override {
     hspec-meta = self.hspec-meta_2_10_5;
   }));
 


### PR DESCRIPTION
###### Description of changes

I did replace all for each hspec package until `nix-env -f . -qaP --out-path` worked

fixes evaluation of https://github.com/NixOS/nixpkgs/pull/228965

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
