### PR TITLE
lib.importApply: init

### DIFF
--- a/lib/modules.nix
+++ b/lib/modules.nix
@@ -1366,27 +1366,37 @@ let
       ]);
     };
 
-  /*
-    Imports a nix file much like the module system would, but also pass extra
-    arguments.
+  /**
+    `importApply file arg :: Path -> a -> Module`,  where `import file :: a -> Module`
 
-    This solves the problem of being unable to pass a value from the lexical
-    scope to a single module. This occurs when you return a module from a rich
-    scope, such as that of a flake.
+    `importApply` imports a Nix expression file much like the module system would,
+    after passing an extra positional argument to the function in the file.
 
-    While you could do `import <file> { ... }` yourself, the result
-    is not as good, because `import` is unaware and does not return the location.
-    `importApply` does keep this location, so that it can be used in error
-    messages.
+    This function should be used when declaring a module in a file that refers to
+    values from a different scope, such as that in a flake.
 
-    The nix file must contain a function that returns a module. A module may
-    itself be a function. See the example below.
+    It solves the problems of alternative solutions:
+
+    - While `importApply file arg` is _mostly_ equivalent to
+      `import file arg`, the latter returns a module without a location,
+      as `import` only returns the contained expression. This leads to worse
+      error messages.
+
+    - Using `specialArgs` to provide arguments to all modules. This effectively
+      creates an incomplete module, and requires the user of the module to
+      manually pass the `specialArgs` to the configuration, which is error-prone,
+      verbose, and unnecessary.
+
+    The nix file must contain a function that returns a module.
+    A module may itself be a function, so the file is often a function with two
+    positional arguments instead of one. See the example below.
 
     This function does not add support for deduplication and `disabledModules`,
-    although that could be achieved by wrapping the returned module. The reason
-    for this is that second argument of `importApply` may not be the same for
-    different invocations of `importApply`. Hence, the file name may not be a
-    key.
+    although that could be achieved by wrapping the returned module and setting
+    the `_key` module attribute.
+    The reason for this omission is that the file path is not guaranteed to be
+    a unique identifier for the module, as two instances of the module may
+    reference different `arg`s in their closures.
 
     Example
 
@@ -1405,8 +1415,8 @@ let
 
   */
   importApply =
-    modulePath: staticArgs:
-      lib.setDefaultModuleLocation modulePath (import modulePath staticArgs);
+    modulePath: staticArg:
+      lib.setDefaultModuleLocation modulePath (import modulePath staticArg);
 
   /* Use this function to import a JSON file as NixOS configuration.
 

--- a/lib/tests/modules.sh
+++ b/lib/tests/modules.sh
@@ -247,6 +247,14 @@ checkConfigOutput '^true$' "$@" ./define-enable.nix ./define-attrsOfSub-if-foo-e
 checkConfigOutput '^true$' "$@" ./define-enable.nix ./define-attrsOfSub-foo-if-enable.nix
 checkConfigOutput '^true$' "$@" ./define-enable.nix ./define-attrsOfSub-foo-enable-if.nix
 
+# Check importApply
+checkConfigOutput '"abc"' config.value ./importApply.nix
+# importApply does not set a key.
+# Disabling the function file is not sufficient, because importApply can't reasonably assume that the key is unique.
+# e.g. user may call it multiple times with different arguments and expect each of the module to apply.
+# While this is excusable for the disabledModules aspect, it is not for the deduplication of modules.
+checkConfigOutput '"abc"' config.value ./importApply-disabling.nix
+
 # Check disabledModules with config definitions and option declarations.
 set -- config.enable ./define-enable.nix ./declare-enable.nix
 checkConfigOutput '^true$' "$@"

--- a/lib/tests/modules/importApply-disabling.nix
+++ b/lib/tests/modules/importApply-disabling.nix
@@ -1,0 +1,4 @@
+{
+  imports = [ ./importApply.nix ];
+  disabledModules = [ ./importApply-function.nix ];
+}

--- a/lib/tests/modules/importApply-function.nix
+++ b/lib/tests/modules/importApply-function.nix
@@ -1,0 +1,5 @@
+{ foo }:
+{ lib, config, ... }:
+{
+  value = foo;
+}

--- a/lib/tests/modules/importApply.nix
+++ b/lib/tests/modules/importApply.nix
@@ -1,0 +1,8 @@
+{ lib, ... }: {
+  options.value = lib.mkOption {
+    default = 1;
+  };
+  imports = [
+    (lib.modules.importApply ./importApply-function.nix { foo = "abc"; })
+  ];
+}

--- a/lib/tests/modules/importApply.nix
+++ b/lib/tests/modules/importApply.nix
@@ -1,8 +1,5 @@
-{ lib, ... }: {
-  options.value = lib.mkOption {
-    default = 1;
-  };
-  imports = [
-    (lib.modules.importApply ./importApply-function.nix { foo = "abc"; })
-  ];
+{ lib, ... }:
+{
+  options.value = lib.mkOption { default = 1; };
+  imports = [ (lib.modules.importApply ./importApply-function.nix { foo = "abc"; }) ];
 }


### PR DESCRIPTION
###### Description of changes

Brings variables from rich scopes to modules defined in separate files.

A helper for importing functions in files that return a module.

>    This solves the problem of being unable to pass a value from the lexical
    scope to a single module. This occurs when you return a module from a rich
    scope, such as that of a flake.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
