### PR TITLE
ocamlPackages.ppx_deriving_qcheck: init at 0.20

### DIFF
--- a/pkgs/development/ocaml-modules/qcheck/ppx_deriving_qcheck.nix
+++ b/pkgs/development/ocaml-modules/qcheck/ppx_deriving_qcheck.nix
@@ -1,0 +1,20 @@
+{ buildDunePackage, qcheck-core
+, qcheck, ppxlib, ppx_deriving }:
+
+buildDunePackage {
+  pname = "ppx_deriving_qcheck";
+
+  inherit (qcheck-core) version src patches;
+
+  duneVersion = "3";
+
+  propagatedBuildInputs = [
+    qcheck
+    ppxlib
+    ppx_deriving
+  ];
+
+  meta = qcheck-core.meta // {
+    description = "PPX Deriver for QCheck";
+  };
+}

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -1356,6 +1356,8 @@ let
 
     ppx_deriving_protobuf = callPackage ../development/ocaml-modules/ppx_deriving_protobuf {};
 
+    ppx_deriving_qcheck = callPackage ../development/ocaml-modules/qcheck/ppx_deriving_qcheck.nix {};
+
     ppx_deriving_rpc = callPackage ../development/ocaml-modules/ppx_deriving_rpc { };
 
     ppx_deriving_yaml = callPackage ../development/ocaml-modules/ppx_deriving_yaml {};


### PR DESCRIPTION
###### Description of changes

A missing package provided by the [github:c-cube/qcheck](https://github.com/c-cube/qcheck) repository otherwise providing `qcheck`, `qcheck-core`, `qcheck-ounit` and `qcheck-alcotest`.

https://github.com/c-cube/qcheck/blob/v0.20/CHANGELOG.md

###### Things done

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [X] x86_64-darwin
  - [X] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).