### PR TITLE
ocamlPackages.lsp: fix propagatedInputs

### DIFF
--- a/pkgs/development/ocaml-modules/linol/default.nix
+++ b/pkgs/development/ocaml-modules/linol/default.nix
@@ -5,7 +5,7 @@ rec {
   pname = "linol";
   version = "2023-04-25";
 
-  minimalOCamlVersion = "4.08";
+  minimalOCamlVersion = "4.14";
   duneVersion = "3";
 
   src = fetchFromGitHub {

--- a/pkgs/development/ocaml-modules/ocaml-lsp/lsp.nix
+++ b/pkgs/development/ocaml-modules/ocaml-lsp/lsp.nix
@@ -84,11 +84,31 @@ buildDunePackage rec {
 
   nativeBuildInputs = lib.optional (lib.versionOlder version "1.7.0") cppo;
 
-  propagatedBuildInputs = [
-    csexp
-    jsonrpc
-    uutf
-  ] ++ lib.optional (lib.versionOlder version "1.7.0") stdlib-shims;
+  propagatedBuildInputs =
+    if lib.versionAtLeast version "1.14.0" then [
+      jsonrpc
+      ppx_yojson_conv_lib
+      uutf
+    ] else if lib.versionAtLeast version "1.10.0" then [
+      dyn
+      jsonrpc
+      ordering
+      ppx_yojson_conv_lib
+      stdune
+      uutf
+    ] else if lib.versionAtLeast version "1.7.0" then [
+      csexp
+      jsonrpc
+      pp
+      ppx_yojson_conv_lib
+      uutf
+    ] else [
+      csexp
+      jsonrpc
+      ppx_yojson_conv_lib
+      stdlib-shims
+      uutf
+    ];
 
   meta = jsonrpc.meta // {
     description = "LSP protocol implementation in OCaml";


### PR DESCRIPTION
###### Description of changes

The `ocamlPackages.linol` packages fail to build with OCaml < 4.14, for various reasons. Hence this PR.

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
