### PR TITLE
arrow-cpp: 11.0.0 -> 12.0.0

### DIFF
--- a/pkgs/development/libraries/arrow-cpp/default.nix
+++ b/pkgs/development/libraries/arrow-cpp/default.nix
@@ -55,16 +55,16 @@ let
     name = "arrow-testing";
     owner = "apache";
     repo = "arrow-testing";
-    rev = "ecab1162cbec872e17d949ecc86181670aee045c";
-    hash = "sha256-w6rEuxfLTEO8DyXV44G6JOMeTfYtskFCOj9rHXNmj2Y=";
+    rev = "47f7b56b25683202c1fd957668e13f2abafc0f12";
+    hash = "sha256-ZDznR+yi0hm5O1s9as8zq5nh1QxJ8kXCRwbNQlzXpnI=";
   };
 
   parquet-testing = fetchFromGitHub {
     name = "parquet-testing";
     owner = "apache";
     repo = "parquet-testing";
-    rev = "5b82793ef7196f7b3583e85669ced211cd8b5ff2";
-    hash = "sha256-gcOvk7qFHZgJWE9CpucC8zwayYw47VbC3lmSRu4JQFg=";
+    rev = "b2e7cc755159196e3a068c8594f7acbaecfdaaac";
+    hash = "sha256-IFvGTOkaRSNgZOj8DziRj88yH5JRF+wgSDZ5N0GNvjk=";
   };
 
   aws-sdk-cpp-arrow = aws-sdk-cpp.override {
@@ -81,12 +81,13 @@ let
 in
 stdenv.mkDerivation rec {
   pname = "arrow-cpp";
-  version = "11.0.0";
+  version = "12.0.0";
 
   src = fetchurl {
     url = "mirror://apache/arrow/arrow-${version}/apache-arrow-${version}.tar.gz";
-    hash = "sha256-Ldjw6ghIpYeFYo7jpXZ1VI1QnhchOi9dcrDZALQ/VDA=";
+    hash = "sha256-3dg0eIJ3XlOvfQlloZArfY/NCgMP0U94PU+F6CE1LVI=";
   };
+
   sourceRoot = "apache-arrow-${version}/cpp";
 
   # versions are all taken from

--- a/pkgs/development/python-modules/pyarrow/default.nix
+++ b/pkgs/development/python-modules/pyarrow/default.nix
@@ -85,15 +85,6 @@ buildPythonPackage rec {
 
   __darwinAllowLocalNetworking = true;
 
-  # fix on current master
-  patches = [
-    (fetchpatch {
-      url = "https://github.com/apache/arrow/commit/bce43175aa8cfb4534d3efbcc092f697f25f0f5a.patch";
-      hash = "sha256-naOAQjQgSKIoCAGCKr7N4dCkOMtweAdfggGOQKDY3k0=";
-      stripLen = 1;
-    })
-  ];
-
   preBuild = ''
     export PYARROW_PARALLEL=$NIX_BUILD_CORES
   '';
@@ -106,6 +97,9 @@ buildPythonPackage rec {
   '';
 
   pytestFlagsArray = [
+    # A couple of tests are missing fixture imports, luckily pytest offers a
+    # clean solution.
+    "--fixtures pyarrow/tests/conftest.py"
     # Deselect a single test because pyarrow prints a 2-line error message where
     # only a single line is expected. The additional line of output comes from
     # the glog library which is an optional dependency of arrow-cpp that is


### PR DESCRIPTION
###### Description of changes


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
