### PR TITLE
nixosTests.pgadmin4: increase test coverage

### DIFF
--- a/nixos/tests/pgadmin4.nix
+++ b/nixos/tests/pgadmin4.nix
@@ -43,7 +43,7 @@ import ./make-test-python.nix ({ pkgs, lib, ... }:
       machine.wait_for_unit("pgadmin")
       machine.wait_until_succeeds("curl -sS localhost:5051")
       machine.wait_until_succeeds("curl -sS localhost:5051/login | grep \"<title>pgAdmin 4</title>\" > /dev/null")
-      # check for missing support files (css, js etc). Should catch not-generated files during build. See e.g. Pull #229184
+      # check for missing support files (css, js etc). Should catch not-generated files during build. See e.g. https://github.com/NixOS/nixpkgs/pull/229184
       machine.succeed("wget -nv --level=1 --spider --recursive localhost:5051/login")
 
     # pgadmin4 module saves the configuration to /etc/pgadmin/config_system.py

--- a/nixos/tests/pgadmin4.nix
+++ b/nixos/tests/pgadmin4.nix
@@ -9,6 +9,7 @@ import ./make-test-python.nix ({ pkgs, lib, ... }:
     imports = [ ./common/user-account.nix ];
 
     environment.systemPackages = with pkgs; [
+      wget
       curl
       pgadmin4-desktopmode
     ];
@@ -40,8 +41,10 @@ import ./make-test-python.nix ({ pkgs, lib, ... }:
     with subtest("Check pgadmin module"):
       machine.wait_for_unit("postgresql")
       machine.wait_for_unit("pgadmin")
-      machine.wait_until_succeeds("curl -s localhost:5051")
-      machine.wait_until_succeeds("curl -s localhost:5051/login | grep \"<title>pgAdmin 4</title>\" > /dev/null")
+      machine.wait_until_succeeds("curl -sS localhost:5051")
+      machine.wait_until_succeeds("curl -sS localhost:5051/login | grep \"<title>pgAdmin 4</title>\" > /dev/null")
+      # check for missing support files (css, js etc). Should catch not-generated files during build. See e.g. Pull #229184
+      machine.succeed("wget -nv --level=1 --spider --recursive localhost:5051/login")
 
     # pgadmin4 module saves the configuration to /etc/pgadmin/config_system.py
     # pgadmin4-desktopmode tries to read that as well. This normally fails with a PermissionError, as the config file
@@ -51,7 +54,8 @@ import ./make-test-python.nix ({ pkgs, lib, ... }:
     # because of the wrong config for desktopmode.
     with subtest("Check pgadmin standalone desktop mode"):
       machine.execute("sudo -u alice pgadmin4 >&2 &", timeout=60)
-      machine.wait_until_succeeds("curl -s localhost:5050")
-      machine.wait_until_succeeds("curl -s localhost:5050/browser/ | grep \"<title>pgAdmin 4</title>\" > /dev/null")
+      machine.wait_until_succeeds("curl -sS localhost:5050")
+      machine.wait_until_succeeds("curl -sS localhost:5050/browser/ | grep \"<title>pgAdmin 4</title>\" > /dev/null")
+      machine.succeed("wget -nv --level=1 --spider --recursive localhost:5050/browser")
   '';
 })


### PR DESCRIPTION
###### Description of changes

This should now catch errors, if the support files haven't been generated correctly by yarn.

The missing generated support files (css, js) were fixed for example in https://github.com/NixOS/nixpkgs/pull/229184.
The changes introduced in this commit should now catch such errors.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
- [x] Tested with nixpkgs in a vm before and after #229184 to make sure it catches said errors
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
