### PR TITLE
CGIF: init at 0.3.1

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -8188,6 +8188,11 @@
     githubId = 55951;
     name = "Joe DeVivo";
   };
+  joedupuis = {
+    github = "JoeDupuis";
+    githubId = 1518299;
+    name = "Joé Dupuis";
+  };
   joelancaster = {
     email = "joe.a.lancas@gmail.com";
     github = "JoeLancaster";

--- a/pkgs/development/libraries/cgif/default.nix
+++ b/pkgs/development/libraries/cgif/default.nix
@@ -1,0 +1,36 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, pkg-config
+, meson
+, ninja
+}:
+stdenv.mkDerivation rec {
+  pname = "cgif";
+  version = "0.3.1";
+
+  src = fetchFromGitHub {
+    owner = "dloebl";
+    repo = "cgif";
+    rev = "V${version}";
+    sha256 = "sha256-G7WWWdpZIb3A6Xt2HNZfAdg+uBKdOYJoy3FdBio98OY=";
+  };
+
+  depsBuildBuild = [
+    pkg-config
+  ];
+
+  nativeBuildInputs = [
+    pkg-config
+    meson
+    ninja
+  ];
+
+  meta = with lib; {
+    homepage = "https://github.com/dloebl/cgif";
+    description = "GIF encoder written in C";
+    license = licenses.mit;
+    maintainers = with maintainers; [ joedupuis ];
+    platforms = platforms.unix;
+  };
+}


### PR DESCRIPTION
Needed for GIF saving support to libvips.

###### Description of changes
Add CGIF a new package https://github.com/dloebl/cgif

CGIF is an optional dependency of [libvips](https://github.com/NixOS/nixpkgs/blob/nixos-22.11/pkgs/tools/graphics/vips/default.nix)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md). 

