### PR TITLE
mate.atril: 1.26.0 -> 1.26.1

### DIFF
--- a/pkgs/desktops/mate/atril/default.nix
+++ b/pkgs/desktops/mate/atril/default.nix
@@ -25,8 +25,6 @@
 , mateUpdateScript
 }:
 
-with lib;
-
 stdenv.mkDerivation rec {
   pname = "atril";
   version = "1.26.0";
@@ -54,18 +52,18 @@ stdenv.mkDerivation rec {
     hicolor-icon-theme
     texlive.bin.core # for synctex, used by the pdf back-end
   ]
-  ++ optionals enableDjvu [ djvulibre ]
-  ++ optionals enableEpub [ webkitgtk ]
-  ++ optionals enablePostScript [ libspectre ]
-  ++ optionals enableXps [ libgxps ]
+  ++ lib.optionals enableDjvu [ djvulibre ]
+  ++ lib.optionals enableEpub [ webkitgtk ]
+  ++ lib.optionals enablePostScript [ libspectre ]
+  ++ lib.optionals enableXps [ libgxps ]
   ;
 
   configureFlags = [ ]
-    ++ optionals (enableDjvu) [ "--enable-djvu" ]
-    ++ optionals (enableEpub) [ "--enable-epub" ]
-    ++ optionals (enablePostScript) [ "--enable-ps" ]
-    ++ optionals (enableXps) [ "--enable-xps" ]
-    ++ optionals (enableImages) [ "--enable-pixbuf" ];
+    ++ lib.optionals (enableDjvu) [ "--enable-djvu" ]
+    ++ lib.optionals (enableEpub) [ "--enable-epub" ]
+    ++ lib.optionals (enablePostScript) [ "--enable-ps" ]
+    ++ lib.optionals (enableXps) [ "--enable-xps" ]
+    ++ lib.optionals (enableImages) [ "--enable-pixbuf" ];
 
   env.NIX_CFLAGS_COMPILE = "-I${glib.dev}/include/gio-unix-2.0";
 

--- a/pkgs/desktops/mate/atril/default.nix
+++ b/pkgs/desktops/mate/atril/default.nix
@@ -27,11 +27,11 @@
 
 stdenv.mkDerivation rec {
   pname = "atril";
-  version = "1.26.0";
+  version = "1.26.1";
 
   src = fetchurl {
     url = "https://pub.mate-desktop.org/releases/${lib.versions.majorMinor version}/${pname}-${version}.tar.xz";
-    sha256 = "0pz44k3axhjhhwfrfvnwvxak1dmjkwqs63rhrbcaagyymrp7cpki";
+    sha256 = "pTphOsuXAaGK1nG/WQJU0c6Da6CuG+LAvYlI/fa0kaQ=";
   };
 
   nativeBuildInputs = [


### PR DESCRIPTION
###### Description of changes

https://github.com/mate-desktop/atril/compare/v1.26.0...v1.26.1
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
