### PR TITLE
python39Packages.jupyter-client: Fix build for Python 3.9

### DIFF
--- a/pkgs/development/python-modules/jupyter-client/default.nix
+++ b/pkgs/development/python-modules/jupyter-client/default.nix
@@ -11,6 +11,8 @@
 , traitlets
 , isPyPy
 , py
+, pythonOlder
+, importlib-metadata
 }:
 
 buildPythonPackage rec {
@@ -35,6 +37,8 @@ buildPythonPackage rec {
     pyzmq
     tornado
     traitlets
+  ] ++ lib.optionals (pythonOlder "3.10") [
+    importlib-metadata
   ] ++ lib.optional isPyPy py;
 
   # Circular dependency with ipykernel


### PR DESCRIPTION
###### Description of changes

Jupyter fails to build on Python 3.9 with

```
ERROR: Could not find a version that satisfies the requirement importlib-metadata>=4.8.3; python_version < "3.10" (from jupyter-client) (from versions: none)
ERROR: No matching distribution found for importlib-metadata>=4.8.3; python_version < "3.10"
error: builder for '/nix/store/ia5pd064xw6yyi4z5yqqxak36zgvwvps-python3.9-jupyter_client-8.0.3.drv' failed with exit code 1
error: 1 dependencies of derivation '/nix/store/ck1z2184lljmi9phbbck9v45gwh4xp8h-python3-3.9.16-env.drv' failed to build
```

This adds the missing `importlib-metadata` dependency for python < 3.10 for those who need to still use 3.9. 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
