### PR TITLE
libpkgconf: fix typo

### DIFF
--- a/pkgs/development/tools/misc/pkgconf/default.nix
+++ b/pkgs/development/tools/misc/pkgconf/default.nix
@@ -35,7 +35,7 @@ stdenv.mkDerivation rec {
   # reason, but in this case the dev output is for the `libpkgconf` library,
   # while the aclocal stuff is for the tool. The tool is already for use during
   # development, so there is no reason to have separate "dev-bin" and "dev-lib"
-  # outputs or someting.
+  # outputs or something.
   + ''
     mv ${placeholder "dev"}/share ${placeholder "out"}
   '';


### PR DESCRIPTION
###### Description of changes

Fixed a typo "someting" -> "something"

###### Things done

- [X] all "built", "tested" and "release notes" not applicable
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).