### PR TITLE
elementary-planner: 2.7 -> unstable-2023-04-20

### DIFF
--- a/pkgs/applications/office/elementary-planner/default.nix
+++ b/pkgs/applications/office/elementary-planner/default.nix
@@ -1,38 +1,35 @@
-{ lib, stdenv
+{ stdenv
+, lib
 , fetchFromGitHub
+, desktop-file-utils
 , meson
 , ninja
 , pkg-config
-, desktop-file-utils
 , python3
 , vala
-, wrapGAppsHook
+, wrapGAppsHook4
 , evolution-data-server
-, libical
-, libgee
-, json-glib
 , glib
 , glib-networking
+, gtk4
+, json-glib
+, libadwaita
+, libgee
+, libical
+, pantheon
 , sqlite
-, libsoup
-, libgdata
-, gtk3
-, pantheon /* granite, icons, maintainers */
-, webkitgtk
-, libpeas
-, libhandy
-, curl
+, webkitgtk_6_0
 }:
 
 stdenv.mkDerivation rec {
   pname = "elementary-planner";
-  version = "2.7";
+  version = "unstable-2023-04-20";
 
   src = fetchFromGitHub {
     owner = "alainm23";
     repo = "planner";
-    rev = version;
-    sha256 = "sha256-3eFPGRcZWhzFYi52TbHmpFNLI0pWYcHbbBI7efqZwYE=";
+    rev = "97c0f1c30d087e2ac459241bfdb9b606a12a77ce";
+    sha256 = "sha256-W4Hfa9zgKpGKfd7QSTLF2FT0vSJ5mQMV+W9WWltZlL4=";
   };
 
   nativeBuildInputs = [
@@ -42,64 +39,40 @@ stdenv.mkDerivation rec {
     pkg-config
     python3
     vala
-    wrapGAppsHook
+    wrapGAppsHook4
   ];
 
   buildInputs = [
     evolution-data-server
     glib
     glib-networking
-    gtk3
+    gtk4
     json-glib
+    libadwaita
     libgee
     libical
-    libpeas
-    libsoup
-    pantheon.elementary-icon-theme
-    pantheon.granite
+    pantheon.granite7
     sqlite
-    webkitgtk
-    libhandy
-    curl
+    webkitgtk_6_0
+  ];
+
+  mesonFlags = [
+    "-Dproduction=true"
   ];
 
   postPatch = ''
-    # The GTK theme has been renamed in elementary OS 6
-    # https://github.com/elementary/flatpak-platform/blob/6.1.0/io.elementary.Sdk.json#L182
-    # Remove this in https://github.com/NixOS/nixpkgs/pull/159249
-    substituteInPlace src/Application.vala \
-      --replace '"gtk-theme-name", "elementary"' '"gtk-theme-name", "io.elementary.stylesheet.blueberry"'
-
-    # Fix build with vala 0.56
-    # https://github.com/alainm23/planner/pull/884
-    substituteInPlace src/Application.vala \
-      --replace "public const OptionEntry[] PLANNER_OPTIONS" "private const OptionEntry[] PLANNER_OPTIONS"
-
     chmod +x build-aux/meson/post_install.py
     patchShebangs build-aux/meson/post_install.py
-  '';
-
-  preFixup = ''
-    gappsWrapperArgs+=(
-      # The GTK theme is hardcoded.
-      --prefix XDG_DATA_DIRS : "${pantheon.elementary-gtk-theme}/share"
-      # The icon theme is hardcoded.
-      --prefix XDG_DATA_DIRS : "$XDG_ICON_DIRS"
-    )
-  '';
-
-  postFixup = ''
-    ln -s $out/bin/com.github.alainm23.planner $out/bin/planner
+    substituteInPlace build-aux/meson/post_install.py \
+      --replace "gtk-update-icon-cache" "gtk4-update-icon-cache"
   '';
 
   meta = with lib; {
-    description = "Task manager with Todoist support designed for GNU/Linux 🚀️";
-    homepage = "https://planner-todo.web.app";
-    license = licenses.gpl3;
+    description = "Task manager with Todoist support designed for GNU/Linux";
+    homepage = "https://useplanner.com";
+    license = licenses.gpl3Plus;
     maintainers = with maintainers; [ dtzWill ] ++ teams.pantheon.members;
     platforms = platforms.linux;
-    mainProgram = "com.github.alainm23.planner";
-    broken = true; # https://github.com/alainm23/planner/issues/928
+    mainProgram = "com.github.alainm23.task-planner";
   };
 }
-


### PR DESCRIPTION
https://github.com/alainm23/planner/compare/2.7...97c0f1c30d087e2ac459241bfdb9b606a12a77ce

(Also unmarked as broken. The latest tag won't build due to libsoup 3 migration)

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
