### PR TITLE
ocamlPackages.ppxlib: use Dune 3

### DIFF
--- a/pkgs/development/compilers/stanc/default.nix
+++ b/pkgs/development/compilers/stanc/default.nix
@@ -8,6 +8,7 @@ ocamlPackages.buildDunePackage rec {
   version = "2.32.0";
 
   minimalOCamlVersion = "4.12";
+  duneVersion = "3";
 
   src = fetchFromGitHub {
     owner = "stan-dev";

--- a/pkgs/development/ocaml-modules/bitstring/default.nix
+++ b/pkgs/development/ocaml-modules/bitstring/default.nix
@@ -4,7 +4,7 @@ buildDunePackage rec {
   pname = "bitstring";
   version = "4.1.0";
 
-  useDune2 = true;
+  duneVersion = "3";
 
   src = fetchFromGitHub {
     owner = "xguerin";

--- a/pkgs/development/ocaml-modules/bitstring/ppx.nix
+++ b/pkgs/development/ocaml-modules/bitstring/ppx.nix
@@ -9,7 +9,9 @@ else
 
 buildDunePackage rec {
   pname = "ppx_bitstring";
-  inherit (bitstring) version useDune2 src;
+  inherit (bitstring) version src;
+
+  duneVersion = "3";
 
   buildInputs = [ bitstring ppxlib ];
 

--- a/pkgs/development/ocaml-modules/brisk-reconciler/default.nix
+++ b/pkgs/development/ocaml-modules/brisk-reconciler/default.nix
@@ -4,6 +4,8 @@ buildDunePackage rec {
   pname = "brisk-reconciler";
   version = "unstable-2020-12-02";
 
+  duneVersion = "3";
+
   src = fetchFromGitHub {
     owner = "briskml";
     repo = "brisk-reconciler";

--- a/pkgs/development/ocaml-modules/camlimages/default.nix
+++ b/pkgs/development/ocaml-modules/camlimages/default.nix
@@ -1,4 +1,4 @@
-{ lib, fetchFromGitLab, buildDunePackage, dune-configurator, cppo
+{ lib, fetchFromGitLab, buildDunePackage, findlib, dune-configurator, cppo
 , graphics, lablgtk, stdio
 }:
 
@@ -6,9 +6,9 @@ buildDunePackage rec {
   pname = "camlimages";
   version = "5.0.4";
 
-  useDune2 = true;
+  duneVersion = "3";
 
-  minimumOCamlVersion = "4.07";
+  minimalOCamlVersion = "4.07";
 
   src = fetchFromGitLab {
     owner = "camlspotter";
@@ -18,7 +18,7 @@ buildDunePackage rec {
   };
 
   nativeBuildInputs = [ cppo ];
-  buildInputs = [ dune-configurator graphics lablgtk stdio ];
+  buildInputs = [ dune-configurator findlib graphics lablgtk stdio ];
 
   meta = with lib; {
     branch = "5.0";

--- a/pkgs/development/ocaml-modules/ctypes_stubs_js/default.nix
+++ b/pkgs/development/ocaml-modules/ctypes_stubs_js/default.nix
@@ -9,6 +9,7 @@ buildDunePackage rec {
   pname = "ctypes_stubs_js";
   version = "0.1";
 
+  duneVersion = "3";
   minimalOCamlVersion = "4.08";
 
   src = fetchFromGitLab {

--- a/pkgs/development/ocaml-modules/genspio/default.nix
+++ b/pkgs/development/ocaml-modules/genspio/default.nix
@@ -6,6 +6,8 @@ buildDunePackage rec {
   pname = "genspio";
   version = "0.0.3";
 
+  duneVersion = "3";
+
   src = fetchFromGitHub {
     owner = "hammerlab";
     repo = pname;

--- a/pkgs/development/ocaml-modules/integers_stubs_js/default.nix
+++ b/pkgs/development/ocaml-modules/integers_stubs_js/default.nix
@@ -8,6 +8,7 @@ buildDunePackage rec {
   version = "1.0";
 
   minimalOCamlVersion = "4.08";
+  duneVersion = "3";
 
   src = fetchFromGitHub {
     owner = "o1-labs";

--- a/pkgs/development/ocaml-modules/janestreet/0.14.nix
+++ b/pkgs/development/ocaml-modules/janestreet/0.14.nix
@@ -12,7 +12,7 @@ with self;
   accessor = janePackage {
     pname = "accessor";
     version = "0.14.1";
-    minimumOCamlVersion = "4.09";
+    minimalOCamlVersion = "4.09";
     hash = "0wm2081kzd5zsqs516cn3f975bnnmnyynv8fa818gmfa65i6mxm8";
     meta.description = "A library that makes it nicer to work with nested functional data structures";
     propagatedBuildInputs = [ higher_kinded ];
@@ -21,7 +21,7 @@ with self;
   accessor_async = janePackage {
     pname = "accessor_async";
     version = "0.14.1";
-    minimumOCamlVersion = "4.09";
+    minimalOCamlVersion = "4.09";
     hash = "1193hzvlzm7vcl9p67fs8al2pvkw9n2wz009m2l3lp35mrx8aq1w";
     meta.description = "Accessors for Async types, for use with the Accessor library";
     propagatedBuildInputs = [ accessor_core async_kernel ];
@@ -30,14 +30,14 @@ with self;
   accessor_base = janePackage {
     pname = "accessor_base";
     version = "0.14.1";
-    minimumOCamlVersion = "4.09";
+    minimalOCamlVersion = "4.09";
     hash = "1xjbvvijkyw4dlys47x4896y3kqm2zn0yg60cqrp57i2dwxg0nsj";
     meta.description = "Accessors for Base types, for use with the Accessor library";
     propagatedBuildInputs = [ ppx_accessor ];
   };
 
   accessor_core = janePackage {
-    minimumOCamlVersion = "4.09";
+    minimalOCamlVersion = "4.09";
     pname = "accessor_core";
     version = "0.14.1";
     hash = "1cdkv34m6czhacivpbb2sasj83fgcid6gnqk30ig9i84z8nh2gw2";
@@ -84,7 +84,6 @@ with self;
 
   async_js = janePackage {
     pname = "async_js";
-    duneVersion = "3";
     hash = "0rld8792lfwbinn9rhrgacivz49vppgy29smpqnvpga89wchjv0v";
     meta.description = "A small library that provide Async support for JavaScript platforms";
     buildInputs = [ js_of_ocaml-ppx ];
@@ -120,7 +119,6 @@ with self;
   };
 
   async_smtp = janePackage {
-    duneVersion = "3";
     pname = "async_smtp";
     hash = "1xf3illn7vikdxldpnc29n4z8sv9f0wsdgdvl4iv93qlvjk8gzck";
     meta.description = "SMTP client and server";
@@ -151,7 +149,7 @@ with self;
     pname = "base";
     version = "0.14.1";
     hash = "1hizjxmiqlj2zzkwplzjamw9rbnl0kh44sxgjpzdij99qnfkzylf";
-    minimumOCamlVersion = "4.07";
+    minimalOCamlVersion = "4.07";
     meta.description = "Full standard library replacement for OCaml";
     buildInputs = [ dune-configurator ];
     propagatedBuildInputs = [ sexplib0 ];
@@ -161,7 +159,7 @@ with self;
   base_bigstring = janePackage {
     pname = "base_bigstring";
     hash = "1ald2m7qywhxbygv58dzpgaj54p38zn0aiqd1z7i95kf3bsnsjqa";
-    minimumOCamlVersion = "4.07";
+    minimalOCamlVersion = "4.07";
     meta.description = "String type based on [Bigarray], for use in I/O and C-bindings";
     propagatedBuildInputs = [ ppx_jane ];
   };
@@ -170,7 +168,7 @@ with self;
     pname = "base_quickcheck";
     version = "0.14.1";
     hash = "0apq3d9xb0zdaqsl4cjk5skyig57ff1plndb2mh0nn3czvfhifxs";
-    minimumOCamlVersion = "4.04.2";
+    minimalOCamlVersion = "4.04.2";
     meta.description = "Randomized testing framework, designed for compatibility with Base";
     propagatedBuildInputs = [ ppx_base ppx_fields_conv ppx_let ppx_sexp_value splittable_random ];
   };
@@ -185,14 +183,13 @@ with self;
   bin_prot = janePackage {
     pname = "bin_prot";
     hash = "1qyqbfp4zdc2jb87370cdgancisqffhf9x60zgh2m31kqik8annr";
-    minimumOCamlVersion = "4.04.2";
+    minimalOCamlVersion = "4.04.2";
     meta.description = "A binary protocol generator";
     propagatedBuildInputs = [ ppx_compare ppx_custom_printf ppx_fields_conv ppx_optcomp ppx_variants_conv ];
   };
 
   bonsai = janePackage {
     pname = "bonsai";
-    duneVersion = "3";
     hash = "0k4grabwqc9sy4shzp77bgfvyajvvc0l8qq89ia7cvlwvly7gv6a";
     meta.description = "A library for building dynamic webapps, using Js_of_ocaml";
     buildInputs = [ ppx_pattern_bind ];
@@ -202,7 +199,7 @@ with self;
   cinaps = janePackage {
     pname = "cinaps";
     hash = "0ms1j2kh7i5slyw9v4w9kdz52dkwl5gqcnvn89prgimhk2vmichj";
-    minimumOCamlVersion = "4.07";
+    minimalOCamlVersion = "4.07";
     meta.description = "Trivial metaprogramming tool";
     propagatedBuildInputs = [ re ];
     checkInputs = [ ppx_jane ];
@@ -271,7 +268,6 @@ with self;
   };
 
   email_message = janePackage {
-    duneVersion = "3";
     pname = "email_message";
     hash = "0k8hjkq91ikl7wjxs04k523jbkhl6q4abj6v0lzlbjiybmrpp69n";
     meta.description = "E-mail message parser";
@@ -295,7 +291,7 @@ with self;
   fieldslib = janePackage {
     pname = "fieldslib";
     hash = "0nxx35lrb4f6zfs5l80a7cg7azf19c6g31vn9qjjpaxf6lgkck2n";
-    minimumOCamlVersion = "4.04.2";
+    minimalOCamlVersion = "4.04.2";
     meta.description = "Syntax extension to define first class values representing record fields, to get and set record fields, iterate and fold over all fields of a record and create new record values";
     propagatedBuildInputs = [ base ];
   };
@@ -303,7 +299,7 @@ with self;
   higher_kinded = janePackage {
     pname = "higher_kinded";
     version = "0.14.1";
-    minimumOCamlVersion = "4.09";
+    minimalOCamlVersion = "4.09";
     hash = "05jvxgqsx3j2v8rqpd91ah76dgc1q2dz38kjklmx0vms4r4gvlsx";
     meta.description = "A library with an encoding of higher kinded types in OCaml";
     propagatedBuildInputs = [ base ppx_jane ];
@@ -311,7 +307,6 @@ with self;
 
   incr_dom = janePackage {
     pname = "incr_dom";
-    duneVersion = "3";
     hash = "0mi98cwi4npdh5vvcz0pb4sbb9j9dydl52s51rswwc3kn8mipxfx";
     meta.description = "A library for building dynamic webapps, using Js_of_ocaml";
     buildInputs = [ js_of_ocaml-ppx ];
@@ -344,7 +339,7 @@ with self;
   jane-street-headers = janePackage {
     pname = "jane-street-headers";
     hash = "12n40mlgjnc09fxc0hp0npsxdlxja2w828683zpb32nrzqkg6z4c";
-    minimumOCamlVersion = "4.04.2";
+    minimalOCamlVersion = "4.04.2";
     meta.description = "Jane Street C header files";
   };
 
@@ -358,7 +353,7 @@ with self;
   ocaml-compiler-libs = janePackage {
     pname = "ocaml-compiler-libs";
     version = "0.12.4";
-    minimumOCamlVersion = "4.04.1";
+    minimalOCamlVersion = "4.04.1";
     hash = "sha256-W+KUguz55yYAriHRMcQy8gRPzh2TZSJnexG1JI8TLgI=";
     meta.description = "OCaml compiler libraries repackaged";
   };
@@ -367,7 +362,7 @@ with self;
     pname = "parsexp";
     version = "0.14.1";
     hash = "1nr0ncb8l2mkk8pqzknr7fsqw5kpz8y102kyv5bc0x7c36v0d4zy";
-    minimumOCamlVersion = "4.04.2";
+    minimalOCamlVersion = "4.04.2";
     meta.description = "S-expression parsing library";
     propagatedBuildInputs = [ base sexplib0 ];
   };
@@ -382,7 +377,7 @@ with self;
   posixat = janePackage {
     pname = "posixat";
     hash = "0aana1lzq4514kna7hr301b5iv6gcg6zhgrx8s8vaad1q38yfp6c";
-    minimumOCamlVersion = "4.07";
+    minimalOCamlVersion = "4.07";
     propagatedBuildInputs = [ ppx_optcomp ppx_sexp_conv ];
     meta.description = "Binding to the posix *at functions";
   };
@@ -390,7 +385,7 @@ with self;
   ppx_accessor = janePackage {
     pname = "ppx_accessor";
     version = "0.14.3";
-    minimumOCamlVersion = "4.09";
+    minimalOCamlVersion = "4.09";
     hash = "sha256:1c8blzh2f34vbm1z3mnvh670c6vda70chw805n2hmkd9j46l0cll";
     meta.description = "[@@deriving] plugin to generate accessors for use with the Accessor libraries";
     propagatedBuildInputs = [ accessor ];
@@ -399,7 +394,7 @@ with self;
   ppx_assert = janePackage {
     pname = "ppx_assert";
     hash = "03mzgm4smrczp5dg3mpr6zc2v6a54n0r01k4ww820yrr25hcf8ip";
-    minimumOCamlVersion = "4.04.2";
+    minimalOCamlVersion = "4.04.2";
     meta.description = "Assert-like extension nodes that raise useful errors on failure";
     propagatedBuildInputs = [ ppx_cold ppx_compare ppx_here ppx_sexp_conv ];
   };
@@ -407,7 +402,7 @@ with self;
   ppx_base = janePackage {
     pname = "ppx_base";
     hash = "1wv3q0qyghm0c5izq03y97lv3czqk116059mg62wx6valn22a000";
-    minimumOCamlVersion = "4.04.2";
+    minimalOCamlVersion = "4.04.2";
     meta = {
       description = "Base set of ppx rewriters";
       mainProgram = "ppx-base";
@@ -419,7 +414,7 @@ with self;
     pname = "ppx_bench";
     version = "0.14.1";
     hash = "12r7jgqgpb4i4cry3rgyl2nmxcscs5w7mmk06diz7i49r27p96im";
-    minimumOCamlVersion = "4.04.2";
+    minimalOCamlVersion = "4.04.2";
     meta.description = "Syntax extension for writing in-line benchmarks in ocaml code";
     propagatedBuildInputs = [ ppx_inline_test ];
   };
@@ -427,7 +422,7 @@ with self;
   ppx_bin_prot = janePackage {
     pname = "ppx_bin_prot";
     hash = "1qryjxhyz3kn5jz5wm62j59lhjhd1mp7nbsj0np9qnbpapnnr1zg";
-    minimumOCamlVersion = "4.04.2";
+    minimalOCamlVersion = "4.04.2";
     meta.description = "Generation of bin_prot readers and writers from types";
     propagatedBuildInputs = [ bin_prot ppx_here ];
     doCheck = false; # circular dependency with ppx_jane
@@ -436,7 +431,7 @@ with self;
   ppx_cold = janePackage {
     pname = "ppx_cold";
     hash = "0ciqs6f9ab73gq4krj14xzzba4ydcxph214m87i1s0xp25hwxr8v";
-    minimumOCamlVersion = "4.04.2";
+    minimalOCamlVersion = "4.04.2";
     meta.description = "Expands [@cold] into [@inline never][@specialise never][@local never]";
     propagatedBuildInputs = [ ppxlib ];
   };
@@ -444,7 +439,7 @@ with self;
   ppx_compare = janePackage {
     pname = "ppx_compare";
     hash = "11pj76dimx2f7l8m85myzp6yzx9xcg0bqi97s7ayssvkckm57390";
-    minimumOCamlVersion = "4.04.2";
+    minimalOCamlVersion = "4.04.2";
     meta.description = "Generation of comparison functions from types";
     propagatedBuildInputs = [ ppxlib base ];
     doCheck = false; # test build rule broken
@@ -454,7 +449,7 @@ with self;
     pname = "ppx_custom_printf";
     version = "0.14.1";
     hash = "0c1m65kn27zvwmfwy7kk46ga76yw2a3ik9jygpy1b6nn6pi026w9";
-    minimumOCamlVersion = "4.04.2";
+    minimalOCamlVersion = "4.04.2";
     meta.description = "Printf-style format-strings for user-defined string conversion";
     propagatedBuildInputs = [ ppx_sexp_conv ];
   };
@@ -462,7 +457,7 @@ with self;
   ppx_enumerate = janePackage {
     pname = "ppx_enumerate";
     hash = "1sriid4vh10p80wwvn46v1g16m646qw5r5xzwlymyz5gbvq2zf40";
-    minimumOCamlVersion = "4.04.2";
+    minimalOCamlVersion = "4.04.2";
     meta.description = "Generate a list containing all values of a finite type";
     propagatedBuildInputs = [ ppxlib ];
   };
@@ -471,7 +466,7 @@ with self;
     pname = "ppx_expect";
     version = "0.14.1";
     hash = "0vbbnjrzpyk5p0js21lafr6fcp2wqka89p1876rdf472cmg0l7fv";
-    minimumOCamlVersion = "4.04.2";
+    minimalOCamlVersion = "4.04.2";
     meta.description = "Cram like framework for OCaml";
     propagatedBuildInputs = [ ppx_here ppx_inline_test re ];
     doCheck = false; # circular dependency with ppx_jane
@@ -481,7 +476,7 @@ with self;
     pname = "ppx_fields_conv";
     version = "0.14.2";
     hash = "1zwirwqry24b48bg7d4yc845hvcirxyymzbw95aaxdcck84d30n8";
-    minimumOCamlVersion = "4.04.2";
+    minimalOCamlVersion = "4.04.2";
     meta.description = "Generation of accessor and iteration functions for ocaml records";
     propagatedBuildInputs = [ fieldslib ppxlib ];
   };
@@ -489,7 +484,7 @@ with self;
   ppx_fixed_literal = janePackage {
     pname = "ppx_fixed_literal";
     hash = "0s7rb4dhz4ibhh42a9sfxjj3zbwfyfmaihr92hpdv5j9xqn3n8mi";
-    minimumOCamlVersion = "4.04.2";
+    minimalOCamlVersion = "4.04.2";
     meta.description = "Simpler notation for fixed point literals";
     propagatedBuildInputs = [ ppxlib ];
   };
@@ -497,7 +492,7 @@ with self;
   ppx_hash = janePackage {
     pname = "ppx_hash";
     hash = "1zf03xdrg4jig7pdcrdpbabyjkdpifb31z2z1bf9wfdawybdhwkq";
-    minimumOCamlVersion = "4.04.2";
+    minimalOCamlVersion = "4.04.2";
     meta.description = "A ppx rewriter that generates hash functions from type expressions and definitions";
     propagatedBuildInputs = [ ppx_compare ppx_sexp_conv ];
   };
@@ -505,7 +500,7 @@ with self;
   ppx_here = janePackage {
     pname = "ppx_here";
     hash = "09zcyigaalqccs9s0h7n0535clgfmqb9s4p1jbgcqji9zj8w426s";
-    minimumOCamlVersion = "4.04.2";
+    minimalOCamlVersion = "4.04.2";
     meta.description = "Expands [%here] into its location";
     propagatedBuildInputs = [ ppxlib ];
     doCheck = false; # test build rules broken
@@ -515,7 +510,7 @@ with self;
     pname = "ppx_inline_test";
     version = "0.14.1";
     hash = "1ajdna1m9l1l3nfigyy33zkfa3yarfr6s086jdw2pcfwlq1fhhl4";
-    minimumOCamlVersion = "4.04.2";
+    minimalOCamlVersion = "4.04.2";
     meta.description = "Syntax extension for writing in-line tests in ocaml code";
     propagatedBuildInputs = [ ppxlib time_now ];
     doCheck = false; # test build rules broken
@@ -524,7 +519,7 @@ with self;
   ppx_jane = janePackage {
     pname = "ppx_jane";
     hash = "1kk238fvrcylymwm7xwc7llbyspmx1y662ypq00vy70g112rir7j";
-    minimumOCamlVersion = "4.04.2";
+    minimalOCamlVersion = "4.04.2";
     meta = {
       description = "Standard Jane Street ppx rewriters";
       mainProgram = "ppx-jane";
@@ -536,7 +531,7 @@ with self;
     pname = "ppx_js_style";
     version = "0.14.1";
     hash = "16ax6ww9h36xyn9acbm8zxv0ajs344sm37lgj2zd2bvgsqv24kxj";
-    minimumOCamlVersion = "4.04.2";
+    minimalOCamlVersion = "4.04.2";
     meta.description = "Code style checker for Jane Street Packages";
     propagatedBuildInputs = [ octavius ppxlib ];
   };
@@ -544,7 +539,7 @@ with self;
   ppx_let = janePackage {
     pname = "ppx_let";
     hash = "1jq3g88xv9g6y9im67hiig3cfn5anwwnq09mp7yn7a86ha5r9w3i";
-    minimumOCamlVersion = "4.04.2";
+    minimalOCamlVersion = "4.04.2";
     meta.description = "Monadic let-bindings";
     propagatedBuildInputs = [ ppxlib ];
   };
@@ -552,7 +547,7 @@ with self;
   ppx_log = janePackage {
     pname = "ppx_log";
     hash = "10hnr5lpww3fw0bnidzngalbgy0j1wvz1g5ki9c9h558pnpvsazr";
-    minimumOCamlVersion = "4.08.0";
+    minimalOCamlVersion = "4.08.0";
     meta.description = "Ppx_sexp_message-like extension nodes for lazily rendering log messages";
     propagatedBuildInputs = [ async_unix ppx_jane sexplib ];
   };
@@ -560,7 +555,7 @@ with self;
   ppx_module_timer = janePackage {
     pname = "ppx_module_timer";
     hash = "163q1rpblwv82fxwyf0p4j9zpsj0jzvkfmzb03r0l49gqhn89mp6";
-    minimumOCamlVersion = "4.04.2";
+    minimalOCamlVersion = "4.04.2";
     meta.description = "Ppx rewriter that records top-level module startup times";
     propagatedBuildInputs = [ time_now ];
   };
@@ -569,7 +564,7 @@ with self;
     pname = "ppx_optcomp";
     version = "0.14.3";
     hash = "1iflgfzs23asw3k6098v84al5zqx59rx2qjw0mhvk56avlx71pkw";
-    minimumOCamlVersion = "4.04.2";
+    minimalOCamlVersion = "4.04.2";
     meta.description = "Optional compilation for OCaml";
     propagatedBuildInputs = [ ppxlib ];
   };
@@ -577,7 +572,7 @@ with self;
   ppx_optional = janePackage {
     pname = "ppx_optional";
     hash = "1d7rsdqiccxp2w4ykb9klarddm2qrrym3brbnhzx2hm78iyj3hzv";
-    minimumOCamlVersion = "4.04.2";
+    minimalOCamlVersion = "4.04.2";
     meta.description = "Pattern matching on flat options";
     propagatedBuildInputs = [ ppxlib ];
   };
@@ -585,7 +580,7 @@ with self;
   ppx_pattern_bind = janePackage {
     pname = "ppx_pattern_bind";
     hash = "0yxkwnn30nxgrspi191zma95bgrh134aqh2bnpj3wg0245ki55zv";
-    minimumOCamlVersion = "4.07";
+    minimalOCamlVersion = "4.07";
     meta.description = "A ppx for writing fast incremental bind nodes in a pattern match";
     propagatedBuildInputs = [ ppx_let ];
   };
@@ -593,7 +588,7 @@ with self;
   ppx_pipebang = janePackage {
     pname = "ppx_pipebang";
     hash = "0450b3p2rpnnn5yyvbkcd3c33jr2z0dp8blwxddaj2lv7nzl5dzf";
-    minimumOCamlVersion = "4.04.2";
+    minimalOCamlVersion = "4.04.2";
     meta.description = "A ppx rewriter that inlines reverse application operators `|>` and `|!`";
     propagatedBuildInputs = [ ppxlib ];
   };
@@ -613,7 +608,7 @@ with self;
   ppx_sexp_conv = janePackage {
     pname = "ppx_sexp_conv";
     version = "0.14.3";
-    minimumOCamlVersion = "4.04.2";
+    minimalOCamlVersion = "4.04.2";
     hash = "0dbri9d00ydi0dw1cavswnqdmhjaaz80vap29ns2lr6mhhlvyjmj";
     meta.description = "[@@deriving] plugin to generate S-expression conversion functions";
     propagatedBuildInputs = [ (ppxlib.override { version = "0.24.0"; }) sexplib0 base ];
@@ -623,7 +618,7 @@ with self;
     pname = "ppx_sexp_message";
     version = "0.14.1";
     hash = "1lvsr0d68kakih1ll33hy6dxbjkly6lmky4q6z0h0hrcbd6z48k4";
-    minimumOCamlVersion = "4.04.2";
+    minimalOCamlVersion = "4.04.2";
     meta.description = "A ppx rewriter for easy construction of s-expressions";
     propagatedBuildInputs = [ ppx_here ppx_sexp_conv ];
   };
@@ -631,7 +626,7 @@ with self;
   ppx_sexp_value = janePackage {
     pname = "ppx_sexp_value";
     hash = "1d1c92pyypqkd9473d59j0sfppxvcxggbc62w8bkqnbxrdmvirn9";
-    minimumOCamlVersion = "4.04.2";
+    minimalOCamlVersion = "4.04.2";
     meta.description = "A ppx rewriter that simplifies building s-expressions from ocaml values";
     propagatedBuildInputs = [ ppx_here ppx_sexp_conv ];
   };
@@ -640,7 +635,7 @@ with self;
     pname = "ppx_stable";
     version = "0.14.1";
     hash = "1sp1kn23qr0pfypa4ilvhqq5y11y13xpfygfl582ra9kik5xqfa1";
-    minimumOCamlVersion = "4.04.2";
+    minimalOCamlVersion = "4.04.2";
     meta.description = "Stable types conversions generator";
     propagatedBuildInputs = [ ppxlib ];
   };
@@ -648,7 +643,7 @@ with self;
   ppx_string = janePackage {
     pname = "ppx_string";
     version = "0.14.1";
-    minimumOCamlVersion = "4.04.2";
+    minimalOCamlVersion = "4.04.2";
     hash = "0a8khmg0y32kyn3q6idwgh0d6d1s6ms1w75gj3dzng0v7y4h6jx4";
     meta.description = "Ppx extension for string interpolation";
     propagatedBuildInputs = [ ppx_base ppxlib stdio ];
@@ -657,7 +652,7 @@ with self;
   ppx_typerep_conv = janePackage {
     pname = "ppx_typerep_conv";
     version = "0.14.2";
-    minimumOCamlVersion = "4.04.2";
+    minimalOCamlVersion = "4.04.2";
     hash = "0yk9vkpnwr8labgfncqdi4rfkj88d8mb3cr8m4gdqpi3f2r27hf0";
     meta.description = "Generation of runtime types from type declarations";
     propagatedBuildInputs = [ ppxlib typerep ];
@@ -666,7 +661,7 @@ with self;
   ppx_variants_conv = janePackage {
     pname = "ppx_variants_conv";
     version = "0.14.2";
-    minimumOCamlVersion = "4.04.2";
+    minimalOCamlVersion = "4.04.2";
     hash = "1p11fiz4m160hs0xzg4g9rxchp053sz3s3d1lyciqixad1xi47a4";
     meta.description = "Generation of accessor and iteration functions for ocaml variant types";
     propagatedBuildInputs = [ variantslib ppxlib ];
@@ -746,7 +741,7 @@ with self;
   sexp_pretty = janePackage {
     pname = "sexp_pretty";
     hash = "0dax0wm511zgvr7p6kcd5gygi58118by7hsv7hymy8ldfcky5cwd";
-    minimumOCamlVersion = "4.07";
+    minimalOCamlVersion = "4.07";
     meta.description = "S-expression pretty-printer";
     propagatedBuildInputs = [ ppx_base re sexplib ];
   };
@@ -754,7 +749,7 @@ with self;
   sexp_select = janePackage {
     pname = "sexp_select";
     hash = "1lchhfqw4afw38fnarwylqc2qp7k6xwx3j7m9gy8ygjgd0vgd729";
-    minimumOCamlVersion = "4.07";
+    minimalOCamlVersion = "4.07";
     propagatedBuildInputs = [ base ppx_jane ];
     meta.description = "A library to use CSS-style selectors to traverse sexp trees";
   };
@@ -762,14 +757,14 @@ with self;
   sexplib0 = janePackage {
     pname = "sexplib0";
     hash = "06sb3zqhb3dwqsmn15d769hfgqwqhxnm52iqim9l767gvlwpmibb";
-    minimumOCamlVersion = "4.04.2";
+    minimalOCamlVersion = "4.04.2";
     meta.description = "Library containing the definition of S-expressions and some base converters";
   };
 
   sexplib = janePackage {
     pname = "sexplib";
     hash = "03c3j1ihx4pjbb0x3arrcif3wvp3iva2ivnywhiak4mbbslgsnzr";
-    minimumOCamlVersion = "4.04.2";
+    minimalOCamlVersion = "4.04.2";
     meta.description = "Library for serializing OCaml values to and from S-expressions";
     propagatedBuildInputs = [ num parsexp ];
   };
@@ -786,7 +781,7 @@ with self;
   shexp = janePackage {
     pname = "shexp";
     hash = "1h6hsnbg6bk32f8iv6kd6im4mv2pjsjpd1mjsfx80p1n9273xack";
-    minimumOCamlVersion = "4.07";
+    minimalOCamlVersion = "4.07";
     propagatedBuildInputs = [ posixat spawn ];
     meta.description = "Process library and s-expression based shell";
   };
@@ -794,7 +789,7 @@ with self;
   spawn = janePackage {
     pname = "spawn";
     version = "0.13.0";
-    minimumOCamlVersion = "4.02.3";
+    minimalOCamlVersion = "4.02.3";
     hash = "1w003k1kw1lmyiqlk58gkxx8rac7dchiqlz6ah7aj7bh49b36ppf";
     meta.description = "Spawning sub-processes";
     buildInputs = [ ppx_expect ];
@@ -818,7 +813,7 @@ with self;
   stdio = janePackage {
     pname = "stdio";
     hash = "0vv6d8absy4hvjd1babv7avpsdlvjpnd5hq691h39d0h3pvs6l98";
-    minimumOCamlVersion = "4.04.2";
+    minimalOCamlVersion = "4.04.2";
     meta.description = "Standard IO library for OCaml";
     propagatedBuildInputs = [ base ];
   };
@@ -833,7 +828,7 @@ with self;
   time_now = janePackage {
     pname = "time_now";
     hash = "1lyq8zdz93hvpi4hpxh88kds30k5ljil8js9clcqyxrldp5n9mw0";
-    minimumOCamlVersion = "4.04.2";
+    minimalOCamlVersion = "4.04.2";
     meta.description = "Reports the current time";
     buildInputs = [ jst-config ppx_optcomp ];
     propagatedBuildInputs = [ jane-street-headers base ppx_base ];
@@ -856,7 +851,7 @@ with self;
   typerep = janePackage {
     pname = "typerep";
     hash = "0wc7h853ka3s3lxxgm61ypidl0lzgc9abdkil6f72anl0c417y90";
-    minimumOCamlVersion = "4.04.2";
+    minimalOCamlVersion = "4.04.2";
     meta.description = "Typerep is a library for runtime types";
     propagatedBuildInputs = [ base ];
   };
@@ -864,14 +859,13 @@ with self;
   variantslib = janePackage {
     pname = "variantslib";
     hash = "0vy0hpiaawmydh08nqlwjx52pasp74383yi0pshwbdxin99n9mxd";
-    minimumOCamlVersion = "4.04.2";
+    minimalOCamlVersion = "4.04.2";
     meta.description = "Part of Jane Street's Core library";
     propagatedBuildInputs = [ base ];
   };
 
   vcaml = janePackage {
     pname = "vcaml";
-    duneVersion = "3";
     hash = "0ykwrn8bvwx26ad4wb36jw9xnlwsdpnnx88396laxvcfimrp13qs";
     meta.description = "OCaml bindings for the Neovim API";
     propagatedBuildInputs = [ angstrom-async async_extra faraday ];
@@ -879,7 +873,6 @@ with self;
 
   virtual_dom = janePackage {
     pname = "virtual_dom";
-    duneVersion = "3";
     hash = "0vcydxx0jhbd5hbriahgp947mc7n3xymyrsfny1c4adk6aaq3c5w";
     meta.description = "OCaml bindings for the virtual-dom library";
     buildInputs = [ js_of_ocaml-ppx ];
@@ -889,7 +882,7 @@ with self;
   zarith_stubs_js = janePackage {
     pname = "zarith_stubs_js";
     hash = "16p4bn5spkrx31fr4np945v9mwdq55706v3wl19s5fy6x83gvb86";
-    minimumOCamlVersion = "4.04.2";
+    minimalOCamlVersion = "4.04.2";
     meta.description = "Javascripts stubs for the Zarith library";
     doCheck = false; # requires workspace with zarith
   };

--- a/pkgs/development/ocaml-modules/janestreet/0.15.nix
+++ b/pkgs/development/ocaml-modules/janestreet/0.15.nix
@@ -13,7 +13,7 @@ with self;
 
   abstract_algebra = janePackage {
     pname = "abstract_algebra";
-    minimumOCamlVersion = "4.08";
+    minimalOCamlVersion = "4.08";
     hash = "12imf6ibm7qb8r1fpqnrl20x2z14zl3ri1vzg0z8qby9l8bv2fbd";
     meta.description = "A small library describing abstract algebra concepts";
     propagatedBuildInputs = [ base ppx_jane ];
@@ -21,7 +21,7 @@ with self;
 
   accessor = janePackage {
     pname = "accessor";
-    minimumOCamlVersion = "4.09";
+    minimalOCamlVersion = "4.09";
     hash = "17rzf0jpc9s3yrxcnn630jhgsw5mrnrhwbfh62hqxqanascc5rxh";
     meta.description = "A library that makes it nicer to work with nested functional data structures";
     propagatedBuildInputs = [ higher_kinded ];
@@ -29,7 +29,7 @@ with self;
 
   accessor_async = janePackage {
     pname = "accessor_async";
-    minimumOCamlVersion = "4.09";
+    minimalOCamlVersion = "4.09";
     hash = "17r6af55ms0i496jsfx0xpdm336c2vhyf49b3s8s1gpz521wrgmc";
     meta.description = "Accessors for Async types, for use with the Accessor library";
     propagatedBuildInputs = [ accessor_core async_kernel ];
@@ -37,14 +37,14 @@ with self;
 
   accessor_base = janePackage {
     pname = "accessor_base";
-    minimumOCamlVersion = "4.09";
+    minimalOCamlVersion = "4.09";
     hash = "1qvq005vxf6n1c7swzb4bzcqdh471bfb9gcmdj4m57xg85xznc1n";
     meta.description = "Accessors for Base types, for use with the Accessor library";
     propagatedBuildInputs = [ ppx_accessor ];
   };
 
   accessor_core = janePackage {
-    minimumOCamlVersion = "4.09";
+    minimalOCamlVersion = "4.09";
     pname = "accessor_core";
     hash = "0zrs5zbyrhfbah73g22l19bw1mmljhyb3l2mrwcxgbjq9pqp0k9v";
     meta.description = "Accessors for Core types, for use with the Accessor library";
@@ -89,7 +89,6 @@ with self;
 
   async_js = janePackage {
     pname = "async_js";
-    duneVersion = "3";
     hash = "184j077bz686k5lrqswircnrdqldb316ngpzq7xri1pcsl39sy3q";
     meta.description = "A small library that provide Async support for JavaScript platforms";
     buildInputs = [ js_of_ocaml-ppx ];
@@ -111,7 +110,6 @@ with self;
   };
 
   async_rpc_websocket = janePackage {
-    duneVersion = "3";
     pname = "async_rpc_websocket";
     hash = "1n93jhkz5r76xcc40c4i4sxcyfz1dbppz8sjfxpwcwjyi6lyhp1p";
     meta.description = "Library to serve and dispatch Async RPCs over websockets";
@@ -133,10 +131,9 @@ with self;
   };
 
   async_smtp = janePackage {
-    duneVersion = "3";
     pname = "async_smtp";
     hash = "1m00j7wcb0blipnc1m6by70gd96a1k621b4dgvgffp8as04a461r";
-    minimumOCamlVersion = "4.12";
+    minimalOCamlVersion = "4.12";
     meta.description = "SMTP client and server";
     propagatedBuildInputs = [ async_extra async_inotify async_sendfile async_shell async_ssl email_message resource_cache re2_stable sexp_macro ];
   };
@@ -162,7 +159,6 @@ with self;
   };
 
   async_websocket = janePackage {
-    duneVersion = "3";
     pname = "async_websocket";
     hash = "16ixqfnx9jp77bvx11dlzsq0pzfpyiif60hl2q06zncyswky9xgb";
     meta.description = "A library that implements the websocket protocol on top of Async";
@@ -173,7 +169,7 @@ with self;
     pname = "base";
     version = "0.15.1";
     hash = "sha256-CDKQVF+hAvJTo5QmRvyOfQNrdRgz6m+64q9UzNHlJEA=";
-    minimumOCamlVersion = "4.10";
+    minimalOCamlVersion = "4.10";
     meta.description = "Full standard library replacement for OCaml";
     buildInputs = [ dune-configurator ];
     propagatedBuildInputs = [ sexplib0 ];
@@ -183,7 +179,7 @@ with self;
   base_bigstring = janePackage {
     pname = "base_bigstring";
     hash = "1hv3hw2fwqmkrxms1g6rw3c18mmla1z5bva3anx45mnff903iv4q";
-    minimumOCamlVersion = "4.08";
+    minimalOCamlVersion = "4.08";
     meta.description = "String type based on [Bigarray], for use in I/O and C-bindings";
     propagatedBuildInputs = [ int_repr ppx_jane ];
   };
@@ -191,7 +187,7 @@ with self;
   base_quickcheck = janePackage {
     pname = "base_quickcheck";
     hash = "0q73kfr67cz5wp4qn4rq3lpa922hqmvwdiinnans0js65fvlgqsi";
-    minimumOCamlVersion = "4.04.2";
+    minimalOCamlVersion = "4.04.2";
     meta.description = "Randomized testing framework, designed for compatibility with Base";
     propagatedBuildInputs = [ ppx_base ppx_fields_conv ppx_let ppx_sexp_value splittable_random ];
   };
@@ -206,14 +202,13 @@ with self;
   bin_prot = janePackage {
     pname = "bin_prot";
     hash = "1qfqglscc25wwnjx7byqmjcnjww1msnr8940gyg8h93wdq43fjnh";
-    minimumOCamlVersion = "4.04.2";
+    minimalOCamlVersion = "4.04.2";
     meta.description = "A binary protocol generator";
     propagatedBuildInputs = [ ppx_compare ppx_custom_printf ppx_fields_conv ppx_optcomp ppx_variants_conv ];
   };
 
   bonsai = janePackage {
     pname = "bonsai";
-    duneVersion = "3";
     hash = "150zx2g1dmhyrxwqq8j7f2m3hjpmk5bk182ihx2gdbarhw1ainpm";
     meta.description = "A library for building dynamic webapps, using Js_of_ocaml";
     buildInputs = [ ppx_pattern_bind ];
@@ -240,14 +235,13 @@ with self;
     pname = "cinaps";
     version = "0.15.1";
     hash = "0g856cxmxg4vicwslhqldplkpwi158s2d62vwzv26xg5m6wjn9rg";
-    minimumOCamlVersion = "4.04";
+    minimalOCamlVersion = "4.04";
     meta.description = "Trivial metaprogramming tool";
     propagatedBuildInputs = [ re ];
     doCheck = false; # fails because ppx_base doesn't include ppx_js_style
   };
 
   cohttp_async_websocket = janePackage {
-    duneVersion = "3";
     pname = "cohttp_async_websocket";
     hash = "0d0smavnxpnwrmhlcf3b5a3cm3n9kz1y8fh6l28xv6zrn4sc7ik8";
     meta.description = "Websocket library for use with cohttp and async";
@@ -255,7 +249,6 @@ with self;
   };
 
   cohttp_static_handler = janePackage {
-    duneVersion = "3";
     pname = "cohttp_static_handler";
     version = "0.15.0";
     hash = "sha256-ENaH8ChvjeMc9WeNIhkeNBB7YK9vB4lw95o6FFZI1ys=";
@@ -331,7 +324,6 @@ with self;
   };
 
   email_message = janePackage {
-    duneVersion = "3";
     pname = "email_message";
     hash = "00h66l2g5rjaay0hbyqy4v9i866g779miriwv20h9k4mliqdq7in";
     meta.description = "E-mail message parser";
@@ -355,14 +347,14 @@ with self;
   fieldslib = janePackage {
     pname = "fieldslib";
     hash = "0xwf9mdxlyr3f0vv5y82cyw2bsckwl8rwf6jm6bai1gqpgxjq756";
-    minimumOCamlVersion = "4.04.2";
+    minimalOCamlVersion = "4.04.2";
     meta.description = "Syntax extension to define first class values representing record fields, to get and set record fields, iterate and fold over all fields of a record and create new record values";
     propagatedBuildInputs = [ base ];
   };
 
   file_path = janePackage {
     pname = "file_path";
-    minimumOCamlVersion = "4.11";
+    minimalOCamlVersion = "4.11";
     hash = "0vjvxviryywwwfdazcijwhpajp2d4mavlki7lj4qaafjrw62x14k";
     meta.description =
       "A library for typed manipulation of UNIX-style file paths";
@@ -386,7 +378,7 @@ with self;
 
   fzf = janePackage {
     pname = "fzf";
-    minimumOCamlVersion = "4.08";
+    minimalOCamlVersion = "4.08";
     hash = "1ha0i6dx5bgwzbdi4rn98wjwi2imv5p2i7qs7hy0c6cmg88xbdry";
     meta.description = "A library for running the fzf command line tool";
     propagatedBuildInputs = [ async core_kernel ppx_jane ];
@@ -397,7 +389,7 @@ with self;
 
   higher_kinded = janePackage {
     pname = "higher_kinded";
-    minimumOCamlVersion = "4.09";
+    minimalOCamlVersion = "4.09";
     hash = "0rafxxajqswi070h8sinhjna0swh1hc6d7i3q7y099yj3wlr2y1l";
     meta.description = "A library with an encoding of higher kinded types in OCaml";
     propagatedBuildInputs = [ base ppx_jane ];
@@ -405,7 +397,6 @@ with self;
 
   incr_dom = janePackage {
     pname = "incr_dom";
-    duneVersion = "3";
     hash = "1sija9w2im8vdp61h387w0mww9hh7jgkgsjcccps4lbv936ac7c1";
     meta.description = "A library for building dynamic webapps, using Js_of_ocaml";
     buildInputs = [ js_of_ocaml-ppx ];
@@ -445,13 +436,12 @@ with self;
   jane-street-headers = janePackage {
     pname = "jane-street-headers";
     hash = "1lzk3w66x4429n2j75lwm55xafc46mywgdrbh9nc9jwqwgzf0wwx";
-    minimumOCamlVersion = "4.04.2";
+    minimalOCamlVersion = "4.04.2";
     meta.description = "Jane Street C header files";
   };
 
   jsonaf = janePackage {
     pname = "jsonaf";
-    duneVersion = "3";
     hash = "1j9rn8vsvfpgmdpmdqb5qhvss5171j8n3ii1bcgnavqinchbvqa6";
     meta.description = "A library for parsing, manipulating, and serializing data structured as JSON";
     propagatedBuildInputs = [ base ppx_jane angstrom faraday ];
@@ -474,7 +464,7 @@ with self;
   ocaml-compiler-libs = janePackage {
     pname = "ocaml-compiler-libs";
     version = "0.12.4";
-    minimumOCamlVersion = "4.04.1";
+    minimalOCamlVersion = "4.04.1";
     hash = "00if2f7j9d8igdkj4rck3p74y17j6b233l91mq02drzrxj199qjv";
     meta.description = "OCaml compiler libraries repackaged";
   };
@@ -488,7 +478,7 @@ with self;
 
   ocaml_intrinsics = janePackage {
     pname = "ocaml_intrinsics";
-    minimumOCamlVersion = "4.08";
+    minimalOCamlVersion = "4.08";
     version = "0.15.2";
     hash = "sha256-f5zqrKaokj1aEvbu7lOuK0RoWSklFr6QFpV+oWbIX9U=";
     meta.description = "Intrinsics";
@@ -499,7 +489,7 @@ with self;
   parsexp = janePackage {
     pname = "parsexp";
     hash = "1grzpxi39318vcqhwf723hqh11k68irh59zb3dyg9lw8wjn7752a";
-    minimumOCamlVersion = "4.04.2";
+    minimalOCamlVersion = "4.04.2";
     meta.description = "S-expression parsing library";
     propagatedBuildInputs = [ base sexplib0 ];
   };
@@ -527,14 +517,14 @@ with self;
   posixat = janePackage {
     pname = "posixat";
     hash = "1xgycwa0janrfn9psb7xrm0820blr82mqf1lvjy9ipqalj7v9w1f";
-    minimumOCamlVersion = "4.07";
+    minimalOCamlVersion = "4.07";
     propagatedBuildInputs = [ ppx_optcomp ppx_sexp_conv ];
     meta.description = "Binding to the posix *at functions";
   };
 
   ppx_accessor = janePackage {
     pname = "ppx_accessor";
-    minimumOCamlVersion = "4.09";
+    minimalOCamlVersion = "4.09";
     hash = "0qv51if1nk0zff2v6q946h8ac7bpd5xa4ivyixl9g4h2mk29w4qb";
     meta.description = "[@@deriving] plugin to generate accessors for use with the Accessor libraries";
     propagatedBuildInputs = [ accessor ];
@@ -543,7 +533,7 @@ with self;
   ppx_assert = janePackage {
     pname = "ppx_assert";
     hash = "0dic250q3flrjs3i70a2qqqnhqqj75ddlixpy7hdfghjw32azw90";
-    minimumOCamlVersion = "4.04.2";
+    minimalOCamlVersion = "4.04.2";
     meta.description = "Assert-like extension nodes that raise useful errors on failure";
     propagatedBuildInputs = [ ppx_cold ppx_compare ppx_here ppx_sexp_conv ];
   };
@@ -551,7 +541,7 @@ with self;
   ppx_base = janePackage {
     pname = "ppx_base";
     hash = "13rfmy2fxvwi7z5l1mai474ri5anqjm8q4hs7dblplsjjd9m5ld1";
-    minimumOCamlVersion = "4.04.2";
+    minimalOCamlVersion = "4.04.2";
     meta.description = "Base set of ppx rewriters";
     propagatedBuildInputs = [ ppx_cold ppx_enumerate ppx_hash ];
   };
@@ -559,7 +549,7 @@ with self;
   ppx_bench = janePackage {
     pname = "ppx_bench";
     hash = "0bc0gbm922417wqisafxh35jslcp7xy1s0h0a1q32rhx0ivxx3g6";
-    minimumOCamlVersion = "4.04.2";
+    minimalOCamlVersion = "4.04.2";
     meta.description = "Syntax extension for writing in-line benchmarks in ocaml code";
     propagatedBuildInputs = [ ppx_inline_test ];
   };
@@ -567,7 +557,7 @@ with self;
   ppx_bin_prot = janePackage {
     pname = "ppx_bin_prot";
     hash = "1280wsls061fmvmdysjqn3lv4mnkyg400jnjf4jyfr14s33h1ad5";
-    minimumOCamlVersion = "4.04.2";
+    minimalOCamlVersion = "4.04.2";
     meta.description = "Generation of bin_prot readers and writers from types";
     propagatedBuildInputs = [ bin_prot ppx_here ];
     doCheck = false; # circular dependency with ppx_jane
@@ -576,7 +566,7 @@ with self;
   ppx_cold = janePackage {
     pname = "ppx_cold";
     hash = "0x7xgpvy0l28k971xy08ibhr4w9nh8d9zvxc6jfxxx4fbfcv5gca";
-    minimumOCamlVersion = "4.04.2";
+    minimalOCamlVersion = "4.04.2";
     meta.description = "Expands [@cold] into [@inline never][@specialise never][@local never]";
     propagatedBuildInputs = [ ppxlib ];
   };
@@ -584,7 +574,7 @@ with self;
   ppx_compare = janePackage {
     pname = "ppx_compare";
     hash = "1wjwqkr71p61vjidbr80l93y4kkad7xsfyp04w8qfqrj7h5nm625";
-    minimumOCamlVersion = "4.04.2";
+    minimalOCamlVersion = "4.04.2";
     meta.description = "Generation of comparison functions from types";
     propagatedBuildInputs = [ ppxlib base ];
   };
@@ -592,14 +582,13 @@ with self;
   ppx_custom_printf = janePackage {
     pname = "ppx_custom_printf";
     hash = "1k8nmq6kwqz2wpkm9ymq749dz1vd8lxrjc711knp1wyz5935hnsv";
-    minimumOCamlVersion = "4.04.2";
+    minimalOCamlVersion = "4.04.2";
     meta.description = "Printf-style format-strings for user-defined string conversion";
     propagatedBuildInputs = [ ppx_sexp_conv ];
   };
 
   ppx_css = janePackage {
     pname = "ppx_css";
-    duneVersion = "3";
     hash = "09dpmj3f3m3z1ji9hq775iqr3cfmv5gh7q9zlblizj4wx4y0ibyi";
     meta.description = "A ppx that takes in css strings and produces a module for accessing the unique names defined within";
     propagatedBuildInputs = [ core_kernel ppxlib js_of_ocaml js_of_ocaml-ppx sedlex ];
@@ -608,7 +597,7 @@ with self;
   ppx_disable_unused_warnings = janePackage {
     pname = "ppx_disable_unused_warnings";
     hash = "0sb5i4v7p9df2bxk66rjs30k9fqdrwsq1jgykjv6wyrx2d9bv955";
-    minimumOCamlVersion = "4.04.2";
+    minimalOCamlVersion = "4.04.2";
     meta.description = "Expands [@disable_unused_warnings] into [@warning \"-20-26-32-33-34-35-36-37-38-39-60-66-67\"]";
     propagatedBuildInputs = [ ppxlib ];
   };
@@ -616,7 +605,7 @@ with self;
   ppx_enumerate = janePackage {
     pname = "ppx_enumerate";
     hash = "1i0f6jv5cappw3idd70wpg76d7x6mvxapa89kri1bwz47hhg4pkz";
-    minimumOCamlVersion = "4.04.2";
+    minimalOCamlVersion = "4.04.2";
     meta.description = "Generate a list containing all values of a finite type";
     propagatedBuildInputs = [ ppxlib ];
   };
@@ -625,7 +614,7 @@ with self;
     pname = "ppx_expect";
     version = "0.15.1";
     hash = "sha256-qlOipzTTdN9yQ35sItKmWpCv74kbuJLDg4IHNVTKvow=";
-    minimumOCamlVersion = "4.04.2";
+    minimalOCamlVersion = "4.04.2";
     meta.description = "Cram like framework for OCaml";
     propagatedBuildInputs = [ ppx_here ppx_inline_test re ];
     doCheck = false; # test build rules broken
@@ -634,7 +623,7 @@ with self;
   ppx_fields_conv = janePackage {
     pname = "ppx_fields_conv";
     hash = "094wsnw7fcwgl9xg6vkjb0wbgpn9scsp847yhdd184sz9v1amz14";
-    minimumOCamlVersion = "4.04.2";
+    minimalOCamlVersion = "4.04.2";
     meta.description = "Generation of accessor and iteration functions for ocaml records";
     propagatedBuildInputs = [ fieldslib ppxlib ];
   };
@@ -642,7 +631,7 @@ with self;
   ppx_fixed_literal = janePackage {
     pname = "ppx_fixed_literal";
     hash = "10siwcqrqa4gh0mg6fkaby0jjskc01r81pcblc67h3vmbjjh08j9";
-    minimumOCamlVersion = "4.04.2";
+    minimalOCamlVersion = "4.04.2";
     meta.description = "Simpler notation for fixed point literals";
     propagatedBuildInputs = [ ppxlib ];
   };
@@ -650,7 +639,7 @@ with self;
   ppx_hash = janePackage {
     pname = "ppx_hash";
     hash = "15agkwavadllzxdv4syjna02083nfnap8qs4yqf5s0adjw73fzyg";
-    minimumOCamlVersion = "4.04.2";
+    minimalOCamlVersion = "4.04.2";
     meta.description = "A ppx rewriter that generates hash functions from type expressions and definitions";
     propagatedBuildInputs = [ ppx_compare ppx_sexp_conv ];
   };
@@ -658,7 +647,7 @@ with self;
   ppx_here = janePackage {
     pname = "ppx_here";
     hash = "0jv81k8x18q8rxdyfwavrvx8yq9k5m3abpmgdg6zipx2ajcjzvag";
-    minimumOCamlVersion = "4.04.2";
+    minimalOCamlVersion = "4.04.2";
     meta.description = "Expands [%here] into its location";
     propagatedBuildInputs = [ ppxlib ];
     doCheck = false; # test build rules broken
@@ -667,7 +656,7 @@ with self;
   ppx_ignore_instrumentation = janePackage {
     pname = "ppx_ignore_instrumentation";
     hash = "16fgig88g3jr0m3i636fr52h29h1yzhi8nhnl4029zn808kcdyj2";
-    minimumOCamlVersion = "4.08";
+    minimalOCamlVersion = "4.08";
     meta.description = "Ignore Jane Street specific instrumentation extensions";
     propagatedBuildInputs = [ ppxlib ];
   };
@@ -675,7 +664,7 @@ with self;
   ppx_inline_test = janePackage {
     pname = "ppx_inline_test";
     hash = "1a0gaj9p6gbn5j7c258mnzr7yjlq0hqi3aqqgyj1g2dbk1sxdbjz";
-    minimumOCamlVersion = "4.04.2";
+    minimalOCamlVersion = "4.04.2";
     meta.description = "Syntax extension for writing in-line tests in ocaml code";
     propagatedBuildInputs = [ ppxlib time_now ];
     doCheck = false; # test build rules broken
@@ -684,17 +673,16 @@ with self;
   ppx_jane = janePackage {
     pname = "ppx_jane";
     hash = "1p6847gdfnnj6qpa4yh57s6wwpsl7rfgy0q7993chz24h9mhz5lk";
-    minimumOCamlVersion = "4.04.2";
+    minimalOCamlVersion = "4.04.2";
     meta.description = "Standard Jane Street ppx rewriters";
     propagatedBuildInputs = [ base_quickcheck ppx_bin_prot ppx_disable_unused_warnings ppx_expect ppx_fixed_literal ppx_ignore_instrumentation ppx_log ppx_module_timer ppx_optcomp ppx_optional ppx_pipebang ppx_stable ppx_string ppx_typerep_conv ppx_variants_conv ];
   };
 
   ppx_jsonaf_conv = janePackage {
     pname = "ppx_jsonaf_conv";
-    duneVersion = "3";
     version = "0.15.1";
     hash = "0wprs7qmscklyskj4famhaqqisi6jypy414aqba14qdyi43w0cv3";
-    minimumOCamlVersion = "4.08";
+    minimalOCamlVersion = "4.08";
     meta.description =
       "[@@deriving] plugin to generate Jsonaf conversion functions";
     propagatedBuildInputs = [ base jsonaf ppx_jane ppxlib ];
@@ -703,7 +691,7 @@ with self;
   ppx_js_style = janePackage {
     pname = "ppx_js_style";
     hash = "0q2p9pvmlncgv0hprph95xiv7s6q44ynvp4yl4dckf1qx68rb3ba";
-    minimumOCamlVersion = "4.04.2";
+    minimalOCamlVersion = "4.04.2";
     meta.description = "Code style checker for Jane Street Packages";
     propagatedBuildInputs = [ octavius ppxlib ];
   };
@@ -711,7 +699,7 @@ with self;
   ppx_let = janePackage {
     pname = "ppx_let";
     hash = "04v3fq0vnvvavxbc7hfsrg8732pwxbyw8pjl3xfplqdqci6fj15n";
-    minimumOCamlVersion = "4.04.2";
+    minimalOCamlVersion = "4.04.2";
     meta.description = "Monadic let-bindings";
     propagatedBuildInputs = [ ppxlib ppx_here ];
   };
@@ -719,7 +707,7 @@ with self;
   ppx_log = janePackage {
     pname = "ppx_log";
     hash = "08i9gz3f4w3bmlrfdw7ja9awsfkhhldz03bnnc4hijfmn8sawzi0";
-    minimumOCamlVersion = "4.08.0";
+    minimalOCamlVersion = "4.08.0";
     meta.description = "Ppx_sexp_message-like extension nodes for lazily rendering log messages";
     propagatedBuildInputs = [ base ppx_here ppx_sexp_conv ppx_sexp_message sexplib ];
   };
@@ -727,7 +715,7 @@ with self;
   ppx_module_timer = janePackage {
     pname = "ppx_module_timer";
     hash = "0lzi5hxi10p89ddqbrc667267f888kqslal76gfhmszyk60n20av";
-    minimumOCamlVersion = "4.04.2";
+    minimalOCamlVersion = "4.04.2";
     meta.description = "Ppx rewriter that records top-level module startup times";
     propagatedBuildInputs = [ time_now ];
   };
@@ -735,7 +723,7 @@ with self;
   ppx_optcomp = janePackage {
     pname = "ppx_optcomp";
     hash = "0ypivfipi8fcr9pqyvl2ajpcivmr1irdwwv248i4x6mggpc2pl0b";
-    minimumOCamlVersion = "4.04.2";
+    minimalOCamlVersion = "4.04.2";
     meta.description = "Optional compilation for OCaml";
     propagatedBuildInputs = [ ppxlib ];
   };
@@ -743,7 +731,7 @@ with self;
   ppx_optional = janePackage {
     pname = "ppx_optional";
     hash = "0amxwxhkyzamgnxx400qhvxzqr3m4sazhhkc516lm007pynv7xq2";
-    minimumOCamlVersion = "4.04.2";
+    minimalOCamlVersion = "4.04.2";
     meta.description = "Pattern matching on flat options";
     propagatedBuildInputs = [ ppxlib ];
   };
@@ -751,7 +739,7 @@ with self;
   ppx_pattern_bind = janePackage {
     pname = "ppx_pattern_bind";
     hash = "01nfdk9yvk92r7sjl4ngxfsx8fyqh2dsjxz0i299nszv9jc4rn4f";
-    minimumOCamlVersion = "4.07";
+    minimalOCamlVersion = "4.07";
     meta.description = "A ppx for writing fast incremental bind nodes in a pattern match";
     propagatedBuildInputs = [ ppx_let ];
   };
@@ -759,7 +747,7 @@ with self;
   ppx_pipebang = janePackage {
     pname = "ppx_pipebang";
     hash = "0sm5dghyalhws3hy1cc2ih36az1k4q02hcgj6l26gwyma3y4irvq";
-    minimumOCamlVersion = "4.04.2";
+    minimalOCamlVersion = "4.04.2";
     meta.description = "A ppx rewriter that inlines reverse application operators `|>` and `|!`";
     propagatedBuildInputs = [ ppxlib ];
   };
@@ -783,7 +771,7 @@ with self;
   ppx_sexp_message = janePackage {
     pname = "ppx_sexp_message";
     hash = "0a7hx50bkkc5n5msc3zzc4ixnp7674x3mallknb9j31jnd8l90nj";
-    minimumOCamlVersion = "4.04.2";
+    minimalOCamlVersion = "4.04.2";
     meta.description = "A ppx rewriter for easy construction of s-expressions";
     propagatedBuildInputs = [ ppx_here ppx_sexp_conv ];
   };
@@ -791,7 +779,7 @@ with self;
   ppx_sexp_value = janePackage {
     pname = "ppx_sexp_value";
     hash = "0kz83j9v6yz3v8c6vr9ilhkcci4hhjd6i6r6afnx72jh6i7d3hnv";
-    minimumOCamlVersion = "4.04.2";
+    minimalOCamlVersion = "4.04.2";
     meta.description = "A ppx rewriter that simplifies building s-expressions from ocaml values";
     propagatedBuildInputs = [ ppx_here ppx_sexp_conv ];
   };
@@ -799,14 +787,14 @@ with self;
   ppx_stable = janePackage {
     pname = "ppx_stable";
     hash = "1as0v0x8c9ilyhngax55lvwyyi4a2wshyan668v0f2s1608cwb1l";
-    minimumOCamlVersion = "4.04.2";
+    minimalOCamlVersion = "4.04.2";
     meta.description = "Stable types conversions generator";
     propagatedBuildInputs = [ ppxlib ];
   };
 
   ppx_string = janePackage {
     pname = "ppx_string";
-    minimumOCamlVersion = "4.04.2";
+    minimalOCamlVersion = "4.04.2";
     hash = "1dp5frk6cig5m3m5rrh2alw63snyf845x7zlkkaljip02pqcbw1s";
     meta.description = "Ppx extension for string interpolation";
     propagatedBuildInputs = [ ppx_base ppxlib stdio ];
@@ -821,7 +809,7 @@ with self;
 
   ppx_typerep_conv = janePackage {
     pname = "ppx_typerep_conv";
-    minimumOCamlVersion = "4.04.2";
+    minimalOCamlVersion = "4.04.2";
     hash = "1q1lzykpm83ra4l5jh4rfddhd3c96kx4s4rvx0w4b51z1qk56zam";
     meta.description = "Generation of runtime types from type declarations";
     propagatedBuildInputs = [ ppxlib typerep ];
@@ -829,7 +817,7 @@ with self;
 
   ppx_variants_conv = janePackage {
     pname = "ppx_variants_conv";
-    minimumOCamlVersion = "4.04.2";
+    minimalOCamlVersion = "4.04.2";
     hash = "1dh0bw9dn246k00pymf59yjkl6x6bxd76lkk9b5xpq2692wwlc3s";
     meta.description = "Generation of accessor and iteration functions for ocaml variant types";
     propagatedBuildInputs = [ variantslib ppxlib ];
@@ -900,7 +888,6 @@ with self;
 
   sexp = janePackage {
     pname = "sexp";
-    duneVersion = "3";
     hash = "00xlsymm1mpgs8cqkb6c36vh5hfw0saghvwiqh7jry65qc5nvv9z";
     propagatedBuildInputs = [
       async
@@ -934,7 +921,7 @@ with self;
     pname = "sexp_pretty";
     version = "0.15.1";
     hash = "sha256-UJEO2P4C7ZaD110MEfkG4FXfGDVAAW2TAK489faV6SM=";
-    minimumOCamlVersion = "4.07";
+    minimalOCamlVersion = "4.07";
     meta.description = "S-expression pretty-printer";
     propagatedBuildInputs = [ ppx_base re sexplib ];
   };
@@ -942,7 +929,7 @@ with self;
   sexp_select = janePackage {
     pname = "sexp_select";
     hash = "0mmvga9w3gbb2gd1h4l8f1c3l2lrpn1zld2a8xgqyfqfff3vg31p";
-    minimumOCamlVersion = "4.07";
+    minimalOCamlVersion = "4.07";
     propagatedBuildInputs = [ base ppx_jane ];
     meta.description = "A library to use CSS-style selectors to traverse sexp trees";
   };
@@ -951,7 +938,7 @@ with self;
     pname = "sexplib0";
     version = "0.15.1";
     hash = "sha256-6K0yrCbVFcUalN4cQuDI1TvWvNDjfXXRDhJKUskbqRY=";
-    minimumOCamlVersion = "4.04.2";
+    minimalOCamlVersion = "4.04.2";
     meta.description = "Library containing the definition of S-expressions and some base converters";
   };
 
@@ -959,7 +946,7 @@ with self;
     pname = "sexplib";
     version = "0.15.1";
     hash = "sha256-LkGNnp717LMHeWe1Ka6qUZcpw8fKSsd5MusaLgFjm70=";
-    minimumOCamlVersion = "4.04.2";
+    minimalOCamlVersion = "4.04.2";
     meta.description = "Library for serializing OCaml values to and from S-expressions";
     propagatedBuildInputs = [ num parsexp ];
   };
@@ -976,14 +963,14 @@ with self;
   shexp = janePackage {
     pname = "shexp";
     hash = "05iswnhi92f4yvrh76j3254bvls6fbrdb56mv6vc6mi5f8z4l79i";
-    minimumOCamlVersion = "4.07";
+    minimalOCamlVersion = "4.07";
     propagatedBuildInputs = [ posixat spawn ];
     meta.description = "Process library and s-expression based shell";
   };
 
   spawn = janePackage {
     pname = "spawn";
-    minimumOCamlVersion = "4.02.3";
+    minimalOCamlVersion = "4.02.3";
     hash = "1fjr91psas5zmk1hxvxh0dchhn0pkyzlr4gg232f5g9vdgissi0p";
     meta.description = "Spawning sub-processes";
     buildInputs = [ ppx_expect ];
@@ -1006,7 +993,7 @@ with self;
   stdio = janePackage {
     pname = "stdio";
     hash = "0g00b00kpjcadikq2asng35w7kvd24q9ldkiylwmn3gv3lrbipa8";
-    minimumOCamlVersion = "4.04.2";
+    minimalOCamlVersion = "4.04.2";
     meta.description = "Standard IO library for OCaml";
     propagatedBuildInputs = [ base ];
   };
@@ -1028,7 +1015,7 @@ with self;
   time_now = janePackage {
     pname = "time_now";
     hash = "1pa0hyh470j9jylii4983qagb6hq2dz6s0q2fnrcph9qbw83bc0c";
-    minimumOCamlVersion = "4.04.2";
+    minimalOCamlVersion = "4.04.2";
     meta.description = "Reports the current time";
     buildInputs = [ jst-config ppx_optcomp ];
     propagatedBuildInputs = [ jane-street-headers base ppx_base ];
@@ -1051,7 +1038,7 @@ with self;
   typerep = janePackage {
     pname = "typerep";
     hash = "1qxfi01qim0hrgd6d0bgvpxg36i99mmm8cw4wqpr9kxyqvgzv26z";
-    minimumOCamlVersion = "4.04.2";
+    minimalOCamlVersion = "4.04.2";
     meta.description = "Typerep is a library for runtime types";
     propagatedBuildInputs = [ base ];
   };
@@ -1059,13 +1046,12 @@ with self;
   variantslib = janePackage {
     pname = "variantslib";
     hash = "033ns8ph6bd8g5cdfryjfcnrnzkdshppjyw5kl7cvszjfrz33ij7";
-    minimumOCamlVersion = "4.04.2";
+    minimalOCamlVersion = "4.04.2";
     meta.description = "Part of Jane Street's Core library";
     propagatedBuildInputs = [ base ];
   };
 
   vcaml = janePackage {
-    duneVersion = "3";
     pname = "vcaml";
     hash = "12fd29x9dgf4f14xrx7z4y1bm1wbfynrs3jismjbiqnckfpbqrib";
     meta.description = "OCaml bindings for the Neovim API";
@@ -1077,14 +1063,13 @@ with self;
     hash = "15xia9v4ighzm0gv3vbqk9nvg47cvzqmfnl2zr67yxv4b98kyzv3";
     meta.description = "OCaml bindings for the virtual-dom library";
     buildInputs = [ js_of_ocaml-ppx ];
-    duneVersion = "3";
     propagatedBuildInputs = [ core_kernel gen_js_api js_of_ocaml lambdasoup tyxml ];
   };
 
   zarith_stubs_js = janePackage {
     pname = "zarith_stubs_js";
     hash = "119xgr3kla9q1bvs4a5z2ivbmsrz4db3a9z0gf77ryqg4i22ywvl";
-    minimumOCamlVersion = "4.04.2";
+    minimalOCamlVersion = "4.04.2";
     meta.description = "Javascripts stubs for the Zarith library";
   };
 

--- a/pkgs/development/ocaml-modules/janestreet/janePackage_0_14.nix
+++ b/pkgs/development/ocaml-modules/janestreet/janePackage_0_14.nix
@@ -3,16 +3,16 @@
 { pname
 , version ? defaultVersion
 , hash
-, minimumOCamlVersion ? "4.08"
+, minimalOCamlVersion ? "4.08"
 , doCheck ? true
 , buildInputs ? []
 , ...}@args:
 
 buildDunePackage (args // {
-  useDune2 = true;
+  duneVersion = "3";
   inherit version buildInputs;
 
-  inherit minimumOCamlVersion;
+  inherit minimalOCamlVersion;
 
   src = fetchFromGitHub {
     owner = "janestreet";

--- a/pkgs/development/ocaml-modules/janestreet/janePackage_0_15.nix
+++ b/pkgs/development/ocaml-modules/janestreet/janePackage_0_15.nix
@@ -3,16 +3,16 @@
 { pname
 , version ? defaultVersion
 , hash
-, minimumOCamlVersion ? "4.11"
+, minimalOCamlVersion ? "4.11"
 , doCheck ? true
 , buildInputs ? []
 , ...}@args:
 
 buildDunePackage (args // {
-  useDune2 = true;
+  duneVersion = "3";
   inherit version buildInputs;
 
-  inherit minimumOCamlVersion;
+  inherit minimalOCamlVersion;
 
   src = fetchFromGitHub {
     owner = "janestreet";

--- a/pkgs/development/ocaml-modules/jingoo/default.nix
+++ b/pkgs/development/ocaml-modules/jingoo/default.nix
@@ -6,9 +6,9 @@ buildDunePackage rec {
   pname = "jingoo";
   version = "1.4.4";
 
-  useDune2 = true;
+  duneVersion = "3";
 
-  minimumOCamlVersion = "4.04";
+  minimalOCamlVersion = "4.05";
 
   src = fetchFromGitHub {
     owner = "tategakibunko";

--- a/pkgs/development/ocaml-modules/lens/default.nix
+++ b/pkgs/development/ocaml-modules/lens/default.nix
@@ -4,7 +4,7 @@ buildDunePackage rec {
   pname = "lens";
   version = "1.2.5";
 
-  useDune2 = true;
+  duneVersion = "3";
 
   src = fetchFromGitHub {
     owner = "pdonadeo";

--- a/pkgs/development/ocaml-modules/ocaml-lsp/default.nix
+++ b/pkgs/development/ocaml-modules/ocaml-lsp/default.nix
@@ -3,7 +3,7 @@
 buildDunePackage rec {
   pname = "ocaml-lsp-server";
   inherit (lsp) version src preBuild;
-  duneVersion = if lib.versionAtLeast version "1.10.0" then "3" else "2";
+  duneVersion = "3";
 
   buildInputs = lsp.buildInputs ++ [ lsp re ]
   ++ lib.optional (lib.versionAtLeast version "1.9") spawn

--- a/pkgs/development/ocaml-modules/ocaml-lsp/jsonrpc.nix
+++ b/pkgs/development/ocaml-modules/ocaml-lsp/jsonrpc.nix
@@ -40,7 +40,7 @@ buildDunePackage rec {
     inherit (params) sha256;
   };
 
-  duneVersion = if lib.versionAtLeast version "1.10.0" then "3" else "2";
+  duneVersion = "3";
   minimalOCamlVersion = "4.06";
 
   buildInputs =

--- a/pkgs/development/ocaml-modules/ocaml-lsp/lsp.nix
+++ b/pkgs/development/ocaml-modules/ocaml-lsp/lsp.nix
@@ -25,7 +25,7 @@
 buildDunePackage rec {
   pname = "lsp";
   inherit (jsonrpc) version src;
-  duneVersion = if lib.versionAtLeast version "1.10.0" then "3" else "2";
+  duneVersion = "3";
   minimalOCamlVersion =
     if lib.versionAtLeast version "1.7.0" then
       "4.12"

--- a/pkgs/development/ocaml-modules/ocaml-monadic/default.nix
+++ b/pkgs/development/ocaml-modules/ocaml-monadic/default.nix
@@ -6,7 +6,7 @@ buildDunePackage rec {
   pname = "ocaml-monadic";
   version = "0.5.0";
 
-  useDune2 = true;
+  duneVersion = "3";
 
   src = fetchFromGitHub {
     owner = "zepalmer";

--- a/pkgs/development/ocaml-modules/ocamlformat-rpc-lib/default.nix
+++ b/pkgs/development/ocaml-modules/ocamlformat-rpc-lib/default.nix
@@ -21,8 +21,8 @@ buildDunePackage rec {
     inherit (source) sha256;
   };
 
-  minimumOCamlVersion = "4.08";
-  useDune2 = true;
+  minimalOCamlVersion = "4.08";
+  duneVersion = "3";
 
   propagatedBuildInputs = [ csexp sexplib0 ];
 

--- a/pkgs/development/ocaml-modules/ocf/default.nix
+++ b/pkgs/development/ocaml-modules/ocf/default.nix
@@ -3,7 +3,7 @@
 buildDunePackage rec {
   pname = "ocf";
   version = "0.8.0";
-  useDune2 = true;
+  duneVersion = "3";
   minimalOCamlVersion = "4.03";
   src = fetchFromGitLab {
     domain = "framagit.org";

--- a/pkgs/development/ocaml-modules/ocf/ppx.nix
+++ b/pkgs/development/ocaml-modules/ocf/ppx.nix
@@ -4,7 +4,9 @@ buildDunePackage {
   pname = "ocf_ppx";
   minimalOCamlVersion = "4.11";
 
-  inherit (ocf) src version useDune2;
+  inherit (ocf) src version;
+
+  duneVersion = "3";
 
   buildInputs = [ ppxlib ocf ];
 

--- a/pkgs/development/ocaml-modules/ocsigen-ppx-rpc/default.nix
+++ b/pkgs/development/ocaml-modules/ocsigen-ppx-rpc/default.nix
@@ -4,6 +4,8 @@ buildDunePackage rec {
   pname = "ocsigen-ppx-rpc";
   version = "1.0";
 
+  duneVersion = "3";
+
   src = fetchFromGitHub {
     owner = "ocsigen";
     repo = pname;

--- a/pkgs/development/ocaml-modules/pp/default.nix
+++ b/pkgs/development/ocaml-modules/pp/default.nix
@@ -1,5 +1,5 @@
 { buildDunePackage
-, fetchzip
+, fetchurl
 , ppx_expect
 , lib
 }:
@@ -8,12 +8,12 @@ buildDunePackage rec {
   pname = "pp";
   version = "1.1.2";
 
-  src = fetchzip {
+  src = fetchurl {
     url = "https://github.com/ocaml-dune/pp/releases/download/${version}/pp-${version}.tbz";
-    sha256 = "1l1im054pxrkj7zk8m6yj4qfdpxkajpjfvy818ggf0j4nxkaihc5";
+    hash = "sha256-5KTpjZaxu3aVD81tpOk4yG2YnfTX5I8C96RFlfWvHVY=";
   };
 
-  useDune2 = true;
+  duneVersion = "3";
   minimalOCamlVersion = "4.08";
 
   checkInputs = [ ppx_expect ];

--- a/pkgs/development/ocaml-modules/ppx_bap/default.nix
+++ b/pkgs/development/ocaml-modules/ppx_bap/default.nix
@@ -15,9 +15,9 @@
 buildDunePackage rec {
   pname = "ppx_bap";
   version = "0.14";
-  useDune2 = true;
+  duneVersion = "3";
 
-  minimumOCamlVersion = "4.07";
+  minimalOCamlVersion = "4.07";
 
   src = fetchFromGitHub {
     owner = "BinaryAnalysisPlatform";

--- a/pkgs/development/ocaml-modules/ppx_deriving/default.nix
+++ b/pkgs/development/ocaml-modules/ppx_deriving/default.nix
@@ -2,6 +2,7 @@
 , fetchurl
 , buildDunePackage
 , ocaml
+, findlib
 , cppo
 , ppxlib
 , ppx_derivers
@@ -32,7 +33,7 @@ buildDunePackage rec {
   pname = "ppx_deriving";
   inherit (params) version;
 
-  useDune2 = true;
+  duneVersion = "3";
 
   src = fetchurl {
     url = "https://github.com/ocaml-ppx/ppx_deriving/releases/download/v${version}/ppx_deriving-v${version}.tbz";
@@ -42,7 +43,7 @@ buildDunePackage rec {
   strictDeps = true;
 
   nativeBuildInputs = [ cppo ];
-  buildInputs = [ ppxlib ];
+  buildInputs = [ findlib ppxlib ];
   propagatedBuildInputs = [
     (if params.useOMP2
     then ocaml-migrate-parsetree-2

--- a/pkgs/development/ocaml-modules/ppx_deriving_protobuf/default.nix
+++ b/pkgs/development/ocaml-modules/ppx_deriving_protobuf/default.nix
@@ -6,7 +6,7 @@ buildDunePackage rec {
   pname = "ppx_deriving_protobuf";
   version = "3.0.0";
 
-  useDune2 = true;
+  duneVersion = "3";
 
   src = fetchurl {
     url = "https://github.com/ocaml-ppx/ppx_deriving_protobuf/releases/download/v${version}/ppx_deriving_protobuf-v${version}.tbz";

--- a/pkgs/development/ocaml-modules/ppx_deriving_yojson/default.nix
+++ b/pkgs/development/ocaml-modules/ppx_deriving_yojson/default.nix
@@ -17,6 +17,7 @@ buildDunePackage rec {
   inherit (param) version;
 
   minimalOCamlVersion = "4.07";
+  duneVersion = "3";
 
   src = fetchFromGitHub {
     owner = "ocaml-ppx";

--- a/pkgs/development/ocaml-modules/ppx_gen_rec/default.nix
+++ b/pkgs/development/ocaml-modules/ppx_gen_rec/default.nix
@@ -9,8 +9,8 @@ buildDunePackage rec {
     sha256 = "sha256-/mMj5UT22KQGVy1sjgEoOgPzyCYyeDPtWJYNDvQ9nlk=";
   };
 
-  minimumOCamlVersion = "4.07";
-  useDune2 = true;
+  minimalOCamlVersion = "4.07";
+  duneVersion = "3";
 
   buildInputs = [ ppxlib ];
 

--- a/pkgs/development/ocaml-modules/ppx_import/default.nix
+++ b/pkgs/development/ocaml-modules/ppx_import/default.nix
@@ -26,6 +26,7 @@ buildDunePackage rec {
   inherit version;
 
   minimalOCamlVersion = "4.05";
+  duneVersion = "3";
 
   src = fetchurl {
     url = "https://github.com/ocaml-ppx/ppx_import/releases/download/${version}/ppx_import-${version}.tbz";

--- a/pkgs/development/ocaml-modules/ppxlib/default.nix
+++ b/pkgs/development/ocaml-modules/ppxlib/default.nix
@@ -66,7 +66,7 @@ buildDunePackage rec {
   pname = "ppxlib";
   inherit version;
 
-  duneVersion = if param.useDune2 or true then "2" else "1";
+  duneVersion = if param.useDune2 or true then "3" else "1";
 
   src = fetchurl {
     url = "https://github.com/ocaml-ppx/ppxlib/releases/download/${version}/ppxlib-${version}.tbz";

--- a/pkgs/development/ocaml-modules/secp256k1/default.nix
+++ b/pkgs/development/ocaml-modules/secp256k1/default.nix
@@ -4,6 +4,8 @@ buildDunePackage rec {
   pname = "secp256k1";
   version = "0.4.4";
 
+  duneVersion = "3";
+
   src = fetchFromGitHub {
     owner = "dakk";
     repo = "secp256k1-ml";

--- a/pkgs/development/ocaml-modules/visitors/default.nix
+++ b/pkgs/development/ocaml-modules/visitors/default.nix
@@ -4,9 +4,9 @@ buildDunePackage rec {
   pname = "visitors";
   version = "20210608";
 
-  useDune2 = true;
+  duneVersion = "3";
 
-  minimumOCamlVersion = "4.08";
+  minimalOCamlVersion = "4.08";
 
   src = fetchFromGitLab {
     owner = "fpottier";


### PR DESCRIPTION
###### Description of changes

Fixes `coqPackages_8_12.coq-elpi` (failure reported there: https://github.com/NixOS/nixpkgs/pull/225376#discussion_r1172327754). cc @proux01

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
