### PR TITLE
pythonPackages.{anki,aqt}: init at 2.1.63

### DIFF
--- a/pkgs/development/python-modules/anki/addon_demo.py
+++ b/pkgs/development/python-modules/anki/addon_demo.py
@@ -1,0 +1,37 @@
+# Copyright: Ankitects Pty Ltd and contributors
+# License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
+
+# This file was modified by Paul Hervot (not affiliated with Ankitects) on may
+# 8th 2023 to make it pass a mypy check with the intent of using it as a test
+# case for the nixpkgs packaging of aqt, it isn't functional beyond that.
+# Original from https://github.com/ankitects/anki-addons/blob/main/demos/card_did_render/__init__.py
+
+"""
+An example of how you can transform the rendered card content in Anki 2.1.20.
+"""
+
+from typing import Tuple
+
+# explicit collection import to avoid a circular dependency when importing hooks
+import anki.collection
+
+from anki import hooks
+from anki.template import TemplateRenderContext, TemplateRenderOutput
+
+
+def on_card_did_render(output: TemplateRenderOutput, context: TemplateRenderContext):
+    # let's uppercase the characters of the front text
+    output.question_text = output.question_text.upper()
+
+    # if the note is tagged "easy", show the answer in green
+    # otherwise, in red
+    if context.note().has_tag("easy"):
+        colour = "green"
+    else:
+        colour = "red"
+
+    output.answer_text += f"<style>.card {{ color: {colour}; }}</style>"
+
+
+# register our function to be called when the hook fires
+hooks.card_did_render.append(on_card_did_render)

--- a/pkgs/development/python-modules/anki/default.nix
+++ b/pkgs/development/python-modules/anki/default.nix
@@ -1,0 +1,73 @@
+{ lib
+, beautifulsoup4
+, buildPythonPackage
+, callPackage
+, decorator
+, distro
+, fetchPypi
+, markdown
+, orjson
+, protobuf
+, pytestCheckHook
+, pythonOlder
+, requests
+, setuptools-scm
+}:
+
+buildPythonPackage rec {
+  pname = "anki";
+  version = "2.1.63";
+  format = "wheel";
+
+  disabled = pythonOlder "3.9";
+
+  src = fetchPypi {
+    inherit format pname version;
+    dist = "cp39";
+    python = "cp39";
+    abi = "abi3";
+    # TODO: also available for windows (amd64), manylinux_2_31 (aarch64) and
+    # macosx (10.13 for and x86_64 and 11.0 for arm64)
+    platform = "manylinux_2_28_x86_64";
+    hash = "sha256-7Hi5Os/GoOX93uKvRQfo3WP1tjZ2BnmrkB4yLWHaPYw=";
+  };
+
+  propagatedBuildInputs = [
+    beautifulsoup4
+    decorator
+    distro
+    markdown
+    orjson
+    protobuf
+    requests
+  ];
+
+  pythonImportsCheck = [
+    "anki"
+  ];
+
+  passthru.tests = {
+    # Check that a simple addon that uses this Python module passes a mypy check
+    addon-typecheck = callPackage ./tests.nix {};
+  };
+
+  meta = with lib; {
+    description = "Spaced repetition flashcard program (exported backend functions)";
+    homepage = "https://apps.ankiweb.net/";
+    longDescription = ''
+      Anki is a program which makes remembering things easy. Because it is a lot
+      more efficient than traditional study methods, you can either greatly
+      decrease your time spent studying, or greatly increase the amount you learn.
+
+      Anyone who needs to remember things in their daily life can benefit from
+      Anki. Since it is content-agnostic and supports images, audio, videos and
+      scientific markup (via LaTeX), the possibilities are endless. For example:
+      learning a language, studying for medical and law exams, memorizing
+      people's names and faces, brushing up on geography, mastering long poems,
+      or even practicing guitar chords!
+    '';
+    license = licenses.agpl3Plus;
+    changelog = "https://changes.ankiweb.net/changes/2.1.60-69.html#changes-in-${builtins.replaceStrings ["."] [""] version}";
+    maintainers = with maintainers; [ Dettorer ];
+  };
+}

--- a/pkgs/development/python-modules/anki/tests.nix
+++ b/pkgs/development/python-modules/anki/tests.nix
@@ -1,0 +1,13 @@
+{ runCommand, anki, python39 }:
+
+let
+  inherit (anki) pname version;
+in
+  runCommand "${pname}-tests" {
+    nativeBuildInputs = [ (python39.withPackages (ps: [ ps.anki ps.mypy ])) ];
+  } ''
+    mypy ${./addon_demo.py}
+    if [ $? -eq 0 ]; then
+      touch $out
+    fi
+  ''

--- a/pkgs/development/python-modules/aqt/addon_demo.py
+++ b/pkgs/development/python-modules/aqt/addon_demo.py
@@ -1,0 +1,78 @@
+# -*- coding: utf-8 -*-
+# Copyright: Ankitects Pty Ltd and contributors
+# License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
+
+# This file was modified by Paul Hervot (not affiliated with Ankitects) on may
+# 8th 2023 to make it pass a mypy check with the intent of using it as a test
+# case for the nixpkgs packaging of aqt, it isn't functional beyond that.
+# original from https://github.com/ankitects/anki-addons/blob/main/demos/av_player/__init__.py
+
+"""
+Some quick examples of audio handling in 2.1.20.
+"""
+
+from typing import Any, Callable, List, Optional, Tuple
+
+#  from anki.sound import AVTag, SoundOrVideoTag
+from aqt import gui_hooks, mw
+from aqt.sound import (
+    MpvManager,
+    SimpleMplayerSlaveModePlayer,
+    SimpleProcessPlayer,
+    SoundOrVideoPlayer,
+    av_player,
+)
+
+# Play files faster in mpv/mplayer
+######################################
+
+
+def set_speed(player: Any, speed: float) -> None:
+    if isinstance(player, MpvManager):
+        player.set_property("speed", speed)
+    elif isinstance(player, SimpleMplayerSlaveModePlayer):
+        player.command("speed_set", speed)
+
+
+# automatically play fast
+
+
+def did_begin_playing(player: Any, _: Any) -> None:
+    # mplayer seems to lose commands sent to it immediately after startup,
+    # so we add a delay for it - an alternate approach would be to adjust
+    # the command line arguments passed to it
+    if mw is None:
+        return
+    if isinstance(player, SimpleMplayerSlaveModePlayer):
+        mw.progress.timer(500, lambda: set_speed(player, 1.25), False)
+    else:
+        set_speed(player, 1.25)
+
+
+gui_hooks.av_player_did_begin_playing.append(did_begin_playing)
+
+# shortcut key to make slower
+
+
+def on_shortcuts_change(state: str, shortcuts: List[Tuple[str, Callable]]) -> None:
+    if state == "review":
+        shortcuts.append(("8", lambda: set_speed(av_player.current_player, 0.75)))
+
+
+gui_hooks.state_shortcuts_will_change.append(on_shortcuts_change)
+
+# Play .ogg files in the external program 'myplayer'
+########################################################
+
+
+class MyPlayer(SimpleProcessPlayer, SoundOrVideoPlayer):
+    args = ["myplayer"]
+
+    #  def rank_for_tag(self, tag: AVTag) -> Optional[int]:
+        #  if isinstance(tag, SoundOrVideoTag) and tag.filename.endswith(".ogg"):
+            #  return 100
+        #  return None
+
+
+if mw is not None:
+    av_player.players.append(MyPlayer(mw.taskman))

--- a/pkgs/development/python-modules/aqt/default.nix
+++ b/pkgs/development/python-modules/aqt/default.nix
@@ -1,0 +1,83 @@
+{ lib
+, anki
+, beautifulsoup4
+, buildPythonPackage
+, callPackage
+, fetchPypi
+, flask
+, flask-cors
+, jsonschema
+, pyqt5
+, pyqt5_sip
+, pyqt6
+, pyqt6-sip
+, pyqt6-webengine
+, pyqtwebengine
+, pytestCheckHook
+, pythonOlder
+, requests
+, send2trash
+, setuptools-scm
+, waitress
+}:
+
+buildPythonPackage rec {
+  pname = "aqt";
+  version = "2.1.63";
+  format = "wheel";
+
+  disabled = pythonOlder "3.9";
+
+  src = fetchPypi {
+    inherit format pname version;
+    dist = "py3";
+    python = "py3";
+    hash = "sha256-GxPKoRRTfNEN7Llo2qcoy9mFK23f+kDxnJmGFH0wdwU=";
+  };
+
+  propagatedBuildInputs = [
+    anki
+    beautifulsoup4
+    flask
+    flask-cors
+    jsonschema
+    pyqt5
+    pyqt5_sip
+    pyqt6
+    pyqt6-sip
+    pyqt6-webengine
+    pyqtwebengine
+    requests
+    send2trash
+    waitress
+  ];
+
+  pythonImportsCheck = [
+    "aqt"
+  ];
+
+  passthru.tests = {
+    # Check that a simple addon that uses this Python module passes a mypy check
+    addon-typecheck = callPackage ./tests.nix {};
+  };
+
+  meta = with lib; {
+    description = "Spaced repetition flashcard program (exported GUI functions)";
+    homepage = "https://apps.ankiweb.net/";
+    longDescription = ''
+      Anki is a program which makes remembering things easy. Because it is a lot
+      more efficient than traditional study methods, you can either greatly
+      decrease your time spent studying, or greatly increase the amount you learn.
+
+      Anyone who needs to remember things in their daily life can benefit from
+      Anki. Since it is content-agnostic and supports images, audio, videos and
+      scientific markup (via LaTeX), the possibilities are endless. For example:
+      learning a language, studying for medical and law exams, memorizing
+      people's names and faces, brushing up on geography, mastering long poems,
+      or even practicing guitar chords!
+    '';
+    license = licenses.agpl3Plus;
+    changelog = "https://changes.ankiweb.net/changes/2.1.60-69.html#changes-in-${builtins.replaceStrings ["."] [""] version}";
+    maintainers = with maintainers; [ Dettorer ];
+  };
+}

--- a/pkgs/development/python-modules/aqt/tests.nix
+++ b/pkgs/development/python-modules/aqt/tests.nix
@@ -1,0 +1,13 @@
+{ runCommand, aqt, python39 }:
+
+let
+  inherit (aqt) pname version;
+in
+  runCommand "${pname}-tests" {
+    nativeBuildInputs = [ (python39.withPackages (ps: [ ps.aqt ps.mypy ])) ];
+  } ''
+    mypy ${./addon_demo.py}
+    if [ $? -eq 0 ]; then
+      touch $out
+    fi
+  ''

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -616,6 +616,8 @@ self: super: with self; {
 
   aqipy-atmotech = callPackage ../development/python-modules/aqipy-atmotech { };
 
+  aqt = callPackage ../development/python-modules/aqt { };
+
   aqualogic = callPackage ../development/python-modules/aqualogic { };
 
   arabic-reshaper = callPackage ../development/python-modules/arabic-reshaper { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -514,6 +514,8 @@ self: super: with self; {
 
   aniso8601 = callPackage ../development/python-modules/aniso8601 { };
 
+  anki = callPackage ../development/python-modules/anki { };
+
   annexremote = callPackage ../development/python-modules/annexremote { };
 
   annotated-types = callPackage ../development/python-modules/annotated-types { };


### PR DESCRIPTION
###### Description of changes

These two Python modules constitute the public Python library for Anki (https://apps.ankiweb.net/), they are used by addon developers. At run time, Anki addons actually use the modules present in the concrete Anki instance that loaded them, and not the ones that may be present in `PYTHONPATH`. However, making these modules available in `PYTHONPATH` is still useful to addon developers as it allows development tools to do type checking and autocompletions. This usecase is the motivation for this PR as well as the justification for the testing strategy.

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (no binary files, I tested that autocompletion and type checking could be correctly used with these modules)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
