### PR TITLE
oelint-adv: init at 3.21.4

### DIFF
--- a/pkgs/development/python-modules/oelint-parser/default.nix
+++ b/pkgs/development/python-modules/oelint-parser/default.nix
@@ -1,0 +1,51 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, pythonOlder
+, pythonRelaxDepsHook
+, regex
+, pytestCheckHook
+, pytest-cov
+, pytest-forked
+, pytest-random-order
+, pytest-socket
+, pytest-sugar
+}:
+
+buildPythonPackage rec {
+  pname = "oelint-parser";
+  version = "2.10.5";
+
+  src = fetchFromGitHub {
+    owner = "priv-kweihmann";
+    repo = pname;
+    rev = version;
+    hash = "sha256-gB4+oo3zcOLK4M7hIOalxp13g18qRtN4iPwPGcly920=";
+  };
+
+  disabled = pythonOlder "3.7";
+
+  nativeBuildInputs = [ pythonRelaxDepsHook ];
+  pythonRelaxDeps = true;
+
+  propagatedBuildInputs = [ regex ];
+
+  checkInputs = [
+    pytest-cov
+    pytest-forked
+    pytest-random-order
+    pytest-socket
+    pytest-sugar
+    pytestCheckHook
+  ];
+
+  pythonImportsCheck = [ "oelint_parser" ];
+
+  meta = with lib; {
+    description = "Alternative parser for bitbake recipes";
+    homepage = "https://github.com/priv-kweihmann/oelint-parser";
+    changelog = "https://github.com/priv-kweihmann/oelint-parser/releases/tag/${version}";
+    license = licenses.bsd2;
+    maintainers = with maintainers; [ christoph-heiss ];
+  };
+}

--- a/pkgs/development/tools/oelint-adv/default.nix
+++ b/pkgs/development/tools/oelint-adv/default.nix
@@ -1,0 +1,55 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, pythonOlder
+, pythonRelaxDepsHook
+, anytree
+, colorama
+, oelint-parser
+, urllib3
+, pytestCheckHook
+, pytest-cov
+, pytest-forked
+, pytest-random-order
+, pytest-socket
+, pytest-sugar
+}:
+
+buildPythonPackage rec {
+  pname = "oelint-adv";
+  version = "3.21.4";
+
+  src = fetchFromGitHub {
+    owner = "priv-kweihmann";
+    repo = pname;
+    rev = version;
+    hash = "sha256-OAvL0VZXAXYp4RvNzPtMHMU5AkQLj6tu/My270BaMTM=";
+  };
+
+  disabled = pythonOlder "3.7";
+
+  nativeBuildInputs = [ pythonRelaxDepsHook ];
+  pythonRelaxDeps = true;
+
+  propagatedBuildInputs = [ anytree colorama oelint-parser urllib3 ];
+
+  checkInputs = [
+    pytest-cov
+    pytest-forked
+    pytest-random-order
+    pytest-socket
+    pytest-sugar
+    pytestCheckHook
+  ];
+
+  pytestFlagsArray = [ "--cov-fail-under=30" ];
+  disabledTests = [ "oelint.vars.homepageping" ];
+
+  meta = with lib; {
+    description = "Advanced linter for BitBake recipes based on oelint";
+    homepage = "https://github.com/priv-kweihmann/oelint-adv";
+    changelog = "https://github.com/priv-kweihmann/oelint-adv/releases/tag/${version}";
+    license = licenses.bsd2;
+    maintainers = with maintainers; [ christoph-heiss ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -19120,6 +19120,8 @@ with pkgs;
 
   omake = callPackage ../development/tools/ocaml/omake { };
 
+  oelint-adv = with python3Packages; callPackage ../development/tools/oelint-adv { };
+
   omniorb = callPackage ../development/tools/omniorb { };
 
   openai = with python3Packages; toPythonApplication openai;

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -6999,6 +6999,8 @@ self: super: with self; {
 
   odp-amsterdam = callPackage ../development/python-modules/odp-amsterdam { };
 
+  oelint-parser = callPackage ../development/python-modules/oelint-parser { };
+
   offtrac = callPackage ../development/python-modules/offtrac { };
 
   ofxclient = callPackage ../development/python-modules/ofxclient { };


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

This adds [oelint-adv](https://github.com/priv-kweihmann/oelint-adv), a linter for BitBake files/recipes. Additionally adds [oelint-parser](https://github.com/priv-kweihmann/oelint-parser) as a Python 3 module, which is required by the former. 

~~The tests for both modules currently fail due to some weird issue I still have to figure out. I would submit an update later to fix it, or we block merging until this is resolved - I'm fine with either.~~

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
