### PR TITLE
python311Packages.pyzmq: 24.0.1 -> 25.0.2

### DIFF
--- a/pkgs/development/python-modules/pyzmq/default.nix
+++ b/pkgs/development/python-modules/pyzmq/default.nix
@@ -2,6 +2,7 @@
 , buildPythonPackage
 , fetchPypi
 , py
+, pytest-asyncio
 , pytestCheckHook
 , python
 , pythonOlder
@@ -11,14 +12,14 @@
 
 buildPythonPackage rec {
   pname = "pyzmq";
-  version = "24.0.1";
+  version = "25.0.2";
   format = "setuptools";
 
-  disabled = pythonOlder "3.6";
+  disabled = pythonOlder "3.7";
 
   src = fetchPypi {
     inherit pname version;
-    hash = "sha256-IW9dfbtnFmdZ5ZsEebyoK4rPm+1gFbUmuOsQFD+wjnc=";
+    hash = "sha256-a4wbu3DoaNyIgBqlMsrmvU47UjN4RpK3hvF60pYuUUk=";
   };
 
   buildInputs = [
@@ -30,6 +31,7 @@ buildPythonPackage rec {
   ];
 
   nativeCheckInputs = [
+    pytest-asyncio
     pytestCheckHook
     tornado
   ];
@@ -51,6 +53,14 @@ buildPythonPackage rec {
     # Test fails
     "test_mockable"
     # Issues with the sandbox
+    "test_callable_check"
+    "test_on_recv_wake"
+    "test_deny"
+    "test_allow"
+    "test_on_recv_basic"
+    "test_on_recv_async"
+    "TestThreadAuthentication"
+    "TestAsyncioAuthentication"
     "TestFutureSocket"
     "TestIOLoop"
     "TestPubLog"
@@ -62,6 +72,7 @@ buildPythonPackage rec {
   meta = with lib; {
     description = "Python bindings for ØMQ";
     homepage = "https://pyzmq.readthedocs.io/";
+    changelog = "https://github.com/zeromq/pyzmq/blob/v${version}/docs/source/changelog.md";
     license = with licenses; [ bsd3 /* or */ lgpl3Only ];
     maintainers = with maintainers; [ ];
   };

--- a/pkgs/development/python-modules/pyzmq/default.nix
+++ b/pkgs/development/python-modules/pyzmq/default.nix
@@ -12,14 +12,14 @@
 
 buildPythonPackage rec {
   pname = "pyzmq";
-  version = "25.0.2";
+  version = "25.1.1";
   format = "setuptools";
 
   disabled = pythonOlder "3.7";
 
   src = fetchPypi {
     inherit pname version;
-    hash = "sha256-a4wbu3DoaNyIgBqlMsrmvU47UjN4RpK3hvF60pYuUUk=";
+    hash = "sha256-JZwiSFtxq6zfqL95cgzXvPS50SizDqVU8BrnH9v9qiM=";
   };
 
   buildInputs = [


### PR DESCRIPTION
Changelog: https://github.com/zeromq/pyzmq/blob/v25.0.2/docs/source/changelog.md

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
