### PR TITLE
openvr: mark as broken on Darwin

### DIFF
--- a/pkgs/development/libraries/openvr/default.nix
+++ b/pkgs/development/libraries/openvr/default.nix
@@ -47,7 +47,8 @@ stdenv.mkDerivation rec {
 
   cmakeFlags = [ "-DUSE_SYSTEM_JSONCPP=ON" "-DBUILD_SHARED=1" ];
 
-  meta = with lib;{
+  meta = with lib; {
+    broken = stdenv.isDarwin;
     homepage = "https://github.com/ValveSoftware/openvr";
     description = "An API and runtime that allows access to VR hardware from multiple vendors without requiring that applications have specific knowledge of the hardware they are targeting";
     license = licenses.bsd3;

--- a/pkgs/development/libraries/openvr/default.nix
+++ b/pkgs/development/libraries/openvr/default.nix
@@ -5,6 +5,8 @@
 , jsoncpp
 , fetchFromGitHub
 , fetchpatch2
+, Foundation
+, AppKit
 }:
 
 stdenv.mkDerivation rec {
@@ -41,7 +43,7 @@ stdenv.mkDerivation rec {
   '';
 
   nativeBuildInputs = [ cmake ];
-  buildInputs = [ jsoncpp libGL ];
+  buildInputs = [ jsoncpp libGL ] ++ lib.optionals stdenv.isDarwin [ Foundation AppKit ];
 
   cmakeFlags = [ "-DUSE_SYSTEM_JSONCPP=ON" "-DBUILD_SHARED=1" ];
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -23163,7 +23163,9 @@ with pkgs;
 
   openvdb = callPackage ../development/libraries/openvdb { };
 
-  openvr = callPackage ../development/libraries/openvr { };
+  openvr = callPackage ../development/libraries/openvr {
+    inherit (darwin.apple_sdk.frameworks) Foundation AppKit;
+  };
 
   inherit (callPackages ../development/libraries/libressl { })
     libressl_3_4


### PR DESCRIPTION
###### Description of changes
This adds CoreFoundation and AppKit as build inputs in an attempt to fix Darwin builds. From my limited testing this doesn't seem to be enough, as the compilation will still fail with the following error:

```
[ 11%] Building CXX object src/CMakeFiles/openvr_api.dir/vrcore/dirtools_public.cpp.o
[ 22%] Building CXX object src/CMakeFiles/openvr_api.dir/vrcore/pathtools_public.cpp.o
[ 44%] Building CXX object src/CMakeFiles/openvr_api.dir/vrcore/envvartools_public.cpp.o
[ 44%] Building CXX object src/CMakeFiles/openvr_api.dir/openvr_api_public.cpp.o
[ 55%] Building CXX object src/CMakeFiles/openvr_api.dir/vrcore/hmderrors_public.cpp.o
[ 66%] Building CXX object src/CMakeFiles/openvr_api.dir/vrcore/sharedlibtools_public.cpp.o
[ 77%] Building CXX object src/CMakeFiles/openvr_api.dir/vrcore/strtools_public.cpp.o
[ 88%] Building CXX object src/CMakeFiles/openvr_api.dir/vrcore/vrpathregistry_public.cpp.o
[100%] Linking CXX shared library /tmp/nix-build-openvr-1.23.8.drv-0/source/bin/osx64/libopenvr_api.dylib
fatal error: /nix/store/qm48dbbhmqk70hm35s9hzbmgvwd6slvs-cctools-binutils-darwin-973.0.1/bin/lipo: /private/tmp/nix-build-openvr-1.23.8.drv-0/-d51d9b.out and /private/tmp/nix-build-openvr-1.23.8.drv-0/-429727.out have the same architectures (x86_64) and can't be in the same fat output file
clang-11: error: lipo command failed with exit code 1 (use -v to see invocation)
make[2]: *** [src/CMakeFiles/openvr_api.dir/build.make:209: /tmp/nix-build-openvr-1.23.8.drv-0/source/bin/osx64/libopenvr_api.dylib] Error 1
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
