### PR TITLE
lib.systems: accept *-unknown-elf triples

### DIFF
--- a/lib/systems/parse.nix
+++ b/lib/systems/parse.nix
@@ -419,8 +419,7 @@ rec {
       else   { cpu = elemAt l 0;                      kernel = elemAt l 1;                   };
     "3" =
       # cpu-kernel-environment
-      if elemAt l 1 == "linux" ||
-         elem (elemAt l 2) ["eabi" "eabihf" "elf" "gnu"]
+      if elemAt l 1 == "linux"
       then {
         cpu    = elemAt l 0;
         kernel = elemAt l 1;
@@ -429,16 +428,20 @@ rec {
       }
       # cpu-vendor-os
       else if elemAt l 1 == "apple" ||
-              elem (elemAt l 2) [ "wasi" "redox" "mmixware" "ghcjs" "mingw32" ] ||
+              elem (elemAt l 2) [ "elf" "ghcjs" "gnu" "mingw32" "mmixware" "redox" "wasi" ] ||
+              hasPrefix "eabi" (elemAt l 2) ||
               hasPrefix "freebsd" (elemAt l 2) ||
               hasPrefix "netbsd" (elemAt l 2) ||
               hasPrefix "genode" (elemAt l 2)
       then {
+        kernel = "none";
+      } // {
         cpu    = elemAt l 0;
-        vendor = elemAt l 1;
-        kernel = if elemAt l 2 == "mingw32"
-                 then "windows"  # autotools breaks on -gnu for window
-                 else elemAt l 2;
+        vendor = if elemAt l 1 == "none" then "unknown" else elemAt l 1;
+        ${if hasPrefix "eabi" (elemAt l 2) || elem (elemAt l 2) [ "elf" "gnu" ] then "abi" else "kernel"} =
+          if elemAt l 2 == "mingw32"
+          then "windows"  # autotools breaks on -gnu for windows
+          else elemAt l 2;
       }
       else throw "Target specification with 3 components is ambiguous";
     "4" =    { cpu = elemAt l 0; vendor = elemAt l 1; kernel = elemAt l 2; abi = elemAt l 3; };


### PR DESCRIPTION
###### Description of changes

These are the canonical GNU triples for various embedded targets. Previously, we only accepted the LLVM-style *-none-elf, which was problematic, because a Matrix user reported needing riscv64-unknown-elf-gcc for some software, and it makes sense for us to be able to produce that.  Nixpkgs used to accept such triples, but it was broken by 3b32c920d56.

With this change, both forms are accepted, and parse equally. Tested that riscv64-unknown-elf is now parsed correctly, and all examples still evaluate.

Link: https://github.com/NixOS/nixpkgs/issues/165836
Fixes: 3b32c920d56 ("systems/parse.nix: support eabihf")
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
