### PR TITLE
nixos/modules/virtualisation: improve podman systemd units

### DIFF
--- a/nixos/modules/virtualisation/oci-containers.nix
+++ b/nixos/modules/virtualisation/oci-containers.nix
@@ -100,6 +100,9 @@ let
         log-driver = mkOption {
           type = types.str;
           default = if cfg.backend == "podman" then "passthrough" else "journald";
+          defaultText = literalExpression ''
+            if cfg.backend == "podman" then "passthrough" else "journald";
+          '';
           description = lib.mdDoc ''
             Logging driver for the container.  The default of
             `"journald"` means that the container's logs will be

--- a/nixos/modules/virtualisation/oci-containers.nix
+++ b/nixos/modules/virtualisation/oci-containers.nix
@@ -99,7 +99,7 @@ let
 
         log-driver = mkOption {
           type = types.str;
-          default = "journald";
+          default = if cfg.backend == "podman" then "passthrough" else "journald";
           description = lib.mdDoc ''
             Logging driver for the container.  The default of
             `"journald"` means that the container's logs will be
@@ -268,7 +268,7 @@ let
       "--entrypoint=${escapeShellArg container.entrypoint}"
       ++ lib.optionals (cfg.backend == "podman") [
         "--cidfile=/run/podman-${escapedName}.ctr-id"
-        "--cgroups=no-conmon"
+        "--cgroups=split"
         "--sdnotify=conmon"
         "-d"
         "--replace"
@@ -314,6 +314,9 @@ let
       Environment="PODMAN_SYSTEMD_UNIT=podman-${name}.service";
       Type="notify";
       NotifyAccess="all";
+      Delegate="yes";
+      StandardOutput="journal";
+      StandardError="journal";
     };
   };
 

--- a/pkgs/build-support/docker/examples.nix
+++ b/pkgs/build-support/docker/examples.nix
@@ -65,11 +65,11 @@ rec {
     nginxConf = pkgs.writeText "nginx.conf" ''
       user nobody nobody;
       daemon off;
-      error_log /dev/stdout info;
+      error_log stderr info;
       pid /dev/null;
       events {}
       http {
-        access_log /dev/stdout;
+        access_log off;
         server {
           listen ${nginxPort};
           index index.html;


### PR DESCRIPTION
Hello,

I made the generated systemd service more in line with what podman generate systemd does.

Default log-driver to passthrough to directly mount stdout in the container and use split cgroup to create separate cgroup for conmon and for container.

This will break programs that use /dev/stdout or /dev/stderr as a file because they will be a socket instead of a file, like the example nginx image that I had to edit. The advantage is that the containers stdout only ends up in journald and not also in a file, resulting in less disk usage.

Is this something we want to do in NixOS ?

Maybe another thing to look at is Quadlet : https://docs.podman.io/en/latest/markdown/podman-systemd.unit.5.html

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
