### PR TITLE
vivictpp: init at 0.3.1

### DIFF
--- a/pkgs/applications/video/vivictpp/default.nix
+++ b/pkgs/applications/video/vivictpp/default.nix
@@ -1,0 +1,73 @@
+{ lib, stdenv, fetchFromGitHub
+, meson, cmake, ninja, pkg-config
+, python3, git
+, SDL2, SDL2_ttf
+, freetype, harfbuzz
+, ffmpeg
+, cacert }:
+
+let
+  version = "0.3.1";
+  withSubprojects = stdenv.mkDerivation {
+    name = "sources-with-subprojects";
+
+    src = fetchFromGitHub {
+      owner = "vivictorg";
+      repo = "vivictpp";
+      rev = "v${version}";
+      hash = "sha256-6YfYeUrM7cq8hnOPMq0Uq/HToFBDri0N/r0SU0LeT/Y=";
+    };
+
+    nativeBuildInputs = [
+      meson
+      cacert
+      git
+    ];
+
+    buildCommand = ''
+      cp -r --no-preserve=mode $src $out
+      cd $out
+
+      meson subprojects download
+      find subprojects -type d -name .git -prune -execdir rm -r {} +
+    '';
+
+    outputHashMode = "recursive";
+    outputHash = "sha256-lIm2Bwy61St9d1e6QSm5ZpSIDR9ucaQKBPHATTDEgW4=";
+  };
+in stdenv.mkDerivation rec {
+  pname = "vivictpp";
+  inherit version;
+
+  src = withSubprojects;
+
+  nativeBuildInputs = [
+    meson
+    cmake
+    ninja
+    pkg-config
+
+    python3
+    git
+  ];
+
+  buildInputs = [
+    SDL2
+    SDL2_ttf
+    freetype
+    harfbuzz
+    ffmpeg
+  ];
+
+  preConfigure = ''
+    patchShebangs .
+  '';
+
+  meta = with lib; {
+    description = "An easy to use tool for subjective comparison of the visual quality of different encodings of the same video source";
+    homepage = "https://github.com/vivictorg/vivictpp";
+    license = licenses.gpl2Plus;
+    platforms = platforms.unix;
+    maintainers = with maintainers; [ tilpner ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -34845,6 +34845,8 @@ with pkgs;
       else null;
   };
 
+  vivictpp = callPackage ../applications/video/vivictpp { };
+
   vpcs = callPackage ../applications/virtualization/vpcs { };
 
   primusLib = callPackage ../tools/X11/primus/lib.nix {


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Add [vivictpp](https://github.com/vivictorg/vivictpp), "an easy to use tool for subjective comparison of the visual quality of different encodings of the same video source".

It allows you to play back two videos at the same time, and then use your cursor to reveal different portions of them for easy visual comparison.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
