### PR TITLE
bisq-desktop: 1.9.9 -> 1.9.10

### DIFF
--- a/pkgs/applications/blockchains/bisq-desktop/default.nix
+++ b/pkgs/applications/blockchains/bisq-desktop/default.nix
@@ -57,11 +57,11 @@ let
 in
 stdenv.mkDerivation rec {
   pname = "bisq-desktop";
-  version = "1.9.9";
+  version = "1.9.10";
 
   src = fetchurl {
     url = "https://github.com/bisq-network/bisq/releases/download/v${version}/Bisq-64bit-${version}.deb";
-    sha256 = "0jisxzajsc4wfvxabvfzd0x9y1fxzg39fkhap1781q7wyi4ry9kd";
+    sha256 = "1p6hwamc3vzhfg4dgrmh0vf8cxi9s46a14pjnjdyg9zgn4dyr1nm";
   };
 
   nativeBuildInputs = [ makeWrapper copyDesktopItems imagemagick dpkg zip xz ];


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

There are two changes included in this PR:

1. Update bisq-desktop to 1.9.10. See release notes https://github.com/bisq-network/bisq/releases/tag/v1.9.10
2. Add the ability to customize the JAVA_TOOLS_OPTIONS environment variable in order to allow users to configure the Java VM initialization process. See https://docs.oracle.com/en/java/javase/11/docs/specs/jvmti.html#tooloptions

Instead of having a fixed value, now `JAVA_TOOLS_OPTIONS` can be modified using the derivation input `overrideJavaToolOptions`, which is a function that is provided the default `JAVA_TOOLS_OPTIONS` settings in the form of a set, and returns an equivalent set. Something like this:

overrideJavaToolOptions = { flags, options } @ attrs: attrs

The default implementation is the identity function, which in turn causes `JAVA_TOOLS_OPTIONS` to retain the default settings. However, the implementation can be replaced by users in order to modify the _flags_ (a list of settings which can be toggled on/off) and _options_ (a set of settings which have a value).

For example, the default _flag_ "XX:+UseG1GC" can be removed by filtering it out:

```
(bisq-desktop.override { 
  overrideJavaToolOptions = orig: { 
    flags = builtins.filter (flag: flag != "XX:+UseG1GC") orig.flags; 
    options = orig.options;
  };
})
```

An option can be added by merging it with the original options:

```
(bisq-desktop.override { 
  overrideJavaToolOptions = orig: { 
    flags = orig.flags;
    options = { "Dglass.gtk.uiScale" = "2.0"; } // orig.options;
  };
})
```


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
