### PR TITLE
haskellPackages: ghcWithPackages needs buildHaskellPackages scope

### DIFF
--- a/pkgs/development/haskell-modules/make-package-set.nix
+++ b/pkgs/development/haskell-modules/make-package-set.nix
@@ -281,7 +281,7 @@ in package-set { inherit pkgs lib callPackage; } self // {
     # GHC is setup with a package database with all the specified Haskell packages.
     #
     # ghcWithPackages :: (HaskellPkgSet -> [ HaskellPkg ]) -> Derivation
-    ghcWithPackages = self.callPackage ./with-packages-wrapper.nix {
+    ghcWithPackages = buildHaskellPackages.callPackage ./with-packages-wrapper.nix {
       haskellPackages = self;
     };
 


### PR DESCRIPTION
ghc and also ghcWithPackages (when taken from a haskell package set) are a bit weird—in the same way stdenv is: ghc is actually from buildPackages (pkgsBuildHost) wheras the main package set belongs to pkgsHostTarget. ghc (and stdenv) is included in the package set due to its special relation to the set: it is built by that ghc, so constituted by the compiler in a manner of speaking.

For ghc this works in a straightforward way: It is packaged independently from the haskell package sets and passed to make-package-set.nix to create the different sets we expose. With ghcWithPackages an error crept in, though: Since it needs to receive the haskellPackages fix point (and thus can't be instantiated before the package set), it is defined in make-package-set.nix. Here it was neglected to make sure that it also has the same scope as ghc, i.e. buildHaskellPackages/buildPackages: Otherwise the shell the wrapper scripts use to invoke ghc (originally from buildPackages) would be from pkgsHostTarget—in the cross case, the wrapper scripts would be executable by neither host nor build platform. We want them to work on the build platform, though.

Note that this creates a weird mismatch where it is hard to see which of the alternatives would be more natural: ghcWithPackages and ghcWithHoogle now use packages from the package set they are a member of, but have *-ghc and hoogle executables that are executable on the build platform. This works because ghc originates from buildPackages (as discussed) and hoogleWithPackages is taken from buildHaskellPackages. This does imply though that while set.ghcWithHoogle will be executable on the build platform, set.hoogleWithPackages will be executable on the host platform—both will use the fix point of set for the package selector function. This is maybe a confusing asymmetry, but it seems like a valid use case to cross-compile a hoogle instance. Most development tools use ghcWithHoogle (or equivalent), so that use case is covered as well in principle.

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
