### PR TITLE
cinnamon.mint-l-{icons, theme}: init

### DIFF
--- a/pkgs/desktops/cinnamon/default.nix
+++ b/pkgs/desktops/cinnamon/default.nix
@@ -39,6 +39,7 @@ lib.makeScope pkgs.newScope (self: with self; {
   mint-artwork = callPackage ./mint-artwork { };
   mint-cursor-themes = callPackage ./mint-cursor-themes { };
   mint-l-icons = callPackage ./mint-l-icons { };
+  mint-l-theme = callPackage ./mint-l-theme { };
   mint-themes = callPackage ./mint-themes { };
   mint-x-icons = callPackage ./mint-x-icons { };
   mint-y-icons = callPackage ./mint-y-icons { };

--- a/pkgs/desktops/cinnamon/default.nix
+++ b/pkgs/desktops/cinnamon/default.nix
@@ -38,6 +38,7 @@ lib.makeScope pkgs.newScope (self: with self; {
   nemo-with-extensions = callPackage ./nemo/wrapper.nix { };
   mint-artwork = callPackage ./mint-artwork { };
   mint-cursor-themes = callPackage ./mint-cursor-themes { };
+  mint-l-icons = callPackage ./mint-l-icons { };
   mint-themes = callPackage ./mint-themes { };
   mint-x-icons = callPackage ./mint-x-icons { };
   mint-y-icons = callPackage ./mint-y-icons { };

--- a/pkgs/desktops/cinnamon/mint-l-icons/default.nix
+++ b/pkgs/desktops/cinnamon/mint-l-icons/default.nix
@@ -1,0 +1,53 @@
+{ stdenvNoCC
+, lib
+, fetchFromGitHub
+, gnome
+, gnome-icon-theme
+, hicolor-icon-theme
+, gtk3
+}:
+
+stdenvNoCC.mkDerivation rec {
+  pname = "mint-l-icons";
+  version = "1.6.4";
+
+  src = fetchFromGitHub {
+    owner = "linuxmint";
+    repo = pname;
+    rev = version;
+    hash = "sha256-C6BnBIOKeewsaQPPXWWo70eQpO1pJS0+xVQghPj/TTE=";
+  };
+
+  propagatedBuildInputs = [
+    gnome.adwaita-icon-theme
+    gnome-icon-theme
+    hicolor-icon-theme
+  ];
+
+  nativeBuildInputs = [
+    gtk3
+  ];
+
+  dontDropIconThemeCache = true;
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out
+    mv usr/share $out
+
+    for theme in $out/share/icons/*; do
+      gtk-update-icon-cache $theme
+    done
+
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    homepage = "https://github.com/linuxmint/mint-l-icons";
+    description = "Mint-L icon theme";
+    license = licenses.gpl3Plus; # from debian/copyright
+    platforms = platforms.linux;
+    maintainers = teams.cinnamon.members;
+  };
+}

--- a/pkgs/desktops/cinnamon/mint-l-theme/default.nix
+++ b/pkgs/desktops/cinnamon/mint-l-theme/default.nix
@@ -1,0 +1,46 @@
+{ stdenvNoCC
+, lib
+, fetchFromGitHub
+, python3
+, sassc
+, sass
+}:
+
+stdenvNoCC.mkDerivation rec {
+  pname = "mint-l-theme";
+  version = "1.9.3";
+
+  src = fetchFromGitHub {
+    owner = "linuxmint";
+    repo = pname;
+    rev = version;
+    hash = "sha256-x+elC1NWcd+x8dNewwKPZBdkxSzEbo7jsG8B9DcWdoA=";
+  };
+
+  nativeBuildInputs = [
+    python3
+    sassc
+    sass
+  ];
+
+  postPatch = ''
+    patchShebangs .
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out
+    mv usr/share $out
+
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    homepage = "https://github.com/linuxmint/mint-l-theme";
+    description = "Mint-L theme for the Cinnamon desktop";
+    license = licenses.gpl3Plus; # from debian/copyright
+    platforms = platforms.linux;
+    maintainers = teams.cinnamon.members;
+  };
+}


### PR DESCRIPTION
###### Description of changes

Fork of early Mint-Y. This will be part of Linux Mint 21.2.

I expect the Cinnamon 5.8 packaging will start in a few days/weeks. I will likely only start shipping Mint-L by default after we have https://github.com/linuxmint/cinnamon/pull/11548/files since the theme list is already long enough :sweat_smile: 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
