### PR TITLE
getoptions: Don't require busybox on macOS

### DIFF
--- a/pkgs/tools/misc/getoptions/default.nix
+++ b/pkgs/tools/misc/getoptions/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenvNoCC, fetchFromGitHub, shellcheck, shellspec, busybox-sandbox-shell, ksh, mksh, yash, zsh }:
+{ lib, stdenvNoCC, fetchFromGitHub, shellspec, busybox-sandbox-shell, ksh, mksh, yash, zsh }:
 
 stdenvNoCC.mkDerivation rec {
   pname = "getoptions";
@@ -15,13 +15,16 @@ stdenvNoCC.mkDerivation rec {
 
   doCheck = true;
 
-  nativeCheckInputs = [ shellcheck shellspec busybox-sandbox-shell ksh mksh yash zsh ];
+  nativeCheckInputs = [ shellspec ksh mksh yash zsh ]
+    ++ lib.lists.optional (!stdenvNoCC.isDarwin) busybox-sandbox-shell;
 
   preCheck = ''
     sed -i '/shellspec -s posh/d' Makefile
+    '' + lib.strings.optionalString stdenvNoCC.isDarwin ''
+    sed -i "/shellspec -s 'busybox ash'/d" Makefile
   '';
 
-  checkTarget = "check testall";
+  checkTarget = "testall";
 
   meta = with lib; {
     description = "An elegant option/argument parser for shell scripts (full support for bash and all POSIX shells)";


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

I made the dependency on busybox conditional as it does not exist on macOS in nixpkgs.
I also changed the `checkTarget` to remove `check` based on [upstream](https://github.com/ko1nksm/getoptions/blob/a6c2df16302a2d0cd4cafb5396ef3421b2c3a1aa/.github/workflows/test.yml#L24) (this caused the tests to pass for me).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
