### PR TITLE
oscilloscope-terminal: init at pre-release 0.1

### DIFF
--- a/pkgs/applications/terminal-emulators/oscilloscope-terminal/default.nix
+++ b/pkgs/applications/terminal-emulators/oscilloscope-terminal/default.nix
@@ -1,0 +1,50 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, cmake
+, SDL2
+, bash
+, shell ? bash # dunno how to override this...
+, WIDTH ? 80
+, HEIGHT ? 24
+, BLOCK_SIZE ? 2048
+, BLOCKSFRAME ? 4
+, SAMP_RATE ? 192000
+}:
+
+stdenv.mkDerivation rec {
+  pname = "oscilloscope-terminal";
+  version = "unstable-2023-05-12";
+
+  src = fetchFromGitHub {
+    owner = "arf20";
+    repo = "oscilloscope-terminal";
+    rev = "dad28ec3c4e8c75d1400f387370491f4c868dda9";
+    hash = "sha256-fjM1g6YM6+Sen4/rzNXduuDDVD2eSV+UdDPzJUvW0SY=";
+  };
+
+  nativeBuildInputs = [ cmake ];
+
+  buildInputs = [ SDL2 ];
+
+  postPatch = ''
+    substituteInPlace CMakeLists.txt \
+      --replace "target_link_libraries(oscilloscope-terminal Threads::Threads SDL2main SDL2 GL)" \
+                "target_link_libraries(oscilloscope-terminal Threads::Threads SDL2 GL)"
+
+    substituteInPlace terminal.cpp --replace "/bin/bash" "${shell}${shell.shellPath}"
+
+    substituteInPlace main.hpp --replace "WIDTH   80" "WIDTH   ${toString WIDTH}"
+    substituteInPlace main.hpp --replace "HEIGHT  24" "HEIGHT  ${toString HEIGHT}"
+    substituteInPlace main.hpp --replace "BLOCKSFRAME 4" "BLOCKSFRAME ${toString BLOCKSFRAME}"
+    substituteInPlace main.hpp --replace "BLOCK_SIZE  2048" "BLOCK_SIZE  ${toString BLOCK_SIZE}"
+    substituteInPlace main.hpp --replace "SAMP_RATE   192000" "SAMP_RATE   ${toString SAMP_RATE}"
+  '';
+
+  meta = with lib; {
+    description = "Turns your oscilloscope (+sound card) into a Linux terminal emulator";
+    homepage = "https://github.com/arf20/oscilloscope-terminal";
+    license = licenses.gpl3Only;
+    maintainers = with maintainers; [ evils ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2617,6 +2617,8 @@ with pkgs;
 
   mrxvt = callPackage ../applications/terminal-emulators/mrxvt { };
 
+  oscilloscope-terminal = callPackage ../applications/terminal-emulators/oscilloscope-terminal { };
+
   roxterm = callPackage ../applications/terminal-emulators/roxterm { };
 
   rxvt = callPackage ../applications/terminal-emulators/rxvt { };


### PR DESCRIPTION
###### Description of changes

![photo_2023-05-10_01-20-23](https://github.com/NixOS/nixpkgs/assets/30512529/ac514569-3bd8-451b-adfb-189756383c09)

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
