### PR TITLE
tplay: init at 0.3.1 (wip)

### DIFF
--- a/pkgs/tools/misc/tplay/default.nix
+++ b/pkgs/tools/misc/tplay/default.nix
@@ -1,4 +1,5 @@
 { lib
+, stdenv
 , fetchFromGitHub
 , rustPlatform
 , pkg-config
@@ -6,22 +7,26 @@
 , ffmpeg
 , llvmPackages_13
 , glibc
+, openssl
+, alsa-lib
+, rust-cbindgen
 }:
 
 let llvmPackages = llvmPackages_13; in
 rustPlatform.buildRustPackage rec {
   pname = "tplay";
-  version = "0.4.5";
+  version = "unstable-2023-10-23";
 
   src = fetchFromGitHub {
     # owner = "maxcurzi";
     owner = "maxcurzi";
     repo = pname;
-    rev = "v${version}";
-    hash = "sha256-qt5I5rel88NWJZ6dYLCp063PfVmGTzkUUKgF3JkhLQk=";
+    # rev = "v${version}";
+    rev = "1f07e66e8331cc8abec04b7285d5759ccba8154b";
+    hash = "sha256-zGnnLDqP3vqS2KWBNZ1+7YrqKbRHe33c9dCWmFAb68c=";
   };
 
-  cargoHash = "sha256-7gG7V+QNp3YeRoLMSVO7bZL25jNr5EwT4FrvXoT2Gpo=";
+  cargoHash = "sha256-eVWOLA+5TVZulMs1q9+62EE7IGdWYugolp7QL6Qe03I=";
 
   configurePhase = ''
     export LIBCLANG_PATH="${llvmPackages.libclang.lib}/lib";
@@ -33,13 +38,19 @@ rustPlatform.buildRustPackage rec {
     llvmPackages.llvm
     pkg-config
     rustPlatform.bindgenHook
+    rust-cbindgen
   ];
 
   buildInputs = [
-    llvmPackages.libclang
-    glibc
-    opencv
+    alsa-lib
     ffmpeg
+    glibc
+    llvmPackages.clang
+    llvmPackages.libclang
+    opencv
+    openssl
+    stdenv.cc.cc.lib
+    stdenv.cc.cc
   ];
 
   meta = with lib; {

--- a/pkgs/tools/misc/tplay/default.nix
+++ b/pkgs/tools/misc/tplay/default.nix
@@ -1,0 +1,51 @@
+{ lib
+, fetchFromGitHub
+, rustPlatform
+, pkg-config
+, opencv
+, ffmpeg
+, llvmPackages_13
+, glibc
+}:
+
+let llvmPackages = llvmPackages_13; in
+rustPlatform.buildRustPackage rec {
+  pname = "tplay";
+  version = "0.4.5";
+
+  src = fetchFromGitHub {
+    # owner = "maxcurzi";
+    owner = "maxcurzi";
+    repo = pname;
+    rev = "v${version}";
+    hash = "sha256-qt5I5rel88NWJZ6dYLCp063PfVmGTzkUUKgF3JkhLQk=";
+  };
+
+  cargoHash = "sha256-7gG7V+QNp3YeRoLMSVO7bZL25jNr5EwT4FrvXoT2Gpo=";
+
+  configurePhase = ''
+    export LIBCLANG_PATH="${llvmPackages.libclang.lib}/lib";
+  '';
+
+  nativeBuildInputs = [
+    llvmPackages.clang
+    llvmPackages.libclang
+    llvmPackages.llvm
+    pkg-config
+    rustPlatform.bindgenHook
+  ];
+
+  buildInputs = [
+    llvmPackages.libclang
+    glibc
+    opencv
+    ffmpeg
+  ];
+
+  meta = with lib; {
+    homepage = "https://github.com/maxcurzi/tplay";
+    description = "A terminal ASCII media player. View images, gifs, videos, webcam, YouTube, etc.. directly in the terminal as ASCII art.";
+    license = licenses.mit;
+    platforms = lib.platforms.unix;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -13975,6 +13975,8 @@ with pkgs;
 
   toybox = darwin.apple_sdk_11_0.callPackage ../tools/misc/toybox { };
 
+  tplay = callPackage ../tools/misc/tplay { };
+
   trackma = callPackage ../tools/misc/trackma { };
 
   trackma-curses = trackma.override { withCurses = true; };


### PR DESCRIPTION
###### Description of changes

Draft:

1. This uses my fork with Cargo.lock added.
2. This doesn't build, `opencv` fails to build via cargo:

```
tplay>   === Detected OpenCV module header dir at: /nix/store/wyc32im5p1vl9qv4h6jhq1fx6g8hbzic-opencv-4.7.0/include/opencv4/opencv2
tplay>   === Found OpenCV version: 4.7.0 in headers located at: /nix/store/wyc32im5p1vl9qv4h6jhq1fx6g8hbzic-opencv-4.7.0/include/opencv4
tplay>   === Generating code in: /build/source/target/x86_64-unknown-linux-gnu/release/build/opencv-5ea55105c2eccf01/out
tplay>   === Placing generated bindings into: /build/source/target/x86_64-unknown-linux-gnu/release/build/opencv-5ea55105c2eccf01/out/opencv
tplay>   === Using OpenCV headers from: /nix/store/wyc32im5p1vl9qv4h6jhq1fx6g8hbzic-opencv-4.7.0/include/opencv4
tplay>   === Clang: clang version 11.1.0
tplay>   === Clang command line args: [
tplay>       "-isystem/nix/store/7jc6w98k05chdcs40pb9skflfkk8c50h-compiler-rt-libc-11.1.0-dev/include",
tplay>       "-isystem/nix/store/s4mlim0d9aigjcx9xgh5j25kra9q91mr-clang-11.1.0-dev/include",
tplay>       "-isystem/nix/store/xc1pa2l2pxychc7yirdm2jqwm7b35x75-glibc-2.37-8-dev/include",
tplay>       "-isystem/nix/store/wyc32im5p1vl9qv4h6jhq1fx6g8hbzic-opencv-4.7.0/include",
tplay>       "-isystem/nix/store/8b6iqs31p8kriw9c98p4v7qdx4fvm9j7-gcc-12.2.0/include/c++/12.2.0",
tplay>       "-isystem/nix/store/8b6iqs31p8kriw9c98p4v7qdx4fvm9j7-gcc-12.2.0/include/c++/12.2.0/x86_64-unknown-linux-gnu",
tplay>       "-isystem/nix/store/jyhyc4w89ra87qlss72hhynacb3xbdn3-clang-wrapper-11.1.0/resource-root/include",
tplay>       "-I/nix/store/wyc32im5p1vl9qv4h6jhq1fx6g8hbzic-opencv-4.7.0/include/opencv4",
tplay>       "-F/nix/store/wyc32im5p1vl9qv4h6jhq1fx6g8hbzic-opencv-4.7.0/include/opencv4",
tplay>       "-I/build/cargo-vendor-dir/opencv-0.80.0/src_cpp",
tplay>       "-F/build/cargo-vendor-dir/opencv-0.80.0/src_cpp",
tplay>       "-DOCVRS_PARSING_HEADERS",
tplay>       "-includeocvrs_ephemeral.hpp",
tplay>       "-std=c++14",
tplay>   ]
tplay>   === Building binding-generator binary:
tplay>   === error: failed to get `libc` as a dependency of package `opencv v0.80.0 (/build/cargo-vendor-dir/opencv-0.80.0)`
tplay>   ===
tplay>   === Caused by:
tplay>   ===   failed to load source for dependency `libc`
tplay>   ===
tplay>   === Caused by:
tplay>   ===   Unable to update registry `crates-io`
tplay>   ===
tplay>   === Caused by:
tplay>   ===   failed to update replaced source registry `crates-io`
tplay>   ===
tplay>   === Caused by:
       > warning: build failed, waiting for other jobs to finish...
       For full logs, run 'nix log /nix/store/cifxjpbjcbfaciaxjr61b5dh41a5mfnh-tplay-0.3.1.drv'.
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
