### PR TITLE
gnum4: fix build on loongarch64-linux

### DIFF
--- a/pkgs/development/tools/misc/gnum4/default.nix
+++ b/pkgs/development/tools/misc/gnum4/default.nix
@@ -14,6 +14,13 @@ stdenv.mkDerivation rec {
     sha256 = "sha256-swapHA/ZO8QoDPwumMt6s5gf91oYe+oyk4EfRSyJqMg=";
   };
 
+  # https://gitweb.gentoo.org/repo/gentoo.git/tree/sys-devel/m4/m4-1.4.19-r1.ebuild
+  patches = lib.optional stdenv.hostPlatform.isLoongArch64 ./loong-fix-build.patch;
+  postPatch = if stdenv.hostPlatform.isLoongArch64 then ''
+    touch ./aclocal.m4 ./lib/config.hin ./configure ./doc/stamp-vti || die
+    find . -name Makefile.in -exec touch {} + || die
+  '' else null;
+
   strictDeps = true;
   enableParallelBuilding = true;
 

--- a/pkgs/development/tools/misc/gnum4/loong-fix-build.patch
+++ b/pkgs/development/tools/misc/gnum4/loong-fix-build.patch
@@ -1,0 +1,30 @@
+[xen0n: this is https://github.com/sunhaiyong1978/CLFS-for-LoongArch/blob/1.0/patches/stack-direction-add-loongarch.patch with line number tweak, and change to generated file added as well.]
+From: Sun Haiyong <youbest@sina.com>
+Date: Tue, 31 Aug 2021 11:11:52 +0800
+Subject: [PATCH] stack-direction: Add support for loongarch CPU
+
+* m4/stack-direction.m4 (SV_STACK_DIRECTION): When the CPU is loongarch,
+set "sv_cv_stack_direction" to "-1" .
+--- a/m4/stack-direction.m4
++++ b/m4/stack-direction.m4
+@@ -31,6 +31,7 @@ AC_DEFUN([SV_STACK_DIRECTION],
+       i?86 | x86_64 | \
+       i860 | \
+       ia64 | \
++      loongarch* | \
+       m32r | \
+       m68* | \
+       m88k | \
+--- a/configure
++++ b/configure
+@@ -46399,6 +46399,7 @@ else $as_nop
+       i?86 | x86_64 | \
+       i860 | \
+       ia64 | \
++      loongarch* | \
+       m32r | \
+       m68* | \
+       m88k | \
+-- 
+2.17.2
+


### PR DESCRIPTION
###### Description of changes

While adding `autoreconfHook` should work for cross builds, `gnum4` appears so early in the native bootstrap that `autoreconfHook` would cause infinite recursion. As a result, a brutal `postPatch` from Gentoo.

Follow-up of #229539.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
