### PR TITLE
networkd-notify: init at unstable-2022-11-29

### DIFF
--- a/pkgs/tools/networking/networkd-notify/default.nix
+++ b/pkgs/tools/networking/networkd-notify/default.nix
@@ -1,0 +1,49 @@
+{ lib
+, fetchFromGitLab
+, buildPythonApplication
+, dbus-python
+, pygobject3
+, systemd
+, wirelesstools
+}:
+
+buildPythonApplication rec {
+  pname = "networkd-notify";
+  version = "unstable-2022-11-29";
+  # There is no setup.py, just a single Python script.
+  format = "other";
+
+  src = fetchFromGitLab {
+    owner = "wavexx";
+    repo = pname;
+    rev = "c2f3e71076a0f51c097064b1eb2505a361c7cc0e";
+    sha256 = "sha256-fanP1EWERT2Jy4OnMo8OMdR9flginYUgMw+XgmDve3o=";
+  };
+
+  propagatedBuildInputs = [
+    dbus-python
+    pygobject3
+  ];
+
+  patchPhase = ''
+    sed -i \
+      -e '/^NETWORKCTL = /c\NETWORKCTL = ["${systemd}/bin/networkctl"]' \
+      -e '/^IWCONFIG = /c\IWCONFIG = ["${wirelesstools}/bin/iwconfig"]' \
+      networkd-notify
+  '';
+
+  dontBuild = true;
+
+  installPhase = ''
+    install -D networkd-notify -t "$out/bin/"
+    install -D -m0644 networkd-notify.desktop -t "$out/share/applications/"
+  '';
+
+  meta = with lib; {
+    description = "Desktop notification integration for systemd-networkd";
+    homepage = "https://gitlab.com/wavexx/networkd-notify";
+    maintainers = with maintainers; [ danc86 ];
+    license = licenses.gpl3;
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1612,6 +1612,10 @@ with pkgs;
 
   mpy-utils = python3Packages.callPackage ../tools/misc/mpy-utils { };
 
+  networkd-notify = python3Packages.callPackage ../tools/networking/networkd-notify {
+    systemd = pkgs.systemd;
+  };
+
   nominatim = callPackage ../servers/nominatim { };
 
   ocs-url = libsForQt5.callPackage ../tools/misc/ocs-url { };


### PR DESCRIPTION
###### Description of changes

networkd-notify is a small program which sends desktop notifications whenever an interface changes state in networkd.

https://gitlab.com/wavexx/networkd-notify

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - ~[ ] x86_64-darwin~
  - ~[ ] aarch64-darwin~
- ~[ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))~
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - ~[ ] (Package updates) Added a release notes entry if the change is major or breaking~
  - ~[ ] (Module updates) Added a release notes entry if the change is significant~
  - ~[ ] (Module addition) Added a release notes entry if adding a new NixOS module~
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).