### PR TITLE
ocamlPackages: remove last meaningful uses of `useDune2`

### DIFF
--- a/pkgs/development/ocaml-modules/ocaml-result/default.nix
+++ b/pkgs/development/ocaml-modules/ocaml-result/default.nix
@@ -1,10 +1,8 @@
 { lib, buildDunePackage, fetchurl, ocaml }:
 
-buildDunePackage rec {
+buildDunePackage (rec {
   pname = "result";
   version = "1.5";
-
-  useDune2 = lib.versionAtLeast ocaml.version "4.08";
 
   src = fetchurl {
     url = "https://github.com/janestreet/result/releases/download/${version}/result-${version}.tbz";
@@ -21,4 +19,6 @@ buildDunePackage rec {
     '';
     license = lib.licenses.bsd3;
   };
-}
+} // lib.optionalAttrs (!lib.versionAtLeast ocaml.version "4.08") {
+  duneVersion = "1";
+})

--- a/pkgs/development/ocaml-modules/octavius/default.nix
+++ b/pkgs/development/ocaml-modules/octavius/default.nix
@@ -1,6 +1,6 @@
 { lib, fetchFromGitHub, buildDunePackage, ocaml }:
 
-buildDunePackage rec {
+buildDunePackage (rec {
   pname = "octavius";
   version = "1.2.2";
 
@@ -11,8 +11,7 @@ buildDunePackage rec {
     sha256 = "sha256-/S6WpIo1c5J9uM3xgtAM/elhnsl0XimnIFsKy3ootbA=";
   };
 
-  minimumOCamlVersion = "4.03";
-  useDune2 = lib.versionAtLeast ocaml.version "4.08";
+  minimalOCamlVersion = "4.03";
 
   doCheck = true;
 
@@ -22,4 +21,6 @@ buildDunePackage rec {
     license = licenses.isc;
     maintainers = with maintainers; [ vbgl ];
   };
-}
+} // lib.optionalAttrs (!lib.versionAtLeast ocaml.version "4.08") {
+  duneVersion = "1";
+})

--- a/pkgs/development/ocaml-modules/ppx_derivers/default.nix
+++ b/pkgs/development/ocaml-modules/ppx_derivers/default.nix
@@ -1,12 +1,10 @@
 { lib, fetchFromGitHub, buildDunePackage, ocaml }:
 
-buildDunePackage rec {
+buildDunePackage (rec {
   pname = "ppx_derivers";
   version = "1.2.1";
 
-  useDune2 = lib.versionAtLeast ocaml.version "4.08";
-
-  minimumOCamlVersion = "4.02";
+  minimalOCamlVersion = "4.02";
 
   src = fetchFromGitHub {
     owner = "diml";
@@ -21,4 +19,6 @@ buildDunePackage rec {
     maintainers = [ lib.maintainers.vbgl ];
     inherit (src.meta) homepage;
   };
-}
+} // lib.optionalAttrs (!lib.versionAtLeast ocaml.version "4.08") {
+  duneVersion = "1";
+})

--- a/pkgs/development/ocaml-modules/re/default.nix
+++ b/pkgs/development/ocaml-modules/re/default.nix
@@ -13,13 +13,11 @@ let version_sha = if lib.versionAtLeast ocaml.version "4.08"
     };
 in
 
-buildDunePackage rec {
+buildDunePackage (rec {
   pname = "re";
   version = version_sha.version;
 
   minimalOCamlVersion = "4.02";
-
-  useDune2 = lib.versionAtLeast ocaml.version "4.08";
 
   src = fetchurl {
     url = "https://github.com/ocaml/ocaml-re/releases/download/${version}/re-${version}.tbz";
@@ -36,4 +34,6 @@ buildDunePackage rec {
     license = lib.licenses.lgpl2;
     maintainers = with lib.maintainers; [ vbgl ];
   };
-}
+} // lib.optionalAttrs (!lib.versionAtLeast ocaml.version "4.08") {
+  duneVersion = "1";
+})

--- a/pkgs/development/ocaml-modules/stdlib-shims/default.nix
+++ b/pkgs/development/ocaml-modules/stdlib-shims/default.nix
@@ -1,14 +1,13 @@
 { buildDunePackage, lib, fetchurl, ocaml }:
 
-buildDunePackage rec {
+buildDunePackage (rec {
   pname = "stdlib-shims";
   version = "0.3.0";
   src = fetchurl {
     url = "https://github.com/ocaml/${pname}/releases/download/${version}/${pname}-${version}.tbz";
     sha256 = "0jnqsv6pqp5b5g7lcjwgd75zqqvcwcl5a32zi03zg1kvj79p5gxs";
   };
-  useDune2 = lib.versionAtLeast ocaml.version "4.08";
-  minimumOCamlVersion = "4.02";
+  minimalOCamlVersion = "4.02";
   doCheck = true;
   meta = {
     description = "Shims for forward-compatibility between versions of the OCaml standard library";
@@ -16,4 +15,6 @@ buildDunePackage rec {
     inherit (ocaml.meta) license;
     maintainers = [ lib.maintainers.vbgl ];
   };
-}
+} // lib.optionalAttrs (!lib.versionAtLeast ocaml.version "4.08") {
+  duneVersion = "1";
+})


### PR DESCRIPTION
###### Description of changes

The `useDune2` argument to `buildDunePackage` has long been superseded by `duneVersion`.

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
