### PR TITLE
tuxedo-touchpad-switch: init at 1.0.7

### DIFF
--- a/pkgs/misc/drivers/tuxedo-touchpad-switch/default.nix
+++ b/pkgs/misc/drivers/tuxedo-touchpad-switch/default.nix
@@ -1,0 +1,37 @@
+{ lib, stdenv, fetchFromGitHub, pkg-config, cmake, glib, udev }:
+
+stdenv.mkDerivation rec {
+  pname = "tuxedo-touchpad-switch";
+  version = "1.0.7";
+
+  src = fetchFromGitHub {
+    owner = "tuxedocomputers";
+    repo = "tuxedo-touchpad-switch";
+    rev = "v${version}";
+    sha256 = "sha256-6it84mQkTGko5uiqdWRmgwfpQnNLK+14J7YCC2Ni98k=";
+  };
+
+  nativeBuildInputs = [ pkg-config cmake ];
+  buildInputs = [ glib udev ];
+
+  # default install target assumes FHS paths
+  installPhase = ''
+    runHook preInstall
+
+    install -Dm555 tuxedo-touchpad-switch -t $out/bin
+    install -Dm444 ../res/99-tuxedo-touchpad-switch.rules -t $out/lib/udev/rules.d
+    install -Dm444 ../res/tuxedo-touchpad-switch-lockfile -t $out/etc
+    install -Dm444 ../res/tuxedo-touchpad-switch.desktop -t $out/share/gdm/greeter/autostart
+    install -Dm444 ../res/tuxedo-touchpad-switch.desktop -t $out/etc/xdg/autostart
+
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    description = "A Driver to enable and disable the touchpads on TongFang/Uniwill laptops";
+    homepage = "https://github.com/tuxedocomputers/tuxedo-touchpad-switch";
+    license = licenses.gpl3Plus;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ geri1701 ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -38440,6 +38440,8 @@ with pkgs;
 
   epson-workforce-635-nx625-series = callPackage ../misc/drivers/epson-workforce-635-nx625-series { };
 
+  tuxedo-touchpad-switch = callPackage ../misc/drivers/tuxedo-touchpad-switch { };
+
   foomatic-db = callPackage ../misc/cups/drivers/foomatic-db { };
   foomatic-db-engine = callPackage ../misc/cups/drivers/foomatic-db-engine { };
   foomatic-db-nonfree = callPackage ../misc/cups/drivers/foomatic-db-nonfree { };


### PR DESCRIPTION
###### Description of changes

Close  #207293

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
