### PR TITLE
 koreader: 2022.08 -> 2023.04 

### DIFF
--- a/pkgs/applications/misc/koreader/default.nix
+++ b/pkgs/applications/misc/koreader/default.nix
@@ -9,14 +9,17 @@
 , luajit
 , sdcv
 , SDL2 }:
+let
+  luajit_lua52 = luajit.override { enable52Compat = true; };
+in
 stdenv.mkDerivation rec {
   pname = "koreader";
-  version = "2022.08";
+  version = "2023.04";
 
   src = fetchurl {
     url =
       "https://github.com/koreader/koreader/releases/download/v${version}/koreader-${version}-amd64.deb";
-    sha256 = "sha256-+JBJNJTAnC5gpuo8cehfe/3YwGIW5iFA8bZ8nfz9qsk=";
+    sha256 = "sha256-tRUeRB1+UcWT49dchN0YDvd0L5n1YRdtMSFc8yy6m5o=";
   };
 
   src_repo = fetchFromGitHub {
@@ -24,7 +27,7 @@ stdenv.mkDerivation rec {
     owner = "koreader";
     rev = "v${version}";
     fetchSubmodules = true;
-    sha256 = "sha256-MHQYEzMyZMEQrzR8+Rvci8XjDK2DMUPxjsiWTrrKiAw=";
+    sha256 = "sha256-c3j6hs0W0H2jDg6JVfU6ov7r7kucbqrQqf9PAvYBcJ0=";
   };
 
   sourceRoot = ".";
@@ -33,7 +36,7 @@ stdenv.mkDerivation rec {
     glib
     gnutar
     gtk3-x11
-    luajit
+    luajit_lua52
     sdcv
     SDL2
   ];
@@ -45,7 +48,7 @@ stdenv.mkDerivation rec {
   installPhase = ''
     mkdir -p $out
     cp -R usr/* $out/
-    ln -sf ${luajit}/bin/luajit $out/lib/koreader/luajit
+    ln -sf ${luajit_lua52}/bin/luajit $out/lib/koreader/luajit
     ln -sf ${sdcv}/bin/sdcv $out/lib/koreader/sdcv
     ln -sf ${gnutar}/bin/tar $out/lib/koreader/tar
     find ${src_repo}/resources/fonts -type d -execdir cp -r '{}' $out/lib/koreader/fonts \;


### PR DESCRIPTION
###### Description of changes

[koreader: fix startup](https://github.com/NixOS/nixpkgs/commit/dfd449b9588fae491e5d92d565e1e2e2472d6c5e)

koreader looks for fonts/NotoSans-Regular.ttf at startup but our version
of noto fonts provide different files under different names (eg
NotoSans[wdth,wght].ttf) so koreader crashes.

Let's use the font files provided in the source repo instead. (they are
not in the debian package it seems)

[koreader: 2022.08 -> 2023.04](https://github.com/NixOS/nixpkgs/commit/e12f96e61edad2f8011a2b92c241d19e191f2e58)

changelogs:
https://github.com/koreader/koreader/releases/tag/v2022.10
https://github.com/koreader/koreader/releases/tag/v2022.11
https://github.com/koreader/koreader/releases/tag/v2023.01
https://github.com/koreader/koreader/releases/tag/v2023.03
https://github.com/koreader/koreader/releases/tag/v2023.04

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
