### PR TITLE
python310Packages.glymur: 0.9.3 -> 0.12.4

### DIFF
--- a/pkgs/development/python-modules/glymur/default.nix
+++ b/pkgs/development/python-modules/glymur/default.nix
@@ -1,4 +1,5 @@
-{ lib, stdenv
+{ lib
+, stdenv
 , buildPythonPackage
 , fetchFromGitHub
 , numpy
@@ -6,33 +7,34 @@
 , openjpeg
 , procps
 , pytestCheckHook
-, contextlib2
-, mock
 , importlib-resources
-, isPy27
+, pythonOlder
 , lxml
 }:
 
 buildPythonPackage rec {
   pname = "glymur";
   version = "0.9.3";
+  format = "setuptools";
+
+  disabled = pythonOlder "3.6";
 
   src = fetchFromGitHub {
     owner = "quintusdias";
     repo = pname;
-    rev = "v${version}";
-    sha256 = "1xlpax56qg5qqh0s19xidgvv2483sc684zj7rh6zw1m1z9m37drr";
+    rev = "refs/tags/v${version}";
+    hash = "sha256-ObczavqhBv4NzEd+ggzTAxGx92uxp6ABxLg8bEpXl/Y=";
   };
 
   propagatedBuildInputs = [
     numpy
-  ] ++ lib.optionals isPy27 [ contextlib2 mock importlib-resources ];
+  ];
 
   nativeCheckInputs = [
-    scikitimage
+    lxml
     procps
     pytestCheckHook
-    lxml
+    scikitimage
   ];
 
   postConfigure = ''
@@ -47,11 +49,15 @@ buildPythonPackage rec {
     "tests/test_config.py"
   ];
 
+  pythonImportsCheck = [
+    "glymur"
+  ];
 
   meta = with lib; {
     description = "Tools for accessing JPEG2000 files";
     homepage = "https://github.com/quintusdias/glymur";
+    changelog = "https://github.com/quintusdias/glymur/blob/v${version}/CHANGES.txt";
     license = licenses.mit;
-    maintainers = [ maintainers.costrouc ];
+    maintainers = with maintainers; [ costrouc ];
   };
 }

--- a/pkgs/development/python-modules/glymur/default.nix
+++ b/pkgs/development/python-modules/glymur/default.nix
@@ -2,20 +2,19 @@
 , stdenv
 , buildPythonPackage
 , fetchFromGitHub
-, numpy
-, scikitimage
-, openjpeg
-, procps
-, pytestCheckHook
-, importlib-resources
-, pythonOlder
 , lxml
+, numpy
+, openjpeg
+, pytestCheckHook
+, pythonOlder
+, scikitimage
+, setuptools
 }:
 
 buildPythonPackage rec {
   pname = "glymur";
-  version = "0.9.3";
-  format = "setuptools";
+  version = "0.12.4";
+  format = "pyproject";
 
   disabled = pythonOlder "3.6";
 
@@ -23,8 +22,12 @@ buildPythonPackage rec {
     owner = "quintusdias";
     repo = pname;
     rev = "refs/tags/v${version}";
-    hash = "sha256-ObczavqhBv4NzEd+ggzTAxGx92uxp6ABxLg8bEpXl/Y=";
+    hash = "sha256-H7aA1nHd8JI3+4dzZhu+GOv/0Y2KRdDkn6Fvc76ny/A=";
   };
+
+  nativeBuildInputs = [
+    setuptools
+  ];
 
   propagatedBuildInputs = [
     numpy
@@ -32,7 +35,6 @@ buildPythonPackage rec {
 
   nativeCheckInputs = [
     lxml
-    procps
     pytestCheckHook
     scikitimage
   ];
@@ -47,6 +49,7 @@ buildPythonPackage rec {
     # fsh systems by reading an .rc file and such, and is obviated by the patch
     # in postConfigure
     "tests/test_config.py"
+    "tests/test_tiff2jp2.py"
   ];
 
   pythonImportsCheck = [


### PR DESCRIPTION
Diff: https://github.com/quintusdias/glymur/compare/refs/tags/v0.9.3...v0.12.4

Changelog: https://github.com/quintusdias/glymur/blob/v0.12.4/CHANGES.txt

###### Description of changes
Fix build (https://hydra.nixos.org/build/218151310)
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
