### PR TITLE
podofo: 0.9.8 -> 0.10.0

### DIFF
--- a/pkgs/development/libraries/podofo/default.nix
+++ b/pkgs/development/libraries/podofo/default.nix
@@ -1,26 +1,61 @@
-{ lib, stdenv, fetchurl, cmake, zlib, freetype, libjpeg, libtiff, fontconfig
-, openssl, libpng, lua5, pkg-config, libidn, expat
+{ lib
+, stdenv
+, fetchFromGitHub
+, cmake
+, expat
+, fontconfig
+, freetype
+, libidn
+, libjpeg
+, libpng
+, libtiff
+, libxml2
+, lua5
+, openssl
+, pkg-config
+, zlib
+, catch2
 }:
 
-stdenv.mkDerivation rec {
-  version = "0.9.8";
+stdenv.mkDerivation (finalAttrs: rec {
+  version = "0.10.0";
   pname = "podofo";
 
-  src = fetchurl {
-    url = "mirror://sourceforge/podofo/${pname}-${version}.tar.gz";
-    sha256 = "sha256-XeYH4V8ZK4rZBzgwB1nYjeoPXM3OO/AASKDJMrxkUVQ=";
+  src = fetchFromGitHub {
+    owner = pname;
+    repo = pname;
+    rev = version;
+    hash = "sha256-W61ufT/YT8DLVpGM2ai7ZFE6mR+vassyK8Ool/nAfU4=";
+    fetchSubmodules = true;  # includes test data
   };
+
+  prePatch = ''
+    # remove any possibility it may try to use these
+    rm -r extern/deps
+  '';
 
   outputs = [ "out" "dev" "lib" ];
 
   nativeBuildInputs = [ cmake pkg-config ];
 
-  buildInputs = [ zlib freetype libjpeg libtiff fontconfig openssl libpng
-                  libidn expat lua5 ];
+  buildInputs = [
+    expat
+    fontconfig
+    freetype
+    libidn
+    libjpeg
+    libpng
+    libtiff
+    libxml2
+    lua5
+    openssl
+    zlib
+  ];
+
+  nativeCheckInputs = [ catch2 ];
 
   cmakeFlags = [
-    "-DPODOFO_BUILD_SHARED=ON"
-    "-DPODOFO_BUILD_STATIC=OFF"
+    "-DPODOFO_BUILD_TEST=${if finalAttrs.finalPackage.doCheck then "ON" else "OFF"}"
     "-DCMAKE_BUILD_WITH_INSTALL_NAME_DIR=ON"
   ];
 
@@ -28,10 +63,12 @@ stdenv.mkDerivation rec {
     moveToOutput lib "$lib"
   '';
 
+  doCheck = true;
+
   meta = with lib; {
     homepage = "https://podofo.sourceforge.net";
     description = "A library to work with the PDF file format";
     platforms = platforms.all;
     license = with licenses; [ gpl2Plus lgpl2Plus ];
   };
-}
+})


### PR DESCRIPTION
###### Description of changes

I've got this working and have enabled the tests, but it looks like some reverse-dependencies aren't ready for its api change yet (https://github.com/podofo/podofo/wiki/PoDoFo-API-migration-guide), e.g. calibre (opened issue upstream https://bugs.launchpad.net/calibre/+bug/2018942).

Pushing commits to fix any of these is welcome.

~In the meantime I'm going to see if I can address CVE-2023-2241 without the bump...~ I'm fairly convinced 0.9.8 is not vulnerable - looks like it was introduced through and error in 0.10.0.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
