### PR TITLE
nixos/maddy: `tls.loader` add acme support, add secrets option

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2305.section.md
+++ b/nixos/doc/manual/release-notes/rl-2305.section.md
@@ -330,7 +330,7 @@ In addition to numerous new and upgraded packages, this release has the followin
 
 - `services.maddy` got several updates:
   - Configuration of users and their credentials using `services.maddy.ensureCredentials`.
-  - Configuration of TLS key and certificate files using `services.maddy.tls`.
+  - TLS configuration is now possible via `services.maddy.tls` with two loaders present: ACME and file based.
 
 - The `dnsmasq` service now takes configuration via the
   `services.dnsmasq.settings` attribute set. The option

--- a/nixos/modules/services/mail/maddy.nix
+++ b/nixos/modules/services/mail/maddy.nix
@@ -206,7 +206,7 @@ in {
           Server configuration, see
           [https://maddy.email](https://maddy.email) for
           more information. The default configuration of this module will setup
-          minimal maddy instance for mail transfer without TLS encryption.
+          minimal Maddy instance for mail transfer without TLS encryption.
 
           ::: {.note}
           This should not be used in a production environment.
@@ -216,13 +216,24 @@ in {
 
       tls = {
         loader = mkOption {
-          type = with types; nullOr (enum [ "file" "off" ]);
+          type = with types; nullOr (enum [ "off" "file" "acme" ]);
           default = "off";
           description = lib.mdDoc ''
             TLS certificates are obtained by modules called "certificate
-            loaders". Currently only the file loader is supported which reads
-            certificates from files specifying the options `keyPaths` and
-            `certPaths`.
+            loaders".
+
+            The `file` loader module reads certificates from files specified by
+            the `certificates` option.
+
+            Alternatively the `acme` module can be used to automatically obtain
+            certificates using the ACME protocol.
+
+            Module configuration is done via the `tls.extraConfig` option.
+
+            Secrets such as API keys or passwords should not be supplied in
+            plaintext. Instead the `secrets` option can be used to read secrets
+            at runtime as environment variables. Secrets can be referenced with
+            `{env:VAR}`.
           '';
         };
 
@@ -261,11 +272,13 @@ in {
         extraConfig = mkOption {
           type = with types; nullOr lines;
           description = lib.mdDoc ''
-            Arguments for the specific certificate loader. Note that Maddy uses
-            secure defaults for the TLS configuration so there is no need to
-            change anything in most cases.
-            See [upstream manual](https://maddy.email/reference/tls/) for
-            available options.
+            Arguments for the specified certificate loader.
+
+            In case the `tls` loader is set, the defaults are considered secure
+            and there is no need to change anything in most cases.
+            For available options see [upstream manual](https://maddy.email/reference/tls/).
+
+            For ACME configuration, see [following page](https://maddy.email/reference/tls-acme).
           '';
           default = "";
         };
@@ -321,20 +334,41 @@ in {
         });
       };
 
+      secrets = lib.mkOption {
+        type = lib.types.path;
+        description = lib.mdDoc ''
+          A file containing the various secrets. Should be in the format
+          expected by systemd's `EnvironmentFile` directory. Secrets can be
+          referenced in the format `{env:VAR}`.
+        '';
+      };
+
     };
   };
 
   config = mkIf cfg.enable {
 
-    assertions = [{
-      assertion = cfg.tls.loader == "file" -> cfg.tls.certificates != [];
-      message = ''
-        If maddy is configured to use TLS, tls.certificates with attribute sets
-        of certPath and keyPath must be provided.
-        Read more about obtaining TLS certificates here:
-        https://maddy.email/tutorials/setting-up/#tls-certificates
-      '';
-    }];
+    assertions = [
+      {
+        assertion = cfg.tls.loader == "file" -> cfg.tls.certificates != [];
+        message = ''
+          If Maddy is configured to use TLS, tls.certificates with attribute sets
+          of certPath and keyPath must be provided.
+          Read more about obtaining TLS certificates here:
+          https://maddy.email/tutorials/setting-up/#tls-certificates
+        '';
+      }
+      {
+        assertion = cfg.tls.loader == "acme" -> cfg.tls.extraConfig != "";
+        message = ''
+          If Maddy is configured to obtain TLS certificates using the ACME
+          loader, extra configuration options must be supplied via
+          tls.extraConfig option.
+          See upstream documentation for more details:
+          https://maddy.email/reference/tls-acme
+        '';
+      }
+    ];
 
     systemd = {
 
@@ -345,6 +379,7 @@ in {
             User = cfg.user;
             Group = cfg.group;
             StateDirectory = [ "maddy" ];
+            EnvironmentFile = lib.mkIf (cfg.secrets != null) "${cfg.secrets}";
           };
           restartTriggers = [ config.environment.etc."maddy/maddy.conf".source ];
           wantedBy = [ "multi-user.target" ];
@@ -391,6 +426,12 @@ in {
           ) cfg.tls.certificates)} ${optionalString (cfg.tls.extraConfig != "") ''
             { ${cfg.tls.extraConfig} }
           ''}
+        '' else if (cfg.tls.loader == "acme") then ''
+          tls {
+            loader acme {
+              ${cfg.tls.extraConfig}
+            }
+          }
         '' else if (cfg.tls.loader == "off") then ''
           tls off
         '' else ""}


### PR DESCRIPTION
###### Description of changes

- Add acme support for the `tls.loader` option.
- Add `secrets` option to load secrets via environment file.

```
services.maddy = {
  enable = true;
  hostname = "localhost";
  ensureAccounts = [
    "admin@localhost"
    "user1@localhost"
    "user2@localhost"
  ];
  ensureCredentials = {
    "admin@localhost".passwordFile = /secrets/admin-localhost;
    "user1@localhost".passwordFile = /secrets/user1-localhost;
    "user2@localhost".passwordFile = /secrets/user2-localhost;
  };
  tls = {
    loader = "acme";
    extraConfig = ''
      email put-your-email-here@example.org
      agreed # indicate your agreement with Let's Encrypt ToS
      challenge dns-01
      dns gandi {
        api_token "{env:GANDI_API_KEY}"
      }
    '';
  };
  secrets = /var/secrets/maddy_secrets;
};
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [x] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
