### PR TITLE
python3Packages.lmfit: init at 1.2.1

### DIFF
--- a/pkgs/development/python-modules/lmfit/default.nix
+++ b/pkgs/development/python-modules/lmfit/default.nix
@@ -1,0 +1,61 @@
+{ lib,
+  buildPythonPackage,
+  fetchPypi,
+  setuptools,
+  setuptools-scm,
+  asteval,
+  numpy,
+  scipy,
+  uncertainties,
+  pytestCheckHook,
+  pandas,
+  matplotlib,
+}:
+
+buildPythonPackage rec {
+  pname = "lmfit";
+  version = "1.2.1";
+
+  format = "pyproject";
+
+  src = fetchPypi {
+    inherit pname version;
+    hash = "sha256-AM71vRRb+BtzYwt4kmrySyTxgFQh5iEcpYVYiqfMQVs=";
+  };
+
+  postPatch = ''
+    substituteInPlace setup.cfg --replace "--cov=lmfit --cov-report html" ""
+  '';
+
+  nativeBuildInputs = [
+    setuptools
+    setuptools-scm
+  ];
+
+  propagatedBuildInputs = [
+    asteval
+    numpy
+    scipy
+    uncertainties
+  ];
+
+  nativeCheckInputs = [
+    pytestCheckHook
+    pandas
+    matplotlib
+  ];
+
+  disabledTests = [
+    # https://github.com/lmfit/lmfit-py/issues/878
+    "test_emcee_multiprocessing"
+    "test_explicit_independent_vars"
+    "test_result_eval_custom_x"
+  ];
+
+  meta = with lib; {
+    description = "Least-Squares Minimization with Bounds and Constraints";
+    homepage = "https://lmfit-py.readthedocs.io/";
+    license = licenses.bsd3;
+    maintainers = with maintainers; [ nomeata ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5777,6 +5777,8 @@ self: super: with self; {
     inherit (pkgs) lmdb;
   };
 
+  lmfit = callPackage ../development/python-modules/lmfit { };
+
   lml = callPackage ../development/python-modules/lml { };
 
   lmnotify = callPackage ../development/python-modules/lmnotify { };


### PR DESCRIPTION
###### Description of changes

Adds a new python package. Yay, more packages!

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable: Unit tests run, basic usage works.
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
