### PR TITLE
wireworld: init at unstable-2023-05-09

### DIFF
--- a/pkgs/games/wireworld/default.nix
+++ b/pkgs/games/wireworld/default.nix
@@ -1,0 +1,57 @@
+{ lib
+, stdenv
+, fetchFromGitLab
+, zip
+, love
+, makeWrapper
+, makeDesktopItem
+, copyDesktopItems
+}:
+
+stdenv.mkDerivation rec {
+  pname = "wireworld";
+  version = "unstable-2023-05-09";
+
+  src = fetchFromGitLab {
+    owner = "blinry";
+    repo = pname;
+    rev = "03b82bf5d604d6d4ad3c07b224583de6c396fd17";
+    hash = "sha256-8BshnGLuA8lmG9g7FU349DWKP/fZvlvjrQBau/LSJ4E=";
+  };
+
+  nativeBuildInputs = [ makeWrapper copyDesktopItems zip ];
+
+  desktopItems = [
+    (makeDesktopItem {
+      name = "Wireworld";
+      exec = pname;
+      comment = "";
+      desktopName = "Wireworld";
+      genericName = "Wireworld";
+      categories = [ "Game" ];
+    })
+  ];
+
+  installPhase = ''
+    runHook preInstall
+    zip -9 -r Wireworld.love ./*
+    install -Dm444 -t $out/share/games/lovegames/ Wireworld.love
+    makeWrapper ${love}/bin/love $out/bin/Wireworld \
+      --add-flags $out/share/games/lovegames/Wireworld.love
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    description = "Fascinating electronics logic puzzles, game where you'll learn how to build clocks, diodes, and logic gates";
+    license = with licenses; [
+      mit
+      ofl
+      blueOak100
+      cc-by-sa-30
+      cc-by-sa-40
+    ];
+    downloadPage = "https://ldjam.com/events/ludum-dare/53/wireworld";
+    maintainers = with lib.maintainers; [ janik ];
+  };
+
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -39932,6 +39932,9 @@ with pkgs;
 
   wiremock = callPackage ../tools/networking/wiremock { };
 
+  wireworld = callPackage ../games/wireworld { };
+
+
   teseq = callPackage ../applications/misc/teseq {  };
 
   ape = callPackage ../applications/misc/ape { };


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [X] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [X] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
