### PR TITLE
python3Packages.s3transfer: remove unused inputs, fix cross compilation

### DIFF
--- a/pkgs/development/python-modules/s3transfer/default.nix
+++ b/pkgs/development/python-modules/s3transfer/default.nix
@@ -40,6 +40,6 @@ buildPythonPackage rec {
     description = "Library for managing Amazon S3 transfers";
     homepage = "https://github.com/boto/s3transfer";
     license = licenses.asl20;
-    maintainers = with maintainers; [ ];
+    maintainers = with maintainers; [ nickcao ];
   };
 }

--- a/pkgs/development/python-modules/s3transfer/default.nix
+++ b/pkgs/development/python-modules/s3transfer/default.nix
@@ -1,13 +1,10 @@
 { lib
 , botocore
 , buildPythonPackage
-, docutils
 , fetchFromGitHub
-, mock
 , pytestCheckHook
 , pythonOlder
 , stdenv
-, wheel
 }:
 
 buildPythonPackage rec {
@@ -26,16 +23,11 @@ buildPythonPackage rec {
 
   propagatedBuildInputs = [ botocore ];
 
-  buildInputs = [ docutils mock pytestCheckHook wheel ];
+  nativeCheckInputs = [ pytestCheckHook ];
 
   disabledTestPaths = [
     # Requires network access
-    "tests/integration/test_copy.py"
-    "tests/integration/test_delete.py"
-    "tests/integration/test_download.py"
-    "tests/integration/test_processpool.py"
-    "tests/integration/test_s3transfer.py"
-    "tests/integration/test_upload.py"
+    "tests/integration"
   ] ++
   # There was a change in python 3.8 that defaults multiprocessing to spawn instead of fork on macOS
   # See https://bugs.python.org/issue33725 and https://github.com/python/cpython/pull/13603.


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] riscv64-linux (cross)
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
