### PR TITLE
python3Packages.sourmash: init at 4.8.3

### DIFF
--- a/pkgs/development/python-modules/sourmash/default.nix
+++ b/pkgs/development/python-modules/sourmash/default.nix
@@ -1,0 +1,78 @@
+{ lib
+, fetchPypi
+, buildPythonPackage
+, pythonOlder
+, rustPlatform
+, bitstring
+, cachetools
+, cffi
+, deprecation
+, iconv
+, matplotlib
+, numpy
+, scipy
+, screed
+, hypothesis
+, pytest-xdist
+, pyyaml
+, pytestCheckHook
+}:
+
+buildPythonPackage rec {
+  pname = "sourmash";
+  version = "4.8.3";
+  format = "pyproject";
+  disabled = pythonOlder "3.8";
+
+  src = fetchPypi {
+    inherit pname version;
+    hash = "sha256-LIMpL9cLafytRFyPam/FBNi757j1v6o1FG/K2JknDQY=";
+  };
+
+  cargoDeps = rustPlatform.fetchCargoTarball {
+    inherit src;
+    name = "${pname}-${version}";
+    hash = "sha256-mcJzFRYkdxuqqXH+ryg5v+9tQtuN1hkEeW2DF+wEJ/w=";
+  };
+
+  nativeBuildInputs = with rustPlatform; [
+    cargoSetupHook
+    maturinBuildHook
+  ];
+
+  buildInputs = [ iconv ];
+
+  propagatedBuildInputs = [
+    bitstring
+    cachetools
+    cffi
+    deprecation
+    matplotlib
+    numpy
+    scipy
+    screed
+  ];
+
+  pythonImportsCheck = [ "sourmash" ];
+  nativeCheckInputs = [
+    hypothesis
+    pytest-xdist
+    pytestCheckHook
+    pyyaml
+  ];
+
+  # TODO(luizirber): Working on fixing these upstream
+  disabledTests = [
+    "test_compare_no_such_file"
+    "test_do_sourmash_index_multiscaled_rescale_fail"
+    "test_metagenome_kreport_out_fail"
+  ];
+
+  meta = with lib; {
+    description = "Quickly search, compare, and analyze genomic and metagenomic data sets";
+    homepage = "https://sourmash.bio";
+    changelog = "https://github.com/sourmash-bio/sourmash/releases/tag/v${version}";
+    maintainers = with maintainers; [ luizirber ];
+    license = licenses.bsd3;
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -11879,6 +11879,8 @@ self: super: with self; {
 
   soupsieve = callPackage ../development/python-modules/soupsieve { };
 
+  sourmash = callPackage ../development/python-modules/sourmash { };
+
   soxr = callPackage ../development/python-modules/soxr {
     libsoxr = pkgs.soxr;
   };


### PR DESCRIPTION
###### Description of changes

`sourmash` is a bioinformatics tool for quickly searching, comparing, and analyzing genomic and metagenomic data sets. 

Homepage: https://sourmash.bio
GitHub: https://github.com/sourmash-bio/sourmash

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [-] (Package updates) Added a release notes entry if the change is major or breaking
  - [-] (Module updates) Added a release notes entry if the change is significant
  - [-] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).