### PR TITLE
nixosTests.gitea,nixosTests.forgejo,nixosTests.wiki-js: fix test on `i686-linux`

### DIFF
--- a/nixos/tests/gitea.nix
+++ b/nixos/tests/gitea.nix
@@ -30,7 +30,7 @@ let
 
     nodes = {
       server = { config, pkgs, ... }: {
-        virtualisation.memorySize = 2048;
+        virtualisation.memorySize = 2047;
         services.gitea = {
           enable = true;
           database = { inherit type; };

--- a/nixos/tests/wiki-js.nix
+++ b/nixos/tests/wiki-js.nix
@@ -5,7 +5,7 @@ import ./make-test-python.nix ({ pkgs, lib, ...} : {
   };
 
   nodes.machine = { pkgs, ... }: {
-    virtualisation.memorySize = 2048;
+    virtualisation.memorySize = 2047;
     services.wiki-js = {
       enable = true;
       settings.db.host = "/run/postgresql";


### PR DESCRIPTION
###### Description of changes

Fail pattern:
1. Unsuspecting `qemu-kvm` notice:
```
server # qemu-kvm: at most 2047 MB RAM can be simulated
```

2. Hard fail
```
Traceback (most recent call last):
  File "/nix/store/xyn5cv0cdsya888ip6bhjma20z10zr9n-nixos-test-driver-1.1/bin/.nixos-test-driver-wrapped", line 9, in <module>
    sys.exit(main())
  File "/nix/store/xyn5cv0cdsya888ip6bhjma20z10zr9n-nixos-test-driver-1.1/lib/python3.10/site-packages/test_driver/__init__.py", line 112, in main
    driver.run_tests()
  File "/nix/store/xyn5cv0cdsya888ip6bhjma20z10zr9n-nixos-test-driver-1.1/lib/python3.10/site-packages/test_driver/driver.py", line 147, in run_tests
    self.test_script()
  File "/nix/store/xyn5cv0cdsya888ip6bhjma20z10zr9n-nixos-test-driver-1.1/lib/python3.10/site-packages/test_driver/driver.py", line 143, in test_script
    exec(self.tests, symbols, None)
  File "<string>", line 2, in <module>
  File "/nix/store/xyn5cv0cdsya888ip6bhjma20z10zr9n-nixos-test-driver-1.1/lib/python3.10/site-packages/test_driver/machine.py", line 452, in wait_for_unit
    retry(check_active, timeout)
  File "/nix/store/xyn5cv0cdsya888ip6bhjma20z10zr9n-nixos-test-driver-1.1/lib/python3.10/site-packages/test_driver/machine.py", line 126, in retry
    if fn(False):
  File "/nix/store/xyn5cv0cdsya888ip6bhjma20z10zr9n-nixos-test-driver-1.1/lib/python3.10/site-packages/test_driver/machine.py", line 432, in check_active
    info = self.get_unit_info(unit, user)
  File "/nix/store/xyn5cv0cdsya888ip6bhjma20z10zr9n-nixos-test-driver-1.1/lib/python3.10/site-packages/test_driver/machine.py", line 455, in get_unit_info
    status, lines = self.systemctl(f'--no-pager show "{unit}"', user)
  File "/nix/store/xyn5cv0cdsya888ip6bhjma20z10zr9n-nixos-test-driver-1.1/lib/python3.10/site-packages/test_driver/machine.py", line 484, in systemctl
    return self.execute(f"systemctl {q}")
  File "/nix/store/xyn5cv0cdsya888ip6bhjma20z10zr9n-nixos-test-driver-1.1/lib/python3.10/site-packages/test_driver/machine.py", line 532, in execute
    self.shell.send(out_command.encode())
```

(Took me a while to consider those lines are related)

See
https://hydra.nixos.org/build/218857277
https://hydra.nixos.org/build/218857285
https://hydra.nixos.org/build/218857515/ 

#230712

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [x] i686-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
