### PR TITLE
tarball job: tag both derivations as big-parallel

### DIFF
--- a/pkgs/top-level/make-tarball.nix
+++ b/pkgs/top-level/make-tarball.nix
@@ -32,6 +32,8 @@ pkgs.releaseTools.sourceTarball {
     echo "git-revision is $(cat .git-revision)"
   '';
 
+  requiredSystemFeatures = [ "big-parallel" ]; # 1 thread but ~36G RAM (!) see #227945
+
   nixpkgs-basic-release-checks = import ./nixpkgs-basic-release-checks.nix
    { inherit nix pkgs nixpkgs supportedSystems; };
 

--- a/pkgs/top-level/nixpkgs-basic-release-checks.nix
+++ b/pkgs/top-level/nixpkgs-basic-release-checks.nix
@@ -1,6 +1,12 @@
 { supportedSystems, nixpkgs, pkgs, nix }:
 
-pkgs.runCommand "nixpkgs-release-checks" { src = nixpkgs; buildInputs = [nix]; } ''
+pkgs.runCommand "nixpkgs-release-checks"
+  {
+    src = nixpkgs;
+    buildInputs = [ nix ];
+    requiredSystemFeatures = [ "big-parallel" ]; # 1 thread but ~10G RAM; see #227945
+  }
+  ''
     set -o pipefail
 
     export NIX_STORE_DIR=$TMPDIR/store


### PR DESCRIPTION
The aim here is to avoid exhausting RAM of our normal machines on hydra.nixos.org.  See #227945 for details.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
