### PR TITLE
python3.pkgs.jinja2: don't build offline documentation by default

### DIFF
--- a/pkgs/applications/misc/privacyidea/default.nix
+++ b/pkgs/applications/misc/privacyidea/default.nix
@@ -52,7 +52,7 @@ let
         doCheck = false;
       });
       # Required by flask-1.1
-      jinja2 = (super.jinja2.override { enableDocumentation = false; }).overridePythonAttrs (old: rec {
+      jinja2 = super.jinja2.overridePythonAttrs (old: rec {
         version = "2.11.3";
         src = old.src.override {
           inherit version;

--- a/pkgs/development/python-modules/jinja2/default.nix
+++ b/pkgs/development/python-modules/jinja2/default.nix
@@ -10,7 +10,7 @@
 , pallets-sphinx-themes
 , sphinxcontrib-log-cabinet
 , sphinx-issues
-, enableDocumentation ? true
+, enableDocumentation ? false
 }:
 
 buildPythonPackage rec {

--- a/pkgs/development/python-modules/sphinx/default.nix
+++ b/pkgs/development/python-modules/sphinx/default.nix
@@ -64,7 +64,7 @@ buildPythonPackage rec {
     alabaster
     docutils
     imagesize
-    (jinja2.override { enableDocumentation = false; })
+    jinja2
     packaging
     pygments
     requests


### PR DESCRIPTION
###### Description of changes

E.g. `systemd` fails like this:
    
        last 25 log lines:
        > Checking for function "blkid_probe_set_hint" with dependency blkid: YES
        > Run-time dependency libkmod found: YES 30
        > Run-time dependency xencontrol found: NO (tried pkgconfig and cmake)
        > Run-time dependency libmicrohttpd found: NO (tried pkgconfig and cmake)
        > Checking for function "crypt_activate_by_token_pin" : NO
        > Run-time dependency libiptc found: NO (tried pkgconfig and cmake)
        > Run-time dependency libqrencode found: NO (tried pkgconfig and cmake)
        > Run-time dependency gnutls found: NO (tried pkgconfig and cmake)
        > Run-time dependency openssl found: NO (tried pkgconfig, system and cmake)
        > Run-time dependency p11-kit-1 found: NO (tried pkgconfig and cmake)
        > Run-time dependency tss2-esys tss2-rc tss2-mu found: NO (tried pkgconfig and cmake)
        > Run-time dependency libdw found: NO (tried pkgconfig and cmake)
        > Run-time dependency zlib found: NO (tried pkgconfig, cmake and system)
        > Library bz2 found: NO
        > Run-time dependency liblzma found: NO (tried pkgconfig and cmake)
        > Run-time dependency libzstd found: NO (tried pkgconfig and cmake)
        > Run-time dependency xkbcommon found: NO (tried pkgconfig and cmake)
        > Run-time dependency libpcre2-8 found: NO (tried pkgconfig and cmake)
        > Run-time dependency dbus-1 found: NO (tried pkgconfig and cmake)
        > Message: default-dnssec cannot be set to yes or allow-downgrade openssl and gcrypt are disabled. Setting default-dnssec to no.
        > Program python3 (jinja2) found: NO
        >
        > meson.build:1949:15: ERROR: python3 is missing modules: jinja2
    
Upon trying more packages I realized that this is not the only one (it
appears to be related to `python3.withPackages` in some cases).

For now, flip the default to unbreak a lot of stuff and remove the
`enableDocumentation = false;` hacks from a bunch of other packages.


cc @KAction 

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
