### PR TITLE
libbpf: upgrade to 1.2.0

### DIFF
--- a/nixos/tests/bpf.nix
+++ b/nixos/tests/bpf.nix
@@ -26,8 +26,11 @@ import ./make-test-python.nix ({ pkgs, ... }: {
         "    printf(\"tgid: %d\", ((struct task_struct*) curtask)->tgid); exit() "
         "}'"))
     # module BTF (bpftrace >= 0.17)
-    print(machine.succeed("bpftrace -e 'kfunc:nft_trans_alloc_gfp { "
-        "    printf(\"portid: %d\\n\",args->ctx->portid); "
+    # test is currently disabled on aarch64 as kfunc does not work there yet
+    # https://github.com/iovisor/bpftrace/issues/2496
+    print(machine.succeed("uname -m | grep aarch64 || "
+        "bpftrace -e 'kfunc:nft_trans_alloc_gfp { "
+        "    printf(\"portid: %d\\n\", args->ctx->portid); "
         "} BEGIN { exit() }'"))
   '';
 })

--- a/pkgs/os-specific/linux/libbpf/default.nix
+++ b/pkgs/os-specific/linux/libbpf/default.nix
@@ -9,13 +9,13 @@
 
 stdenv.mkDerivation rec {
   pname = "libbpf";
-  version = "1.1.0";
+  version = "1.2.0";
 
   src = fetchFromGitHub {
     owner = "libbpf";
     repo = "libbpf";
     rev = "v${version}";
-    sha256 = "sha256-/vt6IA1o0gjFtXUWhEKIZ1DUWIN2LOvrhLfFzJBACGY=";
+    sha256 = "sha256-NimK4pdYcai21hZHdP1mBX1MOlNY61iDJ+PDYwpRuVE=";
   };
 
   nativeBuildInputs = [ pkg-config ];


### PR DESCRIPTION
###### Description of changes

Tested bpftrace with this, no apparently problem. Looks like they're doing their job of keeping API stable since 1.0 at least it's good to see!

libbpf 1.2.0 changelog:

## User space-side features and APIs:                                                                  
 
- completely overhauled ["Libbpf
overview"](https://libbpf.readthedocs.io/en/latest/libbpf_overview.html) landing documentation page;
- support attaching to uprobes/uretprobes to functions defined in Android APK archives;
- support for BPF link-based `struct_ops` programs:
  - `SEC(".struct_ops.link")` annotations;
  - `bpf_map__attach_struct_ops()` attach API;
  - `bpf_link__update_map()` link update API;
- support sleepable `SEC("struct_ops.s")` programs;
- improved thread-safety of libbpf print callbacks and `libbpf_set_print()`;
- improve handling and reporting of missing BPF kfuncs;
- `bpf_{btf,link,map,prog}_get_info_by_fd()` APIs;
- `bpf_xdp_query_opts()` supports fetching XDP/XSK supported features;
- `perf_buffer__new()` allows customizing notification/sampling period now;
- BPF verifier logging improvements:
  - pass-through BPF verifier log level and flags to kernel as is;
  - support `log_true_size` for getting required log buffer size to fit BPF verifier log completely;
- allow precise control over kprobe/uprobe attach mode: legacy, perf-based, link-based.
 
 
## BPF-side features and APIs;                                                                         
 
- support for BPF open-coded iterators: `bpf_for()`, `bpf_repeat()`, `bpf_for_each()`;
- `bpf_ksym_exists()` macro to check existence of ksyms/kfuncs and kconfig values;
- `BPF_UPROBE()` and `BPF_URETPROBE()` macros;
- `BPF_KPROBE()` and `BPF_UPROBE()` macros allow fetching up to 8 passed in registers arguments,
depending on architecture support;
- `BPF_KSYSCALL()` supports fetching all 6 syscall arguments now;
- LoongArch support in bpf_tracing.h;
- USDT support for 32-bit ARM architecture.


## Bug fixes                                                                                           

- fix legacy kprobe events names sanitization;
- fix clobbering errno in some cases;
- fix BPF map's `BPF_F_MMAPABLE` flag sanitization;
- fix BPF-side USDT support code on s390x architecture;
- fix `BPF_PROBE_READ{_STR}_INTO()` on s390x architecture;
- fix kernel version setting for Debian kernels;
- fix netlink protocol handling in some cases;
- improve robustness of attaching to legacy kprobes and uprobes;
- fix double-free during static linking empty ELF sections;
- a bunch of other small fixes here and there.



###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
