### PR TITLE
bitwarden: 2023.3.2 -> 2023.4.0; backport update to build against Node 18

### DIFF
--- a/pkgs/tools/security/bitwarden/default.nix
+++ b/pkgs/tools/security/bitwarden/default.nix
@@ -4,6 +4,7 @@
 , dbus
 , electron
 , fetchFromGitHub
+, fetchpatch
 , glib
 , gnome
 , gtk3
@@ -12,7 +13,7 @@
 , makeDesktopItem
 , makeWrapper
 , moreutils
-, nodejs_16
+, nodejs_18
 , pkg-config
 , python3
 , rustPlatform
@@ -23,7 +24,7 @@ let
   description = "A secure and free password manager for all of your devices";
   icon = "bitwarden";
 
-  buildNpmPackage' = buildNpmPackage.override { nodejs = nodejs_16; };
+  buildNpmPackage' = buildNpmPackage.override { nodejs = nodejs_18; };
 
   version = "2023.4.0";
   src = applyPatches {
@@ -34,7 +35,13 @@ let
       sha256 = "sha256-TTKDl6Py3k+fAy/kcyiMbAAKQdhVnZTyRXV8D/VpKBE=";
     };
 
-    patches = [ ];
+    patches = [
+      # Bump electron to 24 and node to 18
+      (fetchpatch {
+        url = "https://github.com/bitwarden/clients/pull/5205.patch";
+        hash = "sha256-sKSrh8RHXtxGczyZScjTeiGZgTZCQ7f45ULj/j9cp6M=";
+      })
+    ];
   };
 
   desktop-native = rustPlatform.buildRustPackage {
@@ -94,7 +101,7 @@ buildNpmPackage' {
   npmBuildFlags = [
     "--workspace apps/desktop"
   ];
-  npmDepsHash = "sha256-Y7yGM1poNMALipa0mr/iiTLP1zk3K1BqVBdopy6f6fE=";
+  npmDepsHash = "sha256-UXDn09qyM8GwfUiWLDhhyrGFZeKtTRmQArstw+tm5iE=";
 
   ELECTRON_SKIP_BINARY_DOWNLOAD = "1";
 
@@ -114,7 +121,7 @@ buildNpmPackage' {
   postBuild = ''
     pushd apps/desktop
 
-    "$(npm bin)"/electron-builder \
+    npm exec electron-builder -- \
       --dir \
       -c.electronDist=${electron}/lib/electron \
       -c.electronVersion=${electron.version}

--- a/pkgs/tools/security/bitwarden/default.nix
+++ b/pkgs/tools/security/bitwarden/default.nix
@@ -1,4 +1,5 @@
 { lib
+, applyPatches
 , buildNpmPackage
 , dbus
 , electron
@@ -25,20 +26,22 @@ let
   buildNpmPackage' = buildNpmPackage.override { nodejs = nodejs_16; };
 
   version = "2023.4.0";
-  src = fetchFromGitHub {
-    owner = "bitwarden";
-    repo = "clients";
-    rev = "desktop-v${version}";
-    sha256 = "sha256-TTKDl6Py3k+fAy/kcyiMbAAKQdhVnZTyRXV8D/VpKBE=";
+  src = applyPatches {
+    src = fetchFromGitHub {
+      owner = "bitwarden";
+      repo = "clients";
+      rev = "desktop-v${version}";
+      sha256 = "sha256-TTKDl6Py3k+fAy/kcyiMbAAKQdhVnZTyRXV8D/VpKBE=";
+    };
+
+    patches = [ ];
   };
 
   desktop-native = rustPlatform.buildRustPackage {
     pname = "bitwarden-desktop-native";
     inherit src version;
-    sourceRoot = "source/apps/desktop/desktop_native";
+    sourceRoot = "source-patched/apps/desktop/desktop_native";
     cargoSha256 = "sha256-VW9DmSh9jvqFCZjH1SAYkydSGjXSVEbv4CmtoJBiw5Y=";
-
-    patchFlags = [ "-p4" ];
 
     nativeBuildInputs = [
       pkg-config

--- a/pkgs/tools/security/bitwarden/default.nix
+++ b/pkgs/tools/security/bitwarden/default.nix
@@ -2,7 +2,7 @@
 , applyPatches
 , buildNpmPackage
 , dbus
-, electron
+, electron_24
 , fetchFromGitHub
 , fetchpatch
 , glib
@@ -25,6 +25,7 @@ let
   icon = "bitwarden";
 
   buildNpmPackage' = buildNpmPackage.override { nodejs = nodejs_18; };
+  electron = electron_24;
 
   version = "2023.4.0";
   src = applyPatches {
@@ -113,6 +114,11 @@ buildNpmPackage' {
   ];
 
   preBuild = ''
+    if [[ $(jq --raw-output '.devDependencies.electron' < package.json | grep -E --only-matching '^[0-9]+') != ${lib.escapeShellArg (lib.versions.major electron.version)} ]]; then
+      echo 'ERROR: electron version mismatch'
+      exit 1
+    fi
+
     jq 'del(.scripts.postinstall)' apps/desktop/package.json | sponge apps/desktop/package.json
     jq '.scripts.build = ""' apps/desktop/desktop_native/package.json | sponge apps/desktop/desktop_native/package.json
     cp ${desktop-native}/lib/libdesktop_native.so apps/desktop/desktop_native/desktop_native.linux-x64-musl.node

--- a/pkgs/tools/security/bitwarden/default.nix
+++ b/pkgs/tools/security/bitwarden/default.nix
@@ -24,19 +24,19 @@ let
 
   buildNpmPackage' = buildNpmPackage.override { nodejs = nodejs_16; };
 
-  version = "2023.3.2";
+  version = "2023.4.0";
   src = fetchFromGitHub {
     owner = "bitwarden";
     repo = "clients";
     rev = "desktop-v${version}";
-    sha256 = "sha256-KQDM7XDUA+yRv8y1K//rMCs4J36df42RVsiAXazJeYQ=";
+    sha256 = "sha256-TTKDl6Py3k+fAy/kcyiMbAAKQdhVnZTyRXV8D/VpKBE=";
   };
 
   desktop-native = rustPlatform.buildRustPackage {
     pname = "bitwarden-desktop-native";
     inherit src version;
     sourceRoot = "source/apps/desktop/desktop_native";
-    cargoSha256 = "sha256-XsAmVYWPPnY0cgBzpO2aWx/fh85fKr8kMO98cDMzOKk=";
+    cargoSha256 = "sha256-VW9DmSh9jvqFCZjH1SAYkydSGjXSVEbv4CmtoJBiw5Y=";
 
     patchFlags = [ "-p4" ];
 
@@ -91,7 +91,7 @@ buildNpmPackage' {
   npmBuildFlags = [
     "--workspace apps/desktop"
   ];
-  npmDepsHash = "sha256-RmkTWhakZstCCMLQ3iJ8KD5Yt5ZafXc8NDgncJMLaxs=";
+  npmDepsHash = "sha256-Y7yGM1poNMALipa0mr/iiTLP1zk3K1BqVBdopy6f6fE=";
 
   ELECTRON_SKIP_BINARY_DOWNLOAD = "1";
 


### PR DESCRIPTION
###### Description of changes

- Backport patch from Bitwarden master to achieve this as they have done
  (unreleased) upgrade 16→18, and have several other changes along with
  it. We want this now because Node 16 is being marked insecure soon for
  NixOS 23.05; see https://github.com/NixOS/nixpkgs/pull/229910.
- These changes should be in the next release in a few weeks
- `npm bin` no longer exists, use `npm exec` instead

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
