### PR TITLE
python310Packages.django-stubs-ext: 0.8.0 -> 4.2.0, python310Packages.django-stubs: 1.15.0 -> 4.2.0 

### DIFF
--- a/pkgs/development/python-modules/django-stubs-ext/default.nix
+++ b/pkgs/development/python-modules/django-stubs-ext/default.nix
@@ -1,18 +1,39 @@
-{ buildPythonPackage, django, fetchPypi, lib, typing-extensions }:
+{ lib
+, buildPythonPackage
+, django
+, fetchPypi
+, pytestCheckHook
+, pythonOlder
+, typing-extensions
+}:
 
 buildPythonPackage rec {
   pname = "django-stubs-ext";
-  version = "0.8.0";
+  version = "4.2.0";
+  format = "setuptools";
+
+  disabled = pythonOlder "3.8";
 
   src = fetchPypi {
     inherit pname version;
-    hash = "sha256-mpup4oCHN5Sd6WoPzosFTxLTjkYQEdd+vAdP/oxD38s=";
+    hash = "sha256-d4nwyuynFS/vB61rlN7HMQoF0Ljat395eeGdsAN7USc=";
   };
 
   # setup.cfg tries to pull in nonexistent LICENSE.txt file
   postPatch = "rm setup.cfg";
 
-  propagatedBuildInputs = [ django typing-extensions ];
+  propagatedBuildInputs = [
+    django
+    typing-extensions
+  ];
+
+  nativeCheckInputs = [
+    pytestCheckHook
+  ];
+
+  pythonImportsCheck = [
+    "django_stubs_ext"
+  ];
 
   meta = with lib; {
     description = "Extensions and monkey-patching for django-stubs";

--- a/pkgs/development/python-modules/django-stubs/default.nix
+++ b/pkgs/development/python-modules/django-stubs/default.nix
@@ -1,9 +1,11 @@
-{ buildPythonPackage
+{ lib
+, buildPythonPackage
 , django
 , django-stubs-ext
 , fetchPypi
-, lib
 , mypy
+, pytestCheckHook
+, pythonOlder
 , tomli
 , types-pytz
 , types-pyyaml
@@ -12,26 +14,35 @@
 
 buildPythonPackage rec {
   pname = "django-stubs";
-  version = "1.15.0";
+  version = "4.2.0";
+  format = "setuptools";
+
+  disabled = pythonOlder "3.7";
 
   src = fetchPypi {
     inherit pname version;
-    hash = "sha256-C7+esXLFsG7M/y1wTHw5BuSixhRt+MMu6fOlHikmVYE=";
+    hash = "sha256-k7r/gk8KBW5xA2tCO5QqdPB7kJ5F4/o4GFuRD1l8XAg=";
   };
 
   propagatedBuildInputs = [
     django
     django-stubs-ext
     mypy
-    tomli
     types-pytz
     types-pyyaml
     typing-extensions
+  ] ++ lib.optionals (pythonOlder "3.11") [
+    tomli
+  ];
+
+  nativeCheckInputs = [
+    pytestCheckHook
   ];
 
   meta = with lib; {
     description = "PEP-484 stubs for Django";
     homepage = "https://github.com/typeddjango/django-stubs";
+    changelog = "https://github.com/typeddjango/django-stubs/releases/tag/${version}";
     license = licenses.mit;
     maintainers = with maintainers; [ elohmeier ];
   };


### PR DESCRIPTION
Changelog: https://github.com/typeddjango/django-stubs/releases/tag/4.2.0

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
