### PR TITLE
cloud-init: add patch for vultr

### DIFF
--- a/pkgs/tools/virtualization/cloud-init/0003-vultr-remove-check_route-check.patch
+++ b/pkgs/tools/virtualization/cloud-init/0003-vultr-remove-check_route-check.patch
@@ -1,0 +1,110 @@
+From 6df2a198013ebed9aeff119ee0d15cb2d616474c Mon Sep 17 00:00:00 2001
+From: zimbatm <zimbatm@zimbatm.com>
+Date: Sun, 30 Apr 2023 12:13:54 +0200
+Subject: [PATCH] vultr: remove check_route check
+
+The heuristic is assuming that the URL will contain an IP, and that the
+route explicitly lists that IP (eg: 0.0.0.0/0 should match but doesn't).
+In order for the heuristic to be 100% reliable, it would have to
+replicate exactly what the system is doing both in terms of DNS and
+route resolution.
+
+Because the HTTP request below is already exercising the python nd
+system resolution, it is simpler to just remove this check and lean on
+the HTTP request to provide the answer if the network is up or not.
+---
+ cloudinit/sources/helpers/vultr.py    | 22 ----------------------
+ tests/unittests/sources/test_vultr.py | 12 ------------
+ 2 files changed, 34 deletions(-)
+
+diff --git a/cloudinit/sources/helpers/vultr.py b/cloudinit/sources/helpers/vultr.py
+index 71676bb1..aac2a610 100644
+--- a/cloudinit/sources/helpers/vultr.py
++++ b/cloudinit/sources/helpers/vultr.py
+@@ -32,10 +32,6 @@ def get_metadata(
+                 iface=iface,
+                 connectivity_url_data={"url": url},
+             ):
+-                # Check for the metadata route, skip if not there
+-                if not check_route(url):
+-                    continue
+-
+                 # Fetch the metadata
+                 v1 = read_metadata(url, timeout, retries, sec_between, agent)
+ 
+@@ -75,24 +71,6 @@ def get_interface_list():
+     return ifaces
+ 
+ 
+-# Check for /32 route that our dhcp servers inject
+-# in order to determine if this a customer-run dhcp server
+-def check_route(url):
+-    # Get routes, confirm entry exists
+-    routes = netinfo.route_info()
+-
+-    # If no tools exist and empty dict is returned
+-    if "ipv4" not in routes:
+-        return False
+-
+-    # Parse each route into a more searchable format
+-    for route in routes["ipv4"]:
+-        if route.get("destination", None) in url:
+-            return True
+-
+-    return False
+-
+-
+ # Read the system information from SMBIOS
+ def get_sysinfo():
+     return {
+diff --git a/tests/unittests/sources/test_vultr.py b/tests/unittests/sources/test_vultr.py
+index ba21ae24..7fa02b1c 100644
+--- a/tests/unittests/sources/test_vultr.py
++++ b/tests/unittests/sources/test_vultr.py
+@@ -274,14 +274,6 @@ INTERFACE_MAP = {
+ FINAL_INTERFACE_USED = ""
+ 
+ 
+-# Static override, pylint doesnt like this in
+-# classes without self
+-def check_route(url):
+-    if FINAL_INTERFACE_USED == "eth0":
+-        return True
+-    return False
+-
+-
+ class TestDataSourceVultr(CiTestCase):
+     def setUp(self):
+         global VULTR_V1_3
+@@ -431,7 +423,6 @@ class TestDataSourceVultr(CiTestCase):
+     @mock.patch(
+         "cloudinit.net.ephemeral.EphemeralDHCPv4.__exit__", override_exit
+     )
+-    @mock.patch("cloudinit.sources.helpers.vultr.check_route")
+     @mock.patch("cloudinit.sources.helpers.vultr.is_vultr")
+     @mock.patch("cloudinit.sources.helpers.vultr.read_metadata")
+     @mock.patch("cloudinit.sources.helpers.vultr.get_interface_list")
+@@ -440,12 +431,10 @@ class TestDataSourceVultr(CiTestCase):
+         mock_interface_list,
+         mock_read_metadata,
+         mock_isvultr,
+-        mock_check_route,
+     ):
+         mock_read_metadata.return_value = {}
+         mock_isvultr.return_value = True
+         mock_interface_list.return_value = FILTERED_INTERFACES
+-        mock_check_route.return_value = True
+ 
+         distro = mock.MagicMock()
+         distro.get_tmp_exec_path = self.tmp_dir
+@@ -461,7 +450,6 @@ class TestDataSourceVultr(CiTestCase):
+         self.assertEqual(FINAL_INTERFACE_USED, INTERFACES[3])
+ 
+     # Test route checking sucessful DHCPs
+-    @mock.patch("cloudinit.sources.helpers.vultr.check_route", check_route)
+     @mock.patch(
+         "cloudinit.net.ephemeral.EphemeralDHCPv4.__init__",
+         ephemeral_init_always,
+-- 
+2.40.0
+

--- a/pkgs/tools/virtualization/cloud-init/default.nix
+++ b/pkgs/tools/virtualization/cloud-init/default.nix
@@ -26,7 +26,13 @@ python3.pkgs.buildPythonApplication rec {
     hash = "sha256-tn4flcrf04hVWhqkmK4qDenXcnV93pP+C+8J63b6FXQ=";
   };
 
-  patches = [ ./0001-add-nixos-support.patch ./0002-Add-Udhcpc-support.patch ];
+  patches = [
+    ./0001-add-nixos-support.patch
+    # upstream: https://github.com/canonical/cloud-init/pull/2125
+    ./0002-Add-Udhcpc-support.patch
+    # upstream: https://github.com/canonical/cloud-init/pull/2151
+    ./0003-vultr-remove-check_route-check.patch
+  ];
 
   prePatch = ''
     substituteInPlace setup.py \


### PR DESCRIPTION
###### Description of changes

This patch fixes the DataSourceVultr logic so cloud-init works properly
on Vultr.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
