### PR TITLE
ctags: fix typo

### DIFF
--- a/pkgs/development/tools/misc/ctags/wrapped.nix
+++ b/pkgs/development/tools/misc/ctags/wrapped.nix
@@ -53,7 +53,7 @@ with pkgs.lib;
     "--regex-PHP=/function[ \\t]+([^ (]*)/\\1/f/"
   ];
 
-  # Javascript: also find unnamed functions and funtions beeing passed within a dict.
+  # Javascript: also find unnamed functions and functions beeing passed within a dict.
   # the dict properties is used to implement duck typing in frameworks
   # var foo = function () { ... }
   # {


### PR DESCRIPTION
###### Description of changes

Fixed a typo "funtions" -> functions

###### Things done

- [X] all "built", "tested" and "release notes" not applicable
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
