### PR TITLE
gitlab: 15.11.0 -> 15.11.1

### DIFF
--- a/pkgs/applications/version-management/gitlab/data.json
+++ b/pkgs/applications/version-management/gitlab/data.json
@@ -1,14 +1,14 @@
 {
-  "version": "15.11.0",
-  "repo_hash": "sha256-oLdw6hDn7DLWvAt2RoHkixXCkzKm0dt7iid65MPH7kM=",
-  "yarn_hash": "0b4k43512p8lm1bmiq5piv8wg1f0x2h9q8pgwnms7b2xb4sfn0g1",
+  "version": "15.11.1",
+  "repo_hash": "sha256-xhwWn/+GSAKYy5YcjgIUPJUvhBquvCWu6eFg5ZiNM7s=",
+  "yarn_hash": "02ipm7agjy3c75df76c00k3qq5gpw3d876f6x91xnwizswsv9agb",
   "owner": "gitlab-org",
   "repo": "gitlab",
-  "rev": "v15.11.0-ee",
+  "rev": "v15.11.1-ee",
   "passthru": {
-    "GITALY_SERVER_VERSION": "15.11.0",
-    "GITLAB_PAGES_VERSION": "15.11.0",
+    "GITALY_SERVER_VERSION": "15.11.1",
+    "GITLAB_PAGES_VERSION": "15.11.1",
     "GITLAB_SHELL_VERSION": "14.18.0",
-    "GITLAB_WORKHORSE_VERSION": "15.11.0"
+    "GITLAB_WORKHORSE_VERSION": "15.11.1"
   }
 }

--- a/pkgs/applications/version-management/gitlab/gitaly/default.nix
+++ b/pkgs/applications/version-management/gitlab/gitaly/default.nix
@@ -11,7 +11,7 @@ let
     gemdir = ./.;
   };
 
-  version = "15.11.0";
+  version = "15.11.1";
   package_version = "v${lib.versions.major version}";
   gitaly_package = "gitlab.com/gitlab-org/gitaly/${package_version}";
 
@@ -22,7 +22,7 @@ let
       owner = "gitlab-org";
       repo = "gitaly";
       rev = "v${version}";
-      sha256 = "sha256-kpqSDtj9ctS5PVWTJv5z/HVXYjIlP6CU/FGgueXwKic=";
+      sha256 = "sha256-D12R9liFsrH0XwGSLkmhCbWMbPXrp0kzus4t4Kuw4cg=";
     };
 
     vendorSha256 = "sha256-gJelagGPogeCdJtRpj4RaYlqzZRhtU0EIhmj1aK4ZOk=";

--- a/pkgs/applications/version-management/gitlab/gitlab-pages/default.nix
+++ b/pkgs/applications/version-management/gitlab/gitlab-pages/default.nix
@@ -2,13 +2,13 @@
 
 buildGoModule rec {
   pname = "gitlab-pages";
-  version = "15.11.0";
+  version = "15.11.1";
 
   src = fetchFromGitLab {
     owner = "gitlab-org";
     repo = "gitlab-pages";
     rev = "v${version}";
-    sha256 = "sha256-nYpDyLg9nhl6EA0nwUzA+DFtyZVDnwplQTi1KJTwFbU=";
+    sha256 = "sha256-BPChY2t0ygH73XZYDWDb0EVPqrniMxzg3JWgcmsAesA=";
   };
 
   vendorHash = "sha256-s3HHoz9URACuVVhePQQFviTqlQU7vCLOjTJPBlus1Vo=";

--- a/pkgs/applications/version-management/gitlab/gitlab-workhorse/default.nix
+++ b/pkgs/applications/version-management/gitlab/gitlab-workhorse/default.nix
@@ -5,7 +5,7 @@ in
 buildGoModule rec {
   pname = "gitlab-workhorse";
 
-  version = "15.11.0";
+  version = "15.11.1";
 
   src = fetchFromGitLab {
     owner = data.owner;


### PR DESCRIPTION
###### Description of changes
https://about.gitlab.com/releases/2023/05/02/security-release-gitlab-15-11-1-released/

Fixes [CVE-2023-2182](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2023-2182)
Fixes [CVE-2023-1965](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2023-1965)
Fixes [CVE-2023-1621](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2023-1621)
Fixes [CVE-2023-2069](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2023-2069)
Fixes [CVE-2023-1178](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2023-1178)
Fixes [CVE-2023-0805](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2023-0805)
Fixes [CVE-2023-0756](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2023-0756)
Fixes [CVE-2023-1836](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2023-1836)
Fixes [CVE-2022-4376](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-4376)

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
