### PR TITLE
nomachine-client: 7.10.1 → 8.4.2

### DIFF
--- a/pkgs/tools/admin/nomachine-client/default.nix
+++ b/pkgs/tools/admin/nomachine-client/default.nix
@@ -1,8 +1,8 @@
 { lib, stdenv, file, fetchurl, makeWrapper,
   autoPatchelfHook, jsoncpp, libpulseaudio }:
 let
-  versionMajor = "7.10";
-  versionMinor = "1";
+  versionMajor = "8.4";
+  versionMinor = "2";
   versionBuild_x86_64 = "1";
   versionBuild_i686 = "1";
 in
@@ -14,22 +14,22 @@ in
       if stdenv.hostPlatform.system == "x86_64-linux" then
         fetchurl {
           url = "https://download.nomachine.com/download/${versionMajor}/Linux/nomachine_${version}_${versionBuild_x86_64}_x86_64.tar.gz";
-          sha256 = "sha256-alClFaNbQ76r8LukbygesWWXA5rx6VEzxK+bY5tOfO0=";
+          sha256 = "sha256-r4yRmnMd6uNay7CqmyqYj9F6huoqD8eBby+oDNk1T34=";
         }
       else if stdenv.hostPlatform.system == "i686-linux" then
         fetchurl {
           url = "https://download.nomachine.com/download/${versionMajor}/Linux/nomachine_${version}_${versionBuild_i686}_i686.tar.gz";
-          sha256 = "sha256-UDvrjb/2rXvSvpiA+UwiVi4YyXhFLNiEtrszqjAPGXc=";
+          sha256 = "sha256-TvEU1hDvPXQbF7fMI89I2bhap1Y0oetUoFl3yR5eTGg=";
         }
       else
         throw "NoMachine client is not supported on ${stdenv.hostPlatform.system}";
 
     # nxusb-legacy is only needed for kernel versions < 3
     postUnpack = ''
-      mv $(find . -type f -name nxclient.tar.gz) .
+      mv $(find . -type f -name nxrunner.tar.gz) .
       mv $(find . -type f -name nxplayer.tar.gz) .
       rm -r NX/
-      tar xf nxclient.tar.gz
+      tar xf nxrunner.tar.gz
       tar xf nxplayer.tar.gz
       rm $(find . -maxdepth 1 -type f)
       rm -r NX/share/src/nxusb-legacy
@@ -40,7 +40,7 @@ in
     buildInputs = [ jsoncpp libpulseaudio ];
 
     installPhase = ''
-      rm bin/nxplayer bin/nxclient
+      rm bin/nxplayer bin/nxrunner
 
       mkdir -p $out/NX
       cp -r bin lib share $out/NX/
@@ -68,7 +68,7 @@ in
 
     postFixup = ''
       makeWrapper $out/bin/nxplayer.bin $out/bin/nxplayer --set NX_SYSTEM $out/NX
-      makeWrapper $out/bin/nxclient.bin $out/bin/nxclient --set NX_SYSTEM $out/NX
+      makeWrapper $out/bin/nxrunner.bin $out/bin/nxrunner --set NX_SYSTEM $out/NX
 
       # libnxcau.so needs libpulse.so.0 for audio to work, but doesn't
       # have a DT_NEEDED entry for it.


### PR DESCRIPTION
###### Description of changes

NoMachine client version 8 is a new major version of the client:
https://www.nomachine.com/what-s-new-in-nomachine

To be honest `nxplayer` basically looks the same as the old one, but my network administrator told me off for using an outdated version (7.10.1) and asked me to upgrade.

They appear to have renamed `nxclient` to `nxrunner` in this release, so there are corresponding changes in the package.

I'm not sure if this warrants a release note -- all the new stuff in version 8 seems to be on the server side, there doesn't seem to be anything major or breaking in `nxplayer` itself that I can find. Its config and cache seems to be freely shareable between versions 7 and 8 so there are no incompatibilities there at least.

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- ~[ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))~
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - ~[ ] (Module updates) Added a release notes entry if the change is significant~
  - ~[ ] (Module addition) Added a release notes entry if adding a new NixOS module~
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
