### PR TITLE
ocamlPackages.github*: init at 4.4.1

### DIFF
--- a/pkgs/development/ocaml-modules/github/data.nix
+++ b/pkgs/development/ocaml-modules/github/data.nix
@@ -1,0 +1,23 @@
+{ lib, buildDunePackage, github
+, yojson, atdgen
+}:
+
+buildDunePackage {
+  pname = "github-data";
+  inherit (github) version src;
+
+  duneVersion = "3";
+
+  nativeBuildInputs = [
+    atdgen
+  ];
+
+  propagatedBuildInputs = [
+    yojson
+    atdgen
+  ];
+
+  meta = github.meta // {
+    description = "GitHub APIv3 data library";
+  };
+}

--- a/pkgs/development/ocaml-modules/github/default.nix
+++ b/pkgs/development/ocaml-modules/github/default.nix
@@ -1,0 +1,34 @@
+{ lib, buildDunePackage, fetchFromGitHub
+, uri, cohttp, lwt, cohttp-lwt, github-data, yojson, stringext
+}:
+
+buildDunePackage rec {
+  pname = "github";
+  version = "4.4.1";
+
+  src = fetchFromGitHub {
+    owner = "mirage";
+    repo = "ocaml-github";
+    rev = version;
+    sha256 = "sha256-psUIiIvjVV2NTlBtHnBisWreaKKnsqIjKT2+mLnfsxg=";
+  };
+
+  duneVersion = "3";
+
+  propagatedBuildInputs = [
+    uri
+    cohttp
+    lwt
+    cohttp-lwt
+    github-data
+    yojson
+    stringext
+  ];
+
+  meta = with lib; {
+    homepage = "https://github.com/mirage/ocaml-github";
+    description = "GitHub APIv3 OCaml library";
+    license = licenses.mit;
+    maintainers = with maintainers; [ niols ];
+  };
+}

--- a/pkgs/development/ocaml-modules/github/jsoo.nix
+++ b/pkgs/development/ocaml-modules/github/jsoo.nix
@@ -1,0 +1,21 @@
+{ lib, buildDunePackage, github
+, cohttp, cohttp-lwt-jsoo, js_of_ocaml-lwt
+}:
+
+buildDunePackage {
+  pname = "github-jsoo";
+  inherit (github) version src;
+
+  duneVersion = "3";
+
+  propagatedBuildInputs = [
+    github
+    cohttp
+    cohttp-lwt-jsoo
+    js_of_ocaml-lwt
+  ];
+
+  meta = github.meta // {
+    description = "GitHub APIv3 JavaScript library";
+  };
+}

--- a/pkgs/development/ocaml-modules/github/unix.nix
+++ b/pkgs/development/ocaml-modules/github/unix.nix
@@ -1,0 +1,23 @@
+{ lib, buildDunePackage, github
+, cohttp, cohttp-lwt-unix, stringext, cmdliner, lwt
+}:
+
+buildDunePackage {
+  pname = "github-unix";
+  inherit (github) version src;
+
+  duneVersion = "3";
+
+  propagatedBuildInputs = [
+    github
+    cohttp
+    cohttp-lwt-unix
+    stringext
+    cmdliner
+    lwt
+  ];
+
+  meta = github.meta // {
+    description = "GitHub APIv3 Unix library";
+  };
+}

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -571,6 +571,11 @@ let
       git-binary = pkgs.git;
     };
 
+    github = callPackage ../development/ocaml-modules/github {  };
+    github-data = callPackage ../development/ocaml-modules/github/data.nix {  };
+    github-jsoo = callPackage ../development/ocaml-modules/github/jsoo.nix {  };
+    github-unix = callPackage ../development/ocaml-modules/github/unix.nix {  };
+
     gluten = callPackage ../development/ocaml-modules/gluten { };
     gluten-lwt = callPackage ../development/ocaml-modules/gluten/lwt.nix { };
     gluten-lwt-unix = callPackage ../development/ocaml-modules/gluten/lwt-unix.nix { };


### PR DESCRIPTION
###### Description of changes

This PR adds the OCaml package `github` and its sub-packages `github-data`, `github-jsoo` and `github-unix`, providing bindings for the GitHub API (v3) in OCaml.

- [Homepage/GitHub repo](https://github.com/mirage/ocaml-github/)
- [Change log](https://github.com/mirage/ocaml-github/blob/4.4.1/CHANGES.md) (since the dawn of time)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [X] x86_64-darwin
  - [X] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).