### PR TITLE
hdf4: enable fortran and netcdf support

### DIFF
--- a/pkgs/tools/misc/hdf4/default.nix
+++ b/pkgs/tools/misc/hdf4/default.nix
@@ -12,6 +12,9 @@
 , szip
 , javaSupport ? false
 , jdk
+, fortranSupport ? false
+, gfortran
+, netcdfSupport ? false
 }:
 stdenv.mkDerivation rec {
   pname = "hdf";
@@ -50,7 +53,7 @@ stdenv.mkDerivation rec {
     cmake
   ] ++ lib.optionals stdenv.isDarwin [
     fixDarwinDylibNames
-  ];
+  ] ++ lib.optional fortranSupport gfortran;
 
   buildInputs = [
     libjpeg
@@ -75,9 +78,8 @@ stdenv.mkDerivation rec {
     "-DHDF4_BUILD_UTILS=ON"
     "-DHDF4_BUILD_WITH_INSTALL_NAME=OFF"
     "-DHDF4_ENABLE_JPEG_LIB_SUPPORT=ON"
-    "-DHDF4_ENABLE_NETCDF=OFF"
+    "-DHDF4_ENABLE_NETCDF=${if netcdfSupport then "ON" else "OFF"}"
     "-DHDF4_ENABLE_Z_LIB_SUPPORT=ON"
-    "-DHDF4_BUILD_FORTRAN=OFF"
     "-DJPEG_DIR=${libjpeg}"
   ] ++ lib.optionals javaSupport [
     "-DHDF4_BUILD_JAVA=ON"
@@ -85,7 +87,13 @@ stdenv.mkDerivation rec {
   ] ++ lib.optionals szipSupport [
     "-DHDF4_ENABLE_SZIP_ENCODING=ON"
     "-DHDF4_ENABLE_SZIP_SUPPORT=ON"
-  ];
+  ] ++ (if fortranSupport
+  then [
+    "-DHDF4_BUILD_FORTRAN=ON"
+    "-DCMAKE_Fortran_FLAGS=-fallow-argument-mismatch"
+  ]
+  else [ "-DHDF4_BUILD_FORTRAN=OFF" ]
+  );
 
   doCheck = true;
 


### PR DESCRIPTION
###### Description of changes

Some exotic quantum mechanics packages require the fortran and NetCDF support of HDF4 and I think there is no harm in enabling them by default. This PR does exactly this.

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
