### PR TITLE
openssl: Fix windows cross compile

### DIFF
--- a/pkgs/development/libraries/openssl/default.nix
+++ b/pkgs/development/libraries/openssl/default.nix
@@ -69,7 +69,9 @@ let
       !(stdenv.hostPlatform.useLLVM or false) &&
       stdenv.cc.isGNU;
 
-    nativeBuildInputs = [ makeWrapper perl ]
+    nativeBuildInputs =
+         lib.optional (!stdenv.hostPlatform.isWindows) makeWrapper
+      ++ [ perl ]
       ++ lib.optionals static [ removeReferencesTo ];
     buildInputs = lib.optional withCryptodev cryptodev
       ++ lib.optional withZlib zlib;
@@ -170,12 +172,16 @@ let
       mkdir -p $bin
       mv $out/bin $bin/bin
 
+    '' + lib.optionalString (!stdenv.hostPlatform.isWindows)
+      # makeWrapper is broken for windows cross (https://github.com/NixOS/nixpkgs/issues/120726)
+    ''
       # c_rehash is a legacy perl script with the same functionality
       # as `openssl rehash`
       # this wrapper script is created to maintain backwards compatibility without
       # depending on perl
       makeWrapper $bin/bin/openssl $bin/bin/c_rehash \
         --add-flags "rehash"
+    '' + ''
 
       mkdir $dev
       mv $out/include $dev/


### PR DESCRIPTION
Windows cross compile of openssl was broken by 18f1be707120b0bb5e2ddfb5058bc8d3c16f18cb

You can test with:

```
nix build .#pkgsCross.mingwW64.openssl
```

It currently fails because of https://github.com/NixOS/nixpkgs/issues/120726

This fix disables the use of `makeWrapper` when `!stdenv.hostPlatform.isWindows` in the same way the old version skipped using `c_rehash` for windows builds to work.

