### PR TITLE
rusty-psn-gui: fix build, cleanup

### DIFF
--- a/pkgs/applications/misc/rusty-psn/default.nix
+++ b/pkgs/applications/misc/rusty-psn/default.nix
@@ -5,6 +5,11 @@
 , makeDesktopItem
 , copyDesktopItems
 , pkg-config
+, cmake
+, fontconfig
+, glib
+, gtk3
+, freetype
 , openssl
 , xorg
 , libGL
@@ -26,10 +31,18 @@ rustPlatform.buildRustPackage rec {
 
   nativeBuildInputs = [
     pkg-config
+  ] ++ lib.optionals withGui [
     copyDesktopItems
+    cmake
   ];
 
-  buildInputs = if withGui then [
+  buildInputs = [
+    openssl
+  ] ++ lib.optionals withGui [
+    fontconfig
+    glib
+    gtk3
+    freetype
     openssl
     xorg.libxcb
     xorg.libX11
@@ -39,8 +52,6 @@ rustPlatform.buildRustPackage rec {
     xorg.libxcb
     libGL
     libGL.dev
-  ] else [
-    openssl
   ];
 
   buildNoDefaultFeatures = true;


### PR DESCRIPTION
###### Description of changes

Failing Hydra build: https://hydra.nixos.org/build/218305203

Fix building of the GUI variant of rusty-psn as pointed out via https://github.com/NixOS/nixpkgs/issues/230712 : Missing dependencies.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
