### PR TITLE
update-python-libraries: always check PyPI 

### DIFF
--- a/pkgs/development/interpreters/python/update-python-libraries/update-python-libraries.py
+++ b/pkgs/development/interpreters/python/update-python-libraries/update-python-libraries.py
@@ -347,18 +347,19 @@ FORMATS = {
     'flit'              :   'tar.gz'
 }
 
+
+FETCHER_RE = re.compile(f'src = (?:\\w+\\.)*({"|".join([re.escape(fetcher) for fetcher in FETCHERS.keys()])})')
+
+
 def _determine_fetcher(text):
-    # Count occurrences of fetchers.
-    nfetchers = sum(text.count('src = {}'.format(fetcher)) for fetcher in FETCHERS.keys())
+    # Find occurrences of fetchers.
+    found = FETCHER_RE.findall(text)
+    nfetchers = len(found)
     if nfetchers == 0:
         raise ValueError("no fetcher.")
     elif nfetchers > 1:
         raise ValueError("multiple fetchers.")
-    else:
-        # Then we check which fetcher to use.
-        for fetcher in FETCHERS.keys():
-            if 'src = {}'.format(fetcher) in text:
-                return fetcher
+    return found[0]
 
 
 def _determine_extension(text, fetcher):

--- a/pkgs/development/python-modules/asn1ate/default.nix
+++ b/pkgs/development/python-modules/asn1ate/default.nix
@@ -2,7 +2,7 @@
 
 buildPythonPackage rec {
   pname = "asn1ate";
-  version= "0.6";
+  version = "0.6";
 
   src = fetchFromGitHub {
     sha256 = "1p8hv4gsyqsdr0gafcq497n52pybiqmc22di8ai4nsj60fv0km45";

--- a/pkgs/development/python-modules/ev3dev2/default.nix
+++ b/pkgs/development/python-modules/ev3dev2/default.nix
@@ -33,5 +33,6 @@ buildPythonPackage rec {
     homepage = "https://github.com/ev3dev/ev3dev-lang-python";
     license = with licenses; [ mit ];
     maintainers = with maintainers; [ emilytrau ];
+    pypiName = "python-ev3dev2";
   };
 }

--- a/pkgs/development/python-modules/iterative-telemetry/default.nix
+++ b/pkgs/development/python-modules/iterative-telemetry/default.nix
@@ -12,7 +12,7 @@
 }:
 
 buildPythonPackage rec {
-  pname = "iterative-telemtry";
+  pname = "iterative-telemetry";
   version = "0.0.7";
   format = "pyproject";
 

--- a/pkgs/development/python-modules/jupyter-server/default.nix
+++ b/pkgs/development/python-modules/jupyter-server/default.nix
@@ -42,7 +42,7 @@ buildPythonPackage rec {
   src = fetchPypi {
     pname = "jupyter_server";
     inherit version;
-    hash= "sha256-jddZkukLfKVWeUoe1cylEmPGl6vG0N9WGvV0qhwKAz8=";
+    hash = "sha256-jddZkukLfKVWeUoe1cylEmPGl6vG0N9WGvV0qhwKAz8=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/development/python-modules/kbcstorage/default.nix
+++ b/pkgs/development/python-modules/kbcstorage/default.nix
@@ -63,5 +63,6 @@ buildPythonPackage rec {
     changelog = "https://github.com/keboola/sapi-python-client/releases/tag/${version}";
     license = licenses.mit;
     maintainers = with maintainers; [ mrmebelman ];
+    pypiName = "kbcstorage";
   };
 }

--- a/pkgs/development/python-modules/laszip/default.nix
+++ b/pkgs/development/python-modules/laszip/default.nix
@@ -53,6 +53,7 @@ buildPythonPackage rec {
     homepage = "https://github.com/tmontaigu/laszip-python";
     license = licenses.mit;
     maintainers = with maintainers; [ matthewcroughan ];
+    pypiName = "laszip";
   };
 }
 

--- a/pkgs/development/python-modules/libvirt/default.nix
+++ b/pkgs/development/python-modules/libvirt/default.nix
@@ -24,5 +24,6 @@ buildPythonPackage rec {
     description = "libvirt Python bindings";
     license = licenses.lgpl2;
     maintainers = [ maintainers.fpletz ];
+    pypiName = "libvirt-python";
   };
 }

--- a/pkgs/development/python-modules/lz4/default.nix
+++ b/pkgs/development/python-modules/lz4/default.nix
@@ -62,5 +62,6 @@ buildPythonPackage rec {
     changelog = "https://github.com/python-lz4/python-lz4/releases/tag/v${version}";
     license = licenses.bsd3;
     maintainers = with maintainers; [ costrouc ];
+    pypiName = "lz4";
   };
 }

--- a/pkgs/development/python-modules/mkdocs-minify/default.nix
+++ b/pkgs/development/python-modules/mkdocs-minify/default.nix
@@ -39,5 +39,6 @@ buildPythonPackage rec {
     homepage = "https://github.com/byrnereese/mkdocs-minify-plugin";
     license = licenses.mit;
     maintainers = with maintainers; [ tfc ];
+    pypiName = "mkdocs-minify-plugin";
   };
 }

--- a/pkgs/development/python-modules/mne-python/default.nix
+++ b/pkgs/development/python-modules/mne-python/default.nix
@@ -70,5 +70,6 @@ buildPythonPackage rec {
     homepage = "https://mne.tools";
     license = licenses.bsd3;
     maintainers = with maintainers; [ bcdarwin ];
+    pypiName = "mne";
   };
 }

--- a/pkgs/development/python-modules/mygpoclient/default.nix
+++ b/pkgs/development/python-modules/mygpoclient/default.nix
@@ -1,7 +1,7 @@
 { lib, stdenv, fetchFromGitHub, buildPythonPackage, nose, minimock }:
 
 buildPythonPackage rec {
-  pname = "mypgoclient";
+  pname = "mygpoclient";
   version = "1.8";
 
   src = fetchFromGitHub {

--- a/pkgs/development/python-modules/napari-npe2/default.nix
+++ b/pkgs/development/python-modules/napari-npe2/default.nix
@@ -60,5 +60,6 @@ buildPythonPackage rec {
     homepage = "https://github.com/napari/npe2";
     license = licenses.bsd3;
     maintainers = with maintainers; [ SomeoneSerge ];
+    pypiName = "npe2";
   };
 }

--- a/pkgs/development/python-modules/permissionedforms/default.nix
+++ b/pkgs/development/python-modules/permissionedforms/default.nix
@@ -35,5 +35,6 @@ buildPythonPackage rec {
     changelog = "https://github.com/wagtail/permissionedforms/blob/v${version}/CHANGELOG.md";
     license = licenses.bsd3;
     maintainers = with maintainers; [ sephi ];
+    pypiName = "django-permissionedforms";
   };
 }

--- a/pkgs/development/python-modules/prettytable/default.nix
+++ b/pkgs/development/python-modules/prettytable/default.nix
@@ -21,7 +21,7 @@ buildPythonPackage rec {
     owner = "jazzband";
     repo = "prettytable";
     rev = "refs/tags/${version}";
-    hash= "sha256-J6oWNug2MEkUZSi67mM5H/Nf4tdSTB/ku34plp1XWCM=";
+    hash = "sha256-J6oWNug2MEkUZSi67mM5H/Nf4tdSTB/ku34plp1XWCM=";
   };
 
   SETUPTOOLS_SCM_PRETEND_VERSION = version;

--- a/pkgs/development/python-modules/primer3/default.nix
+++ b/pkgs/development/python-modules/primer3/default.nix
@@ -31,5 +31,6 @@ buildPythonPackage rec {
     homepage = "https://github.com/libnano/primer3-py";
     license = with licenses; [ gpl2Only ];
     maintainers = with maintainers; [ fab ];
+    pypiName = "primer3-py";
   };
 }

--- a/pkgs/development/python-modules/py-tree-sitter/default.nix
+++ b/pkgs/development/python-modules/py-tree-sitter/default.nix
@@ -30,5 +30,6 @@ buildPythonPackage rec {
     license = licenses.mit;
     maintainers = with maintainers; [ siraben ];
     platforms = platforms.unix;
+    pypiName = "tree-sitter";
   };
 }

--- a/pkgs/development/python-modules/pymatgen/default.nix
+++ b/pkgs/development/python-modules/pymatgen/default.nix
@@ -32,7 +32,7 @@ buildPythonPackage rec {
   src = fetchFromGitHub {
     owner = "materialsproject";
     repo = "pymatgen";
-    rev= "v${version}";
+    rev = "v${version}";
     hash = "sha256-B2piRWx9TfKlGTPOAAGsq2GxyfHIRBVFpk6dxES0WF0=";
   };
 

--- a/pkgs/development/python-modules/pyosmium/default.nix
+++ b/pkgs/development/python-modules/pyosmium/default.nix
@@ -64,5 +64,6 @@ buildPythonPackage rec {
     changelog = "https://github.com/osmcode/pyosmium/blob/v${version}/CHANGELOG.md";
     license = licenses.bsd2;
     maintainers = with maintainers; [ sikmir ];
+    pypiName = "osmium";
   };
 }

--- a/pkgs/development/python-modules/python-ethtool/default.nix
+++ b/pkgs/development/python-modules/python-ethtool/default.nix
@@ -30,5 +30,6 @@ buildPythonPackage rec {
     homepage = "https://github.com/fedora-python/python-ethtool";
     license = licenses.gpl2Plus;
     maintainers = with maintainers; [ elohmeier ];
+    pypiName = "ethtool";
   };
 }

--- a/pkgs/development/python-modules/qreactor/default.nix
+++ b/pkgs/development/python-modules/qreactor/default.nix
@@ -37,5 +37,6 @@ buildPythonPackage rec {
     description = "Twisted and PyQt5/qtpy eventloop integration base";
     license = licenses.mit;
     maintainers = with maintainers; [ raboof ];
+    pypiName = "qt-reactor";
   };
 }

--- a/pkgs/development/python-modules/rtslib/default.nix
+++ b/pkgs/development/python-modules/rtslib/default.nix
@@ -25,5 +25,6 @@ buildPythonPackage rec {
     description = "A Python object API for managing the Linux LIO kernel target";
     homepage = "https://github.com/open-iscsi/rtslib-fb";
     license = licenses.asl20;
+    pypiName = "rtslib-fb";
   };
 }

--- a/pkgs/development/python-modules/tcxparser/default.nix
+++ b/pkgs/development/python-modules/tcxparser/default.nix
@@ -39,6 +39,7 @@ buildPythonPackage rec {
     homepage = "https://github.com/vkurup/python-tcxparser";
     license = licenses.bsd2;
     maintainers = with maintainers; [ firefly-cpp ];
+    pypiName = "python-tcxparser";
   };
 }
 

--- a/pkgs/development/python-modules/trino-python-client/default.nix
+++ b/pkgs/development/python-modules/trino-python-client/default.nix
@@ -77,5 +77,6 @@ buildPythonPackage rec {
     homepage = "https://github.com/trinodb/trino-python-client";
     license = licenses.asl20;
     maintainers = with maintainers; [ cpcloud ];
+    pypiName = "trino";
   };
 }

--- a/pkgs/development/python-modules/usbtmc/default.nix
+++ b/pkgs/development/python-modules/usbtmc/default.nix
@@ -18,5 +18,6 @@ buildPythonPackage rec {
     homepage = "http://alexforencich.com/wiki/en/python-usbtmc/start";
     license = licenses.mit;
     maintainers = with maintainers; [ bjornfor ];
+    pypiName = "python-usbtmc";
   };
 }

--- a/pkgs/development/python-modules/vncdo/default.nix
+++ b/pkgs/development/python-modules/vncdo/default.nix
@@ -33,6 +33,7 @@ buildPythonPackage rec {
     license = licenses.mit;
     maintainers = with maintainers; [ elitak ];
     platforms = with platforms; linux ++ darwin;
+    pypiName = "vncdotool";
   };
 
 }

--- a/pkgs/stdenv/generic/check-meta.nix
+++ b/pkgs/stdenv/generic/check-meta.nix
@@ -294,6 +294,10 @@ let
     # https://github.com/NixOS/hydra/blob/53335323ae79ca1a42643f58e520b376898ce641/doc/manual/src/jobs.md#meta-fields
     isHydraChannel = bool;
 
+    # Used by update-python-libraries for Python modules that have a PyPI name
+    # different from their pname
+    pypiName = nullOr str;
+
     # Weirder stuff that doesn't appear in the documentation?
     maxSilent = int;
     knownVulnerabilities = listOf str;


### PR DESCRIPTION
###### Description of changes

Also support more Git-based fetchers. Logic for handling Git-based
fetchers is rewritten to first check PyPI for releases, then fall back
to GitHub releases and Git tags. `meta.pypiName` is added to some
packages with Git-based fetchers to facilitate this; if absent, `pname`
is used as the PyPI name by default.

Close #230424.

Other than the packages touched here directly, a few examples that didn't update before but do now:

```
# releases on PyPI but not GH
nix-shell maintainers/scripts/update.nix --argstr package python310Packages.aria2p
nix-shell maintainers/scripts/update.nix --argstr package python310Packages.eth-account

# use attr_path more consistently
nix-shell maintainers/scripts/update.nix --argstr package python310Packages.django_treebeard
nix-shell maintainers/scripts/update.nix --argstr package python310Packages.flask_marshmallow

# support more Git-based fetchers
nix-shell maintainers/scripts/update.nix --argstr package python310Packages.nbxmpp

# support Python applications not in `python3Packages`:
nix-shell maintainers/scripts/update.nix --argstr package aws-sam-cli
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
