### PR TITLE
shikane: init at 0.2.0

### DIFF
--- a/pkgs/tools/wayland/shikane/default.nix
+++ b/pkgs/tools/wayland/shikane/default.nix
@@ -1,0 +1,45 @@
+{ lib
+, rustPlatform
+, fetchFromGitLab
+, installShellFiles
+, pandoc
+}:
+
+rustPlatform.buildRustPackage rec {
+  pname = "shikane";
+  version = "0.2.0";
+
+  src = fetchFromGitLab {
+    owner = "w0lff";
+    repo = "shikane";
+    rev = "v${version}";
+    hash = "sha256-S55elFZQT234fKlISFi21QJtnf2yB0O2u2vSNFhzgBg=";
+  };
+
+  cargoHash = "sha256-4wisXVaZa2GBFKywl48beQgg4c+lawL3L/837ZU1Y94=";
+
+  nativeBuildInputs = [
+    installShellFiles
+    pandoc
+  ];
+
+  postBuild = ''
+    bash ./scripts/build-docs.sh man
+  '';
+
+  postInstall = ''
+    installManPage ./build/shikane.*
+  '';
+
+  # upstream has no tests
+  doCheck = false;
+
+  meta = with lib; {
+    description = "A dynamic output configuration tool that automatically detects and configures connected outputs based on a set of profiles";
+    homepage = "https://gitlab.com/w0lff/shikane";
+    changelog = "https://gitlab.com/w0lff/shikane/-/tags/v${version}";
+    license = licenses.mit;
+    maintainers = with maintainers; [ michaelpachec0 natsukium ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4279,6 +4279,8 @@ with pkgs;
 
   oguri = callPackage  ../tools/wayland/oguri { };
 
+  shikane = callPackage ../tools/wayland/shikane { };
+
   shotman = callPackage ../tools/wayland/shotman { };
 
   slurp = callPackage ../tools/wayland/slurp { };


### PR DESCRIPTION
###### Description of changes

A dynamic output configuration tool that automatically detects and configures connected outputs based on a set of profiles.
https://gitlab.com/w0lff/shikane

closes #229161 

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
