### PR TITLE
hblock: init at 3.4.1

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -579,6 +579,12 @@
     githubId = 20405311;
     name = "Aksh Gupta";
   };
+  alanpearce = {
+    email = "alan@alanpearce.eu";
+    github = "alanpearce";
+    githubId = 850317;
+    name = "Alan Pearce";
+  };
   alapshin = {
     email = "alapshin@fastmail.com";
     github = "alapshin";

--- a/pkgs/tools/networking/hblock/default.nix
+++ b/pkgs/tools/networking/hblock/default.nix
@@ -1,0 +1,39 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, makeWrapper
+, coreutils
+, gawk
+, curl
+, gnugrep
+}:
+
+stdenv.mkDerivation rec {
+  pname = "hblock";
+  version = "3.4.1";
+
+  src = fetchFromGitHub {
+    owner = "hectorm";
+    repo = "hblock";
+    rev = "v${version}";
+    hash = "sha256-yOX/CsWs5HVH9s0KCzZm6PPqlDJHxz46jJB6KKC7Hsg=";
+  };
+
+  buildInputs = [ coreutils curl gnugrep gawk ];
+  nativeBuildInputs = [ makeWrapper ];
+
+  installFlags = [
+    "prefix=$(out)"
+  ];
+  postInstall = ''
+    wrapProgram "$out/bin/hblock" \
+      --prefix PATH : ${lib.makeBinPath [ coreutils curl gnugrep gawk ]}
+  '';
+
+  meta = with lib; {
+    description = "Improve your security and privacy by blocking ads, tracking and malware domains";
+    homepage = "https://github.com/hectorm/hblock";
+    license = licenses.mit;
+    maintainers = with maintainers; [ alanpearce ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1567,6 +1567,8 @@ with pkgs;
 
   fwbuilder = libsForQt5.callPackage ../tools/security/fwbuilder { };
 
+  hblock = callPackage ../tools/networking/hblock { };
+
   headsetcontrol = callPackage ../tools/audio/headsetcontrol { };
 
   headset-charge-indicator = callPackage ../tools/audio/headset-charge-indicator { };


### PR DESCRIPTION
###### Description of changes

Tool to collate security/privacy-focused blocklists outputting a hosts file or other formats such as [RPZ](https://en.wikipedia.org/wiki/Response_policy_zone).

https://github.com/hectorm/hblock

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [X] aarch64-linux
  - [ ] x86_64-darwin
  - [X] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [X] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [X] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
