### PR TITLE
botamusique: pin pymumble at 1.6.1

### DIFF
--- a/pkgs/tools/audio/botamusique/default.nix
+++ b/pkgs/tools/audio/botamusique/default.nix
@@ -2,7 +2,7 @@
 , lib
 , stdenv
 , fetchFromGitHub
-, python3Packages
+, python3
 , ffmpeg
 , makeWrapper
 , nixosTests
@@ -37,8 +37,21 @@ let
     src = src + "/web";
   })).nodeDependencies;
 
+  python = python3.override {
+    packageOverrides = self: super: {
+      pymumble = super.pymumble.overridePythonAttrs (oldAttrs: rec {
+        version = "1.6.1";
+        src = fetchFromGitHub {
+          inherit (oldAttrs.src) owner repo;
+          rev = "refs/tags/${version}";
+          hash = "sha256-+sT5pqdm4A2rrUcUUmvsH+iazg80+/go0zM1vr9oeuE=";
+        };
+      });
+    };
+  };
+
   # Python needed to instantiate the html templates
-  buildPython = python3Packages.python.withPackages (ps: [ ps.jinja2 ]);
+  buildPython = python.withPackages (ps: [ ps.jinja2 ]);
 in
 stdenv.mkDerivation rec {
   pname = "botamusique";
@@ -70,10 +83,10 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [
     makeWrapper
     nodejs
-    python3Packages.wrapPython
+    python.pkgs.wrapPython
   ];
 
-  pythonPath = with python3Packages; [
+  pythonPath = with python.pkgs; [
     flask
     magic
     mutagen


### PR DESCRIPTION
https://hydra.nixos.org/build/218905263

ZHF #230712 

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
