### PR TITLE
spotify: Fix login with firefox

### DIFF
--- a/pkgs/applications/audio/spotify/linux.nix
+++ b/pkgs/applications/audio/spotify/linux.nix
@@ -1,5 +1,5 @@
 { fetchurl, lib, stdenv, squashfsTools, xorg, alsa-lib, makeShellWrapper, wrapGAppsHook, openssl, freetype
-, glib, pango, cairo, atk, gdk-pixbuf, gtk3, cups, nspr, nss, libpng, libnotify
+, glib, pango, cairo, atk, gdk-pixbuf, gtk3, cups, nspr, nss_latest, libpng, libnotify
 , libgcrypt, systemd, fontconfig, dbus, expat, ffmpeg, curlWithGnuTls, zlib, gnome
 , at-spi2-atk, at-spi2-core, libpulseaudio, libdrm, mesa, libxkbcommon
 , pname, meta, harfbuzz
@@ -47,7 +47,7 @@ let
     libpulseaudio
     libxkbcommon
     mesa
-    nss
+    nss_latest
     pango
     stdenv.cc.cc
     systemd


### PR DESCRIPTION
- Spotify uses `LD_LIBRARY_PATH` environment variable to load dependencies.
  - One of those dependencies is `nss_esr`.
- Firefox is linked against `nss_latest`.
- Spotify opens a URL in web browser to log in.
  - Firefox process executed as a child will inherit environment variables from Spotify. - NSS library will be replaced, resulting in missing symbols.

        firefox.desktop[2946438]: XPCOMGlueLoad error for file /nix/store/8yc9g32afmgcv1j02y1zh69rhskpkcdc-firefox-112.0.2/lib/firefox/libxul.so:
        firefox.desktop[2946438]: /nix/store/br95hq0v4l2akqi1x7474ni3fm6nzp7v-nss-3.79.4/lib/libssl3.so: version `NSS_3.80' not found (required by /nix/store/8yc9g32afmgcv1j02y1zh69rhskpkcdc-firefox-112.0.2/lib/firefox/libxul.so)
        firefox.desktop[2946438]: Couldn't load XPCOM.

Ideally, we would not use `LD_LIBRARY_PATH` but switching to the same nss version as Firefox uses is an easy workaround.

https://github.com/NixOS/nixpkgs/issues/47885#issuecomment-1464733915

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
