### PR TITLE
tandoor-recipes: 1.4.4 -> 1.4.9

### DIFF
--- a/nixos/modules/services/misc/tandoor-recipes.nix
+++ b/nixos/modules/services/misc/tandoor-recipes.nix
@@ -9,6 +9,7 @@ let
   env = {
     GUNICORN_CMD_ARGS = "--bind=${cfg.address}:${toString cfg.port}";
     DEBUG = "0";
+    DEBUG_TOOLBAR = "0";
     MEDIA_ROOT = "/var/lib/tandoor-recipes";
   } // optionalAttrs (config.time.timeZone != null) {
     TIMEZONE = config.time.timeZone;

--- a/pkgs/applications/misc/tandoor-recipes/common.nix
+++ b/pkgs/applications/misc/tandoor-recipes/common.nix
@@ -1,15 +1,15 @@
 { lib, fetchFromGitHub }:
 rec {
-  version = "1.4.4";
+  version = "1.4.9";
 
   src = fetchFromGitHub {
     owner = "TandoorRecipes";
     repo = "recipes";
     rev = version;
-    sha256 = "sha256-1wqZoOT2Aafbs2P0mL33jw5HkrLIitUcRt6bQQcHx40=";
+    sha256 = "sha256-h424lUm/wmCHXkMW2XejogvH3wL/+J67cG4m8rIWM1U=";
   };
 
-  yarnSha256 = "sha256-gH0q3pJ2BC5pAU9KSo3C9DDRUnpypoyLOEqKSrkxYrk=";
+  yarnSha256 = "sha256-LJ0uL66tcK6zL8Mkd2UB8dHsslMTtf8wQmgbZdvOT6s=";
 
   meta = with lib; {
     homepage = "https://tandoor.dev/";

--- a/pkgs/applications/misc/tandoor-recipes/default.nix
+++ b/pkgs/applications/misc/tandoor-recipes/default.nix
@@ -2,6 +2,7 @@
 , nixosTests
 , python3
 , fetchFromGitHub
+, fetchpatch
 }:
 let
   python = python3.override {
@@ -41,6 +42,12 @@ python.pkgs.pythonPackages.buildPythonPackage rec {
   patches = [
     # Allow setting MEDIA_ROOT through environment variable
     ./media-root.patch
+    # Address CVE-2023-31047 on Django 4.2.1+
+    (fetchpatch {
+      name = "fix-multiple-file-field";
+      url = "https://github.com/TandoorRecipes/recipes/pull/2458/commits/6b04c922977317354a367487427b15a8ed619be9.patch";
+      hash = "sha256-KmfjJSrB/4tOWtU7zrDJ/AOG4XlmWy/halw8IEEXdZ0=";
+    })
   ];
 
   propagatedBuildInputs = with python.pkgs; [
@@ -101,8 +108,10 @@ python.pkgs.pythonPackages.buildPythonPackage rec {
   buildPhase = ''
     runHook preBuild
 
-    # Avoid dependency on django debug toolbar
+    # Disable debug logging
     export DEBUG=0
+    # Avoid dependency on django debug toolbar
+    export DEBUG_TOOLBAR=0
 
     # See https://github.com/TandoorRecipes/recipes/issues/2043
     mkdir cookbook/static/themes/maps/

--- a/pkgs/applications/misc/tandoor-recipes/frontend.nix
+++ b/pkgs/applications/misc/tandoor-recipes/frontend.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchYarnDeps, fixup_yarn_lock, callPackage, nodejs_16 }:
+{ stdenv, fetchYarnDeps, fixup_yarn_lock, callPackage, nodejs }:
 let
   common = callPackage ./common.nix { };
 in
@@ -15,9 +15,8 @@ stdenv.mkDerivation {
 
   nativeBuildInputs = [
     fixup_yarn_lock
-    # Use Node JS 16 because of @achrinza/node-ipc@9.2.2
-    nodejs_16
-    nodejs_16.pkgs.yarn
+    nodejs
+    nodejs.pkgs.yarn
   ];
 
   configurePhase = ''

--- a/pkgs/development/python-modules/django-js-reverse/default.nix
+++ b/pkgs/development/python-modules/django-js-reverse/default.nix
@@ -1,9 +1,11 @@
 { lib
 , buildPythonPackage
+, pythonAtLeast
 , fetchpatch
 , fetchFromGitHub
 , python
 , django
+, packaging
 , nodejs
 , js2py
 , six
@@ -11,26 +13,19 @@
 
 buildPythonPackage rec {
   pname = "django-js-reverse";
-  # Support for Django 4.0 not yet released
-  version = "unstable-2022-09-16";
+  version = "0.10.1-b1";
 
   src = fetchFromGitHub {
-    owner = "ierror";
+    owner = "BITSOLVER";
     repo = "django-js-reverse";
-    rev = "7cab78c4531780ab4b32033d5104ccd5be1a246a";
-    hash = "sha256-oA4R5MciDMcSsb+GAgWB5jhj+nl7E8t69u0qlx2G93E=";
+    rev = version;
+    hash = "sha256-i78UsxVwxyDAc8LrOVEXLG0tdidoQhvUx7GvPDaH0KY=";
   };
-
-  patches = [
-    (fetchpatch {
-      name = "fix-requires_system_checks-list-or-tuple";
-      url = "https://github.com/ierror/django-js-reverse/commit/1477ba44b62c419d12ebec86e56973f1ae56f712.patch";
-      hash = "sha256-xUtCziewVhnCOaNWddJBH4/Vvhwjjq/wcQDvh2YzWMQ=";
-    })
-  ];
 
   propagatedBuildInputs = [
     django
+  ] ++ lib.optionals (pythonAtLeast "3.7") [
+    packaging
   ];
 
   nativeCheckInputs = [

--- a/pkgs/development/python-modules/recipe-scrapers/default.nix
+++ b/pkgs/development/python-modules/recipe-scrapers/default.nix
@@ -13,14 +13,14 @@
 
 buildPythonPackage rec {
   pname = "recipe-scrapers";
-  version = "14.32.1";
+  version = "14.36.1";
   format = "pyproject";
 
   src = fetchFromGitHub {
     owner = "hhursev";
     repo = "recipe-scrapers";
     rev = "refs/tags/${version}";
-    hash = "sha256-6iUagD1PTTAraBHOWLjHiLFFsImO30w84p+6IcIv52c=";
+    hash = "sha256-JadtlJMxRib8FpNC4QGYXfUEJGyB1aniDbsbsBYU3no=";
   };
 
   nativeBuildInputs = [


### PR DESCRIPTION
###### Description of changes

Updates the package that wasn't auto-updated by @r-ryantm, and address #229894 breaking the build.

Changelog: [1.4.4...1.4.9](https://github.com/TandoorRecipes/recipes/compare/1.4.4...1.4.9)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [X] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
