### PR TITLE
r2modman: init at 3.1.42

### DIFF
--- a/pkgs/games/r2modman/default.nix
+++ b/pkgs/games/r2modman/default.nix
@@ -1,0 +1,113 @@
+{ lib
+, stdenv
+, yarn
+, fetchYarnDeps
+, fixup_yarn_lock
+, nodejs
+, electron
+, fetchFromGitHub
+, gitUpdater
+, makeWrapper
+, makeDesktopItem
+, copyDesktopItems
+}:
+
+stdenv.mkDerivation rec {
+  pname = "r2modman";
+  version = "3.1.42";
+
+  src = fetchFromGitHub {
+    owner = "ebkr";
+    repo = "r2modmanPlus";
+    rev = "v${version}";
+    hash = "sha256-16sE706iivYoI40JJUkqVmtxkYsgAFBg+0tXOc6scqc=";
+  };
+
+  offlineCache = fetchYarnDeps {
+    yarnLock = "${src}/yarn.lock";
+    hash = "sha256-CXitb/b2tvTfrkFrFv4KP4WdmMg+1sDtC/s2u5ezDfI=";
+  };
+
+  nativeBuildInputs = [
+    yarn
+    fixup_yarn_lock
+    nodejs
+    makeWrapper
+    copyDesktopItems
+  ];
+
+  configurePhase = ''
+    runHook preConfigure
+
+    # Workaround for webpack bug
+    # https://github.com/webpack/webpack/issues/14532
+    export NODE_OPTIONS="--openssl-legacy-provider"
+    export HOME=$(mktemp -d)
+    yarn config --offline set yarn-offline-mirror $offlineCache
+    fixup_yarn_lock yarn.lock
+    yarn install --offline --frozen-lockfile --ignore-platform --ignore-scripts --no-progress --non-interactive
+    patchShebangs node_modules/
+
+    runHook postConfigure
+  '';
+
+  buildPhase = ''
+    runHook preBuild
+
+    yarn --offline quasar build --mode electron --skip-pkg
+
+    # Remove dev dependencies.
+    yarn install --production --offline --frozen-lockfile --ignore-platform --ignore-scripts --no-progress --non-interactive
+
+    runHook postBuild
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/share/r2modman
+    cp -r dist/electron/UnPackaged/. node_modules $out/share/r2modman
+
+    (
+      cd public/icons
+      for img in *png; do
+        dimensions=''${img#favicon-}
+        dimensions=''${dimensions%.png}
+        mkdir -p $out/share/icons/hicolor/$dimensions/apps
+        cp $img $out/share/icons/hicolor/$dimensions/apps/${pname}.png
+      done
+    )
+
+    makeWrapper '${electron}/bin/electron' "$out/bin/r2modman" \
+      --inherit-argv0 \
+      --add-flags "$out/share/r2modman" \
+      --add-flags "\''${NIXOS_OZONE_WL:+\''${WAYLAND_DISPLAY:+--ozone-platform-hint=auto --enable-features=WaylandWindowDecorations}}"
+
+    runHook postInstall
+  '';
+
+  desktopItems = [
+    (makeDesktopItem {
+      name = pname;
+      exec = pname;
+      icon = pname;
+      desktopName = pname;
+      comment = meta.description;
+      categories = [ "Game" ];
+      keywords = [ "launcher" "mod manager" "thunderstore" ];
+    })
+  ];
+
+  passthru.updateScript = gitUpdater {
+    rev-prefix = "v";
+  };
+
+  meta = with lib; {
+    description = "Unofficial Thunderstore mod manager";
+    homepage = "https://github.com/ebkr/r2modmanPlus";
+    changelog = "https://github.com/ebkr/r2modmanPlus/releases/tag/v${version}";
+    license = licenses.mit;
+    maintainers = with maintainers; [ aidalgol huantian ];
+    inherit (electron.meta) platforms;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -36542,6 +36542,8 @@ with pkgs;
 
   r2mod_cli = callPackage ../games/r2mod_cli { };
 
+  r2modman = callPackage ../games/r2modman { };
+
   racer = callPackage ../games/racer { };
 
   randtype = callPackage ../games/randtype { };


### PR DESCRIPTION
###### Description of changes
Add r2modman, an unofficial [Thunderstore](https://thunderstore.io/) mod manager.

Builds from source, superseding PR #201708.

Closes #143659

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
