### PR TITLE
netdata: 1.38.1 -> 1.39.0

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2305.section.md
+++ b/nixos/doc/manual/release-notes/rl-2305.section.md
@@ -387,6 +387,8 @@ In addition to numerous new and upgraded packages, this release has the followin
   }
   ```
 
+- `services.netdata` offers a `deadlineBeforeStopSec` option which enable users who have netdata instance that takes time to initialize to not have systemd kill them for no reason.
+
 - `services.dhcpcd` service now don't solicit or accept IPv6 Router Advertisements on interfaces that use static IPv6 addresses.
   If network uses both IPv6 Unique local addresses (ULA) and global IPv6 address auto-configuration with SLAAC, must add the parameter `networking.dhcpcd.IPv6rs = true;`.
 

--- a/nixos/modules/services/monitoring/netdata.nix
+++ b/nixos/modules/services/monitoring/netdata.nix
@@ -169,6 +169,20 @@ in {
           See: <https://learn.netdata.cloud/docs/agent/anonymous-statistics>
         '';
       };
+
+      deadlineBeforeStopSec = mkOption {
+        type = types.int;
+        default = 120;
+        description = lib.mdDoc ''
+          In order to detect when netdata is misbehaving, we run a concurrent task pinging netdata (wait-for-netdata-up)
+          in the systemd unit.
+
+          If after a while, this task does not succeed, we stop the unit and mark it as failed.
+
+          You can control this deadline in seconds with this option, it's useful to bump it
+          if you have (1) a lot of data (2) doing upgrades (3) have low IOPS/throughput.
+        '';
+      };
     };
   };
 
@@ -205,7 +219,7 @@ in {
           while [ "$(${pkgs.netdata}/bin/netdatacli ping)" != pong ]; do sleep 0.5; done
         '';
 
-        TimeoutStopSec = 60;
+        TimeoutStopSec = cfg.deadlineBeforeStopSec;
         Restart = "on-failure";
         # User and group
         User = cfg.user;

--- a/pkgs/tools/system/netdata/default.nix
+++ b/pkgs/tools/system/netdata/default.nix
@@ -1,8 +1,8 @@
-{ lib, stdenv, callPackage, fetchFromGitHub, autoreconfHook, pkg-config, makeWrapper
+{ lib, stdenv, fetchFromGitHub, autoreconfHook, pkg-config, makeWrapper
 , CoreFoundation, IOKit, libossp_uuid
 , nixosTests
 , netdata-go-plugins
-, bash, curl, jemalloc, libuv, zlib
+, bash, curl, jemalloc, libuv, zlib, libyaml
 , libcap, libuuid, lm_sensors, protobuf
 , withCups ? false, cups
 , withDBengine ? true, lz4
@@ -17,14 +17,14 @@
 
 stdenv.mkDerivation rec {
   # Don't forget to update go.d.plugin.nix as well
-  version = "1.38.1";
+  version = "1.39.0";
   pname = "netdata";
 
   src = fetchFromGitHub {
     owner = "netdata";
     repo = "netdata";
     rev = "v${version}";
-    sha256 = "sha256-y+rjqS95JS1PU+iR8c7spcg1UoYCjpzbpunTAgTJ35U=";
+    sha256 = "sha256-YegHgyj9X8YDSsEV65v8oSnRDv57oz3PCkLA1vy+LYA=";
     fetchSubmodules = true;
   };
 
@@ -32,7 +32,7 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ autoreconfHook pkg-config makeWrapper protobuf ];
   # bash is only used to rewrite shebangs
-  buildInputs = [ bash curl jemalloc libuv zlib ]
+  buildInputs = [ bash curl jemalloc libuv zlib libyaml ]
     ++ lib.optionals stdenv.isDarwin [ CoreFoundation IOKit libossp_uuid ]
     ++ lib.optionals (!stdenv.isDarwin) [ libcap libuuid ]
     ++ lib.optionals withCups [ cups ]

--- a/pkgs/tools/system/netdata/no-files-in-etc-and-var.patch
+++ b/pkgs/tools/system/netdata/no-files-in-etc-and-var.patch
@@ -1,5 +1,5 @@
 diff --git a/collectors/Makefile.am b/collectors/Makefile.am
-index a0a972e8f..b4a2a5f53 100644
+index 24e4c3f09..b3c354943 100644
 --- a/collectors/Makefile.am
 +++ b/collectors/Makefile.am
 @@ -30,7 +30,7 @@ usercustompluginsconfigdir=$(configdir)/custom-plugins.d
@@ -38,7 +38,7 @@ index 2d5f92a6b..8b11c7502 100644
  
  dist_noinst_DATA = \
 diff --git a/collectors/python.d.plugin/Makefile.am b/collectors/python.d.plugin/Makefile.am
-index 667f1627c..eb6810057 100644
+index ca49c1c02..1b9bcc446 100644
 --- a/collectors/python.d.plugin/Makefile.am
 +++ b/collectors/python.d.plugin/Makefile.am
 @@ -32,7 +32,7 @@ dist_userpythonconfig_DATA = \
@@ -62,7 +62,7 @@ index c8144c137..f8aaa89b6 100644
 +no-install-exec-local:
  	$(INSTALL) -d $(DESTDIR)$(userstatsdconfigdir)
 diff --git a/health/Makefile.am b/health/Makefile.am
-index d5eb88468..ab246e77a 100644
+index ea1b6e961..071fdd564 100644
 --- a/health/Makefile.am
 +++ b/health/Makefile.am
 @@ -19,7 +19,7 @@ dist_userhealthconfig_DATA = \
@@ -75,10 +75,10 @@ index d5eb88468..ab246e77a 100644
  
  healthconfigdir=$(libconfigdir)/health.d
 diff --git a/system/Makefile.am b/system/Makefile.am
-index a88ccab65..bda6ee2b6 100644
+index 13466639d..e7cc7acea 100644
 --- a/system/Makefile.am
 +++ b/system/Makefile.am
-@@ -19,15 +19,13 @@ include $(top_srcdir)/build/subst.inc
+@@ -21,11 +21,9 @@ include $(top_srcdir)/build/subst.inc
  SUFFIXES = .in
  
  dist_config_SCRIPTS = \
@@ -89,17 +89,21 @@ index a88ccab65..bda6ee2b6 100644
 -    .install-type \
      $(NULL)
  
+ libconfigvnodesdir=$(libconfigdir)/vnodes
+@@ -45,7 +43,7 @@ libsysrunitdir=$(libsysdir)/runit
+ libsyssystemddir=$(libsysdir)/systemd
+ 
  # Explicitly install directories to avoid permission issues due to umask
 -install-exec-local:
 +no-install-exec-local:
  	$(INSTALL) -d $(DESTDIR)$(configdir)
- 
- nodist_noinst_DATA = \
+ 	$(INSTALL) -d $(DESTDIR)$(libsysdir)
+ 	$(INSTALL) -d $(DESTDIR)$(libsyscrondir)
 diff --git a/web/Makefile.am b/web/Makefile.am
-index ccaccd764..16a2977e5 100644
+index be2c545c3..55f373114 100644
 --- a/web/Makefile.am
 +++ b/web/Makefile.am
-@@ -12,7 +12,7 @@ SUBDIRS = \
+@@ -13,7 +13,7 @@ SUBDIRS = \
  usersslconfigdir=$(configdir)/ssl
  
  # Explicitly install directories to avoid permission issues due to umask
@@ -108,3 +112,6 @@ index ccaccd764..16a2977e5 100644
  	$(INSTALL) -d $(DESTDIR)$(usersslconfigdir)
  
  dist_noinst_DATA = \
+-- 
+2.40.1
+


### PR DESCRIPTION
###### Description of changes

https://github.com/netdata/netdata/releases/tag/v1.39.0


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
