### PR TITLE
ledgerblue: 0.1.44 -> 0.1.47, fix build

### DIFF
--- a/pkgs/development/python-modules/ledgerblue/default.nix
+++ b/pkgs/development/python-modules/ledgerblue/default.nix
@@ -1,13 +1,16 @@
 { lib
 , buildPythonPackage
+, bleak
 , ecpy
 , fetchPypi
 , future
 , hidapi
+, nfcpy
 , pillow
 , protobuf
 , pycrypto
 , pycryptodomex
+, pyelftools
 , pythonOlder
 , python-u2flib-host
 , websocket-client
@@ -15,24 +18,27 @@
 
 buildPythonPackage rec {
   pname = "ledgerblue";
-  version = "0.1.44";
+  version = "0.1.47";
   format = "setuptools";
 
   disabled = pythonOlder "3.7";
 
   src = fetchPypi {
     inherit pname version;
-    hash = "sha256-pOLpeej10G7Br8juTuQOSuCbhMjAP4aY0/JwnmJRblk=";
+    hash = "sha256-xe8ude2JzrdmJqwzqLlxRO697IjcGuQgGG6c3nQ/drg=";
   };
 
   propagatedBuildInputs = [
+    bleak
     ecpy
     future
     hidapi
+    nfcpy
     pillow
     protobuf
     pycrypto
     pycryptodomex
+    pyelftools
     python-u2flib-host
     websocket-client
   ];

--- a/pkgs/development/python-modules/ndeflib/default.nix
+++ b/pkgs/development/python-modules/ndeflib/default.nix
@@ -1,0 +1,39 @@
+{ lib
+, buildPythonPackage
+, pytest
+, pythonOlder
+, fetchPypi
+}:
+
+buildPythonPackage rec {
+  pname = "ndeflib";
+  version = "0.3.3";
+  format = "setuptools";
+
+  disabled = pythonOlder "3.5";
+
+  src = fetchPypi {
+    inherit pname version;
+    hash = "sha256-HVaChVi5sW8oIqQFGCQ0Y0e2at9TIOqGBwdItvJFSog=";
+  };
+
+  doTest = true;
+
+  pythonImportsCheck = [
+    "ndef"
+  ];
+
+  nativeCheckInputs = [ pytest ];
+
+  # Two tests in AlternativeCarrierRecord fail, upstream hasn't been updated in a few years
+  checkPhase = ''
+    python3 -m pytest -k "not TestAlternativeCarrierRecord" tests/
+  '';
+
+  meta = with lib; {
+    description = "NFC Data Exchange Format decoder and encoder";
+    homepage = "https://github.com/nfcpy/ndeflib";
+    license = licenses.isc;
+    maintainers = with maintainers; [ RaghavSood ];
+  };
+}

--- a/pkgs/development/python-modules/nfcpy/default.nix
+++ b/pkgs/development/python-modules/nfcpy/default.nix
@@ -1,0 +1,42 @@
+{ lib
+, buildPythonPackage
+, libusb1
+, ndeflib
+, pydes
+, pyserial
+, pythonOlder
+, fetchPypi
+}:
+
+buildPythonPackage rec {
+  pname = "nfcpy";
+  version = "1.0.4";
+  format = "setuptools";
+
+  disabled = pythonOlder "3.7";
+
+  src = fetchPypi {
+    inherit pname version;
+    hash = "sha256-5b0I0BGeHZ6V0FIV+Diwe0TQO2Ua3dxSPMGjiJK4r2s=";
+  };
+
+  propagatedBuildInputs = [
+    libusb1
+    ndeflib
+    pydes
+    pyserial
+  ];
+
+  doCheck = false;
+
+  pythonImportsCheck = [
+    "nfc"
+  ];
+
+  meta = with lib; {
+    description = "Python module for Near Field Communication";
+    homepage = "https://github.com/nfcpy/nfcpy";
+    license = licenses.eupl11;
+    maintainers = with maintainers; [ RaghavSood ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -6550,6 +6550,8 @@ self: super: with self; {
 
   nextdns = callPackage ../development/python-modules/nextdns { };
 
+  nfcpy = callPackage ../development/python-modules/nfcpy { };
+
   nftables = toPythonModule (pkgs.nftables.override {
     python3 = python;
     withPython = true;

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -6484,6 +6484,8 @@ self: super: with self; {
 
   nclib = callPackage ../development/python-modules/nclib { };
 
+  ndeflib = callPackage ../development/python-modules/ndeflib { };
+
   ndg-httpsclient = callPackage ../development/python-modules/ndg-httpsclient { };
 
   ndindex = callPackage ../development/python-modules/ndindex { };


### PR DESCRIPTION
###### Description of changes

Aims to address https://github.com/NixOS/nixpkgs/issues/226162

###### Things done

ndeflib: init at 0.3.3 (new dependency for ledgerblue)
nfcpy: init at 1.0.4 (new dependency for ledgerblue)
ledgerblue: 0.1.44 -> 0.1.47

ndeflib has two broken tests - as far as I can tell, this is likely due to the library not being updated for a few years and drifting

I'm unable to get tests for nfcpy working - the openssl wrapping seems somewhat flaky and fragile, and doesn't mesh well with nixpkgs.


<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
