### PR TITLE
elm: fix typo

### DIFF
--- a/pkgs/development/compilers/elm/default.nix
+++ b/pkgs/development/compilers/elm/default.nix
@@ -123,7 +123,7 @@ let
 in lib.makeScope pkgs.newScope (self: with self; {
   inherit fetchElmDeps nodejs;
 
-  /* Node/NPM based dependecies can be upgraded using script `packages/generate-node-packages.sh`.
+  /* Node/NPM based dependencies can be upgraded using script `packages/generate-node-packages.sh`.
 
       * Packages which rely on `bin-wrap` will fail by default
         and can be patched using `patchBinwrap` function defined in `packages/lib.nix`.


### PR DESCRIPTION
###### Description of changes

Fixed a typo "dependecies" -> "dependencies"

###### Things done

- [X] all "built", "tested" and "release notes" not applicable
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
