### PR TITLE
vimPlugins.markdown-preview-nvim: fix plugin dependencies

### DIFF
--- a/pkgs/applications/editors/vim/plugins/markdown-preview-nvim/package.json
+++ b/pkgs/applications/editors/vim/plugins/markdown-preview-nvim/package.json
@@ -1,48 +1,16 @@
 {
   "name": "markdown-preview",
-  "version": "0.0.10",
+  "version": "0.0.1",
   "description": "markdown preview plugin for (neo)vim",
-  "bin": "./app/server.js",
+  "bin": "./index.js",
   "repository": "https://github.com/iamcco/markdown-preview.nvim.git",
   "author": "年糕小豆汤 <ooiss@qq.com>",
   "license": "MIT",
   "private": true,
-  "scripts": {
-    "watch": "tsc -w -p ./",
-    "build-app": "cd app && rm -rf ./.next && next build && next export",
-    "build-lib": "tsc -p ./",
-    "build": "tsc -p ./ && cd app && rm -rf ./.next && next build && next export && yarn && pkg --targets node16-linux-x64,node16-macos-x64,node16-win-x64 --out-path ./bin . && rm -rf ./node_modules ./.next"
-  },
   "dependencies": {
+    "log4js": "6.4.0",
     "@chemzqm/neovim": "^5.7.9",
-    "chart.js": "^2.7.3",
-    "highlight.js": "^10.4.1",
-    "log4js": "^6.4.0",
-    "markdown-it": "^12.3.2",
-    "markdown-it-anchor": "^5.2.4",
-    "markdown-it-deflist": "^2.0.3",
-    "markdown-it-emoji": "^1.4.0",
-    "markdown-it-footnote": "^3.0.1",
-    "markdown-it-task-lists": "^2.1.1",
-    "markdown-it-toc-done-right": "^4.0.1",
-    "md-it-meta": "^0.0.2",
-    "msgpack-lite": "^0.1.26",
-    "next": "^7.0.2",
-    "next-routes": "^1.4.2",
-    "plantuml-encoder": "^1.4.0",
-    "react": "^16.5.2",
-    "react-dom": "^16.5.2",
-    "socket.io": "^2.1.1",
-    "socket.io-client": "^2.1.1"
-  },
-  "devDependencies": {
-    "@types/node": "16",
-    "pkg": "^5.6.0",
-    "prettier": "^2.6.2",
-    "tslint": "^6.1.3",
-    "tslint-config-prettier": "^1.18.0",
-    "tslint-plugin-prettier": "^2.3.0",
-    "typescript": "^4.6.4",
-    "yuuko-tsconfig": "^1.0.0"
+    "socket.io": "2.4.0",
+    "tslib": "1.9.3"
   }
 }

--- a/pkgs/applications/editors/vim/plugins/overrides.nix
+++ b/pkgs/applications/editors/vim/plugins/overrides.nix
@@ -642,6 +642,25 @@ self: super: {
     doInstallCheck = true;
     installCheckPhase = ''
       node $out/app/index.js --version
+
+      # check for required app/node_modules deps
+      deps=(
+          "log4js"
+          "@chemzqm/neovim"
+          "socket.io"
+          "tslib"
+      )
+
+      for dep in ''${deps[@]}; do
+        nodeDep="$out/app/node_modules/$dep"
+        if [ ! -d "$nodeDep" ]
+        then
+          echo "$nodeDep is missing"
+          exit 1
+        else
+          echo "$nodeDep exists"
+        fi
+      done
     '';
   });
 


### PR DESCRIPTION
###### Description of changes

Reverting package.json changes to the [previous version](https://github.com/NixOS/nixpkgs/commit/78c16ea2aee7ed2cd1fe887e0e532a57968592a2#diff-975a3c27ece42d3f2afbc464deb9e43d4c0f8ea7f4e60756a60db7d57d58c5d8), because it breaks the plugin.

Current version of package.json installs incorrect dependencies, the plugin expects [app](https://github.com/iamcco/markdown-preview.nvim/blob/master/app/package.json) dependencies instead of [root](https://github.com/iamcco/markdown-preview.nvim/blob/master/package.json).

```
node:internal/modules/cjs/loader:1078
  throw err;
  ^
Error: Cannot find module 'tslib'
Require stack:
- /nix/store/rg7nwn36rm5xc15x48y2baidlqy3w857-vimplugin-markdown-preview.nvim-2022-05-13/app/lib/app/index.js
- /nix/store/rg7nwn36rm5xc15x48y2baidlqy3w857-vimplugin-markdown-preview.nvim-2022-05-13/app/index.js
    at Module._resolveFilename (node:internal/modules/cjs/loader:1075:15)
    at Module._load (node:internal/modules/cjs/loader:920:27)
    at Module.require (node:internal/modules/cjs/loader:1141:19)
    at require (node:internal/modules/cjs/helpers:110:18)
    at Object.<anonymous> (/nix/store/rg7nwn36rm5xc15x48y2baidlqy3w857-vimplugin-markdown-preview.nvim-2022-05-13/app/lib/app/index.js:3:17)
    at Module._compile (node:internal/modules/cjs/loader:1254:14)
    at Module._extensions..js (node:internal/modules/cjs/loader:1308:10)
    at Module.load (node:internal/modules/cjs/loader:1117:32)
    at Module._load (node:internal/modules/cjs/loader:958:12)
    at Module.require (node:internal/modules/cjs/loader:1141:19) {
  code: 'MODULE_NOT_FOUND',
  requireStack: [
    '/nix/store/rg7nwn36rm5xc15x48y2baidlqy3w857-vimplugin-markdown-preview.nvim-2022-05-13/app/lib/app/index.js',
    '/nix/store/rg7nwn36rm5xc15x48y2baidlqy3w857-vimplugin-markdown-preview.nvim-2022-05-13/app/index.js'
  ]
}
Node.js v18.16.0
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

