### PR TITLE
nodehun: init at 3.0.2

### DIFF
--- a/pkgs/development/node-packages/node-packages.json
+++ b/pkgs/development/node-packages/node-packages.json
@@ -238,6 +238,7 @@
 , "node-pre-gyp"
 , "node-red"
 , "node2nix"
+, "nodehun"
 , "nodemon"
 , "np"
 , "npm"

--- a/pkgs/development/node-packages/overrides.nix
+++ b/pkgs/development/node-packages/overrides.nix
@@ -367,6 +367,23 @@ final: prev: {
     '';
   };
 
+  nodehun = prev.nodehun.override {
+    nativeBuildInputs = [final.node-gyp];
+    disallowedReferences = [ nodejs ];
+    postInstall = ''
+      # Only keep the necessary parts of build/Release to reduce closure size
+      cd $out/lib/node_modules/nodehun
+      mv build build_old
+      mkdir build
+      cp -r build_old/Release build/
+      rm -rf build_old
+      rm -rf build/Release/.deps
+
+      # Remove a development script to eliminate runtime dependency on node
+      rm node_modules/node-addon-api/tools/conversion.js
+    '';
+  };
+
   parcel = prev.parcel.override {
     buildInputs = [ final.node-gyp-build ];
     preRebuild = ''


### PR DESCRIPTION
###### Description of changes

This Node package is used for spellchecking using [Hunspell](https://github.com/hunspell/hunspell), the industry-standard spellchecking package. 

Its home page is here: https://github.com/Wulf/nodehun

###### Things done

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [X] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
