### PR TITLE
libgcrypt: Correct known vulnerability

### DIFF
--- a/pkgs/development/libraries/libgcrypt/1.8.nix
+++ b/pkgs/development/libraries/libgcrypt/1.8.nix
@@ -69,7 +69,7 @@ stdenv.mkDerivation rec {
     license = licenses.lgpl2Plus;
     platforms = platforms.all;
     knownVulnerabilities = [
-      "CVE-2018-12437" # CVE is about LibTomCrypt
+      "CVE-2021-40528"
     ];
   };
 }


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Remove [CVE-2018-12437] known vulnerability from the `libgcrypt_1_8` package as [CVE-2018-12437] describes a  _"memory-cache side-channel attack on ECDSA signatures, aka the Return Of the Hidden Number Problem or ROHNP"_ in [libtomcrypt](https://github.com/libtom/libtomcrypt).

ℹ️ The corresponding known vulnerability for libgcrypt is [CVE-2018-0495], which is addressed in libgcrypt >= 1.8.3.

Add [CVE-2021-40528] to the `libgcrypt_1_8` package as [searching through the libgcrypt related CVEs](https://cve.mitre.org/cgi-bin/cvekey.cgi?keyword=libgcrypt) [CVE-2021-40528] shows version of libgcrypt < 1.9.4 are affected by it.

❓ Please let me know if you'd prefer this PRs merge base to be `master` instead of `staging`.

[CVE-2018-12437]: https://www.opencve.io/cve/CVE-2018-12437
[CVE-2018-0495]: https://www.opencve.io/cve/CVE-2018-0495
[CVE-2021-40528]: https://www.opencve.io/cve/CVE-2021-40528

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
