### PR TITLE
lib/options: fix rendering of options with only a defaultText

### DIFF
--- a/lib/options.nix
+++ b/lib/options.nix
@@ -261,7 +261,7 @@ rec {
     concatMap (opt:
       let
         name = showOption opt.loc;
-        docOption = rec {
+        docOption = {
           loc = opt.loc;
           inherit name;
           description = opt.description or null;
@@ -280,9 +280,9 @@ rec {
               renderOptionValue opt.example
             );
         }
-        // optionalAttrs (opt ? default) {
+        // optionalAttrs (opt ? defaultText || opt ? default) {
           default =
-            builtins.addErrorContext "while evaluating the default value of option `${name}`" (
+            builtins.addErrorContext "while evaluating the ${if opt?defaultText then "defaultText" else "default value"} of option `${name}`" (
               renderOptionValue (opt.defaultText or opt.default)
             );
         }


### PR DESCRIPTION
Some options have their default value set in the `config` instead of `default`, for example to push `mkDefault`s down an attribute set. In those cases, it's useful to provide a `defaultText` for informational purposes.

Example: https://github.com/NixOS/nixpkgs/pull/201907/files#diff-096be6a8082e1da2fb353e226eb4a9565545c78c5cd9261fa2cc6d3e0b8773deR221

# Things done

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).