### PR TITLE
darwin.stdenv: Update to LLVM 15 and clang to 15.0.7

### DIFF
--- a/pkgs/development/tools/misc/indent/default.nix
+++ b/pkgs/development/tools/misc/indent/default.nix
@@ -16,8 +16,10 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ texinfo ];
   pkgsBuildBuild = [ buildPackages.stdenv.cc ]; # needed when cross-compiling
 
-  env.NIX_CFLAGS_COMPILE = lib.optionalString stdenv.cc.isClang
-    "-Wno-implicit-function-declaration";
+  env.NIX_CFLAGS_COMPILE = toString (
+    lib.optional stdenv.cc.isClang "-Wno-implicit-function-declaration"
+    ++ lib.optional (stdenv.cc.isClang && lib.versionAtLeast (lib.getVersion stdenv.cc) "13")  "-Wno-unused-but-set-variable"
+  );
 
   hardeningDisable = [ "format" ];
 

--- a/pkgs/development/tools/misc/pkg-config/default.nix
+++ b/pkgs/development/tools/misc/pkg-config/default.nix
@@ -35,6 +35,9 @@ stdenv.mkDerivation rec {
          "ac_cv_func_posix_getgrgid_r=yes"
        ];
 
+  # Silence "incompatible integer to pointer conversion passing 'gsize'" when building with Clang.
+  env.NIX_CFLAGS_COMPILE = lib.optionalString stdenv.cc.isClang "-Wno-int-conversion";
+
   enableParallelBuilding = true;
   doCheck = true;
 

--- a/pkgs/os-specific/darwin/apple-sdk-11.0/default.nix
+++ b/pkgs/os-specific/darwin/apple-sdk-11.0/default.nix
@@ -61,7 +61,9 @@ let
   mkStdenv = stdenv:
     if stdenv.isAarch64 then stdenv
     else
+
       (overrideCC stdenv (mkCc stdenv.cc)).override {
+        extraBuildInputs = [ pkgs.darwin.apple_sdk_11_0.frameworks.CoreFoundation ];
         targetPlatform = stdenv.targetPlatform // {
           darwinMinVersion = "10.12";
           darwinSdkVersion = "11.0";

--- a/pkgs/os-specific/darwin/apple-sdk/default.nix
+++ b/pkgs/os-specific/darwin/apple-sdk/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, xar, cpio, pkgs, python3, pbzx, lib, darwin-stubs, print-reexports }:
+{ stdenv, fetchurl, xar, cpio, pkgs, python3Minimal, pbzx, lib, darwin-stubs, print-reexports }:
 
 let
   # sadly needs to be exported because security_tool needs it
@@ -16,7 +16,7 @@ let
       sha256 = "13xq34sb7383b37hwy076gnhf96prpk1b4087p87xnwswxbrisih";
     };
 
-    nativeBuildInputs = [ xar cpio python3 pbzx ];
+    nativeBuildInputs = [ xar cpio python3Minimal pbzx ];
 
     outputs = [ "out" "dev" "man" ];
 

--- a/pkgs/os-specific/darwin/apple-source-releases/configd/default.nix
+++ b/pkgs/os-specific/darwin/apple-source-releases/configd/default.nix
@@ -1,67 +1,32 @@
-{ lib, stdenv, appleDerivation', launchd, bootstrap_cmds, xnu, ppp, IOKit, eap8021x, Security
+{ lib, stdenv, appleDerivation', launchd, bootstrap_cmds, xnu, xpc, ppp, IOKit, eap8021x, Security
 , headersOnly ? false }:
 
 appleDerivation' stdenv {
   meta.broken = stdenv.cc.nativeLibc;
 
   nativeBuildInputs = lib.optionals (!headersOnly) [ bootstrap_cmds ];
-  buildInputs = lib.optionals (!headersOnly) [ launchd ppp IOKit eap8021x ];
+  buildInputs = lib.optionals (!headersOnly) [ launchd ppp xpc IOKit eap8021x ];
 
   propagatedBuildInputs = lib.optionals (!headersOnly) [ Security ];
 
+  env = lib.optionalAttrs (!headersOnly) {
+    NIX_CFLAGS_COMPILE = toString [
+      "-ISystemConfiguration.framework/Headers"
+      "-I${xnu}/Library/Frameworks/System.framework/Versions/B/PrivateHeaders"
+    ];
+  };
+
   patchPhase = lib.optionalString (!headersOnly) ''
-    HACK=$PWD/hack
-    mkdir $HACK
-    cp -r ${xnu}/Library/Frameworks/System.framework/Versions/B/PrivateHeaders/net $HACK
-
-
-    substituteInPlace SystemConfiguration.fproj/SCNetworkReachabilityInternal.h \
-      --replace '#include <xpc/xpc.h>' ""
+    substituteInPlace SystemConfiguration.fproj/reachability/SCNetworkReachabilityServer_client.c \
+      --replace '#include <xpc/private.h>' ""
 
     substituteInPlace SystemConfiguration.fproj/SCNetworkReachability.c \
       --replace ''$'#define\tHAVE_VPN_STATUS' ""
-
-    substituteInPlace SystemConfiguration.fproj/reachability/SCNetworkReachabilityServer_client.c \
-      --replace '#include <xpc/xpc.h>' '#include "fake_xpc.h"' \
-      --replace '#include <xpc/private.h>' "" \
 
     # Our neutered CoreFoundation doesn't have this function, but I think we'll live...
     substituteInPlace SystemConfiguration.fproj/SCNetworkConnectionPrivate.c \
       --replace 'CFPreferencesAppValueIsForced(serviceID, USER_PREFERENCES_APPLICATION_ID)' 'FALSE' \
       --replace 'CFPreferencesAppValueIsForced(userPrivate->serviceID, USER_PREFERENCES_APPLICATION_ID)' 'FALSE'
-
-    cat >SystemConfiguration.fproj/fake_xpc.h <<EOF
-    typedef void *xpc_type_t;
-    typedef void *xpc_object_t;
-    typedef void *xpc_connection_t;
-
-    xpc_type_t xpc_get_type(xpc_object_t object);
-    xpc_object_t xpc_dictionary_create(const char * const *keys, const xpc_object_t *values, size_t count);
-    char *xpc_copy_description(xpc_object_t object);
-    int64_t  xpc_dictionary_get_int64(xpc_object_t xdict, const char *key);
-    uint64_t xpc_dictionary_get_uint64(xpc_object_t xdict, const char *key);
-    void xpc_connection_set_event_handler(xpc_connection_t connection, void *handler);
-
-    extern const struct _xpc_type_s _xpc_type_error;
-    #define XPC_TYPE_ERROR (&_xpc_type_error)
-
-    extern const struct _xpc_type_s _xpc_type_dictionary;
-    #define XPC_TYPE_DICTIONARY (&_xpc_type_dictionary)
-
-    extern const struct _xpc_type_s _xpc_type_array;
-    #define XPC_TYPE_ARRAY (&_xpc_type_array)
-
-    extern const struct _xpc_dictionary_s _xpc_error_connection_interrupted;
-    #define XPC_ERROR_CONNECTION_INTERRUPTED (&_xpc_error_connection_interrupted)
-
-    extern const struct _xpc_dictionary_s _xpc_error_connection_invalid;
-    #define XPC_ERROR_CONNECTION_INVALID (&_xpc_error_connection_invalid)
-
-    extern const char *const _xpc_error_key_description;
-    #define XPC_ERROR_KEY_DESCRIPTION _xpc_error_key_description
-
-    #define XPC_CONNECTION_MACH_SERVICE_PRIVILEGED (1 << 1)
-    EOF
   '';
 
   dontBuild = headersOnly;
@@ -177,9 +142,9 @@ appleDerivation' stdenv {
     $CC -I. -Ihelper -Iderived -F. -c DHCP.c -o DHCP.o
     $CC -I. -Ihelper -Iderived -F. -c moh.c -o moh.o
     $CC -I. -Ihelper -Iderived -F. -c DeviceOnHold.c -o DeviceOnHold.o
-    $CC -I. -Ihelper -Iderived -I $HACK -F. -c LinkConfiguration.c -o LinkConfiguration.o
+    $CC -I. -Ihelper -Iderived -F. -c LinkConfiguration.c -o LinkConfiguration.o
     $CC -I. -Ihelper -Iderived -F. -c dy_framework.c -o dy_framework.o
-    $CC -I. -Ihelper -Iderived -I $HACK -F. -c VLANConfiguration.c -o VLANConfiguration.o
+    $CC -I. -Ihelper -Iderived -F. -c VLANConfiguration.c -o VLANConfiguration.o
     $CC -I. -Ihelper -Iderived -F. -c derived/configUser.c -o configUser.o
     $CC -I. -Ihelper -Iderived -F. -c SCPreferencesPathKey.c -o SCPreferencesPathKey.o
     $CC -I. -Ihelper -Iderived -I../dnsinfo -F. -c derived/shared_dns_infoUser.c -o shared_dns_infoUser.o
@@ -188,8 +153,8 @@ appleDerivation' stdenv {
     $CC -I. -Ihelper -Iderived -F. -c SCNetworkProtocol.c -o SCNetworkProtocol.o
     $CC -I. -Ihelper -Iderived -F. -c SCNetworkService.c -o SCNetworkService.o
     $CC -I. -Ihelper -Iderived -F. -c SCNetworkSet.c -o SCNetworkSet.o
-    $CC -I. -Ihelper -Iderived -I $HACK -F. -c BondConfiguration.c -o BondConfiguration.o
-    $CC -I. -Ihelper -Iderived -I $HACK -F. -c BridgeConfiguration.c -o BridgeConfiguration.o
+    $CC -I. -Ihelper -Iderived -F. -c BondConfiguration.c -o BondConfiguration.o
+    $CC -I. -Ihelper -Iderived -F. -c BridgeConfiguration.c -o BridgeConfiguration.o
     $CC -I. -Ihelper -Iderived -F. -c helper/SCHelper_client.c -o SCHelper_client.o
     $CC -I. -Ihelper -Iderived -F. -c SCPreferencesKeychainPrivate.c -o SCPreferencesKeychainPrivate.o
     $CC -I. -Ihelper -Iderived -F. -c SCNetworkSignature.c -o SCNetworkSignature.o

--- a/pkgs/os-specific/darwin/apple-source-releases/default.nix
+++ b/pkgs/os-specific/darwin/apple-source-releases/default.nix
@@ -248,6 +248,7 @@ developerToolsPackages_11_3_1 // macosPackages_11_0_1 // {
     CommonCrypto    = applePackage "CommonCrypto"      "osx-10.12.6"     "sha256-FLgODBrfv+XsGaAjddncYAm/BIJJYw6LcwX/z7ncKFM=" {};
     configd         = applePackage "configd"           "osx-10.8.5"      "sha256-6I3FWNjTgds5abEcZrD++s9b+P9a2+qUf8KFAb72DwI=" {
       Security      = applePackage "Security/boot.nix" "osx-10.9.5"      "sha256-7qr0IamjCXCobIJ6V9KtvbMBkJDfRCy4C5eqpHJlQLI=" {};
+      inherit (pkgs.darwin.apple_sdk.libs) xpc;
     };
     copyfile        = applePackage "copyfile"          "osx-10.12.6"     "sha256-uHqLFOIpXK+n0RHyOZzVsP2DDZcFDivKCnqHBaXvHns=" {};
     Csu             = applePackage "Csu"               "osx-10.11.6"     "sha256-h6a/sQMEVeFxKNWAPgKBXjWhyL2L2nvX9BQUMaTQ6sY=" {};
@@ -310,6 +311,7 @@ developerToolsPackages_11_3_1 // macosPackages_11_0_1 // {
     configdHeaders  = applePackage "configd"           "osx-10.8.5"      "sha256-6I3FWNjTgds5abEcZrD++s9b+P9a2+qUf8KFAb72DwI=" {
       headersOnly = true;
       Security    = null;
+      xpc         = null;
     };
     libutilHeaders  = pkgs.darwin.libutil.override { headersOnly = true; };
     hfsHeaders      = pkgs.darwin.hfs.override { headersOnly = true; };

--- a/pkgs/os-specific/darwin/apple-source-releases/xnu/default.nix
+++ b/pkgs/os-specific/darwin/apple-source-releases/xnu/default.nix
@@ -34,7 +34,7 @@ appleDerivation' (if headersOnly then stdenvNoCC else stdenv) (
       --replace "-Werror " ""
 
     substituteInPlace SETUP/kextsymboltool/Makefile \
-      --replace "-lstdc++" "-lc++"
+      --replace "-lstdc++" "-lc++ -lc++abi"
 
     substituteInPlace libsyscall/xcodescripts/mach_install_mig.sh \
       --replace "/usr/include" "/include" \

--- a/pkgs/os-specific/darwin/cctools/llvm.nix
+++ b/pkgs/os-specific/darwin/cctools/llvm.nix
@@ -1,0 +1,80 @@
+# Create a cctools-compatible bintools that uses equivalent tools from LLVM in place of the ones
+# from cctools when possible.
+
+{ lib, stdenv, makeWrapper, cctools-port, llvmPackages, useLLD ? false }:
+
+let
+  # `lipo` crashes when running the LLVM test suite when building a fat bundle. This is fixed in LLVM 16.
+  # See https://github.com/llvm/llvm-project/issues/59535
+  use_llvm_lipo = lib.versionAtLeast llvmPackages.release_version "16";
+
+  llvm_bins = [
+    "bitcode_strip"
+    "dwarfdump"
+    "nm"
+    "objdump"
+    "otool"
+    "ranlib"
+    "size"
+    "strings"
+    "strip"
+  ] ++ lib.optional use_llvm_lipo "lipo";
+
+  # Only include the tools that LLVM doesn’t provide and that are present normally on Darwin.
+  cctools_bins = [
+    "cmpdylib"
+    "codesign_allocate"
+    "ctf_insert"
+    "install_name_tool"
+    "libtool"
+    "nmedit"
+    "pagestuff"
+    "segedit"
+    "vtool"
+  ] ++ lib.optional (! use_llvm_lipo) "lipo";
+
+  ld_path = if useLLD
+    then "${lib.getBin llvmPackages.lld}/bin/ld64"
+    else "${lib.getBin cctools-port}/bin/ld";
+
+  inherit (stdenv.cc) targetPrefix;
+in
+stdenv.mkDerivation {
+  pname = "cctools-llvm-${if useLLD then "lld" else "ld64"}";
+  version = llvmPackages.release_version;
+
+  nativeBuildInputs = [ makeWrapper ];
+
+  outputs = [ "out" "dev" "man" ];
+
+  buildCommand = ''
+    mkdir -p "$out/bin"
+    ln -s "${lib.getDev cctools-port}" "$dev"
+    ln -s "${lib.getMan cctools-port}" "$man" # FIXME
+
+    # Use the clang-integrated assembler instead of using `as` from cctools.
+    makeWrapper "${lib.getBin llvmPackages.clang-unwrapped}/bin/clang" "$out/bin/${targetPrefix}as" \
+      --add-flags "-x assembler -integrated-as -c"
+
+    ln -s "${lib.getBin llvmPackages.bintools-unwrapped}/bin/llvm-ar" "$out/bin/${targetPrefix}ar"
+
+    for tool in ${toString llvm_bins}; do
+      llvmTool=''${tool/_/-}
+      ln -s "${lib.getBin llvmPackages.llvm}/bin/llvm-$llvmTool" "$out/bin/${targetPrefix}$tool"
+    done
+
+    # llvm-libtool-darwin is not yet capable of being a drop-in replacement for libtool when used with xcbuild.
+    # ln -s "${lib.getBin llvmPackages.llvm}/bin/llvm-libtool-darwin" "$out/bin/${targetPrefix}libtool"
+
+    # Don’t use `install_name_tool` from LLVM for now because it causes the build of darwin.CF to fail.
+    # ln -s "${lib.getBin llvmPackages.llvm}/bin/llvm-objcopy" "$out/bin/${targetPrefix}install_name_tool"
+
+    for tool in ${toString cctools_bins}; do
+      ln -s "${lib.getBin cctools-port}/bin/${targetPrefix}$tool" "$out/bin/${targetPrefix}$tool"
+    done
+
+    ln -s "${ld_path}" "$out/bin/${targetPrefix}ld"
+  '';
+
+  passthru = { inherit targetPrefix; };
+}

--- a/pkgs/os-specific/darwin/rewrite-tbd/default.nix
+++ b/pkgs/os-specific/darwin/rewrite-tbd/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, lib, fetchFromGitHub, cmake, pkg-config, libyaml }:
+{ stdenv, lib, fetchFromGitHub, gnumake, libyaml }:
 
 stdenv.mkDerivation {
   pname = "rewrite-tbd";
@@ -11,8 +11,17 @@ stdenv.mkDerivation {
     sha256 = "08sk91zwj6n9x2ymwid2k7y0rwv5b7p6h1b25ipx1dv0i43p6v1a";
   };
 
-  nativeBuildInputs = [ cmake pkg-config ];
+  # Nix takes care of these paths. Avoiding the use of `pkg-config` prevents an infinite recursion.
+  postPatch = ''
+    substituteInPlace Makefile.boot \
+      --replace '$(shell pkg-config --cflags yaml-0.1)' "" \
+      --replace '$(shell pkg-config --libs yaml-0.1)' "-lyaml"
+  '';
+
+  nativeBuildInputs = [ gnumake ];
   buildInputs = [ libyaml ];
+
+  makeFlags = [ "-f" "Makefile.boot" "PREFIX=${placeholder "out"}"];
 
   meta = with lib; {
     homepage = "https://github.com/thefloweringash/rewrite-tbd/";

--- a/pkgs/os-specific/darwin/swift-corelibs/corefoundation.nix
+++ b/pkgs/os-specific/darwin/swift-corelibs/corefoundation.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchFromGitHub, fetchurl, ninja, python3, curl, libxml2, objc4, ICU }:
+{ lib, stdenv, fetchFromGitHub, fetchurl, makeSetupHook, ninja, python3, curl, libxml2, objc4, ICU }:
 
 let
   # 10.12 adds a new sysdir.h that our version of CF in the main derivation depends on, but
@@ -104,4 +104,6 @@ stdenv.mkDerivation {
       ln -s Versions/Current/$i $base/$i
     done
   '';
+
+    darwinEnvHook = makeSetupHook { name = "darwin-env-hook"; } ./pure-corefoundation-hook.sh;
 }

--- a/pkgs/os-specific/darwin/swift-corelibs/pure-corefoundation-hook.sh
+++ b/pkgs/os-specific/darwin/swift-corelibs/pure-corefoundation-hook.sh
@@ -1,0 +1,7 @@
+usePureCoreFoundation() {
+# Avoid overriding value set by the impure CF
+    if [ -z "${NIX_COREFOUNDATION_RPATH:-}" ]; then
+        export NIX_COREFOUNDATION_RPATH=@out@/Library/Frameworks
+    fi
+}
+addEnvHooks "$hostOffset" usePureCoreFoundation

--- a/pkgs/stdenv/darwin/default.nix
+++ b/pkgs/stdenv/darwin/default.nix
@@ -1109,8 +1109,8 @@ in
         bash
         gawk
         gnugrep
-        gnugrep.pcre2.out
         patch
+        gnugrep.pcre2.out
         gettext
         binutils.bintools
         binutils.bintools.lib

--- a/pkgs/stdenv/darwin/default.nix
+++ b/pkgs/stdenv/darwin/default.nix
@@ -4,7 +4,6 @@
 , config
 , overlays
 , crossOverlays ? [ ]
-, bootstrapLlvmVersion ? "11.1.0"
   # Allow passing in bootstrap files directly so we can test the stdenv bootstrap process when changing the bootstrap tools
 , bootstrapFiles ? if localSystem.isAarch64 then
     let
@@ -44,26 +43,25 @@ let
   useAppleSDKLibs = localSystem.isAarch64;
   haveKRB5 = localSystem.isx86_64;
 
-  # final toolchain is injected into llvmPackages_${finalLlvmVersion}
-  finalLlvmVersion = lib.versions.major bootstrapLlvmVersion;
-  finalLlvmPackages = "llvmPackages_${finalLlvmVersion}";
-
   commonImpureHostDeps = [
     "/bin/sh"
     "/usr/lib/libSystem.B.dylib"
     "/usr/lib/system/libunc.dylib" # This dependency is "hidden", so our scanning code doesn't pick it up
   ];
 
-in
-rec {
+  isFromNixpkgs = pkg: !(isFromBootstrapFiles pkg);
+  isFromBootstrapFiles =
+    pkg: pkg.passthru.isFromBootstrapFiles or false;
+  isBuiltByNixpkgsCompiler =
+    pkg: isFromNixpkgs pkg && isFromNixpkgs pkg.stdenv.cc.cc;
+  isBuiltByBootstrapFilesCompiler =
+    pkg: isFromNixpkgs pkg && isFromBootstrapFiles pkg.stdenv.cc.cc;
+
   commonPreHook = ''
     export NIX_ENFORCE_NO_NATIVE=''${NIX_ENFORCE_NO_NATIVE-1}
     export NIX_ENFORCE_PURITY=''${NIX_ENFORCE_PURITY-1}
     export NIX_IGNORE_LD_THROUGH_GCC=1
     unset SDKROOT
-
-    stripAllFlags=" " # the Darwin "strip" command doesn't know "-s"
-    stripDebugFlags="-S" # the Darwin "strip" command does something odd with "-p"
   '';
 
   bootstrapTools = derivation ({
@@ -80,122 +78,93 @@ rec {
     __contentAddressed = true;
     outputHashAlgo = "sha256";
     outputHashMode = "recursive";
-  });
+  }) // { passthru.isFromBootstrapFiles = true; };
 
-  stageFun = step: last: { shell ? "${bootstrapTools}/bin/bash"
-                         , overrides ? (self: super: { })
-                         , extraPreHook ? ""
-                         , extraNativeBuildInputs
-                         , extraBuildInputs
-                         , libcxx
-                         , allowedRequisites ? null
-                         }:
+  stageFun = prevStage:
+    { name, overrides ? (self: super: { }), extraNativeBuildInputs ? [ ], extraPreHook ? "" }:
+
     let
-      name = "bootstrap-stage${toString step}";
+      cc = if prevStage.llvmPackages.clang-unwrapped == null
+           then null else
+           lib.makeOverridable (import ../../build-support/cc-wrapper) {
+        name = "${name}-clang-wrapper";
 
-      buildPackages = lib.optionalAttrs (last ? stdenv) {
-        inherit (last) stdenv;
+        nativeTools = false;
+        nativeLibc = false;
+
+        buildPackages = lib.optionalAttrs (prevStage ? stdenv) {
+          inherit (prevStage) stdenv;
+        };
+
+        extraPackages = [
+          prevStage.llvmPackages.libcxxabi
+          prevStage.llvmPackages.compiler-rt
+        ];
+
+        extraBuildCommands =
+          let
+            inherit (prevStage.llvmPackages) clang-unwrapped compiler-rt release_version;
+          in
+          ''
+            rsrc="$out/resource-root"
+            mkdir "$rsrc"
+            ln -s "${clang-unwrapped.lib}/lib/clang"/${release_version}/include "$rsrc"
+            ln -s "${compiler-rt.out}/lib"   "$rsrc/lib"
+            ln -s "${compiler-rt.out}/share" "$rsrc/share"
+            echo "-resource-dir=$rsrc" >> $out/nix-support/cc-cflags
+          '';
+
+        cc = prevStage.llvmPackages.clang-unwrapped;
+        bintools = prevStage.darwin.binutils;
+
+        isClang = true;
+        libc = prevStage.darwin.Libsystem;
+        inherit (prevStage.llvmPackages) libcxx;
+
+        inherit lib;
+        inherit (prevStage) coreutils gnugrep;
+
+        stdenvNoCC = prevStage.ccWrapperStdenv;
       };
-
-      doSign = localSystem.isAarch64 && last != null;
-      doUpdateAutoTools = localSystem.isAarch64 && last != null;
-
-      mkExtraBuildCommands = cc: ''
-        rsrc="$out/resource-root"
-        mkdir "$rsrc"
-        ln -s "${cc.lib or cc}/lib/clang/${cc.version}/include" "$rsrc"
-        ln -s "${last.pkgs."${finalLlvmPackages}".compiler-rt.out}/lib" "$rsrc/lib"
-        echo "-resource-dir=$rsrc" >> $out/nix-support/cc-cflags
-      '';
-
-      mkCC = overrides: import ../../build-support/cc-wrapper (
-        let args = {
-          inherit lib shell;
-          inherit (last) stdenvNoCC;
-
-          nativeTools = false;
-          nativeLibc = false;
-          inherit buildPackages libcxx;
-          inherit (last.pkgs) coreutils gnugrep;
-          bintools = last.pkgs.darwin.binutils;
-          libc = last.pkgs.darwin.Libsystem;
-          isClang = true;
-          cc = last.pkgs."${finalLlvmPackages}".clang-unwrapped;
-        }; in args // (overrides args)
-      );
-
-      cc = if last == null then "/dev/null" else
-      mkCC ({ cc, ... }: {
-        extraPackages = [
-          last.pkgs."${finalLlvmPackages}".libcxxabi
-          last.pkgs."${finalLlvmPackages}".compiler-rt
-        ];
-        extraBuildCommands = mkExtraBuildCommands cc;
-      });
-
-      ccNoLibcxx = if last == null then "/dev/null" else
-      mkCC ({ cc, ... }: {
-        libcxx = null;
-        extraPackages = [
-          last.pkgs."${finalLlvmPackages}".compiler-rt
-        ];
-        extraBuildCommands = ''
-          echo "-rtlib=compiler-rt" >> $out/nix-support/cc-cflags
-          echo "-B${last.pkgs."${finalLlvmPackages}".compiler-rt}/lib" >> $out/nix-support/cc-cflags
-          echo "-nostdlib++" >> $out/nix-support/cc-cflags
-        '' + mkExtraBuildCommands cc;
-      });
 
       thisStdenv = import ../generic {
         name = "${name}-stdenv-darwin";
-
-        inherit config shell extraBuildInputs;
-
-        extraNativeBuildInputs = extraNativeBuildInputs ++ lib.optionals doUpdateAutoTools [
-          last.pkgs.updateAutotoolsGnuConfigScriptsHook
-          last.pkgs.gnu-config
-        ];
-
-        allowedRequisites = if allowedRequisites == null then null else allowedRequisites ++ [
-          cc.expand-response-params
-          cc.bintools
-        ] ++ lib.optionals doUpdateAutoTools [
-          last.pkgs.updateAutotoolsGnuConfigScriptsHook
-          last.pkgs.gnu-config
-        ] ++ lib.optionals doSign [
-          last.pkgs.darwin.postLinkSignHook
-          last.pkgs.darwin.sigtool
-          last.pkgs.darwin.signingUtils
-        ];
 
         buildPlatform = localSystem;
         hostPlatform = localSystem;
         targetPlatform = localSystem;
 
-        inherit cc;
+        inherit config extraNativeBuildInputs;
 
-        preHook = lib.optionalString (shell == "${bootstrapTools}/bin/bash") ''
-          # Don't patch #!/interpreter because it leads to retained
-          # dependencies on the bootstrapTools in the final stdenv.
-          dontPatchShebangs=1
-        '' + ''
-          ${commonPreHook}
-          ${extraPreHook}
-        '';
+        extraBuildInputs = [ prevStage.darwin.CF ];
+
+        preHook =
+          ''
+            # Don't patch #!/interpreter because it leads to retained
+            # dependencies on the bootstrapTools in the final stdenv.
+            dontPatchShebangs=1
+            ${commonPreHook}
+            ${extraPreHook}
+          '' + lib.optionalString (prevStage.darwin ? locale) ''
+            export PATH_LOCALE=${prevStage.darwin.locale}/share/locale
+          '';
+
+        shell = "${bootstrapTools}/bin/bash";
         initialPath = [ bootstrapTools ];
 
         fetchurlBoot = import ../../build-support/fetchurl {
           inherit lib;
-          stdenvNoCC = stage0.stdenv;
+          stdenvNoCC = prevStage.ccWrapperStdenv or thisStdenv;
           curl = bootstrapTools;
         };
+
+        inherit cc;
 
         # The stdenvs themselves don't use mkDerivation, so I need to specify this here
         __stdenvImpureHostDeps = commonImpureHostDeps;
         __extraImpureHostDeps = commonImpureHostDeps;
 
         overrides = self: super: (overrides self super) // {
-          inherit ccNoLibcxx;
           fetchurl = thisStdenv.fetchurlBoot;
         };
       };
@@ -205,94 +174,117 @@ rec {
       inherit config overlays;
       stdenv = thisStdenv;
     };
+in
+  assert bootstrapTools.passthru.isFromBootstrapFiles or false;  # sanity check
+[
+  ({}: {
+    __raw = true;
 
-  stage0 = stageFun 0 null {
-    overrides = self: super: with stage0; {
-      coreutils = stdenv.mkDerivation {
-        name = "bootstrap-stage0-coreutils";
+    coreutils = null;
+    gnugrep = null;
+
+    pbzx = null;
+    cpio = null;
+
+    darwin = {
+      binutils = null;
+      binutils-unwrapped = null;
+      cctools = null;
+      print-reexports = null;
+      rewrite-tbd = null;
+      sigtool = null;
+      CF = null;
+      Libsystem = null;
+    };
+
+    llvmPackages = {
+      clang-unwrapped = null;
+      libllvm = null;
+      libcxx = null;
+      libcxxabi = null;
+      compiler-rt = null;
+    };
+  })
+
+  # Create a stage with the bootstrap tools. This will be used to build the subsequent stages and
+  # build up the standard environment.
+  #
+  # Note: Each stage depends only on the the packages in `prevStage`. If a package is not to be
+  # rebuilt, it should be passed through by inheriting it.
+  (prevStage: stageFun prevStage {
+    name = "bootstrap-stage0";
+
+    overrides = self: super: {
+      # We thread stage0's stdenv through under this name so downstream stages
+      # can use it for wrapping gcc too. This way, downstream stages don't need
+      # to refer to this stage directly, which violates the principle that each
+      # stage should only access the stage that came before it.
+      ccWrapperStdenv = self.stdenv;
+
+      coreutils = bootstrapTools;
+      gnugrep = bootstrapTools;
+
+      pbzx = bootstrapTools;
+      cpio = self.stdenv.mkDerivation {
+        name = "bootstrap-stage0-cpio";
         buildCommand = ''
-          mkdir -p $out
-          ln -s ${bootstrapTools}/bin $out/bin
+          mkdir -p $out/bin
+          ln -s ${bootstrapFiles.cpio} $out/bin/cpio
         '';
+        passthru.isFromBootstrapFiles = true;
       };
 
-      gnugrep = stdenv.mkDerivation {
-        name = "bootstrap-stage0-gnugrep";
-        buildCommand = ''
-          mkdir -p $out
-          ln -s ${bootstrapTools}/bin $out/bin
-        '';
-      };
-
-      pbzx = self.runCommandLocal "bootstrap-stage0-pbzx" { } ''
-        mkdir -p $out/bin
-        ln -s ${bootstrapTools}/bin/pbzx $out/bin
-      '';
-
-      cpio = self.runCommandLocal "bootstrap-stage0-cpio" { } ''
-        mkdir -p $out/bin
-        ln -s ${bootstrapFiles.cpio} $out/bin/cpio
-      '';
-
-      darwin = super.darwin.overrideScope (selfDarwin: superDarwin: {
-        darwin-stubs = superDarwin.darwin-stubs.override { inherit (self) stdenvNoCC fetchurl; };
-
-        dyld = {
-          name = "bootstrap-stage0-dyld";
-          buildCommand = ''
-            mkdir -p $out
-            ln -s ${bootstrapTools}/lib     $out/lib
-            ln -s ${bootstrapTools}/include $out/include
-          '';
-        };
-
-        sigtool = self.runCommandLocal "bootstrap-stage0-sigtool" { } ''
-           mkdir -p $out/bin
-           ln -s ${bootstrapTools}/bin/sigtool  $out/bin
-           ln -s ${bootstrapTools}/bin/codesign $out/bin
-        '';
-
-        print-reexports = self.runCommandLocal "bootstrap-stage0-print-reexports" { } ''
-          mkdir -p $out/bin
-          ln -s ${bootstrapTools}/bin/print-reexports $out/bin
-        '';
-
-        rewrite-tbd = self.runCommandLocal "bootstrap-stage0-rewrite-tbd" { } ''
-          mkdir -p $out/bin
-          ln -s ${bootstrapTools}/bin/rewrite-tbd $out/bin
-        '';
-
+      darwin = super.darwin.overrideScope (selfDarwin: _: {
         binutils-unwrapped = bootstrapTools // {
-          name = "bootstrap-stage0-binutils";
+          version = "boot";
         };
 
-        cctools = bootstrapTools // {
-          name = "bootstrap-stage0-cctools";
-          targetPrefix = "";
-        };
-
-        binutils = lib.makeOverridable (import ../../build-support/bintools-wrapper) {
-          shell = "${bootstrapTools}/bin/bash";
-          inherit lib;
-          inherit (self) stdenvNoCC;
+        binutils = (import ../../build-support/bintools-wrapper) {
+          name = "bootstrap-stage0-binutils-wrapper";
 
           nativeTools = false;
           nativeLibc = false;
-          inherit (self) buildPackages coreutils gnugrep;
+
+          buildPackages = { };
           libc = selfDarwin.Libsystem;
+
+          inherit lib;
+          inherit (self) stdenvNoCC coreutils gnugrep;
+
           bintools = selfDarwin.binutils-unwrapped;
+
           inherit (selfDarwin) postLinkSignHook signingUtils;
         };
+
+        cctools = bootstrapTools // {
+          targetPrefix = "";
+          version = "boot";
+          man = bootstrapTools;
+        };
+
+        locale = self.stdenv.mkDerivation {
+          name = "bootstrap-stage0-locale";
+          buildCommand = ''
+            mkdir -p $out/share/locale
+          '';
+        };
+
+        print-reexports = bootstrapTools;
+
+        rewrite-tbd = bootstrapTools;
+
+        sigtool = bootstrapTools;
       } // lib.optionalAttrs (! useAppleSDKLibs) {
-        CF = stdenv.mkDerivation {
+        CF = self.stdenv.mkDerivation {
           name = "bootstrap-stage0-CF";
           buildCommand = ''
             mkdir -p $out/Library/Frameworks
             ln -s ${bootstrapTools}/Library/Frameworks/CoreFoundation.framework $out/Library/Frameworks
           '';
+          passthru.isFromBootstrapFiles = true;
         };
 
-        Libsystem = stdenv.mkDerivation {
+        Libsystem = self.stdenv.mkDerivation {
           name = "bootstrap-stage0-Libsystem";
           buildCommand = ''
             mkdir -p $out
@@ -314,405 +306,786 @@ rec {
 
             ln -s ${bootstrapTools}/include-Libsystem $out/include
           '';
+          passthru.isFromBootstrapFiles = true;
         };
       });
 
-      "${finalLlvmPackages}" = {
-        clang-unwrapped = stdenv.mkDerivation {
-          name = "bootstrap-stage0-clang";
-          version = bootstrapLlvmVersion;
-          buildCommand = ''
-            mkdir -p $out/lib
-            ln -s ${bootstrapTools}/bin $out/bin
-            ln -s ${bootstrapTools}/lib/clang $out/lib/clang
-            ln -s ${bootstrapTools}/include $out/include
-          '';
-        };
-
-        libcxx = stdenv.mkDerivation {
-          name = "bootstrap-stage0-libcxx";
-          dontUnpack = true;
-          installPhase = ''
-            mkdir -p $out/lib $out/include
-            ln -s ${bootstrapTools}/lib/libc++.dylib $out/lib/libc++.dylib
-            ln -s ${bootstrapTools}/include/c++      $out/include/c++
-          '';
-          passthru = {
-            isLLVM = true;
-            cxxabi = self."${finalLlvmPackages}".libcxxabi;
-          };
-        };
-
-        libcxxabi = stdenv.mkDerivation {
-          name = "bootstrap-stage0-libcxxabi";
-          buildCommand = ''
-            mkdir -p $out/lib
-            ln -s ${bootstrapTools}/lib/libc++abi.dylib $out/lib/libc++abi.dylib
-          '';
-          passthru = {
-            libName = "c++abi";
-          };
-        };
-
-        compiler-rt = stdenv.mkDerivation {
-          name = "bootstrap-stage0-compiler-rt";
-          buildCommand = ''
-            mkdir -p $out/lib
-            ln -s ${bootstrapTools}/lib/libclang_rt* $out/lib
-            ln -s ${bootstrapTools}/lib/darwin       $out/lib/darwin
-          '';
-        };
-      };
-    };
-
-    extraNativeBuildInputs = [ ];
-    extraBuildInputs = [ ];
-    libcxx = null;
-  };
-
-  stage1 = prevStage:
-    let
-      persistent = self: super: with prevStage; {
-        cmake = super.cmakeMinimal;
-
-        curl = super.curlMinimal;
-
-        inherit pbzx cpio;
-
-        python3 = super.python3Minimal;
-
-        ninja = super.ninja.override { buildDocs = false; };
-
-        "${finalLlvmPackages}" = super."${finalLlvmPackages}" // (
-          let
-            tools = super."${finalLlvmPackages}".tools.extend (_: _: {
-              inherit (pkgs."${finalLlvmPackages}") clang-unwrapped;
-            });
-            libraries = super."${finalLlvmPackages}".libraries.extend (_: _: {
-              inherit (pkgs."${finalLlvmPackages}") compiler-rt libcxx libcxxabi;
-            });
-          in
-          { inherit tools libraries; } // tools // libraries
-        );
-
-        darwin = super.darwin.overrideScope (selfDarwin: _: {
-          inherit (darwin) rewrite-tbd binutils-unwrapped;
-
-          signingUtils = darwin.signingUtils.override {
-            inherit (selfDarwin) sigtool;
-          };
-
-          binutils = darwin.binutils.override {
-            coreutils = self.coreutils;
-            libc = selfDarwin.Libsystem;
-            inherit (selfDarwin) postLinkSignHook signingUtils;
-          };
-        });
-      };
-    in
-    with prevStage; stageFun 1 prevStage {
-      extraPreHook = "export NIX_CFLAGS_COMPILE+=\" -F${bootstrapTools}/Library/Frameworks\"";
-      extraNativeBuildInputs = [ ];
-      extraBuildInputs = [ pkgs.darwin.CF ];
-      libcxx = pkgs."${finalLlvmPackages}".libcxx;
-
-      allowedRequisites =
-        [ bootstrapTools ] ++
-        (with pkgs; [ coreutils gnugrep ]) ++
-        (with pkgs."${finalLlvmPackages}"; [ libcxx libcxxabi compiler-rt clang-unwrapped ]) ++
-        (with pkgs.darwin; [ Libsystem CF ] ++ lib.optional useAppleSDKLibs objc4);
-
-      overrides = persistent;
-    };
-
-  stage2 = prevStage:
-    let
-      persistent = self: super: with prevStage; {
-        inherit
-          zlib patchutils m4 scons flex perl bison unifdef unzip openssl python3
-          libxml2 gettext sharutils gmp libarchive ncurses pkg-config libedit groff
-          openssh sqlite sed serf openldap db cyrus-sasl expat apr-util subversion xz
-          findfreetype libssh curl cmake autoconf automake libtool ed cpio coreutils
-          libssh2 nghttp2 libkrb5 ninja brotli libiconv;
-
-        "${finalLlvmPackages}" = super."${finalLlvmPackages}" // (
-          let
-            tools = super."${finalLlvmPackages}".tools.extend (_: _: {
-              inherit (pkgs."${finalLlvmPackages}") clang-unwrapped;
-            });
-            libraries = super."${finalLlvmPackages}".libraries.extend (_: libSuper: {
-              inherit (pkgs."${finalLlvmPackages}") compiler-rt;
-              libcxx = libSuper.libcxx.override {
-                stdenv = overrideCC self.stdenv self.ccNoLibcxx;
+      llvmPackages = super.llvmPackages // (
+        let
+          tools = super.llvmPackages.tools.extend (selfTools: _: {
+            libclang = self.stdenv.mkDerivation {
+              name = "bootstrap-stage0-clang";
+              version = "boot";
+              outputs = [ "out" "lib" ];
+              buildCommand = ''
+                mkdir -p $out/lib
+                ln -s $out $lib
+                ln -s ${bootstrapTools}/bin       $out/bin
+                ln -s ${bootstrapTools}/lib/clang $out/lib
+                ln -s ${bootstrapTools}/include   $out
+              '';
+              passthru.isFromBootstrapFiles = true;
+            };
+            clang-unwrapped = selfTools.libclang;
+            libllvm = self.stdenv.mkDerivation {
+              name = "bootstrap-stage0-llvm";
+              outputs = [ "out" "lib" ];
+              buildCommand = ''
+                mkdir -p $out/bin $out/lib
+                ln -s $out $lib
+                ln -s ${bootstrapTools}/bin/strip    $out/bin/llvm-strip
+                ln -s ${bootstrapTools}/lib/libLLVM* $out/lib
+              '';
+              passthru.isFromBootstrapFiles = true;
+            };
+            llvm = selfTools.libllvm;
+          });
+          libraries = super.llvmPackages.libraries.extend (_: _: {
+            libcxx = self.stdenv.mkDerivation {
+              name = "bootstrap-stage0-libcxx";
+              buildCommand = ''
+                mkdir -p $out/lib $out/include
+                ln -s ${bootstrapTools}/lib/libc++.dylib $out/lib
+                ln -s ${bootstrapTools}/include/c++      $out/include
+              '';
+              passthru = {
+                isLLVM = true;
+                cxxabi = self.llvmPackages.libcxxabi;
+                isFromBootstrapFiles = true;
               };
-              libcxxabi = libSuper.libcxxabi.override ({
-                stdenv = overrideCC self.stdenv self.ccNoLibcxx;
-              } // lib.optionalAttrs (builtins.any (v: finalLlvmVersion == v) [ 7 11 12 13 ]) {
-                # TODO: the bootstrapping of llvm packages isn't consistent.
-                # `standalone` may be redundant if darwin behaves like useLLVM (or
-                # has useLLVM = true).
-                standalone = true;
+            };
+            libcxxabi = self.stdenv.mkDerivation {
+              name = "bootstrap-stage0-libcxxabi";
+              buildCommand = ''
+                mkdir -p $out/lib
+                ln -s ${bootstrapTools}/lib/libc++abi.dylib $out/lib
+              '';
+              passthru = {
+                libName = "c++abi";
+                isFromBootstrapFiles = true;
+              };
+            };
+            compiler-rt = self.stdenv.mkDerivation {
+              name = "bootstrap-stage0-compiler-rt";
+              buildCommand = ''
+                mkdir -p $out/lib $out/share
+                ln -s ${bootstrapTools}/lib/libclang_rt* $out/lib
+                ln -s ${bootstrapTools}/lib/darwin       $out/lib
+              '';
+              passthru.isFromBootstrapFiles = true;
+            };
+          });
+        in
+        # Define `release_version` as a `*`, so it’s interpreted as a glob. This is necessary
+        # because the version of clang in the bootstrap tools is not known ahead of time. This
+        # should be safe because the bootstrap tools should never contain multiple clangs.
+        { inherit tools libraries; release_version = "*"; } // tools // libraries
+      );
+    };
+
+    # The bootstrap tools may use `strip` from cctools, so use a compatible set of flags until LLVM
+    # is rebuilt, and darwin.binutils can use its implementation instead.
+    extraPreHook = ''
+      stripAllFlags=" "    # the cctools "strip" command doesn't know "-s"
+      stripDebugFlags="-S" # the cctools "strip" command does something odd with "-p"
+    '';
+  })
+
+  # This stage is primarily responsible for building the linker and setting up versions of
+  # certain dependencies needed by the rest of the build process. It is necessary to rebuild the
+  # linker because the `compiler-rt` build process checks the version and attempts to manually
+  # run `codesign` if it detects a version of `ld64` it considers too old. If that happens, the
+  # build process will fail for a few different reasons:
+  #  - sigtool is too old and does not accept the `--sign` argument;
+  #  - sigtool is new enough to accept the `--sign` argument, but it aborts when it is invoked on a
+  #    binary that is already signed; or
+  #  - compiler-rt attempts to invoke `codesign` on x86_64-darwin, but `sigtool` is not currently
+  #    part of the x86_64-darwin bootstrap tools.
+  #
+  # This stage also builds CF and Libsystem to simplify assertions and assumptions for later by
+  # making sure both packages are present on x86_64-darwin and aarch64-darwin.
+  (prevStage:
+    # previous stage0 stdenv:
+    assert lib.all isFromBootstrapFiles (with prevStage; [ coreutils cpio gnugrep pbzx ]);
+
+    assert lib.all isFromBootstrapFiles (with prevStage.darwin; [
+      binutils-unwrapped cctools print-reexports rewrite-tbd sigtool
+    ]);
+
+    assert (! useAppleSDKLibs) -> lib.all isFromBootstrapFiles (with prevStage.darwin; [ CF Libsystem ]);
+    assert    useAppleSDKLibs  -> lib.all        isFromNixpkgs (with prevStage.darwin; [ CF Libsystem ]);
+    assert lib.all isFromNixpkgs (with prevStage.darwin; [ dyld launchd xnu ]);
+
+    assert lib.all isFromBootstrapFiles (with prevStage.llvmPackages; [
+      clang-unwrapped libclang libllvm llvm compiler-rt libcxx libcxxabi
+    ]);
+
+    stageFun prevStage {
+    name = "bootstrap-stage1";
+
+    overrides = self: super: {
+      inherit (prevStage) ccWrapperStdenv
+        coreutils gnugrep;
+
+      cmake = super.cmakeMinimal;
+
+      curl = super.curlMinimal;
+
+      libffi = super.libffi.override { doCheck = false; };
+
+      # Avoid pulling in a full python and its extra dependencies for the llvm/clang builds.
+      libxml2 = super.libxml2.override { pythonSupport = false; };
+
+      ninja = super.ninja.override { buildDocs = false; };
+
+      python3 = super.python3Minimal;
+
+      darwin = super.darwin.overrideScope (selfDarwin: superDarwin: {
+        signingUtils = prevStage.darwin.signingUtils.override {
+          inherit (selfDarwin) sigtool;
+        };
+
+        binutils = superDarwin.binutils.override {
+          inherit (self) coreutils;
+          inherit (selfDarwin) postLinkSignHook signingUtils;
+
+          bintools = selfDarwin.binutils-unwrapped;
+          libc = selfDarwin.Libsystem;
+        };
+
+        binutils-unwrapped = superDarwin.binutils-unwrapped.override {
+          inherit (selfDarwin) cctools;
+        };
+
+        cctools = selfDarwin.cctools-port;
+      });
+
+      llvmPackages = super.llvmPackages // (
+        let
+          tools = super.llvmPackages.tools.extend (_: _: {
+            inherit (prevStage.llvmPackages) clang-unwrapped libclang libllvm llvm;
+          });
+          libraries = super.llvmPackages.libraries.extend (_: _: {
+            inherit (prevStage.llvmPackages) compiler-rt libcxx libcxxabi;
+          });
+        in
+        { inherit tools libraries; inherit (prevStage.llvmPackages) release_version; } // tools // libraries
+      );
+    };
+
+    extraNativeBuildInputs = lib.optionals localSystem.isAarch64 [
+      prevStage.updateAutotoolsGnuConfigScriptsHook
+      prevStage.gnu-config
+    ];
+
+    # The bootstrap tools may use `strip` from cctools, so use a compatible set of flags until LLVM
+    # is rebuilt, and darwin.binutils can use its implementation instead.
+    extraPreHook = ''
+      stripAllFlags=" "    # the cctools "strip" command doesn't know "-s"
+      stripDebugFlags="-S" # the cctools "strip" command does something odd with "-p"
+    '';
+  })
+
+  # Build sysctl and Python for use by LLVM’s check phase. These must be built in their own stage,
+  # or an infinite recursion results on x86_64-darwin when using the source-based SDK.
+  (prevStage:
+    # previous stage1 stdenv:
+    assert lib.all isFromBootstrapFiles (with prevStage; [ coreutils gnugrep ]);
+
+    assert lib.all isBuiltByBootstrapFilesCompiler (with prevStage; [
+      autoconf automake bash binutils-unwrapped bison brotli cmake cpio curl cyrus_sasl db
+      ed expat flex gettext gmp groff libedit libffi libiconv libidn2 libkrb5 libssh2
+      libtool libunistring libxml2 m4 ncurses nghttp2 ninja openldap openssh openssl
+      patchutils pbzx perl pkg-config.pkg-config python3 scons serf sqlite subversion
+      sysctl.provider unzip which xz zlib zstd
+    ]);
+
+    assert lib.all isBuiltByBootstrapFilesCompiler (with prevStage.darwin; [
+      binutils-unwrapped cctools libiconv locale libtapi print-reexports rewrite-tbd sigtool
+    ]);
+
+    assert (! useAppleSDKLibs) -> lib.all isBuiltByBootstrapFilesCompiler (with prevStage.darwin; [ CF Libsystem ICU ]);
+    assert    useAppleSDKLibs  -> lib.all                   isFromNixpkgs (with prevStage.darwin; [ CF Libsystem libobjc]);
+    assert lib.all isFromNixpkgs (with prevStage.darwin; [ dyld launchd xnu ]);
+
+    assert lib.all isFromBootstrapFiles (with prevStage.llvmPackages; [
+      clang-unwrapped libclang libllvm llvm compiler-rt libcxx libcxxabi
+    ]);
+
+    assert lib.getVersion prevStage.stdenv.cc.bintools.bintools == "boot";
+
+    stageFun prevStage {
+    name = "bootstrap-stage1-sysctl";
+
+    overrides = self: super: {
+      inherit (prevStage) ccWrapperStdenv
+        autoconf automake bash binutils binutils-unwrapped bison brotli cmake cpio coreutils
+        curl cyrus_sasl db ed expat flex gettext gmp gnugrep groff libedit libffi libiconv
+        libidn2 libkrb5 libssh2 libtool libunistring libxml2 m4 ncurses nghttp2 ninja
+        openldap openssh openssl patchutils pbzx perl pkg-config scons sed serf sharutils
+        sqlite subversion unzip which xz zlib zstd;
+
+      # Support for the SystemConfiguration framework is required to run the LLVM tests, but trying
+      # to override python3Minimal does not appear to work.
+      python3 = (super.python3.override {
+        inherit (self) libffi;
+        inherit (self.darwin) configd;
+        openssl = null;
+        readline = null;
+        ncurses = null;
+        gdbm = null;
+        sqlite = null;
+        tzdata = null;
+        stripConfig = true;
+        stripIdlelib = true;
+        stripTests = true;
+        stripTkinter = true;
+        rebuildBytecode = false;
+        stripBytecode = true;
+        includeSiteCustomize = false;
+        enableOptimizations = false;
+        enableLTO = false;
+        mimetypesSupport = false;
+      }).overrideAttrs (_: { pname = "python3-minimal-scproxy"; });
+
+      darwin = super.darwin.overrideScope (_: superDarwin: {
+        inherit (prevStage.darwin)
+          CF Libsystem ICU configd binutils-unwrapped cctools cctools-port darwin-stubs dyld
+          launchd libclosure libdispatch libobjc objc4 locale postLinkSignHook
+          print-reexports rewrite-tbd signingUtils sigtool;
+      });
+
+      llvmPackages = super.llvmPackages // (
+        let
+          tools = super.llvmPackages.tools.extend (_: _: {
+            inherit (prevStage.llvmPackages) clang-unwrapped libclang libllvm llvm;
+            clang = prevStage.stdenv.cc;
+          });
+          libraries = super.llvmPackages.libraries.extend (_: _: {
+            inherit (prevStage.llvmPackages) compiler-rt libcxx libcxxabi;
+          });
+        in
+        { inherit tools libraries; inherit (prevStage.llvmPackages) release_version; } // tools // libraries
+      );
+    };
+
+    extraNativeBuildInputs = lib.optionals localSystem.isAarch64 [
+      prevStage.updateAutotoolsGnuConfigScriptsHook
+      prevStage.gnu-config
+    ];
+
+    # Until LLVM is rebuilt, assume `strip` is the one from cctools.
+    extraPreHook = ''
+      stripAllFlags=" "    # the cctools "strip" command doesn't know "-s"
+      stripDebugFlags="-S" # the cctools "strip" command does something odd with "-p"
+    '';
+  })
+
+  # First rebuild of LLVM. While this LLVM is linked to a bunch of junk from the bootstrap tools,
+  # the libc++ and libc++abi it produces are not. The compiler will be rebuilt in a later stage,
+  # but those libraries will be used in the final stdenv.
+  #
+  # Rebuild coreutils and gnugrep to avoid unwanted references to the bootstrap tools on `PATH`.
+  (prevStage:
+    # previous stage-sysctl stdenv:
+    assert lib.all isFromBootstrapFiles (with prevStage; [ coreutils gnugrep ]);
+
+    assert lib.all isBuiltByBootstrapFilesCompiler (with prevStage; [
+      autoconf automake bash binutils-unwrapped bison brotli cmake cpio curl cyrus_sasl db
+      ed expat flex gettext gmp groff libedit libffi libiconv libidn2 libkrb5 libssh2
+      libtool libunistring libxml2 m4 ncurses nghttp2 ninja openldap openssh openssl
+      patchutils pbzx perl pkg-config.pkg-config python3 scons serf sqlite subversion
+      sysctl.provider unzip which xz zlib zstd
+    ]);
+
+    assert lib.all isBuiltByBootstrapFilesCompiler (with prevStage.darwin; [
+      binutils-unwrapped cctools libiconv locale libtapi print-reexports rewrite-tbd sigtool
+    ]);
+
+    assert (! useAppleSDKLibs) -> lib.all isBuiltByBootstrapFilesCompiler (with prevStage.darwin; [ CF Libsystem ICU ]);
+    assert    useAppleSDKLibs  -> lib.all                   isFromNixpkgs (with prevStage.darwin; [ CF Libsystem libobjc ]);
+    assert lib.all isFromNixpkgs (with prevStage.darwin; [ dyld launchd xnu ]);
+
+    assert lib.all isFromBootstrapFiles (with prevStage.llvmPackages; [
+      clang-unwrapped libclang libllvm llvm compiler-rt libcxx libcxxabi
+    ]);
+
+    assert lib.getVersion prevStage.stdenv.cc.bintools.bintools == lib.getVersion prevStage.darwin.cctools-port;
+
+    stageFun prevStage {
+    name = "bootstrap-stage-xclang";
+
+    overrides = self: super: {
+      inherit (prevStage) ccWrapperStdenv
+        autoconf automake bash binutils binutils-unwrapped bison brotli cmake cpio curl
+        cyrus_sasl db ed expat flex gettext gmp groff libedit libffi libiconv libidn2
+        libkrb5 libssh2 libtool libunistring libxml2 m4 ncurses nghttp2 ninja openldap
+        openssh openssl patchutils pbzx perl pkg-config python3 scons sed serf sharutils
+        sqlite subversion sysctl unzip which xz zlib zstd;
+
+      llvmPackages = super.llvmPackages // (
+        let
+          llvmMajor = lib.versions.major super.llvmPackages.release_version;
+
+          libraries = super.llvmPackages.libraries.extend (selfLib: superLib: {
+            compiler-rt = superLib.compiler-rt.override ({
+              inherit (selfLib) libcxxabi;
+              stdenv = self.overrideCC self.stdenv (self.llvmPackages.clangNoCompilerRtWithLibc.override {
+                inherit (selfLib) libcxx;
               });
             });
-          in
-          { inherit tools libraries; } // tools // libraries
-        );
+            libcxx = superLib.libcxx.override ({
+              inherit (selfLib) libcxxabi;
+              stdenv = self.overrideCC self.stdenv (self.llvmPackages.clangNoCompilerRtWithLibc.override {
+                nixSupport.cc-cflags = [ "-nostdlib" ];
+                nixSupport.cc-ldflags = [ "-lSystem" ];
+              });
+            });
+            libcxxabi = superLib.libcxxabi.override ({
+              stdenv = self.overrideCC self.stdenv self.llvmPackages.clangNoCompilerRtWithLibc;
+            } // lib.optionalAttrs (builtins.any (v: llvmMajor == v) [ 7 11 12 13 ]) {
+              # TODO: the bootstrapping of llvm packages isn't consistent.
+              # `standalone` may be redundant if darwin behaves like useLLVM (or
+              # has useLLVM = true).
+              standalone = true;
+            });
+          });
+        in
+        { inherit libraries; } // libraries
+      );
 
-        darwin = super.darwin.overrideScope (_: _: {
-          inherit (darwin)
-            binutils dyld Libsystem xnu configd ICU libdispatch libclosure
-            launchd CF objc4 darwin-stubs sigtool postLinkSignHook signingUtils;
-        });
-      };
-    in
-    with prevStage; stageFun 2 prevStage {
-      extraPreHook = ''
-        export PATH_LOCALE=${pkgs.darwin.locale}/share/locale
-      '';
-
-      extraNativeBuildInputs = [ pkgs.xz ];
-      extraBuildInputs = [ pkgs.darwin.CF ];
-      libcxx = pkgs."${finalLlvmPackages}".libcxx;
-
-      allowedRequisites =
-        [ bootstrapTools ] ++
-        (with pkgs; [
-          xz.bin
-          xz.out
-          zlib
-          libxml2.out
-          curl.out
-          openssl.out
-          libssh2.out
-          nghttp2.lib
-          coreutils
-          gnugrep
-          gnugrep.pcre2.out
-          gmp
-          libiconv
-          brotli.lib
-          file
-        ] ++ lib.optional haveKRB5 libkrb5) ++
-        (with pkgs."${finalLlvmPackages}"; [
-          libcxx
-          libcxxabi
-          compiler-rt
-          clang-unwrapped
-        ]) ++
-        (with pkgs.darwin; [ dyld Libsystem CF ICU locale ] ++ lib.optional useAppleSDKLibs objc4);
-
-      overrides = persistent;
+      # Switch from cctools-port to cctools-llvm now that LLVM has been built.
+      darwin = super.darwin.overrideScope (_: _: {
+        inherit (prevStage.darwin)
+          CF Libsystem ICU configd darwin-stubs dyld launchd
+          libclosure libdispatch libobjc objc4 locale postLinkSignHook print-reexports rewrite-tbd
+          signingUtils sigtool;
+      });
     };
 
-  stage3 = prevStage:
-    let
-      persistent = self: super: with prevStage; {
-        inherit
-          patchutils m4 scons flex perl bison unifdef unzip openssl python3
-          gettext sharutils libarchive pkg-config groff bash subversion
-          openssh sqlite sed serf openldap db cyrus-sasl expat apr-util
-          findfreetype libssh curl cmake autoconf automake libtool cpio
-          libssh2 nghttp2 libkrb5 ninja;
+    extraNativeBuildInputs = lib.optionals localSystem.isAarch64 [
+      prevStage.updateAutotoolsGnuConfigScriptsHook
+      prevStage.gnu-config
+    ];
 
-        # Avoid pulling in a full python and its extra dependencies for the llvm/clang builds.
-        libxml2 = super.libxml2.override { pythonSupport = false; };
+    extraPreHook = ''
+      stripAllFlags=" "    # the cctools "strip" command doesn't know "-s"
+      stripDebugFlags="-S" # the cctools "strip" command does something odd with "-p"
+    '';
+  })
 
-        "${finalLlvmPackages}" = super."${finalLlvmPackages}" // (
-          let
-            libraries = super."${finalLlvmPackages}".libraries.extend (_: _: {
-              inherit (pkgs."${finalLlvmPackages}") libcxx libcxxabi;
-            });
-          in
-          { inherit libraries; } // libraries
-        );
+  # This stage rebuilds Libsystem using the new compiler.
+   (prevStage:
+    # previous stage1 stdenv:
+    assert lib.all isBuiltByBootstrapFilesCompiler (with prevStage; [
+      autoconf automake bash binutils-unwrapped bison cmake coreutils cpio cyrus_sasl db ed
+      expat flex gettext gmp gnugrep groff libedit libtool m4 ninja openldap openssh
+      patchutils pbzx perl pkg-config.pkg-config python3 scons serf sqlite subversion
+      sysctl.provider unzip which xz
+    ]);
 
-        darwin = super.darwin.overrideScope (_: _: {
-          inherit (darwin)
-            dyld Libsystem xnu configd libdispatch libclosure launchd libiconv
-            locale darwin-stubs sigtool;
-        });
-      };
-    in
-    with prevStage; stageFun 3 prevStage {
-      shell = "${pkgs.bash}/bin/bash";
+    assert lib.all isBuiltByBootstrapFilesCompiler (with prevStage; [
+      ncurses libffi libiconv libxml2 zlib
+      brotli curl libidn2 libiconv libkrb5 libssh2 libunistring nghttp2 openssl zlib zstd
+    ]);
 
-      # We have a valid shell here (this one has no bootstrap-tools runtime deps) so stageFun
-      # enables patchShebangs above. Unfortunately, patchShebangs ignores our $SHELL setting
-      # and instead goes by $PATH, which happens to contain bootstrapTools. So it goes and
-      # patches our shebangs back to point at bootstrapTools. This makes sure bash comes first.
-      extraNativeBuildInputs = with pkgs; [ xz ];
-      extraBuildInputs = [ pkgs.darwin.CF pkgs.bash ];
-      libcxx = pkgs."${finalLlvmPackages}".libcxx;
+    assert lib.all isBuiltByBootstrapFilesCompiler (with prevStage.darwin; [
+      binutils-unwrapped cctools locale libtapi print-reexports rewrite-tbd sigtool
+    ]);
 
-      extraPreHook = ''
-        export PATH=${pkgs.bash}/bin:$PATH
-        export PATH_LOCALE=${pkgs.darwin.locale}/share/locale
-      '';
+    assert (! useAppleSDKLibs) -> lib.all isBuiltByBootstrapFilesCompiler (with prevStage.darwin; [ CF Libsystem ICU ]);
+    assert    useAppleSDKLibs  -> lib.all                   isFromNixpkgs (with prevStage.darwin; [ CF Libsystem libobjc ]);
+    assert lib.all isFromNixpkgs (with prevStage.darwin; [ dyld launchd libclosure libdispatch xnu ]);
 
-      allowedRequisites =
-        [ bootstrapTools ] ++
-        (with pkgs; [
-          xz.bin
-          xz.out
-          bash
-          zlib
-          libxml2.out
-          curl.out
-          openssl.out
-          libssh2.out
-          nghttp2.lib
-          coreutils
-          gnugrep
-          gnugrep.pcre2.out
-          gmp
-          libiconv
-          brotli.lib
-          file
-        ] ++ lib.optional haveKRB5 libkrb5) ++
-        (with pkgs."${finalLlvmPackages}"; [
-          libcxx
-          libcxx.dev
-          libcxxabi
-          libcxxabi.dev
-          compiler-rt
-          clang-unwrapped
-        ]) ++
-        (with pkgs.darwin; [ dyld ICU Libsystem locale ] ++ lib.optional useAppleSDKLibs objc4);
+    assert lib.all isBuiltByBootstrapFilesCompiler (with prevStage.llvmPackages; [
+      clang-unwrapped libclang libllvm llvm
+    ]);
+    assert lib.all isBuiltByNixpkgsCompiler (with prevStage.llvmPackages; [ compiler-rt libcxx libcxxabi ]);
 
-      overrides = persistent;
-    };
+    assert lib.getVersion prevStage.stdenv.cc.bintools.bintools == lib.getVersion prevStage.darwin.cctools-port;
 
-  stage4 = prevStage:
-    let
-      persistent = self: super: with prevStage; {
-        inherit
-          gnumake gzip gnused bzip2 ed xz patch bash python3
-          ncurses libffi zlib gmp gnugrep cmake
-          coreutils findutils diffutils patchutils ninja libxml2;
-        inherit (gnugrep) pcre2;
+    stageFun prevStage {
 
-        # Hack to make sure we don't link ncurses in bootstrap tools. The proper
-        # solution is to avoid passing -L/nix-store/...-bootstrap-tools/lib,
-        # quite a sledgehammer just to get the C runtime.
-        gettext = super.gettext.overrideAttrs (drv: {
-          configureFlags = drv.configureFlags ++ [
-            "--disable-curses"
-          ];
-        });
+    name = "bootstrap-stage2";
 
-        "${finalLlvmPackages}" = super."${finalLlvmPackages}" // (
-          let
-            tools = super."${finalLlvmPackages}".tools.extend (llvmSelf: _: {
-              clang-unwrapped-all-outputs = pkgs."${finalLlvmPackages}".clang-unwrapped-all-outputs.override { llvm = llvmSelf.llvm; };
-              libllvm = pkgs."${finalLlvmPackages}".libllvm.override { inherit libxml2; };
-            });
-            libraries = super."${finalLlvmPackages}".libraries.extend (llvmSelf: _: {
-              inherit (pkgs."${finalLlvmPackages}") libcxx libcxxabi compiler-rt;
-            });
-          in
-          { inherit tools libraries; } // tools // libraries
-        );
+    overrides = self: super: {
+      inherit (prevStage) ccWrapperStdenv
+        autoconf automake bash bison cmake coreutils cpio cyrus_sasl db ed expat flex
+        gettext gnugrep gmp groff libedit libtool m4 ninja openldap openssh patchutils pbzx
+        perl pkg-config python3 scons serf sqlite subversion sysctl unzip which xz
+        ncurses libffi libiconv libxml2 zlib
+        brotli curl libidn2 libkrb5 libssh2 libunistring nghttp2 openssl zstd;
 
-        darwin = super.darwin.overrideScope (_: superDarwin: {
-          inherit (darwin) dyld Libsystem libiconv locale darwin-stubs;
+      darwin = super.darwin.overrideScope (selfDarwin: superDarwin: {
+        inherit (prevStage.darwin) CF ICU darwin-stubs launchd libiconv libobjc objc4 locale
+        print-reexports rewrite-tbd sigtool signingUtils;
 
-          # See useAppleSDKLibs in darwin-packages.nix
-          CF = if useAppleSDKLibs then super.darwin.CF else
-          superDarwin.CF.override {
-            inherit libxml2;
-            python3 = prevStage.python3;
+        # Rewrap binutils so it uses the rebuilt Libsystem.
+        binutils = superDarwin.binutils.override {
+          buildPackages = {
+            inherit (prevStage) stdenv;
           };
-        });
-      };
-    in
-    with prevStage; stageFun 4 prevStage {
-      shell = "${pkgs.bash}/bin/bash";
-      extraNativeBuildInputs = with pkgs; [ xz ];
-      extraBuildInputs = [ pkgs.darwin.CF pkgs.bash ];
-      libcxx = pkgs."${finalLlvmPackages}".libcxx;
+          libc = selfDarwin.Libsystem;
+        } // {
+          passthru = { inherit (prevStage.bintools.passthru) isFromBootstrapFiles; };
+        };
+      });
 
-      extraPreHook = ''
-        export PATH_LOCALE=${pkgs.darwin.locale}/share/locale
-      '';
-      overrides = persistent;
+      llvmPackages = super.llvmPackages // (
+        let
+          tools = super.llvmPackages.tools.extend (_: _: {
+            inherit (prevStage.llvmPackages) clang-unwrapped libclang libllvm llvm;
+            clang = prevStage.stdenv.cc;
+          });
+          libraries = super.llvmPackages.libraries.extend (_: _: {
+            inherit (prevStage.llvmPackages) compiler-rt libcxx libcxxabi;
+          });
+        in
+        { inherit tools libraries; inherit (prevStage.llvmPackages) release_version; } // tools // libraries
+      );
     };
 
-  stdenvDarwin = prevStage:
+    extraNativeBuildInputs = lib.optionals localSystem.isAarch64 [
+      prevStage.updateAutotoolsGnuConfigScriptsHook
+      prevStage.gnu-config
+    ];
+
+    extraPreHook = ''
+      stripDebugFlags="-S" # llvm-strip does not support "-p" for Mach-O
+    '';
+  })
+
+  # Rebuild LLVM with LLVM.
+  (prevStage:
+    # previous stage2 stdenv:
+    assert lib.all isBuiltByBootstrapFilesCompiler (with prevStage; [
+      autoconf automake bash bison cmake coreutils cpio cyrus_sasl db ed expat flex gettext
+      gmp gnugrep groff libedit libtool m4 ninja openldap openssh patchutils pbzx perl
+      pkg-config.pkg-config python3 scons serf sqlite subversion sysctl.provider unzip which xz
+      ncurses libffi libiconv libxml2 zlib
+      brotli curl libidn2 libiconv libkrb5 libssh2 libunistring nghttp2 openssl zlib zstd
+    ]);
+    assert lib.all isBuiltByNixpkgsCompiler (with prevStage; [
+      binutils-unwrapped
+    ]);
+
+    assert lib.all isBuiltByBootstrapFilesCompiler (with prevStage.darwin; [
+      locale print-reexports rewrite-tbd sigtool libiconv
+    ]);
+    assert lib.all isBuiltByNixpkgsCompiler (with prevStage.darwin; [
+      binutils-unwrapped cctools libtapi
+    ]);
+
+    assert (! useAppleSDKLibs) -> lib.all isBuiltByBootstrapFilesCompiler (with prevStage.darwin; [ CF ICU ]);
+    assert    useAppleSDKLibs  -> lib.all                   isFromNixpkgs (with prevStage.darwin; [ CF libobjc ]);
+
+    assert (! useAppleSDKLibs) -> lib.all isBuiltByNixpkgsCompiler (with prevStage.darwin; [ Libsystem ]);
+    assert    useAppleSDKLibs  -> lib.all            isFromNixpkgs (with prevStage.darwin; [ Libsystem ]);
+    assert lib.all isFromNixpkgs (with prevStage.darwin; [ dyld launchd libclosure libdispatch xnu ]);
+
+    assert lib.all isBuiltByBootstrapFilesCompiler (with prevStage.llvmPackages; [
+      clang-unwrapped libclang libllvm llvm
+    ]);
+    assert lib.all isBuiltByNixpkgsCompiler (with prevStage.llvmPackages; [ libcxx libcxxabi ]);
+
+    assert lib.getVersion prevStage.stdenv.cc.bintools.bintools == lib.getVersion prevStage.darwin.cctools-llvm;
+
+    stageFun prevStage {
+
+    name = "bootstrap-stage3";
+
+    overrides = self: super: {
+      inherit (prevStage) ccWrapperStdenv
+        autoconf automake bash binutils binutils-unwrapped bison cmake coreutils cpio
+        cyrus_sasl db ed expat flex gettext gmp gnugrep groff libedit libtool m4 ninja
+        openldap openssh patchutils pbzx perl pkg-config python3 scons sed serf sharutils
+        sqlite subversion sysctl unzip which xz;
+
+        # Rebuild the following dependencies along with LLVM, so it can link against them.
+        # ncurses libffi libiconv libxml2 zlib
+
+        # CF requires the following dependencies, which should be rebuilt along with it. CF is built
+        # in this stage instead of along with libSystem because curl depends on libSystem.
+        # brotli curl libidn2 libkrb5 libssh2 libunistring nghttp2 openssl zstd ICU
+
+      libffi = super.libffi.override { doCheck = false; };
+
+      # Avoid pulling in a full python and its extra dependencies for the llvm/clang builds.
+      libxml2 = super.libxml2.override { pythonSupport = false; };
+
+      darwin = super.darwin.overrideScope (selfDarwin: superDarwin: {
+        inherit (prevStage.darwin)
+          Libsystem binutils binutils-unwrapped cctools cctools-llvm cctools-port
+          configd darwin-stubs dyld launchd libclosure libdispatch libtapi locale
+          postLinkSignHook print-reexports rewrite-tbd signingUtils sigtool;
+
+          # CF on noon-source SDKs is CoreFoundation from `apple_sdk.frameworks`. It requires
+          # libobjc. Rebuild them both together.
+          # libobjc
+      });
+
+      llvmPackages = super.llvmPackages // (
+        let
+          libraries = super.llvmPackages.libraries.extend (_: _: {
+           inherit (prevStage.llvmPackages) compiler-rt libcxx libcxxabi;
+          });
+        in
+        { inherit libraries; } // libraries
+      );
+    };
+
+    extraNativeBuildInputs = lib.optionals localSystem.isAarch64 [
+      prevStage.updateAutotoolsGnuConfigScriptsHook
+      prevStage.gnu-config
+    ];
+
+    extraPreHook = ''
+      stripDebugFlags="-S" # llvm-strip does not support "-p" for Mach-O
+    '';
+  })
+
+  # Construct a standard environment with the new clang. Also use the new compiler to rebuild
+  # everything that will be part of the final stdenv.
+  (prevStage:
+    # previous stage3 stdenv:
+    assert lib.all isBuiltByBootstrapFilesCompiler (with prevStage; [
+      autoconf automake bash bison cmake cpio coreutils cyrus_sasl db ed expat flex gettext
+      gmp gnugrep groff libedit libtool m4 ninja openldap openssh patchutils pbzx perl
+      pkg-config.pkg-config python3 scons serf sqlite subversion sysctl.provider unzip which xz
+    ]);
+
+    assert lib.all isBuiltByNixpkgsCompiler (with prevStage; [
+      binutils-unwrapped curl ncurses libffi libiconv libxml2 zlib
+      brotli curl libidn2 libiconv libkrb5 libssh2 libunistring nghttp2 openssl zlib zstd
+    ]);
+
+    assert lib.all isBuiltByBootstrapFilesCompiler (with prevStage.darwin; [
+      locale print-reexports rewrite-tbd sigtool
+    ]);
+    assert lib.all isBuiltByNixpkgsCompiler (with prevStage.darwin; [
+      binutils-unwrapped cctools libiconv libtapi
+    ]);
+
+    assert (! useAppleSDKLibs) -> lib.all isBuiltByNixpkgsCompiler (with prevStage.darwin; [ CF Libsystem ICU ]);
+    assert    useAppleSDKLibs  -> lib.all            isFromNixpkgs (with prevStage.darwin; [ CF Libsystem libobjc ]);
+    assert lib.all isFromNixpkgs (with prevStage.darwin; [ dyld launchd libclosure libdispatch xnu ]);
+
+    assert lib.all isBuiltByNixpkgsCompiler (with prevStage.llvmPackages; [
+      clang-unwrapped libclang libllvm llvm compiler-rt libcxx libcxxabi
+    ]);
+
+    assert lib.getVersion prevStage.stdenv.cc.bintools.bintools == lib.getVersion prevStage.darwin.cctools-llvm;
+
+    stageFun prevStage {
+
+    name = "bootstrap-stage4";
+
+    overrides = self: super: {
+      inherit (prevStage) ccWrapperStdenv
+        autoconf automake bison cmake cpio cyrus_sasl db expat flex groff libedit libtool m4
+        ninja openldap openssh patchutils pbzx perl pkg-config python3 scons serf sqlite
+        subversion sysctl unzip which
+
+        # These were built in an earlier stage to build LLVM and CF. Don’t rebuild them.
+        ncurses libffi libiconv libxml2 zlib
+        brotli curl libidn2 libkrb5 libssh2 libunistring nghttp2 openssl zstd;
+
+      darwin = super.darwin.overrideScope (selfDarwin: superDarwin: {
+        inherit (prevStage.darwin) dyld CF ICU Libsystem darwin-stubs libiconv
+          # libobjc is required by CoreFoundation on aarch64-darwin. Don’t rebuild it.
+          libobjc objc4;
+
+        signingUtils = superDarwin.signingUtils.override {
+          inherit (selfDarwin) sigtool;
+        };
+
+        binutils = superDarwin.binutils.override {
+          shell = self.bash + "/bin/bash";
+
+          buildPackages = {
+            inherit (prevStage) stdenv;
+          };
+
+          bintools = selfDarwin.binutils-unwrapped;
+          libc = selfDarwin.Libsystem;
+        };
+      });
+
+      llvmPackages = super.llvmPackages // (
+        let
+          tools = super.llvmPackages.tools.extend (_: _: {
+            inherit (prevStage.llvmPackages) clang-unwrapped libclang libllvm llvm;
+            libcxxClang = lib.makeOverridable (import ../../build-support/cc-wrapper) {
+              nativeTools = false;
+              nativeLibc = false;
+
+              buildPackages = {
+                inherit (prevStage) stdenv;
+              };
+
+              extraPackages = [
+                self.llvmPackages.libcxxabi
+                self.llvmPackages.compiler-rt
+              ];
+
+              extraBuildCommands =
+                let
+                  inherit (self.llvmPackages) clang-unwrapped compiler-rt release_version;
+                in
+                ''
+                  rsrc="$out/resource-root"
+                  mkdir "$rsrc"
+                  ln -s "${clang-unwrapped.lib}/lib/clang/${release_version}/include" "$rsrc"
+                  ln -s "${compiler-rt.out}/lib"   "$rsrc/lib"
+                  ln -s "${compiler-rt.out}/share" "$rsrc/share"
+                  echo "-resource-dir=$rsrc" >> $out/nix-support/cc-cflags
+                '';
+
+              cc = self.llvmPackages.clang-unwrapped;
+              bintools = self.darwin.binutils;
+
+              isClang = true;
+              libc = self.darwin.Libsystem;
+              inherit (self.llvmPackages) libcxx;
+
+              inherit lib;
+              inherit (self) stdenvNoCC coreutils gnugrep;
+
+              shell = self.bash + "/bin/bash";
+            };
+          });
+          libraries = super.llvmPackages.libraries.extend (_: _:{
+            inherit (prevStage.llvmPackages) compiler-rt libcxx libcxxabi;
+          });
+        in
+        { inherit tools libraries; } // tools // libraries
+      );
+    };
+
+    extraNativeBuildInputs = lib.optionals localSystem.isAarch64 [
+      prevStage.updateAutotoolsGnuConfigScriptsHook
+      prevStage.gnu-config
+    ];
+
+    extraPreHook = ''
+      stripDebugFlags="-S" # llvm-strip does not support "-p" for Mach-O
+    '';
+  })
+
+  # Construct the final stdenv. The version of LLVM provided should match the one defined in
+  # `all-packages.nix` for Darwin. Nothing should depend on the bootstrap tools or originate from
+  # the bootstrap tools.
+  #
+  # When updating the Darwin stdenv, make sure that the result has no dependency (`nix-store -qR`)
+  # on `bootstrapTools` or the binutils built in stage 1.
+  (prevStage:
+    # previous stage4 stdenv:
+    assert lib.all isBuiltByNixpkgsCompiler (with prevStage; [
+      bash binutils-unwrapped brotli bzip2 curl diffutils ed file findutils gawk gettext gmp
+      gnugrep gnumake gnused gnutar gzip libffi libiconv libidn2 libkrb5 libssh2 libunistring libxml2
+      ncurses nghttp2 openssl patch pcre xz zlib zstd
+    ]);
+
+    assert lib.all isBuiltByNixpkgsCompiler (with prevStage.darwin; [
+      binutils-unwrapped cctools libiconv locale
+       libtapi print-reexports rewrite-tbd sigtool
+    ]);
+
+    assert (! useAppleSDKLibs) -> lib.all isBuiltByNixpkgsCompiler (with prevStage.darwin; [ CF Libsystem ICU libobjc ]);
+    assert    useAppleSDKLibs  -> lib.all            isFromNixpkgs (with prevStage.darwin; [ CF Libsystem libobjc]);
+    assert lib.all isFromNixpkgs (with prevStage.darwin; [ dyld launchd libclosure libdispatch xnu ]);
+
+    assert lib.all isBuiltByNixpkgsCompiler (with prevStage.llvmPackages; [
+      clang-unwrapped libclang libllvm llvm compiler-rt libcxx libcxxabi
+    ]);
+
+    assert lib.all isBuiltByBootstrapFilesCompiler (with prevStage; [
+      autoconf automake bison cmake cpio cyrus_sasl db expat flex groff libedit libtool m4 ninja
+      openldap openssh patchutils pbzx perl pkg-config.pkg-config python3 scons serf sqlite
+      subversion sysctl.provider unzip which
+    ]);
+
+    assert prevStage.darwin.cctools == prevStage.darwin.cctools-llvm;
+
     let
       doSign = localSystem.isAarch64;
-      pkgs = prevStage;
-      persistent = self: super: with prevStage; {
-        inherit
-          gnumake gzip gnused bzip2 gawk ed xz patch bash
-          ncurses libffi zlib gmp gnugrep
-          coreutils findutils diffutils patchutils pbzx;
-        inherit (gnugrep) pcre2;
+
+      persistent = self: super: {
+        inherit (prevStage)
+          bash binutils brotli bzip2 coreutils curl diffutils ed file findutils gawk gettext
+          gmp gnugrep gnumake gnused gnutar gzip libffi libidn2 libiconv libssh2
+          libunistring libxml2 ncurses nghttp2 openssl patch pre xz zlib zstd;
 
         darwin = super.darwin.overrideScope (_: _: {
-          inherit (darwin) dyld ICU Libsystem Csu libiconv rewrite-tbd;
+          inherit (prevStage.darwin) dyld Libsystem CF ICU locale libobjc libtapi;
         } // lib.optionalAttrs (super.stdenv.targetPlatform == localSystem) {
-          inherit (darwin) binutils binutils-unwrapped cctools;
+          inherit (prevStage.darwin) binutils binutils-unwrapped cctools cctools-llvm cctools-port;
         });
       } // lib.optionalAttrs (super.stdenv.targetPlatform == localSystem) {
-        inherit llvm;
+        inherit (prevStage) llvm;
 
         # Need to get rid of these when cross-compiling.
-        "${finalLlvmPackages}" = super."${finalLlvmPackages}" // (
+        llvmPackages = super.llvmPackages // (
           let
-            tools = super."${finalLlvmPackages}".tools.extend (_: super: {
-              inherit (pkgs."${finalLlvmPackages}") llvm clang-unwrapped;
+            tools = super.llvmPackages.tools.extend (_: _: {
+              inherit (prevStage.llvmPackages) clang clang-unwrapped libclang libllvm llvm;
             });
-            libraries = super."${finalLlvmPackages}".libraries.extend (_: _: {
-              inherit (pkgs."${finalLlvmPackages}") compiler-rt libcxx libcxxabi;
+            libraries = super.llvmPackages.libraries.extend (_: _: {
+              inherit (prevStage.llvmPackages) compiler-rt libcxx libcxxabi;
             });
           in
           { inherit tools libraries; } // tools // libraries
         );
 
-        inherit binutils binutils-unwrapped;
+        inherit (prevStage) binutils binutils-unwrapped;
       };
-    in
-    import ../generic rec {
-      name = "stdenv-darwin";
 
-      inherit config;
-      inherit (pkgs.stdenv) fetchurlBoot;
+      cc = prevStage.llvmPackages.clang;
+    in
+    {
+    inherit config overlays;
+    stdenv = import ../generic {
+      name = "stdenv-darwin";
 
       buildPlatform = localSystem;
       hostPlatform = localSystem;
       targetPlatform = localSystem;
 
+      inherit config;
+
       preHook = commonPreHook + ''
-        export NIX_COREFOUNDATION_RPATH=${pkgs.darwin.CF}/Library/Frameworks
-        export PATH_LOCALE=${pkgs.darwin.locale}/share/locale
+        stripDebugFlags="-S" # llvm-strip does not support "-p" for Mach-O
+        export PATH_LOCALE=${prevStage.darwin.locale}/share/locale
       '';
 
-      __stdenvImpureHostDeps = commonImpureHostDeps;
-      __extraImpureHostDeps = commonImpureHostDeps;
-
-      initialPath = import ../generic/common-path.nix { inherit pkgs; };
-      shell = "${pkgs.bash}/bin/bash";
-
-      cc = pkgs."${finalLlvmPackages}".libcxxClang;
+      initialPath = ((import ../generic/common-path.nix) { pkgs = prevStage; });
 
       extraNativeBuildInputs = lib.optionals localSystem.isAarch64 [
-        pkgs.updateAutotoolsGnuConfigScriptsHook
+        prevStage.updateAutotoolsGnuConfigScriptsHook
       ];
 
-      extraBuildInputs = [ pkgs.darwin.CF ];
+      extraBuildInputs = [ prevStage.darwin.CF ];
+
+      inherit cc;
+
+      shell = cc.shell;
+
+      inherit (prevStage.stdenv) fetchurlBoot;
 
       extraAttrs = {
-        libc = pkgs.darwin.Libsystem;
-        shellPackage = pkgs.bash;
         inherit bootstrapTools;
+        libc = prevStage.darwin.Libsystem;
+        shellPackage = prevStage.bash;
       } // lib.optionalAttrs useAppleSDKLibs {
         # This objc4 will be propagated to all builds using the final stdenv,
         # and we shouldn't mix different builds, because they would be
         # conflicting LLVM modules. Export it here so we can grab it later.
-        inherit (pkgs.darwin) objc4;
+        inherit (prevStage.darwin) objc4;
       };
 
-      allowedRequisites = (with pkgs; [
+      disallowedRequisites = [ bootstrapTools.out ];
+
+      allowedRequisites = (with prevStage; [
         xz.out
         xz.bin
         gmp.out
@@ -726,6 +1099,7 @@ rec {
         coreutils
         ed
         diffutils
+        libiconv
         gnutar
         gzip
         ncurses.out
@@ -735,8 +1109,8 @@ rec {
         bash
         gawk
         gnugrep
-        patch
         gnugrep.pcre2.out
+        patch
         gettext
         binutils.bintools
         binutils.bintools.lib
@@ -753,35 +1127,41 @@ rec {
         cc.expand-response-params
         libxml2.out
         file
-      ] ++ lib.optional haveKRB5 libkrb5
-      ++ lib.optionals localSystem.isAarch64 [
-        pkgs.updateAutotoolsGnuConfigScriptsHook
-        pkgs.gnu-config
       ])
-      ++ (with pkgs."${finalLlvmPackages}"; [
+      ++ lib.optional haveKRB5 prevStage.libkrb5
+      ++ lib.optionals localSystem.isAarch64 [
+        prevStage.updateAutotoolsGnuConfigScriptsHook
+        prevStage.gnu-config
+      ]
+      ++ (with prevStage.llvmPackages; [
+        bintools-unwrapped
         libcxx
         libcxx.dev
         libcxxabi
         libcxxabi.dev
+        lld
         llvm
         llvm.lib
         compiler-rt
         compiler-rt.dev
         clang-unwrapped
-        libclang.dev
-        libclang.lib
+        clang-unwrapped.lib
       ])
-      ++ (with pkgs.darwin; [
+      ++ (with prevStage.darwin; [
         dyld
         Libsystem
         CF
-        cctools
+        cctools-llvm
+        cctools-port
         ICU
-        libiconv
         locale
         libtapi
-      ] ++ lib.optional useAppleSDKLibs objc4
+      ]
+      ++ lib.optional useAppleSDKLibs objc4
       ++ lib.optionals doSign [ postLinkSignHook sigtool signingUtils ]);
+
+      __stdenvImpureHostDeps = commonImpureHostDeps;
+      __extraImpureHostDeps = commonImpureHostDeps;
 
       overrides = lib.composeExtensions persistent (self: super: {
         darwin = super.darwin.overrideScope (_: superDarwin: {
@@ -794,16 +1174,24 @@ rec {
         inherit cc;
       });
     };
+  })
 
-  stagesDarwin = [
-    ({}: stage0)
-    stage1
-    stage2
-    stage3
-    stage4
-    (prevStage: {
-      inherit config overlays;
-      stdenv = stdenvDarwin prevStage;
-    })
-  ];
-}
+  # This "no-op" stage is just a place to put the assertions about stage6.
+  (prevStage:
+    # previous final stage stdenv:
+    assert isBuiltByNixpkgsCompiler prevStage.darwin.sigtool;
+    assert isBuiltByNixpkgsCompiler prevStage.darwin.binutils-unwrapped;
+    assert isBuiltByNixpkgsCompiler prevStage.darwin.print-reexports;
+    assert isBuiltByNixpkgsCompiler prevStage.darwin.rewrite-tbd;
+    assert isBuiltByNixpkgsCompiler prevStage.darwin.cctools;
+
+    assert            isFromNixpkgs prevStage.darwin.CF;
+    assert            isFromNixpkgs prevStage.darwin.Libsystem;
+
+    assert isBuiltByNixpkgsCompiler prevStage.llvmPackages.clang-unwrapped;
+    assert isBuiltByNixpkgsCompiler prevStage.llvmPackages.libllvm;
+    assert isBuiltByNixpkgsCompiler prevStage.llvmPackages.libcxx;
+    assert isBuiltByNixpkgsCompiler prevStage.llvmPackages.libcxxabi;
+    assert isBuiltByNixpkgsCompiler prevStage.llvmPackages.compiler-rt;
+    { inherit (prevStage) config overlays stdenv; })
+]

--- a/pkgs/stdenv/default.nix
+++ b/pkgs/stdenv/default.nix
@@ -28,7 +28,7 @@ let
   # the GNU C compiler, and so on.
   stagesLinux = import ./linux args;
 
-  inherit (import ./darwin args) stagesDarwin;
+  stagesDarwin = import ./darwin args;
 
   stagesCross = import ./cross args;
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -15790,7 +15790,7 @@ with pkgs;
     # This returns the minimum supported version for the platform. The
     # assumption is that or any later version is good.
     choose = platform:
-      /**/ if platform.isDarwin then 11
+      /**/ if platform.isDarwin then 15
       else if platform.isFreeBSD then 12
       else if platform.isAndroid then 12
       else if platform.isLinux then 11

--- a/pkgs/top-level/darwin-packages.nix
+++ b/pkgs/top-level/darwin-packages.nix
@@ -100,11 +100,17 @@ impure-cmds // appleSourcePackages // chooseLibs // {
     bintools = self.binutils-unwrapped;
   };
 
-  cctools = callPackage ../os-specific/darwin/cctools/port.nix {
+  cctools = self.cctools-llvm;
+
+  cctools-port = callPackage ../os-specific/darwin/cctools/port.nix {
     stdenv = if stdenv.isDarwin then stdenv else pkgs.libcxxStdenv;
   };
 
   cctools-apple = callPackage ../os-specific/darwin/cctools/apple.nix {
+    stdenv = if stdenv.isDarwin then stdenv else pkgs.libcxxStdenv;
+  };
+
+  cctools-llvm = callPackage ../os-specific/darwin/cctools/llvm.nix {
     stdenv = if stdenv.isDarwin then stdenv else pkgs.libcxxStdenv;
   };
 


### PR DESCRIPTION
###### Description of changes

Bumps LLVM and clang to 15.0.7 on Darwin. This was prompted by #229210 because the 13.3 SDK does not build with LLVM 11. This PR reworks the Darwin stdenv to decouple it from the bootstrap tools is written not to need updates to bootstrap tools and includes changes to allow LLVM to be bumped without requiring a bump to the bootstrap tools.

See the comments in 309dc9d8f1e explaining the rework of the Darwin stden bootstrap process. My hope is this will make future bumps easier and more approachable for non-Darwin developers. It should also make experimentation a little safer. I’d like to see if any space could be saved by enabling LTO during the bootstrap, but that’s out of scope for this PR.

###### Issues to be resolved

These have all been resolved. The changes needed for the bootstrap are included in this PR. The others are being handled in separate PRs, which will be linked below.

- [X] Disable LLVM tests when building the stdenv. This causes an infinite recursion currently. I have a workaround, but ideally it should be disabled in the bootstrap.
- [X] `pkg-config` requires disabling a warning, or the build fails. It’s vendoring a very old version of GLib. Unfortunately, nixpkgs does not provide a way to use the nixpkgs `glib` package. I also tried, and it caused an infinite recursion.
- [X] `codesign` in bootstrap tools is too old for LLVM, but I’ve included a workaround. A bootstrap tools update would obviate the change.
- [X] Updating platform definition now that LLVM understands `apple-m1`. This should likely go in another PR, but it’s included here for testing. See #166401.

###### Testing Done

Running `nixpkgs-review` on a stdenv change is obviously going to rebuild an infeasible amount of packages. I have attempted to build and run a number of packages to catch common failures. I’ve tried to change things needed to build the stdenv from those that fix common problems. See below for PRs related to those (and sandbox issues I encountered along the way).

###### Related PRs

These fail to build due to the changes.

- #234117
- #234219

These are Darwin sandbox-related fixes. They’re not strictly necessary, but they allow Darwin users to build more things with the sandbox enabled.

- #234106
- #234111
- #234115
- #234119
- #234122
- #234125
- #234129
- #234132

This fix is related to running the store on case-sensitive APFS. It’s the first thing that has broken for me. Most case sensitivity issues during builds are due to `/tmp` being insensitive.

- #234105
(more fixes coming tomorrow)

###### Things done

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

[1]: https://github.com/reckenrode/nix-packages/tree/96b37cf5b91c092c924d4494d4d3fbb8adc48b65/pkgs/unit/ff/ffxiv