### PR TITLE
mapbox-gl-native: fix build

### DIFF
--- a/pkgs/development/libraries/mapbox-gl-native/default.nix
+++ b/pkgs/development/libraries/mapbox-gl-native/default.nix
@@ -35,6 +35,11 @@ mkDerivation rec {
       url = "https://aur.archlinux.org/cgit/aur.git/plain/fix-compilation.patch?h=mapbox-gl-native";
       hash = "sha256-KgJHyoIdKdnQo+gedns3C+mEXlaTH/UtyQsaYR1T3iI=";
     })
+    (fetchpatch {
+      name = "fix-narrowing-conversion.patch";
+      url = "https://github.com/mapbox/mapbox-gl-native/commit/2955d0e479f57a39a0af4a0fa7ca7683455cca58.patch";
+      hash = "sha256-Jk7OLb9/mVtc2mm0AL1h9zcSiQ54jogNI+q6ojY0HEo=";
+    })
   ];
 
   postPatch = ''


### PR DESCRIPTION
Pull request submitted upstream:
https://github.com/mapbox/mapbox-gl-native/pull/16666

###### Description of changes

Simple patch to fix compilation. Submitted upstream, but use local copy until upstream PR is accepted.

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

ZHF: #230712