### PR TITLE
ocamlPackages.opam-publish: init at 2.2.0

### DIFF
--- a/lib/licenses.nix
+++ b/lib/licenses.nix
@@ -856,6 +856,11 @@ in mkLicense lset) ({
     free = false;
   };
 
+  ocamlLgplLinkingException = {
+    spdxId = "OCaml-LGPL-linking-exception";
+    fullName = "OCaml LGPL Linking Exception";
+  };
+
   ocamlpro_nc = {
     fullName = "OCamlPro Non Commercial license version 1";
     url = "https://alt-ergo.ocamlpro.com/http/alt-ergo-2.2.0/OCamlPro-Non-Commercial-License.pdf";

--- a/pkgs/development/tools/ocaml/opam-publish/default.nix
+++ b/pkgs/development/tools/ocaml/opam-publish/default.nix
@@ -1,0 +1,34 @@
+{ lib, fetchFromGitHub, ocamlPackages }:
+
+with ocamlPackages;
+
+buildDunePackage rec {
+  pname = "opam-publish";
+  version = "2.2.0";
+
+  src = fetchFromGitHub {
+    owner = "ocaml-opam";
+    repo = pname;
+    rev = version;
+    sha256 = "sha256-FNAWok5tjTOwwpNZ0Xcu9E/R8iXStZqCk/Vqdf9l+zs=";
+  };
+
+  duneVersion = "3";
+
+  buildInputs = [
+    cmdliner
+    lwt_ssl
+    opam-core
+    opam-format
+    opam-state
+    github
+    github-unix
+  ];
+
+  meta = with lib; {
+    homepage = "https://github.com/ocaml-opam/${pname}";
+    description = "A tool to ease contributions to opam repositories";
+    license = with licenses; [ lgpl21Only ocamlLgplLinkingException ];
+    maintainers = with maintainers; [ niols ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6178,6 +6178,8 @@ with pkgs;
 
   ondir = callPackage ../tools/misc/ondir { };
 
+  opam-publish = callPackage ../development/tools/ocaml/opam-publish { };
+
   opencomposite = callPackage ../development/libraries/opencomposite { };
 
   opencomposite-helper = callPackage ../development/libraries/opencomposite/helper.nix { };


### PR DESCRIPTION
#### Description of changes

This PR adds to OCaml package `opam-publish`, “a tool to ease contributions to opam repositories.”

- [Homepage/GitHub repo](https://github.com/ocaml-opam/opam-publish)
- [Change log](https://github.com/ocaml-opam/opam-publish/blob/2.2.0/CHANGES) (since the dawn of time)

`opam-publish`'s license is “LGPL 2.1 only with OCaml LGPL linking exception”. Since the OCaml LGPL linking exception in question has [an SPDX page](https://spdx.org/licenses/OCaml-LGPL-linking-exception.html), I thought it was OK to add it to `lib.licenses`. I hope it is indeed OK.

`opam-publish` relies on the OCaml `github-*` packages, and therefore this PR should be merged after #229662.

#### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [X] x86_64-darwin
  - [X] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
