### PR TITLE
networkmanager-sstp: 1.3.1 -> unstable-2023-03-09

### DIFF
--- a/pkgs/tools/networking/networkmanager/sstp/default.nix
+++ b/pkgs/tools/networking/networkmanager/sstp/default.nix
@@ -1,6 +1,7 @@
 { stdenv
 , lib
-, fetchurl
+, fetchFromGitLab
+, autoreconfHook
 , file
 , glib
 , gnome
@@ -19,15 +20,19 @@
 
 stdenv.mkDerivation rec {
   pname = "NetworkManager-sstp";
-  version = "1.3.1";
+  version = "unstable-2023-03-09";
   name = "${pname}${lib.optionalString withGnome "-gnome"}-${version}";
 
-  src = fetchurl {
-    url = "mirror://gnome/sources/${pname}/${lib.versions.majorMinor version}/${pname}-${version}.tar.xz";
-    sha256 = "fQMSawiaCk/2ZeMHVVcM7PaFEKbP7bUS9Lh+htrGHX0=";
+  src = fetchFromGitLab {
+    domain = "gitlab.gnome.org";
+    owner = "GNOME";
+    repo = "network-manager-sstp";
+    rev = "852db07dc7d19c37e398d831410bd94c8659a210";
+    hash = "sha256-DxgcuTza2G5a7F2mBtDaEuynu7F1Ex9pnAESAjyoRq8=";
   };
 
   nativeBuildInputs = [
+    autoreconfHook
     file
     gettext
     pkg-config
@@ -54,6 +59,7 @@ stdenv.mkDerivation rec {
   configureFlags = [
     "--with-gnome=${if withGnome then "yes" else "no"}"
     "--with-gtk4=${if withGnome then "yes" else "no"}"
+    "--with-pppd-plugin-dir=$(out)/lib/pppd/2.5.0"
     "--enable-absolute-paths"
   ];
 


### PR DESCRIPTION
###### Description of changes

#217132 fallout

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
