### PR TITLE
python3Packages.flet: init at 0.6.2

### DIFF
--- a/pkgs/development/python-modules/flet-core/default.nix
+++ b/pkgs/development/python-modules/flet-core/default.nix
@@ -1,0 +1,35 @@
+{ lib
+, python3
+, buildPythonPackage
+, fetchPypi
+}:
+
+buildPythonPackage rec {
+  pname = "flet-core";
+  version = "0.6.2";
+  format = "pyproject";
+
+  src = fetchPypi {
+    pname = "flet_core";
+    inherit version;
+    hash = "sha256-WMkm+47xhuYz1HsiPfF7YbOCg7Xlbj9oHI9nVtwAb/w=";
+  };
+
+  nativeBuildInputs = with python3.pkgs; [
+    poetry-core
+  ];
+
+  propagatedBuildInputs = with python3.pkgs; [
+    typing-extensions
+    repath
+  ];
+
+  doCheck = false;
+
+  meta = {
+    description = "The library is the foundation of Flet framework and is not intended to be used directly";
+    homepage = "https://flet.dev/";
+    license = lib.licenses.asl20;
+    maintainers = [ lib.maintainers.heyimnova ];
+  };
+}

--- a/pkgs/development/python-modules/flet/default.nix
+++ b/pkgs/development/python-modules/flet/default.nix
@@ -1,0 +1,50 @@
+{ lib
+, python3
+, buildPythonPackage
+, fetchPypi
+}:
+
+buildPythonPackage rec {
+  pname = "flet";
+  version = "0.6.2";
+  format = "pyproject";
+
+  src = fetchPypi {
+    inherit pname version;
+    hash = "sha256-EDNATwO2N4jXVC5H1VmXqC9XGTnQo8vLvTEozRYZuj4=";
+  };
+
+  patches = [
+    ./pyproject.toml.patch
+  ];
+
+  nativeBuildInputs = with python3.pkgs; [
+    poetry-core
+  ];
+
+  propagatedBuildInputs = with python3.pkgs; [
+    flet-core
+    typing-extensions
+    websocket-client
+    watchdog
+    oauthlib
+    websockets
+    httpx
+    packaging
+  ];
+
+  doCheck = false;
+
+  pythonImportsCheck = [
+    "flet"
+  ];
+
+  meta = {
+    description = "A framework that enables you to easily build realtime web, mobile, and desktop apps in Python";
+    homepage = "https://flet.dev/";
+    changelog = "https://github.com/flet-dev/flet/releases/tag/v${version}";
+    license = lib.licenses.asl20;
+    maintainers = [ lib.maintainers.heyimnova ];
+    mainProgram = "flet";
+  };
+}

--- a/pkgs/development/python-modules/flet/pyproject.toml.patch
+++ b/pkgs/development/python-modules/flet/pyproject.toml.patch
@@ -1,0 +1,11 @@
+--- a/pyproject.toml
++++ b/pyproject.toml
+@@ -20,7 +20,7 @@ flet-core = "0.6.2"
+ python = "^3.7"
+ typing-extensions = { version = "^4.4.0", python = "<3.8" }
+ websocket-client = "^1.4.2"
+-watchdog = "^2.2.1"
++watchdog = ">=2.2.1"
+ oauthlib = "^3.2.2"
+ websockets = "^10.4"
+ httpx = "^0.23.3"

--- a/pkgs/development/python-modules/repath/default.nix
+++ b/pkgs/development/python-modules/repath/default.nix
@@ -1,0 +1,30 @@
+{ lib
+, python3
+, buildPythonPackage
+, fetchPypi
+}:
+
+buildPythonPackage rec {
+  pname = "repath";
+  version = "0.9.0";
+
+  src = fetchPypi {
+    inherit pname version;
+    hash = "sha256-gpITm6xqDkP9nXBgXU6NrrJdRmcuSE7TGiTHzgrvD7c=";
+  };
+
+  propagatedBuildInputs = with python3.pkgs; [
+    six
+  ];
+
+  pythonImportsCheck = [
+    "repath"
+  ];
+
+  meta = {
+    description = "A port of the node module path-to-regexp to Python";
+    homepage = "https://github.com/nickcoutsos/python-repath";
+    license = lib.licenses.mit;
+    maintainers = [ lib.maintainers.heyimnova ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -10252,6 +10252,8 @@ self: super: with self; {
 
   reparser = callPackage ../development/python-modules/reparser { };
 
+  repath = callPackage ../development/python-modules/repath { };
+
   repeated-test = callPackage ../development/python-modules/repeated-test { };
 
   repocheck = callPackage ../development/python-modules/repocheck { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -3641,6 +3641,8 @@ self: super: with self; {
 
   fleep = callPackage ../development/python-modules/fleep { };
 
+  flet = callPackage ../development/python-modules/flet { };
+
   flet-core = callPackage ../development/python-modules/flet-core { };
 
   flexmock = callPackage ../development/python-modules/flexmock { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -3641,6 +3641,8 @@ self: super: with self; {
 
   fleep = callPackage ../development/python-modules/fleep { };
 
+  flet-core = callPackage ../development/python-modules/flet-core { };
+
   flexmock = callPackage ../development/python-modules/flexmock { };
 
   flickrapi = callPackage ../development/python-modules/flickrapi { };


### PR DESCRIPTION
###### Description of changes

python3Packages.flet: init at 0.6.2
python3Packages.flet-core: init at 0.6.2
python3Packages.repath: init at 0.9.0

Add the [Flet](https://flet.dev/) Python module, a framework for easily building Flutter apps with Python. Also add [flet-core](https://pypi.org/project/flet-core/) as it is a dependency of [flet](https://pypi.org/project/flet/), and add [repath](https://pypi.org/project/repath/) as it is a dependency of flet-core.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
