### PR TITLE
python310Packages.django-simple-captcha: 0.5.14 -> 0.5.17

### DIFF
--- a/pkgs/development/python-modules/django-simple-captcha/default.nix
+++ b/pkgs/development/python-modules/django-simple-captcha/default.nix
@@ -2,7 +2,6 @@
 , buildPythonPackage
 , fetchPypi
 , python
-, six
 , testfixtures
 , django
 , django-ranged-response
@@ -13,26 +12,32 @@
 
 buildPythonPackage rec {
   pname = "django-simple-captcha";
-  version = "0.5.14";
+  version = "0.5.17";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "84b5c188e6ae50e9ecec5e5d734c5bc4d2a50fbbca7f59d2c12da9a3bbee5051";
-    extension = "zip";
+    hash = "sha256-lknmbatOce+sv+8C9IuDuRaEiYNSoatW8Whs5xAzsyg=";
   };
 
-  nativeCheckInputs = [ testfixtures ];
+  nativeCheckInputs = [
+    testfixtures
+  ];
+
   checkPhase = ''
     cd testproject
     ${python.interpreter} manage.py test captcha
   '';
 
-  propagatedBuildInputs = [ django django-ranged-response six pillow ]
-  ++ lib.optional withTTS flite;
+  propagatedBuildInputs = [
+    django
+    django-ranged-response
+    pillow
+  ] ++ lib.optional withTTS flite;
 
   meta = with lib; {
-    description = "An extremely simple, yet highly customizable Django application to add captcha images to any Django form";
+    description = "Customizable Django application to add captcha images to any Django form";
     homepage = "https://github.com/mbi/django-simple-captcha";
+    changelog = "https://github.com/mbi/django-simple-captcha/blob/v${version}/CHANGES";
     license = licenses.mit;
     maintainers = with maintainers; [ mrmebelman schmittlauch ];
   };


### PR DESCRIPTION
Changelog: https://github.com/mbi/django-simple-captcha/blob/v0.5.17/CHANGES

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
