### PR TITLE
wireshark: build with QT 6

### DIFF
--- a/pkgs/applications/networking/sniffers/wireshark/default.nix
+++ b/pkgs/applications/networking/sniffers/wireshark/default.nix
@@ -39,14 +39,14 @@
 , makeWrapper
 , wrapGAppsHook
 , withQt ? true
-, qt5 ? null
+, qt6 ? null
 , ApplicationServices
 , SystemConfiguration
 , gmp
 , asciidoctor
 }:
 
-assert withQt -> qt5 != null;
+assert withQt -> qt6 != null;
 
 let
   version = "4.0.5";
@@ -70,6 +70,7 @@ stdenv.mkDerivation {
     # Fix `extcap` and `plugins` paths. See https://bugs.wireshark.org/bugzilla/show_bug.cgi?id=16444
     "-DCMAKE_INSTALL_LIBDIR=lib"
     "-DLEMON_C_COMPILER=cc"
+    "-DUSE_qt6=ON"
   ] ++ lib.optionals (stdenv.buildPlatform != stdenv.hostPlatform) [
     "-DHAVE_C99_VSNPRINTF_EXITCODE=0"
     "-DHAVE_C99_VSNPRINTF_EXITCODE__TRYRUN_OUTPUT="
@@ -79,7 +80,7 @@ stdenv.mkDerivation {
   env.NIX_CFLAGS_COMPILE = toString [ "-DQT_NO_DEBUG" ];
 
   nativeBuildInputs = [ asciidoctor bison cmake ninja flex makeWrapper pkg-config python3 perl ]
-    ++ lib.optionals withQt [ qt5.wrapQtAppsHook wrapGAppsHook ];
+    ++ lib.optionals withQt [ qt6.wrapQtAppsHook wrapGAppsHook ];
 
   depsBuildBuild = [ buildPackages.stdenv.cc ];
 
@@ -108,11 +109,10 @@ stdenv.mkDerivation {
     c-ares
     glib
     zlib
-  ] ++ lib.optionals withQt (with qt5; [ qtbase qtmultimedia qtsvg qttools ])
-  ++ lib.optionals (withQt && stdenv.isLinux) [ qt5.qtwayland ]
+  ] ++ lib.optionals withQt (with qt6; [ qtbase qtmultimedia qtsvg qttools qt5compat ])
+  ++ lib.optionals (withQt && stdenv.isLinux) [ qt6.qtwayland ]
   ++ lib.optionals stdenv.isLinux [ libcap libnl sbc ]
-  ++ lib.optionals stdenv.isDarwin [ SystemConfiguration ApplicationServices gmp ]
-  ++ lib.optionals (withQt && stdenv.isDarwin) (with qt5; [ qtmacextras ]);
+  ++ lib.optionals stdenv.isDarwin [ SystemConfiguration ApplicationServices gmp ];
 
   strictDeps = true;
 


### PR DESCRIPTION
###### Description of changes

Wireshark 4 supports Qt 6 so let's use that.

Tested on GNOME 44 Wayland, nothing was broken and the window decorations now look better.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
