### PR TITLE
cpython: add loongarch triplets

### DIFF
--- a/pkgs/development/interpreters/python/cpython/default.nix
+++ b/pkgs/development/interpreters/python/cpython/default.nix
@@ -288,6 +288,9 @@ in with passthru; stdenv.mkDerivation {
     ./3.8/0001-On-all-posix-systems-not-just-Darwin-set-LDSHARED-if.patch
     # Use sysconfigdata to find headers. Fixes cross-compilation of extension modules.
     ./3.7/fix-finding-headers-when-cross-compiling.patch
+  ] ++ optionals stdenv.hostPlatform.isLoongArch64 [
+    # https://github.com/python/cpython/issues/90656
+    ./loongarch-support.patch
   ];
 
   postPatch = ''

--- a/pkgs/development/interpreters/python/cpython/loongarch-support.patch
+++ b/pkgs/development/interpreters/python/cpython/loongarch-support.patch
@@ -1,0 +1,50 @@
+diff --git a/configure b/configure
+index 8133d47f61..334c98e208 100755
+--- a/configure
++++ b/configure
+@@ -6215,6 +6215,20 @@ cat > conftest.c <<EOF
+ #  else
+ #   error unknown platform triplet
+ #  endif
++# elif defined(__loongarch__)
++#  if defined(__loongarch_lp64)
++#   if defined(__loongarch_soft_float)
++        loongarch64-linux-gnusf
++#   elif defined(__loongarch_single_float)
++        loongarch64-linux-gnuf32
++#   elif defined(__loongarch_double_float)
++        loongarch64-linux-gnu
++#   else
++#     error unknown platform triplet
++#   endif 
++#  else
++#    error unknown platform triplet
++#  endif
+ # else
+ #   error unknown platform triplet
+ # endif
+diff --git a/configure.ac b/configure.ac
+index 3f20d8980d..acde94a181 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -959,6 +959,20 @@ cat > conftest.c <<EOF
+         hppa-linux-gnu
+ # elif defined(__ia64__)
+         ia64-linux-gnu
++# elif defined(__loongarch__)
++#  if defined(__loongarch_lp64)
++#   if defined(__loongarch_soft_float)
++        loongarch64-linux-gnusf
++#   elif defined(__loongarch_single_float)
++        loongarch64-linux-gnuf32
++#   elif defined(__loongarch_double_float)
++        loongarch64-linux-gnu
++#   else
++#    error unknown platform triplet
++#   endif
++#  else
++#   error unknown platform triplet
++#  endif
+ # elif defined(__m68k__) && !defined(__mcoldfire__)
+         m68k-linux-gnu
+ # elif defined(__mips_hard_float) && defined(__mips_isa_rev) && (__mips_isa_rev >=6) && defined(_MIPSEL)


### PR DESCRIPTION
  Using patch ref on: https://github.com/python/cpython/issues/90656
  to add `loongarch` triplets for using `cpython` in `loongarch`

  Note: This patch is being reviewed by `cpython`

Test build `pkgsCross.python38/11.withPackages(ps: with ps; [requests])` successes. *which need pip and pip is depend on cpython.*

###### Description of changes

1. add patch into `cpython` folder to add `loongarch` triplets.
2. using patch if `hostPlatform` is `loongarch`

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).