### PR TITLE
systemd: Build tests in Linux VM

### DIFF
--- a/pkgs/os-specific/linux/systemd/default.nix
+++ b/pkgs/os-specific/linux/systemd/default.nix
@@ -452,7 +452,7 @@ stdenv.mkDerivation (finalAttrs: {
     "-Ddebug-shell=${bashInteractive}/bin/bash"
     "-Dglib=${lib.boolToString withTests}"
     # while we do not run tests we should also not build them. Removes about 600 targets
-    "-Dtests=false"
+    "-Dtests=${lib.boolToString withTests}"
     "-Dacl=${lib.boolToString withAcl}"
     "-Danalyze=${lib.boolToString withAnalyze}"
     "-Daudit=${lib.boolToString withAudit}"
@@ -677,7 +677,7 @@ stdenv.mkDerivation (finalAttrs: {
     "-D__UAPI_DEF_ETHHDR=0"
   ]);
 
-  doCheck = false; # fails a bunch of tests
+  doCheck = withTests; # fails a bunch of tests
 
   # trigger the test -n "$DESTDIR" || mutate in upstreams build system
   preInstall = ''

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -27446,6 +27446,21 @@ with pkgs;
     withLibidn2 = true;
   };
 
+  systemdTests = vmTools.runInLinuxVM ((systemd.override {
+    withTests = true;
+  }).overrideAttrs (old: {
+    postPatch = ''
+      ${old.postPatch or ""}
+      mkdir -p /usr/bin
+      ln -s ${coreutils}/bin/env /usr/bin/env
+    '';
+    # systemd-detect-virt should be on PATH
+    preCheck = ''
+      PATH=${lib.getBin systemd}/bin:$PATH
+    '';
+    memSize = 1024;
+  }));
+
 
   udev =
     if (with stdenv.hostPlatform; isLinux && isStatic) then libudev-zero


### PR DESCRIPTION
This adds a package that is functionally equivalent to the `systemd` package, except that it's built in a Linux VM so that its tests can run. Surprisingly, out of the box, all but a few of these tests pass. This is a draft PR because the derivation obviously doesn't build yet. But it'd be nice to have an indicator in Hydra of whether or not systemd's tests are passing.