### PR TITLE
obs-studio-plugins.obs-websocket: init at 4.9.1-compat

### DIFF
--- a/pkgs/applications/video/obs-studio/plugins/default.nix
+++ b/pkgs/applications/video/obs-studio/plugins/default.nix
@@ -44,7 +44,7 @@
     obs-vkcapture32 = pkgsi686Linux.obs-studio-plugins.obs-vkcapture;
   };
 
-  obs-websocket = throw "obs-websocket has been removed: Functionality has been integrated into obs-studio itself.";
+  obs-websocket = qt6Packages.callPackage ./obs-websocket.nix { }; # Websocket 4.x compatibility for OBS Studio 28+
 
   wlrobs = callPackage ./wlrobs.nix { };
 }

--- a/pkgs/applications/video/obs-studio/plugins/obs-websocket.nix
+++ b/pkgs/applications/video/obs-studio/plugins/obs-websocket.nix
@@ -1,0 +1,41 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, cmake
+, asio
+, obs-studio
+, qtbase
+, websocketpp
+}:
+
+stdenv.mkDerivation rec {
+  pname = "obs-websocket";
+  version = "4.9.1-compat";
+
+  src = fetchFromGitHub {
+    owner = "obsproject";
+    repo = "obs-websocket";
+    rev = version;
+    sha256 = "sha256-cHsJxoQjwbWLxiHgIa3Es0mu62vyLCAd1wULeZqZsJM=";
+  };
+
+  nativeBuildInputs = [ cmake ];
+  buildInputs = [ asio obs-studio qtbase websocketpp ];
+
+  dontWrapQtApps = true;
+
+  postInstall = ''
+    mkdir $out/lib $out/share
+    mv $out/obs-plugins/64bit $out/lib/obs-plugins
+    rm -rf $out/obs-plugins
+    mv $out/data $out/share/obs
+  '';
+
+  meta = with lib; {
+    description = "Legacy websocket 4.9.1 protocol support for OBS Studio 28 or above";
+    homepage = "https://github.com/obsproject/obs-websocket";
+    maintainers = with maintainers; [ flexiondotorg ];
+    license = licenses.gpl2Plus;
+    platforms = [ "x86_64-linux" "i686-linux" ];
+  };
+}


### PR DESCRIPTION
###### Description of changes

Legacy websocket 4.9.1 protocol support for OBS Studio 28 or above: https://github.com/obsproject/obs-websocket

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

Result of `nixpkgs-review` run on x86_64-linux [1](https://github.com/Mic92/nixpkgs-review)
<details>
  <summary>1 package built:</summary>
  <ul>
    <li>obs-studio-plugins.obs-websocket</li>
  </ul>
</details>

```
result
├── lib
│  └── obs-plugins
│     └── obs-websocket-compat.so
└── share
   └── obs
      └── obs-plugins
         └── obs-websocket-compat
            └── locale
               └── en-US.ini
```