### PR TITLE
deepin.dde-daemon: fix can't set custom wallpapers

### DIFF
--- a/pkgs/desktops/deepin/go-package/dde-daemon/0005-fix-custom-wallpapers-path.diff
+++ b/pkgs/desktops/deepin/go-package/dde-daemon/0005-fix-custom-wallpapers-path.diff
@@ -1,0 +1,22 @@
+diff --git a/bin/dde-system-daemon/wallpaper.go b/bin/dde-system-daemon/wallpaper.go
+index d4af13da..1ff36f84 100644
+--- a/bin/dde-system-daemon/wallpaper.go
++++ b/bin/dde-system-daemon/wallpaper.go
+@@ -24,7 +24,7 @@ import (
+ 
+ const maxCount = 5
+ const maxSize = 32 * 1024 * 1024
+-const wallPaperDir = "/usr/share/wallpapers/custom-wallpapers/"
++const wallPaperDir = "/var/lib/dde-daemon/wallpapers/custom-wallpapers/"
+ 
+ func GetUserDir(username string) (string, error) {
+ 	dir := filepath.Join(wallPaperDir, username)
+@@ -136,7 +136,7 @@ func (d *Daemon) SaveCustomWallPaper(sender dbus.Sender, username string, file s
+ 		"-u",
+ 		username,
+ 		"--",
+-		"head",
++		"@coreutils@/bin/head",
+ 		"-c",
+ 		"0",
+ 		file,

--- a/pkgs/desktops/deepin/go-package/dde-daemon/default.nix
+++ b/pkgs/desktops/deepin/go-package/dde-daemon/default.nix
@@ -32,6 +32,9 @@
 , xdotool
 , getconf
 , dbus
+, coreutils
+, util-linux
+, dde-session-ui
 }:
 
 buildGoPackage rec {
@@ -55,6 +58,10 @@ buildGoPackage rec {
       src = ./0004-aviod-use-hardcode-path.patch;
       inherit dbus;
     })
+    (substituteAll {
+      src = ./0005-fix-custom-wallpapers-path.diff;
+      inherit coreutils;
+    })
   ];
 
   postPatch = ''
@@ -70,7 +77,7 @@ buildGoPackage rec {
     substituteInPlace system/uadp/crypto.go \
       --replace "/usr/share/uadp" "/var/lib/dde-daemon/uadp"
 
-    substituteInPlace appearance/background/{background.go,custom_wallpapers.go} accounts/user.go bin/dde-system-daemon/wallpaper.go \
+    substituteInPlace appearance/background/{background.go,custom_wallpapers.go} accounts/user.go \
      --replace "/usr/share/wallpapers" "/run/current-system/sw/share/wallpapers"
 
     substituteInPlace appearance/manager.go timedate/zoneinfo/zone.go \
@@ -136,6 +143,12 @@ buildGoPackage rec {
     runHook preInstall
     make install DESTDIR="$out" PREFIX="/" -C go/src/${goPackagePath}
     runHook postInstall
+  '';
+
+  preFixup = ''
+    gappsWrapperArgs+=(
+      --prefix PATH : "${lib.makeBinPath [ util-linux dde-session-ui ]}"
+    )
   '';
 
   postFixup = ''


### PR DESCRIPTION
###### Description of changes
1. Add runtime dependencies to PATH （runuser[util-linux], dde-pixmix[dde-session-ui]）
2. `/usr/share/ ` should be read-only， move custom-wallpapers to /var/lib/dde-daemon

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
