### PR TITLE
krusader: 2.7.2 -> 2.8.0

### DIFF
--- a/pkgs/applications/file-managers/krusader/compat-fix.patch
+++ b/pkgs/applications/file-managers/krusader/compat-fix.patch
@@ -1,0 +1,20 @@
+diff --git a/app/compat.h b/app/compat.h
+index b63d561..c051f35 100644
+--- a/app/compat.h
++++ b/app/compat.h
+@@ -11,13 +11,13 @@
+ 
+ #if __has_include(<KCompletion/kcompletion_version.h>)
+ #  include <KCompletion/kcompletion_version.h>
+-#else // Pre KF-5.91 header layout
++#elif __has_include(<kcompletion_version.h>) // Pre KF-5.91 header layout
+ #  include <kcompletion_version.h>
+ #endif
+ 
+ #if __has_include(<KArchive/karchive_version.h>)
+ #  include <KArchive/karchive_version.h>
+-#else // Pre KF-5.91 header layout
++#elif __has_include(<karchive_version.h>) // Pre KF-5.91 header layout
+ #  include <karchive_version.h>
+ #endif
+ 

--- a/pkgs/applications/file-managers/krusader/default.nix
+++ b/pkgs/applications/file-managers/krusader/default.nix
@@ -15,12 +15,17 @@
 
 mkDerivation rec {
   pname = "krusader";
-  version = "2.7.2";
+  version = "2.8.0";
 
   src = fetchurl {
     url = "mirror://kde/stable/${pname}/${version}/${pname}-${version}.tar.xz";
-    hash = "sha256-QaOaQ7PELdHR7K6obfMMr/agYf7MHWb2CFmyo8qXYQk=";
+    hash = "sha256-jkzwWpMYsLwbCUGBG5iLLyuwwEoNHjeZghKpGQzywpo=";
   };
+
+  patches = [
+    # Fix compilation error due to forceful header include
+    ./compat-fix.patch
+  ];
 
   nativeBuildInputs = [
     extra-cmake-modules


### PR DESCRIPTION
###### Description of changes

Updated to 2.8.0
Closes #221217
[Changelog](https://invent.kde.org/utilities/krusader/-/blob/master/ChangeLog)

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
