### PR TITLE
mkNugetSource: remove mono from build closure

### DIFF
--- a/pkgs/build-support/dotnet/make-nuget-source/default.nix
+++ b/pkgs/build-support/dotnet/make-nuget-source/default.nix
@@ -1,4 +1,4 @@
-{ dotnetPackages, lib, xml2, stdenvNoCC }:
+{ lib, python3, stdenvNoCC }:
 
 { name
 , description ? ""
@@ -10,21 +10,21 @@ let
     inherit name;
 
     meta.description = description;
-    nativeBuildInputs = [ dotnetPackages.Nuget xml2 ];
+    nativeBuildInputs = [ python3 ];
 
     buildCommand = ''
-      export HOME=$(mktemp -d)
       mkdir -p $out/{lib,share}
 
-      ${lib.concatMapStringsSep "\n" (dep: ''
-        nuget init "${dep}" "$out/lib"
-      '') deps}
+      (
+        shopt -s nullglob
+        for nupkg in ${lib.concatMapStringsSep " " (dep: "\"${dep}\"/*.nupkg") deps}; do
+          cp --no-clobber "$nupkg" $out/lib
+        done
+      )
 
       # Generates a list of all licenses' spdx ids, if available.
       # Note that this currently ignores any license provided in plain text (e.g. "LICENSE.txt")
-      find "$out/lib" -name "*.nuspec" -exec sh -c \
-        "NUSPEC=\$(xml2 < {}) && echo "\$NUSPEC" | grep license/@type=expression | tr -s \  '\n' | grep "license=" | cut -d'=' -f2" \
-      \; | sort -u > $out/share/licenses
+      python ${./extract-licenses-from-nupkgs.py} $out/lib > $out/share/licenses
     '';
   } // { # We need data from `$out` for `meta`, so we have to use overrides as to not hit infinite recursion.
     meta.licence = let

--- a/pkgs/build-support/dotnet/make-nuget-source/extract-licenses-from-nupkgs.py
+++ b/pkgs/build-support/dotnet/make-nuget-source/extract-licenses-from-nupkgs.py
@@ -1,0 +1,30 @@
+#!/usr/bin/env python3
+"""
+Opens each .nupkg file in a directory, and extracts the SPDX license identifiers
+from them if they exist. The SPDX license identifier is stored in the
+'<license type="expression">...</license>' tag in the .nuspec file.
+All found license identifiers will be printed to stdout.
+"""
+
+from glob import glob
+from pathlib import Path
+import sys
+import xml.etree.ElementTree as ET
+import zipfile
+
+all_licenses = set()
+
+if len(sys.argv) < 2:
+    print(f"Usage: {sys.argv[0]} DIRECTORY")
+    sys.exit(1)
+
+nupkg_dir = Path(sys.argv[1])
+for nupkg_name in glob("*.nupkg", root_dir=nupkg_dir):
+    with zipfile.ZipFile(nupkg_dir / nupkg_name) as nupkg:
+        for nuspec_name in [name for name in nupkg.namelist() if name.endswith(".nuspec")]:
+            with nupkg.open(nuspec_name) as nuspec_stream:
+                nuspec = ET.parse(nuspec_stream)
+                licenses = nuspec.findall(".//{*}license[@type='expression']")
+                all_licenses.update([license.text for license in licenses])
+
+print("\n".join(sorted(all_licenses)))


### PR DESCRIPTION
###### Description of changes

A directory full of *.nupkg files is a valid nuget source. We do not need mono and the Nuget command line tool to create this structure. This has two advantages:

- Nuget is currently broken due to a kernel bug affecting mono (#229476). Replacing the mkNugetSource implementation allows affected users on 6.1+ kernels compile .NET core packages again.
- It removes mono from the build closure of .NET core packages. .NET core builds should not depend on .NET framework tools like mono.

There is no equivalent of the `nuget init` command in .NET core. The closest command is `dotnet nuget push`, which just copies the *.nupkg files around anyway, just like this PR does with `cp`.

`nuget init` used to extract the *.nuspec files from the nupkgs, this new implementation doesn't. .NET core doesn't care, but it makes the license extraction more difficult. What was previously done with find/grep/xml2 is now a python script (extract-licenses-from-nupkgs.py).

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
