### PR TITLE
gamescope: 3.11.52-beta6 -> 3.12.0-beta9

### DIFF
--- a/pkgs/applications/window-managers/gamescope/default.nix
+++ b/pkgs/applications/window-managers/gamescope/default.nix
@@ -1,6 +1,5 @@
 { stdenv
 , fetchFromGitHub
-, fetchpatch
 , meson
 , pkg-config
 , ninja
@@ -11,6 +10,8 @@
 , wayland
 , wayland-protocols
 , libxkbcommon
+, glm
+, gbenchmark
 , libcap
 , SDL2
 , pipewire
@@ -31,13 +32,13 @@
 }:
 let
   pname = "gamescope";
-  version = "3.11.52-beta6";
+  version = "3.12.0-beta9";
 
   vkroots = fetchFromGitHub {
     owner = "Joshua-Ashton";
     repo = "vkroots";
     rev = "26757103dde8133bab432d172b8841df6bb48155";
-    sha256 = "sha256-eet+FMRO2aBQJcCPOKNKGuQv5oDIrgdVPRO00c5gkL0=";
+    hash = "sha256-eet+FMRO2aBQJcCPOKNKGuQv5oDIrgdVPRO00c5gkL0=";
   };
 in
 stdenv.mkDerivation {
@@ -47,36 +48,11 @@ stdenv.mkDerivation {
     owner = "ValveSoftware";
     repo = "gamescope";
     rev = "refs/tags/${version}";
-    hash = "sha256-2gn6VQfmwwl86mmnRh+J1uxSIpA5x/Papq578seJ3n8=";
+    hash = "sha256-nPFHMRp3uq2CIxY3EdaoTltqyb5z0kFwXw5U9ajbrfo=";
   };
 
   patches = [
     ./use-pkgconfig.patch
-
-    # https://github.com/Plagman/gamescope/pull/811
-    (fetchpatch {
-      name = "fix-openvr-dependency-name.patch";
-      url = "https://github.com/Plagman/gamescope/commit/557e56badec7d4c56263d3463ca9cdb195e368d7.patch";
-      sha256 = "sha256-9Y1tJ24EsdtZEOCEA30+FJBrdzXX+Nj3nTb5kgcPfBE=";
-    })
-    # https://github.com/Plagman/gamescope/pull/813
-    (fetchpatch {
-      name = "fix-openvr-include.patch";
-      url = "https://github.com/Plagman/gamescope/commit/1331b9f81ea4b3ae692a832ed85a464c3fd4c5e9.patch";
-      sha256 = "sha256-wDtFpM/nMcqSbIpR7K5Tyf0845r3l4kQHfwll1VL4Mc=";
-    })
-    # https://github.com/Plagman/gamescope/pull/812
-    (fetchpatch {
-      name = "bump-libdisplay-info-maximum-version.patch";
-      url = "https://github.com/Plagman/gamescope/commit/b430c5b9a05951755051fd4e41ce20496705fbbc.patch";
-      sha256 = "sha256-YHtwudMUHiE8i3ZbiC9gkSjrlS0/7ydjmJsY1a8ZI2E=";
-    })
-    # https://github.com/Plagman/gamescope/pull/824
-    (fetchpatch {
-      name = "update-libdisplay-info-pkgconfig-filename.patch";
-      url = "https://github.com/Plagman/gamescope/commit/5a672f09aa07c7c5d674789f3c685c8173e7a2cf.patch";
-      sha256 = "sha256-7NX54WIsJDvZT3C58N2FQasV9PJyKkJrLGYS1r4f+kc=";
-    })
   ];
 
   nativeBuildInputs = [
@@ -109,6 +85,8 @@ stdenv.mkDerivation {
     seatd
     libinput
     libxkbcommon
+    glm
+    gbenchmark
     udev
     pixman
     pipewire


### PR DESCRIPTION
###### Description of changes

gamescope: 3.11.52-beta6 -> 3.12.0-beta9

glm was added as a dependency in 3.12.0-beta1.[[0]]
gbenchmark was added as a dependency in 3.12.0-beta4.[[1]]

The patches that were previously needed for 3.11.52-beta6 were merged upstream.[[2]][[3]][[4]][[5]]

There are no other noteworthy packaging changes: https://github.com/ValveSoftware/gamescope/compare/3.11.52-beta6...3.12.0-beta9

[0]: https://github.com/ValveSoftware/gamescope/pull/849
[1]: https://github.com/ValveSoftware/gamescope/pull/872
[2]: https://github.com/ValveSoftware/gamescope/pull/811
[3]: https://github.com/ValveSoftware/gamescope/pull/813
[4]: https://github.com/ValveSoftware/gamescope/pull/812
[5]: https://github.com/ValveSoftware/gamescope/pull/824

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
