### PR TITLE
handlr-regex: init at 0.8.5

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -1061,6 +1061,12 @@
     githubId = 1342360;
     name = "Andrew Morgan";
   };
+  anomalocaris = {
+    email = "duncan@anomalocaris.xyz";
+    github = "Anomalocaridid";
+    githubId = 29845794;
+    name = "Duncan Russell";
+  };
   anpin = {
     email = "pavel@anpin.fyi";
     github = "anpin";

--- a/pkgs/tools/misc/handlr-regex/default.nix
+++ b/pkgs/tools/misc/handlr-regex/default.nix
@@ -1,0 +1,38 @@
+{ lib, stdenv, rustPlatform, fetchFromGitHub, shared-mime-info, libiconv, installShellFiles }:
+
+rustPlatform.buildRustPackage rec {
+  pname = "handlr-regex";
+  version = "0.8.5";
+
+  src = fetchFromGitHub {
+    owner = "Anomalocaridid";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "sha256-X0j62Ntu/ouBVm09iKxU3pps8mbL5V5gA65Maa4b0AY=";
+  };
+
+  cargoSha256 = "sha256-byR7CM876z5tAXmbcUfI0CnJrc/D6CxfjBJhuJMSFmg=";
+
+  nativeBuildInputs = [ installShellFiles shared-mime-info ];
+  buildInputs = [ libiconv ];
+
+  preCheck = ''
+    export HOME=$TEMPDIR
+  '';
+
+  postInstall = ''
+    installShellCompletion \
+      --zsh assets/completions/_handlr \
+      --bash assets/completions/handlr \
+      --fish assets/completions/handlr.fish
+
+    installManPage assets/manual/man1/*
+  '';
+
+  meta = with lib; {
+    description = "Fork of handlr with support for regex";
+    homepage = "https://github.com/Anomalocaridid/handlr-regex";
+    license = licenses.mit;
+    maintainers = with maintainers; [ anomalocaris ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -31922,6 +31922,8 @@ with pkgs;
 
   handlr = callPackage ../tools/misc/handlr { };
 
+  handlr-regex = callPackage ../tools/misc/handlr-regex { };
+
   jftui = callPackage ../applications/video/jftui { };
 
   lime = callPackage ../development/libraries/lime { };


### PR DESCRIPTION
###### Description of changes
Add [handlr-regex](https://github.com/Anomalocaridid/handlr-regex), a fork of the resource opener handlr that adds a handful of features, most notably the ability to associate files and URIs to programs using regular expressions.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
