### PR TITLE
mydumper: fix typo

### DIFF
--- a/pkgs/tools/backup/mydumper/default.nix
+++ b/pkgs/tools/backup/mydumper/default.nix
@@ -33,7 +33,7 @@ stdenv.mkDerivation rec {
   ];
 
   meta = with lib; {
-    description = "High-perfomance MySQL backup tool";
+    description = "High-performance MySQL backup tool";
     homepage = "https://github.com/maxbube/mydumper";
     changelog = "https://github.com/mydumper/mydumper/releases/tag/v${version}";
     license = licenses.gpl3Plus;


### PR DESCRIPTION
###### Description of changes

Fixed a typo "perfomance" -> "performance"

###### Things done

- [X] all "built", "tested" and "release notes" not applicable
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).