### PR TITLE
alkimia: fix typo

### DIFF
--- a/pkgs/development/libraries/alkimia/default.nix
+++ b/pkgs/development/libraries/alkimia/default.nix
@@ -27,7 +27,7 @@ mkDerivation rec {
       logic that will be used by all financial applications in KDE.
 
       The target is to share financial related information over
-      application bounderies.
+      application boundaries.
     '';
     license = lib.licenses.lgpl21Plus;
     platforms = qtbase.meta.platforms;


### PR DESCRIPTION
###### Description of changes

Fixed a typo "bounderies"

###### Things done

- [X] "built", "tested" and "release notes" not applicable
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
