### PR TITLE
cocogitto: fix typo

### DIFF
--- a/pkgs/development/tools/cocogitto/default.nix
+++ b/pkgs/development/tools/cocogitto/default.nix
@@ -13,7 +13,7 @@ rustPlatform.buildRustPackage rec {
 
   cargoHash = "sha256-P/xwE3oLVsIoxPmG+S0htSHhZxCj79z2ARGe2WzWCEo=";
 
-  # Test depend on git configuration that would likly exist in a normal user enviroment
+  # Test depend on git configuration that would likely exist in a normal user environment
   # and might be failing to create the test repository it works in.
   doCheck = false;
 


### PR DESCRIPTION

###### Description of changes

Fixed a typo
"enviroment" -> "environment"
"likly" -> "likely"

###### Things done

- [X] all "built", "tested" and "release notes" not applicable
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
