### PR TITLE
[22.11] freetype: add patch for CVE-2023-2004

### DIFF
--- a/pkgs/development/libraries/freetype/2.12.1-CVE-2023-2004.patch
+++ b/pkgs/development/libraries/freetype/2.12.1-CVE-2023-2004.patch
@@ -1,0 +1,24 @@
+Based on upstream e6fda039ad638866b7a6a5d046f03278ba1b7611, adapted
+to apply to 2.12.1.
+
+diff --git a/src/truetype/ttgxvar.c b/src/truetype/ttgxvar.c
+index 6a0edef29..eff7219b8 100644
+--- a/src/truetype/ttgxvar.c
++++ b/src/truetype/ttgxvar.c
+@@ -42,6 +42,7 @@
+ #include <ft2build.h>
+ #include <freetype/internal/ftdebug.h>
+ #include FT_CONFIG_CONFIG_H
++#include <freetype/internal/ftcalc.h>
+ #include <freetype/internal/ftstream.h>
+ #include <freetype/internal/sfnt.h>
+ #include <freetype/tttags.h>
+@@ -1140,7 +1141,7 @@
+                 delta == 1 ? "" : "s",
+                 vertical ? "VVAR" : "HVAR" ));
+ 
+-    *avalue += delta;
++    *avalue = ADD_INT( *avalue, delta );
+ 
+   Exit:
+     return error;

--- a/pkgs/development/libraries/freetype/default.nix
+++ b/pkgs/development/libraries/freetype/default.nix
@@ -43,6 +43,7 @@ stdenv.mkDerivation rec {
 
   patches = [
     ./enable-table-validation.patch
+    ./2.12.1-CVE-2023-2004.patch
   ] ++ lib.optional useEncumberedCode ./enable-subpixel-rendering.patch;
 
   outputs = [ "out" "dev" ];


### PR DESCRIPTION
###### Description of changes

https://nvd.nist.gov/vuln/detail/CVE-2023-2004

Have built `passthru.tests` on macos 10.15 & nixos x86_64. Also built `pkgsStatic`, `pkgsMusl` & `pkgsCross.aarch64-multiplatform` variants on x86_64 linux. Builds, aarch64-linux.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
