### PR TITLE
or-tools, protobuf: remove dev output

### DIFF
--- a/pkgs/development/libraries/science/math/or-tools/default.nix
+++ b/pkgs/development/libraries/science/math/or-tools/default.nix
@@ -109,7 +109,7 @@ stdenv.mkDerivation rec {
     pip install --prefix="$python" python/
   '';
 
-  outputs = [ "out" "dev" "python" ];
+  outputs = [ "out" "python" ];
 
   meta = with lib; {
     homepage = "https://github.com/google/or-tools";

--- a/pkgs/development/python-modules/protobuf/default.nix
+++ b/pkgs/development/python-modules/protobuf/default.nix
@@ -41,8 +41,6 @@ buildPythonPackage {
     fi
   '';
 
-  outputs = [ "out" "dev" ];
-
   buildInputs = [ protobuf ];
 
   propagatedNativeBuildInputs = [


### PR DESCRIPTION
###### Description of changes

I added `dev` outputs to `or-tools` and `python3Packages.protobuf` in #205199 to fix build-platform contamination while cross-compiling, but this has caused some unforeseen problems that I don't have time to look into fully right now. Therefore, this PR just removes the `dev` outputs, which should fix the builds but will make build-platform protobuf part of the `or-tools` runtime closure when cross-compiling.

Adding a `dev` output to `or-tools` breaks downstream packages because `or-tools` has buggy CMake scripts that don't respect `CMAKE_INSTALL_INCLUDEDIR`, which needs to be fixed upstream. See: https://github.com/NixOS/nixpkgs/pull/224312#issuecomment-1528873826

protobuf's `dev` output causes issues with `makePythonPath` and/or `requiredPythonModules` which aren't expecting split outputs. This looks like a bug in those functions, but I don't have time to investigate right now. See: https://github.com/NixOS/nixpkgs/pull/205199#issuecomment-1526602718

cc @mweinelt @hzeller 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
