### PR TITLE
davinci-resolve: overriding appimage-run to use buildFHSEnvChroot

### DIFF
--- a/pkgs/applications/video/davinci-resolve/default.nix
+++ b/pkgs/applications/video/davinci-resolve/default.nix
@@ -9,6 +9,7 @@
 , libGLU
 , xorg
 , buildFHSEnv
+, buildFHSEnvChroot
 , bash
 , writeText
 , ocl-icd
@@ -26,7 +27,11 @@ let
       pname = "davinci-resolve";
       version = "17.4.3";
 
-      nativeBuildInputs = [ unzip appimage-run addOpenGLRunpath ];
+      nativeBuildInputs = [
+        unzip
+        (appimage-run.override { buildFHSEnv = buildFHSEnvChroot; } )
+        addOpenGLRunpath
+      ];
 
       # Pretty sure, there are missing dependencies ...
       buildInputs = [ libGLU xorg.libXxf86vm ];


### PR DESCRIPTION
###### Description of changes

#226671 The way davinci-resolve was using appimage-run threw the following build errors:

```
DaVinci_Resolve_17.4.3_Linux.run is now installed in /build/home/.cache/appimage-run/0942a051d270a19f39d312a347c8cd0ebf45327ae
d008646f99d7bff78d5d8c4
This will install DaVinci Resolve on this computer
#Starting DaVinci Resolve install

Linux localhost 5.15.94 #1-NixOS SMP Tue Feb 14 18:18:05 UTC 2023 x86_64 GNU/Linux

Install Location : /nix/store/b0lv2di80qgnfhk7hxppmwz3xial1kny-davinci-resolve-17.4.3
User ID: 0

User Home: /build

Error: Installer failed
 Failed to copy file: share
 ```
 
 Overriding `appimage-run` to use `buildFHSEnvChroot` instead seems to resolve the build error.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).