### PR TITLE
memento: init at v1.1.0

### DIFF
--- a/pkgs/applications/video/memento/default.nix
+++ b/pkgs/applications/video/memento/default.nix
@@ -1,0 +1,63 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, cmake
+, qtbase
+, qtx11extras ? null # qt5 only
+, wrapQtAppsHook
+
+# before that => zeal
+, sqlite
+, json_c
+, mecab
+, libzip
+, mpv
+, yt-dlp
+# optional
+, makeWrapper}:
+
+let
+  isQt5 = lib.versions.major qtbase.version == "5";
+
+in
+stdenv.mkDerivation (finalAttrs: {
+  pname = "memento";
+  version = "v1.1.0";
+
+  src = fetchFromGitHub {
+    owner = "ripose-jp";
+    repo = "Memento";
+    rev = finalAttrs.version;
+    hash = "sha256-29AzQ+Z2PNs65Tvmt2Z5Ra2G3Yhm4LVBpAqvnSsnE0Y=";
+  };
+
+  nativeBuildInputs = [
+    cmake
+    makeWrapper
+    wrapQtAppsHook
+  ];
+
+  buildInputs = [
+    qtbase
+    sqlite
+    json_c
+    libzip
+    mecab
+  ] ++ lib.optionals isQt5 [ qtx11extras ];
+
+  propagatedBuildInputs = [ mpv  ];
+
+  preFixup = ''
+     wrapProgram "$out/bin/memento" \
+       --prefix PATH : "${yt-dlp}/bin" \
+  '';
+
+  meta = with lib; {
+    description = "An mpv-based video player for studying Japanese";
+    homepage = "https://ripose-jp.github.io/Memento/";
+    license = licenses.gpl2;
+    maintainers = with maintainers; [ teto ];
+    platforms = platforms.linux;
+  };
+})
+

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -32402,6 +32402,8 @@ with pkgs;
 
   mailspring = callPackage ../applications/networking/mailreaders/mailspring { };
 
+  memento = libsForQt5.callPackage ../applications/video/memento { };
+
   mm = callPackage ../applications/networking/instant-messengers/mm { };
 
   mm-common = callPackage ../development/libraries/mm-common { };


### PR DESCRIPTION
a reader with kanji reading

I've tried to load videos from youtube but it ocmplains that youtube-dl is too old. The version has 2021 in its name but looks like it's the latest one so not sure where hte problem is.

Still need to add some dictionairies else a warning pops up upon launch.

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
