### PR TITLE
doomretro: init at 4.9.1

### DIFF
--- a/pkgs/games/doom-ports/doomretro/default.nix
+++ b/pkgs/games/doom-ports/doomretro/default.nix
@@ -1,0 +1,71 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, cmake
+, pkg-config
+, SDL2
+, SDL2_image
+, SDL2_mixer
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "doomretro";
+  version = "4.9.1";
+
+  src = fetchFromGitHub {
+    owner = "bradharding";
+    repo = "doomretro";
+    rev = "v${finalAttrs.version}";
+    hash = "sha256-WCTCDOjBxVOkD06jF9wF2ELoyMhWa4lnZz82GbI1Axs=";
+  };
+
+  nativeBuildInputs = [
+    cmake
+    pkg-config
+  ];
+
+  buildInputs = [
+    SDL2
+    SDL2_image
+    SDL2_mixer
+  ];
+
+  meta = {
+    homepage = "https://www.doomretro.com/";
+    description = "A classic, refined DOOM source port";
+    longDescription = ''
+      DOOM Retro is the classic, refined DOOM source port for Windows PC. It
+      represents how I like my DOOM to be today, in all its dark and gritty,
+      unapologetically pixelated glory. I have strived to craft a unique and
+      cohesive set of compelling features, while continuing to uphold my respect
+      for that classic, nostalgic DOOM experience many of us, after all this
+      time, still hold dear.
+
+      DOOM Retro has been under relentless, meticulous development since its
+      debut on December 10, 2013 commemorating DOOM's 20th anniversary, and it
+      has absolutely no intention of stopping. Its source code was originally
+      derived from Chocolate DOOM but is now very much its own beast. It does
+      include the usual, necessary enhancements that you'll find in all those
+      other DOOM source ports out there, but it also has many of its own cool,
+      original ideas that continues to set itself apart.
+
+      DOOM Retro is and always will be intentionally minimalistic in its
+      approach, and does a few things differently. It supports all vanilla,
+      limit removing, BOOM, MBF and MBF21-compatible maps and mods. In order to
+      freely implement certain features, and due to the nature of DOOM demos,
+      DOOM Retro does not support their recording or playback.
+
+      DOOM Retro is singleplayer only. Written in C, and released as free, open
+      source software under version 3 of the GNU General Public License, DOOM
+      Retro's 100,000 or so lines of code are diligently maintained in this
+      public Git repository and regularly compiled into both 32 and 64-bit
+      Windows apps using Microsoft Visual Studio Community 2022. Although next
+      to no support is provided, DOOM Retro's source code may also be compiled
+      and run under Linux and macOS.
+    '';
+    changelog = "https://github.com/bradharding/doomretro/releases/tag/${finalAttrs.src.rev}";
+    license = lib.licenses.gpl3Plus;
+    maintainers = with lib.maintainers; [ AndersonTorres ];
+    platforms = lib.platforms.unix;
+  };
+})

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -35727,6 +35727,8 @@ with pkgs;
 
   doomseeker = qt5.callPackage ../games/doom-ports/doomseeker { };
 
+  doomretro = callPackage ../games/doom-ports/doomretro { };
+
   chocolate-doom = callPackage ../games/doom-ports/chocolate-doom { };
 
   crispy-doom = callPackage ../games/doom-ports/crispy-doom { };


### PR DESCRIPTION
Yet another Doom port. As expected, it needs a WAD file to effectively run.

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
