### PR TITLE
python310Packages.xnatpy: init at 0.5.1

### DIFF
--- a/pkgs/development/python-modules/xnatpy/default.nix
+++ b/pkgs/development/python-modules/xnatpy/default.nix
@@ -1,0 +1,50 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, pythonOlder
+, setuptools
+, click
+, isodate
+, progressbar2
+, pydicom
+, requests
+}:
+
+buildPythonPackage rec {
+  pname = "xnatpy";
+  version = "0.5.1";
+  format = "pyproject";
+
+  disabled = pythonOlder "3.7";
+
+  src = fetchPypi {
+    pname = "xnat";
+    inherit version;
+    hash = "sha256-iOw9cVWP5Am4S9JQ0NTmtew38KZiKmau+19K2KG2aKQ=";
+  };
+
+  nativeBuildInputs = [ setuptools ];
+
+  propagatedBuildInputs = [
+    click
+    isodate
+    progressbar2
+    pydicom
+    requests
+  ];
+
+  # tests missing in PyPI dist and require network access and Docker container
+  doCheck = false;
+
+  pythonImportsCheck = [ "xnat" ];
+
+  meta = with lib; {
+    homepage = "https://xnat.readthedocs.io";
+    description =
+      "A new XNAT client (distinct from pyxnat) that exposes XNAT objects/functions as Python objects/functions";
+    changelog = "https://gitlab.com/radiology/infrastructure/xnatpy/-/blob/${version}/CHANGELOG?ref_type=tags";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ bcdarwin ];
+    mainProgram = "xnat";
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -12932,6 +12932,8 @@ self: super: with self; {
 
   xmodem = callPackage ../development/python-modules/xmodem { };
 
+  xnatpy = callPackage ../development/python-modules/xnatpy { };
+
   xnd = callPackage ../development/python-modules/xnd { };
 
   xpath-expressions = callPackage ../development/python-modules/xpath-expressions { };


### PR DESCRIPTION
###### Description of changes

Add xnatpy, a Pythonic interface to XNAT servers.

###### Things done


- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).