### PR TITLE
gcc-arm-embedded: pass args to gdb

### DIFF
--- a/pkgs/development/compilers/gcc-arm-embedded/11/default.nix
+++ b/pkgs/development/compilers/gcc-arm-embedded/11/default.nix
@@ -50,7 +50,7 @@ stdenv.mkDerivation rec {
     #!${runtimeShell}
     export PYTHONPATH=${python38}/lib/python3.8
     export PYTHONHOME=${python38}/bin/python3.8
-    $out/bin/arm-none-eabi-gdb-unwrapped
+    exec $out/bin/arm-none-eabi-gdb-unwrapped "\$@"
     EOF
     chmod +x $out/bin/arm-none-eabi-gdb
   '';

--- a/pkgs/development/compilers/gcc-arm-embedded/12/default.nix
+++ b/pkgs/development/compilers/gcc-arm-embedded/12/default.nix
@@ -52,7 +52,7 @@ stdenv.mkDerivation rec {
     #!${runtimeShell}
     export PYTHONPATH=${python38}/lib/python3.8
     export PYTHONHOME=${python38}/bin/python3.8
-    $out/bin/arm-none-eabi-gdb-unwrapped
+    exec $out/bin/arm-none-eabi-gdb-unwrapped "\$@"
     EOF
     chmod +x $out/bin/arm-none-eabi-gdb
   '';


### PR DESCRIPTION
###### Description of changes

The wrapper around `arm-none-eabi-gdb` was not passing through the command line arguments. This would cause build systems that attempted to determine the gdb version to hang.

Match the other wrapper by adding `"$@"`, and using `exec` to call the unwrapped process.


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
