### PR TITLE
steam: fix missing gsettings-schemas dependency

### DIFF
--- a/pkgs/build-support/build-fhsenv-bubblewrap/buildFHSEnv.nix
+++ b/pkgs/build-support/build-fhsenv-bubblewrap/buildFHSEnv.nix
@@ -76,6 +76,19 @@ let
     # XDG_DATA_DIRS is used by pressure-vessel (steam proton) and vulkan loaders to find the corresponding icd
     export XDG_DATA_DIRS=$XDG_DATA_DIRS''${XDG_DATA_DIRS:+:}/run/opengl-driver/share:/run/opengl-driver-32/share
 
+    # Following XDG spec [1], XDG_DATA_DIRS should default to "/usr/local/share:/usr/share".
+    # In nix, it is commonly set without containing these values, so we add them as fallback.
+    #
+    # [1] <https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html>
+    case ":$XDG_DATA_DIRS:" in
+      *:/usr/local/share:*) ;;
+      *) export XDG_DATA_DIRS="$XDG_DATA_DIRS''${XDG_DATA_DIRS:+:}/usr/local/share" ;;
+    esac
+    case ":$XDG_DATA_DIRS:" in
+      *:/usr/share:*) ;;
+      *) export XDG_DATA_DIRS="$XDG_DATA_DIRS''${XDG_DATA_DIRS:+:}/usr/share" ;;
+    esac
+
     # Force compilers and other tools to look in default search paths
     unset NIX_ENFORCE_PURITY
     export NIX_CC_WRAPPER_TARGET_HOST_${stdenv.cc.suffixSalt}=1

--- a/pkgs/build-support/build-fhsenv-chroot/env.nix
+++ b/pkgs/build-support/build-fhsenv-chroot/env.nix
@@ -63,6 +63,19 @@ let
     # XDG_DATA_DIRS is used by pressure-vessel (steam proton) and vulkan loaders to find the corresponding icd
     export XDG_DATA_DIRS=$XDG_DATA_DIRS''${XDG_DATA_DIRS:+:}/run/opengl-driver/share:/run/opengl-driver-32/share
 
+    # Following XDG spec [1], XDG_DATA_DIRS should default to "/usr/local/share:/usr/share".
+    # In nix, it is commonly set without containing these values, so we add them as fallback.
+    #
+    # [1] <https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html>
+    case ":$XDG_DATA_DIRS:" in
+      *:/usr/local/share:*) ;;
+      *) export XDG_DATA_DIRS="$XDG_DATA_DIRS''${XDG_DATA_DIRS:+:}/usr/local/share" ;;
+    esac
+    case ":$XDG_DATA_DIRS:" in
+      *:/usr/share:*) ;;
+      *) export XDG_DATA_DIRS="$XDG_DATA_DIRS''${XDG_DATA_DIRS:+:}/usr/share" ;;
+    esac
+
     # Force compilers and other tools to look in default search paths
     unset NIX_ENFORCE_PURITY
     export NIX_CC_WRAPPER_TARGET_HOST_${stdenv.cc.suffixSalt}=1

--- a/pkgs/games/steam/fhsenv.nix
+++ b/pkgs/games/steam/fhsenv.nix
@@ -116,6 +116,7 @@ in buildFHSEnv rec {
     SDL2
     libusb1
     dbus-glib
+    gsettings-desktop-schemas
     ffmpeg
     libudev0-shim
 


### PR DESCRIPTION
###### Description of changes

The latest steam beta release broke because it's fhsenv is missing `gsettings-desktop-schemas`.

Gsettings tries to locate schemas in this order (Simplified):

1. Under `GSETTINGS_SCHEMA_DIR` (This variable is normally not set)
2. Relative to `XDG_DATA_DIRS` (This variable is normally set)
3. Relative to `/usr/share` (The default value of `XDG_DATA_DIRS`, which is currently no searched)

If it searched `/usr/share` it would succeed, but since `XDG_DATA_DIRS` is set and does not contain `/usr/share` it does not.

I originally planned to simply append to `GSETTINGS_SCHEMA_DIR` like this:
```sh
for d in /usr/share/gsettings-schemas/*; do
  export GSETTINGS_SCHEMA_DIR=$GSETTINGS_SCHEMA_DIR:"$d/glib-2.0/schemas/"
done
```

However it seemed like a more general solution to set the default values of `XDG_DATA_DIRS` as a fallback.

`/usr/local/share` is also added to be more consistent with spec, but that path currently cannot be created.

Fixes https://github.com/NixOS/nixpkgs/issues/230246
Related https://github.com/NixOS/nixpkgs/pull/173811
Related https://github.com/NixOS/nixpkgs/pull/161739

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
