### PR TITLE
kdevelop: fix typo

### DIFF
--- a/pkgs/applications/kde/kdevelop/kdevelop.nix
+++ b/pkgs/applications/kde/kdevelop/kdevelop.nix
@@ -62,7 +62,7 @@ mkDerivation rec {
         A free, opensource IDE (Integrated Development Environment)
         for MS Windows, Mac OsX, Linux, Solaris and FreeBSD. It is a
         feature-full, plugin extendable IDE for C/C++ and other
-        programing languages. It is based on KDevPlatform, KDE and Qt
+        programming languages. It is based on KDevPlatform, KDE and Qt
         libraries and is under development since 1998.
       '';
     homepage = "https://www.kdevelop.org";


### PR DESCRIPTION
###### Description of changes

Fixed a typo "programing" -> "programming"

###### Things done

- [X] all "built", "tested" and "release notes" not applicable
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
