### PR TITLE
openvi: init at 7.3.22

### DIFF
--- a/pkgs/applications/editors/openvi/default.nix
+++ b/pkgs/applications/editors/openvi/default.nix
@@ -1,0 +1,46 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, fetchpatch
+, ncurses
+}:
+
+stdenv.mkDerivation rec {
+  pname = "openvi";
+  version = "7.3.22";
+
+  src = fetchFromGitHub {
+    owner = "johnsonjh";
+    repo = "OpenVi";
+    rev = version;
+    hash = "sha256-yXYiH2FCT7ffRPmb28V54+KO1RLs8L9KHk3remkMWmA=";
+  };
+
+  patches = [
+    # do not attempt to install to /var/tmp/vi.recover
+    (fetchpatch {
+      url = "https://github.com/johnsonjh/OpenVi/commit/5205f0234369963c443e83ca5028ca63feaaac91.patch";
+      hash = "sha256-hoKzQLnpdRbc48wffWbzFtivr20VqEPs4WRPXuDa/88=";
+    })
+  ];
+
+  buildInputs = [ ncurses ];
+
+  makeFlags = [
+    "PREFIX=$(out)"
+    # command -p will yield command not found erorr
+    "PAWK=awk"
+    # silently fail the chown command
+    "IUSGR=$(USER)"
+  ];
+
+  enableParallelBuilding = true;
+
+  meta = with lib; {
+    homepage = "https://github.com/johnsonjh/OpenVi";
+    description = "Portable OpenBSD vi for UNIX systems";
+    license = licenses.bsd3;
+    platforms = platforms.unix;
+    maintainers = with maintainers; [ aleksana ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -32897,6 +32897,8 @@ with pkgs;
 
   opentx = libsForQt5.callPackage ../applications/misc/opentx { };
 
+  openvi = darwin.apple_sdk_11_0.callPackage ../applications/editors/openvi { };
+
   opera = callPackage ../applications/networking/browsers/opera { };
 
   orca = python3Packages.callPackage ../applications/misc/orca {


### PR DESCRIPTION
###### Description of changes

Yet another vi editor in this repo, ported from OpenBSD, hope someone enjoy it :3

https://github.com/johnsonjh/OpenVi

The result does contain a few manpages, but sadly when I tried to add `outputs = [ "out" "man" ];` it gave me `pop_var_context: head of shell_variables not a function context` . So I gave up on it.

I also didn't add `mainProgram` because the result contains three executables: `oex`, `ovi` and `oview`, just like the situation with nvi.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
