### PR TITLE
tangram: 2.0 -> 3.0

### DIFF
--- a/pkgs/applications/networking/instant-messengers/tangram/default.nix
+++ b/pkgs/applications/networking/instant-messengers/tangram/default.nix
@@ -25,13 +25,13 @@
 
 stdenv.mkDerivation rec {
   pname = "tangram";
-  version = "2.0";
+  version = "3.0";
 
   src = fetchFromGitHub {
     owner = "sonnyp";
     repo = "Tangram";
     rev = "v${version}";
-    hash = "sha256-ocHE8IztiNm9A1hbzzHXstWpPaOau/IrQ44ccxbsGb0=";
+    hash = "sha256-6QOkvsYFgFFyxnDlA5Xpl3FnsSZOj9ooehCPOmpKe8M=";
     fetchSubmodules = true;
   };
 
@@ -70,7 +70,7 @@ stdenv.mkDerivation rec {
 
   postPatch = ''
     substituteInPlace src/meson.build --replace "/app/bin/blueprint-compiler" "blueprint-compiler"
-    substituteInPlace {src/,}re.sonny.Tangram troll/gjspack/bin/gjspack \
+    substituteInPlace src/bin.js troll/gjspack/bin/gjspack \
       --replace "#!/usr/bin/env -S gjs -m" "#!${gjs}/bin/gjs -m"
   '';
 


### PR DESCRIPTION
###### Description of changes

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).