### PR TITLE
gnome.zenity: 3.91.0 → 3.92.0

### DIFF
--- a/pkgs/desktops/gnome/core/zenity/default.nix
+++ b/pkgs/desktops/gnome/core/zenity/default.nix
@@ -1,6 +1,7 @@
 { stdenv
 , lib
 , fetchurl
+, fetchpatch2
 , meson
 , ninja
 , pkg-config
@@ -15,12 +16,40 @@
 
 stdenv.mkDerivation rec {
   pname = "zenity";
-  version = "3.91.0";
+  version = "3.92.0";
 
   src = fetchurl {
     url = "mirror://gnome/sources/zenity/${lib.versions.majorMinor version}/${pname}-${version}.tar.xz";
-    sha256 = "N2GeCYAwgXj9vPaDItmaB7MzbBwLuY7ysyycsQkCI5k=";
+    sha256 = "bSvCP2bL2PfhlVVvDDG9ZfClx4vLGuow6XFty/qxqKk=";
   };
+
+  patches = [
+    # Add non-fatal deprecation warning for --attach, --icon-name, --hint
+    # To reduce issues like https://github.com/BuddiesOfBudgie/budgie-desktop/issues/356
+    (fetchpatch2 {
+      url = "https://gitlab.gnome.org/GNOME/zenity/-/commit/181ca36ad4790b425f79b20be40dd25804208463.patch";
+      sha256 = "Z6XOn5XnBzJSti8tD4EGezCpHmYAsIxBf7s4W3rBc9I=";
+    })
+    (fetchpatch2 {
+      url = "https://gitlab.gnome.org/GNOME/zenity/-/commit/70abb01173562dba40916c522bd20b4ba5a55904.patch";
+      sha256 = "yBm7AxJiTPh2BFb+79L4WSh8xOcM6AHuvLzIEEFY80s=";
+    })
+    (fetchpatch2 {
+      url = "https://gitlab.gnome.org/GNOME/zenity/-/commit/df445feb0c0fab6865d96fb693a32fbc26503d83.patch";
+      sha256 = "DTeBCsahceNZCfNziO2taXiMEdAFgm5Bx9OrlZv0LsM=";
+    })
+    (fetchpatch2 {
+      url = "https://gitlab.gnome.org/GNOME/zenity/-/commit/54bd43cbe30fbe5c9f01e42e8f3de63405770e2a.patch";
+      sha256 = "tR9CKt24w7D3EA6FLu6qroS5rTkfIsaQnuY4KzgDKMY=";
+    })
+
+    # Restore the availability of running multiple instances of zenity
+    # https://gitlab.gnome.org/GNOME/zenity/-/issues/58
+    (fetchpatch2 {
+      url = "https://gitlab.gnome.org/GNOME/zenity/-/commit/cd32ad7d3fa66dccc77d96a0fd3a61bf137250f6.patch";
+      sha256 = "4XCuJgXsNIiBXv4NM1JRoiqgBqyxnro0HHapkK2fM8o=";
+    })
+  ];
 
   nativeBuildInputs = [
     meson


### PR DESCRIPTION
https://gitlab.gnome.org/GNOME/zenity/-/compare/3.91.0...3.92.0

We are on development release right now, but sounds like we already brought in [breaking changes](https://github.com/BuddiesOfBudgie/budgie-desktop/blob/v10.7.2/src/wm/wm.vala#L527) so I just keep tracking development release.



Still keeping the webkitgtk option disabled assuming we don't want to pull that into closure.

Edit: I am now aware of https://github.com/GNOME/zenity/commit/70abb01173562dba40916c522bd20b4ba5a55904 https://github.com/GNOME/zenity/commit/df445feb0c0fab6865d96fb693a32fbc26503d83 https://github.com/GNOME/zenity/commit/54bd43cbe30fbe5c9f01e42e8f3de63405770e2a which should help with some of the breaking changes


<!--


-->

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
