### PR TITLE
qc: init at 0.0.4

### DIFF
--- a/pkgs/development/tools/qc/default.nix
+++ b/pkgs/development/tools/qc/default.nix
@@ -1,0 +1,40 @@
+{ lib, buildGoModule, fetchFromGitHub, installShellFiles }:
+
+buildGoModule rec {
+  pname = "qc";
+  version = "0.4.0";
+
+  src = fetchFromGitHub {
+    owner = "qownnotes";
+    repo = "qc";
+    rev = "v${version}";
+    hash = "sha256-6dH7pmsd7kUgwHplvCfNqoq/ucDY/UZnyVxC3VvV+fQ=";
+  };
+
+  vendorHash = "sha256-7t5rQliLm6pMUHhtev/kNrQ7AOvmA/rR93SwNQhov6o=";
+
+  ldflags = [
+    "-s" "-w" "-X=github.com/qownnotes/qc/cmd.version=${version}"
+  ];
+
+  doCheck = false;
+
+  subPackages = [ "." ];
+
+  nativeBuildInputs = [
+    installShellFiles
+  ];
+
+  postInstall = ''
+    installShellCompletion --cmd qc \
+      --zsh ./misc/completions/zsh/_qc
+  '';
+
+  meta = with lib; {
+    description = "QOwnNotes command-line snippet manager";
+    homepage = "https://github.com/qownnotes/qc";
+    license = licenses.mit;
+    maintainers = with maintainers; [ pbek totoroot ];
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -18824,6 +18824,8 @@ with pkgs;
 
   pylint-exit = callPackage ../development/tools/pylint-exit { };
 
+  qc = callPackage ../development/tools/qc { };
+
   qtcreator = libsForQt5.callPackage ../development/tools/qtcreator {
     inherit (linuxPackages) perf;
   };


### PR DESCRIPTION
###### Description of changes

As follow up from #226157...

Adds `qc`, the **QOwnNotes command-line snippet manager**.
https://github.com/qownnotes/qc

You can use the **QOwnNotes command-line snippet manager** to **execute command snippets** stored
in **notes** in [QOwnNotes](https://www.qownnotes.org/) from the command line.

This app is a companion to https://github.com/NixOS/nixpkgs/tree/nixos-22.11/pkgs/applications/office/qownnotes.

Note: The build config is almost the same as https://github.com/NixOS/nixpkgs/blob/master/pkgs/development/tools/pet/default.nix.

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

