### PR TITLE
mox: init at 0.0.5

### DIFF
--- a/pkgs/servers/mail/mox/default.nix
+++ b/pkgs/servers/mail/mox/default.nix
@@ -1,0 +1,34 @@
+{ lib
+, buildGoModule
+, fetchFromGitHub
+}:
+
+buildGoModule rec {
+  pname = "mox";
+  version = "0.0.5";
+
+  src = fetchFromGitHub {
+    owner = "mjl-";
+    repo = "mox";
+    rev = "v${version}";
+    hash = "sha256-f5/K6cPqJJkbdiVCNGOTd9Fjx2/gvSZCxeR6nnEaeJw=";
+  };
+
+  # set the version during buildtime
+  patches = [ ./version.patch ];
+
+  vendorHash = null;
+
+  ldflags = [
+    "-s"
+    "-w"
+    "-X github.com/mjl-/mox/moxvar.Version=${version}"
+  ];
+
+  meta = {
+    description = "Modern full-featured open source secure mail server for low-maintenance self-hosted email";
+    homepage = "https://github.com/mjl-/mox";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ dit7ya ];
+  };
+}

--- a/pkgs/servers/mail/mox/version.patch
+++ b/pkgs/servers/mail/mox/version.patch
@@ -1,0 +1,45 @@
+diff --git a/moxvar/version.go b/moxvar/version.go
+index 8c6bac8..69b5f7c 100644
+--- a/moxvar/version.go
++++ b/moxvar/version.go
+@@ -1,38 +1,5 @@
+ // Package moxvar provides the version number of a mox build.
+ package moxvar
+ 
+-import (
+-	"runtime/debug"
+-)
+-
+-// Version is set at runtime based on the Go module used to build.
+-var Version = "(devel)"
+-
+-func init() {
+-	buildInfo, ok := debug.ReadBuildInfo()
+-	if !ok {
+-		return
+-	}
+-	Version = buildInfo.Main.Version
+-	if Version == "(devel)" {
+-		var vcsRev, vcsMod string
+-		for _, setting := range buildInfo.Settings {
+-			if setting.Key == "vcs.revision" {
+-				vcsRev = setting.Value
+-			} else if setting.Key == "vcs.modified" {
+-				vcsMod = setting.Value
+-			}
+-		}
+-		if vcsRev == "" {
+-			return
+-		}
+-		Version = vcsRev
+-		switch vcsMod {
+-		case "false":
+-		case "true":
+-			Version += "+modifications"
+-		default:
+-			Version += "+unknown"
+-		}
+-	}
+-}
++// Version is set via a build flag
++var Version string;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6167,6 +6167,8 @@ with pkgs;
 
   mountain-duck = callPackage ../tools/filesystems/mountain-duck { };
 
+  mox = callPackage ../servers/mail/mox { };
+
   mozlz4a = callPackage ../tools/compression/mozlz4a { };
 
   msr-tools = callPackage ../os-specific/linux/msr-tools { };


### PR DESCRIPTION
###### Description of changes

modern full-featured open source secure mail server for low-maintenance self-hosted email 

https://github.com/mjl-/mox

NOTE: This is not tested beyond basic commands.



<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
