### PR TITLE
python.pkgs.jinja2: fix build of both python and documentation

### DIFF
--- a/pkgs/applications/misc/privacyidea/default.nix
+++ b/pkgs/applications/misc/privacyidea/default.nix
@@ -52,7 +52,7 @@ let
         doCheck = false;
       });
       # Required by flask-1.1
-      jinja2 = super.jinja2.overridePythonAttrs (old: rec {
+      jinja2 = (super.jinja2.override { enableDocumentation = false; }).overridePythonAttrs (old: rec {
         version = "2.11.3";
         src = old.src.override {
           inherit version;

--- a/pkgs/development/python-modules/jinja2/default.nix
+++ b/pkgs/development/python-modules/jinja2/default.nix
@@ -10,7 +10,7 @@
 , pallets-sphinx-themes
 , sphinxcontrib-log-cabinet
 , sphinx-issues
-, enableDocumentation ? false
+, enableDocumentation ? true
 }:
 
 buildPythonPackage rec {

--- a/pkgs/development/python-modules/sphinx/default.nix
+++ b/pkgs/development/python-modules/sphinx/default.nix
@@ -64,7 +64,7 @@ buildPythonPackage rec {
     alabaster
     docutils
     imagesize
-    jinja2
+    (jinja2.override { enableDocumentation = false; })
     packaging
     pygments
     requests


### PR DESCRIPTION
- Revert "python3.pkgs.jinja2: don't build offline documentation by default"
- python3.pkgs.jinja2: make sure python files are installed

I did rebuilt systemd locally, should be good now. Solution is not exactly elegant, better ways to make pip do right thing are welcome.

@happysalada @Ma27 @flokli 