### PR TITLE
tclx: 8.4.1 -> 8.6.1, add fgaz to maintainers

### DIFF
--- a/pkgs/development/libraries/tclx/default.nix
+++ b/pkgs/development/libraries/tclx/default.nix
@@ -20,6 +20,6 @@ tcl.mkTclDerivation rec {
     homepage = "https://tclx.sourceforge.net/";
     description = "Tcl extensions";
     license = lib.licenses.tcltk;
-    maintainers = with lib.maintainers; [ kovirobi ];
+    maintainers = with lib.maintainers; [ kovirobi fgaz ];
   };
 }

--- a/pkgs/development/libraries/tclx/default.nix
+++ b/pkgs/development/libraries/tclx/default.nix
@@ -1,12 +1,17 @@
-{ lib, fetchurl, tcl }:
+{ lib
+, fetchFromGitHub
+, tcl
+}:
 
 tcl.mkTclDerivation rec {
   pname = "tclx";
-  version = "8.4.1";
+  version = "8.6.1";
 
-  src = fetchurl {
-    url = "mirror://sourceforge/tclx/tclx${version}.tar.bz2";
-    sha256 = "1v2qwzzidz0is58fd1p7wfdbscxm3ip2wlbqkj5jdhf6drh1zd59";
+  src = fetchFromGitHub {
+    owner = "flightaware";
+    repo = "tclx";
+    rev = "v${version}";
+    hash = "sha256-HdbuU0IR8q/0g2fIs1xtug4oox/D24C8E2VbEJC5B1A=";
   };
 
   # required in order for tclx to properly detect tclx.tcl at runtime
@@ -17,7 +22,7 @@ tcl.mkTclDerivation rec {
   '';
 
   meta = {
-    homepage = "https://tclx.sourceforge.net/";
+    homepage = "https://github.com/flightaware/tclx";
     description = "Tcl extensions";
     license = lib.licenses.tcltk;
     maintainers = with lib.maintainers; [ kovirobi fgaz ];


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
https://github.com/flightaware/tclx

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
