### PR TITLE
veusz: 3.3.1 -> 3.6.2 & fix

### DIFF
--- a/pkgs/applications/graphics/veusz/default.nix
+++ b/pkgs/applications/graphics/veusz/default.nix
@@ -6,14 +6,18 @@
 
 python3Packages.buildPythonApplication rec {
   pname = "veusz";
-  version = "3.3.1";
+  version = "3.6.2";
 
   src = python3Packages.fetchPypi {
     inherit pname version;
-    sha256 = "4ClgYwiU21wHDve2q9cItSAVb9hbR2F+fJc8znGI8OA=";
+    sha256 = "whcaxF5LMEJNj8NSYeLpnb5uJboRl+vCQ1WxBrJjldE=";
   };
 
-  nativeBuildInputs = [ wrapQtAppsHook python3Packages.sip_4 ];
+  nativeBuildInputs = [
+    wrapQtAppsHook
+    python3Packages.sip
+    python3Packages.tomli
+  ];
 
   buildInputs = [ qtbase ];
 
@@ -24,22 +28,17 @@ python3Packages.buildPythonApplication rec {
     wrapQtApp "$out/bin/veusz"
   '';
 
-  # Since sip 6 (we use sip 4 here, but pyqt5 is built with sip 6), sip files are
-  # placed in a different directory layout and --sip-dir won't work anymore.
-  # --sip-dir expects a directory with a PyQt5 subdirectory (where sip files are located),
-  # but the new directory layout places sip files in a subdirectory named 'bindings'.
-  # To workaround this, we patch the full path into pyqtdistutils.py.
+  # pyqt_setuptools.py uses the platlib path from sysconfig, but NixOS doesn't
+  # really have a corresponding path, so patching the location of PyQt5 inplace
   postPatch = ''
-    substituteInPlace pyqtdistutils.py \
-      --replace "'-I', pyqt5_include_dir," "'-I', '${python3Packages.pyqt5}/${python3Packages.python.sitePackages}/PyQt5/bindings',"
+    substituteInPlace pyqt_setuptools.py \
+      --replace "get_path('platlib')" "'${python3Packages.pyqt5}/${python3Packages.python.sitePackages}'"
     patchShebangs tests/runselftest.py
   '';
 
   # you can find these options at
   # https://github.com/veusz/veusz/blob/53b99dffa999f2bc41fdc5335d7797ae857c761f/pyqtdistutils.py#L71
-  # --sip-dir cannot be used here for the reasons explained above
   setupPyBuildFlags = [
-    "--qt-include-dir=${qtbase.dev}/include"
     # veusz tries to find a libinfix and fails without one
     # but we simply don't need a libinfix, so set it to empty here
     "--qt-libinfix="


### PR DESCRIPTION
###### Description of changes

Updated and fixed veusz (should fix #214079)
- veusz 3.6.2 uses SIP 5+ (where veusz 3.3.1 used SIP 4)
- added tomli to nativeBuildInputs, as it is used in `pyqt_setuptools.py`

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
