### PR TITLE
systemd: 251.15 -> 251.16

### DIFF
--- a/pkgs/os-specific/linux/systemd/default.nix
+++ b/pkgs/os-specific/linux/systemd/default.nix
@@ -122,7 +122,7 @@ assert withHomed -> withCryptsetup;
 let
   wantCurl = withRemote || withImportd;
   wantGcrypt = withResolved || withImportd;
-  version = "251.15";
+  version = "251.16";
 
   # Bump this variable on every (major) version change. See below (in the meson options list) for why.
   # command:
@@ -139,7 +139,7 @@ stdenv.mkDerivation {
     owner = "systemd";
     repo = "systemd-stable";
     rev = "v${version}";
-    sha256 = "sha256-/vLu5aNW9qudZJhbisiq7Oteh5IP2hi71OEI2dZi0EA=";
+    sha256 = "sha256-46EM3sETMm5zAoLKtcGYCwmI7EYFeze/Pr4R/hwZL7Q=";
   };
 
   # On major changes, or when otherwise required, you *must* reformat the patches,


### PR DESCRIPTION
Changelog:

```
5f8a449eab test-network: add workaround for bug in iproute2 v6.2.0
d95989f4de coredumpctl: fix bash completion matching
11c53ec3b1 test: create temporary units under /run
17af002034 core/transaction: use hashmap_remove_value() to make not remove job with same ID
23bfa90166 fuzz-journal-remote: fix potential fd-leak
67bba19aed fuzz-journal-remote: remove temporary files on exit
86ec045f25 hwdb: update to 46b8c3f5b297ac034f2d024c1f3d84ad2c17f410
fb1078b2e8 sd-journal: make journal_file_copy_entry() return earlier
905553acb1 sd-journal: copy boot ID
6e42053a12 sd-journal: tighten variable scope
3d88973ff6 journal: Don't try to write garbage if journal entry is corrupted
42589738cf core: fix property getter method for NFileDescriptorStore bus property
2d216fdb2c mkosi: disable fedora builds
f8344c2006 test: bump the base VM memory to 768M
f7be8106e8 test: allow overriding $QEMU_MEM when running w/ ASan
f8bd6cd7d6 test: use setpriv instead of su for user switch from root
bbe058c449 test: wrap mkfs.*/mksquashfs/mkswap binaries when running w/ ASan
f7b20156b3 test: bump the D-Bus related timeouts to 120s
085d847ae7 coredump filter: add mask for 'all' using UINT32_MAX, not UINT64_MAX
30a4629e47 coredump filter: fix stack overflow with =all
7ee604ab53 build(deps): bump github/super-linter from 4.9.7 to 4.10.1
b4c431fc7e cryptenroll: fix a memory leak
eeb91ba62e portablectl: add --extension to bash completion
783885a98a man: /usr/lib/systemd/random-seed -> /usr/lib/systemd/systemd-random-seed
3776e1f2ee test: drop uses of "&& { echo 'unexpected success'; exit 1; }"
f12531d653 man: fix LogControl1 manpage example
3fc9c413a9 pam: cache sd-bus separately per module
1f36857e4b pam_systemd_home: clean up sd-bus when called about something else's user
b1f2d0da63 man: clarify sd_bus_default
ce99445126 man: add working example to LogControl1 manpage
479718f743 detect-virt: add message at debug level
42094f7b79 list: fix double evaluation
a09b9fca5b mountpoint-util: check /proc is mounted on failure
47bbd034c3 test: prefix the transient unit with test- to make coverage runs happy
1bbf03374e kmod-setup: bypass heavy virtio-rng check if we are not running in a VM anyway
3411ab6a9a kmod-setup: use STARTSWITH_SET() where appropriate
48b9984e64 creds: make available to all ExecStartPre= and ExecStart= processes
4730d729cb user-util:remove duplicate includes
226ba320d3 virt: Further improve detection of EC2 metal instances
2b003d91ad string-util: add strstrafter()
369b81c021 test: add a couple of tests with invalid UTF-8 characters
cb8e9f29db test: add a simple test for getenv_path_list()
f92b6fe962 shared: add a missing include
78e20624b2 test: stop the test unit when it's not needed anymore
491530f2e7 Synposis and description of networkctl man page reflecting only part of its functionality  (#27264)
42d1f6a067 core/main: fix a typo for --log-target
4e9ed04401 test: add some tests for RuntimeMaxSec
7aa7e9e93d scope: do not disable timer event source when state is SCOPE_RUNNING
468acc7264 Fix cross-reference of manual for LogsDirectory
857fdbc608 pid1: fix coredump_filter setting
db89c44f82 Uphold/StopWhenUnneeded/BindsTo: requeue when job finishes
fe3e998ac8 Uphold/StopWhenUnneeded/BindsTo: add retry timer on rate limit
6c1046121d man: add util-linux to the package list for Fedora container
ab287e91bf man: link to Fedora 37
7e67870804 systemctl: suppress error for try-* if unit is masked
b8af3f5d8c ci: drop checkout from release workflow
372b22c6a8 ci: don't run release wf on `systemd-security`
cfb4a5343b shell-completion: add --xml-interface option of busctl to the rules
ddc80a6c47 busctl: add --xml-interface to the help message
95d729a278 test: update description
62c29bc87b ci: add permissions to make a release
d277048bb4 test/test-functions: fix typo in install_suse_systemd()
4b1da60389 test: install symlinks with valid targets on SUSE and Debian
3e88053037 localed: fix invalid free after shifting pointers using strstrip
83a29385fa test: bump the timeout for non-qemu runs to 90s
4af462fcbc man/systemd-mount: Clearify documentation about --bind-device
7fb9c442b7 resolve: change DNS_PACKET_UNICAST_SIZE_LARGE_MAX to 1232 (#27171)
2866dee297 man: netdev: Clarify wireguard IPv6 endpoint format
a92fc49cf4 ci: do one build with no tpm/p11kit/fido2
2ae7492eac man: mention -o option for systemd-journal-remote
2d458aa454 manager: remove transient unit directory during startup
b4588585f5 core: a more informative error when SetProperties/StartTransientUnit fails
fc9215ad58 journald: fix log message
29b01b2e41 Added unit test for strv_env_name_is_valid() function listed in env-util.c (#27100)
cf07a7c6ac test: make make_addresses() actually return the addresses
a42abcdb0b coverage: add a wrapper for execveat()
7245c4bdba man: add example for sd_bus_call_method
7d728849c2 man: link up new online coredump docs from man page
fdb1ceed47 tree-wide: reset optind to 0 when GNU extensions in optstring are used
6ed548a51c units: let's establish the coredump socket before writting core_pattern sysctl
7e1fab3526 test: do not remove state directory on failure
8e18fbb3f8 man: fix shellcheck warning for html.in
785b116cc1 busctl: also assume --full if not writing to terminal
03e5cdfdae busctl: use size_t for set size
f5ef1d5853 busctl: do not truncate property values when --full
03f8b9d1fe oomd: add inline comments with param names
cca2d36a85 test: add more testcases for rm_rf()
03b90ce85d rm-rf: also chmod() directory if it cannot be opened
999eebacac rm-rf: mask file mode with 07777 when passed to chmod()
37db6597da rm-rf: fix errno handling
```

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
