### PR TITLE
OrangePi r1 plus lts

### DIFF
--- a/pkgs/misc/uboot/default.nix
+++ b/pkgs/misc/uboot/default.nix
@@ -391,6 +391,103 @@ in {
     filesToInstall = ["u-boot-sunxi-with-spl.bin"];
   };
 
+  ubootOrangePiR1PlusLts = let
+    rkbin = fetchFromGitHub {
+      owner = "armbian";
+      repo = "rkbin";
+      rev = "5d409529dbbc12959111787e77c349b3e832bc52";
+      sha256 = "09r4dzxsbs3pff4sh70qnyp30s3rc7pkc46v1m3152s7jqjasp31";
+    };
+  in buildUBoot {
+    version = "2022.07";
+    src = fetchFromGitHub {
+      owner = "u-boot";
+      repo = "u-boot";
+      rev = "v2022.07";
+      sha256 = "1EONRmYLsD0uxo+kpE6mLIYkYMU09Yt0EvSbHhj5prw=";
+    };
+    defconfig = "orangepi_r1_plus_lts_rk3328_defconfig";
+    extraMakeFlags = [ "u-boot-dtb.bin" ];
+    extraPatches = [
+      (fetchpatch {
+        url = "https://raw.githubusercontent.com/armbian/build/420f16c7ead971f1c443314ef41d9a02473cf260/patch/u-boot/u-boot-rockchip64/add-board-orangepi-r1-plus-0.patch";
+        sha256 = "sha256-x7dUMiBJWwD7nM/eqRWODNHw5OMSsNsRH6IEclii9TQ=";
+      })
+      (fetchpatch {
+        url = "https://raw.githubusercontent.com/armbian/build/420f16c7ead971f1c443314ef41d9a02473cf260/patch/u-boot/u-boot-rockchip64/add-board-orangepi-r1-plus-lts.patch";
+        sha256 = "sha256-T3hAKZFyp4yJ0BGyfHsT0MPSOdA8mFqvcBW2Kb8pa7s=";
+      })
+      (fetchpatch {
+        url = "https://raw.githubusercontent.com/armbian/build/420f16c7ead971f1c443314ef41d9a02473cf260/patch/u-boot/u-boot-rockchip64/add-trust-ini.patch";
+        sha256 = "sha256-bfceynwI4d4bLJvkg8OwUY2N65C02Yl3KFmpE7N6kAk=";
+      })
+      (fetchpatch {
+        url = "https://raw.githubusercontent.com/armbian/build/420f16c7ead971f1c443314ef41d9a02473cf260/patch/u-boot/u-boot-rockchip64/enable-DT-overlays-support.patch";
+        sha256 = "sha256-xm4/yZlCNDyi9QfdUnpOqjsEeIFFc+BDkYy2qnblD74=";
+      })
+      (fetchpatch {
+        url = "https://raw.githubusercontent.com/armbian/build/420f16c7ead971f1c443314ef41d9a02473cf260/patch/u-boot/u-boot-rockchip64/general-add-xtx-spi-nor-chips.patch";
+        sha256 = "sha256-fHaTwUXDO8CcX6RRyMgEyZ7CZX0LzEha/IKulGRQbzw=";
+      })
+      (fetchpatch {
+        url = "https://raw.githubusercontent.com/armbian/build/420f16c7ead971f1c443314ef41d9a02473cf260/patch/u-boot/u-boot-rockchip64/general-dwc-otg-usb-fix.patch";
+        sha256 = "sha256-e1MsmAxkSXB2qHmSkD7DSv56VhcEJmIN1c2XuLZPMKM=";
+      })
+      (fetchpatch {
+        url = "https://raw.githubusercontent.com/armbian/build/420f16c7ead971f1c443314ef41d9a02473cf260/patch/u-boot/u-boot-rockchip64/general-set-eth1addr.patch";
+        sha256 = "sha256-u/kiWf0vz3Yw+rEgAO+BPw/PkKom3SM2F9jOS/6/Nu0=";
+      })
+        (fetchpatch {
+        url = "https://raw.githubusercontent.com/armbian/build/420f16c7ead971f1c443314ef41d9a02473cf260/patch/u-boot/u-boot-rockchip64/general-support-recovery-button.patch";
+        sha256 = "sha256-uP1eLOALtxS7Ue9heVAkYFDwvW0lTZdQfhVioh5oBNc=";
+      })
+      (fetchpatch {
+        url = "https://raw.githubusercontent.com/armbian/build/420f16c7ead971f1c443314ef41d9a02473cf260/patch/u-boot/u-boot-rockchip64/general-support-rmii-integrated-phy.patch";
+        sha256 = "sha256-y4FaQ1OQGVvkD8Sot0jNJMuGO6p9o2u03JiL5MKihm4=";
+      })
+      (fetchpatch {
+        url = "https://raw.githubusercontent.com/armbian/build/420f16c7ead971f1c443314ef41d9a02473cf260/patch/u-boot/u-boot-rockchip64/rk3328-efuse-driver.patch";
+        sha256 = "sha256-ly2dJb1BRXuITfNYCiqqIxqErWQnrdonhpaLwmeKAm4=";
+      })
+      (fetchpatch {
+        url = "https://raw.githubusercontent.com/armbian/build/420f16c7ead971f1c443314ef41d9a02473cf260/patch/u-boot/u-boot-rockchip64/rk3328-resets-for-mmc-controllers.patch";
+        sha256 = "sha256-abd2V0D2Cm5hw+JiWa80c7kmhcV8G6wbyyxw/ZAWu+0=";
+      })
+      (fetchpatch {
+        url = "https://raw.githubusercontent.com/armbian/build/420f16c7ead971f1c443314ef41d9a02473cf260/patch/u-boot/u-boot-rockchip64/rk3328-sdmmc_ext-node.patch";
+        sha256 = "sha256-EHS/aBik4V4pbEU9GHhCXCBgdoExbVvUzB01KDx4zM8=";
+      })
+      (fetchpatch {
+        url = "https://raw.githubusercontent.com/armbian/build/420f16c7ead971f1c443314ef41d9a02473cf260/patch/u-boot/u-boot-rockchip64/sdmmc-force-fifo-mode-in-spl.patch";
+        sha256 = "sha256-+oy6kG/wAvd89M+ZS6a2xlKWzzdHV6UCtd1SaTmLJaI=";
+      })
+    ];
+    extraMeta = {
+      platforms = [ "aarch64-linux" ];
+      license = lib.licenses.unfreeRedistributableFirmware;
+    };
+    BL31 = "${armTrustedFirmwareRK3328}/bl31.elf";
+    filesToInstall = [ "u-boot.img" "idbloader.img" "trust.bin" ];
+    postBuild = ''
+      # deduced from https://github.com/armbian/build/blob/420f16c7ead971f1c443314ef41d9a02473cf260/config/boards/orangepi-r1plus-lts.conf#L4
+      # and https://github.com/armbian/build/blob/420f16c7ead971f1c443314ef41d9a02473cf260/config/sources/families/include/rockchip64_common.inc#L42
+      BOOT_SOC=rk3328
+
+      # see https://github.com/orangepi-xunlong/orangepi-build/blob/f00cd197b4a9873f36093d4f4748b733642059a7/external/config/sources/families/include/rockchip64_common.inc#L29-L35
+      # or rather https://github.com/armbian/build/blob/420f16c7ead971f1c443314ef41d9a02473cf260/config/sources/families/include/rockchip64_common.inc#L70-L75
+      DDR_BLOB=${rkbin}/rk33/rk3328_ddr_333MHz_v1.16.bin
+      MINILOADER_BLOB=${rkbin}/rk33/rk322xh_miniloader_v2.50.bin
+      BL31_BLOB=${rkbin}/rk33/rk322xh_bl31_v1.44.elf
+
+      # see https://github.com/armbian/build/blob/420f16c7ead971f1c443314ef41d9a02473cf260/config/sources/families/include/rockchip64_common.inc#L213-L216
+      ./tools/mkimage -n $BOOT_SOC -T rksd -d $DDR_BLOB idbloader.img
+      cat $MINILOADER_BLOB >> idbloader.img
+
+      ${pkgs.ubootRockchipTools}/bin/loaderimage --pack --uboot ./u-boot-dtb.bin u-boot.img 0x200000
+      ${pkgs.ubootRockchipTools}/bin/trust_merger --verbose --replace bl31.elf $BL31_BLOB trust.ini
+    '';
+  };
+
   ubootOrangePi3 = buildUBoot {
     defconfig = "orangepi_3_defconfig";
     extraMeta.platforms = ["aarch64-linux"];

--- a/pkgs/misc/uboot/default.nix
+++ b/pkgs/misc/uboot/default.nix
@@ -21,6 +21,7 @@
 , armTrustedFirmwareRK3399
 , armTrustedFirmwareS905
 , buildPackages
+, pkgs
 }:
 
 let
@@ -144,6 +145,30 @@ in {
       "tools/mkimage"
     ];
   };
+
+  ubootRockchipTools = stdenv.mkDerivation ({
+    src = fetchFromGitHub {
+      owner = "rockchip-linux";
+      repo = "u-boot";
+      rev = "ef1dd650042f61915c4859ecc94623a09a3529fa";
+      sha256 = "sha256-w0hp1UGxCtSBlu9YJx6KUjeHfPCB+QqoNDlLp7AshoM=";
+    };
+
+    name = "uboot-rockchip-tools";
+    configurePhase = "make allnoconfig";
+    makeFlags = "CONFIG_ARCH_ROCKCHIP=y NO_SDL=1 tools";
+    installPhase = ''
+      mkdir -p $out/bin
+      cp tools/loaderimage tools/trust_merger $out/bin
+    '';
+
+    meta = with lib; {
+      homepage = "https://opensource.rock-chips.com/wiki_U-Boot";
+      description = "Tools required to create u-boot images for rockchip based boards";
+      license = licenses.gpl2;
+      maintainers = with maintainers; [ zauberpony ];
+    };
+  });
 
   ubootA20OlinuxinoLime = buildUBoot {
     defconfig = "A20-OLinuXino-Lime_defconfig";

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -28563,6 +28563,7 @@ with pkgs;
     ubootOdroidC2
     ubootOdroidXU3
     ubootOlimexA64Olinuxino
+    ubootOrangePiR1PlusLts
     ubootOrangePi3
     ubootOrangePiPc
     ubootOrangePiZeroPlus2H5

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -28546,6 +28546,7 @@ with pkgs;
   inherit (callPackage ../misc/uboot {})
     buildUBoot
     ubootTools
+    ubootRockchipTools
     ubootA20OlinuxinoLime
     ubootA20OlinuxinoLime2EMMC
     ubootBananaPi


### PR DESCRIPTION
###### Description of changes

This PR adds support for the Bootloader u-boot for the [OrangePi R1 Plus LTS](http://www.orangepi.org/html/hardWare/computerAndMicrocontrollers/details/orange-pi-R1-Plus-LTS.html). I built it mainly by dissecting the armbian build for this board. References are in the code as comments.

Since it requires some rockchip-specific tools only available in rockchip's forked u-boot repository… I added another packages, ubootRockipTools, I hope that's okay to do both in one PR, otherwise let me know, and I'll split it.

###### POC, Nixos on OrangePi R1 Plus LTS

[Support for OrangePi R1 Plus LTS landed in upstream linux](https://github.com/torvalds/linux/commit/387b3bbac5ea6a0a105d685237f033ffe0f184f1), should be released with 6.4.
So once the generic arm-images for nixos includes a kernel with that version/commit, creating a nixos-image should be as easy as for other boards.

In the meantime, building a custom kernel is required, but the OrangePI R1 Plus LTS just booted that way ;)

```
{ pkgs, ... }: {
  imports = [
    <nixpkgs/nixos/modules/installer/sd-card/sd-image-aarch64.nix>
  ];

  # disable zfs — not required and broken for 6.3
  nixpkgs.overlays = [
    (final: super: {
      zfs = super.zfs.overrideAttrs (_: {
        meta.platforms = [ ];
      });
    })
  ];

  boot.kernelPackages = pkgs.linuxPackages_testing;

  nixpkgs.config.allowUnfree = true;

  networking.hostName = "orangepi-r1-plus-lts";

  sdImage.compressImage = false;
  sdImage.postBuildCommands = ''
    dd if=${pkgs.ubootOrangePiR1PlusLts}/idbloader.img of=$img conv=fsync,notrunc bs=512 seek=64
    dd if=${pkgs.ubootOrangePiR1PlusLts}/u-boot.img of=$img conv=fsync,notrunc bs=512 seek=16384
    dd if=${pkgs.ubootOrangePiR1PlusLts}/trust.img of=$bin conv=fsync,notrunc bs=512 seek=24576
  '';

  services.openssh.enable = true;

  # put your own configuration here, for example ssh keys:
  users.users.root.openssh.authorizedKeys.keys = [
    $YOUR_SSH_KEY
  ];
}

```


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
