### PR TITLE
systemd-repart definitions in initrd

### DIFF
--- a/nixos/modules/system/boot/systemd/repart.nix
+++ b/nixos/modules/system/boot/systemd/repart.nix
@@ -72,11 +72,6 @@ in
   };
 
   config = lib.mkIf (cfg.enable || initrdCfg.enable) {
-    # Always link the definitions into /etc so that they are also included in
-    # the /nix/store of the sysroot during early userspace (i.e. while in the
-    # initrd).
-    environment.etc."repart.d".source = definitionsDirectory;
-
     boot.initrd.systemd = lib.mkIf initrdCfg.enable {
       additionalUpstreamUnits = [
         "systemd-repart.service"
@@ -86,6 +81,8 @@ in
         "${config.boot.initrd.systemd.package}/bin/systemd-repart"
       ];
 
+      contents."/etc/repart.d".source = definitionsDirectory;
+
       # Override defaults in upstream unit.
       services.systemd-repart = {
         # systemd-repart tries to create directories in /var/tmp by default to
@@ -93,29 +90,29 @@ in
         # the initrd, however, /var/tmp does not provide more persistence than
         # /tmp, so we re-use it here.
         environment."TMPDIR" = "/tmp";
-        # Unset the conditions as they cannot be met before activation because
-        # the definition files are not stored in the expected locations.
-        unitConfig.ConditionDirectoryNotEmpty = [
-          " " # required to unset the previous value.
-        ];
         serviceConfig = {
-          # systemd-repart runs before the activation script. Thus we cannot
-          # rely on them being linked in /etc already. Instead we have to
-          # explicitly pass their location in the sysroot to the binary.
           ExecStart = [
             " " # required to unset the previous value.
+            # When running in the initrd, systemd-repart by default searches
+            # for definition files in /sysroot or /sysusr. We tell it to look
+            # in the initrd itself.
             ''${config.boot.initrd.systemd.package}/bin/systemd-repart \
-                  --definitions=/sysroot${definitionsDirectory} \
+                  --definitions=/etc/repart.d \
                   --dry-run=no
             ''
           ];
         };
-        # Because the initrd does not have the `initrd-usr-fs.target` the
-        # upestream unit runs too early in the boot process, before the sysroot
-        # is available. However, systemd-repart needs access to the sysroot to
-        # find the definition files.
+        # systemd-repart needs to run after /sysroot (or /sysuser, but we don't
+        # have it) has been mounted because otherwise it cannot determine the
+        # device (i.e disk) to operate on. If you want to run systemd-repart
+        # without /sysroot, you have to explicitly tell it which device to
+        # operate on.
         after = [ "sysroot.mount" ];
       };
+    };
+
+    environment.etc = lib.mkIf cfg.enable {
+      "repart.d".source = definitionsDirectory;
     };
 
     systemd = lib.mkIf cfg.enable {

--- a/nixos/modules/system/boot/systemd/repart.nix
+++ b/nixos/modules/system/boot/systemd/repart.nix
@@ -88,6 +88,11 @@ in
 
       # Override defaults in upstream unit.
       services.systemd-repart = {
+        # systemd-repart tries to create directories in /var/tmp by default to
+        # store large temporary files that benefit from persistence on disk. In
+        # the initrd, however, /var/tmp does not provide more persistence than
+        # /tmp, so we re-use it here.
+        environment."TMPDIR" = "/tmp";
         # Unset the conditions as they cannot be met before activation because
         # the definition files are not stored in the expected locations.
         unitConfig.ConditionDirectoryNotEmpty = [
@@ -119,5 +124,4 @@ in
       ];
     };
   };
-
 }


### PR DESCRIPTION
###### Description of changes

This PR includes two commits, the first fixing systemd-repart in the initrd (which was broken since the update to systemd v253), and the second which changes the definition files to be stored in the initrd directly.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
