### PR TITLE
setuptools-scm: add setup hook for version and sources inclusion

### DIFF
--- a/pkgs/development/python-modules/setuptools-scm/default.nix
+++ b/pkgs/development/python-modules/setuptools-scm/default.nix
@@ -45,6 +45,8 @@ buildPythonPackage rec {
     pytest = callPackage ./tests.nix { };
   };
 
+  setupHook = ./setup-hook.sh;
+
   meta = with lib; {
     homepage = "https://github.com/pypa/setuptools_scm/";
     description = "Handles managing your python package versions in scm metadata";

--- a/pkgs/development/python-modules/setuptools-scm/setup-hook.sh
+++ b/pkgs/development/python-modules/setuptools-scm/setup-hook.sh
@@ -1,0 +1,32 @@
+# Let built package know its version.
+# Usually, when a package uses setuptools-scm as a build-time dependency, it
+# expects to get the package version from SCM data. However, while doing a nix
+# build, the source tree doesn't contain SCM data, so we should almost always
+# get the version from the derivation attribute.
+version-pretend-hook() {
+    if [ -z "$dontPretendSetuptoolsSCMVersion" -a -z "$SETUPTOOLS_SCM_PRETEND_VERSION" ]; then
+        echo Setting SETUPTOOLS_SCM_PRETEND_VERSION to $version
+        export SETUPTOOLS_SCM_PRETEND_VERSION="$version"
+    fi
+}
+
+# Include all tracked files.
+# When a package uses setuptools-scm as a build-time dependency, it usually
+# expects it to include all scm-tracked files in the built package, by default.
+# This is the official setuptools-scm behavior, documented in
+# https://setuptools-scm.readthedocs.io/en/latest/usage/#file-finders-hook-makes-most-of-manifestin-unnecessary
+# and https://setuptools.pypa.io/en/latest/userguide/datafiles.html.
+# However, while doing a nix build, the source tree doesn't contain SCM data,
+# so it would include only `.py` files by default.
+# We generate a MANIFEST.in automatically that includes all tracked files to
+# emulate this behavior of setuptools-scm.
+include-tracked-files-hook() {
+    if [ -z "$dontIncludeSetuptoolsSCMTrackedFiles" ]; then
+        echo Including all tracked files automatically
+        old_manifest="$(if [ -f MANIFEST.in ]; then cat MANIFEST.in; fi)"
+        echo 'global-include **' > MANIFEST.in
+        echo "$old_manifest" >> MANIFEST.in
+    fi
+}
+
+preBuildHooks+=(version-pretend-hook include-tracked-files-hook)


### PR DESCRIPTION


###### Description of changes
Packages using this build-time dependency expect to be able to know their version, which is autogenerated by extracting metadata from the SCM. For example, from Git tags.

Also they assume that all SCM-tracked files are included in sdist and bdist, as documented here:

- https://github.com/pypa/setuptools_scm/#file-finders-hook-makes-most-of-manifestin-unnecessary
- https://setuptools.pypa.io/en/latest/userguide/datafiles.html

None of these behaviors were happening while on nix builds, where SCM data is stripped off from sources by default.

These build hooks should put nix builds closer to normal ones with Python's `build` app.

A similar fix was used in https://github.com/nix-community/poetry2nix/pull/1077 (for the version problem only) and has given good results so far.

@moduon MT-1075
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
