### PR TITLE
stdenv: always update config script on loongarch64-linux

### DIFF
--- a/pkgs/stdenv/linux/default.nix
+++ b/pkgs/stdenv/linux/default.nix
@@ -310,6 +310,10 @@ in
       # top-level pkgs as an override either.
       perl = super.perl.override { enableThreading = false; enableCrypt = false; };
     };
+
+    # `gettext` comes with obsolete config.sub/config.guess that don't recognize LoongArch64.
+    extraNativeBuildInputs =
+      lib.optional (localSystem.isLoongArch64) prevStage.updateAutotoolsGnuConfigScriptsHook;
   })
 
   # First rebuild of gcc; this is linked against all sorts of junk
@@ -387,6 +391,10 @@ in
             '';
           });
       };
+
+      # `gettext` comes with obsolete config.sub/config.guess that don't recognize LoongArch64.
+      extraNativeBuildInputs =
+        lib.optional (localSystem.isLoongArch64) prevStage.updateAutotoolsGnuConfigScriptsHook;
     })
 
   # 2nd stdenv that contains our own rebuilt binutils and is used for
@@ -469,9 +477,10 @@ in
 
     };
 
+    # `gettext` comes with obsolete config.sub/config.guess that don't recognize LoongArch64.
     # `libtool` comes with obsolete config.sub/config.guess that don't recognize Risc-V.
     extraNativeBuildInputs =
-      lib.optional (localSystem.isRiscV) prevStage.updateAutotoolsGnuConfigScriptsHook;
+      lib.optional (localSystem.isLoongArch64 || localSystem.isRiscV) prevStage.updateAutotoolsGnuConfigScriptsHook;
   })
 
 


### PR DESCRIPTION
###### Description of changes

```
$ result/bin/nix-build -A stdenv.__bootPackages.stdenv.__bootPackages.stdenv.__bootPackages.stdenv.__bootPackages.stdenv
/nix/store/cpy1x992qfbxamam5wvsbz2i8g5rdfp5-bootstrap-stage2-stdenv-linux
```

---

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] loongarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
