### PR TITLE
bytewax: 0.15.1 -> 0.16.0

### DIFF
--- a/pkgs/development/python-modules/bytewax/default.nix
+++ b/pkgs/development/python-modules/bytewax/default.nix
@@ -10,15 +10,14 @@
 , protobuf
 , cmake
 , gcc
-, dill
-, multiprocess
+, confluent-kafka
 , pytestCheckHook
 , pythonAtLeast
 }:
 
 buildPythonPackage rec {
   pname = "bytewax";
-  version = "0.15.1";
+  version = "0.16.0";
   format = "pyproject";
 
   disabled = pythonAtLeast "3.11";
@@ -27,7 +26,7 @@ buildPythonPackage rec {
     owner = "bytewax";
     repo = pname;
     rev = "v${version}";
-    hash = "sha256-4HZUu3WSrhxusvuVz8+8mndTu/9DML1tCH52eaWy+oE=";
+    hash = "sha256-XdFkFhN8Z15Zw5HZ2wmnNFoTzyRtIbB7TAtOpKwuKyY=";
   };
 
   # Remove docs tests, myst-docutils in nixpkgs is not compatible with package requirements.
@@ -36,7 +35,7 @@ buildPythonPackage rec {
 
   cargoDeps = rustPlatform.fetchCargoTarball {
     inherit src;
-    hash = "sha256-IfVX3k9AsqP84aagCLSwxmutUoEkP8haD+t+VY4V02U=";
+    hash = "sha256-XGE1qPHi13/+8jjNCIgfzPudw561T0vUfJv5xnKySAg=";
   };
 
   nativeBuildInputs = [
@@ -54,12 +53,14 @@ buildPythonPackage rec {
     protobuf
   ];
 
-  propagatedBuildInputs = [
-    dill
-    multiprocess
-  ];
+  preCheck = ''
+    export PY_IGNORE_IMPORTMISMATCH=1
+  '';
 
-  checkInputs = [ pytestCheckHook ];
+  checkInputs = [
+    pytestCheckHook
+    confluent-kafka
+  ];
 
   meta = with lib; {
     description = "Python Stream Processing";

--- a/pkgs/development/python-modules/bytewax/remove-docs-test.patch
+++ b/pkgs/development/python-modules/bytewax/remove-docs-test.patch
@@ -1,10 +1,10 @@
 diff --git a/pyproject.toml b/pyproject.toml
-index 9b6ee4b..4a82c15 100644
+index 41b5c90..e7c7b2d 100644
 --- a/pyproject.toml
 +++ b/pyproject.toml
-@@ -56,5 +56,4 @@ testpaths = [
- 
-     # TODO: Turn back on markdown tests once we stabilize inputs.
- 
+@@ -50,6 +50,5 @@ doctest_optionflags = "NORMALIZE_WHITESPACE"
+ testpaths = [
+     "pytests",
+     "pysrc",
 -    "docs",
  ]


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
