### PR TITLE
grive2: pull gcc-12 upstream fix

### DIFF
--- a/pkgs/tools/filesystems/grive2/default.nix
+++ b/pkgs/tools/filesystems/grive2/default.nix
@@ -1,4 +1,16 @@
-{ lib, stdenv, fetchFromGitHub, pkg-config, yajl, cmake, libgcrypt, curl, expat, boost, libiberty }:
+{ lib
+, stdenv
+, fetchFromGitHub
+, fetchpatch
+, pkg-config
+, yajl
+, cmake
+, libgcrypt
+, curl
+, expat
+, boost
+, libiberty
+}:
 
 stdenv.mkDerivation rec {
   version = "0.5.3";
@@ -11,6 +23,16 @@ stdenv.mkDerivation rec {
     sha256 = "sha256-P6gitA5cXfNbNDy4ohRLyXj/5dUXkCkOdE/9rJPzNCg=";
   };
 
+  patches = [
+    # Backport gcc-12 support:
+    #   https://github.com/vitalif/grive2/pull/363
+    (fetchpatch {
+      name = "gcc-12.patch";
+      url = "https://github.com/vitalif/grive2/commit/3cf1c058a3e61deb370dde36024a106a213ab2c6.patch";
+      hash = "sha256-v2Pb6Qvgml/fYzh/VCjOvEVnFYMkOHqROvLLe61DmKA=";
+    })
+  ];
+
   nativeBuildInputs = [ cmake pkg-config ];
 
   buildInputs = [ libgcrypt yajl curl expat boost libiberty ];
@@ -21,5 +43,4 @@ stdenv.mkDerivation rec {
     license = licenses.gpl2;
     platforms = platforms.linux;
   };
-
 }


### PR DESCRIPTION
Without the change build fails on `master` as:

    [ 14%] Building CXX object libgrive/CMakeFiles/grive.dir/src/base/Syncer.cc.o
    In file included from /build/source/libgrive/src/base/Syncer.cc:20:
    /build/source/libgrive/src/base/Syncer.hh:58:22: error: 'unique_ptr' in namespace 'std' does not name a template type
       58 |         virtual std::unique_ptr<Feed> GetFolders() = 0;
          |                      ^~~~~~~~~~

Full build log: https://hydra.nixos.org/log/48jk4w7l1frlf6x8xjli2vyqqxk24ib1-grive2-0.5.3.drv

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
