### PR TITLE
system76-scheduler: don't enable unconditionally

### DIFF
--- a/nixos/modules/services/desktops/system76-scheduler.nix
+++ b/nixos/modules/services/desktops/system76-scheduler.nix
@@ -226,7 +226,7 @@ in {
     };
   };
 
-  config = {
+  config = mkIf cfg.enable {
     environment.systemPackages = [ cfg.package ];
     services.dbus.packages = [ cfg.package ];
 


### PR DESCRIPTION
system76-scheduler is always enabled, which is an oversight.