### PR TITLE
nixos/tests/installer.nix: add missing kbd.dev

### DIFF
--- a/nixos/tests/installer.nix
+++ b/nixos/tests/installer.nix
@@ -345,6 +345,7 @@ let
             (docbook-xsl-ns.override {
               withManOptDedupPatch = true;
             })
+            kbd.dev
             kmod.dev
             libarchive.dev
             libxml2.bin


### PR DESCRIPTION
Sometimes the tests fail since splitting kbd.dev in PR #226247
https://hydra.nixos.org/build/218620685/nixlog/2/tail
Apparently the failure isn't 100% reproducible; I don't know how/why.


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
