### PR TITLE
koreader: 2022.08 -> 2023.04

### DIFF
--- a/pkgs/applications/misc/koreader/default.nix
+++ b/pkgs/applications/misc/koreader/default.nix
@@ -10,15 +10,25 @@
 , SDL2
 , noto-fonts
 , nerdfonts }:
-let font-droid = nerdfonts.override { fonts = [ "DroidSansMono" ]; };
+let
+  font-droid = nerdfonts.override { fonts = [ "DroidSansMono" ]; };
+
+  patchedLuajit = luajit.overrideAttrs (old: {
+    patches = (old.patches or []) ++ [
+      (fetchurl {
+        url = "https://github.com/koreader/koreader-base/raw/4216c40d662660c9bbc48e79893b437e97518254/thirdparty/luajit/koreader-luajit-enable-table_pack.patch";
+        hash = "sha256-SKaKsb8AHW82KXPErep6+/RZ+d9WPX2ULZPowgkmmQM=";
+      })
+    ];
+  });
 in stdenv.mkDerivation rec {
   pname = "koreader";
-  version = "2022.08";
+  version = "2023.04";
 
   src = fetchurl {
     url =
       "https://github.com/koreader/koreader/releases/download/v${version}/koreader-${version}-amd64.deb";
-    sha256 = "sha256-+JBJNJTAnC5gpuo8cehfe/3YwGIW5iFA8bZ8nfz9qsk=";
+    sha256 = "sha256-tRUeRB1+UcWT49dchN0YDvd0L5n1YRdtMSFc8yy6m5o=";
   };
 
   sourceRoot = ".";
@@ -27,7 +37,7 @@ in stdenv.mkDerivation rec {
     glib
     gnutar
     gtk3-x11
-    luajit
+    patchedLuajit
     sdcv
     SDL2
   ];
@@ -39,14 +49,23 @@ in stdenv.mkDerivation rec {
   installPhase = ''
     mkdir -p $out
     cp -R usr/* $out/
-    ln -sf ${luajit}/bin/luajit $out/lib/koreader/luajit
+    ln -sf ${patchedLuajit}/bin/luajit $out/lib/koreader/luajit
     ln -sf ${sdcv}/bin/sdcv $out/lib/koreader/sdcv
     ln -sf ${gnutar}/bin/tar $out/lib/koreader/tar
     find $out -xtype l -delete
-    for i in ${noto-fonts}/share/fonts/truetype/noto/*; do
-        ln -s "$i" $out/lib/koreader/fonts/noto/
-    done
-    ln -s "${font-droid}/share/fonts/opentype/NerdFonts/Droid Sans Mono Nerd Font Complete Mono.otf" $out/lib/koreader/fonts/droid/DroidSansMono.ttf
+    # TODO: fix font file names either here or in font.lua
+    # for i in ${noto-fonts}/share/fonts/truetype/*ttf; do
+    #     ln -s "$i" $out/lib/koreader/fonts/noto/
+    # done
+
+    ln -s "${noto-fonts}/share/fonts/noto/NotoSans[wdth,wght].ttf" $out/lib/koreader/fonts/noto/NotoSans-Regular.ttf
+    ln -s "${noto-fonts}/share/fonts/noto/NotoSans[wdth,wght].ttf" $out/lib/koreader/fonts/noto/NotoSans-Bold.ttf
+    ln -s "${noto-fonts}/share/fonts/noto/NotoSans-Italic[wdth,wght].ttf" $out/lib/koreader/fonts/noto/NotoSans-Italic.ttf
+    ln -s "${noto-fonts}/share/fonts/noto/NotoNaskhArabicUI[wght].ttf" $out/lib/koreader/fonts/noto/NotoSansArabicUI-Regular.ttf
+    ln -s "${noto-fonts}/share/fonts/noto/NotoSansDevanagari[wdth,wght].ttf" $out/lib/koreader/fonts/noto/NotoSansDevanagariUI-Regular.ttf
+    ln -s "${noto-fonts}/share/fonts/noto/NotoSansBengali[wdth,wght].ttf" $out/lib/koreader/fonts/noto/NotoSansBengaliUI-Regular.ttf
+
+    ln -s "${font-droid}/share/fonts/opentype/NerdFonts/DroidSansMNerdFontMono-Regular.otf" $out/lib/koreader/fonts/droid/DroidSansMono.ttf
     wrapProgram $out/bin/koreader --prefix LD_LIBRARY_PATH : ${
       lib.makeLibraryPath [ gtk3-x11 SDL2 glib ]
     }


### PR DESCRIPTION
###### Description of changes

- Updates package to latest release; [upstream changelog](https://github.com/koreader/koreader/compare/v2022.08...v2023.04) based on automated pull-request in #197418
- ships a patched `luajit` based on upstream patch in https://github.com/koreader/koreader-base/commit/4216c40d662660c9bbc48e79893b437e97518254; I am kind of nervous about shipping a patched luajit like this, the alternative would be to patch invocations to table.pack in 8 locations, or to provide a different patch which monkeypatches `table.pack` if we decide against shipping a patched luajit.
- links only the necessary noto-font ttfs manually; their file names have changed in ways that make the `for` loop too naive.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

cc @contrun @neonfuz