### PR TITLE
lib.types: Add configuration type

### DIFF
--- a/lib/tests/modules/types-configuration/gradual-type-arbitrary-class.nix
+++ b/lib/tests/modules/types-configuration/gradual-type-arbitrary-class.nix
@@ -1,0 +1,30 @@
+{ config, lib, ... }: {
+  imports = [
+    {
+      options.example1 = lib.mkOption {
+        type = lib.types.configuration { };
+      };
+    }
+    {
+      options.example1 = lib.mkOption {
+        type = lib.types.configuration { };
+      };
+    }
+  ];
+  options.result = lib.mkOption { type = lib.types.attrsOf lib.types.raw; };
+
+  config = {
+    result.example1 = config.example1;
+    example1 = lib.evalModules {
+      class = "exampleBarClass";
+      modules = [ {
+        options = {
+          foo = lib.mkOption { type = lib.types.str; };
+        };
+        config = {
+          foo = "bar";
+        };
+      } ];
+    };
+  };
+}

--- a/lib/tests/modules/types-configuration/gradual-type.nix
+++ b/lib/tests/modules/types-configuration/gradual-type.nix
@@ -1,0 +1,29 @@
+{ config, lib, ... }: {
+  imports = [
+    {
+      options.example1 = lib.mkOption {
+        type = lib.types.configuration { };
+      };
+    }
+    {
+      options.example1 = lib.mkOption {
+        type = lib.types.configuration { };
+      };
+    }
+  ];
+  options.result = lib.mkOption { type = lib.types.attrsOf lib.types.raw; };
+
+  config = {
+    result.example1 = config.example1;
+    example1 = lib.evalModules {
+      modules = [ {
+        options = {
+          foo = lib.mkOption { type = lib.types.str; };
+        };
+        config = {
+          foo = "bar";
+        };
+      } ];
+    };
+  };
+}

--- a/lib/tests/modules/types-configuration/gradual-value.nix
+++ b/lib/tests/modules/types-configuration/gradual-value.nix
@@ -1,0 +1,29 @@
+{ config, lib, ... }: {
+  imports = [
+    {
+      options.example1 = lib.mkOption {
+        type = lib.types.configuration { class = "exampleFooClass"; allowUnknownClass = true; };
+      };
+    }
+    {
+      options.example1 = lib.mkOption {
+        type = lib.types.configuration { };
+      };
+    }
+  ];
+  options.result = lib.mkOption { type = lib.types.attrsOf lib.types.raw; };
+
+  config = {
+    result.example1 = config.example1;
+    example1 = lib.evalModules {
+      modules = [ {
+        options = {
+          foo = lib.mkOption { type = lib.types.str; };
+        };
+        config = {
+          foo = "bar";
+        };
+      } ];
+    };
+  };
+}

--- a/lib/tests/modules/types-configuration/mismatch.nix
+++ b/lib/tests/modules/types-configuration/mismatch.nix
@@ -1,0 +1,30 @@
+{ config, lib, ... }: {
+  imports = [
+    {
+      options.example1 = lib.mkOption {
+        type = lib.types.configuration { class = "exampleFooClass"; };
+      };
+    }
+    {
+      options.example1 = lib.mkOption {
+        type = lib.types.configuration { };
+      };
+    }
+  ];
+  options.result = lib.mkOption { type = lib.types.attrsOf lib.types.raw; };
+
+  config = {
+    result.example1 = config.example1;
+    example1 = lib.evalModules {
+      class = "exampleBarClass";
+      modules = [ {
+        options = {
+          foo = lib.mkOption { type = lib.types.str; };
+        };
+        config = {
+          foo = "bar";
+        };
+      } ];
+    };
+  };
+}

--- a/lib/tests/modules/types-configuration/non-gradual-value.nix
+++ b/lib/tests/modules/types-configuration/non-gradual-value.nix
@@ -1,0 +1,29 @@
+{ config, lib, ... }: {
+  imports = [
+    {
+      options.example1 = lib.mkOption {
+        type = lib.types.configuration { class = "exampleFooClass"; };
+      };
+    }
+    {
+      options.example1 = lib.mkOption {
+        type = lib.types.configuration { };
+      };
+    }
+  ];
+  options.result = lib.mkOption { type = lib.types.attrsOf lib.types.raw; };
+
+  config = {
+    result.example1 = config.example1;
+    example1 = lib.evalModules {
+      modules = [ {
+        options = {
+          foo = lib.mkOption { type = lib.types.str; };
+        };
+        config = {
+          foo = "bar";
+        };
+      } ];
+    };
+  };
+}

--- a/lib/tests/modules/types-configuration/type-merge-fail.nix
+++ b/lib/tests/modules/types-configuration/type-merge-fail.nix
@@ -1,0 +1,30 @@
+{ config, lib, ... }: {
+  imports = [
+    {
+      options.example1 = lib.mkOption {
+        type = lib.types.configuration { class = "classFooExample"; };
+      };
+    }
+    {
+      options.example1 = lib.mkOption {
+        type = lib.types.configuration { class = "classBarExample"; };
+      };
+    }
+
+    {
+      options.example2 = lib.mkOption {
+        type = lib.types.configuration { class = "classFooExample"; };
+      };
+    }
+
+  ];
+  options.result = lib.mkOption { type = lib.types.attrsOf lib.types.raw; };
+
+  config = {
+    result.example1 = config.example1;
+    example1 = lib.evalModules { modules = [ ]; };
+
+    result.example2 = config.example2;
+    example2 = lib.evalModules { modules = [ ]; class = "classBarExample"; };
+  };
+}

--- a/lib/tests/modules/types-configuration/type-merge-ok.nix
+++ b/lib/tests/modules/types-configuration/type-merge-ok.nix
@@ -1,0 +1,27 @@
+{ config, lib, ... }: {
+  imports = [
+    {
+      options.example1 = lib.mkOption {
+        type = lib.types.configuration { class = "classFooExample"; allowUnknownClass = true; };
+      };
+    }
+    {
+      options.example1 = lib.mkOption {
+        type = lib.types.configuration { };
+      };
+    }
+  ];
+  options.result = lib.mkOption { type = lib.types.attrsOf lib.types.raw; };
+
+  config = {
+    result.example1 = config.example1;
+    example1 = lib.evalModules { modules = [ {
+      options = {
+        foo = lib.mkOption { type = lib.types.str; };
+      };
+      config = {
+        foo = "bar";
+      };
+    } ]; };
+  };
+}

--- a/nixos/doc/manual/development/option-types.section.md
+++ b/nixos/doc/manual/development/option-types.section.md
@@ -196,6 +196,22 @@ merging is handled.
 
 Submodules are detailed in [Submodule](#section-option-types-submodule).
 
+Usually you want submodules, but this section describes all types that allow modules to be used.
+
+<!-- TODO: support markdown tables in NixOS docs, or move this to Nixpkgs. Unprettified it works in Nixpkgs docs! -->
+
+```
+   Type            | Type declaration       | Definition values          | Merged option value
+ .-----------------|------------------------|----------------------------|----------------------------.
+ | deferredModule  | some options, perhaps  | unevaluated modules        | unevaluated modules        |
+ |                 |                        |                            |                            |
+ | submodule       | all options, usually   | unevaluated modules        | evaluated config           |
+ |                 |                        |                            |                            |
+ | configuration   | nothing except class   | evaluated { config, ... }  | evaluated { config, ... }  |
+ |                 |                        | (only one)                 | (not merged)               |
+ '-----------------|------------------------|----------------------------|----------------------------'
+```
+
 `types.submodule` *`o`*
 
 :   A set of sub options *`o`*. *`o`* can be an attribute set, a function
@@ -262,6 +278,37 @@ Submodules are detailed in [Submodule](#section-option-types-submodule).
     user to affect all submodules in an `attrsOf submodule` at once. This is
     more convenient and discoverable than expecting the module user to
     type-merge with the `attrsOf submodule` option.
+
+`types.configuration {` *`class`*, *`allowUnknownClass`* `? false,` *`allowLegacyType`* ` ? false }`
+
+:   The result of a `lib.evalModules` invocation. While it is generally
+    preferable to use a `submodule` to represent configurations, it is possible
+    to accept the result of another, otherwise stand-alone module system
+    invocation.
+
+    This module system invocation may come from a different module system
+    application. NixOS and home-manager are examples of module system applications.
+
+    The type check of this module system result is influenced by the following
+    parameters.
+
+    -   *`class`*, an optional string. When set to non-null, it requires that
+        the configuration was created with the same `class`. Any module system
+        application should set the `class` argument in its main `evalModules`
+        invocation.
+
+        This **must not** be used before the `class` string is set in stone,
+        even if `allowUnknownClass == true`.
+
+    -   *`allowUnknownClass`*, an optional boolean that defaults to `false`.
+        When `true`, configurations without a `class` will be accepted. This is
+        allows for a migration period during which configurations of older
+        versions of the module system application.
+
+    -   *`allowLegacyType`*, an optional boolean that defaults to `false`.
+        When `true`, configurations without a `_type` attribute, are permitted.
+        These are returned by Nixpkgs `lib` versions before 23.05.
+
 
 ## Composed types {#sec-option-types-composed}
 


### PR DESCRIPTION
###### Description of changes

Add a type for the result of lib.evalModules` invocation.

While it is generally preferable to use a `submodule` to represent configurations, this type does occur in the wild. For instance, it should be used in [flake.nixosConfigurations](https://flake.parts/options/flake-parts.html#opt-flake.nixosConfigurations) (flake.parts).

Although this type is not used within the nixpkgs repo, it would be appropriate for this type to be bundled with the module system, as it describes part of the module system.


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
