### PR TITLE
otf2bdf: init at 3.1

### DIFF
--- a/pkgs/applications/misc/otf2bdf/default.nix
+++ b/pkgs/applications/misc/otf2bdf/default.nix
@@ -1,0 +1,36 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, freetype
+}:
+
+stdenv.mkDerivation rec {
+  pname = "otf2bdf";
+  version = "3.1";
+
+  # Original site http://sofia.nmsu.edu/~mleisher/Software/otf2bdf/ unreachable,
+  # This is a mirror.
+  src = fetchFromGitHub {
+    owner = "jirutka";
+    repo  = "otf2bdf";
+    rev   = "v${version}";
+    hash  = "sha256-HK9ZrnwKhhYcBvSl+3RwFD7m/WSaPkGKX6utXnk5k+A=";
+  };
+
+  buildInputs = [ freetype ];
+
+  installPhase = ''
+    mkdir -p $out/bin $out/share/man/man1
+    install otf2bdf $out/bin
+    cp otf2bdf.man $out/share/man/man1/otf2bdf.1
+  '';
+
+  meta = with lib; {
+    #homepage = "http://sofia.nmsu.edu/~mleisher/Software/otf2bdf/";  # timeout
+    homepage = "https://github.com/jirutka/otf2bdf";
+    description = "OpenType to BDF font converter";
+    license = licenses.mit0;
+    platforms = platforms.all;
+    maintainers = with maintainers; [ hzeller ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5542,6 +5542,8 @@ with pkgs;
 
   osv-scanner = callPackage ../tools/security/osv-scanner { };
 
+  otf2bdf = callPackage ../applications/misc/otf2bdf { };
+
   pastel = callPackage ../applications/misc/pastel {
     inherit (darwin.apple_sdk.frameworks) Security;
   };


### PR DESCRIPTION
###### Description of changes

Initial  packaging of `otf2bdf`,  a font conversion program taking scaleable fonts and generating a commonly used bitmap font format, "bdf".

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
