### PR TITLE
python310Packages.ipyniivue: init at 1.0.2

### DIFF
--- a/pkgs/development/python-modules/ipyniivue/default.nix
+++ b/pkgs/development/python-modules/ipyniivue/default.nix
@@ -1,0 +1,38 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, pythonOlder
+, hatchling
+, hatch-jupyter-builder
+, ipywidgets
+, jupyter-ui-poll
+, pytestCheckHook
+}:
+
+buildPythonPackage rec {
+  pname = "ipyniivue";
+  version = "1.0.2";
+  format = "pyproject";
+
+  disabled = pythonOlder "3.7";
+
+  src = fetchPypi {
+    inherit pname version;
+    hash = "sha256-vFbEV/ZMXvKZeQUR536OZQ/5uIkt4tOWcCGRPMdc34I";
+  };
+
+  nativeBuildInputs = [ hatchling hatch-jupyter-builder ];
+
+  propagatedBuildInputs = [ ipywidgets jupyter-ui-poll ];
+
+  nativeCheckImports = [ pytestCheckHook ];
+  pythonImportsCheck = [ "ipyniivue" ];
+
+  meta = with lib; {
+    description = "Show a nifti image in a webgl 2.0 canvas within a jupyter notebook cell";
+    homepage = "https://github.com/niivue/ipyniivue";
+    changelog = "https://github.com/niivue/ipyniivue/releases/tag/${version}";
+    license = licenses.bsd3;
+    maintainers = with maintainers; [ bcdarwin ];
+  };
+}

--- a/pkgs/development/python-modules/jupyter-ui-poll/default.nix
+++ b/pkgs/development/python-modules/jupyter-ui-poll/default.nix
@@ -1,0 +1,38 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, pythonOlder
+, setuptools
+, ipython
+}:
+
+buildPythonPackage rec {
+  pname = "jupyter-ui-poll";
+  version = "0.2.2";
+  format = "pyproject";
+
+  disabled = pythonOlder "3.6";
+
+  src = fetchFromGitHub {
+    owner = "Kirill888";
+    repo = "jupyter-ui-poll";
+    rev = "refs/tags/v${version}";
+    hash = "sha256-DWZFvzx0aNTmf1x8Rq19OT0PFRxdpKefWYFh8C116Fw";
+  };
+
+  nativeBuildInputs = [ setuptools ];
+  propagatedBuildInputs = [
+    ipython
+  ];
+
+  doCheck = false;  # no tests in package :(
+  pythonImportsCheck = [ "jupyter_ui_poll" ];
+
+  meta = with lib; {
+    description = "Block jupyter cell execution while interacting with widgets";
+    homepage = "https://github.com/Kirill888/jupyter-ui-poll";
+    changelog = "https://github.com/Kirill888/jupyter-ui-poll/releases/tag/v${version}";
+    license = licenses.mit;
+    maintainers = with maintainers; [ bcdarwin ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -4883,6 +4883,8 @@ self: super: with self; {
 
   ipydatawidgets = callPackage ../development/python-modules/ipydatawidgets { };
 
+  ipyniivue = callPackage ../development/python-modules/ipyniivue { };
+
   ipykernel = callPackage ../development/python-modules/ipykernel { };
 
   ipympl = callPackage ../development/python-modules/ipympl { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5195,6 +5195,8 @@ self: super: with self; {
 
   jupyter-server-ydoc = callPackage ../development/python-modules/jupyter-server-ydoc { };
 
+  jupyter-ui-poll = callPackage ../development/python-modules/jupyter-ui-poll { };
+
   jupyter-ydoc = callPackage ../development/python-modules/jupyter-ydoc { };
 
   jupyterhub = callPackage ../development/python-modules/jupyterhub { };


### PR DESCRIPTION
python310Packages.jupyter-ui-poll: init at 0.2.2

###### Description of changes

Add `python310Packages.ipyniivue`, a package for displaying NIfTI medical imaging data in Jupyter notebooks, and its dependency `python310Packages.jupyter-ui-poll` for handling user input in widgets.

###### Things done

In addition, I checked that the example in the README runs correctly in a Jupyter notebook.

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
