### PR TITLE
python3Packages.freetype-py: 2.1.0.post1 → 2.4.0

### DIFF
--- a/pkgs/development/python-modules/freetype-py/default.nix
+++ b/pkgs/development/python-modules/freetype-py/default.nix
@@ -43,6 +43,6 @@ buildPythonPackage rec {
     homepage = "https://github.com/rougier/freetype-py";
     description = "FreeType (high-level Python API)";
     license = licenses.bsd3;
-    maintainers = with maintainers; [ goertzenator ];
+    maintainers = with maintainers; [ danc86 ];
   };
 }

--- a/pkgs/development/python-modules/freetype-py/default.nix
+++ b/pkgs/development/python-modules/freetype-py/default.nix
@@ -10,11 +10,12 @@
 
 buildPythonPackage rec {
   pname = "freetype-py";
-  version = "2.1.0.post1";
+  version = "2.4.0";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "1k62fx53qrv9nb73mpqi2r11wzbx41qfv5qppvh6rylywnrknf3n";
+    extension = "zip";
+    hash = "sha256-itgRldL48zmrphcAzr+9d9760UnFH1m3WipeN4M64S4=";
   };
 
   patches = [


### PR DESCRIPTION
###### Description of changes

New upstream release with various improvements and fixes, it appears to be API compatible:
https://github.com/rougier/freetype-py/releases/tag/v2.2.0
https://github.com/rougier/freetype-py/releases/tag/v2.3.0
https://github.com/rougier/freetype-py/releases/tag/v2.4.0

In particular, it includes this commit adding variable font support which is needed for some other Python libraries in the Google Fonts ecosystem that I am trying to package:
https://github.com/rougier/freetype-py/commit/cbcdac654b03b2942c44eda082e1010f06b74c9c

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- ~[ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))~
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- ~[ ] Tested basic functionality of all binary files (usually in `./result/bin/`)~
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - ~[ ] (Package updates) Added a release notes entry if the change is major or breaking~
  - ~[ ] (Module updates) Added a release notes entry if the change is significant~
  - ~[ ] (Module addition) Added a release notes entry if adding a new NixOS module~
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).