### PR TITLE
ocamlPackages.ocp-indent: fix for Dune 3

### DIFF
--- a/pkgs/development/tools/ocaml/ocaml-top/default.nix
+++ b/pkgs/development/tools/ocaml/ocaml-top/default.nix
@@ -4,6 +4,8 @@ with ocamlPackages; buildDunePackage rec {
   pname = "ocaml-top";
   version = "1.2.0";
 
+  duneVersion = "3";
+
   src = fetchFromGitHub {
     owner = "OCamlPro";
     repo = "ocaml-top";

--- a/pkgs/development/tools/ocaml/ocp-indent/default.nix
+++ b/pkgs/development/tools/ocaml/ocp-indent/default.nix
@@ -1,10 +1,10 @@
-{ lib, fetchFromGitHub, buildDunePackage, cmdliner }:
+{ lib, fetchFromGitHub, buildDunePackage, cmdliner, findlib }:
 
 buildDunePackage rec {
   version = "1.8.2";
   pname = "ocp-indent";
 
-  useDune2 = true;
+  duneVersion = "3";
 
   src = fetchFromGitHub {
     owner = "OCamlPro";
@@ -13,9 +13,10 @@ buildDunePackage rec {
     sha256 = "sha256-IyvURw/6R0eKrnahV1fqLV0iIeypykrmxDbliECgbLc=";
   };
 
-  minimumOCamlVersion = "4.02";
+  minimalOCamlVersion = "4.03";
 
   buildInputs = [ cmdliner ];
+  propagatedBuildInputs = [ findlib ];
 
   meta = with lib; {
     homepage = "https://www.typerex.org/ocp-indent.html";

--- a/pkgs/development/tools/ocaml/ocp-index/default.nix
+++ b/pkgs/development/tools/ocaml/ocp-index/default.nix
@@ -4,6 +4,8 @@ buildDunePackage rec {
   pname = "ocp-index";
   version = "1.3.4";
 
+  duneVersion = "3";
+
   minimalOCamlVersion = "4.08";
 
   src = fetchFromGitHub {


### PR DESCRIPTION
###### Description of changes

Add a missing input.

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
