### PR TITLE
antora: repackage using buildNpmPackage

### DIFF
--- a/pkgs/development/node-packages/aliases.nix
+++ b/pkgs/development/node-packages/aliases.nix
@@ -33,7 +33,8 @@ let
       aliases;
 in
 
-mapAliases ({
+mapAliases {
+  "@antora/cli" = pkgs.antora;
   "@githubnext/github-copilot-cli" = pkgs.github-copilot-cli; # Added 2023-05-02
   "@nestjs/cli" = pkgs.nest-cli;
-})
+}

--- a/pkgs/development/node-packages/node-packages.json
+++ b/pkgs/development/node-packages/node-packages.json
@@ -1,8 +1,6 @@
 [
   "@angular/cli"
 , "@antfu/ni"
-, "@antora/cli"
-, "@antora/site-generator-default"
 , "@astrojs/language-server"
 , "@bitwarden/cli"
 , "@commitlint/cli"

--- a/pkgs/development/tools/documentation/antora/default.nix
+++ b/pkgs/development/tools/documentation/antora/default.nix
@@ -1,24 +1,33 @@
-{ lib, nodePackages }:
+{ lib, buildNpmPackage, fetchFromGitLab }:
 
-let
-  linkNodeDeps = ({ pkg, deps, name ? "" }:
-    let
-      targetModule = if name != "" then name else lib.getName pkg;
-    in nodePackages.${pkg}.override (oldAttrs: {
-      postInstall = ''
-        mkdir -p $out/lib/node_modules/${targetModule}/node_modules
-        ${lib.concatStringsSep "\n" (map (dep: ''
-          ln -s ${nodePackages.${dep}}/lib/node_modules/${lib.getName dep} \
-            $out/lib/node_modules/${targetModule}/node_modules/${lib.getName dep}
-        '') deps
-        )}
-      '';
-    })
-);
-in linkNodeDeps {
- pkg = "@antora/cli";
- name = "@antora/cli";
- deps = [
-   "@antora/site-generator-default"
- ];
+buildNpmPackage rec {
+  pname = "antora";
+  version = "3.1.3";
+
+  src = fetchFromGitLab {
+    owner = pname;
+    repo = pname;
+    rev = "v${version}";
+    hash = "sha256-pOEIARvDXc40sljeyUk51DY6LuhVk7pHfrd9YF5Dsu4=";
+  };
+
+  npmDepsHash = "sha256-G1/AMwCD2OWuAkqz6zGp1lmaiCAyKIdtwqC902hkZGo=";
+
+  # This is to stop tests from being ran, as some of them fail due to trying to query remote repositories
+  postPatch = ''
+    substituteInPlace package.json --replace \
+      '"_mocha"' '""'
+  '';
+
+  postInstall = ''
+    mkdir -p $out/bin
+    ln -s $out/lib/node_modules/antora-build/packages/cli/bin/antora $out/bin/antora
+  '';
+
+  meta = with lib; {
+    description = "A modular documentation site generator. Designed for users of Asciidoctor.";
+    homepage = "https://antora.org";
+    license = licenses.mpl20;
+    maintainers = [ maintainers.ehllie ];
+  };
 }


### PR DESCRIPTION
###### Description of changes
Repackages `nodePackages.@antora/cli` to be built using `buildNpmPackage` as per the suggestion in #229475
@winterqt 
###### Things done
I've had to link the long `$out/lib/node_modules/antora-build/packages/cli/bin/antora` path to `$out/bin/antora` because the the base repository is a monorepo containing a bunch of tools. I tried setting an npm flag `--package cli` to only build the `@antora/cli`, but that doesn't seem to have changed anything. Is there a better way of doing this?

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
