### PR TITLE
ocamlPackages.eio: init at 0.10; mtime: 1.4.0 → 2.0.0; iomux init at 0.3; domain-local-await: init at 0.2.0

### DIFF
--- a/pkgs/applications/science/logic/acgtk/default.nix
+++ b/pkgs/applications/science/logic/acgtk/default.nix
@@ -18,7 +18,7 @@ stdenv.mkDerivation {
   nativeBuildInputs = with ocamlPackages; [ menhir ocaml findlib dune_3 ];
 
   buildInputs = with ocamlPackages; [
-    ansiterminal cairo2 cmdliner fmt logs menhirLib mtime sedlex yojson
+    ansiterminal cairo2 cmdliner fmt logs menhirLib mtime_1 sedlex yojson
   ];
 
   buildPhase = ''

--- a/pkgs/development/compilers/ligo/default.nix
+++ b/pkgs/development/compilers/ligo/default.nix
@@ -116,7 +116,7 @@ ocamlPackages.buildDunePackage rec {
     bls12-381
     bls12-381-signature
     ptime
-    mtime
+    mtime_1
     lwt_log
     secp256k1-internal
     resto

--- a/pkgs/development/ocaml-modules/domain-local-await/default.nix
+++ b/pkgs/development/ocaml-modules/domain-local-await/default.nix
@@ -1,0 +1,34 @@
+{ lib
+, buildDunePackage
+, fetchurl
+, mdx
+}:
+
+buildDunePackage rec {
+  pname = "domain-local-await";
+  version = "0.2.0";
+
+  minimalOCamlVersion = "5.0";
+  duneVersion = "3";
+
+  src = fetchurl {
+    url = "https://github.com/ocaml-multicore/${pname}/releases/download/${version}/${pname}-${version}.tbz";
+    sha256 = "2DCJsI3nGPtbXnU8jRvzR1iNAkNuekVy4Lid1qnHXDo=";
+  };
+
+  checkInputs = [
+    mdx
+  ];
+
+  nativeCheckInputs = [
+    mdx.bin
+  ];
+
+  meta = {
+    homepage = "https://github.com/ocaml-multicore/ocaml-${pname}";
+    changelog = "https://github.com/ocaml-multicore/ocaml-${pname}/raw/v${version}/CHANGES.md";
+    description = "A scheduler independent blocking mechanism";
+    license = with lib.licenses; [ bsd0 ];
+    maintainers = with lib.maintainers; [ toastal ];
+  };
+}

--- a/pkgs/development/ocaml-modules/eio/default.nix
+++ b/pkgs/development/ocaml-modules/eio/default.nix
@@ -1,0 +1,60 @@
+{ lib
+, buildDunePackage
+, bigstringaf
+, cstruct
+, domain-local-await
+, dune-configurator
+, fetchurl
+, fmt
+, hmap
+, lwt-dllist
+, mtime
+, optint
+, psq
+, alcotest
+, crowbar
+, mdx
+}:
+
+buildDunePackage rec {
+  pname = "eio";
+  version = "0.10";
+
+  minimalOCamlVersion = "5.0";
+  duneVersion = "3";
+
+  src = fetchurl {
+    url = "https://github.com/ocaml-multicore/${pname}/releases/download/v${version}/${pname}-${version}.tbz";
+    sha256 = "OQ94FFB7gTPWwl46Z6dC1zHHymYlKyh7H7DjrU0Q7sw=";
+  };
+
+  propagatedBuildInputs = [
+    bigstringaf
+    cstruct
+    domain-local-await
+    fmt
+    hmap
+    lwt-dllist
+    mtime
+    optint
+    psq
+  ];
+
+  checkInputs = [
+    alcotest
+    crowbar
+    mdx
+  ];
+
+  nativeCheckInputs = [
+    mdx.bin
+  ];
+
+  meta = {
+    homepage = "https://github.com/ocaml-multicore/ocaml-${pname}";
+    changelog = "https://github.com/ocaml-multicore/ocaml-${pname}/raw/v${version}/CHANGES.md";
+    description = "Effects-Based Parallel IO for OCaml";
+    license = with lib.licenses; [ isc ];
+    maintainers = with lib.maintainers; [ toastal ];
+  };
+}

--- a/pkgs/development/ocaml-modules/eio/linux.nix
+++ b/pkgs/development/ocaml-modules/eio/linux.nix
@@ -1,0 +1,23 @@
+{ buildDunePackage
+, eio
+, fmt
+, logs
+, uring
+}:
+
+buildDunePackage {
+  pname = "eio_linux";
+  inherit (eio) meta src version;
+
+  minimalOCamlVersion = "5.0";
+  duneVersion = "3";
+
+  dontStrip = true;
+
+  propagatedBuildInputs = [
+    eio
+    fmt
+    logs
+    uring
+  ];
+}

--- a/pkgs/development/ocaml-modules/eio/main.nix
+++ b/pkgs/development/ocaml-modules/eio/main.nix
@@ -1,0 +1,23 @@
+{ lib
+, stdenv
+, buildDunePackage
+, eio
+, eio_posix
+, uring
+}:
+
+buildDunePackage {
+  pname = "eio_main";
+  inherit (eio) meta src version;
+
+  minimalOCamlVersion = "5.0";
+  duneVersion = "3";
+
+  dontStrip = true;
+
+  propagatedBuildInputs = [
+    eio_posix
+  ] ++ lib.optionals stdenv.isLinux [
+    uring
+  ];
+}

--- a/pkgs/development/ocaml-modules/eio/posix.nix
+++ b/pkgs/development/ocaml-modules/eio/posix.nix
@@ -1,0 +1,28 @@
+{ buildDunePackage
+, dune-configurator
+, eio
+, fmt
+, logs
+, iomux
+}:
+
+buildDunePackage {
+  pname = "eio_posix";
+  inherit (eio) meta src version;
+
+  minimalOCamlVersion = "5.0";
+  duneVersion = "3";
+
+  dontStrip = true;
+
+  buildInputs = [
+    dune-configurator
+  ];
+
+  propagatedBuildInputs = [
+    eio
+    fmt
+    logs
+    iomux
+  ];
+}

--- a/pkgs/development/ocaml-modules/iomux/default.nix
+++ b/pkgs/development/ocaml-modules/iomux/default.nix
@@ -1,0 +1,34 @@
+{ lib
+, fetchurl
+, buildDunePackage
+, dune-configurator
+, alcotest
+}:
+
+buildDunePackage rec {
+  pname = "iomux";
+  version = "0.3";
+
+  minimalOCamlVersion = "4.08";
+  duneVersion = "3";
+
+  src = fetchurl {
+    url = "https://github.com/haesbaert/ocaml-${pname}/releases/download/v${version}/${pname}-${version}.tbz";
+    sha256 = "zNJ3vVOv0BEpHLiC8Y610F87uiMlfYNo28ej0H+EU+c=";
+  };
+
+  buildInputs = [
+    dune-configurator
+  ];
+
+  checkInputs = [
+    alcotest
+  ];
+
+  meta = {
+    homepage = "https://github.com/haesbaert/ocaml-${pname}";
+    description = "IO Multiplexers for OCaml";
+    license = with lib.licenses; [ isc ];
+    maintainers = with lib.maintainers; [ toastal ];
+  };
+}

--- a/pkgs/development/ocaml-modules/mtime/1_x.nix
+++ b/pkgs/development/ocaml-modules/mtime/1_x.nix
@@ -1,0 +1,22 @@
+{ stdenv, lib, fetchurl, ocaml, findlib, ocamlbuild, topkg, mtime }:
+
+lib.throwIfNot (lib.versionAtLeast ocaml.version "4.08")
+  "mtime is not available for OCaml ${ocaml.version}"
+
+stdenv.mkDerivation rec {
+  pname = "ocaml${ocaml.version}-mtime";
+  version = "1.4.0";
+
+  src = fetchurl {
+    url = "https://erratique.ch/software/mtime/releases/mtime-${version}.tbz";
+    sha256 = "VQyYEk8+57Yq8SUuYossaQUHZKqemHDJtf4LK8qjxvc=";
+  };
+
+  nativeBuildInputs = [ ocaml findlib ocamlbuild topkg ];
+  buildInputs = [ topkg ];
+
+  strictDeps = true;
+
+  inherit (topkg) buildPhase installPhase;
+  inherit (mtime) meta;
+}

--- a/pkgs/development/ocaml-modules/mtime/default.nix
+++ b/pkgs/development/ocaml-modules/mtime/default.nix
@@ -5,11 +5,11 @@ lib.throwIfNot (lib.versionAtLeast ocaml.version "4.08")
 
 stdenv.mkDerivation rec {
   pname = "ocaml${ocaml.version}-mtime";
-  version = "1.4.0";
+  version = "2.0.0";
 
   src = fetchurl {
     url = "https://erratique.ch/software/mtime/releases/mtime-${version}.tbz";
-    sha256 = "sha256-VQyYEk8+57Yq8SUuYossaQUHZKqemHDJtf4LK8qjxvc=";
+    sha256 = "Pz2g6gBts0RlsDCE3npYqxWg8W9HgoxQC+U63fHgROs=";
   };
 
   nativeBuildInputs = [ ocaml findlib ocamlbuild topkg ];

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -419,6 +419,11 @@ let
 
     eigen = callPackage ../development/ocaml-modules/eigen { };
 
+    eio = callPackage ../development/ocaml-modules/eio { };
+    eio_linux = callPackage ../development/ocaml-modules/eio/linux.nix { };
+    eio_main = callPackage ../development/ocaml-modules/eio/main.nix { };
+    eio_posix = callPackage ../development/ocaml-modules/eio/posix.nix { };
+
     either = callPackage ../development/ocaml-modules/either { };
 
     elina = callPackage ../development/ocaml-modules/elina { };

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -345,6 +345,8 @@ let
 
     dolog = callPackage ../development/ocaml-modules/dolog { };
 
+    domain-local-await = callPackage ../development/ocaml-modules/domain-local-await { };
+
     domain-name = callPackage ../development/ocaml-modules/domain-name { };
 
     domainslib = callPackage ../development/ocaml-modules/domainslib { };

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -663,6 +663,8 @@ let
 
     integers_stubs_js = callPackage ../development/ocaml-modules/integers_stubs_js { };
 
+    iomux = callPackage ../development/ocaml-modules/iomux { };
+
     io-page = callPackage ../development/ocaml-modules/io-page { };
 
     ipaddr = callPackage ../development/ocaml-modules/ipaddr { };

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -54,11 +54,11 @@ let
 
     atdgen-runtime = callPackage ../development/ocaml-modules/atdgen/runtime.nix { };
 
-    awa = callPackage ../development/ocaml-modules/awa { };
+    awa = callPackage ../development/ocaml-modules/awa { mtime = mtime_1; };
 
-    awa-lwt = callPackage ../development/ocaml-modules/awa/lwt.nix { };
+    awa-lwt = callPackage ../development/ocaml-modules/awa/lwt.nix { mtime = mtime_1; };
 
-    awa-mirage = callPackage ../development/ocaml-modules/awa/mirage.nix { };
+    awa-mirage = callPackage ../development/ocaml-modules/awa/mirage.nix { mtime = mtime_1; };
 
     ### B ###
 
@@ -321,11 +321,11 @@ let
 
     dns-certify =  callPackage ../development/ocaml-modules/dns/certify.nix { };
 
-    dns-cli =  callPackage ../development/ocaml-modules/dns/cli.nix { };
+    dns-cli =  callPackage ../development/ocaml-modules/dns/cli.nix { mtime = mtime_1; };
 
-    dns-client =  callPackage ../development/ocaml-modules/dns/client.nix { };
+    dns-client =  callPackage ../development/ocaml-modules/dns/client.nix { mtime = mtime_1; };
 
-    dns-client-lwt = callPackage ../development/ocaml-modules/dns/client-lwt.nix { };
+    dns-client-lwt = callPackage ../development/ocaml-modules/dns/client-lwt.nix { mtime = mtime_1; };
 
     dns-client-mirage = callPackage ../development/ocaml-modules/dns/client-mirage.nix { };
 
@@ -571,6 +571,7 @@ let
 
     git-unix = callPackage ../development/ocaml-modules/git/unix.nix {
       git-binary = pkgs.git;
+      mtime = mtime_1;
     };
 
     github = callPackage ../development/ocaml-modules/github {  };
@@ -622,7 +623,7 @@ let
 
     happy-eyeballs = callPackage ../development/ocaml-modules/happy-eyeballs { };
 
-    happy-eyeballs-lwt = callPackage ../development/ocaml-modules/happy-eyeballs/lwt.nix { };
+    happy-eyeballs-lwt = callPackage ../development/ocaml-modules/happy-eyeballs/lwt.nix { mtime = mtime_1; };
 
     happy-eyeballs-mirage = callPackage ../development/ocaml-modules/happy-eyeballs/mirage.nix { };
 
@@ -652,7 +653,7 @@ let
 
     imagelib = callPackage ../development/ocaml-modules/imagelib { };
 
-    index = callPackage ../development/ocaml-modules/index { };
+    index = callPackage ../development/ocaml-modules/index { mtime = mtime_1; };
 
     inifiles = callPackage ../development/ocaml-modules/inifiles { };
 
@@ -672,15 +673,15 @@ let
 
     iri = callPackage ../development/ocaml-modules/iri { };
 
-    irmin = callPackage ../development/ocaml-modules/irmin { };
+    irmin = callPackage ../development/ocaml-modules/irmin { mtime = mtime_1; };
 
     irmin-chunk = callPackage ../development/ocaml-modules/irmin/chunk.nix { };
 
-    irmin-containers = callPackage ../development/ocaml-modules/irmin/containers.nix { };
+    irmin-containers = callPackage ../development/ocaml-modules/irmin/containers.nix { mtime = mtime_1; };
 
     irmin-fs = callPackage ../development/ocaml-modules/irmin/fs.nix { };
 
-    irmin-git = callPackage ../development/ocaml-modules/irmin/git.nix { };
+    irmin-git = callPackage ../development/ocaml-modules/irmin/git.nix { mtime = mtime_1; };
 
     irmin-graphql = callPackage ../development/ocaml-modules/irmin/graphql.nix { };
 
@@ -692,9 +693,9 @@ let
 
     irmin-mirage-graphql = callPackage ../development/ocaml-modules/irmin/mirage-graphql.nix { };
 
-    irmin-pack = callPackage ../development/ocaml-modules/irmin/pack.nix { };
+    irmin-pack = callPackage ../development/ocaml-modules/irmin/pack.nix { mtime = mtime_1; };
 
-    irmin-test = callPackage ../development/ocaml-modules/irmin/test.nix { };
+    irmin-test = callPackage ../development/ocaml-modules/irmin/test.nix { mtime = mtime_1; };
 
     irmin-tezos = callPackage ../development/ocaml-modules/irmin/tezos.nix { };
 
@@ -961,6 +962,7 @@ let
 
     metrics-unix = callPackage ../development/ocaml-modules/metrics/unix.nix {
       inherit (pkgs) gnuplot;
+      mtime = mtime_1;
     };
 
     mew = callPackage ../development/ocaml-modules/mew { };
@@ -1007,11 +1009,11 @@ let
 
     mirage-crypto-pk = callPackage ../development/ocaml-modules/mirage-crypto/pk.nix { };
 
-    mirage-crypto-rng = callPackage ../development/ocaml-modules/mirage-crypto/rng.nix { };
+    mirage-crypto-rng = callPackage ../development/ocaml-modules/mirage-crypto/rng.nix { mtime = mtime_1; };
 
     mirage-crypto-rng-async = callPackage ../development/ocaml-modules/mirage-crypto/rng-async.nix { };
 
-    mirage-crypto-rng-lwt = callPackage ../development/ocaml-modules/mirage-crypto/rng-lwt.nix { };
+    mirage-crypto-rng-lwt = callPackage ../development/ocaml-modules/mirage-crypto/rng-lwt.nix { mtime = mtime_1; };
 
     mirage-crypto-rng-mirage = callPackage ../development/ocaml-modules/mirage-crypto/rng-mirage.nix { };
 
@@ -1073,6 +1075,7 @@ let
 
     mrmime = callPackage ../development/ocaml-modules/mrmime { };
 
+    mtime_1 =  callPackage ../development/ocaml-modules/mtime/1_x.nix { };
     mtime =  callPackage ../development/ocaml-modules/mtime { };
 
     multipart-form-data =  callPackage ../development/ocaml-modules/multipart-form-data { };
@@ -1249,7 +1252,7 @@ let
       inherit (pkgs) unzip;
     };
 
-    opium = callPackage ../development/ocaml-modules/opium { };
+    opium = callPackage ../development/ocaml-modules/opium { mtime = mtime_1; };
 
     opti = callPackage ../development/ocaml-modules/opti { };
 
@@ -1400,7 +1403,7 @@ let
 
     prometheus = callPackage ../development/ocaml-modules/prometheus { };
 
-    progress = callPackage ../development/ocaml-modules/progress { };
+    progress = callPackage ../development/ocaml-modules/progress { mtime = mtime_1; };
 
     promise_jsoo = callPackage ../development/ocaml-modules/promise_jsoo { };
 


### PR DESCRIPTION
###### Description of changes

`eio`: https://github.com/ocaml-multicore/eio

required upgrade to `mtime` (separate commit): https://github.com/dbuenzli/mtime
required `iomux` as a dependency for `eio_posix` (separate commit): https://github.com/haesbaert/ocaml-iomux

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
