### PR TITLE
nodePackages: add script to remove attrs for aliases

### DIFF
--- a/pkgs/development/node-packages/aliases.nix
+++ b/pkgs/development/node-packages/aliases.nix
@@ -1,6 +1,10 @@
 pkgs: lib: self: super:
 
 ### Deprecated aliases - for backward compatibility
+###
+### !!! NOTE !!!
+### Use `./remove-attr.py [attrname]` in this directory to remove your alias
+### from the `nodePackages` set without regenerating the entire file.
 
 with self;
 

--- a/pkgs/development/node-packages/node-packages.json
+++ b/pkgs/development/node-packages/node-packages.json
@@ -279,7 +279,7 @@
 , "reveal-md"
 , "rimraf"
 , "rollup"
-, { "rust-analyzer-build-deps": "../../applications/editors/vscode/extensions/rust-lang.rust-analyzer/build-deps" }
+, {"rust-analyzer-build-deps": "../../applications/editors/vscode/extensions/rust-lang.rust-analyzer/build-deps"}
 , "rtlcss"
 , "s3http"
 , "sass"

--- a/pkgs/development/node-packages/remove-attr.py
+++ b/pkgs/development/node-packages/remove-attr.py
@@ -1,0 +1,54 @@
+#!/usr/bin/env nix-shell
+#!nix-shell -i python3 -p
+
+import collections.abc
+import fileinput
+import json
+import os.path
+import re
+import sys
+
+
+def remove(attr):
+    with open(os.path.join(os.path.dirname(__file__), 'node-packages.json'), 'r+') as node_packages_json:
+        packages = json.load(node_packages_json)
+        idx = 0
+        while idx < len(packages):
+            if packages[idx] == attr or (isinstance(packages[idx], collections.abc.Mapping) and next(iter(packages[idx].keys())) == attr):
+                del packages[idx]
+            else:
+                idx += 1
+
+        node_packages_json.seek(0)
+        for idx, package in enumerate(packages):
+            if idx == 0:
+                node_packages_json.write('[\n  ')
+            else:
+                node_packages_json.write(', ')
+            json.dump(package, node_packages_json)
+            node_packages_json.write('\n')
+        node_packages_json.write(']\n')
+        node_packages_json.truncate()
+
+    with fileinput.input(os.path.join(os.path.dirname(__file__), 'node-packages.nix'), inplace=1) as node_packages:
+        safe_attr = re.escape(attr)
+        in_attr = False
+        for line in node_packages:
+            if in_attr:
+                if re.fullmatch(r'  \};\n', line):
+                    in_attr = False
+            else:
+                if re.fullmatch(rf'  (?:{safe_attr}|"{safe_attr}") = nodeEnv\.buildNodePackage \{{\n', line):
+                    in_attr = True
+                else:
+                    sys.stdout.write(line)
+
+
+if __name__ == '__main__':
+    import argparse
+
+    parser = argparse.ArgumentParser(description='Remove a given package from the node-packages.nix file')
+    parser.add_argument('attr', help='The package attribute to remove')
+    args = parser.parse_args()
+
+    remove(args.attr)


### PR DESCRIPTION
###### Description of changes

Follow-up to #229639

Regenerating the entire `nodePackages` package set takes ages and editing the file by hand is difficult

Instead this provides a script to remove packages without regenerating, to make it easier to alias and migrate stuff out of the set

This is a really dumb format-dependent script, but I doubt node2nix is ever going to see changes again that would make this a problem since we are actively trying to move away from it

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).