### PR TITLE
python3Packages.sqlalchemy-jsonfield: 1.0.1.post0 -> 1.0.1.post0+2023-04-24

### DIFF
--- a/pkgs/development/python-modules/sqlalchemy-jsonfield/default.nix
+++ b/pkgs/development/python-modules/sqlalchemy-jsonfield/default.nix
@@ -14,7 +14,7 @@
 
 buildPythonPackage rec {
   pname = "sqlalchemy-jsonfield";
-  version = "1.0.1.post0";
+  version = "1.0.1.post0+2023-04-24";
   format = "setuptools";
 
   disabled = pythonOlder "3.7";
@@ -22,8 +22,8 @@ buildPythonPackage rec {
   src = fetchFromGitHub {
     owner = "penguinolog";
     repo = "sqlalchemy_jsonfield";
-    rev = "refs/tags/${version}";
-    hash = "sha256-dSvqUXZzr+s/v8QEtqrv6slI7p1akXwAxi68D9ctyuU=";
+    rev = "a1efda9755055c1d382257fb4ef78006b713d07e";
+    hash = "sha256-6l4LEGpA8dKPw8M4quStd1nWyshMNiwQojBCxKwRRXA=";
   };
 
   SETUPTOOLS_SCM_PRETEND_VERSION = "v${version}";


### PR DESCRIPTION
Bump to unreleased version to support SQLAlchemy 2 and unbreak the build.

###### Description of changes

https://github.com/penguinolog/sqlalchemy_jsonfield/compare/1.0.1.post0..a1efda9755055c1d382257fb4ef78006b713d07e

CC @ivan-tkatchev, sorry for the previous ping but what do you think about this?

ZHF: https://github.com/NixOS/nixpkgs/issues/230712

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->