### PR TITLE
wasmtime: run tests depending on the platform features

### DIFF
--- a/pkgs/development/interpreters/wasmtime/default.nix
+++ b/pkgs/development/interpreters/wasmtime/default.nix
@@ -14,23 +14,15 @@ rustPlatform.buildRustPackage rec {
 
   cargoHash = "sha256-A2JhjRFKPltHubiJYHBXj2H4cdU43Y2x6UjEpRGPX7U=";
 
-  cargoBuildFlags = [
-    "--package wasmtime-cli"
-    "--package wasmtime-c-api"
-  ];
+  cargoBuildFlags = [ "--package" "wasmtime-cli" "--package" "wasmtime-c-api" ];
 
   outputs = [ "out" "dev" ];
 
-  # We disable tests on x86_64-darwin because Hydra runners do not
-  # support SSE3, SSSE3, SSE4.1 and SSE4.2 at this time. This is
-  # required by wasmtime. Given this is very specific to Hydra
-  # runners, just disable tests on this platform, so we don't get
-  # false positives of this package being broken due to failed runs on
-  # Hydra (e.g. https://hydra.nixos.org/build/187667794/)
-  doCheck = (stdenv.system != "x86_64-darwin");
-  cargoTestFlags = [
-    "--package wasmtime-runtime"
-  ];
+  # SIMD tests are only executed on platforms that support all
+  # required processor features (e.g. SSE3, SSSE3, SSE4.1 and SSE4.2 on x86_64):
+  # https://github.com/bytecodealliance/wasmtime/blob/207cd1ce15ecc504dafaec490c5eae801cac4691/cranelift/codegen/src/isa/x64/mod.rs#L228
+  doCheck = with stdenv.buildPlatform; (isx86_64 -> sse3Support && ssse3Support && sse4_1Support && sse4_2Support);
+  cargoTestFlags = ["--package" "wasmtime-runtime"];
 
   postInstall = ''
     # move libs from out to dev
@@ -45,7 +37,8 @@ rustPlatform.buildRustPackage rec {
   '';
 
   meta = with lib; {
-    description = "Standalone JIT-style runtime for WebAssembly, using Cranelift";
+    description =
+      "Standalone JIT-style runtime for WebAssembly, using Cranelift";
     homepage = "https://github.com/bytecodealliance/wasmtime";
     license = licenses.asl20;
     maintainers = with maintainers; [ ereslibre matthewbauer ];


### PR DESCRIPTION
Run tests depending on the platform features reported by stdenv.

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
