### PR TITLE
python311Packages.typical: 2.8.0 -> 2.8.1

### DIFF
--- a/pkgs/development/python-modules/typical/default.nix
+++ b/pkgs/development/python-modules/typical/default.nix
@@ -2,7 +2,6 @@
 , buildPythonPackage
 , fastjsonschema
 , fetchFromGitHub
-, fetchpatch
 , future-typing
 , inflection
 , mypy
@@ -19,17 +18,16 @@
 
 buildPythonPackage rec {
   pname = "typical";
-  version = "2.8.0";
+  version = "2.8.1";
   format = "pyproject";
 
-  # Support for typing-extensions >= 4.0.0 on Python < 3.10 is missing
   disabled = pythonOlder "3.10";
 
   src = fetchFromGitHub {
     owner = "seandstewart";
     repo = "typical";
-    rev = "v${version}";
-    hash = "sha256-DRjQmoZzWw5vpwIx70wQg6EO/aHqyX7RWpWZ9uOxSTg=";
+    rev = "refs/tags/v${version}";
+    hash = "sha256-2t9Jhdy9NmYBNzdtjjgUnoK2RDEUsAvDkYMcBRzEcmI=";
   };
 
   nativeBuildInputs = [
@@ -53,15 +51,6 @@ buildPythonPackage rec {
     pandas
   ];
 
-  patches = [
-    # Switch to poetry-core, https://github.com/seandstewart/typical/pull/193
-    (fetchpatch {
-      name = "switch-to-poetry-core.patch";
-      url = "https://github.com/seandstewart/typical/commit/66b3c34f8969b7fb1f684f0603e514405bab0dd7.patch";
-      hash = "sha256-c7qJOtHmJRnVEGl+OADB3HpjvMK8aYDD9+0gplOn9pQ=";
-    })
-  ];
-
   disabledTests = [
     # ConstraintValueError: Given value <{'key...
     "test_tagged_union_validate"
@@ -83,6 +72,7 @@ buildPythonPackage rec {
   meta = with lib; {
     description = "Python library for runtime analysis, inference and validation of Python types";
     homepage = "https://python-typical.org/";
+    changelog = "https://github.com/seandstewart/typical/releases/tag/v${version}";
     license = licenses.mit;
     maintainers = with maintainers; [ kfollesdal ];
   };


### PR DESCRIPTION
Diff: https://github.com/seandstewart/typical/compare/refs/tags/v2.8.0...v2.8.1

Changelog: https://github.com/seandstewart/typical/releases/tag/v2.8.1

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
