### PR TITLE
stdenv/darwin: set NIX_COREFOUNDATION_RPATH via hook

### DIFF
--- a/pkgs/os-specific/darwin/swift-corelibs/corefoundation-setup-hook.sh
+++ b/pkgs/os-specific/darwin/swift-corelibs/corefoundation-setup-hook.sh
@@ -1,0 +1,8 @@
+useCoreFoundationFramework () {
+  # Avoid overriding value set by the impure CF
+  if [ -z "${NIX_COREFOUNDATION_RPATH+x}" ]; then
+    export NIX_COREFOUNDATION_RPATH=@out@/Library/Frameworks
+  fi
+}
+
+addEnvHooks "$hostOffset" useCoreFoundationFramework

--- a/pkgs/os-specific/darwin/swift-corelibs/corefoundation.nix
+++ b/pkgs/os-specific/darwin/swift-corelibs/corefoundation.nix
@@ -1,4 +1,5 @@
-{ lib, stdenv, fetchFromGitHub, fetchurl, ninja, python3, curl, libxml2, objc4, ICU }:
+{ lib, stdenv, fetchFromGitHub, fetchurl, ninja, python3, curl, libxml2, objc4, ICU
+, withRpathHook ? true }:
 
 let
   # 10.12 adds a new sysdir.h that our version of CF in the main derivation depends on, but
@@ -10,7 +11,7 @@ let
   };
 in
 
-stdenv.mkDerivation {
+stdenv.mkDerivation ({
   pname = "swift-corefoundation";
   version = "unstable-2018-09-14";
 
@@ -104,4 +105,6 @@ stdenv.mkDerivation {
       ln -s Versions/Current/$i $base/$i
     done
   '';
-}
+} // lib.optionalAttrs withRpathHook {
+  setupHook = ./corefoundation-setup-hook.sh;
+})


### PR DESCRIPTION
This will unset the variable in the cross stdenv where CF is taken out of extraBuildInputs. This is useful for cross compilation to linux where setting RPATH on glibc will break it in runtime.

The hook needs to be turned off during the bootstrapping to prevent unwanted references between the stages.

This is a updated version of https://github.com/NixOS/nixpkgs/pull/111385 authored by @veprbl.

CC @LnL7 who reviewed the original PR.

Closes #111385

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
