### PR TITLE
gvisor: fix typo

### DIFF
--- a/pkgs/applications/virtualization/gvisor/default.nix
+++ b/pkgs/applications/virtualization/gvisor/default.nix
@@ -33,7 +33,7 @@ buildGoModule rec {
   subPackages = [ "runsc" "shim" ];
 
   postInstall = ''
-    # Needed for the 'runsc do' subcomand
+    # Needed for the 'runsc do' subcommand
     wrapProgram $out/bin/runsc \
       --prefix PATH : ${lib.makeBinPath [ iproute2 iptables procps ]}
     mv $out/bin/shim $out/bin/containerd-shim-runsc-v1


### PR DESCRIPTION
###### Description of changes

Fixed a typo "subcomand" -> "subcommand"

###### Things done

- [X] all "built", "tested" and "release notes" not applicable
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).