### PR TITLE
haskellPackages: Add maintainer shlok

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -14233,6 +14233,12 @@
     githubId = 487050;
     name = "Shea Levy";
   };
+  shlok = {
+    email = "sd-nix-maintainer@quant.is";
+    github = "shlok";
+    githubId = 3000933;
+    name = "Shlok Datye";
+  };
   shmish111 = {
     email = "shmish111@gmail.com";
     github = "shmish111";

--- a/pkgs/development/haskell-modules/configuration-hackage2nix/main.yaml
+++ b/pkgs/development/haskell-modules/configuration-hackage2nix/main.yaml
@@ -368,6 +368,9 @@ package-maintainers:
     - taffybar
     - arbtt
     - lentil
+  shlok:
+    - streamly-archive
+    - streamly-lmdb
   sorki:
     - cayenne-lpp
     - blockfrost-client


### PR DESCRIPTION
###### Things done

- [x] Manually modified `maintainers/maintainer-list.nix` and `pkgs/development/haskell-modules/configuration-hackage2nix/main.yaml`.
- [x] Ran `maintainers/scripts/haskell/regenerate-hackage-packages.sh` and included the result in the PR.