### PR TITLE
python3Packages.{pyqt3d,pyqtchart,pyqtdatavisualization}: init; python3Packages.pyqt5: add options

### DIFF
--- a/pkgs/development/python-modules/pyqt/5.x.nix
+++ b/pkgs/development/python-modules/pyqt/5.x.nix
@@ -18,6 +18,7 @@
 , withWebSockets ? false
 , withLocation ? false
 , withSerialPort ? false
+, withTools ? false
 }:
 
 buildPythonPackage rec {
@@ -88,6 +89,7 @@ buildPythonPackage rec {
     ++ lib.optional withWebSockets qtwebsockets
     ++ lib.optional withLocation qtlocation
     ++ lib.optional withSerialPort qtserialport
+    ++ lib.optional withTools qttools
   ;
 
   buildInputs = with libsForQt5; [
@@ -102,6 +104,7 @@ buildPythonPackage rec {
     ++ lib.optional withWebSockets qtwebsockets
     ++ lib.optional withLocation qtlocation
     ++ lib.optional withSerialPort qtserialport
+    ++ lib.optional withTools qttools
   ;
 
   propagatedBuildInputs = [
@@ -134,6 +137,7 @@ buildPythonPackage rec {
     ++ lib.optional withConnectivity "PyQt5.QtBluetooth"
     ++ lib.optional withLocation "PyQt5.QtPositioning"
     ++ lib.optional withSerialPort "PyQt5.QtSerialPort"
+    ++ lib.optional withTools "PyQt5.QtDesigner"
   ;
 
   meta = with lib; {

--- a/pkgs/development/python-modules/pyqt/5.x.nix
+++ b/pkgs/development/python-modules/pyqt/5.x.nix
@@ -17,6 +17,7 @@
 , withWebKit ? false
 , withWebSockets ? false
 , withLocation ? false
+, withSerialPort ? false
 }:
 
 buildPythonPackage rec {
@@ -86,6 +87,7 @@ buildPythonPackage rec {
     ++ lib.optional withWebKit qtwebkit
     ++ lib.optional withWebSockets qtwebsockets
     ++ lib.optional withLocation qtlocation
+    ++ lib.optional withSerialPort qtserialport
   ;
 
   buildInputs = with libsForQt5; [
@@ -99,6 +101,7 @@ buildPythonPackage rec {
     ++ lib.optional withWebKit qtwebkit
     ++ lib.optional withWebSockets qtwebsockets
     ++ lib.optional withLocation qtlocation
+    ++ lib.optional withSerialPort qtserialport
   ;
 
   propagatedBuildInputs = [
@@ -130,6 +133,7 @@ buildPythonPackage rec {
     ++ lib.optional withMultimedia "PyQt5.QtMultimedia"
     ++ lib.optional withConnectivity "PyQt5.QtBluetooth"
     ++ lib.optional withLocation "PyQt5.QtPositioning"
+    ++ lib.optional withSerialPort "PyQt5.QtSerialPort"
   ;
 
   meta = with lib; {

--- a/pkgs/development/python-modules/pyqt3d/default.nix
+++ b/pkgs/development/python-modules/pyqt3d/default.nix
@@ -1,0 +1,77 @@
+{ lib
+, stdenv
+, buildPythonPackage
+, fetchPypi
+, pyqt5
+, pyqt-builder
+, python
+, pythonOlder
+, qt3d
+, setuptools
+, sip
+}:
+
+buildPythonPackage rec {
+  pname = "pyqt3d";
+  version = "5.15.6";
+  format = "pyproject";
+
+  disabled = pythonOlder "3.7";
+
+  src = fetchPypi {
+    pname = "PyQt3D";
+    inherit version;
+    hash = "sha256-fWxtVc2PwiGzE8mVwPhymjdxFJJvA3f46QEdRevziBw=";
+  };
+
+  postPatch = ''
+    substituteInPlace pyproject.toml \
+      --replace "[tool.sip.project]" "[tool.sip.project]''\nsip-include-dirs = [\"${pyqt5}/${python.sitePackages}/PyQt5/bindings\"]"
+  '';
+
+  outputs = [ "out" "dev" ];
+
+  enableParallelBuilding = true;
+  # HACK: paralellize compilation of make calls within pyqt's setup.py
+  # pkgs/stdenv/generic/setup.sh doesn't set this for us because
+  # make gets called by python code and not its build phase
+  # format=pyproject means the pip-build-hook hook gets used to build this project
+  # pkgs/development/interpreters/python/hooks/pip-build-hook.sh
+  # does not use the enableParallelBuilding flag
+  preBuild = ''
+    export MAKEFLAGS+="''${enableParallelBuilding:+-j$NIX_BUILD_CORES}"
+  '';
+
+  dontWrapQtApps = true;
+
+  nativeBuildInputs = [
+    sip
+    qt3d
+    setuptools
+    pyqt-builder
+  ];
+
+  buildInputs = [
+    qt3d
+  ];
+
+  propagatedBuildInputs = [
+    pyqt5
+  ];
+
+  dontConfigure = true;
+
+  # has no tests
+  doCheck = false;
+
+  pythonImportsCheck = [
+    "PyQt5.Qt3DCore"
+  ];
+
+  meta = with lib; {
+    description = "Python bindings for the Qt 3D framework";
+    homepage = "https://riverbankcomputing.com/";
+    license = licenses.gpl3Only;
+    maintainers = with maintainers; [ panicgh ];
+  };
+}

--- a/pkgs/development/python-modules/pyqtchart/default.nix
+++ b/pkgs/development/python-modules/pyqtchart/default.nix
@@ -1,0 +1,77 @@
+{ lib
+, stdenv
+, buildPythonPackage
+, fetchPypi
+, pyqt5
+, pyqt-builder
+, python
+, pythonOlder
+, qtcharts
+, setuptools
+, sip
+}:
+
+buildPythonPackage rec {
+  pname = "pyqtchart";
+  version = "5.15.6";
+  format = "pyproject";
+
+  disabled = pythonOlder "3.7";
+
+  src = fetchPypi {
+    pname = "PyQtChart";
+    inherit version;
+    hash = "sha256-JpF5b+kqKUphdZKlxcNeeF3JH3dZ3vnrItp532N2Izk=";
+  };
+
+  postPatch = ''
+    substituteInPlace pyproject.toml \
+      --replace "[tool.sip.project]" "[tool.sip.project]''\nsip-include-dirs = [\"${pyqt5}/${python.sitePackages}/PyQt5/bindings\"]"
+  '';
+
+  outputs = [ "out" "dev" ];
+
+  enableParallelBuilding = true;
+  # HACK: paralellize compilation of make calls within pyqt's setup.py
+  # pkgs/stdenv/generic/setup.sh doesn't set this for us because
+  # make gets called by python code and not its build phase
+  # format=pyproject means the pip-build-hook hook gets used to build this project
+  # pkgs/development/interpreters/python/hooks/pip-build-hook.sh
+  # does not use the enableParallelBuilding flag
+  preBuild = ''
+    export MAKEFLAGS+="''${enableParallelBuilding:+-j$NIX_BUILD_CORES}"
+  '';
+
+  dontWrapQtApps = true;
+
+  nativeBuildInputs = [
+    sip
+    qtcharts
+    setuptools
+    pyqt-builder
+  ];
+
+  buildInputs = [
+    qtcharts
+  ];
+
+  propagatedBuildInputs = [
+    pyqt5
+  ];
+
+  dontConfigure = true;
+
+  # has no tests
+  doCheck = false;
+
+  pythonImportsCheck = [
+    "PyQt5.QtChart"
+  ];
+
+  meta = with lib; {
+    description = "Python bindings for the Qt Charts library";
+    homepage = "https://riverbankcomputing.com/";
+    license = licenses.gpl3Only;
+    maintainers = with maintainers; [ panicgh ];
+  };
+}

--- a/pkgs/development/python-modules/pyqtdatavisualization/default.nix
+++ b/pkgs/development/python-modules/pyqtdatavisualization/default.nix
@@ -1,0 +1,77 @@
+{ lib
+, stdenv
+, buildPythonPackage
+, fetchPypi
+, pyqt5
+, pyqt-builder
+, python
+, pythonOlder
+, qtdatavis3d
+, setuptools
+, sip
+}:
+
+buildPythonPackage rec {
+  pname = "pyqtdatavisualization";
+  version = "5.15.5";
+  format = "pyproject";
+
+  disabled = pythonOlder "3.7";
+
+  src = fetchPypi {
+    pname = "PyQtDataVisualization";
+    inherit version;
+    hash = "sha256-iSf496pwhX7wDFHj379vg92fOFX0FuDVMVknYcu53H8=";
+  };
+
+  postPatch = ''
+    substituteInPlace pyproject.toml \
+      --replace "[tool.sip.project]" "[tool.sip.project]''\nsip-include-dirs = [\"${pyqt5}/${python.sitePackages}/PyQt5/bindings\"]"
+  '';
+
+  outputs = [ "out" "dev" ];
+
+  enableParallelBuilding = true;
+  # HACK: paralellize compilation of make calls within pyqt's setup.py
+  # pkgs/stdenv/generic/setup.sh doesn't set this for us because
+  # make gets called by python code and not its build phase
+  # format=pyproject means the pip-build-hook hook gets used to build this project
+  # pkgs/development/interpreters/python/hooks/pip-build-hook.sh
+  # does not use the enableParallelBuilding flag
+  preBuild = ''
+    export MAKEFLAGS+="''${enableParallelBuilding:+-j$NIX_BUILD_CORES}"
+  '';
+
+  dontWrapQtApps = true;
+
+  nativeBuildInputs = [
+    sip
+    qtdatavis3d
+    setuptools
+    pyqt-builder
+  ];
+
+  buildInputs = [
+    qtdatavis3d
+  ];
+
+  propagatedBuildInputs = [
+    pyqt5
+  ];
+
+  dontConfigure = true;
+
+  # has no tests
+  doCheck = false;
+
+  pythonImportsCheck = [
+    "PyQt5.QtDataVisualization"
+  ];
+
+  meta = with lib; {
+    description = "Python bindings for the Qt Data Visualization library";
+    homepage = "https://riverbankcomputing.com/";
+    license = licenses.gpl3Only;
+    maintainers = with maintainers; [ panicgh ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -9181,6 +9181,11 @@ self: super: with self; {
       setuptools sip;
   };
 
+  pyqtdatavisualization = pkgs.libsForQt5.callPackage ../development/python-modules/pyqtdatavisualization {
+    inherit (self) buildPythonPackage pyqt5 pyqt-builder python pythonOlder
+      setuptools sip;
+  };
+
   pyqtgraph = callPackage ../development/python-modules/pyqtgraph { };
 
   pyqtwebengine = pkgs.libsForQt5.callPackage ../development/python-modules/pyqtwebengine {

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -9171,6 +9171,11 @@ self: super: with self; {
 
   pyqt6-webengine = callPackage ../development/python-modules/pyqt6-webengine.nix { };
 
+  pyqtchart = pkgs.libsForQt5.callPackage ../development/python-modules/pyqtchart {
+    inherit (self) buildPythonPackage pyqt5 pyqt-builder python pythonOlder
+      setuptools sip;
+  };
+
   pyqtgraph = callPackage ../development/python-modules/pyqtgraph { };
 
   pyqtwebengine = pkgs.libsForQt5.callPackage ../development/python-modules/pyqtwebengine {

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -9171,6 +9171,11 @@ self: super: with self; {
 
   pyqt6-webengine = callPackage ../development/python-modules/pyqt6-webengine.nix { };
 
+  pyqt3d = pkgs.libsForQt5.callPackage ../development/python-modules/pyqt3d {
+    inherit (self) buildPythonPackage pyqt5 pyqt-builder python pythonOlder
+      setuptools sip;
+  };
+
   pyqtchart = pkgs.libsForQt5.callPackage ../development/python-modules/pyqtchart {
     inherit (self) buildPythonPackage pyqt5 pyqt-builder python pythonOlder
       setuptools sip;


### PR DESCRIPTION
###### Description of changes

~Init PyQt5-stubs with its dependencies. It is needed for future packaging of [nitrokey-app2](https://github.com/Nitrokey/nitrokey-app2).~

Due to its "uncleanliness", I removed pyqt5-stubs from this PR and leave only its dependencies.
If this gets merged, I will create a new PR for nitrokey-app2 and add its required pyqt5-stubs only there, but not to python3Packages.

###### Things done

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [X] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
  *See results at the end.*
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

----

Result of `nixpkgs-review` run on x86_64-linux [1](https://github.com/Mic92/nixpkgs-review)
<details>
  <summary>22 packages built:</summary>
  <ul>
    <li>python310Packages.pyqt3d</li>
    <li>python310Packages.pyqt3d.dev</li>
    <li>python310Packages.pyqt3d.dist</li>
    <li>python310Packages.pyqt5-stubs</li>
    <li>python310Packages.pyqt5-stubs.dist</li>
    <li>python310Packages.pyqtchart</li>
    <li>python310Packages.pyqtchart.dev</li>
    <li>python310Packages.pyqtchart.dist</li>
    <li>python310Packages.pyqtdatavisualization</li>
    <li>python310Packages.pyqtdatavisualization.dev</li>
    <li>python310Packages.pyqtdatavisualization.dist</li>
    <li>python311Packages.pyqt3d</li>
    <li>python311Packages.pyqt3d.dev</li>
    <li>python311Packages.pyqt3d.dist</li>
    <li>python311Packages.pyqt5-stubs</li>
    <li>python311Packages.pyqt5-stubs.dist</li>
    <li>python311Packages.pyqtchart</li>
    <li>python311Packages.pyqtchart.dev</li>
    <li>python311Packages.pyqtchart.dist</li>
    <li>python311Packages.pyqtdatavisualization</li>
    <li>python311Packages.pyqtdatavisualization.dev</li>
    <li>python311Packages.pyqtdatavisualization.dist</li>
  </ul>
</details>