### PR TITLE
flatpak: fix copy error in gtk-icon-cache trigger

### DIFF
--- a/pkgs/development/libraries/flatpak/fix-test-paths.patch
+++ b/pkgs/development/libraries/flatpak/fix-test-paths.patch
@@ -182,7 +182,7 @@ index d9fc8251..d8ddb96e 100755
  
  if command -v gtk-update-icon-cache >/dev/null && test -d "$1/exports/share/icons/hicolor"; then
 -    cp /usr/share/icons/hicolor/index.theme "$1/exports/share/icons/hicolor/"
-+    cp @hicolorIconTheme@/share/icons/hicolor/index.theme "$1/exports/share/icons/hicolor/"
++    cp -f @hicolorIconTheme@/share/icons/hicolor/index.theme "$1/exports/share/icons/hicolor/"
      for dir in "$1"/exports/share/icons/*; do
          if test -f "$dir/index.theme"; then
 -            if ! gtk-update-icon-cache --quiet "$dir"; then


### PR DESCRIPTION
###### Description of changes

The file that get copied gets read only permissions which means that the trigger will fail on all subsequent runs after the first since its write protected. With -f we ignore the write protection of the file.

The error looks like this:
```
F: running triggers from /nix/store/c6p8a6d5i3c187rniv42rdh1c8dsm8q8-flatpak-1.14.4/share/flatpak/triggers
F: running trigger desktop-database.trigger
F: Running '/nix/store/ccgrsmsah1xphh9vii2by50pnckcknqf-bubblewrap-0.8.0/bin/bwrap --unshare-ipc --unshare-net --unshare-pid --ro-bind / / --proc /proc --dev /dev --bind /home/kalle/.local/share/flatpak /home/kalle/.local/share/flatpak /nix/store/c6p8a6d5i3c187rniv42rdh1c8dsm8q8-flatpak-1.14.4/share/flatpak/triggers/desktop-database.trigger /home/kalle/.local/share/flatpak'
F: running trigger gtk-icon-cache.trigger
F: Running '/nix/store/ccgrsmsah1xphh9vii2by50pnckcknqf-bubblewrap-0.8.0/bin/bwrap --unshare-ipc --unshare-net --unshare-pid --ro-bind / / --proc /proc --dev /dev --bind /home/kalle/.local/share/flatpak /home/kalle/.local/share/flatpak /nix/store/c6p8a6d5i3c187rniv42rdh1c8dsm8q8-flatpak-1.14.4/share/flatpak/triggers/gtk-icon-cache.trigger /home/kalle/.local/share/flatpak'
cp: cannot create regular file '/home/kalle/.local/share/flatpak/exports/share/icons/hicolor/index.theme': Permission denied
```

The trigger runs when installing/removing flatpaks, too see it you need to run flatpak with the -v switch.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
