### PR TITLE
Revert "nodejs: explicitly disable __contentAddressed"

### DIFF
--- a/pkgs/development/web/nodejs/nodejs.nix
+++ b/pkgs/development/web/nodejs/nodejs.nix
@@ -96,14 +96,6 @@ let
 
     enableParallelBuilding = true;
 
-    # Don't allow enabling content addressed conversion as `nodejs`
-    # checksums it's image before conversion happens and image loading
-    # breaks:
-    #   $ nix build -f. nodejs --arg config '{ contentAddressedByDefault = true; }'
-    #   $ ./result/bin/node
-    #   Check failed: VerifyChecksum(blob).
-    __contentAddressed = false;
-
     passthru.interpreterName = "nodejs";
 
     passthru.pkgs = callPackage ../../node-packages/default.nix {


### PR DESCRIPTION
Reverts NixOS/nixpkgs#225264

This feature breaks cache.nixos.org caching when using nix version 2.3.16 because that version of nix assumes this is a regular environment variable that ends up in the .drv file and produces a different outpath. Since lib/minver.nix says 2.3 is the minimum required version, it is not reasonable to use features that don't work on that version.

cc @trofi 