### PR TITLE
nixos/lib/test-driver: enable EFI variable reads at runtime

### DIFF
--- a/nixos/lib/test-driver/test_driver/efi.py
+++ b/nixos/lib/test-driver/test_driver/efi.py
@@ -1,0 +1,31 @@
+from enum import IntEnum
+
+class EfiVariableAttributes(IntEnum):
+    NonVolatile = 0x01
+    BootServiceAccess = 0x02
+    RuntimeAccess = 0x04
+    HardwareErrorRecord = 0x08
+    AuthenticatedWriteAccess = 0x10
+    TimeBasedAuthenticatedWriteAccess = 0x20
+    AppendWrite = 0x40
+    EnhancedAuthenticatedAccess = 0x80
+
+class EfiVariable:
+    """
+        An EFI variable represented by its attributes and raw value in bytes.
+        Generally, the value is not encoded in UTF-8, but UCS-2 or UTF-16-LE.
+    """
+    attributes: EfiVariableAttributes
+    value: bytes
+
+    def __init__(self, value: bytes, attributes: bytes):
+        self.value = value
+        self.attributes = EfiVariableAttributes(attributes)
+
+    def value_as_null_terminated_string(self, encoding: str = 'utf-16-le'):
+        """
+            Most often, variables are encoded with a null-terminated \x00.
+            This function gives you the string in a default encoding of UTF-16-LE
+            stripped of the null terminator.
+        """
+        return self.value.decode(encoding).rstrip('\x00')

--- a/nixos/lib/test-driver/test_driver/machine.py
+++ b/nixos/lib/test-driver/test_driver/machine.py
@@ -16,6 +16,7 @@ import tempfile
 import threading
 import time
 
+from test_driver.efi import EfiVariable
 from test_driver.logger import rootlog
 
 CHAR_TO_KEY = {
@@ -1002,6 +1003,33 @@ class Machine:
         Useful during interactive testing.
         """
         self.send_monitor_command(f"hostfwd_add tcp::{host_port}-:{guest_port}")
+
+    def running_under_uefi(self) -> bool:
+        """
+        Returns True if the current environment is running under UEFI, False otherwise.
+        This is achieved by inspecting by the existence of /sys/firmware/efi.
+        """
+        rc, _ = self.execute("test -d /sys/firmware/efi")
+        return (rc == 0)
+
+
+    def read_efi_variable_from_sysfs(self, guid: str, variable_name: str) -> EfiVariable | None:
+        """
+        Read an EFI variable located in efivars sysfs if available.
+        Returns None if the EFI variable does not exist.
+        Raises an assertion error if we are not running under an UEFI environment.
+        """
+        assert self.running_under_uefi(), "This machine is not detected under an UEFI environment"
+        rc, raw_attributes_and_value = self.execute(f"base64 /sys/firmware/efi/efivars/{variable_name}-{guid}")
+        if rc != 0: return None
+        # The return value is a string which is in reality a disguised bytes, we re-encode it properly
+        # using raw_unicode_escape keeping all the escapes properly.
+        # This is not guaranteed to work for all the cases but is good enough for UTF-8/UTF-16 usecases.
+        attributes_and_value = base64.b64decode(raw_attributes_and_value)
+        # First 4 bytes are attributes: https://www.kernel.org/doc/html/latest/filesystems/efivarfs.html
+        attributes = attributes_and_value[:4]
+        value = attributes_and_value[4:]
+        return EfiVariable(value=value, attributes=attributes)
 
     def block(self) -> None:
         """Make the machine unreachable by shutting down eth1 (the multicast


### PR DESCRIPTION
###### Description of changes

This is useful whenever you want to diagnose the current state of UEFI variables, to assert that bootloaders or boot programs (systemd-stub) did their job correctly and set their variables accordingly.

In the future, it can enable inspecting SecureBoot keys also.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
