### PR TITLE
python311.pkgs.dlib: fix build

### DIFF
--- a/pkgs/development/python-modules/dlib/default.nix
+++ b/pkgs/development/python-modules/dlib/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, buildPythonPackage, dlib, python, pytest, more-itertools
+{ stdenv, buildPythonPackage, dlib, python, pytest, more-itertools, fetchpatch
 , sse4Support ? stdenv.hostPlatform.sse4_1Support
 , avxSupport ? stdenv.hostPlatform.avxSupport
 }:
@@ -6,7 +6,28 @@
 buildPythonPackage {
   inherit (dlib) pname version src nativeBuildInputs buildInputs meta;
 
-  patches = [ ./build-cores.patch ];
+  patches = [
+    ./build-cores.patch
+
+    # Upgrade minimum CMake & C++ requirement. Nixpkgs is sufficiently up-to-date
+    # so that is not a problem. Applied to make sure the pybind11 patch applies cleanly.
+    (fetchpatch {
+      url = "https://github.com/davisking/dlib/commit/29288e5d895b21f5508c15294f1303b367534a63.patch";
+      sha256 = "sha256-8GsGOehTFabRf+QOZK6Ek/Xgwp8yLj8UKd7kmneBpXk=";
+    })
+    # Removes a bunch of broken python tests. Also useful to make sure the pybind11
+    # patch applies cleanly.
+    (fetchpatch {
+      url = "https://github.com/davisking/dlib/commit/a517aaa0bbb0524a1a7be3d6637aa6300c2e1dfe.patch";
+      sha256 = "sha256-31/c1ViVPdJ/gQVMV22Nnr01/Yg13s9tPowfh4BedNg=";
+    })
+    # Upgrade pybind11 to 2.4.0. Relevant to fix Python 3.11 support.
+    (fetchpatch {
+      url = "https://github.com/davisking/dlib/commit/65bce59a1512cf222dec01d3e0f29b612dd181f5.patch";
+      sha256 = "sha256-04TGJdn9p9YhDVZHAU9ncgCyR1vrnRxKkTRDSwOk/fw=";
+      excludes = [ ".github/workflows/build_python.yml" ];
+    })
+  ];
 
   nativeCheckInputs = [ pytest more-itertools ];
 


### PR DESCRIPTION

###### Description of changes
Failing Hydra build: https://hydra.nixos.org/build/215620971

Applying the patch that upgrades the vendored `pybind11` fixes the problem.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
