### PR TITLE
juicefs: add mount.juicefs symlink

### DIFF
--- a/pkgs/tools/filesystems/juicefs/default.nix
+++ b/pkgs/tools/filesystems/juicefs/default.nix
@@ -26,6 +26,10 @@ buildGoModule rec {
     rm $out/bin/libjfs
   '';
 
+  postInstall = ''
+    ln -s $out/bin/juicefs $out/bin/mount.juicefs
+  '';
+
   meta = with lib; {
     description = "A distributed POSIX file system built on top of Redis and S3";
     homepage = "https://www.juicefs.com/";


### PR DESCRIPTION
Add mount.juicefs symlink so that /etc/fstab can mount juicefs fsType as required to use the NixOS fileSystems option with juicefs

###### Description of changes

In order to use the NixOS fileSystems option to configure a juicefs mount, 'mount.juicefs' needs to exist, so a symlink is created via postInstall. This mirrors [s3fs](https://github.com/NixOS/nixpkgs/blob/b04b3345f16716f7289724286cdc8474d4758a41/pkgs/tools/filesystems/s3fs/default.nix#L22), another fuse-based filesystem. 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [Y] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [X] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
