### PR TITLE
fedora-backgrounds: init f35 to f38 

### DIFF
--- a/pkgs/data/misc/fedora-backgrounds/default.nix
+++ b/pkgs/data/misc/fedora-backgrounds/default.nix
@@ -31,4 +31,13 @@ in {
     patches = [ ./f34-fix-xfce-path.patch ];
   };
 
+  f35 = fedoraBackground rec {
+    version = "35.0.1";
+    src = fetchurl {
+      url = "https://github.com/fedoradesign/backgrounds/releases/download/v${version}/f${lib.versions.major version}-backgrounds-${version}.tar.xz";
+      hash = "sha256-7t78sQ0BIkzgJ+phO55Bomyz02d8Vx1LAtSkjX8ppgE=";
+    };
+    # Fix broken symlinks in the Xfce background directory.
+    patches = [ ./f35-fix-xfce-path.patch ];
+  };
 }

--- a/pkgs/data/misc/fedora-backgrounds/default.nix
+++ b/pkgs/data/misc/fedora-backgrounds/default.nix
@@ -56,4 +56,12 @@ in {
       hash = "sha256-bkjxJDDU0dZURKIK1sd+EOnPt9vvJ5HqHkc6OhPBBn0=";
     };
   };
+
+  f38 = fedoraBackground rec {
+    version = "38.1.1";
+    src = fetchurl {
+      url = "https://github.com/fedoradesign/backgrounds/releases/download/v${version}/f${lib.versions.major version}-backgrounds-${version}.tar.xz";
+      hash = "sha256-YSNP7GhS5i5mJDsa4UwsXJm8Tv43r9JxrcYIbkXQKm4=";
+    };
+  };
 }

--- a/pkgs/data/misc/fedora-backgrounds/default.nix
+++ b/pkgs/data/misc/fedora-backgrounds/default.nix
@@ -40,4 +40,12 @@ in {
     # Fix broken symlinks in the Xfce background directory.
     patches = [ ./f35-fix-xfce-path.patch ];
   };
+
+  f36 = fedoraBackground rec {
+    version = "36.1.2";
+    src = fetchurl {
+      url = "https://github.com/fedoradesign/backgrounds/releases/download/v${version}/f${lib.versions.major version}-backgrounds-${version}.tar.xz";
+      hash = "sha256-DZr1YHltojl02X/3sErqB/29JBDy/7lDZKnHD+KouHc=";
+    };
+  };
 }

--- a/pkgs/data/misc/fedora-backgrounds/default.nix
+++ b/pkgs/data/misc/fedora-backgrounds/default.nix
@@ -48,4 +48,12 @@ in {
       hash = "sha256-DZr1YHltojl02X/3sErqB/29JBDy/7lDZKnHD+KouHc=";
     };
   };
+
+  f37 = fedoraBackground rec {
+    version = "37.0.5";
+    src = fetchurl {
+      url = "https://github.com/fedoradesign/backgrounds/releases/download/v${version}/f${lib.versions.major version}-backgrounds-${version}.tar.xz";
+      hash = "sha256-bkjxJDDU0dZURKIK1sd+EOnPt9vvJ5HqHkc6OhPBBn0=";
+    };
+  };
 }

--- a/pkgs/data/misc/fedora-backgrounds/f35-fix-xfce-path.patch
+++ b/pkgs/data/misc/fedora-backgrounds/f35-fix-xfce-path.patch
@@ -1,0 +1,26 @@
+diff --git a/default/Makefile b/default/Makefile
+index 2041ce2..f31a0f2 100644
+--- a/default/Makefile
++++ b/default/Makefile
+@@ -1,7 +1,7 @@
+ WP_NAME=f35
+ WP_BIGNAME=F35
+ WP_DIR=$(DESTDIR)/usr/share/backgrounds/$(WP_NAME)
+-WP_DIR_LN=/usr/share/backgrounds/$(WP_NAME)
++WP_DIR_LN=$(DESTDIR)/usr/share/backgrounds/$(WP_NAME)
+ GNOME_BG_DIR=$(DESTDIR)/usr/share/gnome-background-properties
+ KDE_BG_DIR=$(DESTDIR)/usr/share/wallpapers
+ MATE_BG_DIR=$(DESTDIR)/usr/share/mate-background-properties
+diff --git a/extras/Makefile b/extras/Makefile
+index 95e92e4..4d43a22 100644
+--- a/extras/Makefile
++++ b/extras/Makefile
+@@ -45,7 +45,7 @@ install:
+ 	    $(LN_S) ../../../../backgrounds/f35/extras/$${theme}.png \
+ 	            $(KDE_BG_DIR)/F35_$${theme}/contents/images/$${res}.png ; \
+ 	  done; \
+-	  $(LN_S) ../backgrounds/f35/extras/$${theme}.png \
++	  $(LN_S) ../../backgrounds/f35/extras/$${theme}.png \
+ 			$(XFCE_BG_DIR)/f35-$${theme}.png ;\
+ 	done;
+ 

--- a/pkgs/data/misc/fedora-backgrounds/generic.nix
+++ b/pkgs/data/misc/fedora-backgrounds/generic.nix
@@ -31,6 +31,11 @@ stdenvNoCC.mkDerivation {
 
   installFlags = [
     "DESTDIR=$(out)"
+
+    # The Xfce background directory is assumed to be in installed in an
+    # FHS-compliant system. This is only effective for v36.0.0 and later
+    # versions where the following variable is used.
+    "WP_DIR_LN=$(DESTDIR)/share/backgrounds/$(WP_NAME)"
   ];
 
   meta = with lib; {


### PR DESCRIPTION
###### Description of changes

Add missing versions of the Fedora background packages from Fedora 35 to 38 releases. Only tested the backgrounds on GNOME.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
