### PR TITLE
ani-cli: cleanup package

### DIFF
--- a/pkgs/applications/video/ani-cli/default.nix
+++ b/pkgs/applications/video/ani-cli/default.nix
@@ -15,9 +15,13 @@
 , aria2
 , player ? "mpv"
 , chromecastSupport ? false
-, sync ? false
+, syncSupport ? false
 }:
 
+let player = lib.optional (player == "mpv") mpv
+  ++ lib.optional (player == "vlc") vlc
+  ++ lib.optional (player == "iina") iina
+in
 stdenvNoCC.mkDerivation rec {
   pname = "ani-cli";
   version = "4.2";
@@ -31,11 +35,9 @@ stdenvNoCC.mkDerivation rec {
 
   nativeBuildInputs = [ makeWrapper ];
   runtimeDependencies = [ gnugrep gnused curl fzf ffmpeg aria2 ]
-    ++ lib.optional (player == "mpv") mpv
-    ++ lib.optional (player == "vlc") vlc
-    ++ lib.optional (player == "iina") iina
+    ++ player
     ++ lib.optional chromecastSupport catt
-    ++ lib.optional sync syncplay;
+    ++ lib.optional syncSupport syncplay;
 
   installPhase = ''
     runHook preInstall

--- a/pkgs/applications/video/ani-cli/default.nix
+++ b/pkgs/applications/video/ani-cli/default.nix
@@ -4,10 +4,18 @@
 , lib
 , gnugrep
 , gnused
-, wget
+, curl
 , fzf
 , mpv
+, vlc
+, iina
+, catt
+, syncplay
+, ffmpeg
 , aria2
+, player ? "mpv"
+, chromecast ? "false"
+, sync ? "false"
 }:
 
 stdenvNoCC.mkDerivation rec {
@@ -22,23 +30,24 @@ stdenvNoCC.mkDerivation rec {
   };
 
   nativeBuildInputs = [ makeWrapper ];
+  buildInputs = [ gnugrep gnused curl fzf ffmpeg aria2 ]
+                ++ lib.optional (player == "mpv") mpv
+                ++ lib.optional (player == "vlc") vlc
+                ++ lib.optional (player == "iina") iina
+                ++ lib.optional (chromecast != "false") catt
+                ++ lib.optional (sync != "false") syncplay;
 
   installPhase = ''
-    runHook preInstall
-
     install -Dm755 ani-cli $out/bin/ani-cli
-
     wrapProgram $out/bin/ani-cli \
-      --prefix PATH : ${lib.makeBinPath [ gnugrep gnused wget fzf mpv aria2 ]}
-
-    runHook postInstall
+      --prefix PATH : ${lib.makeBinPath buildInputs}
   '';
 
   meta = with lib; {
     homepage = "https://github.com/pystardust/ani-cli";
     description = "A cli tool to browse and play anime";
     license = licenses.gpl3Plus;
-    maintainers = with maintainers; [ skykanin ];
+    maintainers = with maintainers; [ skykanin haxsam ];
     platforms = platforms.unix;
   };
 }

--- a/pkgs/applications/video/ani-cli/default.nix
+++ b/pkgs/applications/video/ani-cli/default.nix
@@ -43,7 +43,7 @@ stdenvNoCC.mkDerivation rec {
     install -Dm755 ani-cli $out/bin/ani-cli
     
     wrapProgram $out/bin/ani-cli \
-      --prefix PATH : ${lib.makeBinPath buildInputs}
+      --prefix PATH : ${lib.makeBinPath runtimeDependencies}
       
     runHook postInstall
   '';

--- a/pkgs/applications/video/ani-cli/default.nix
+++ b/pkgs/applications/video/ani-cli/default.nix
@@ -31,7 +31,7 @@ stdenvNoCC.mkDerivation rec {
 
   nativeBuildInputs = [ makeWrapper ];
   runtimeDependencies = [ gnugrep gnused curl fzf ffmpeg aria2 ]
-    ++ lib.optional (player == "mpv")
+    ++ lib.optional (player == "mpv") mpv
     ++ lib.optional (player == "vlc") vlc
     ++ lib.optional (player == "iina") iina
     ++ lib.optional chromecastSupport catt

--- a/pkgs/applications/video/ani-cli/default.nix
+++ b/pkgs/applications/video/ani-cli/default.nix
@@ -47,7 +47,7 @@ stdenvNoCC.mkDerivation rec {
     homepage = "https://github.com/pystardust/ani-cli";
     description = "A cli tool to browse and play anime";
     license = licenses.gpl3Plus;
-    maintainers = with maintainers; [ skykanin haxsam ];
+    maintainers = with maintainers; [ skykanin ];
     platforms = platforms.unix;
   };
 }

--- a/pkgs/applications/video/ani-cli/default.nix
+++ b/pkgs/applications/video/ani-cli/default.nix
@@ -31,15 +31,15 @@ stdenvNoCC.mkDerivation rec {
 
   nativeBuildInputs = [ makeWrapper ];
   runtimeDependencies = [ gnugrep gnused curl fzf ffmpeg aria2 ]
-		++ lib.optional (player == "mpv")
-		++ lib.optional (player == "vlc") vlc
-		++ lib.optional (player == "iina") iina
-		++ lib.optional chromecastSupport catt
-		++ lib.optional sync syncplay;
+    ++ lib.optional (player == "mpv")
+    ++ lib.optional (player == "vlc") vlc
+    ++ lib.optional (player == "iina") iina
+    ++ lib.optional chromecastSupport catt
+    ++ lib.optional sync syncplay;
 
   installPhase = ''
-		runHook preInstall
-    
+    runHook preInstall
+
     install -Dm755 ani-cli $out/bin/ani-cli
 
     wrapProgram $out/bin/ani-cli \

--- a/pkgs/applications/video/ani-cli/default.nix
+++ b/pkgs/applications/video/ani-cli/default.nix
@@ -31,11 +31,11 @@ stdenvNoCC.mkDerivation rec {
 
   nativeBuildInputs = [ makeWrapper ];
   runtimeDependencies = [ gnugrep gnused curl fzf ffmpeg aria2 ]
-                          ++ lib.optional (player == "mpv") mpv
-                          ++ lib.optional (player == "vlc") vlc
-                          ++ lib.optional (player == "iina") iina
-                          ++ lib.optional chromecastSupport catt
-                          ++ lib.optional sync syncplay;
+    ++ lib.optional (player == "mpv")
+    ++ lib.optional (player == "vlc") vlc 
+    ++ lib.optional (player == "iina") iina
+    ++ lib.optional chromecastSupport catt
+    ++ lib.optional sync syncplay;
 
   installPhase = ''
     runHook preInstall

--- a/pkgs/applications/video/ani-cli/default.nix
+++ b/pkgs/applications/video/ani-cli/default.nix
@@ -14,8 +14,8 @@
 , ffmpeg
 , aria2
 , player ? "mpv"
-, chromecast ? "false"
-, sync ? "false"
+, chromecastSupport ? false
+, sync ? false
 }:
 
 stdenvNoCC.mkDerivation rec {
@@ -30,17 +30,22 @@ stdenvNoCC.mkDerivation rec {
   };
 
   nativeBuildInputs = [ makeWrapper ];
-  buildInputs = [ gnugrep gnused curl fzf ffmpeg aria2 ]
-                ++ lib.optional (player == "mpv") mpv
-                ++ lib.optional (player == "vlc") vlc
-                ++ lib.optional (player == "iina") iina
-                ++ lib.optional (chromecast != "false") catt
-                ++ lib.optional (sync != "false") syncplay;
+  runtimeDependencies = [ gnugrep gnused curl fzf ffmpeg aria2 ]
+                          ++ lib.optional (player == "mpv") mpv
+                          ++ lib.optional (player == "vlc") vlc
+                          ++ lib.optional (player == "iina") iina
+                          ++ lib.optional chromecastSupport catt
+                          ++ lib.optional sync syncplay;
 
   installPhase = ''
+    runHook preInstall
+    
     install -Dm755 ani-cli $out/bin/ani-cli
+    
     wrapProgram $out/bin/ani-cli \
       --prefix PATH : ${lib.makeBinPath buildInputs}
+      
+    runHook postInstall
   '';
 
   meta = with lib; {

--- a/pkgs/applications/video/ani-cli/default.nix
+++ b/pkgs/applications/video/ani-cli/default.nix
@@ -31,20 +31,20 @@ stdenvNoCC.mkDerivation rec {
 
   nativeBuildInputs = [ makeWrapper ];
   runtimeDependencies = [ gnugrep gnused curl fzf ffmpeg aria2 ]
-    ++ lib.optional (player == "mpv")
-    ++ lib.optional (player == "vlc") vlc 
-    ++ lib.optional (player == "iina") iina
-    ++ lib.optional chromecastSupport catt
-    ++ lib.optional sync syncplay;
+		++ lib.optional (player == "mpv")
+		++ lib.optional (player == "vlc") vlc
+		++ lib.optional (player == "iina") iina
+		++ lib.optional chromecastSupport catt
+		++ lib.optional sync syncplay;
 
   installPhase = ''
-    runHook preInstall
+		runHook preInstall
     
     install -Dm755 ani-cli $out/bin/ani-cli
-    
+
     wrapProgram $out/bin/ani-cli \
       --prefix PATH : ${lib.makeBinPath runtimeDependencies}
-      
+
     runHook postInstall
   '';
 


### PR DESCRIPTION
###### Description of changes

A little bit of cleanup also moved the `makeBinPath` into `buildInputs` so that `mkShell` knows the dependencies when used in `inputsFrom`
also added some optional dependencies that can be chosen with `--argstr`

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
