### PR TITLE
cargo-bazel: init at 0.8.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -14343,6 +14343,12 @@
     githubId = 42619;
     name = "Wei-Ming Yang";
   };
+  rickvanprim = {
+    email = "me@rickvanprim.com";
+    github = "rickvanprim";
+    githubId = 13792812;
+    name = "James Leitch";
+  };
   rickynils = {
     email = "rickynils@gmail.com";
     github = "rickynils";

--- a/pkgs/development/tools/rust/cargo-bazel/default.nix
+++ b/pkgs/development/tools/rust/cargo-bazel/default.nix
@@ -1,0 +1,30 @@
+{ lib
+, stdenv
+, fetchCrate
+, rustPlatform
+, Security
+}:
+
+rustPlatform.buildRustPackage rec {
+  pname = "cargo-bazel";
+  version = "0.8.0";
+
+  src = fetchCrate {
+    inherit pname version;
+    sha256 = "FS1WFlK0YNq1QCi3S3f5tMN+Bdcfx2dxhDKRLXLcios=";
+  };
+
+  cargoSha256 = "+PVNB/apG5AR236Ikqt+JTz20zxc0HUi7z6BU6xq/Fw=";
+
+  buildInputs = lib.optional stdenv.isDarwin Security;
+
+  # `test_data` is explicitly excluded from the package published to crates.io, so tests cannot be run
+  doCheck = false;
+
+  meta = with lib; {
+    description = "Part of the `crate_universe` collection of tools which use Cargo to generate build targets for Bazel";
+    homepage = "https://github.com/bazelbuild/rules_rust";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ rickvanprim ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -17030,6 +17030,9 @@ with pkgs;
   cargo-asm = callPackage ../development/tools/rust/cargo-asm {
     inherit (darwin.apple_sdk.frameworks) Security;
   };
+  cargo-bazel = callPackage ../development/tools/rust/cargo-bazel {
+    inherit (darwin.apple_sdk.frameworks) Security;
+  };
   cargo-binutils = callPackage ../development/tools/rust/cargo-binutils { };
   cargo-bloat = callPackage ../development/tools/rust/cargo-bloat { };
   cargo-bolero = callPackage ../development/tools/rust/cargo-bolero { };


### PR DESCRIPTION
###### Description of changes

Add `cargo-bazel` tool from Bazel's `rules_rust`'s `crate_universe`.

See:
https://crates.io/crates/cargo-bazel
https://bazelbuild.github.io/rules_rust/crate_universe.html

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).