### PR TITLE
nixos/pam: Allow password changing via sssd

### DIFF
--- a/nixos/modules/security/pam.nix
+++ b/nixos/modules/security/pam.nix
@@ -638,7 +638,7 @@ let
             password sufficient ${pkgs.pam_mysql}/lib/security/pam_mysql.so config_file=/etc/security/pam_mysql.conf
           '' +
           optionalString config.services.sssd.enable ''
-            password sufficient ${pkgs.sssd}/lib/security/pam_sss.so try_first_pass
+            password sufficient ${pkgs.sssd}/lib/security/pam_sss.so
           '' +
           optionalString config.security.pam.krb5.enable ''
             password sufficient ${pam_krb5}/lib/security/pam_krb5.so use_first_pass

--- a/nixos/modules/security/pam.nix
+++ b/nixos/modules/security/pam.nix
@@ -638,7 +638,7 @@ let
             password sufficient ${pkgs.pam_mysql}/lib/security/pam_mysql.so config_file=/etc/security/pam_mysql.conf
           '' +
           optionalString config.services.sssd.enable ''
-            password sufficient ${pkgs.sssd}/lib/security/pam_sss.so use_authtok
+            password sufficient ${pkgs.sssd}/lib/security/pam_sss.so try_first_pass
           '' +
           optionalString config.security.pam.krb5.enable ''
             password sufficient ${pam_krb5}/lib/security/pam_krb5.so use_first_pass

--- a/nixos/tests/sssd-ldap.nix
+++ b/nixos/tests/sssd-ldap.nix
@@ -9,162 +9,162 @@ let
   testPassword = "foobar";
   testNewPassword = "barfoo";
 in
-  import ./make-test-python.nix ({pkgs, ...}: {
-    name = "sssd-ldap";
+import ./make-test-python.nix ({ pkgs, ... }: {
+  name = "sssd-ldap";
 
-    meta = with pkgs.lib.maintainers; {
-      maintainers = [bbigras];
-    };
+  meta = with pkgs.lib.maintainers; {
+    maintainers = [ bbigras ];
+  };
 
-    nodes.machine = {pkgs, ...}: {
-      security.pam.services.systemd-user.makeHomeDir = true;
-      environment.etc."cert.pem".text = builtins.readFile ./common/acme/server/acme.test.cert.pem;
-      environment.etc."key.pem".text = builtins.readFile ./common/acme/server/acme.test.key.pem;
-      services.openldap = {
-        enable = true;
-        urlList = [ "ldap:///" "ldaps:///" ];
-        settings = {
-          attrs = {
-            olcLogLevel = "conns config";
-            olcTLSCACertificateFile = "/etc/cert.pem";
-            olcTLSCertificateFile = "/etc/cert.pem";
-            olcTLSCertificateKeyFile = "/etc/key.pem";
-            olcTLSCipherSuite = "HIGH:MEDIUM:+3DES:+RC4:+aNULL";
-            olcTLSCRLCheck = "none";
-            olcTLSVerifyClient = "never";
-            olcTLSProtocolMin = "3.1";
-          };
-          children = {
-            "cn=schema".includes = [
-              "${pkgs.openldap}/etc/schema/core.ldif"
-              "${pkgs.openldap}/etc/schema/cosine.ldif"
-              "${pkgs.openldap}/etc/schema/inetorgperson.ldif"
-              "${pkgs.openldap}/etc/schema/nis.ldif"
-            ];
-            "olcDatabase={1}mdb" = {
-              attrs = {
-                objectClass = ["olcDatabaseConfig" "olcMdbConfig"];
-                olcDatabase = "{1}mdb";
-                olcDbDirectory = "/var/lib/openldap/db";
-                olcSuffix = dbSuffix;
-                olcRootDN = "cn=${ldapRootUser},${dbSuffix}";
-                olcRootPW = ldapRootPassword;
-                olcAccess = [
-                  /*
+  nodes.machine = { pkgs, ... }: {
+    security.pam.services.systemd-user.makeHomeDir = true;
+    environment.etc."cert.pem".text = builtins.readFile ./common/acme/server/acme.test.cert.pem;
+    environment.etc."key.pem".text = builtins.readFile ./common/acme/server/acme.test.key.pem;
+    services.openldap = {
+      enable = true;
+      urlList = [ "ldap:///" "ldaps:///" ];
+      settings = {
+        attrs = {
+          olcLogLevel = "conns config";
+          olcTLSCACertificateFile = "/etc/cert.pem";
+          olcTLSCertificateFile = "/etc/cert.pem";
+          olcTLSCertificateKeyFile = "/etc/key.pem";
+          olcTLSCipherSuite = "HIGH:MEDIUM:+3DES:+RC4:+aNULL";
+          olcTLSCRLCheck = "none";
+          olcTLSVerifyClient = "never";
+          olcTLSProtocolMin = "3.1";
+        };
+        children = {
+          "cn=schema".includes = [
+            "${pkgs.openldap}/etc/schema/core.ldif"
+            "${pkgs.openldap}/etc/schema/cosine.ldif"
+            "${pkgs.openldap}/etc/schema/inetorgperson.ldif"
+            "${pkgs.openldap}/etc/schema/nis.ldif"
+          ];
+          "olcDatabase={1}mdb" = {
+            attrs = {
+              objectClass = [ "olcDatabaseConfig" "olcMdbConfig" ];
+              olcDatabase = "{1}mdb";
+              olcDbDirectory = "/var/lib/openldap/db";
+              olcSuffix = dbSuffix;
+              olcRootDN = "cn=${ldapRootUser},${dbSuffix}";
+              olcRootPW = ldapRootPassword;
+              olcAccess = [
+                /*
                   custom access rules for userPassword attributes
                   */
-                  ''
-                    {0}to attrs=userPassword
-                                      by self write
-                                      by anonymous auth
-                                      by * none''
+                ''
+                  {0}to attrs=userPassword
+                                    by self write
+                                    by anonymous auth
+                                    by * none''
 
-                  /*
+                /*
                   allow read on anything else
                   */
-                  ''
-                    {1}to *
-                                      by * read''
-                ];
-              };
+                ''
+                  {1}to *
+                                    by * read''
+              ];
             };
           };
         };
-        declarativeContents = {
-          ${dbSuffix} = ''
-            dn: ${dbSuffix}
-            objectClass: top
-            objectClass: dcObject
-            objectClass: organization
-            o: ${dbDomain}
-
-            dn: ou=posix,${dbSuffix}
-            objectClass: top
-            objectClass: organizationalUnit
-
-            dn: ou=accounts,ou=posix,${dbSuffix}
-            objectClass: top
-            objectClass: organizationalUnit
-
-            dn: uid=${testUser},ou=accounts,ou=posix,${dbSuffix}
-            objectClass: person
-            objectClass: posixAccount
-            userPassword: ${testPassword}
-            homeDirectory: /home/${testUser}
-            uidNumber: 1234
-            gidNumber: 1234
-            cn: ""
-            sn: ""
-          '';
-        };
       };
+      declarativeContents = {
+        ${dbSuffix} = ''
+          dn: ${dbSuffix}
+          objectClass: top
+          objectClass: dcObject
+          objectClass: organization
+          o: ${dbDomain}
 
-      services.sssd = {
-        enable = true;
-        # just for testing purposes, don't put this into the Nix store in production!
-        environmentFile = "${pkgs.writeText "ldap-root" "LDAP_BIND_PW=${ldapRootPassword}"}";
-        config = ''
-          [sssd]
-          config_file_version = 2
-          services = nss, pam, sudo
-          domains = ${dbDomain}
+          dn: ou=posix,${dbSuffix}
+          objectClass: top
+          objectClass: organizationalUnit
 
-          [domain/${dbDomain}]
-          auth_provider = ldap
-          id_provider = ldap
-          ldap_uri = ldaps://127.0.0.1:636
-          ldap_tls_reqcert = allow
-          ldap_tls_cacert = /etc/cert.pem
-          ldap_search_base = ${dbSuffix}
-          ldap_default_bind_dn = cn=${ldapRootUser},${dbSuffix}
-          ldap_default_authtok_type = password
-          ldap_default_authtok = $LDAP_BIND_PW
+          dn: ou=accounts,ou=posix,${dbSuffix}
+          objectClass: top
+          objectClass: organizationalUnit
+
+          dn: uid=${testUser},ou=accounts,ou=posix,${dbSuffix}
+          objectClass: person
+          objectClass: posixAccount
+          userPassword: ${testPassword}
+          homeDirectory: /home/${testUser}
+          uidNumber: 1234
+          gidNumber: 1234
+          cn: ""
+          sn: ""
         '';
       };
     };
 
-    testScript = ''
-      machine.start()
-      machine.wait_for_unit("openldap.service")
-      machine.wait_for_unit("sssd.service")
-      result = machine.execute("getent passwd ${testUser}")
-      if result[0] == 0:
-        assert "${testUser}" in result[1]
-      else:
-        machine.wait_for_console_text("Backend is online")
-        machine.succeed("getent passwd ${testUser}")
+    services.sssd = {
+      enable = true;
+      # just for testing purposes, don't put this into the Nix store in production!
+      environmentFile = "${pkgs.writeText "ldap-root" "LDAP_BIND_PW=${ldapRootPassword}"}";
+      config = ''
+        [sssd]
+        config_file_version = 2
+        services = nss, pam, sudo
+        domains = ${dbDomain}
 
-      with subtest("Log in as ${testUser}"):
-          machine.wait_until_tty_matches("1", "login: ")
-          machine.send_chars("${testUser}\n")
-          machine.wait_until_tty_matches("1", "login: ${testUser}")
-          machine.wait_until_succeeds("pgrep login")
-          machine.wait_until_tty_matches("1", "Password: ")
-          machine.send_chars("${testPassword}\n")
-          machine.wait_until_succeeds("pgrep -u ${testUser} bash")
-          machine.send_chars("touch done\n")
-          machine.wait_for_file("/home/${testUser}/done")
+        [domain/${dbDomain}]
+        auth_provider = ldap
+        id_provider = ldap
+        ldap_uri = ldaps://127.0.0.1:636
+        ldap_tls_reqcert = allow
+        ldap_tls_cacert = /etc/cert.pem
+        ldap_search_base = ${dbSuffix}
+        ldap_default_bind_dn = cn=${ldapRootUser},${dbSuffix}
+        ldap_default_authtok_type = password
+        ldap_default_authtok = $LDAP_BIND_PW
+      '';
+    };
+  };
 
-      with subtest("Change ${testUser}'s password"):
-          machine.send_chars("passwd\n")
-          machine.wait_until_tty_matches("1", "Current Password: ")
-          machine.send_chars("${testPassword}\n")
-          machine.wait_until_tty_matches("1", "New Password: ")
-          machine.send_chars("${testNewPassword}\n")
-          machine.wait_until_tty_matches("1", "Reenter new Password: ")
-          machine.send_chars("${testNewPassword}\n")
-          machine.wait_until_tty_matches("1", "passwd: password updated successfully")
-          machine.send_chars("exit\n")
+  testScript = ''
+    machine.start()
+    machine.wait_for_unit("openldap.service")
+    machine.wait_for_unit("sssd.service")
+    result = machine.execute("getent passwd ${testUser}")
+    if result[0] == 0:
+      assert "${testUser}" in result[1]
+    else:
+      machine.wait_for_console_text("Backend is online")
+      machine.succeed("getent passwd ${testUser}")
 
-      with subtest("Log in as ${testUser} with new password"):
-          machine.wait_until_tty_matches("1", "login: ")
-          machine.send_chars("${testUser}\n")
-          machine.wait_until_tty_matches("1", "login: ${testUser}")
-          machine.wait_until_succeeds("pgrep login")
-          machine.wait_until_tty_matches("1", "Password: ")
-          machine.send_chars("${testNewPassword}\n")
-          machine.wait_until_succeeds("pgrep -u ${testUser} bash")
-          machine.send_chars("touch done2\n")
-          machine.wait_for_file("/home/${testUser}/done2")
-    '';
-  })
+    with subtest("Log in as ${testUser}"):
+        machine.wait_until_tty_matches("1", "login: ")
+        machine.send_chars("${testUser}\n")
+        machine.wait_until_tty_matches("1", "login: ${testUser}")
+        machine.wait_until_succeeds("pgrep login")
+        machine.wait_until_tty_matches("1", "Password: ")
+        machine.send_chars("${testPassword}\n")
+        machine.wait_until_succeeds("pgrep -u ${testUser} bash")
+        machine.send_chars("touch done\n")
+        machine.wait_for_file("/home/${testUser}/done")
+
+    with subtest("Change ${testUser}'s password"):
+        machine.send_chars("passwd\n")
+        machine.wait_until_tty_matches("1", "Current Password: ")
+        machine.send_chars("${testPassword}\n")
+        machine.wait_until_tty_matches("1", "New Password: ")
+        machine.send_chars("${testNewPassword}\n")
+        machine.wait_until_tty_matches("1", "Reenter new Password: ")
+        machine.send_chars("${testNewPassword}\n")
+        machine.wait_until_tty_matches("1", "passwd: password updated successfully")
+        machine.send_chars("exit\n")
+
+    with subtest("Log in as ${testUser} with new password"):
+        machine.wait_until_tty_matches("1", "login: ")
+        machine.send_chars("${testUser}\n")
+        machine.wait_until_tty_matches("1", "login: ${testUser}")
+        machine.wait_until_succeeds("pgrep login")
+        machine.wait_until_tty_matches("1", "Password: ")
+        machine.send_chars("${testNewPassword}\n")
+        machine.wait_until_succeeds("pgrep -u ${testUser} bash")
+        machine.send_chars("touch done2\n")
+        machine.wait_for_file("/home/${testUser}/done2")
+  '';
+})

--- a/nixos/tests/sssd-ldap.nix
+++ b/nixos/tests/sssd-ldap.nix
@@ -6,96 +6,165 @@ let
   ldapRootPassword = "foobar";
 
   testUser = "alice";
-in import ./make-test-python.nix ({pkgs, ...}: {
-  name = "sssd-ldap";
+  testPassword = "foobar";
+  testNewPassword = "barfoo";
+in
+  import ./make-test-python.nix ({pkgs, ...}: {
+    name = "sssd-ldap";
 
-  meta = with pkgs.lib.maintainers; {
-    maintainers = [ bbigras ];
-  };
+    meta = with pkgs.lib.maintainers; {
+      maintainers = [bbigras];
+    };
 
-  nodes.machine = { pkgs, ... }: {
-    services.openldap = {
-      enable = true;
-      settings = {
-        children = {
-          "cn=schema".includes = [
-            "${pkgs.openldap}/etc/schema/core.ldif"
-            "${pkgs.openldap}/etc/schema/cosine.ldif"
-            "${pkgs.openldap}/etc/schema/inetorgperson.ldif"
-            "${pkgs.openldap}/etc/schema/nis.ldif"
-          ];
-          "olcDatabase={1}mdb" = {
-            attrs = {
-              objectClass = [ "olcDatabaseConfig" "olcMdbConfig" ];
-              olcDatabase = "{1}mdb";
-              olcDbDirectory = "/var/lib/openldap/db";
-              olcSuffix = dbSuffix;
-              olcRootDN = "cn=${ldapRootUser},${dbSuffix}";
-              olcRootPW = ldapRootPassword;
+    nodes.machine = {pkgs, ...}: {
+      security.pam.services.systemd-user.makeHomeDir = true;
+      environment.etc."cert.pem".text = builtins.readFile ./common/acme/server/acme.test.cert.pem;
+      environment.etc."key.pem".text = builtins.readFile ./common/acme/server/acme.test.key.pem;
+      services.openldap = {
+        enable = true;
+        urlList = [ "ldap:///" "ldaps:///" ];
+        settings = {
+          attrs = {
+            olcLogLevel = "conns config";
+            olcTLSCACertificateFile = "/etc/cert.pem";
+            olcTLSCertificateFile = "/etc/cert.pem";
+            olcTLSCertificateKeyFile = "/etc/key.pem";
+            olcTLSCipherSuite = "HIGH:MEDIUM:+3DES:+RC4:+aNULL";
+            olcTLSCRLCheck = "none";
+            olcTLSVerifyClient = "never";
+            olcTLSProtocolMin = "3.1";
+          };
+          children = {
+            "cn=schema".includes = [
+              "${pkgs.openldap}/etc/schema/core.ldif"
+              "${pkgs.openldap}/etc/schema/cosine.ldif"
+              "${pkgs.openldap}/etc/schema/inetorgperson.ldif"
+              "${pkgs.openldap}/etc/schema/nis.ldif"
+            ];
+            "olcDatabase={1}mdb" = {
+              attrs = {
+                objectClass = ["olcDatabaseConfig" "olcMdbConfig"];
+                olcDatabase = "{1}mdb";
+                olcDbDirectory = "/var/lib/openldap/db";
+                olcSuffix = dbSuffix;
+                olcRootDN = "cn=${ldapRootUser},${dbSuffix}";
+                olcRootPW = ldapRootPassword;
+                olcAccess = [
+                  /*
+                  custom access rules for userPassword attributes
+                  */
+                  ''
+                    {0}to attrs=userPassword
+                                      by self write
+                                      by anonymous auth
+                                      by * none''
+
+                  /*
+                  allow read on anything else
+                  */
+                  ''
+                    {1}to *
+                                      by * read''
+                ];
+              };
             };
           };
         };
+        declarativeContents = {
+          ${dbSuffix} = ''
+            dn: ${dbSuffix}
+            objectClass: top
+            objectClass: dcObject
+            objectClass: organization
+            o: ${dbDomain}
+
+            dn: ou=posix,${dbSuffix}
+            objectClass: top
+            objectClass: organizationalUnit
+
+            dn: ou=accounts,ou=posix,${dbSuffix}
+            objectClass: top
+            objectClass: organizationalUnit
+
+            dn: uid=${testUser},ou=accounts,ou=posix,${dbSuffix}
+            objectClass: person
+            objectClass: posixAccount
+            userPassword: ${testPassword}
+            homeDirectory: /home/${testUser}
+            uidNumber: 1234
+            gidNumber: 1234
+            cn: ""
+            sn: ""
+          '';
+        };
       };
-      declarativeContents = {
-        ${dbSuffix} = ''
-          dn: ${dbSuffix}
-          objectClass: top
-          objectClass: dcObject
-          objectClass: organization
-          o: ${dbDomain}
 
-          dn: ou=posix,${dbSuffix}
-          objectClass: top
-          objectClass: organizationalUnit
+      services.sssd = {
+        enable = true;
+        # just for testing purposes, don't put this into the Nix store in production!
+        environmentFile = "${pkgs.writeText "ldap-root" "LDAP_BIND_PW=${ldapRootPassword}"}";
+        config = ''
+          [sssd]
+          config_file_version = 2
+          services = nss, pam, sudo
+          domains = ${dbDomain}
 
-          dn: ou=accounts,ou=posix,${dbSuffix}
-          objectClass: top
-          objectClass: organizationalUnit
-
-          dn: uid=${testUser},ou=accounts,ou=posix,${dbSuffix}
-          objectClass: person
-          objectClass: posixAccount
-          # userPassword: somePasswordHash
-          homeDirectory: /home/${testUser}
-          uidNumber: 1234
-          gidNumber: 1234
-          cn: ""
-          sn: ""
+          [domain/${dbDomain}]
+          auth_provider = ldap
+          id_provider = ldap
+          ldap_uri = ldaps://127.0.0.1:636
+          ldap_tls_reqcert = allow
+          ldap_tls_cacert = /etc/cert.pem
+          ldap_search_base = ${dbSuffix}
+          ldap_default_bind_dn = cn=${ldapRootUser},${dbSuffix}
+          ldap_default_authtok_type = password
+          ldap_default_authtok = $LDAP_BIND_PW
         '';
       };
     };
 
-    services.sssd = {
-      enable = true;
-      # just for testing purposes, don't put this into the Nix store in production!
-      environmentFile = "${pkgs.writeText "ldap-root" "LDAP_BIND_PW=${ldapRootPassword}"}";
-      config = ''
-        [sssd]
-        config_file_version = 2
-        services = nss, pam, sudo
-        domains = ${dbDomain}
+    testScript = ''
+      machine.start()
+      machine.wait_for_unit("openldap.service")
+      machine.wait_for_unit("sssd.service")
+      result = machine.execute("getent passwd ${testUser}")
+      if result[0] == 0:
+        assert "${testUser}" in result[1]
+      else:
+        machine.wait_for_console_text("Backend is online")
+        machine.succeed("getent passwd ${testUser}")
 
-        [domain/${dbDomain}]
-        auth_provider = ldap
-        id_provider = ldap
-        ldap_uri = ldap://127.0.0.1:389
-        ldap_search_base = ${dbSuffix}
-        ldap_default_bind_dn = cn=${ldapRootUser},${dbSuffix}
-        ldap_default_authtok_type = password
-        ldap_default_authtok = $LDAP_BIND_PW
-      '';
-    };
-  };
+      with subtest("Log in as ${testUser}"):
+          machine.wait_until_tty_matches("1", "login: ")
+          machine.send_chars("${testUser}\n")
+          machine.wait_until_tty_matches("1", "login: ${testUser}")
+          machine.wait_until_succeeds("pgrep login")
+          machine.wait_until_tty_matches("1", "Password: ")
+          machine.send_chars("${testPassword}\n")
+          machine.wait_until_succeeds("pgrep -u ${testUser} bash")
+          machine.send_chars("touch done\n")
+          machine.wait_for_file("/home/${testUser}/done")
 
-  testScript = ''
-    machine.start()
-    machine.wait_for_unit("openldap.service")
-    machine.wait_for_unit("sssd.service")
-    result = machine.execute("getent passwd ${testUser}")
-    if result[0] == 0:
-      assert "${testUser}" in result[1]
-    else:
-      machine.wait_for_console_text("Backend is online")
-      machine.succeed("getent passwd ${testUser}")
-  '';
-})
+      with subtest("Change ${testUser}'s password"):
+          machine.send_chars("passwd\n")
+          machine.wait_until_tty_matches("1", "Current Password: ")
+          machine.send_chars("${testPassword}\n")
+          machine.wait_until_tty_matches("1", "New Password: ")
+          machine.send_chars("${testNewPassword}\n")
+          machine.wait_until_tty_matches("1", "Reenter new Password: ")
+          machine.send_chars("${testNewPassword}\n")
+          machine.wait_until_tty_matches("1", "passwd: password updated successfully")
+          machine.send_chars("exit\n")
+
+      with subtest("Log in as ${testUser} with new password"):
+          machine.wait_until_tty_matches("1", "login: ")
+          machine.send_chars("${testUser}\n")
+          machine.wait_until_tty_matches("1", "login: ${testUser}")
+          machine.wait_until_succeeds("pgrep login")
+          machine.wait_until_tty_matches("1", "Password: ")
+          machine.send_chars("${testNewPassword}\n")
+          machine.wait_until_succeeds("pgrep -u ${testUser} bash")
+          machine.send_chars("touch done2\n")
+          machine.wait_for_file("/home/${testUser}/done2")
+    '';
+  })

--- a/pkgs/os-specific/linux/pam/default.nix
+++ b/pkgs/os-specific/linux/pam/default.nix
@@ -44,7 +44,7 @@ stdenv.mkDerivation rec {
   doCheck = false; # fails
 
   passthru.tests = {
-    inherit (nixosTests) pam-oath-login pam-u2f shadow;
+    inherit (nixosTests) pam-oath-login pam-u2f shadow sssd-ldap;
   };
 
   meta = with lib; {


### PR DESCRIPTION
###### Description of changes

Modify the pam configuration for sssd to not use `use_authtok`, as the it swallows password change prompts, and otherwise doesn't appear to make a difference.

Also expanded the nixos `sssd-ldap` tests to test login and password change scenarios. This required adding TLS certificates to the openldap server in `sssd-ldap`, as you cannot login without TLS.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
