### PR TITLE
python311Packages.pyinstrument: 4.1.1 -> 4.4.0, python311Packages.strawberry-graphql: 0.176.0 -> 0.176.3 

### DIFF
--- a/pkgs/development/python-modules/pyinstrument/default.nix
+++ b/pkgs/development/python-modules/pyinstrument/default.nix
@@ -6,13 +6,13 @@
 
 buildPythonPackage rec {
   pname = "pyinstrument";
-  version = "4.1.1";
+  version = "4.4.0";
 
   src = fetchFromGitHub {
     owner = "joerick";
     repo = pname;
     rev = "v${version}";
-    hash = "sha256-4gM60UhzN+VnNMTHw6NSU7/LUPHaMgg105D+dO6SDfg=";
+    hash = "sha256-0GbJkYBgSOIZrHSKM93SW93jXD+ieYN6A01kWoFbyvQ=";
   };
 
   # Module import recursion

--- a/pkgs/development/python-modules/strawberry-graphql/default.nix
+++ b/pkgs/development/python-modules/strawberry-graphql/default.nix
@@ -26,6 +26,7 @@
 , pytest-django
 , pytest-emoji
 , pytest-flask
+, pytest-mock
 , pytest-snapshot
 , pytestCheckHook
 , python-dateutil
@@ -41,7 +42,7 @@
 
 buildPythonPackage rec {
   pname = "strawberry-graphql";
-  version = "0.176.0";
+  version = "0.176.3";
   format = "pyproject";
 
   disabled = pythonOlder "3.7";
@@ -50,7 +51,7 @@ buildPythonPackage rec {
     owner = "strawberry-graphql";
     repo = "strawberry";
     rev = "refs/tags/${version}";
-    hash = "sha256-e61wLFqc3HLCWUiVW3Gzbay1Oi8b7HsLT3+jPnbA4YY=";
+    hash = "sha256-O57gCJiLlR3k45V6cRNd9AHo9EGoWd7WRMmnV/8xFyQ=";
   };
 
   patches = [
@@ -149,6 +150,7 @@ buildPythonPackage rec {
     mypy
     pytest-asyncio
     pytest-emoji
+    pytest-mock
     pytest-snapshot
     pytestCheckHook
     sanic-testing


### PR DESCRIPTION
Diff: https://github.com/joerick/pyinstrument/compare/v4.1.1...v4.4.0
Changelog: https://github.com/strawberry-graphql/strawberry/blob/0.176.3/CHANGELOG.md
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
