### PR TITLE
k9s: 0.27.3 -> 0.27.4

### DIFF
--- a/pkgs/applications/networking/cluster/k9s/default.nix
+++ b/pkgs/applications/networking/cluster/k9s/default.nix
@@ -2,13 +2,13 @@
 
 buildGoModule rec {
   pname = "k9s";
-  version = "0.27.3";
+  version = "0.27.4";
 
   src = fetchFromGitHub {
     owner  = "derailed";
     repo   = "k9s";
     rev    = "v${version}";
-    sha256 = "sha256-oUn9qQG4rpunfeHgSlY9THkYv1aGWrVmdTZoEWeZJTs=";
+    sha256 = "sha256-SMdpjeMerIEc0oeNe0SfZyc3yQTq6eif1fDLICNceKY=";
   };
 
   ldflags = [
@@ -20,7 +20,7 @@ buildGoModule rec {
 
   tags = [ "netgo" ];
 
-  vendorHash = "sha256-sQ3D4JUK9epRkDZ7DC+IH+iMaLN+uKM2hZkhqji+0Zc=";
+  vendorHash = "sha256-wh4WjfDBX9xdtF9fBjSLPBbqb6k8H/LpWO9eTn86le4=";
 
   # TODO investigate why some config tests are failing
   doCheck = !(stdenv.isDarwin && stdenv.isAarch64);
@@ -46,6 +46,6 @@ buildGoModule rec {
     description = "Kubernetes CLI To Manage Your Clusters In Style";
     homepage = "https://github.com/derailed/k9s";
     license = licenses.asl20;
-    maintainers = with maintainers; [ Gonzih markus1189 bryanasdev000 ];
+    maintainers = with maintainers; [ Gonzih markus1189 bryanasdev000 qjoly ];
   };
 }


### PR DESCRIPTION
###### Description of changes
**k9s: 0.27.3 -> 0.27.4**
Changelog: 
Resolved Issues
    https://github.com/derailed/k9s/issues/2072 Triggered Job from cronjob is missing annotations
    https://github.com/derailed/k9s/issues/2024 Allow customization of log indicators with skin theme
    https://github.com/derailed/k9s/issues/1971 Zip binary for windows

### Contributed PRs

    https://github.com/derailed/k9s/pull/2073 Fix for missing Job annotations created from Cronjob
    https://github.com/derailed/k9s/pull/2069 Unify all go version to 1.20
    https://github.com/derailed/k9s/pull/2067 Create narsingh skin
    https://github.com/derailed/k9s/pull/2054 Update setup-go action, with caching
    https://github.com/derailed/k9s/pull/2045 Fix: (views) use saved context view when switching
    https://github.com/derailed/k9s/pull/2041 Feat: allow customization of log indicator toggles
    https://github.com/derailed/k9s/pull/2030 Updated monokai skin with help styles, and more monokai appropriate colors
    https://github.com/derailed/k9s/pull/2027 Roles are rendered using same colorer function from skin
    https://github.com/derailed/k9s/pull/2045 Fix: (views) use saved context view when switching\
    https://github.com/derailed/k9s/pull/2011 Fix https://github.com/derailed/k9s/issues/2007: Remove debug command
    https://github.com/derailed/k9s/pull/2006 Feat: add support for renaming contexts

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
