### PR TITLE
rustPlatform.rust: deprecate

### DIFF
--- a/doc/languages-frameworks/rust.section.md
+++ b/doc/languages-frameworks/rust.section.md
@@ -535,7 +535,9 @@ directory of the `tokenizers` project's source archive, we use
 ```nix
 { fetchFromGitHub
 , buildPythonPackage
+, cargo
 , rustPlatform
+, rustc
 , setuptools-rust
 }:
 
@@ -558,11 +560,12 @@ buildPythonPackage rec {
 
   sourceRoot = "source/bindings/python";
 
-  nativeBuildInputs = [ setuptools-rust ] ++ (with rustPlatform; [
-    cargoSetupHook
-    rust.cargo
-    rust.rustc
-  ]);
+  nativeBuildInputs = [
+    cargo
+    rustPlatform.cargoSetupHook
+    rustc
+    setuptools-rust
+  ];
 
   # ...
 }

--- a/pkgs/applications/accessibility/contrast/default.nix
+++ b/pkgs/applications/accessibility/contrast/default.nix
@@ -2,6 +2,7 @@
 , lib
 , fetchFromGitLab
 , cairo
+, cargo
 , desktop-file-utils
 , gettext
 , glib
@@ -12,6 +13,7 @@
 , pango
 , pkg-config
 , rustPlatform
+, rustc
 , wrapGAppsHook4
 }:
 
@@ -40,9 +42,9 @@ stdenv.mkDerivation rec {
     meson
     ninja
     pkg-config
-    rustPlatform.rust.cargo
+    cargo
     rustPlatform.cargoSetupHook
-    rustPlatform.rust.rustc
+    rustc
     wrapGAppsHook4
   ];
 

--- a/pkgs/applications/accessibility/squeekboard/default.nix
+++ b/pkgs/applications/accessibility/squeekboard/default.nix
@@ -1,6 +1,7 @@
 { lib
 , stdenv
 , fetchFromGitLab
+, cargo
 , meson
 , ninja
 , pkg-config
@@ -14,6 +15,7 @@
 , libxml2
 , libxkbcommon
 , rustPlatform
+, rustc
 , feedbackd
 , wrapGAppsHook
 , fetchpatch
@@ -54,11 +56,10 @@ stdenv.mkDerivation rec {
     glib
     wayland
     wrapGAppsHook
-  ] ++ (with rustPlatform; [
-    cargoSetupHook
-    rust.cargo
-    rust.rustc
-  ]);
+    rustPlatform.cargoSetupHook
+    cargo
+    rustc
+  ];
 
   buildInputs = [
     gtk3

--- a/pkgs/applications/audio/amberol/default.nix
+++ b/pkgs/applications/audio/amberol/default.nix
@@ -2,12 +2,14 @@
 , stdenv
 , fetchFromGitLab
 , rustPlatform
+, cargo
 , desktop-file-utils
 , appstream-glib
 , meson
 , ninja
 , pkg-config
 , reuse
+, rustc
 , m4
 , wrapGAppsHook4
 , glib
@@ -48,11 +50,10 @@ stdenv.mkDerivation rec {
     reuse
     m4
     wrapGAppsHook4
-  ] ++ (with rustPlatform; [
-    cargoSetupHook
-    rust.cargo
-    rust.rustc
-  ]);
+    rustPlatform.cargoSetupHook
+    cargo
+    rustc
+  ];
 
   buildInputs = [
     glib

--- a/pkgs/applications/audio/gnome-podcasts/default.nix
+++ b/pkgs/applications/audio/gnome-podcasts/default.nix
@@ -3,11 +3,13 @@
 , rustPlatform
 , fetchFromGitLab
 , fetchpatch
+, cargo
 , meson
 , ninja
 , gettext
 , python3
 , pkg-config
+, rustc
 , glib
 , libhandy
 , gtk3
@@ -55,9 +57,9 @@ stdenv.mkDerivation rec {
     pkg-config
     gettext
     python3
-    rustPlatform.rust.cargo
+    cargo
     rustPlatform.cargoSetupHook
-    rustPlatform.rust.rustc
+    rustc
     wrapGAppsHook
     glib
   ];

--- a/pkgs/applications/audio/helvum/default.nix
+++ b/pkgs/applications/audio/helvum/default.nix
@@ -1,4 +1,5 @@
 { lib
+, cargo
 , clang
 , desktop-file-utils
 , fetchFromGitLab
@@ -11,6 +12,7 @@
 , pipewire
 , pkg-config
 , rustPlatform
+, rustc
 , stdenv
 }:
 
@@ -38,8 +40,8 @@ stdenv.mkDerivation rec {
     ninja
     pkg-config
     rustPlatform.cargoSetupHook
-    rustPlatform.rust.cargo
-    rustPlatform.rust.rustc
+    cargo
+    rustc
     rustPlatform.bindgenHook
   ];
 

--- a/pkgs/applications/audio/mousai/default.nix
+++ b/pkgs/applications/audio/mousai/default.nix
@@ -2,6 +2,7 @@
 , stdenv
 , fetchFromGitHub
 , appstream-glib
+, cargo
 , dbus
 , desktop-file-utils
 , glib
@@ -16,6 +17,7 @@
 , ninja
 , pkg-config
 , rustPlatform
+, rustc
 , wrapGAppsHook4
 }:
 
@@ -43,11 +45,10 @@ stdenv.mkDerivation rec {
     ninja
     pkg-config
     wrapGAppsHook4
-  ] ++ (with rustPlatform; [
-    cargoSetupHook
-    rust.cargo
-    rust.rustc
-  ]);
+    rustPlatform.cargoSetupHook
+    cargo
+    rustc
+  ];
 
   buildInputs = [
     dbus

--- a/pkgs/applications/audio/netease-cloud-music-gtk/default.nix
+++ b/pkgs/applications/audio/netease-cloud-music-gtk/default.nix
@@ -2,6 +2,7 @@
 , stdenv
 , fetchFromGitHub
 , rustPlatform
+, cargo
 , meson
 , ninja
 , pkg-config
@@ -10,6 +11,7 @@
 , appstream-glib
 , desktop-file-utils
 , libxml2
+, rustc
 , wrapGAppsHook4
 , openssl
 , dbus
@@ -47,11 +49,10 @@ stdenv.mkDerivation rec {
     desktop-file-utils # update-desktop-database
     libxml2 # xmllint
     wrapGAppsHook4
-  ] ++ (with rustPlatform; [
-    cargoSetupHook
-    rust.cargo
-    rust.rustc
-  ]);
+    rustPlatform.cargoSetupHook
+    cargo
+    rustc
+  ];
 
   buildInputs = [
     openssl

--- a/pkgs/applications/audio/shortwave/default.nix
+++ b/pkgs/applications/audio/shortwave/default.nix
@@ -1,6 +1,7 @@
 { stdenv
 , lib
 , fetchFromGitLab
+, cargo
 , dbus
 , desktop-file-utils
 , gdk-pixbuf
@@ -15,6 +16,7 @@
 , openssl
 , pkg-config
 , rustPlatform
+, rustc
 , sqlite
 , wrapGAppsHook4
 , cmake
@@ -47,9 +49,9 @@ stdenv.mkDerivation rec {
     meson
     ninja
     pkg-config
-    rustPlatform.rust.cargo
+    cargo
     rustPlatform.cargoSetupHook
-    rustPlatform.rust.rustc
+    rustc
     wrapGAppsHook4
     cmake
   ];

--- a/pkgs/applications/audio/spot/default.nix
+++ b/pkgs/applications/audio/spot/default.nix
@@ -7,7 +7,9 @@
 , gettext
 , python3
 , desktop-file-utils
+, cargo
 , rustPlatform
+, rustc
 , pkg-config
 , glib
 , libadwaita
@@ -45,9 +47,9 @@ stdenv.mkDerivation rec {
     gtk4 # for gtk-update-icon-cache
     glib # for glib-compile-schemas
     desktop-file-utils
-    rustPlatform.rust.cargo
+    cargo
     rustPlatform.cargoSetupHook
-    rustPlatform.rust.rustc
+    rustc
     wrapGAppsHook4
   ];
 

--- a/pkgs/applications/backup/pika-backup/default.nix
+++ b/pkgs/applications/backup/pika-backup/default.nix
@@ -3,6 +3,7 @@
 , fetchFromGitLab
 , rustPlatform
 , substituteAll
+, cargo
 , desktop-file-utils
 , git
 , itstool
@@ -10,6 +11,7 @@
 , ninja
 , pkg-config
 , python3
+, rustc
 , wrapGAppsHook4
 , borgbackup
 , gtk4
@@ -55,11 +57,10 @@ stdenv.mkDerivation rec {
     pkg-config
     python3
     wrapGAppsHook4
-  ] ++ (with rustPlatform; [
-    cargoSetupHook
-    rust.cargo
-    rust.rustc
-  ]);
+    rustPlatform.cargoSetupHook
+    cargo
+    rustc
+  ];
 
   buildInputs = [
     gtk4

--- a/pkgs/applications/graphics/emblem/default.nix
+++ b/pkgs/applications/graphics/emblem/default.nix
@@ -3,11 +3,13 @@
 , fetchFromGitLab
 , rustPlatform
 , appstream-glib
+, cargo
 , desktop-file-utils
 , glib
 , meson
 , ninja
 , pkg-config
+, rustc
 , wrapGAppsHook4
 , gtk4
 , libadwaita
@@ -43,11 +45,10 @@ stdenv.mkDerivation rec {
     ninja
     pkg-config
     wrapGAppsHook4
-  ] ++ (with rustPlatform; [
-    cargoSetupHook
-    rust.cargo
-    rust.rustc
-  ]);
+    rustPlatform.cargoSetupHook
+    cargo
+    rustc
+  ];
 
   buildInputs = [
     gtk4

--- a/pkgs/applications/graphics/eyedropper/default.nix
+++ b/pkgs/applications/graphics/eyedropper/default.nix
@@ -2,12 +2,14 @@
 , stdenv
 , fetchFromGitHub
 , rustPlatform
+, cargo
 , pkg-config
 , meson
 , ninja
 , glib
 , gtk4
 , libadwaita
+, rustc
 , wrapGAppsHook4
 , appstream-glib
 , desktop-file-utils
@@ -37,11 +39,10 @@ stdenv.mkDerivation rec {
     wrapGAppsHook4
     appstream-glib
     desktop-file-utils
-  ] ++ (with rustPlatform; [
-    rust.cargo
-    rust.rustc
-    cargoSetupHook
-  ]);
+    cargo
+    rustc
+    rustPlatform.cargoSetupHook
+  ];
 
   buildInputs = [
     glib

--- a/pkgs/applications/graphics/gnome-decoder/default.nix
+++ b/pkgs/applications/graphics/gnome-decoder/default.nix
@@ -3,9 +3,11 @@
 , fetchFromGitLab
 , libclang
 , rustPlatform
+, cargo
 , meson
 , ninja
 , pkg-config
+, rustc
 , glib
 , gtk4
 , libadwaita
@@ -46,11 +48,10 @@ clangStdenv.mkDerivation rec {
     wrapGAppsHook4
     appstream-glib
     desktop-file-utils
-  ] ++ (with rustPlatform; [
-    rust.cargo
-    rust.rustc
-    cargoSetupHook
-  ]);
+    cargo
+    rustc
+    rustPlatform.cargoSetupHook
+  ];
 
   buildInputs = [
     glib

--- a/pkgs/applications/graphics/gnome-obfuscate/default.nix
+++ b/pkgs/applications/graphics/gnome-obfuscate/default.nix
@@ -1,11 +1,13 @@
 { stdenv
 , lib
 , fetchFromGitLab
+, cargo
 , gettext
 , meson
 , ninja
 , pkg-config
 , rustPlatform
+, rustc
 , wrapGAppsHook4
 , appstream-glib
 , desktop-file-utils
@@ -40,8 +42,8 @@ stdenv.mkDerivation rec {
     ninja
     pkg-config
     rustPlatform.cargoSetupHook
-    rustPlatform.rust.cargo
-    rustPlatform.rust.rustc
+    cargo
+    rustc
     wrapGAppsHook4
     appstream-glib
     desktop-file-utils

--- a/pkgs/applications/graphics/identity/default.nix
+++ b/pkgs/applications/graphics/identity/default.nix
@@ -6,11 +6,13 @@
 , gtk4
 , lib
 , libadwaita
+, cargo
 , meson
 , ninja
 , nix-update-script
 , pkg-config
 , rustPlatform
+, rustc
 , stdenv
 , wrapGAppsHook4
 }:
@@ -41,11 +43,10 @@ stdenv.mkDerivation rec {
     ninja
     pkg-config
     wrapGAppsHook4
-  ] ++ (with rustPlatform; [
-    cargoSetupHook
-    rust.cargo
-    rust.rustc
-  ]);
+    rustPlatform.cargoSetupHook
+    cargo
+    rustc
+  ];
 
   buildInputs = [
     gst_all_1.gst-libav

--- a/pkgs/applications/graphics/paleta/default.nix
+++ b/pkgs/applications/graphics/paleta/default.nix
@@ -2,9 +2,11 @@
 , stdenv
 , rustPlatform
 , fetchFromGitHub
+, cargo
 , meson
 , ninja
 , pkg-config
+, rustc
 , wrapGAppsHook4
 , appstream-glib
 , desktop-file-utils
@@ -37,11 +39,10 @@ stdenv.mkDerivation rec {
     wrapGAppsHook4
     appstream-glib
     desktop-file-utils
-  ] ++ (with rustPlatform; [
-    cargoSetupHook
-    rust.cargo
-    rust.rustc
-  ]);
+    rustPlatform.cargoSetupHook
+    cargo
+    rustc
+  ];
 
   buildInputs = [
     glib

--- a/pkgs/applications/graphics/rnote/default.nix
+++ b/pkgs/applications/graphics/rnote/default.nix
@@ -3,6 +3,7 @@
 , fetchFromGitHub
 , alsa-lib
 , appstream-glib
+, cargo
 , cmake
 , desktop-file-utils
 , glib
@@ -16,6 +17,7 @@
 , poppler
 , python3
 , rustPlatform
+, rustc
 , shared-mime-info
 , wrapGAppsHook4
 , AudioUnit
@@ -51,8 +53,8 @@ stdenv.mkDerivation rec {
     python3 # For the postinstall script
     rustPlatform.bindgenHook
     rustPlatform.cargoSetupHook
-    rustPlatform.rust.cargo
-    rustPlatform.rust.rustc
+    cargo
+    rustc
     shared-mime-info # For update-mime-database
     wrapGAppsHook4
   ];

--- a/pkgs/applications/kde/angelfish.nix
+++ b/pkgs/applications/kde/angelfish.nix
@@ -1,5 +1,6 @@
 { lib
 , mkDerivation
+, cargo
 , cmake
 , corrosion
 , extra-cmake-modules
@@ -17,6 +18,7 @@
 , qqc2-desktop-style
 , qtwebengine
 , rustPlatform
+, rustc
 , srcs
 
 # These must be updated in tandem with package updates.
@@ -46,11 +48,10 @@ mkDerivation rec {
     cmake
     corrosion
     extra-cmake-modules
-  ] ++ (with rustPlatform; [
-    cargoSetupHook
-    rust.cargo
-    rust.rustc
-  ]);
+    rustPlatform.cargoSetupHook
+    cargo
+    rustc
+  ];
 
   buildInputs = [
     kconfig

--- a/pkgs/applications/misc/authenticator/default.nix
+++ b/pkgs/applications/misc/authenticator/default.nix
@@ -2,11 +2,13 @@
 , stdenv
 , fetchFromGitLab
 , appstream-glib
+, cargo
 , desktop-file-utils
 , meson
 , ninja
 , pkg-config
 , rustPlatform
+, rustc
 , wrapGAppsHook4
 , gdk-pixbuf
 , glib
@@ -45,12 +47,11 @@ stdenv.mkDerivation rec {
     ninja
     pkg-config
     wrapGAppsHook4
-  ] ++ (with rustPlatform; [
-    cargoSetupHook
-    rust.cargo
-    rust.rustc
-    bindgenHook
-  ]);
+    rustPlatform.cargoSetupHook
+    cargo
+    rustc
+    rustPlatform.bindgenHook
+  ];
 
   buildInputs = [
     gdk-pixbuf

--- a/pkgs/applications/misc/citations/default.nix
+++ b/pkgs/applications/misc/citations/default.nix
@@ -1,4 +1,5 @@
-{ darwin
+{ cargo
+, darwin
 , desktop-file-utils
 , fetchFromGitLab
 , gettext
@@ -12,6 +13,7 @@
 , pkg-config
 , poppler
 , rustPlatform
+, rustc
 , stdenv
 , testers
 , wrapGAppsHook4
@@ -43,8 +45,8 @@ stdenv.mkDerivation (finalAttrs: {
     ninja
     pkg-config
     rustPlatform.cargoSetupHook
-    rustPlatform.rust.cargo
-    rustPlatform.rust.rustc
+    cargo
+    rustc
     wrapGAppsHook4
   ];
 

--- a/pkgs/applications/misc/furtherance/default.nix
+++ b/pkgs/applications/misc/furtherance/default.nix
@@ -1,5 +1,8 @@
-{ lib, stdenv, fetchFromGitHub, rustPlatform, appstream-glib, desktop-file-utils
-, glib, libadwaita, meson, ninja, pkg-config, wrapGAppsHook4, dbus , gtk4, sqlite }:
+{ lib, stdenv, fetchFromGitHub, rustPlatform
+, appstream-glib, cargo, desktop-file-utils, glib, libadwaita, meson, ninja
+, pkg-config, rustc, wrapGAppsHook4
+, dbus, gtk4, sqlite
+}:
 
 stdenv.mkDerivation rec {
   pname = "furtherance";
@@ -25,8 +28,8 @@ stdenv.mkDerivation rec {
     ninja
     pkg-config
     rustPlatform.cargoSetupHook
-    rustPlatform.rust.cargo
-    rustPlatform.rust.rustc
+    cargo
+    rustc
     wrapGAppsHook4
   ];
 

--- a/pkgs/applications/misc/gnome-solanum/default.nix
+++ b/pkgs/applications/misc/gnome-solanum/default.nix
@@ -3,10 +3,12 @@
 , fetchFromGitLab
 , fetchpatch
 , rustPlatform
+, cargo
 , desktop-file-utils
 , meson
 , ninja
 , pkg-config
+, rustc
 , wrapGAppsHook
 , python3
 , git
@@ -55,11 +57,10 @@ stdenv.mkDerivation rec {
     python3
     git
     desktop-file-utils
-  ] ++ (with rustPlatform; [
-    cargoSetupHook
-    rust.cargo
-    rust.rustc
-  ]);
+    rustPlatform.cargoSetupHook
+    cargo
+    rustc
+  ];
 
   buildInputs = [
     glib

--- a/pkgs/applications/misc/openbangla-keyboard/default.nix
+++ b/pkgs/applications/misc/openbangla-keyboard/default.nix
@@ -1,9 +1,11 @@
 { lib
 , stdenv
 , fetchFromGitHub
+, cargo
 , cmake
 , pkg-config
 , rustPlatform
+, rustc
 , wrapQtAppsHook
 , ibus
 , qtbase
@@ -25,8 +27,8 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [
     cmake
     pkg-config
-    rustPlatform.rust.cargo
-    rustPlatform.rust.rustc
+    cargo
+    rustc
     rustPlatform.cargoSetupHook
     wrapQtAppsHook
   ];

--- a/pkgs/applications/networking/feedreaders/newsflash/default.nix
+++ b/pkgs/applications/networking/feedreaders/newsflash/default.nix
@@ -2,9 +2,11 @@
 , stdenv
 , rustPlatform
 , fetchFromGitLab
+, cargo
 , meson
 , ninja
 , pkg-config
+, rustc
 , wrapGAppsHook4
 , gdk-pixbuf
 , glib
@@ -65,11 +67,10 @@ stdenv.mkDerivation (finalAttrs: {
 
     # Provides glib-compile-resources to compile gresources
     glib
-  ] ++ (with rustPlatform; [
-    cargoSetupHook
-    rust.cargo
-    rust.rustc
-  ]);
+    rustPlatform.cargoSetupHook
+    cargo
+    rustc
+  ];
 
   buildInputs = [
     gtk4

--- a/pkgs/applications/networking/instant-messengers/flare-signal/default.nix
+++ b/pkgs/applications/networking/instant-messengers/flare-signal/default.nix
@@ -1,6 +1,7 @@
 { lib
 , stdenv
 , fetchFromGitLab
+, cargo
 , meson
 , ninja
 , pkg-config
@@ -8,6 +9,7 @@
 , libsecret
 , libadwaita
 , rustPlatform
+, rustc
 , desktop-file-utils
 , wrapGAppsHook4
 }:
@@ -40,11 +42,10 @@ stdenv.mkDerivation rec {
     ninja
     pkg-config
     wrapGAppsHook4
-  ] ++ (with rustPlatform; [
-    cargoSetupHook
-    rust.cargo
-    rust.rustc
-  ]);
+    rustPlatform.cargoSetupHook
+    cargo
+    rustc
+  ];
 
   buildInputs = [
     libadwaita

--- a/pkgs/applications/networking/instant-messengers/fractal-next/default.nix
+++ b/pkgs/applications/networking/instant-messengers/fractal-next/default.nix
@@ -1,9 +1,11 @@
 { stdenv
 , lib
 , fetchFromGitLab
+, cargo
 , meson
 , ninja
 , rustPlatform
+, rustc
 , pkg-config
 , glib
 , gtk4
@@ -49,8 +51,8 @@ stdenv.mkDerivation rec {
     pkg-config
     rustPlatform.bindgenHook
     rustPlatform.cargoSetupHook
-    rustPlatform.rust.cargo
-    rustPlatform.rust.rustc
+    cargo
+    rustc
     desktop-file-utils
     appstream-glib
     wrapGAppsHook4

--- a/pkgs/applications/networking/instant-messengers/fractal/default.nix
+++ b/pkgs/applications/networking/instant-messengers/fractal/default.nix
@@ -2,11 +2,13 @@
 , lib
 , fetchFromGitLab
 , nix-update-script
+, cargo
 , meson
 , ninja
 , gettext
 , python3
 , rustPlatform
+, rustc
 , pkg-config
 , gtksourceview4
 , glib
@@ -49,9 +51,9 @@ stdenv.mkDerivation rec {
     ninja
     pkg-config
     python3
-    rustPlatform.rust.cargo
+    cargo
     rustPlatform.cargoSetupHook
-    rustPlatform.rust.rustc
+    rustc
     wrapGAppsHook
     glib
   ];

--- a/pkgs/applications/networking/p2p/fragments/default.nix
+++ b/pkgs/applications/networking/p2p/fragments/default.nix
@@ -3,6 +3,7 @@
 , fetchFromGitLab
 , fetchpatch
 , appstream-glib
+, cargo
 , dbus
 , desktop-file-utils
 , git
@@ -14,6 +15,7 @@
 , openssl
 , pkg-config
 , rustPlatform
+, rustc
 , sqlite
 , transmission
 , wrapGAppsHook4
@@ -56,11 +58,10 @@ in stdenv.mkDerivation rec {
     ninja
     pkg-config
     wrapGAppsHook4
-  ] ++ (with rustPlatform; [
-    cargoSetupHook
-    rust.cargo
-    rust.rustc
-  ]);
+    rustPlatform.cargoSetupHook
+    cargo
+    rustc
+  ];
 
   buildInputs = [
     dbus

--- a/pkgs/applications/networking/warp/default.nix
+++ b/pkgs/applications/networking/warp/default.nix
@@ -2,6 +2,7 @@
 , stdenv
 , fetchFromGitLab
 , appstream-glib
+, cargo
 , desktop-file-utils
 , itstool
 , meson
@@ -9,6 +10,7 @@
 , pkg-config
 , python3
 , rustPlatform
+, rustc
 , wrapGAppsHook4
 , glib
 , gtk4
@@ -46,11 +48,10 @@ stdenv.mkDerivation rec {
     pkg-config
     python3
     wrapGAppsHook4
-  ] ++ (with rustPlatform; [
-    cargoSetupHook
-    rust.cargo
-    rust.rustc
-  ]);
+    rustPlatform.cargoSetupHook
+    cargo
+    rustc
+  ];
 
   buildInputs = [
     glib

--- a/pkgs/applications/version-management/git-cinnabar/default.nix
+++ b/pkgs/applications/version-management/git-cinnabar/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, lib, fetchFromGitHub, pkg-config, rustPlatform
+{ stdenv, lib, fetchFromGitHub, cargo, pkg-config, rustPlatform
 , bzip2, curl, zlib, zstd, libiconv, CoreServices
 }:
 
@@ -15,7 +15,7 @@ stdenv.mkDerivation rec {
   };
 
   nativeBuildInputs = [
-    pkg-config rustPlatform.cargoSetupHook rustPlatform.rust.cargo
+    pkg-config rustPlatform.cargoSetupHook cargo
   ];
 
   buildInputs = [ bzip2 curl zlib zstd ]

--- a/pkgs/applications/version-management/mercurial/default.nix
+++ b/pkgs/applications/version-management/mercurial/default.nix
@@ -1,6 +1,6 @@
 { lib, stdenv, fetchurl, fetchpatch, python3Packages, makeWrapper, gettext, installShellFiles
 , re2Support ? true
-, rustSupport ? stdenv.hostPlatform.isLinux, rustPlatform
+, rustSupport ? stdenv.hostPlatform.isLinux, cargo, rustPlatform, rustc
 , fullBuild ? false
 , gitSupport ? fullBuild
 , guiSupport ? fullBuild, tk
@@ -44,11 +44,11 @@ let
       ++ lib.optional gitSupport pygit2
       ++ lib.optional highlightSupport pygments;
     nativeBuildInputs = [ makeWrapper gettext installShellFiles ]
-      ++ lib.optionals rustSupport (with rustPlatform; [
-           cargoSetupHook
-           rust.cargo
-           rust.rustc
-         ]);
+      ++ lib.optionals rustSupport [
+           rustPlatform.cargoSetupHook
+           cargo
+           rustc
+         ];
     buildInputs = [ docutils ]
       ++ lib.optionals stdenv.isDarwin [ ApplicationServices ];
 

--- a/pkgs/applications/version-management/sapling/default.nix
+++ b/pkgs/applications/version-management/sapling/default.nix
@@ -4,10 +4,12 @@
 , fetchFromGitHub
 , fetchurl
 , sd
+, cargo
 , curl
 , pkg-config
 , openssl
 , rustPlatform
+, rustc
 , fetchYarnDeps
 , yarn
 , nodejs
@@ -147,11 +149,10 @@ python3Packages.buildPythonApplication {
   nativeBuildInputs = [
     curl
     pkg-config
-  ] ++ (with rustPlatform; [
     myCargoSetupHook
-    rust.cargo
-    rust.rustc
-  ]);
+    cargo
+    rustc
+  ];
 
   buildInputs = [
     openssl

--- a/pkgs/applications/video/kooha/default.nix
+++ b/pkgs/applications/video/kooha/default.nix
@@ -2,6 +2,7 @@
 , stdenv
 , fetchFromGitHub
 , appstream-glib
+, cargo
 , desktop-file-utils
 , glib
 , gst_all_1
@@ -14,6 +15,7 @@
 , ninja
 , pkg-config
 , rustPlatform
+, rustc
 , wayland
 , wrapGAppsHook4
 }:
@@ -42,8 +44,8 @@ stdenv.mkDerivation rec {
     ninja
     pkg-config
     rustPlatform.cargoSetupHook
-    rustPlatform.rust.cargo
-    rustPlatform.rust.rustc
+    cargo
+    rustc
     wrapGAppsHook4
   ];
 

--- a/pkgs/applications/video/video-trimmer/default.nix
+++ b/pkgs/applications/video/video-trimmer/default.nix
@@ -2,8 +2,10 @@
 , lib
 , fetchFromGitLab
 , rustPlatform
+, cargo
 , pkg-config
 , meson
+, rustc
 , wrapGAppsHook4
 , desktop-file-utils
 , blueprint-compiler
@@ -43,11 +45,10 @@ stdenv.mkDerivation rec {
     # `gtk4-update-icon-cache` during installPhase, thanks to:
     # https://gitlab.gnome.org/YaLTeR/video-trimmer/-/merge_requests/12
     gtk4
-  ] ++ (with rustPlatform; [
-    cargoSetupHook
-    rust.cargo
-    rust.rustc
-  ]);
+    rustPlatform.cargoSetupHook
+    cargo
+    rustc
+  ];
 
   buildInputs = [
     gtk4

--- a/pkgs/applications/virtualization/krunvm/default.nix
+++ b/pkgs/applications/virtualization/krunvm/default.nix
@@ -5,9 +5,11 @@
 , asciidoctor
 , buildah
 , buildah-unwrapped
+, cargo
 , libiconv
 , libkrun
 , makeWrapper
+, rustc
 , sigtool
 }:
 
@@ -27,10 +29,10 @@ stdenv.mkDerivation rec {
     hash = "sha256-Y0FNi/+HuN5SqexHTKjcW6lEaeis7xZDYc2/FOAANIA=";
   };
 
-  nativeBuildInputs = with rustPlatform; [
-    cargoSetupHook
-    rust.cargo
-    rust.rustc
+  nativeBuildInputs = [
+    rustPlatform.cargoSetupHook
+    cargo
+    rustc
     asciidoctor
     makeWrapper
   ] ++ lib.optionals stdenv.isDarwin [ sigtool ];

--- a/pkgs/applications/virtualization/pods/default.nix
+++ b/pkgs/applications/virtualization/pods/default.nix
@@ -1,6 +1,7 @@
 { lib
 , stdenv
 , fetchFromGitHub
+, cargo
 , desktop-file-utils
 , glib
 , gtk4
@@ -8,6 +9,7 @@
 , ninja
 , pkg-config
 , rustPlatform
+, rustc
 , wrapGAppsHook4
 , gtksourceview5
 , libadwaita
@@ -38,8 +40,8 @@ stdenv.mkDerivation rec {
     ninja
     pkg-config
     rustPlatform.cargoSetupHook
-    rustPlatform.rust.cargo
-    rustPlatform.rust.rustc
+    cargo
+    rustc
     wrapGAppsHook4
   ];
 

--- a/pkgs/development/compilers/rust/clippy.nix
+++ b/pkgs/development/compilers/rust/clippy.nix
@@ -1,8 +1,8 @@
-{ stdenv, lib, rustPlatform, Security, patchelf }:
+{ stdenv, lib, rustPlatform, rustc, Security, patchelf }:
 
 rustPlatform.buildRustPackage {
   pname = "clippy";
-  inherit (rustPlatform.rust.rustc) version src;
+  inherit (rustc) version src;
 
   separateDebugInfo = true;
 
@@ -13,7 +13,7 @@ rustPlatform.buildRustPackage {
   # changes hash of vendor directory otherwise
   dontUpdateAutotoolsGnuConfigScripts = true;
 
-  buildInputs = [ rustPlatform.rust.rustc.llvm ]
+  buildInputs = [ rustc.llvm ]
     ++ lib.optionals stdenv.isDarwin [ Security ];
 
   # fixes: error: the option `Z` is only accepted on the nightly compiler
@@ -31,8 +31,8 @@ rustPlatform.buildRustPackage {
   # [0]: https://github.com/rust-lang/rust/blob/f77f4d55bdf9d8955d3292f709bd9830c2fdeca5/src/bootstrap/builder.rs#L1543
   # [1]: https://github.com/rust-lang/rust/blob/f77f4d55bdf9d8955d3292f709bd9830c2fdeca5/compiler/rustc_codegen_ssa/src/back/linker.rs#L323-L331
   preFixup = lib.optionalString stdenv.isDarwin ''
-    install_name_tool -add_rpath "${rustPlatform.rust.rustc}/lib" "$out/bin/clippy-driver"
-    install_name_tool -add_rpath "${rustPlatform.rust.rustc}/lib" "$out/bin/cargo-clippy"
+    install_name_tool -add_rpath "${rustc}/lib" "$out/bin/clippy-driver"
+    install_name_tool -add_rpath "${rustc}/lib" "$out/bin/cargo-clippy"
   '';
 
   meta = with lib; {

--- a/pkgs/development/compilers/rust/default.nix
+++ b/pkgs/development/compilers/rust/default.nix
@@ -68,6 +68,7 @@ in
         patches = rustcPatches;
 
         # Use boot package set to break cycle
+        inherit (bootstrapRustPackages) cargo rustc;
         rustPlatform = bootRustPlatform;
       } // lib.optionalAttrs (stdenv.cc.isClang && stdenv.hostPlatform == stdenv.buildPlatform) {
         stdenv = llvmBootstrapForDarwin.stdenv;
@@ -75,7 +76,10 @@ in
         pkgsBuildHost = pkgsBuildBuild // { targetPackages.stdenv = llvmBootstrapForDarwin.stdenv; };
         pkgsBuildTarget = pkgsBuildTarget // { targetPackages.stdenv = llvmBootstrapForDarwin.stdenv; };
       });
-      rustfmt = self.callPackage ./rustfmt.nix { inherit Security; };
+      rustfmt = self.callPackage ./rustfmt.nix {
+        inherit Security;
+        inherit (self.buildRustPackages) rustc;
+      };
       cargo = self.callPackage ./cargo.nix {
         # Use boot package set to break cycle
         rustPlatform = bootRustPlatform;
@@ -83,7 +87,7 @@ in
       };
       cargo-auditable = self.callPackage ./cargo-auditable.nix { };
       cargo-auditable-cargo-wrapper = self.callPackage ./cargo-auditable-cargo-wrapper.nix { };
-      clippy = callPackage ./clippy.nix {
+      clippy = self.callPackage ./clippy.nix {
         # We want to use self, not buildRustPackages, so that
         # buildPackages.clippy uses the cross compiler and supports
         # linting for the target platform.

--- a/pkgs/development/compilers/rust/make-rust-platform.nix
+++ b/pkgs/development/compilers/rust/make-rust-platform.nix
@@ -1,4 +1,4 @@
-{ buildPackages, callPackage, cargo-auditable, stdenv, runCommand }@prev:
+{ lib, buildPackages, callPackage, cargo-auditable, stdenv, runCommand }@prev:
 
 { rustc
 , cargo
@@ -9,7 +9,8 @@
 
 rec {
   rust = {
-    inherit rustc cargo;
+    rustc = lib.warn "rustPlatform.rust.rustc is deprecated. Use rustc instead." rustc;
+    cargo = lib.warn "rustPlatform.rust.cargo is deprecated. Use cargo instead." cargo;
   };
 
   fetchCargoTarball = buildPackages.callPackage ../../../build-support/rust/fetch-cargo-tarball {

--- a/pkgs/development/compilers/rust/rustc.nix
+++ b/pkgs/development/compilers/rust/rustc.nix
@@ -1,7 +1,7 @@
 { lib, stdenv, removeReferencesTo, pkgsBuildBuild, pkgsBuildHost, pkgsBuildTarget, targetPackages
 , llvmShared, llvmSharedForBuild, llvmSharedForHost, llvmSharedForTarget, llvmPackages
 , fetchurl, file, python3
-, darwin, cmake, rust, rustPlatform
+, darwin, cargo, cmake, rust, rustc, rustPlatform
 , pkg-config, openssl, xz
 , libiconv
 , which, libffi
@@ -73,8 +73,8 @@ in stdenv.mkDerivation rec {
     cxxForTarget = "${pkgsBuildTarget.targetPackages.stdenv.cc}/bin/${pkgsBuildTarget.targetPackages.stdenv.cc.targetPrefix}c++";
   in [
     "--release-channel=stable"
-    "--set=build.rustc=${rustPlatform.rust.rustc}/bin/rustc"
-    "--set=build.cargo=${rustPlatform.rust.cargo}/bin/cargo"
+    "--set=build.rustc=${rustc}/bin/rustc"
+    "--set=build.cargo=${cargo}/bin/cargo"
     "--enable-rpath"
     "--enable-vendor"
     "--build=${rust.toRustTargetSpec stdenv.buildPlatform}"
@@ -180,7 +180,7 @@ in stdenv.mkDerivation rec {
   depsBuildBuild = [ pkgsBuildHost.stdenv.cc pkg-config ];
 
   nativeBuildInputs = [
-    file python3 rustPlatform.rust.rustc cmake
+    file python3 rustc cmake
     which libffi removeReferencesTo pkg-config xz
   ];
 

--- a/pkgs/development/compilers/rust/rustfmt.nix
+++ b/pkgs/development/compilers/rust/rustfmt.nix
@@ -1,8 +1,8 @@
-{ lib, stdenv, rustPlatform, Security, asNightly ? false }:
+{ lib, stdenv, rustPlatform, rustc, Security, asNightly ? false }:
 
 rustPlatform.buildRustPackage rec {
   pname = "rustfmt" + lib.optionalString asNightly "-nightly";
-  inherit (rustPlatform.rust.rustc) version src;
+  inherit (rustc) version src;
 
   # the rust source tarball already has all the dependencies vendored, no need to fetch them again
   cargoVendorDir = "vendor";
@@ -12,7 +12,7 @@ rustPlatform.buildRustPackage rec {
   dontUpdateAutotoolsGnuConfigScripts = true;
 
   buildInputs = [
-    rustPlatform.rust.rustc.llvm
+    rustc.llvm
   ] ++ lib.optional stdenv.isDarwin Security;
 
   # As of 1.0.0 and rustc 1.30 rustfmt requires a nightly compiler
@@ -20,7 +20,7 @@ rustPlatform.buildRustPackage rec {
 
   # As of rustc 1.45.0, these env vars are required to build rustfmt (due to
   # https://github.com/rust-lang/rust/pull/72001)
-  CFG_RELEASE = rustPlatform.rust.rustc.version;
+  CFG_RELEASE = rustc.version;
   CFG_RELEASE_CHANNEL = if asNightly then "nightly" else "stable";
 
   meta = with lib; {

--- a/pkgs/development/interpreters/ruby/default.nix
+++ b/pkgs/development/interpreters/ruby/default.nix
@@ -2,7 +2,7 @@
 , fetchurl, fetchpatch, fetchFromSavannah, fetchFromGitHub
 , zlib, gdbm, ncurses, readline, groff, libyaml, libffi, jemalloc, autoreconfHook, bison
 , autoconf, libiconv, libobjc, libunwind, Foundation
-, buildEnv, bundler, bundix, rustPlatform
+, buildEnv, bundler, bundix, cargo, rustPlatform, rustc
 , makeBinaryWrapper, buildRubyGem, defaultGemConfig, removeReferencesTo
 , openssl, openssl_1_1
 , linuxPackages, libsystemtap
@@ -48,7 +48,7 @@ let
       #     $(nix-build -A ruby)/lib/ruby/2.6.0/x86_64-linux/rbconfig.rb
       # - In $out/lib/libruby.so and/or $out/lib/libruby.dylib
       , removeReferencesTo, jitSupport ? yjitSupport
-      , rustPlatform, yjitSupport ? yjitSupported
+      , cargo, rustPlatform, rustc, yjitSupport ? yjitSupported
       , autoreconfHook, bison, autoconf
       , buildEnv, bundler, bundix
       , libiconv, libobjc, libunwind, Foundation
@@ -78,7 +78,7 @@ let
         nativeBuildInputs = [ autoreconfHook bison ]
           ++ (op docSupport groff)
           ++ (ops (dtraceSupport && stdenv.isLinux) [ systemtap libsystemtap ])
-          ++ ops yjitSupport [ rustPlatform.cargoSetupHook rustPlatform.rust.cargo rustPlatform.rust.rustc ]
+          ++ ops yjitSupport [ rustPlatform.cargoSetupHook cargo rustc ]
           ++ op useBaseRuby baseRuby;
         buildInputs = [ autoconf ]
           ++ (op fiddleSupport libffi)

--- a/pkgs/development/libraries/libdeltachat/default.nix
+++ b/pkgs/development/libraries/libdeltachat/default.nix
@@ -1,6 +1,7 @@
 { lib
 , stdenv
 , fetchFromGitHub
+, cargo
 , cmake
 , openssl
 , perl
@@ -45,10 +46,9 @@ stdenv.mkDerivation rec {
     cmake
     perl
     pkg-config
-  ] ++ (with rustPlatform; [
-    cargoSetupHook
-    rust.cargo
-  ]) ++ lib.optionals stdenv.isDarwin [
+    rustPlatform.cargoSetupHook
+    cargo
+  ] ++ lib.optionals stdenv.isDarwin [
     fixDarwinDylibNames
   ];
 

--- a/pkgs/development/libraries/libkrun/default.nix
+++ b/pkgs/development/libraries/libkrun/default.nix
@@ -3,12 +3,14 @@
 , fetchFromGitHub
 , fetchurl
 , rustPlatform
+, cargo
 , pkg-config
 , dtc
 , glibc
 , openssl
 , libiconv
 , libkrunfw
+, rustc
 , Hypervisor
 , sevVariant ? false
 }:
@@ -32,10 +34,10 @@ stdenv.mkDerivation rec {
     hash = "sha256-nbtp7FP+ObVGfDOEzTt4Z7TZwcNlREczTKIAXGSflZU=";
   };
 
-  nativeBuildInputs = with rustPlatform; [
-    cargoSetupHook
-    rust.cargo
-    rust.rustc
+  nativeBuildInputs = [
+    rustPlatform.cargoSetupHook
+    cargo
+    rustc
   ] ++ lib.optional sevVariant pkg-config;
 
   buildInputs = [

--- a/pkgs/development/libraries/matrix-sdk-crypto-nodejs/default.nix
+++ b/pkgs/development/libraries/matrix-sdk-crypto-nodejs/default.nix
@@ -1,4 +1,6 @@
-{ lib, stdenv, fetchFromGitHub, rustPlatform, napi-rs-cli, nodejs, libiconv }:
+{ lib, stdenv, fetchFromGitHub
+, cargo, rustPlatform, rustc, napi-rs-cli, nodejs, libiconv
+}:
 
 stdenv.mkDerivation rec {
   pname = "matrix-sdk-crypto-nodejs";
@@ -26,8 +28,8 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [
     rustPlatform.cargoSetupHook
-    rustPlatform.rust.cargo
-    rustPlatform.rust.rustc
+    cargo
+    rustc
     napi-rs-cli
     nodejs
   ];

--- a/pkgs/development/python-modules/aardwolf/default.nix
+++ b/pkgs/development/python-modules/aardwolf/default.nix
@@ -6,6 +6,7 @@
 , asyauth
 , asysocks
 , buildPythonPackage
+, cargo
 , colorama
 , fetchFromGitHub
 , iconv
@@ -14,6 +15,7 @@
 , pyperclip
 , pythonOlder
 , rustPlatform
+, rustc
 , setuptools-rust
 , tqdm
 , unicrypto
@@ -46,10 +48,9 @@ buildPythonPackage rec {
   nativeBuildInputs = [
     rustPlatform.cargoSetupHook
     setuptools-rust
-  ] ++ (with rustPlatform.rust; [
     cargo
     rustc
-  ]);
+  ];
 
   propagatedBuildInputs = [
     arc4

--- a/pkgs/development/python-modules/bcrypt/default.nix
+++ b/pkgs/development/python-modules/bcrypt/default.nix
@@ -1,6 +1,8 @@
 { lib
 , buildPythonPackage
+, cargo
 , rustPlatform
+, rustc
 , setuptools
 , setuptools-rust
 , isPyPy
@@ -41,11 +43,10 @@ buildPythonPackage rec {
   nativeBuildInputs = [
     setuptools
     setuptools-rust
-  ] ++ (with rustPlatform; [
-    cargoSetupHook
-    rust.cargo
-    rust.rustc
-  ]);
+    rustPlatform.cargoSetupHook
+    cargo
+    rustc
+  ];
 
   # Remove when https://github.com/NixOS/nixpkgs/pull/190093 lands.
   buildInputs = lib.optional stdenv.isDarwin libiconv;

--- a/pkgs/development/python-modules/breezy/default.nix
+++ b/pkgs/development/python-modules/breezy/default.nix
@@ -2,6 +2,7 @@
 , stdenv
 , buildPythonPackage
 , fetchPypi
+, cargo
 , configobj
 , cython
 , dulwich
@@ -18,6 +19,7 @@
 , pythonOlder
 , installShellFiles
 , rustPlatform
+, rustc
 , setuptools-gettext
 , setuptools-rust
 , testers
@@ -49,8 +51,8 @@ buildPythonPackage rec {
     cython
     installShellFiles
     rustPlatform.cargoSetupHook
-    rustPlatform.rust.cargo
-    rustPlatform.rust.rustc
+    cargo
+    rustc
     setuptools-gettext
     setuptools-rust
   ];

--- a/pkgs/development/python-modules/cryptg/default.nix
+++ b/pkgs/development/python-modules/cryptg/default.nix
@@ -3,7 +3,9 @@
 , buildPythonPackage
 , fetchFromGitHub
 , pythonOlder
+, cargo
 , rustPlatform
+, rustc
 , setuptools-rust
 , libiconv
 }:
@@ -27,11 +29,11 @@ buildPythonPackage rec {
     hash = "sha256-AqSVFOB9Lfvk9h3GtoYlEOXBEt7YZYLhCDNKM9upQ2U=";
   };
 
-  nativeBuildInputs = with rustPlatform;[
+  nativeBuildInputs = [
     setuptools-rust
-    cargoSetupHook
-    rust.rustc
-    rust.cargo
+    rustPlatform.cargoSetupHook
+    rustc
+    cargo
   ];
 
   buildInputs = lib.optionals stdenv.isDarwin [

--- a/pkgs/development/python-modules/cryptography/default.nix
+++ b/pkgs/development/python-modules/cryptography/default.nix
@@ -4,6 +4,8 @@
 , buildPythonPackage
 , fetchPypi
 , rustPlatform
+, cargo
+, rustc
 , setuptools-rust
 , openssl
 , Security
@@ -58,7 +60,9 @@ buildPythonPackage rec {
   ] ++ [
     rustPlatform.cargoSetupHook
     setuptools-rust
-  ] ++ (with rustPlatform; [ rust.cargo rust.rustc ]);
+    cargo
+    rustc
+  ];
 
   buildInputs = [ openssl ]
     ++ lib.optionals stdenv.isDarwin [ Security libiconv ]

--- a/pkgs/development/python-modules/etebase/default.nix
+++ b/pkgs/development/python-modules/etebase/default.nix
@@ -3,7 +3,9 @@
 , fetchFromGitHub
 , buildPythonPackage
 , rustPlatform
+, cargo
 , pkg-config
+, rustc
 , rustfmt
 , setuptools-rust
 , openssl
@@ -34,11 +36,10 @@ buildPythonPackage rec {
     pkg-config
     rustfmt
     setuptools-rust
-  ] ++ (with rustPlatform; [
-    cargoSetupHook
-    rust.cargo
-    rust.rustc
-  ]);
+    rustPlatform.cargoSetupHook
+    cargo
+    rustc
+  ];
 
   buildInputs = [ openssl ] ++ lib.optionals stdenv.isDarwin [ Security ];
 

--- a/pkgs/development/python-modules/gb-io/default.nix
+++ b/pkgs/development/python-modules/gb-io/default.nix
@@ -3,6 +3,8 @@
 , fetchFromGitHub
 , buildPythonPackage
 , rustPlatform
+, cargo
+, rustc
 , setuptools-rust
 , unittestCheckHook
 }:
@@ -26,11 +28,12 @@ buildPythonPackage rec {
 
   sourceRoot = "source";
 
-  nativeBuildInputs = [ setuptools-rust ] ++ (with rustPlatform; [
-    cargoSetupHook
-    rust.cargo
-    rust.rustc
-  ]);
+  nativeBuildInputs = [
+    setuptools-rust
+    rustPlatform.cargoSetupHook
+    cargo
+    rustc
+  ];
 
   nativeCheckInputs = [ unittestCheckHook ];
 

--- a/pkgs/development/python-modules/json-stream-rs-tokenizer/default.nix
+++ b/pkgs/development/python-modules/json-stream-rs-tokenizer/default.nix
@@ -2,6 +2,8 @@
 , buildPythonPackage
 , fetchFromGitHub
 , rustPlatform
+, cargo
+, rustc
 , setuptools-rust
 , json-stream-rs-tokenizer
 , json-stream
@@ -31,12 +33,10 @@ buildPythonPackage rec {
 
   nativeBuildInputs = [
     setuptools-rust
-  ]
-  ++ (with rustPlatform; [
-    cargoSetupHook
-    rust.cargo
-    rust.rustc
-  ]);
+    rustPlatform.cargoSetupHook
+    cargo
+    rustc
+  ];
 
   # Tests depend on json-stream, which depends on this package.
   # To avoid infinite recursion, we only enable tests when building passthru.tests.

--- a/pkgs/development/python-modules/libcst/default.nix
+++ b/pkgs/development/python-modules/libcst/default.nix
@@ -2,6 +2,7 @@
 , stdenv
 , buildPythonPackage
 , fetchFromGitHub
+, cargo
 , hypothesis
 , libiconv
 , pytestCheckHook
@@ -9,6 +10,7 @@
 , pythonOlder
 , pyyaml
 , rustPlatform
+, rustc
 , setuptools-rust
 , setuptools-scm
 , typing-extensions
@@ -50,7 +52,9 @@ buildPythonPackage rec {
     setuptools-rust
     setuptools-scm
     rustPlatform.cargoSetupHook
-  ] ++ (with rustPlatform; [ rust.cargo rust.rustc ]);
+    cargo
+    rustc
+  ];
 
   buildInputs = lib.optionals stdenv.isDarwin [ libiconv ];
 

--- a/pkgs/development/python-modules/qiskit-terra/default.nix
+++ b/pkgs/development/python-modules/qiskit-terra/default.nix
@@ -3,7 +3,9 @@
 , pythonOlder
 , buildPythonPackage
 , fetchFromGitHub
+, cargo
 , rustPlatform
+, rustc
   # Python requirements
 , dill
 , numpy
@@ -67,7 +69,7 @@ buildPythonPackage rec {
     hash = "sha256-imktzBpgP+lq6FsVWIUK82+t76gKTgt53kPfKOnsseQ=";
   };
 
-  nativeBuildInputs = [ setuptools-rust ] ++ (with rustPlatform; [ rust.rustc rust.cargo cargoSetupHook ]);
+  nativeBuildInputs = [ setuptools-rust rustc cargo rustPlatform.cargoSetupHook ];
 
   cargoDeps = rustPlatform.fetchCargoTarball {
     inherit src;

--- a/pkgs/development/python-modules/rtoml/default.nix
+++ b/pkgs/development/python-modules/rtoml/default.nix
@@ -1,10 +1,12 @@
 { lib
 , buildPythonPackage
+, cargo
 , fetchFromGitHub
 , libiconv
 , pytestCheckHook
 , pythonOlder
 , rustPlatform
+, rustc
 , setuptools-rust
 }:
 
@@ -29,9 +31,9 @@ buildPythonPackage rec {
 
   nativeBuildInputs = with rustPlatform; [
     setuptools-rust
-    rust.rustc
-    rust.cargo
-    cargoSetupHook
+    rustc
+    cargo
+    rustPlatform.cargoSetupHook
   ];
 
   buildInputs = [

--- a/pkgs/development/python-modules/rustworkx/default.nix
+++ b/pkgs/development/python-modules/rustworkx/default.nix
@@ -1,6 +1,8 @@
 { fetchFromGitHub
 , buildPythonPackage
+, cargo
 , rustPlatform
+, rustc
 , setuptools-rust
 , numpy
 , fixtures
@@ -26,11 +28,12 @@ buildPythonPackage rec {
     hash = "sha256-imhiPj763iumRQb+oeBOpICD1nCvzZx+3yQWu1QRRQQ=";
   };
 
-  nativeBuildInputs = [ setuptools-rust ] ++ (with rustPlatform; [
-    cargoSetupHook
-    rust.cargo
-    rust.rustc
-  ]);
+  nativeBuildInputs = [
+    setuptools-rust
+    rustPlatform.cargoSetupHook
+    cargo
+    rustc
+  ];
 
   buildInputs = [ numpy ] ++ lib.optionals stdenv.isDarwin [ libiconv ];
 

--- a/pkgs/development/python-modules/safetensors/default.nix
+++ b/pkgs/development/python-modules/safetensors/default.nix
@@ -1,12 +1,14 @@
 { stdenv
 , lib
 , buildPythonPackage
+, cargo
 , fetchFromGitHub
 , fetchpatch
 , h5py
 , numpy
 , pythonOlder
 , pytestCheckHook
+, rustc
 , rustPlatform
 , setuptools-rust
 , torch
@@ -45,11 +47,11 @@ buildPythonPackage rec {
 
   sourceRoot = "source/bindings/python";
 
-  nativeBuildInputs = with rustPlatform; [
+  nativeBuildInputs = [
     setuptools-rust
-    rust.cargo
-    rust.rustc
-    cargoSetupHook
+    cargo
+    rustc
+    rustPlatform.cargoSetupHook
   ];
 
   buildInputs = lib.optionals stdenv.isDarwin [ libiconv ];

--- a/pkgs/development/python-modules/setuptools-rust/pyo3-test/default.nix
+++ b/pkgs/development/python-modules/setuptools-rust/pyo3-test/default.nix
@@ -1,5 +1,7 @@
 { callPackage
+, cargo
 , rustPlatform
+, rustc
 , setuptools-rust
 }:
 
@@ -11,11 +13,11 @@ callPackage ../../../tools/rust/maturin/pyo3-test/generic.nix {
   #
   format = "setuptools";
 
-  nativeBuildInputs = [ setuptools-rust ] ++ (with rustPlatform; [
-    cargoSetupHook
-    rust.cargo
-    rust.rustc
-  ]);
+  nativeBuildInputs = [ setuptools-rust ] ++ [
+    rustPlatform.cargoSetupHook
+    cargo
+    rustc
+  ];
 
   preConfigure = ''
     # sourceRoot puts Cargo.lock in the wrong place due to the

--- a/pkgs/development/python-modules/skytemple-rust/default.nix
+++ b/pkgs/development/python-modules/skytemple-rust/default.nix
@@ -1,10 +1,12 @@
 { lib
 , stdenv
 , buildPythonPackage
+, cargo
 , fetchFromGitHub
 , libiconv
 , Foundation
 , rustPlatform
+, rustc
 , setuptools-rust
 , range-typed-integers
 }:
@@ -27,7 +29,7 @@ buildPythonPackage rec {
   };
 
   buildInputs = lib.optionals stdenv.isDarwin [ libiconv Foundation ];
-  nativeBuildInputs = [ setuptools-rust ] ++ (with rustPlatform; [ cargoSetupHook rust.cargo rust.rustc ]);
+  nativeBuildInputs = [ setuptools-rust rustPlatform.cargoSetupHook cargo rustc ];
   propagatedBuildInputs = [ range-typed-integers ];
 
   GETTEXT_SYSTEM = true;

--- a/pkgs/development/python-modules/spacy-alignments/default.nix
+++ b/pkgs/development/python-modules/spacy-alignments/default.nix
@@ -1,10 +1,12 @@
 { lib
 , stdenv
+, cargo
 , fetchPypi
 , fetchpatch
 , buildPythonPackage
 , isPy3k
 , rustPlatform
+, rustc
 , setuptools-rust
 , libiconv
 }:
@@ -28,11 +30,10 @@ buildPythonPackage rec {
 
   nativeBuildInputs = [
     setuptools-rust
-  ] ++ (with rustPlatform; [
-    cargoSetupHook
-    rust.cargo
-    rust.rustc
-  ]);
+    rustPlatform.cargoSetupHook
+    cargo
+    rustc
+  ];
 
   buildInputs = lib.optionals stdenv.isDarwin [ libiconv ];
 

--- a/pkgs/development/python-modules/tiktoken/default.nix
+++ b/pkgs/development/python-modules/tiktoken/default.nix
@@ -4,6 +4,8 @@
 , fetchPypi
 , pythonOlder
 , rustPlatform
+, cargo
+, rustc
 , setuptools-rust
 , libiconv
 , requests
@@ -40,7 +42,9 @@ buildPythonPackage {
   nativeBuildInputs = [
     rustPlatform.cargoSetupHook
     setuptools-rust
-  ] ++ (with rustPlatform; [ rust.cargo rust.rustc ]);
+    cargo
+    rustc
+  ];
 
   buildInputs = lib.optionals stdenv.isDarwin [ libiconv ];
 

--- a/pkgs/development/python-modules/tokenizers/default.nix
+++ b/pkgs/development/python-modules/tokenizers/default.nix
@@ -1,6 +1,7 @@
 { lib
 , stdenv
 , buildPythonPackage
+, cargo
 , datasets
 , fetchFromGitHub
 , fetchurl
@@ -12,6 +13,7 @@
 , pythonOlder
 , requests
 , rustPlatform
+, rustc
 , Security
 , setuptools-rust
 }:
@@ -82,11 +84,10 @@ buildPythonPackage rec {
   nativeBuildInputs = [
     pkg-config
     setuptools-rust
-  ] ++ (with rustPlatform; [
-    cargoSetupHook
-    rust.cargo
-    rust.rustc
-  ]);
+    rustPlatform.cargoSetupHook
+    cargo
+    rustc
+  ];
 
   buildInputs = [
     openssl

--- a/pkgs/development/python-modules/wasmer/default.nix
+++ b/pkgs/development/python-modules/wasmer/default.nix
@@ -1,6 +1,7 @@
 { stdenv
 , lib
 , rustPlatform
+, rustc
 , callPackage
 , fetchFromGitHub
 , buildPythonPackage
@@ -93,7 +94,7 @@ rec {
     pname = "wasmer-compiler-llvm";
     buildAndTestSubdir = "packages/compiler-llvm";
     cargoHash = "sha256-xawbf5gXXV+7I2F2fDSaMvjtFvGDBtqX7wL3c28TSbA=";
-    extraNativeBuildInputs = [ rustPlatform.rust.rustc.llvm ];
+    extraNativeBuildInputs = [ rustc.llvm ];
     extraBuildInputs = [ libffi libxml2.out ncurses zlib ];
   };
 

--- a/pkgs/development/python-modules/watchfiles/default.nix
+++ b/pkgs/development/python-modules/watchfiles/default.nix
@@ -2,8 +2,10 @@
 , stdenv
 , anyio
 , buildPythonPackage
+, cargo
 , fetchFromGitHub
 , rustPlatform
+, rustc
 , setuptools-rust
 , pythonOlder
 , dirty-equals
@@ -41,12 +43,11 @@ buildPythonPackage rec {
   ];
 
   nativeBuildInputs = [
-  ] ++ (with rustPlatform; [
-    cargoSetupHook
-    maturinBuildHook
-    rust.cargo
-    rust.rustc
-  ]);
+    rustPlatform.cargoSetupHook
+    rustPlatform.maturinBuildHook
+    cargo
+    rustc
+  ];
 
   propagatedBuildInputs = [
     anyio

--- a/pkgs/development/python-modules/y-py/default.nix
+++ b/pkgs/development/python-modules/y-py/default.nix
@@ -3,6 +3,8 @@
 , buildPythonPackage
 , fetchPypi
 , rustPlatform
+, cargo
+, rustc
 , libiconv
 , pytestCheckHook
 }:
@@ -24,11 +26,11 @@ buildPythonPackage rec {
     hash = "sha256-tpUDGBIHqXsKPsK+1h2sNuiV2I0pGVBokKh+hdFazRQ=";
   };
 
-  nativeBuildInputs = with rustPlatform; [
-    cargoSetupHook
-    maturinBuildHook
-    rust.cargo
-    rust.rustc
+  nativeBuildInputs = [
+    rustPlatform.cargoSetupHook
+    rustPlatform.maturinBuildHook
+    cargo
+    rustc
   ];
 
   buildInputs = lib.optional stdenv.isDarwin libiconv;

--- a/pkgs/development/tools/ashpd-demo/default.nix
+++ b/pkgs/development/tools/ashpd-demo/default.nix
@@ -2,9 +2,11 @@
 , lib
 , fetchFromGitHub
 , nix-update-script
+, cargo
 , meson
 , ninja
 , rustPlatform
+, rustc
 , pkg-config
 , glib
 , libshumate
@@ -44,9 +46,9 @@ stdenv.mkDerivation rec {
     meson
     ninja
     pkg-config
-    rustPlatform.rust.cargo
+    cargo
     rustPlatform.cargoSetupHook
-    rustPlatform.rust.rustc
+    rustc
     wrapGAppsHook4
     rustPlatform.bindgenHook
     desktop-file-utils

--- a/pkgs/development/tools/build-managers/corrosion/default.nix
+++ b/pkgs/development/tools/build-managers/corrosion/default.nix
@@ -1,8 +1,10 @@
 { lib
 , stdenv
 , fetchFromGitHub
+, cargo
 , cmake
 , rustPlatform
+, rustc
 , libiconv
 }:
 
@@ -30,11 +32,10 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [
     cmake
-  ] ++ (with rustPlatform; [
-    cargoSetupHook
-    rust.cargo
-    rust.rustc
-  ]);
+    rustPlatform.cargoSetupHook
+    cargo
+    rustc
+  ];
 
   meta = with lib; {
     description = "Tool for integrating Rust into an existing CMake project";

--- a/pkgs/development/tools/poetry2nix/poetry2nix/overrides/default.nix
+++ b/pkgs/development/tools/poetry2nix/poetry2nix/overrides/default.nix
@@ -212,7 +212,7 @@ lib.composeManyExtensions [
             nativeBuildInputs = with pkgs;
               (old.nativeBuildInputs or [ ])
                 ++ lib.optionals (lib.versionAtLeast old.version "4")
-                (with pkgs.rustPlatform; [ rust.rustc rust.cargo cargoSetupHook self.setuptools-rust ]);
+                [ rustc cargo rustPlatform.cargoSetupHook self.setuptools-rust ];
           } // lib.optionalAttrs (lib.versionAtLeast old.version "4") {
             cargoDeps =
               pkgs.rustPlatform.fetchCargoTarball
@@ -402,7 +402,7 @@ lib.composeManyExtensions [
                 ++ lib.optionals (lib.versionAtLeast old.version "3.4") [ self.setuptools-rust ]
                 ++ lib.optional (!self.isPyPy) pyBuildPackages.cffi
                 ++ lib.optional (lib.versionAtLeast old.version "3.5" && !isWheel)
-                (with pkgs.rustPlatform; [ cargoSetupHook rust.cargo rust.rustc ])
+                (with pkgs; [ rustPlatform.cargoSetupHook cargo rustc ])
                 ++ [ pkg-config ]
               ;
               buildInputs = (old.buildInputs or [ ])

--- a/pkgs/development/tools/watchman/default.nix
+++ b/pkgs/development/tools/watchman/default.nix
@@ -1,4 +1,5 @@
 { boost
+, cargo
 , cmake
 , config
 , CoreServices
@@ -25,6 +26,7 @@
 , pkg-config
 , python3
 , rustPlatform
+, rustc
 , stateDir ? "/tmp"
 , stdenv
 , wangle
@@ -56,11 +58,10 @@ stdenv.mkDerivation rec {
     cmake
     pkg-config
     ensureNewerSourcesForZipFilesHook
-  ] ++ (with rustPlatform; [
-    cargoSetupHook
-    rust.cargo
-    rust.rustc
-  ]);
+    rustPlatform.cargoSetupHook
+    cargo
+    rustc
+  ];
 
   buildInputs = [
     pcre

--- a/pkgs/games/anki/default.nix
+++ b/pkgs/games/anki/default.nix
@@ -4,6 +4,7 @@
 , fetchFromGitHub
 , fetchYarnDeps
 , fixup_yarn_lock
+, cargo
 , installShellFiles
 , lame
 , mpv-unwrapped
@@ -135,7 +136,7 @@ python3.pkgs.buildPythonApplication {
     offlineYarn
 
     installShellFiles
-    rustPlatform.rust.cargo
+    cargo
     rustPlatform.cargoSetupHook
     ninja
     qt6.wrapQtAppsHook

--- a/pkgs/games/ddnet/default.nix
+++ b/pkgs/games/ddnet/default.nix
@@ -2,10 +2,12 @@
 , stdenv
 , fetchFromGitHub
 , fetchpatch
+, cargo
 , cmake
 , ninja
 , pkg-config
 , rustPlatform
+, rustc
 , curl
 , freetype
 , libGLU
@@ -52,8 +54,8 @@ stdenv.mkDerivation rec {
     cmake
     ninja
     pkg-config
-    rustPlatform.rust.rustc
-    rustPlatform.rust.cargo
+    rustc
+    cargo
     rustPlatform.cargoSetupHook
   ];
 

--- a/pkgs/os-specific/linux/firmware/firmware-manager/default.nix
+++ b/pkgs/os-specific/linux/firmware/firmware-manager/default.nix
@@ -2,7 +2,9 @@
 , stdenv
 , rustPlatform
 , fetchFromGitHub
+, cargo
 , pkg-config
+, rustc
 , openssl
 , udev
 , gtk3
@@ -32,11 +34,11 @@ stdenv.mkDerivation rec {
     substituteInPlace Makefile --replace '$(DESTDIR)/etc' '$(DESTDIR)$(prefix)/etc'
   '';
 
-  nativeBuildInputs = with rustPlatform; [
-    rust.cargo
-    rust.rustc
+  nativeBuildInputs = [
+    cargo
+    rustc
     pkg-config
-    cargoSetupHook
+    rustPlatform.cargoSetupHook
     wrapGAppsHook
   ];
 

--- a/pkgs/servers/ldap/389/default.nix
+++ b/pkgs/servers/ldap/389/default.nix
@@ -3,6 +3,7 @@
 , fetchFromGitHub
 , autoconf
 , automake
+, cargo
 , libtool
 , pkg-config
 , cracklib
@@ -25,6 +26,7 @@
 , pcre2
 , python3
 , rustPlatform
+, rustc
 , openssl
 , withSystemd ? lib.meta.availableOn stdenv.hostPlatform systemd, systemd
 , zlib
@@ -57,8 +59,8 @@ stdenv.mkDerivation rec {
     libtool
     pkg-config
     python3
-    rustPlatform.rust.cargo
-    rustPlatform.rust.rustc
+    cargo
+    rustc
   ]
   ++ lib.optional withCockpit rsync;
 

--- a/pkgs/servers/ldap/lldap/default.nix
+++ b/pkgs/servers/ldap/lldap/default.nix
@@ -6,6 +6,7 @@
 , lldap
 , nixosTests
 , rustPlatform
+, rustc
 , stdenv
 , wasm-bindgen-cli
 , wasm-pack
@@ -25,7 +26,7 @@ let
 
   # replace with upstream wasm rustc, after resolution of
   # https://github.com/NixOS/nixpkgs/issues/89426
-  rustc-wasm = (rustPlatform.rust.rustc.override {
+  rustc-wasm = (rustc.override {
     stdenv = stdenv.override {
       targetPlatform = stdenv.targetPlatform // {
         parsed = {

--- a/pkgs/servers/matrix-synapse/default.nix
+++ b/pkgs/servers/matrix-synapse/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchFromGitHub, python3, openssl, rustPlatform
+{ lib, stdenv, fetchFromGitHub, python3, openssl, cargo, rustPlatform, rustc
 , enableSystemd ? lib.meta.availableOn stdenv.hostPlatform python3.pkgs.systemd
 , nixosTests
 , enableRedis ? true
@@ -38,10 +38,9 @@ buildPythonApplication rec {
     poetry-core
     rustPlatform.cargoSetupHook
     setuptools-rust
-  ] ++ (with rustPlatform.rust; [
     cargo
     rustc
-  ]);
+  ];
 
   buildInputs = [ openssl ];
 

--- a/pkgs/servers/matrix-synapse/matrix-hookshot/default.nix
+++ b/pkgs/servers/matrix-synapse/matrix-hookshot/default.nix
@@ -6,7 +6,9 @@
 , matrix-sdk-crypto-nodejs
 , mkYarnPackage
 , rust
+, cargo
 , rustPlatform
+, rustc
 , napi-rs-cli
 , nodejs
 }:
@@ -44,8 +46,8 @@ mkYarnPackage rec {
 
   nativeBuildInputs = [
     rustPlatform.cargoSetupHook
-    rustPlatform.rust.cargo
-    rustPlatform.rust.rustc
+    cargo
+    rustc
     napi-rs-cli
     makeWrapper
   ];

--- a/pkgs/servers/sql/postgresql/default.nix
+++ b/pkgs/servers/sql/postgresql/default.nix
@@ -22,7 +22,7 @@ let
       # JIT
       , jitSupport ? false
       , nukeReferences, patchelf, llvmPackages
-      , makeRustPlatform, buildPgxExtension, rustPlatform
+      , makeRustPlatform, buildPgxExtension, cargo, rustc
 
       # detection of crypt fails when using llvm stdenv, so we add it manually
       # for <13 (where it got removed: https://github.com/postgres/postgres/commit/c45643d618e35ec2fe91438df15abd4f3c0d85ca)
@@ -215,7 +215,7 @@ let
             stdenv = stdenv';
             rustPlatform = makeRustPlatform {
               stdenv = stdenv';
-              inherit (rustPlatform.rust) rustc cargo;
+              inherit rustc cargo;
             };
           };
         };

--- a/pkgs/tools/filesystems/stratisd/default.nix
+++ b/pkgs/tools/filesystems/stratisd/default.nix
@@ -2,6 +2,8 @@
 , stdenv
 , fetchFromGitHub
 , rustPlatform
+, cargo
+, rustc
 , pkg-config
 , asciidoc
 , ncurses
@@ -52,11 +54,11 @@ stdenv.mkDerivation rec {
       --replace udevadm               "${udev}/bin/udevadm"
   '';
 
-  nativeBuildInputs = with rustPlatform; [
-    cargoSetupHook
-    bindgenHook
-    rust.cargo
-    rust.rustc
+  nativeBuildInputs = [
+    rustPlatform.cargoSetupHook
+    rustPlatform.bindgenHook
+    cargo
+    rustc
     pkg-config
     asciidoc
     ncurses # tput

--- a/pkgs/tools/misc/popsicle/default.nix
+++ b/pkgs/tools/misc/popsicle/default.nix
@@ -1,7 +1,9 @@
 { lib
 , stdenv
 , fetchFromGitHub
+, cargo
 , rustPlatform
+, rustc
 , glib
 , pkg-config
 , gdk-pixbuf
@@ -32,8 +34,8 @@ stdenv.mkDerivation rec {
     glib
     pkg-config
     rustPlatform.cargoSetupHook
-    rustPlatform.rust.cargo
-    rustPlatform.rust.rustc
+    cargo
+    rustc
     wrapGAppsHook
   ];
 

--- a/pkgs/tools/networking/mozillavpn/default.nix
+++ b/pkgs/tools/networking/mozillavpn/default.nix
@@ -1,4 +1,5 @@
 { buildGoModule
+, cargo
 , cmake
 , fetchFromGitHub
 , go
@@ -14,6 +15,7 @@
 , qttools
 , qtwebsockets
 , rustPlatform
+, rustc
 , stdenv
 , wireguard-tools
 , wrapQtAppsHook
@@ -77,8 +79,8 @@ stdenv.mkDerivation {
     python3.pkgs.pyyaml
     python3.pkgs.setuptools
     rustPlatform.cargoSetupHook
-    rustPlatform.rust.cargo
-    rustPlatform.rust.rustc
+    cargo
+    rustc
     wrapQtAppsHook
   ];
 

--- a/pkgs/tools/networking/zerotierone/default.nix
+++ b/pkgs/tools/networking/zerotierone/default.nix
@@ -4,11 +4,13 @@
 , fetchFromGitHub
 
 , buildPackages
+, cargo
 , iproute2
 , lzo
 , openssl
 , pkg-config
 , ronn
+, rustc
 , zlib
 }:
 
@@ -53,8 +55,8 @@ in stdenv.mkDerivation {
     pkg-config
     ronn
     rustPlatform.cargoSetupHook
-    rustPlatform.rust.cargo
-    rustPlatform.rust.rustc
+    cargo
+    rustc
   ];
   buildInputs = [
     iproute2


### PR DESCRIPTION
###### Description of changes

It is almost never correct to use these attributes, because they don't work correctly with splicing.  Compare:

	% nix repl -f . --argstr crossSystem aarch64-linux
	Welcome to Nix 2.10.3. Type :? for help.

	Loading installable ''...
	Added 18988 variables.
	nix-repl> callPackage ({ stdenv, rustc }: (stdenv.mkDerivation { name = ""; nativeBuildInputs = [ rustc ]; }).nativeBuildInputs) {}
	«derivation /nix/store/bjrkg8kcq3hvg5kb03ivb856zy91qpbk-aarch64-unknown-linux-gnu-rustc-1.69.0.drv» ]

	nix-repl> callPackage ({ stdenv, rustPlatform }: (stdenv.mkDerivation { name = ""; nativeBuildInputs = [ rustPlatform.rust.rustc ]; }).nativeBuildInputs) {}
	«derivation /nix/store/ra5r07j52y7akclr827r3dzxzvqnvfbl-rustc-1.69.0.drv» ]

I'm not sure this is fixable.  I don't think it's worth keeping them around considering we have top level attributes.  It makes overriding slightly more annoying, but only slightly.

I'm aiming for zero rebuilds with this.  Draft until I get there.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
