### PR TITLE
nixos/opensnitch: Add support for EPBF process monitor

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2311.section.md
+++ b/nixos/doc/manual/release-notes/rl-2311.section.md
@@ -158,6 +158,8 @@
 
 - `services.fail2ban.jails` can now be configured with attribute sets defining settings and filters instead of lines. The stringed options `daemonConfig` and `extraSettings` have respectively been replaced by `daemonSettings` and `jails.DEFAULT.settings` which use attribute sets.
 
+- The application firewall `opensnitch` now uses the process monitor method eBPF as default as recommended by upstream. The method can be changed with the setting [services.opensnitch.settings.ProcMonitorMethod](#opt-services.opensnitch.settings.ProcMonitorMethod).
+
 - The module [services.ankisyncd](#opt-services.ankisyncd.package) has been switched to [anki-sync-server-rs](https://github.com/ankicommunity/anki-sync-server-rs) from the old python version, which was difficult to update, had not been updated in a while, and did not support recent versions of anki.
 Unfortunately all servers supporting new clients (newer version of anki-sync-server, anki's built in sync server and this new rust package) do not support the older sync protocol that was used in the old server, so such old clients will also need updating and in particular the anki package in nixpkgs is also being updated in this release.
 The module update takes care of the new config syntax and the data itself (user login and cards) are compatible, so users of the module will be able to just log in again after updating both client and server without any extra action.

--- a/pkgs/os-specific/linux/opensnitch-ebpf/default.nix
+++ b/pkgs/os-specific/linux/opensnitch-ebpf/default.nix
@@ -1,0 +1,58 @@
+{ lib
+, kernel
+, stdenv
+, clang-tools
+, llvmPackages
+, elfutils
+, flex
+, bison
+, bc
+, opensnitch
+}:
+
+stdenv.mkDerivation rec {
+  pname = "opensnitch_ebpf";
+  version = "${opensnitch.version}-${kernel.version}";
+
+  inherit (opensnitch) src;
+
+  sourceRoot = "source/ebpf_prog";
+
+  nativeBuildInputs = with llvmPackages; [
+    bc
+    bison
+    clang
+    clang-tools
+    elfutils
+    flex
+    libllvm
+  ];
+
+  # We set -fno-stack-protector here to work around a clang regression.
+  # This is fine - bpf programs do not use stack protectors
+  # https://aur.archlinux.org/cgit/aur.git/tree/PKGBUILD?h=opensnitch-ebpf-module&id=984b952a784eb701f691dd9f2d45dfeb8d15053b
+  env.NIX_CFLAGS_COMPILE = "-fno-stack-protector";
+
+  env.KERNEL_DIR="${kernel.dev}/lib/modules/${kernel.modDirVersion}/source";
+  env.KERNEL_HEADERS="${kernel.dev}/lib/modules/${kernel.modDirVersion}/build";
+
+  extraConfig =''
+    CONFIG_UPROBE_EVENTS=y
+  '';
+
+  installPhase = ''
+    runHook preInstall
+    for file in opensnitch*.o; do
+      install -Dm644 "$file" "$out/etc/opensnitchd/$file"
+    done
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    description = "eBPF process monitor module for OpenSnitch";
+    homepage = "https://github.com/evilsocket/opensnitch";
+    license = licenses.gpl3Only;
+    maintainers = with maintainers; [ onny ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/tools/networking/opensnitch/daemon.nix
+++ b/pkgs/tools/networking/opensnitch/daemon.nix
@@ -56,10 +56,8 @@ buildGoModule rec {
     mv $GOPATH/bin/daemon $GOPATH/bin/opensnitchd
     mkdir -p $out/etc/opensnitchd $out/lib/systemd/system
     cp system-fw.json $out/etc/opensnitchd/
-    substitute default-config.json $out/etc/default-config.json \
-      --replace "/var/log/opensnitchd.log" "/dev/stdout" \
-      --replace "iptables" "nftables" \
-      --replace "ebpf" "proc"
+    substitute default-config.json $out/etc/opensnitchd/default-config.json \
+      --replace "/var/log/opensnitchd.log" "/dev/stdout"
     substitute opensnitchd.service $out/lib/systemd/system/opensnitchd.service \
       --replace "/usr/local/bin/opensnitchd" "$out/bin/opensnitchd" \
       --replace "/etc/opensnitchd/rules" "/var/lib/opensnitch/rules" \

--- a/pkgs/top-level/linux-kernels.nix
+++ b/pkgs/top-level/linux-kernels.nix
@@ -448,6 +448,8 @@ in {
     # Current stable release; don't backport release updates!
     openafs = openafs_1_8;
 
+    opensnitch-ebpf = if lib.versionAtLeast kernel.version "5.10" then callPackage ../os-specific/linux/opensnitch-ebpf { } else null;
+
     facetimehd = callPackage ../os-specific/linux/facetimehd { };
 
     tuxedo-keyboard = if lib.versionAtLeast kernel.version "4.14" then callPackage ../os-specific/linux/tuxedo-keyboard { } else null;


### PR DESCRIPTION
###### Description of changes

Adding support for EPBF process monitor. As described [here](https://github.com/evilsocket/opensnitch/wiki/monitor-method-ebpf) in the manual, this is the default monitor mode for OpenSnitch because it is more efficent and secure.

Nftables usage and epbf monitor mode is now default as defined in [upstream configuration](https://github.com/evilsocket/opensnitch/blob/master/daemon/default-config.json). The old monitor method can be configured like this:
```
services.opensnitch = {
  enable = true;
  settings.ProcMonitorMethod = "proc";
};
```

Optionally depends on upstream ability to configure the kernel module path https://github.com/evilsocket/opensnitch/issues/928

Sucessfull build depends on opensnitch version update https://github.com/NixOS/nixpkgs/pull/246373

Work was done by @Slime90 which I'll add as a co-author to this PR.

Fixes https://github.com/NixOS/nixpkgs/issues/227294

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [x] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
