### PR TITLE
openocd: use packaged libjaylink and jimtcl instead of bundled copies

### DIFF
--- a/pkgs/development/embedded/openocd/default.nix
+++ b/pkgs/development/embedded/openocd/default.nix
@@ -3,6 +3,8 @@
 , fetchurl
 , pkg-config
 , hidapi
+, jimtcl
+, libjaylink
 , libusb1
 , libgpiod
 
@@ -22,11 +24,13 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ pkg-config ];
 
-  buildInputs = [ hidapi libftdi1 libusb1 ]
+  buildInputs = [ hidapi jimtcl libftdi1 libjaylink libusb1 ]
     ++ lib.optional stdenv.isLinux libgpiod;
 
   configureFlags = [
     "--disable-werror"
+    "--disable-internal-jimtcl"
+    "--disable-internal-libjaylink"
     "--enable-jtag_vpi"
     "--enable-buspirate"
     "--enable-remote-bitbang"

--- a/pkgs/development/libraries/libjaylink/default.nix
+++ b/pkgs/development/libraries/libjaylink/default.nix
@@ -31,6 +31,6 @@ stdenv.mkDerivation rec {
     description = "libjaylink is a shared library written in C to access SEGGER J-Link and compatible devices.";
     license = licenses.gpl2Plus;
     maintainers = with maintainers; [ felixsinger ];
-    platforms = platforms.linux;
+    platforms = platforms.unix;
   };
 }


### PR DESCRIPTION
###### Description of changes

Openocd bundles copies of libjaylink and jimtcl, but we can tell it to use our packaged versions instead. This makes openocd more consistent with everything else (patches in libjaylink and jimtcl are applied here too, etc).

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- ~[ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))~
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - ~[ ] (Package updates) Added a release notes entry if the change is major or breaking~
  - ~[ ] (Module updates) Added a release notes entry if the change is significant~
  - ~[ ] (Module addition) Added a release notes entry if adding a new NixOS module~
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).