### PR TITLE
python3Packages.py-partiql-parser: init at 0.3.3

### DIFF
--- a/pkgs/development/python-modules/py-partiql-parser/default.nix
+++ b/pkgs/development/python-modules/py-partiql-parser/default.nix
@@ -1,0 +1,46 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, nix-update-script
+, pytestCheckHook
+, setuptools
+, sure
+}:
+
+buildPythonPackage rec {
+  pname = "py-partiql-parser";
+  version = "0.3.3";
+  format = "pyproject";
+
+  src = fetchFromGitHub {
+    owner = "getmoto";
+    repo = "py-partiql-parser";
+    rev = "refs/tags/${version}";
+    hash = "sha256-7FYIRlr75L0y1d9jgbPpq/G7VC4YMD7IUQVNhfHdCh8=";
+  };
+
+  nativeBuildInputs = [
+    setuptools
+  ];
+
+  nativeCheckInputs = [
+    pytestCheckHook
+    sure
+  ];
+
+  pythonImportsCheck = [
+    "py_partiql_parser"
+  ];
+
+  passthru = {
+    updateScript = nix-update-script { };
+  };
+
+  meta = with lib; {
+    description = "A tokenizer/parser/executor for the PartiQL-language, in Python";
+    homepage = "https://github.com/getmoto/py-partiql-parser";
+    changelog = "https://github.com/getmoto/py-partiql-parser/blob/${version}/CHANGELOG.md";
+    license = licenses.mit;
+    maintainers = with maintainers; [ centromere ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -8178,6 +8178,8 @@ self: super: with self; {
 
   py-nightscout = callPackage ../development/python-modules/py-nightscout { };
 
+  py-partiql-parser = callPackage ../development/python-modules/py-partiql-parser { };
+
   py-pdf-parser = callPackage ../development/python-modules/py-pdf-parser { };
 
   py-serializable = callPackage ../development/python-modules/py-serializable { };


### PR DESCRIPTION
###### Description of changes

Homepage: https://github.com/getmoto/py-partiql-parser

[moto](https://github.com/NixOS/nixpkgs/blob/1a411f23ba299db155a5b45d5e145b85a7aafc42/pkgs/development/python-modules/moto/default.nix) 4.1.8 introduces this package as a dependency. Once this is merged I can submit a PR for moto 4.1.3 -> 4.1.8.

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
