### PR TITLE
therion: init at 6.1.7

### DIFF
--- a/pkgs/applications/misc/therion/default.nix
+++ b/pkgs/applications/misc/therion/default.nix
@@ -1,0 +1,97 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, cmake
+, pkg-config
+, perl
+, tcl
+, tcllib
+, tk
+, expat
+, bwidget
+, python3
+, texlive
+, survex
+, makeWrapper
+, fmt
+, proj
+, wxGTK32
+, vtk
+, freetype
+, libjpeg
+, gettext
+, libGL
+, libGLU
+, sqlite
+, libtiff
+, curl
+, tkimg
+}:
+
+stdenv.mkDerivation rec {
+  pname = "therion";
+  version = "6.1.7";
+
+  src = fetchFromGitHub {
+    owner = "therion";
+    repo = "therion";
+    rev = "v${version}";
+    hash = "sha256-q+p1akGfzBeZejeYiJ8lrSbEIMTsX5YuIG/u35oh0JI=";
+  };
+
+  nativeBuildInputs = [
+    cmake
+    pkg-config
+    perl
+    python3
+    texlive.combined.scheme-tetex
+    makeWrapper
+    tcl.tclPackageHook
+  ];
+
+  preConfigure = ''
+    export OUTDIR=$out
+  '';
+
+  cmakeFlags = [
+    "-DBUILD_THBOOK=OFF"
+  ];
+
+  buildInputs = [
+    expat
+    tkimg
+    proj
+    wxGTK32
+    vtk
+    tk
+    freetype
+    libjpeg
+    gettext
+    libGL
+    libGLU
+    sqlite
+    libtiff
+    curl
+    fmt
+    tcl
+    tcllib
+    bwidget
+  ];
+
+  fixupPhase = ''
+    runHook preFixup
+    wrapProgram $out/bin/therion \
+      --prefix PATH : ${lib.makeBinPath [ survex texlive.combined.scheme-tetex ]}
+    wrapProgram $out/bin/xtherion \
+      --prefix PATH : ${lib.makeBinPath [ tk ]}
+    runHook postFixup
+  '';
+
+  meta = with lib; {
+    description = "Therion – cave surveying software";
+    homepage = "https://therion.speleo.sk/";
+    changelog = "https://github.com/therion/therion/blob/${src.rev}/CHANGES";
+    license = licenses.gpl2Only;
+    maintainers = with maintainers; [ matthewcroughan ];
+  };
+}

--- a/pkgs/development/libraries/tkimg/default.nix
+++ b/pkgs/development/libraries/tkimg/default.nix
@@ -1,0 +1,28 @@
+{ lib, fetchsvn, tcl, tcllib, tk, xorg }:
+
+tcl.mkTclDerivation rec {
+  pname = "tkimg";
+  version = "623";
+
+  src = fetchsvn {
+    url = "svn://svn.code.sf.net/p/tkimg/code/trunk";
+    rev = version;
+    sha256 = "sha256-6GlkqYxXmMGjiJTZS2fQNVSimcKc1BZ/lvzvtkhty+o=";
+  };
+
+  configureFlags = [
+    "--with-tcl=${tcl}/lib"
+    "--with-tk=${tk}/lib"
+    "--with-tkinclude=${tk.dev}/include"
+  ];
+
+  buildInputs = [ xorg.libX11 tcllib ];
+
+  meta = {
+    homepage = "https://sourceforge.net/projects/tkimg/";
+    description = "The Img package adds several image formats to Tcl/Tk";
+    maintainers = with lib.maintainers; [ matthewcroughan ];
+    license = lib.licenses.bsd3;
+    platforms = lib.platforms.unix;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -24046,6 +24046,8 @@ with pkgs;
   tk-8_6 = callPackage ../development/libraries/tk/8.6.nix { };
   tk-8_5 = callPackage ../development/libraries/tk/8.5.nix { tcl = tcl-8_5; };
 
+  tkimg = callPackage ../development/libraries/tkimg { };
+
   tkrzw = callPackage ../development/libraries/tkrzw { };
 
   tl-expected = callPackage ../development/libraries/tl-expected { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -39384,6 +39384,8 @@ with pkgs;
 
   thermald = callPackage ../tools/system/thermald { };
 
+  therion = callPackage ../applications/misc/therion { };
+
   throttled = callPackage ../tools/system/throttled { };
 
   thinkfan = callPackage ../tools/system/thinkfan { };


### PR DESCRIPTION
###### Description of changes

Adds the [Therion](https://therion.speleo.sk/) cave surveying software and one of its tcl dependencies to Nixpkgs. This is my first tcl submission, so I would appreciate some pointers if I'm doing anything wrong.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
