### PR TITLE
add Gaupol application

### DIFF
--- a/pkgs/applications/video/gaupol/default.nix
+++ b/pkgs/applications/video/gaupol/default.nix
@@ -1,0 +1,73 @@
+{ lib
+, python39
+, fetchFromGitHub
+, gnome
+, gobject-introspection
+, gtk3
+, bash
+, cairo
+, glibcLocales
+, wrapGAppsHook
+}:
+
+let
+  python = python39;
+in python.pkgs.buildPythonApplication rec {
+  pname = "gaupol";
+  version = "1.11.0";
+
+  src = fetchFromGitHub {
+    owner = "otsaloma";
+    repo = "gaupol";
+    rev = version;
+    hash = "sha256-iF2ScQFYxYM2o18Cfy6U6JAZxIiZSsGrWEb4yjyECwc=";
+  };
+
+  propagatedBuildInputs = with python.pkgs; [
+    cairo
+    gobject-introspection
+    gtk3
+    pygobject3
+  ];
+
+  nativeBuildInputs = [
+    gobject-introspection
+    wrapGAppsHook
+  ];
+
+  buildInputs = [
+    gtk3
+    gnome.adwaita-icon-theme
+  ];
+
+  checkInputs = [
+    glibcLocales
+  ];
+
+  nativeCheckInputs = with python.pkgs; [
+    flake8
+  ];
+
+
+  checkPhase = ''
+    make check
+  '';
+
+
+  postInstall = ''
+    # Causes fatal ldconfig cache generation attempt on non-NixOS Linux
+    for mkfile in $out/lib/python3.9/site-packages/aeidon/paths.py ; do
+      substituteInPlace $mkfile \
+        --replace '/gaupol-1.11.data/data/share' $out/share
+    done
+  '';
+
+
+  meta = with lib; {
+    homepage = "https://github.com/otsaloma/gaupol";
+    description = "Editor for text-based subtitle files";
+    license = licenses.gpl3Plus;
+    maintainers = with maintainers; [];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -23945,6 +23945,8 @@ with pkgs;
 
   subdl = callPackage ../applications/video/subdl { };
 
+  gaupol = callPackage ../applications/video/gaupol { };
+
   subtitleedit = callPackage ../applications/video/subtitleedit { };
 
   subtitleeditor = callPackage ../applications/video/subtitleeditor { };


### PR DESCRIPTION
###### Description of changes

Adding the Gaupol  application, an editor for text-based subtitles.
https://otsaloma.io/gaupol/

###### Things done



- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

I tested on my personal laptop running NixOS
