### PR TITLE
netatalk: 3.1.13 -> 3.1.15

### DIFF
--- a/pkgs/tools/filesystems/netatalk/default.nix
+++ b/pkgs/tools/filesystems/netatalk/default.nix
@@ -20,85 +20,17 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "netatalk";
-  version = "3.1.13";
+  version = "3.1.15";
 
   src = fetchurl {
     url = "mirror://sourceforge/netatalk/netatalk/netatalk-${finalAttrs.version}.tar.bz2";
-    hash = "sha256-ia2mvP4bOa2U9YwjZlTR2UTyZFw+femLM3TgvTfV4F0=";
+    hash = "sha256-2NSlzA/Yaw2Q4BfWTB9GI+jNv72lcPxCOt4RUak9GfU=";
   };
 
   patches = [
     ./000-no-suid.patch
     ./001-omit-localstatedir-creation.patch
-    (fetchpatch {
-      name = "make-afpstats-python3-compatible.patch";
-      url = "https://github.com/Netatalk/Netatalk/commit/916b515705cf7ba28dc53d13202811c6e1fe6a9e.patch";
-      sha256 = "sha256-DAABpYjQPJLsQBhmtP30gA357w0Qn+AsnFgAeyDC/Rg=";
-    })
   ];
-
-  freeBSDPatches = [
-    # https://bugs.freebsd.org/263123
-    (fetchpatch {
-      name = "patch-etc_afpd_directory.c";
-      url = "https://cgit.freebsd.org/ports/plain/net/netatalk3/files/patch-etc_afpd_directory.c";
-      sha256 = "sha256-07YAJs+EtqGcFXbYHDLbILved1Ebtd8ukQepvzy6et0=";
-    })
-    (fetchpatch {
-      name = "patch-etc_afpd_file.c";
-      url = "https://cgit.freebsd.org/ports/plain/net/netatalk3/files/patch-etc_afpd_file.c";
-      sha256 = "sha256-T1WTNa2G6wxKtvMa/MCX3Vx6XZBHtU6w3enkdGuIWus=";
-    })
-    (fetchpatch {
-      name = "patch-etc_afpd_volume.c";
-      url = "https://cgit.freebsd.org/ports/plain/net/netatalk3/files/patch-etc_afpd_volume.c";
-      sha256 = "sha256-NOZNZGzA0hxrNkoLTvN64h40yApPbMH4qIfBTpQoI0s=";
-    })
-    (fetchpatch {
-      name = "patch-etc_cnid__dbd_cmd__dbd__scanvol.c";
-      url = "https://cgit.freebsd.org/ports/plain/net/netatalk3/files/patch-etc_cnid__dbd_cmd__dbd__scanvol.c";
-      sha256 = "sha256-5QV+tQDo8/XeKwH/e5+Ne+kEOl2uvRDbHMaWysIB6YU=";
-    })
-    (fetchpatch {
-      name = "patch-libatalk_adouble_ad__attr.c";
-      url =
-        "https://cgit.freebsd.org/ports/plain/net/netatalk3/files/patch-libatalk_adouble_ad__attr.c";
-      sha256 = "sha256-Ose6BdilwBOmoYpm8Jat1B3biOXJj4y3U4T49zE0G7Y=";
-    })
-    (fetchpatch {
-      name = "patch-libatalk_adouble_ad__conv.c";
-      url = "https://cgit.freebsd.org/ports/plain/net/netatalk3/files/patch-libatalk_adouble_ad__conv.c";
-      sha256 = "sha256-T27WlKVXosv4bX5Gek2bR2cVDYEee5qrH4mnL9ghbP8=";
-    })
-    (fetchpatch {
-      name = "patch-libatalk_adouble_ad__date.c";
-      url = "https://cgit.freebsd.org/ports/plain/net/netatalk3/files/patch-libatalk_adouble_ad__date.c";
-      sha256 = "sha256-fkW5A+7R5fT3bukRfZaOwFo7AsyPaYajc1hIlDMZMnc=";
-    })
-    (fetchpatch {
-      name = "patch-libatalk_adouble_ad__flush.c";
-      url = "https://cgit.freebsd.org/ports/plain/net/netatalk3/files/patch-libatalk_adouble_ad__flush.c";
-      sha256 = "sha256-k2zTx35tAlsFHym83bZGoWXRomwFV9xT3r2fzr3Zvbk=";
-    })
-    (fetchpatch {
-      name = "patch-libatalk_adouble_ad__open.c";
-      url = "https://cgit.freebsd.org/ports/plain/net/netatalk3/files/patch-libatalk_adouble_ad__open.c";
-      sha256 = "sha256-uV4wwft2IH54+4k5YR+Gz/BpRZBanxX/Ukp8BkohInU=";
-    })
-    # https://bugs.freebsd.org/251203
-    (fetchpatch {
-      name = "patch-libatalk_vfs_extattr.c";
-      url = "https://cgit.freebsd.org/ports/plain/net/netatalk3/files/patch-libatalk_vfs_extattr.c";
-      sha256 = "sha256-lFWF0Qo8PJv7QKvnMn0Fc9Ruzb+FTEWgOMpxc789jWs=";
-    })
-  ];
-
-  postPatch = ''
-    # freeBSD patches are -p0
-    for i in $freeBSDPatches ; do
-      patch -p0 < $i
-    done
-  '';
 
   nativeBuildInputs = [
     autoreconfHook
@@ -123,27 +55,11 @@ stdenv.mkDerivation (finalAttrs: {
     "--with-bdb=${db.dev}"
     "--with-ssl-dir=${openssl.dev}"
     "--with-lockfile=/run/lock/netatalk"
-    "--with-libevent=${libevent.dev}"
     "--localstatedir=/var/lib"
   ];
 
-  # Expose librpcsvc to the linker for afpd
-  # Fixes errors that showed up when closure-size was merged:
-  # afpd-nfsquota.o: In function `callaurpc':
-  # netatalk-3.1.7/etc/afpd/nfsquota.c:78: undefined reference to `xdr_getquota_args'
-  # netatalk-3.1.7/etc/afpd/nfsquota.c:78: undefined reference to `xdr_getquota_rslt'
-  postConfigure = ''
-    ${ed}/bin/ed -v etc/afpd/Makefile << EOF
-    /^afpd_LDADD
-    /am__append_2
-    a
-      ${libtirpc}/lib/libtirpc.so \\
-    .
-    w
-    EOF
-  '';
-
   postInstall = ''
+    sed -i -e "s%/usr/bin/env python%${python3}/bin/python3%" $out/bin/afpstats
     buildPythonPath ${python3.pkgs.dbus-python}
     patchPythonScript $out/bin/afpstats
   '';


### PR DESCRIPTION
netatalk is maintained again!
  remove random patches, use upstream fixes
  Attempt to address #23895

###### Description of changes

https://github.com/Netatalk/netatalk/releases/tag/netatalk-3-1-15
https://github.com/Netatalk/netatalk/releases/tag/netatalk-3-1-14

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [x] Tested netatalk auth and fileserving
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
