### PR TITLE
multiple-outputs.sh: Install static libraries into `$static->$dev->$out`

### DIFF
--- a/pkgs/build-support/setup-hooks/multiple-outputs.sh
+++ b/pkgs/build-support/setup-hooks/multiple-outputs.sh
@@ -190,17 +190,17 @@ _multioutStatics() {
 
     moveToOutput "lib/*.a" "${!outputStatic}"
 
-    local as=`find "${!outputStatic}/lib" -name "*.a" -type f`
-    local acount=`echo -n "$as" | wc -l`
-    if [ $acount != 0 ]; then
-        # Some of *.a files are linker scripts where moving broke the paths.
-        local output
-        for output in $(getAllOutputNames); do
-            if [ "${!output}" = "${!outputStatic}" ]; then continue; fi
-            sed "/^GROUP/s|${!output}/lib/lib|${!outputStatic}/lib/lib|g" \
-              -i $as
-        done
-    fi
+    # local as=`find "${!outputStatic}/lib" -name "*.a" -type f`
+    # local acount=`echo -n "$as" | wc -l`
+    # if [ $acount != 0 ]; then
+    #     # Some of *.a files are linker scripts where moving broke the paths.
+    #     local output
+    #     for output in $(getAllOutputNames); do
+    #         if [ "${!output}" = "${!outputStatic}" ]; then continue; fi
+    #         sed "/^GROUP/s|${!output}/lib/lib|${!outputStatic}/lib/lib|g" \
+    #           -i $as
+    #     done
+    # fi
 }
 
 # Make the "dev" propagate other outputs needed for development.

--- a/pkgs/build-support/setup-hooks/multiple-outputs.sh
+++ b/pkgs/build-support/setup-hooks/multiple-outputs.sh
@@ -195,7 +195,7 @@ _multioutStatics() {
     if [ $acount != 0 ]; then
         # Some of *.a files are linker scripts where moving broke the paths.
         local output
-        for output in $outputs; do
+        for output in $(getAllOutputNames); do
             if [ "${!output}" = "${!outputStatic}" ]; then continue; fi
             sed "/^GROUP/s|${!output}/lib/lib|${!outputStatic}/lib/lib|g" \
               -i $as

--- a/pkgs/development/libraries/glibc/default.nix
+++ b/pkgs/development/libraries/glibc/default.nix
@@ -163,6 +163,7 @@ in
     '';
 
     separateDebugInfo = true;
+    moveToStatic = false; # Default $static output handling breaks things in this drv.
 
     passthru =
       (previousAttrs.passthru or {})


### PR DESCRIPTION
###### Description of changes
During `preFixup`, static libraries (`lib/*.a`) are now installed to the `$static` output if it exists, or the `$dev` output if that exists, or just to `$out` as usual.

This will make it easier to prevent static libs making it into system closures.

Related issues:
https://github.com/NixOS/nixpkgs/issues/164141
https://github.com/NixOS/nixpkgs/issues/224533

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
