### PR TITLE
Updated cve-bin-tool to 3.2

### DIFF
--- a/pkgs/tools/security/cve-bin-tool/default.nix
+++ b/pkgs/tools/security/cve-bin-tool/default.nix
@@ -24,16 +24,18 @@
 , xmlschema
 , setuptools
 , packaging
+, cvss
+, google-cloud-sdk
 }:
 buildPythonApplication rec {
   pname = "cve-bin-tool";
-  version = "3.1.2";
+  version = "3.2";
 
   src = fetchFromGitHub {
     owner = "intel";
     repo = "cve-bin-tool";
     rev = "refs/tags/v${version}";
-    sha256 = "sha256-P2GhGQxa6Y8BmMqFHXSfmqN58E1FbXD9Ndwwr+upK8Q=";
+    sha256 = "sha256-QOnWt6iit0/F6d/MfZ8qJqDuT3IHh0Qjs6BcJkI/CBw=";
   };
 
   # Wants to open a sqlite database, access the internet, etc
@@ -63,6 +65,8 @@ buildPythonApplication rec {
     setuptools
     xmlschema
     packaging
+    cvss
+    google-cloud-sdk
   ];
 
   nativeCheckInputs = [
@@ -73,9 +77,17 @@ buildPythonApplication rec {
     "cve_bin_tool"
   ];
 
-  # required until https://github.com/intel/cve-bin-tool/pull/1665 is merged
   postPatch = ''
+    # Since we disabled the tests for this, we do not care about pytest dependencies.
     sed '/^pytest/d' -i requirements.txt
+
+    # This is used to upload and download data to GCE via the gsutil binary.
+    # Therefore, this is not really a needed python dependency, therefore we just install google-cloud-sdk and
+    # remove this dependency.
+    sed '/^gsutil/d' -i requirements.txt
+
+    # This was solved in https://github.com/intel/cve-bin-tool/pull/2432, but never released from requirements.txt
+    sed 's/^packaging<22.0/packaging/i' -i requirements.txt
   '';
 
   meta = with lib; {


### PR DESCRIPTION
###### Description of changes

Updated cve-bin-tool to 3.2
Resolved build problems with packaging version

It was neccessary to update cve-bin-tool to a newer version to resolve problems
with building. cve-bin-tool<3.2 uses LegacyVersion which was removed from packaging>23.0, which is currently packaged in unstable. 

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
