### PR TITLE
Fix KiCad on macOS

### DIFF
--- a/pkgs/applications/science/electronics/kicad/base.nix
+++ b/pkgs/applications/science/electronics/kicad/base.nix
@@ -75,6 +75,14 @@ stdenv.mkDerivation rec {
     # This is mostly not necessary (we handle the fixups that are actually
     # required in the `postFixup` hook below).
     ./macos-disable-bundle-fixup.patch
+
+    # An `ld-wrapper` hook takes care of codesigning for us.
+    ./macos-disable-codesigning.patch
+
+    # Because we're not copying/symlinking a python interpreter binary + libs
+    # into `KiCad.app/Contents/Frameworks/Python.framework/...` we want to avoid
+    # setting `$PYTHONHOME` to that location.
+    ./macos-dont-set-python-home.patch
   ];
 
   # tagged releases don't have "unknown"

--- a/pkgs/applications/science/electronics/kicad/default.nix
+++ b/pkgs/applications/science/electronics/kicad/default.nix
@@ -207,7 +207,7 @@ stdenv.mkDerivation (finalAttrs: {
     )
   ;
 
-  postInstall = ''
+  postInstall = lib.optional stdenv.hostPlatform.isLinux ''
     mkdir -p $out/share
     ln -s ${finalAttrs.base}/share/applications $out/share/applications
     ln -s ${finalAttrs.base}/share/icons $out/share/icons

--- a/pkgs/applications/science/electronics/kicad/default.nix
+++ b/pkgs/applications/science/electronics/kicad/default.nix
@@ -222,7 +222,6 @@ stdenv.mkDerivation rec {
     maintainers = with lib.maintainers; [ evils kiwi ];
     # kicad is cross platform
     platforms = lib.platforms.all;
-    broken = stdenv.isDarwin;
 
     hydraPlatforms = if (with3d) then [ ] else platforms;
     # We can't download the 3d models on Hydra,

--- a/pkgs/applications/science/electronics/kicad/default.nix
+++ b/pkgs/applications/science/electronics/kicad/default.nix
@@ -24,6 +24,8 @@
 , with3d ? true
 , withI18n ? true
 , srcs ? { }
+
+, testers
 }:
 
 # The `srcs` parameter can be used to override the kicad source code
@@ -204,6 +206,11 @@ stdenv.mkDerivation (finalAttrs: {
     ln -s ${finalAttrs.base}/share/mime $out/share/mime
     ln -s ${finalAttrs.base}/share/metainfo $out/share/metainfo
   '';
+
+  passthru.tests.version = testers.testVersion {
+    package = finalAttrs.finalPackage;
+    command = "kicad-cli --version";
+  };
 
   # can't run this for each pname
   # stable and unstable are in the same versions.nix

--- a/pkgs/applications/science/electronics/kicad/macos-disable-bundle-fixup.patch
+++ b/pkgs/applications/science/electronics/kicad/macos-disable-bundle-fixup.patch
@@ -1,0 +1,187 @@
+diff --git a/bitmap2component/CMakeLists.txt b/bitmap2component/CMakeLists.txt
+index c766530..4fbd162 100644
+--- a/bitmap2component/CMakeLists.txt
++++ b/bitmap2component/CMakeLists.txt
+@@ -68,18 +68,6 @@ if( APPLE )
+         DESTINATION ${KICAD_BIN}
+         COMPONENT binary
+         )
+-    install( CODE "
+-        # override default embedded path settings
+-        ${OSX_BUNDLE_OVERRIDE_PATHS}
+-
+-        # do all the work
+-        include( BundleUtilities )
+-        fixup_bundle( ${KICAD_BIN}/bitmap2component.app/Contents/MacOS/bitmap2component
+-            \"\"
+-            \"${PYTHON_FRAMEWORK}\"
+-            )
+-        " COMPONENT Runtime
+-        )
+ else()
+     install( TARGETS bitmap2component
+         DESTINATION ${KICAD_BIN}
+diff --git a/eeschema/CMakeLists.txt b/eeschema/CMakeLists.txt
+index 92fcfd1..269acf8 100644
+--- a/eeschema/CMakeLists.txt
++++ b/eeschema/CMakeLists.txt
+@@ -548,19 +548,6 @@ if( APPLE )
+         COMPONENT binary
+         )
+ 
+-    install( CODE "
+-            # override default embedded path settings
+-            ${OSX_BUNDLE_OVERRIDE_PATHS}
+-
+-            # do all the work
+-            include( BundleUtilities )
+-            fixup_bundle( ${KICAD_BIN}/eeschema.app/Contents/MacOS/eeschema
+-                \"\"
+-                \"${PYTHON_FRAMEWORK}\"
+-                )
+-            " COMPONENT Runtime
+-        )
+-
+     if( KICAD_SPICE )
+         # bundle libngspice and codemodels
+         get_filename_component( ABS_LIBNGSPICE ${NGSPICE_LIBRARY} ABSOLUTE )
+diff --git a/gerbview/CMakeLists.txt b/gerbview/CMakeLists.txt
+index b56d471..0715228 100644
+--- a/gerbview/CMakeLists.txt
++++ b/gerbview/CMakeLists.txt
+@@ -188,18 +188,6 @@ if( APPLE )
+         DESTINATION ${KICAD_BIN}
+         COMPONENT binary
+         )
+-    install( CODE "
+-            # override default embedded path settings
+-            ${OSX_BUNDLE_OVERRIDE_PATHS}
+-
+-            # do all the work
+-            include( BundleUtilities )
+-            fixup_bundle( ${KICAD_BIN}/gerbview.app/Contents/MacOS/gerbview
+-                \"\"
+-                \"${PYTHON_FRAMEWORK}\"
+-                )
+-            " COMPONENT Runtime
+-        )
+ else()
+     if( MSVC )
+         target_sources( gerbview_kiface PRIVATE ${CMAKE_SOURCE_DIR}/resources/msw/gerbview-dll.rc )
+diff --git a/kicad/CMakeLists.txt b/kicad/CMakeLists.txt
+index f85c5bc..f4a847d 100644
+--- a/kicad/CMakeLists.txt
++++ b/kicad/CMakeLists.txt
+@@ -227,43 +227,6 @@ if( APPLE )
+         # override default embedded path settings
+         ${OSX_BUNDLE_OVERRIDE_PATHS}
+ 
+-        # do all the work
+-
+-        if ( ${PYTHON_FRAMEWORK_HELPER} )
+-            # This idea here is to repair anything that fixup_bundle doesn't handle
+-            # properly for our setup with both Python.framework *and* symlinked subapps
+-            # that's needed for *running* here
+-
+-            # Anything that's needed strictly for packaging and making redistributable
+-            # macOS builds can be defined in kicad-mac-builder
+-
+-            # Of course, making it all work right here would be even slicker,
+-            # but if wishes were horses...
+-
+-            # It would be awesome if we find a better solution (or BundleUtilities works for our corner case better)
+-
+-            execute_process( COMMAND cp -RP ${PYTHON_FRAMEWORK} ${OSX_BUNDLE_INSTALL_LIB_DIR}/)
+-            # We're using cp -RP because CMake's COPY_RESOLVED_BUNDLE... and COPY_DIRECTORY don't handle symlinks correctly
+-
+-            # Add any .so files in the site-packages directory to the list of things to fixup during fixup_bundle
+-            file( GLOB_RECURSE PYTHON_SITE_PACKAGES_LIBS ${OSX_BUNDLE_INSTALL_PYTHON_SITE_PACKAGES_DIR}/*.so )
+-            set( BUNDLE_FIX_LIBS \${BUNDLE_FIX_LIBS} \${PYTHON_SITE_PACKAGES_LIBS} )
+-
+-            fixup_bundle( ${OSX_BUNDLE_INSTALL_BIN_DIR}/kicad
+-                \"\${BUNDLE_FIX_LIBS}\"
+-                \"\${BUNDLE_FIX_DIRS};${PYTHON_FRAMEWORK}\"
+-                IGNORE_ITEM \"Python;python;pythonw;python3;pythonw3;python3.8;pythonw3.8;python3.9;python3.9-intel64\"
+-                )
+-
+-            # BundleUtilities clobbers the rpaths and install_names that we carefully setup in Python.framework, even if
+-            # we mark Python things as IGNORE_ITEMs.  We'll refix them later.
+-        else()
+-            fixup_bundle( ${OSX_BUNDLE_INSTALL_BIN_DIR}/kicad
+-                \"\${BUNDLE_FIX_LIBS}\"
+-                \"\${BUNDLE_FIX_DIRS}\"
+-            )
+-        endif()
+-
+         if( ${SPICE_HELPER} )
+             execute_process( COMMAND install_name_tool -id @executable_path/../PlugIns/sim/libngspice.0.dylib libngspice.0.dylib
+                              WORKING_DIRECTORY ${OSX_BUNDLE_INSTALL_PLUGIN_DIR}/sim )
+diff --git a/pagelayout_editor/CMakeLists.txt b/pagelayout_editor/CMakeLists.txt
+index abb7a0a..bf487c5 100644
+--- a/pagelayout_editor/CMakeLists.txt
++++ b/pagelayout_editor/CMakeLists.txt
+@@ -145,18 +145,6 @@ if( APPLE )
+         DESTINATION ${KICAD_BIN}
+         COMPONENT binary
+         )
+-    install( CODE "
+-        # override default embedded path settings
+-        ${OSX_BUNDLE_OVERRIDE_PATHS}
+-
+-        # do all the work
+-        include( BundleUtilities )
+-        fixup_bundle( ${KICAD_BIN}/pl_editor.app/Contents/MacOS/pl_editor
+-            \"\"
+-            \"${PYTHON_FRAMEWORK}\"
+-            )
+-        " COMPONENT Runtime
+-        )
+ else()
+     if( MSVC )
+         target_sources( pl_editor_kiface PRIVATE ${CMAKE_SOURCE_DIR}/resources/msw/pl_editor-dll.rc )
+diff --git a/pcb_calculator/CMakeLists.txt b/pcb_calculator/CMakeLists.txt
+index f5000b2..8dc2811 100644
+--- a/pcb_calculator/CMakeLists.txt
++++ b/pcb_calculator/CMakeLists.txt
+@@ -143,18 +143,6 @@ if( APPLE )
+         DESTINATION ${KICAD_BIN}
+         COMPONENT binary
+         )
+-    install( CODE "
+-        # override default embedded path settings
+-        ${OSX_BUNDLE_OVERRIDE_PATHS}
+-
+-        # do all the work
+-        include( BundleUtilities )
+-        fixup_bundle( ${KICAD_BIN}/pcb_calculator.app/Contents/MacOS/pcb_calculator
+-            \"\"
+-            \"${PYTHON_FRAMEWORK}\"
+-            )
+-        " COMPONENT Runtime
+-        )
+ else()
+     if( MSVC )
+         target_sources( pcb_calculator_kiface PRIVATE ${CMAKE_SOURCE_DIR}/resources/msw/pcb_calculator-dll.rc  )
+diff --git a/pcbnew/CMakeLists.txt b/pcbnew/CMakeLists.txt
+index fb59e52..3cade84 100644
+--- a/pcbnew/CMakeLists.txt
++++ b/pcbnew/CMakeLists.txt
+@@ -742,18 +742,6 @@ if( APPLE )
+         DESTINATION ${KICAD_BIN}
+         COMPONENT binary
+         )
+-    install( CODE "
+-        # override default embedded path settings
+-        ${OSX_BUNDLE_OVERRIDE_PATHS}
+-
+-        # do all the work
+-        include( BundleUtilities )
+-        fixup_bundle( ${KICAD_BIN}/pcbnew.app/Contents/MacOS/pcbnew
+-            \"\"
+-            \"${PYTHON_FRAMEWORK}\"
+-            )
+-        " COMPONENT Runtime
+-        )
+ else()
+     if( MSVC )
+         target_sources( pcbnew_kiface PRIVATE ${CMAKE_SOURCE_DIR}/resources/msw/pcbnew-dll.rc )

--- a/pkgs/applications/science/electronics/kicad/macos-disable-codesigning.patch
+++ b/pkgs/applications/science/electronics/kicad/macos-disable-codesigning.patch
@@ -1,0 +1,13 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 1007d38..c945de2 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -1057,7 +1057,7 @@ if( KICAD_BUILD_I18N )
+ endif()
+ 
+ if( APPLE )
+-    set( KICAD_OSX_CODESIGN ON
++    set( KICAD_OSX_CODESIGN OFF
+             CACHE BOOL "Sign KiCad.app on macOS" FORCE )
+     set( KICAD_OSX_SIGNING_ID "-"
+             CACHE STRING "macOS Signing ID, defaults to ad-hoc" FORCE )

--- a/pkgs/applications/science/electronics/kicad/macos-dont-set-python-home.patch
+++ b/pkgs/applications/science/electronics/kicad/macos-dont-set-python-home.patch
@@ -1,0 +1,27 @@
+Ordinarily `python3` and friends are put into `Frameworks/Python.framework/...`.
+This isn't the case for the kicad macOS nixpkg and so we don't want to set
+`$PYTHONHOME`.
+
+diff --git a/scripting/python_scripting.cpp b/scripting/python_scripting.cpp
+index 3dab01d..6915d8b 100644
+--- a/scripting/python_scripting.cpp
++++ b/scripting/python_scripting.cpp
+@@ -284,13 +284,18 @@ bool SCRIPTING::scriptingSetup()
+     // set $PYTHONPATH
+     wxSetEnv( wxT( "PYTHONPATH" ), pypath );
+ 
++    // not needed! we want to let the interpreter use its default python home dir
++    //
++    // if we allow `PYTHONHOME` to be set like this modules like `encoding` are not found
++    /*
+     wxString pyhome;
+ 
+     pyhome += Pgm().GetExecutablePath() +
+               wxT( "Contents/Frameworks/Python.framework/Versions/Current" );
+ 
+     // set $PYTHONHOME
+     wxSetEnv( wxT( "PYTHONHOME" ), pyhome );
++    */
+ #else
+     wxString pypath;
+ 


### PR DESCRIPTION
###### Description of changes

Changes to make the KiCad package build and run on macOS.

TODO/Opens:
  - [ ] Is a better fix for `fixup_bundle` possible?
  - [ ] Broken macOS tests
  - [ ] Template dir path doesn't work; doesn't seem to accept `:`s and the paths given aren't right for macOS (can fix the latter issue by having the library packages move all outputs into `share/kicad` on macOS)
  - [ ] Demos: open demo project is missing on macOS
  - [ ] Test on Linux, x86_64-darwin
  - [ ] Test python package on macOS

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
