### PR TITLE
vpv: init at 0.8.1

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -8161,6 +8161,12 @@
     githubId = 16481032;
     name = "Kiba Fox";
   };
+  kidanger = {
+    email = "angerj.dev@gmail.com";
+    github = "kidanger";
+    githubId = 297479;
+    name = "Jérémy Anger";
+  };
   kidd = {
     email = "raimonster@gmail.com";
     github = "kidd";

--- a/pkgs/applications/graphics/vpv/default.nix
+++ b/pkgs/applications/graphics/vpv/default.nix
@@ -1,0 +1,63 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, cmake
+, pkg-config
+, libpng
+, libtiff
+, libjpeg
+, SDL2
+, gdal
+, octave
+, rustPlatform
+, cargo
+}:
+stdenv.mkDerivation (finalAttrs: {
+  pname = "vpv";
+  version = "0.8.1";
+
+  src = fetchFromGitHub {
+    owner = "kidanger";
+    repo = "vpv";
+    rev = "v${finalAttrs.version}";
+    sha256 = "0cphgq1pqmwrjdmq524j5y522iaq6yhp2dpjdv0a3f9558dayxix";
+  };
+
+  cargoRoot = "src/fuzzy-finder";
+  cargoDeps = rustPlatform.fetchCargoTarball {
+    src = finalAttrs.src;
+    sourceRoot = "source/src/fuzzy-finder";
+    hash = "sha256-CDKlmwA2Wj78xPaSiYPmIJ7xmiE5Co+oGGejZU3v1zI=";
+  };
+
+  nativeBuildInputs = [
+    cmake
+    pkg-config
+    rustPlatform.cargoSetupHook
+    cargo
+  ];
+
+  buildInputs = [
+    libpng
+    libtiff
+    libjpeg
+    SDL2
+    gdal
+    octave
+  ];
+
+  cmakeFlags = [
+    "-DUSE_GDAL=ON"
+    "-DUSE_OCTAVE=ON"
+    "-DVPV_VERSION=v${finalAttrs.version}"
+    "-DBUILD_TESTING=ON"
+  ];
+
+  meta = {
+    homepage = "https://github.com/kidanger/vpv";
+    description = "Image viewer for image processing experts";
+    maintainers = [ lib.maintainers.kidanger ];
+    license = lib.licenses.gpl3;
+    broken = stdenv.isDarwin; # the CMake expects the SDL2::SDL2main target for darwin
+  };
+})

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -34714,6 +34714,8 @@ with pkgs;
     autoreconfHook = buildPackages.autoreconfHook269;
   };
 
+  vpv = callPackage ../applications/graphics/vpv { };
+
   vsce = callPackage ../development/tools/vsce { };
 
   vscode = callPackage ../applications/editors/vscode/vscode.nix { };


### PR DESCRIPTION
###### Description of changes

new package: https://github.com/kidanger/vpv (scientific image visualization tool)

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
