### PR TITLE
giada: unstable-2021-09-24 -> unstable-2023-05-02

### DIFF
--- a/pkgs/applications/audio/giada/default.nix
+++ b/pkgs/applications/audio/giada/default.nix
@@ -15,18 +15,21 @@
 , libogg
 , libvorbis
 , libopus
+, libXrandr
+, fmt_8
+, nlohmann_json
 }:
 
 stdenv.mkDerivation rec {
   pname = "giada";
-  version = "unstable-2021-09-24";
+  version = "unstable-2023-05-02";
 
   src = fetchFromGitHub {
     owner = "monocasual";
     repo = pname;
     # Using master with https://github.com/monocasual/giada/pull/509 till a new release is done.
-    rev = "f117a8b8eef08d904ef1ab22c45f0e1fad6b8a56";
-    sha256 = "01hb981lrsyk870zs8xph5fm0z7bbffpkxgw04hq487r804mkx9j";
+    rev = "9bffd0976daa3e73c9c7199d0051cb8518dbab7a";
+    sha256 = "sha256-LatkdqVGRCslaxrwZfZDmzYlqZx/8/3DwdnmLX0cdI4=";
     fetchSubmodules = true;
   };
 
@@ -46,6 +49,9 @@ stdenv.mkDerivation rec {
   ];
 
   buildInputs = [
+    fmt_8
+    nlohmann_json
+    libXrandr
     rtmidi
     fltk
     libsndfile


### PR DESCRIPTION
###### Description of changes

Existing giada was pretty old, but there was a bug in 0.24 that prevented building. 0.25.0 was just marked (not sure if actually released?) a few days ago.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
  - [x] Giada plays music
  - [ ] Verified that juseaide and juce_lv2_helper work. (TBH I'm pretty clueless. I think they're for VSTs? I tried giada and realized I'm waaaaay to clueless to use it, but I thought I'd submit this anyways)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

Result of `nixpkgs-review` run on x86_64-linux [1](https://github.com/Mic92/nixpkgs-review)
<details>
  <summary>1 package built:</summary>
  <ul>
    <li>giada</li>
  </ul>
</details>
