### PR TITLE
python3Packages.django-cryptography: include missing source files

### DIFF
--- a/pkgs/development/python-modules/django-cryptography/default.nix
+++ b/pkgs/development/python-modules/django-cryptography/default.nix
@@ -3,6 +3,7 @@
 , django
 , django-appconf
 , fetchFromGitHub
+, fetchpatch
 , lib
 , python
 , pythonOlder
@@ -30,6 +31,11 @@ buildPythonPackage rec {
     cryptography
     django
     django-appconf
+  ];
+
+  patches = [
+    # See: https://github.com/georgemarshall/django-cryptography/pull/88
+    ./fix-setup-cfg.patch
   ];
 
   pythonImportsCheck = [ "django_cryptography" ];

--- a/pkgs/development/python-modules/django-cryptography/fix-setup-cfg.patch
+++ b/pkgs/development/python-modules/django-cryptography/fix-setup-cfg.patch
@@ -1,0 +1,16 @@
+diff --git a/setup.cfg b/setup.cfg
+index 865b4c3..577d917 100644
+--- a/setup.cfg
++++ b/setup.cfg
+@@ -35,7 +35,10 @@ project_urls =
+     Documentation = https://django-cryptography.readthedocs.io
+ 
+ [options]
+-packages = django_cryptography
++packages =
++    django_cryptography
++    django_cryptography.core
++    django_cryptography.utils
+ python_requires = >=3.6
+ include_package_data = True
+ install_requires =


### PR DESCRIPTION
###### Description of changes

Some source files are missing from the package. This change ensures they are included.

Before:
```
$ find result/lib/python3.10/site-packages/django_cryptography | grep -v pycache
result/lib/python3.10/site-packages/django_cryptography
result/lib/python3.10/site-packages/django_cryptography/fields.py
result/lib/python3.10/site-packages/django_cryptography/conf.py
result/lib/python3.10/site-packages/django_cryptography/__init__.py
```

After:
```
$ find result/lib/python3.10/site-packages/django_cryptography | grep -v pycache
result/lib/python3.10/site-packages/django_cryptography
result/lib/python3.10/site-packages/django_cryptography/core
result/lib/python3.10/site-packages/django_cryptography/core/signing.py
result/lib/python3.10/site-packages/django_cryptography/core/__init__.py
result/lib/python3.10/site-packages/django_cryptography/fields.py
result/lib/python3.10/site-packages/django_cryptography/conf.py
result/lib/python3.10/site-packages/django_cryptography/__init__.py
result/lib/python3.10/site-packages/django_cryptography/utils
result/lib/python3.10/site-packages/django_cryptography/utils/__init__.py
result/lib/python3.10/site-packages/django_cryptography/utils/crypto.py
```

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).