### PR TITLE
nodePackages: add aliases

### DIFF
--- a/maintainers/scripts/remove-old-aliases.py
+++ b/maintainers/scripts/remove-old-aliases.py
@@ -100,11 +100,12 @@ def convert_to_throw(date_older_list: list[str]) -> list[tuple[str, str]]:
             date_older_list.remove(line)
             continue
 
-        alias = before_equal.strip()
+        alias = before_equal
+        alias_unquoted = before_equal.strip('"')
         after_equal_list = [x.strip(";:") for x in after_equal.split()]
 
         converted = (
-            f"{indent}{alias} = throw \"'{alias}' has been renamed to/replaced by"
+            f"{indent}{alias} = throw \"'{alias_unquoted}' has been renamed to/replaced by"
             f" '{after_equal_list.pop(0)}'\";"
             f' # Converted to throw {datetime.today().strftime("%Y-%m-%d")}'
         )

--- a/pkgs/development/node-packages/aliases.nix
+++ b/pkgs/development/node-packages/aliases.nix
@@ -1,0 +1,38 @@
+pkgs: lib: self: super:
+
+### Deprecated aliases - for backward compatibility
+
+with self;
+
+let
+  # Removing recurseForDerivation prevents derivations of aliased attribute
+  # set to appear while listing all the packages available.
+  removeRecurseForDerivations = alias: with lib;
+    if alias.recurseForDerivations or false
+    then removeAttrs alias ["recurseForDerivations"]
+    else alias;
+
+  # Disabling distribution prevents top-level aliases for non-recursed package
+  # sets from building on Hydra.
+  removeDistribute = alias: with lib;
+    if isDerivation alias then
+      dontDistribute alias
+    else alias;
+
+  # Make sure that we are not shadowing something from node-packages.nix.
+  checkInPkgs = n: alias:
+    if builtins.hasAttr n super
+    then throw "Alias ${n} is still in node-packages.nix"
+    else alias;
+
+  mapAliases = aliases:
+    lib.mapAttrs (n: alias:
+      removeDistribute
+        (removeRecurseForDerivations
+          (checkInPkgs n alias)))
+      aliases;
+in
+
+mapAliases ({
+  "@githubnext/github-copilot-cli" = pkgs.github-copilot-cli; # Added 2023-05-02
+})

--- a/pkgs/development/node-packages/default.nix
+++ b/pkgs/development/node-packages/default.nix
@@ -1,4 +1,4 @@
-{ pkgs, lib, nodejs, stdenv}:
+{ config, pkgs, lib, nodejs, stdenv }:
 
 let
   inherit (lib) composeManyExtensions extends makeExtensible mapAttrs;
@@ -15,7 +15,12 @@ let
       })
     ) (import ./main-programs.nix);
 
+  aliases = final: prev:
+    lib.optionalAttrs config.allowAliases
+      (import ./aliases.nix pkgs lib final prev);
+
   extensions = composeManyExtensions [
+    aliases
     mainProgramOverrides
     (import ./overrides.nix { inherit pkgs nodejs; })
   ];

--- a/pkgs/development/node-packages/main-programs.nix
+++ b/pkgs/development/node-packages/main-programs.nix
@@ -20,7 +20,6 @@
   "@commitlint/cli" = "commitlint";
   "@forge/cli" = "forge";
   "@gitbeaker/cli" = "gitbeaker";
-  "@githubnext/github-copilot-cli" = "github-copilot-cli";
   "@google/clasp" = "clasp";
   "@medable/mdctl-cli" = "mdctl";
   "@mermaid-js/mermaid-cli" = "mmdc";

--- a/pkgs/development/node-packages/overrides.nix
+++ b/pkgs/development/node-packages/overrides.nix
@@ -39,8 +39,6 @@ final: prev: {
     ];
   };
 
-  "@githubnext/github-copilot-cli" = pkgs.github-copilot-cli;
-
   "@medable/mdctl-cli" = prev."@medable/mdctl-cli".override (oldAttrs: {
     nativeBuildInputs = with pkgs; with darwin.apple_sdk.frameworks; [
       glib


### PR DESCRIPTION
###### Description of changes

Add aliases for the `nodePackages` set and move the one current alias (in `overrides.nix`) there. It is mostly copied from the main aliases.nix as other package sets with aliases have done

~~This does not allow aliasing to the outer `pkgs` (as with aliasing in other package sets), but this can be added if it is really desired~~ (edit: added `pkgs` argument)

cc: @NixOS/node, @ehllie, @malob (since you added the alias)

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).