### PR TITLE
gscreenshot: fix typo

### DIFF
--- a/pkgs/applications/graphics/gscreenshot/default.nix
+++ b/pkgs/applications/graphics/gscreenshot/default.nix
@@ -62,7 +62,7 @@ python3Packages.buildPythonApplication rec {
 
     longDescription = ''
       gscreenshot provides a common frontend and expanded functionality to a
-      number of X11 and Wayland screenshot and region selection utilties.
+      number of X11 and Wayland screenshot and region selection utilities.
 
       In a nutshell, gscreenshot supports the following:
 


### PR DESCRIPTION
###### Description of changes

Fixed a typo "utilties" -> "utilities"

###### Things done

- [X] all "built", "tested" and "release notes" not applicable
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
