### PR TITLE
haskellPackages.streamly-archive: unbreak

### DIFF
--- a/pkgs/development/haskell-modules/configuration-hackage2nix/broken.yaml
+++ b/pkgs/development/haskell-modules/configuration-hackage2nix/broken.yaml
@@ -5106,7 +5106,6 @@ broken-packages:
   - streaming-png
   - streaming-postgresql-simple
   - streaming-sort
-  - streamly-archive
   - streamly-binary
   - streamly-cassava
   - streamly-examples

--- a/pkgs/development/haskell-modules/configuration-nix.nix
+++ b/pkgs/development/haskell-modules/configuration-nix.nix
@@ -903,8 +903,16 @@ self: super: builtins.intersectAttrs super {
     })
     (self.generateOptparseApplicativeCompletions [ "pnbackup" ] super.pinboard-notes-backup);
 
-  # Pass the correct libarchive into the package.
-  streamly-archive = super.streamly-archive.override { archive = pkgs.libarchive; };
+  streamly-archive = super.streamly-archive.override {
+    # The package requires streamly == 0.9.*.
+    # (We can remove this once the assert starts failing.)
+    streamly =
+      assert (builtins.compareVersions pkgs.haskellPackages.streamly.version "0.9.0" < 0);
+        pkgs.haskellPackages.streamly_0_9_0;
+
+    # Pass the correct libarchive into the package.
+    archive = pkgs.libarchive;
+  };
 
   hlint = overrideCabal (drv: {
     postInstall = ''


### PR DESCRIPTION
###### Things done

- [x] Tested compilation of all pkgs that depend on this change using `nix-build --no-out-link -A haskellPackages.streamly-archive --arg config '{ allowBroken = true; }'`
- [x] Ran `maintainers/scripts/haskell/regenerate-hackage-packages.sh --fast` and included the result in the PR. (Running this without `--fast` yielded a `rm: cannot remove 'transitive-broken.ZwXjyKT': No such file or directory` error, and resulted in a few changes to `transitive-broken.yaml` that had nothing to do with `streamly-archive`.)