### PR TITLE
gomplate: add reminder to switch to go 1.20

### DIFF
--- a/pkgs/development/tools/gomplate/default.nix
+++ b/pkgs/development/tools/gomplate/default.nix
@@ -7,6 +7,10 @@ buildGoModule rec {
   pname = "gomplate";
   version = "3.11.5";
 
+  # gomplate is currently built w/ go 1.19 (see pkgs/top-level/all-packages.nix), but
+  # it seems the reported "go 1.20 build failure" does no longer occurr.
+  # TODO remove indication to use go 1.19 in pkgs/top-level/all-packages.nix when next upgrading gomplate
+
   src = fetchFromGitHub {
     owner = "hairyhenderson";
     repo = pname;


### PR DESCRIPTION
###### Description of changes

This adds a comment reminding whoever will next update gomplate to use go 1.20 instead of 1.19.

The indication to use go 1.19 is in `pkgs/top-level/all-packages.nix` and so people might miss it (or have it missed in the past).

I tried (of course!) building with go 1.20 and got no issues.

I'm hesitant to just edit `all-packages.nix` instead of adding this reminder because... changing the gomplate binary without a version bumb seems like  a bad thing (maybe? let me know if it's actually fine) and adding a bogus version suffix doesn't seem worthwhile, as at this moment there is really no practical reason to use go 1.20 over 1.19.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md) (I think).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
