### PR TITLE
haskellPackages.streamly-lmdb: unbreak

### DIFF
--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -409,6 +409,14 @@ self: super: {
   # 2022-02-14: Strict upper bound: https://github.com/psibi/streamly-bytestring/issues/30
   streamly-bytestring = dontCheck (doJailbreak super.streamly-bytestring);
 
+  # The package requires streamly == 0.9.*.
+  # (We can remove this once the assert starts failing.)
+  streamly-lmdb = super.streamly-lmdb.override {
+    streamly =
+      assert (builtins.compareVersions pkgs.haskellPackages.streamly.version "0.9.0" < 0);
+        pkgs.haskellPackages.streamly_0_9_0;
+  };
+
   # base bound
   digit = doJailbreak super.digit;
 

--- a/pkgs/development/haskell-modules/configuration-hackage2nix/broken.yaml
+++ b/pkgs/development/haskell-modules/configuration-hackage2nix/broken.yaml
@@ -5109,7 +5109,6 @@ broken-packages:
   - streamly-binary
   - streamly-cassava
   - streamly-examples
-  - streamly-lmdb
   - streamly-lz4
   - streamly-process
   - stream-monad

--- a/pkgs/development/haskell-modules/configuration-nix.nix
+++ b/pkgs/development/haskell-modules/configuration-nix.nix
@@ -914,6 +914,9 @@ self: super: builtins.intersectAttrs super {
     archive = pkgs.libarchive;
   };
 
+  # Pass the correct lmdb into the package.
+  streamly-lmdb = super.streamly-lmdb.override { lmdb = pkgs.lmdb; };
+
   hlint = overrideCabal (drv: {
     postInstall = ''
       install -Dm644 data/hlint.1 -t "$out/share/man/man1"


### PR DESCRIPTION
###### Things done

- [x] Manually modified `configuration-nix.nix`, `configuration-common.nix`, and `broken.yaml`.
- [x] Tested compilation of all pkgs that depend on this change using `nix-build --no-out-link -A haskellPackages.streamly-lmdb --arg config '{ allowBroken = true; }'`
- [x] Ran `maintainers/scripts/haskell/regenerate-hackage-packages.sh` and included the result in the PR.