### PR TITLE
haskell-modules: fix typos

### DIFF
--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -1474,7 +1474,7 @@ self: super: {
     ]
           (doDistribute (unmarkBroken (dontCheck (doJailbreak super.reflex-dom-core))))));
 
-  # Tests disabled because they assume to run in the whole jsaddle repo and not the hackage tarbal of jsaddle-warp.
+  # Tests disabled because they assume to run in the whole jsaddle repo and not the hackage tarball of jsaddle-warp.
   jsaddle-warp = dontCheck super.jsaddle-warp;
 
   # 2020-06-24: Jailbreaking because of restrictive test dep bounds
@@ -1867,7 +1867,7 @@ self: super: {
   # Issue reported upstream, no bug tracker url yet.
   darcs = doJailbreak super.darcs;
 
-  # Too strict verion bounds on cryptonite and github.
+  # Too strict version bounds on cryptonite and github.
   # PRs are merged, will be fixed next release or Hackage revision.
   nix-thunk = appendPatches [
     (fetchpatch {

--- a/pkgs/development/haskell-modules/configuration-hackage2nix/main.yaml
+++ b/pkgs/development/haskell-modules/configuration-hackage2nix/main.yaml
@@ -38,7 +38,7 @@ default-package-overrides:
   - hnix-store-remote == 0.5.0.0        # 2022-06-17: Until hnix 0.17
   # reflex-dom-core 0.7.0.2 has no reflex 0.9 compatible release and most likely most people will want to use them together
   - reflex < 0.9.0.0
-  # reqired by haskell-language-server 1.9.0.0
+  # required by haskell-language-server 1.9.0.0
   - implicit-hie < 0.1.3
   # latest version requires Cabal >= 3.8
   - shake-cabal < 0.2.2.3


### PR DESCRIPTION
###### Description of changes

Fixed typos
"tarbal" -> "tarball"
"verion" -> "version"
"reqired" -> "required"

###### Things done

- [X] all "built", "tested" and "release notes" not applicable
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
