### PR TITLE
llvmPackages_16.llvm: fix build on armv7l-linux

### DIFF
--- a/pkgs/development/compilers/llvm/16/llvm/default.nix
+++ b/pkgs/development/compilers/llvm/16/llvm/default.nix
@@ -239,12 +239,6 @@ in
     rm test/tools/gold/X86/split-dwarf.ll
     rm test/tools/llvm-dwarfdump/X86/prettyprint_types.s
     rm test/tools/llvm-dwarfdump/X86/simplified-template-names.s
-
-    # !!! Note: these tests are removed in LLVM 16.
-    #
-    # See here for context: https://github.com/NixOS/nixpkgs/pull/194634#discussion_r999790443
-    rm test/CodeGen/RISCV/rv32zbp.ll
-    rm test/CodeGen/RISCV/rv64zbp.ll
   '' + optionalString (stdenv.hostPlatform.system == "armv6l-linux") ''
     # Seems to require certain floating point hardware (NEON?)
     rm test/ExecutionEngine/frem.ll


### PR DESCRIPTION
###### Description of changes
Fix for
```
llvm> unpacking sources
llvm> unpacking source archive /nix/store/3n7ksbzfx5661kr9i5gmyklm2l8mimn8-llvm-src-16.0.1
llvm> source root is llvm-src-16.0.1/llvm
llvm> patching sources
llvm> applying patch /nix/store/sinjjzbn52f5665m1i2mvj239kp3anpk-gnu-install-dirs.patch
llvm> patching file CMakeLists.txt
llvm> Hunk #1 succeeded at 995 (offset 53 lines).
llvm> patching file cmake/modules/AddLLVM.cmake
llvm> Hunk #1 succeeded at 874 (offset 30 lines).
llvm> Hunk #2 succeeded at 2043 (offset 36 lines).
llvm> Hunk #3 succeeded at 2312 (offset 41 lines).
llvm> patching file cmake/modules/AddOCaml.cmake
llvm> patching file cmake/modules/CMakeLists.txt
llvm> Hunk #1 succeeded at 127 (offset -1 lines).
llvm> patching file docs/CMake.rst
llvm> patching file tools/llvm-config/BuildVariables.inc.in
llvm> patching file tools/llvm-config/llvm-config.cpp
llvm> Hunk #1 succeeded at 366 (offset -3 lines).
llvm> applying patch /nix/store/syssfm9j83s7hlyhxgsn7bn2lbkh5rdz-llvm-lit-cfg-add-libs-to-dylib-path.patch
llvm> patching file test/Unit/lit.cfg.py
llvm> Hunk #2 succeeded at 58 (offset 2 lines).
llvm> patching file test/lit.cfg.py
llvm> Hunk #2 succeeded at 348 (offset 10 lines).
llvm> applying patch /nix/store/lzwpi2h5bwgjl91d7csfcm5vvrz88bf9-lit-shell-script-runner-set-dyld-library-path.patch
llvm> patching file utils/lit/lit/TestRunner.py
llvm> applying patch /nix/store/rcdzyb4rkml4hhjdg3xbscipaz94v3jk-gnu-install-dirs-polly.patch
llvm> patching file tools/polly/cmake/polly_macros.cmake
llvm> applying patch /nix/store/gr73nf6sca9nyzl88x58y3qxrav04yhd-polly-lit-cfg-add-libs-to-dylib-path.patch
llvm> patching file tools/polly/test/lit.cfg
llvm> rm: cannot remove 'test/CodeGen/RISCV/rv32zbp.ll': No such file or directory
llvm> /nix/store/zmssb0gm5il4qd9wd1f4cmmyv8hyfx03-stdenv-linux/setup: line 136: pop_var_context: head of shell_variables not a function context
error: builder for '/nix/store/4mdkng3p41g1m2mksld3lgbxqmjckhps-llvm-16.0.1.drv' failed with exit code 1;
       last 10 log lines:
       > patching file test/lit.cfg.py
       > Hunk #2 succeeded at 348 (offset 10 lines).
       > applying patch /nix/store/lzwpi2h5bwgjl91d7csfcm5vvrz88bf9-lit-shell-script-runner-set-dyld-library-path.patch
       > patching file utils/lit/lit/TestRunner.py
       > applying patch /nix/store/rcdzyb4rkml4hhjdg3xbscipaz94v3jk-gnu-install-dirs-polly.patch
       > patching file tools/polly/cmake/polly_macros.cmake
       > applying patch /nix/store/gr73nf6sca9nyzl88x58y3qxrav04yhd-polly-lit-cfg-add-libs-to-dylib-path.patch
       > patching file tools/polly/test/lit.cfg
       > rm: cannot remove 'test/CodeGen/RISCV/rv32zbp.ll': No such file or directory
       > /nix/store/zmssb0gm5il4qd9wd1f4cmmyv8hyfx03-stdenv-linux/setup: line 136: pop_var_context: head of shell_variables not a function context
       For full logs, run 'nix log /nix/store/4mdkng3p41g1m2mksld3lgbxqmjckhps-llvm-16.0.1.drv'.
```
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] armv7l-linux (native)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
