### PR TITLE
Add Hyprland to GnuPG configuration for default Pinentry flavor

### DIFF
--- a/nixos/modules/programs/gnupg.nix
+++ b/nixos/modules/programs/gnupg.nix
@@ -14,7 +14,7 @@ let
       "qt"
     else if xserverCfg.desktopManager.xfce.enable then
       "gtk2"
-    else if xserverCfg.enable || config.programs.sway.enable then
+    else if xserverCfg.enable || config.programs.sway.enable || config.programs.hyprland.enable then
       "gnome3"
     else
       "curses";


### PR DESCRIPTION
###### Description of changes

This adds [Hyprland](https://hyprland.org/) as a potential condition for enabling `gnome3` as the GnuPG Pinentry flavor by default. Without this, users of Hyprland will be defaulted to the `ncurses` flavor, which will not work outside the terminal.
