### PR TITLE
cage: upgrade to wlroots 0_15

### DIFF
--- a/nixos/tests/cage.nix
+++ b/nixos/tests/cage.nix
@@ -20,13 +20,13 @@ import ./make-test-python.nix ({ pkgs, ...} :
     };
 
     # Need to switch to a different GPU driver than the default one (-vga std) so that Cage can launch:
-    virtualisation.qemu.options = [ "-vga none -device virtio-gpu-pci" ];
+    virtualisation.qemu.options = [ "-vga none" "-device virtio-vga-gl" "-display gtk,gl=on" ];
   };
 
   enableOCR = true;
 
   testScript = { nodes, ... }: let
-    user = nodes.machine.config.users.users.alice;
+    user = nodes.machine.users.users.alice;
   in ''
     with subtest("Wait for cage to boot up"):
         start_all()

--- a/pkgs/applications/window-managers/cage/default.nix
+++ b/pkgs/applications/window-managers/cage/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchFromGitHub
+{ lib, stdenv, fetchFromGitHub, fetchpatch
 , meson, ninja, pkg-config, wayland-scanner, scdoc, makeWrapper
 , wlroots, wayland, wayland-protocols, pixman, libxkbcommon
 , systemd, libGL, libX11, mesa
@@ -16,6 +16,30 @@ stdenv.mkDerivation rec {
     rev = "v${version}";
     sha256 = "0vm96gxinhy48m3x9p1sfldyd03w3gk6iflb7n9kn06j1vqyswr6";
   };
+
+  patches = [
+    # The following 4 patches add support for wlroots 0.15.0
+    (fetchpatch {
+      name = "0001-allow-using-subproject-for-wlroots.patch";
+      url = "https://github.com/cage-kiosk/cage/commit/1a3ab3eb3ad0f4a1addb8f9a9427d8b369b19511.patch";
+      sha256 = "sha256-+j8wy3P+JbKQ+qGWvtnG4/eig4hnm+pv2wU9i5ju3hw=";
+    })
+    (fetchpatch {
+      name = "0002-move-to-gitHub-actions.patch";
+      url = "https://github.com/cage-kiosk/cage/commit/8385b62a9b31028fa356cc4130baebc8b6f4adec.patch";
+      sha256 = "sha256-7ihh/qH0JivsN2R1HWYTUwipMRI2JqraWBZzo57C9RU=";
+    })
+    (fetchpatch {
+      name = "0003-tune-compiler-options.patch";
+      url = "https://github.com/cage-kiosk/cage/commit/388d60d6b88733330fb83dd440051ee805cc7ec7.patch";
+      sha256 = "sha256-3wqbz6SnFam7XmmhZQYDYAz82Z/o4V4asRUKQfawddY=";
+    })
+    (fetchpatch {
+      name = "0004-upgrade-to-wlroots-0_15.patch";
+      url = "https://github.com/cage-kiosk/cage/commit/395189fb051ed722c7b10b6cb11caa8f6904079c.patch";
+      sha256 = "sha256-98DXunJO5760KXFwz1yjd6k1mZ6Updm3M+EYAhj5dm8=";
+    })
+  ];
 
   depsBuildBuild = [
     pkg-config

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -29433,9 +29433,7 @@ with pkgs;
 
   cardo = callPackage ../data/fonts/cardo { };
 
-  cage = callPackage ../applications/window-managers/cage {
-    wlroots = wlroots_0_14;
-  };
+  cage = callPackage ../applications/window-managers/cage { };
 
   calf = callPackage ../applications/audio/calf {
       inherit (gnome2) libglade;


### PR DESCRIPTION
###### Description of changes


wlroots 0.15 compatible tag still not released： https://github.com/cage-kiosk/cage/issues/232

Let's pick up some commit to support  wlroots 0_15 as archlinux did 
https://github.com/archlinux/svntogit-community/blob/packages/cage/trunk/PKGBUILD#L25-L29

This is the last package that depends on wlroot 0.14： https://github.com/NixOS/nixpkgs/issues/151311

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
