### PR TITLE
linux_*, except testing, 4.14: apply patch for CVE-2023-32233

### DIFF
--- a/pkgs/os-specific/linux/kernel/patches.nix
+++ b/pkgs/os-specific/linux/kernel/patches.nix
@@ -62,4 +62,13 @@
     name = "fix-em-ice-bonding";
     patch = ./fix-em-ice-bonding.patch;
   };
+
+  CVE-2023-32233 = rec {
+    name = "CVE-2023-32233";
+    patch = fetchpatch {
+      name = name + ".patch";
+      url = "https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/patch/?id=c1592a89942e9678f7d9c8030efa777c0d57edab";
+      hash = "sha256-DYPWgraXPNeFkjtuDYkFXHnCJ4yDewrukM2CCAqC2BE=";
+    };
+  };
 }

--- a/pkgs/top-level/linux-kernels.nix
+++ b/pkgs/top-level/linux-kernels.nix
@@ -115,6 +115,7 @@ in {
         [ kernelPatches.bridge_stp_helper
           kernelPatches.request_key_helper
           kernelPatches.modinst_arg_list_too_long
+          kernelPatches.CVE-2023-32233
         ];
     };
 
@@ -123,6 +124,7 @@ in {
         kernelPatches.bridge_stp_helper
         kernelPatches.request_key_helper
         kernelPatches.rtl8761b_support
+        kernelPatches.CVE-2023-32233
       ];
     };
 
@@ -130,6 +132,7 @@ in {
       kernelPatches = [
         kernelPatches.bridge_stp_helper
         kernelPatches.request_key_helper
+        kernelPatches.CVE-2023-32233
       ];
     };
 
@@ -137,6 +140,7 @@ in {
       kernelPatches = [
         kernelPatches.bridge_stp_helper
         kernelPatches.request_key_helper
+        kernelPatches.CVE-2023-32233
       ];
     };
 
@@ -145,6 +149,7 @@ in {
         kernelPatches.bridge_stp_helper
         kernelPatches.request_key_helper
         kernelPatches.export-rt-sched-migrate
+        kernelPatches.CVE-2023-32233
       ];
     };
 
@@ -153,6 +158,7 @@ in {
         kernelPatches.bridge_stp_helper
         kernelPatches.request_key_helper
         kernelPatches.fix-em-ice-bonding
+        kernelPatches.CVE-2023-32233
       ];
     };
 
@@ -169,6 +175,7 @@ in {
         kernelPatches.bridge_stp_helper
         kernelPatches.request_key_helper
         kernelPatches.fix-em-ice-bonding
+        kernelPatches.CVE-2023-32233
       ];
     };
 
@@ -178,6 +185,7 @@ in {
         kernelPatches.request_key_helper
         kernelPatches.fix-em-ice-bonding
         kernelPatches.export-rt-sched-migrate
+        kernelPatches.CVE-2023-32233
       ];
     };
 
@@ -186,6 +194,7 @@ in {
         kernelPatches.bridge_stp_helper
         kernelPatches.request_key_helper
         kernelPatches.fix-em-ice-bonding
+        kernelPatches.CVE-2023-32233
       ];
     };
 
@@ -194,6 +203,7 @@ in {
         kernelPatches.bridge_stp_helper
         kernelPatches.request_key_helper
         kernelPatches.fix-em-ice-bonding
+        kernelPatches.CVE-2023-32233
       ];
     };
 


### PR DESCRIPTION
###### Description of changes

https://www.openwall.com/lists/oss-security/2023/05/08/4

If we don't get any stable kernel before fixing that.

Apply cleanly on:

- [ ] Linux testing: has already the fix
- [x] Linux 6.2
- [x] Linux 6.3
- [x] Linux 6.1
- [x] Linux 6.1 RT
- [x] Linux 5.15
- [x] Linux 5.10
- [x] Linux 5.4
- [x] Linux 4.19
- [ ] Linux 4.14: not relevant

Tested on:

- [ ] Linux testing: has already the fix
- [x] Linux 6.2
- [x] Linux 6.3
- [x] Linux 6.1
- [x] Linux 6.1 RT
- [x] Linux 5.15
- [x] Linux 5.10
- [x] Linux 5.4
- [x] Linux 4.19
- [ ] Linux 4.14: not relevant

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
