### PR TITLE
haskellPackages.streamly-archive: improve unbreak

### DIFF
--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -411,6 +411,14 @@ self: super: {
 
   # The package requires streamly == 0.9.*.
   # (We can remove this once the assert starts failing.)
+  streamly-archive = super.streamly-archive.override {
+    streamly =
+      assert (builtins.compareVersions pkgs.haskellPackages.streamly.version "0.9.0" < 0);
+        pkgs.haskellPackages.streamly_0_9_0;
+  };
+
+  # The package requires streamly == 0.9.*.
+  # (We can remove this once the assert starts failing.)
   streamly-lmdb = super.streamly-lmdb.override {
     streamly =
       assert (builtins.compareVersions pkgs.haskellPackages.streamly.version "0.9.0" < 0);

--- a/pkgs/development/haskell-modules/configuration-nix.nix
+++ b/pkgs/development/haskell-modules/configuration-nix.nix
@@ -903,16 +903,8 @@ self: super: builtins.intersectAttrs super {
     })
     (self.generateOptparseApplicativeCompletions [ "pnbackup" ] super.pinboard-notes-backup);
 
-  streamly-archive = super.streamly-archive.override {
-    # The package requires streamly == 0.9.*.
-    # (We can remove this once the assert starts failing.)
-    streamly =
-      assert (builtins.compareVersions pkgs.haskellPackages.streamly.version "0.9.0" < 0);
-        pkgs.haskellPackages.streamly_0_9_0;
-
-    # Pass the correct libarchive into the package.
-    archive = pkgs.libarchive;
-  };
+  # Pass the correct libarchive into the package.
+  streamly-archive = super.streamly-archive.override { archive = pkgs.libarchive; };
 
   # Pass the correct lmdb into the package.
   streamly-lmdb = super.streamly-lmdb.override { lmdb = pkgs.lmdb; };


### PR DESCRIPTION
###### Things done

- [x] Manually modified `configuration-nix.nix` and `configuration-common.nix`, to reflect a more correct setup suggested in this comment by @maralorn: https://github.com/NixOS/nixpkgs/pull/229606#issuecomment-1532886736
- [x] Tested compilation of all pkgs that depend on this change using `nix-build --no-out-link -A haskellPackages.streamly-archive --arg config '{ allowBroken = true; }'`.
- [x] Ran `maintainers/scripts/haskell/regenerate-hackage-packages.sh`, which had no effect (as expected).
