### PR TITLE
python3.pkgs.{shiboken,pyside}6: init at 6.5.0

### DIFF
--- a/pkgs/development/python-modules/pyside6/default.nix
+++ b/pkgs/development/python-modules/pyside6/default.nix
@@ -1,0 +1,77 @@
+{ lib
+, stdenv
+, cmake
+, ninja
+, qt6
+, python
+, shiboken6
+, libxcrypt
+}:
+
+stdenv.mkDerivation rec {
+  pname = "pyside6";
+
+  inherit (shiboken6) version src;
+
+  sourceRoot = "pyside-setup-everywhere-src-${lib.versions.majorMinor version}/sources/${pname}";
+
+  postPatch = ''
+    # Don't ignore optional Qt modules
+    substituteInPlace cmake/PySideHelpers.cmake \
+      --replace \
+        'string(FIND "''${_module_dir}" "''${_core_abs_dir}" found_basepath)' \
+        'set (found_basepath 0)'
+  '';
+
+  nativeBuildInputs = [
+    cmake
+    ninja
+    python
+  ];
+
+  buildInputs = with qt6; [
+    # required
+    qtbase
+    # optional
+    qt3d
+    qtcharts
+    qtconnectivity
+    qtdatavis3d
+    qtdeclarative
+    qthttpserver
+    qtmultimedia
+    qtnetworkauth
+    qtquick3d
+    qtremoteobjects
+    qtscxml
+    qtsensors
+    qtspeech
+    qtsvg
+    qttools
+    qtwebchannel
+    qtwebengine
+    qtwebsockets
+  ] ++ lib.optionals (python.pythonOlder "3.9") [
+    # see similar issue: 202262
+    # libxcrypt is required for crypt.h for building older python modules
+    libxcrypt
+  ];
+
+  propagatedBuildInputs = [
+    shiboken6
+  ];
+
+  cmakeFlags = [
+    "-DBUILD_TESTS=OFF"
+  ];
+
+  dontWrapQtApps = true;
+
+  meta = with lib; {
+    description = "Python bindings for Qt";
+    license = with licenses; [ lgpl3Only gpl2Only gpl3Only ];
+    homepage = "https://wiki.qt.io/Qt_for_Python";
+    maintainers = with maintainers; [ gebner Enzime ];
+    broken = stdenv.isDarwin;
+  };
+}

--- a/pkgs/development/python-modules/shiboken6/default.nix
+++ b/pkgs/development/python-modules/shiboken6/default.nix
@@ -1,0 +1,75 @@
+{ lib
+, fetchurl
+, llvmPackages
+, python
+, qt6
+, cmake
+, autoPatchelfHook
+, stdenv
+, libxcrypt
+}:
+
+llvmPackages.stdenv.mkDerivation rec {
+  pname = "shiboken6";
+  version = "6.5.0";
+
+  src = fetchurl {
+    # https://download.qt.io/official_releases/QtForPython/shiboken6/
+    url = "https://download.qt.io/official_releases/QtForPython/shiboken6/PySide6-${version}-src/pyside-setup-everywhere-src-${version}.tar.xz";
+    sha256 = "sha256-bvU7KRJyZ+OBkX5vk5nOdg7cBkTNWDGYix3nLJ1YOrQ=";
+  };
+
+  sourceRoot = "pyside-setup-everywhere-src-${lib.versions.majorMinor version}/sources/${pname}";
+
+  patches = [
+    ./fix-include-qt-headers.patch
+  ];
+
+  # Due to Shiboken.abi3.so being linked to libshiboken6.abi3.so.6.5 in the build tree,
+  # we need to remove the build tree reference from the RPATH and then add the correct
+  # directory to the RPATH. On Linux, the second part is handled by autoPatchelfHook.
+  # https://bugreports.qt.io/browse/PYSIDE-2233
+  postBuild = ''
+    echo "fixing RPATH of Shiboken.abi3.so"
+  '' + (if stdenv.isDarwin then ''
+    invalid_rpaths=$(otool -l Shiboken.abi3.so | awk '
+        /^[^ ]/ {f = 0}
+        $2 == "LC_RPATH" && $1 == "cmd" {f = 1}
+        f && gsub(/^ *path | \(offset [0-9]+\)$/, "") == 2
+    ' | grep --invert-match /nix/store)
+    install_name_tool $(echo $invalid_rpaths | sed 's/^/-delete_rpath /' | tr '\n' ' ' | sed 's/ $//') Shiboken.abi3.so
+    install_name_tool -add_rpath $out/lib Shiboken.abi3.so
+  '' else ''
+    patchelf Shiboken.abi3.so --shrink-rpath --allowed-rpath-prefixes /nix/store
+  '');
+
+  cmakeFlags = [
+    "-DBUILD_TESTS=OFF"
+  ];
+
+  dontWrapQtApps = true;
+
+  nativeBuildInputs = [
+    cmake
+    python
+  ] ++ lib.optionals stdenv.isLinux [
+    autoPatchelfHook
+  ];
+
+  buildInputs = [
+    llvmPackages.llvm
+    llvmPackages.libclang
+    qt6.qtbase
+  ] ++ (lib.optionals (python.pythonOlder "3.9") [
+    # see similar issue: 202262
+    # libxcrypt is required for crypt.h for building older python modules
+    libxcrypt
+  ]);
+
+  meta = with lib; {
+    description = "Generator for the pyside6 Qt bindings";
+    license = with licenses; [ lgpl3Only gpl2Only gpl3Only ];
+    homepage = "https://wiki.qt.io/Qt_for_Python";
+    maintainers = with maintainers; [ gebner Enzime ];
+  };
+}

--- a/pkgs/development/python-modules/shiboken6/fix-include-qt-headers.patch
+++ b/pkgs/development/python-modules/shiboken6/fix-include-qt-headers.patch
@@ -1,0 +1,80 @@
+--- a/ApiExtractor/clangparser/compilersupport.cpp
++++ b/ApiExtractor/clangparser/compilersupport.cpp
+@@ -16,6 +16,7 @@
+ #include <QtCore/QStandardPaths>
+ #include <QtCore/QStringList>
+ #include <QtCore/QVersionNumber>
++#include <QtCore/QRegularExpression>
+ 
+ #include <clang-c/Index.h>
+ 
+@@ -341,6 +342,13 @@ QByteArrayList emulatedCompilerOptions()
+ {
+     QByteArrayList result;
+     HeaderPaths headerPaths;
++
++    bool isNixDebug = qgetenv("NIX_DEBUG").toInt() > 0;
++    // examples:
++    // /nix/store/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx-qtsensors-6.4.2-dev/include
++    // /nix/store/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx-qtbase-6.4.2-dev/include
++    QRegularExpression qtHeaderRegex(uR"(/[0-9a-z]{32}-qt[a-z0-9]+-)"_s);
++
+     switch (compiler()) {
+     case Compiler::Msvc:
+         result.append(QByteArrayLiteral("-fms-compatibility-version=19.26.28806"));
+@@ -352,9 +360,30 @@ QByteArrayList emulatedCompilerOptions()
+             appendClangBuiltinIncludes(&headerPaths);
+         break;
+     case Compiler::Clang:
+-        headerPaths.append(gppInternalIncludePaths(compilerFromCMake(u"clang++"_s)));
++    // fix: error: cannot jump from switch statement to this case label: case Compiler::Gpp
++    // note: jump bypasses variable initialization: const HeaderPaths clangPaths =
++    {
++        //headerPaths.append(gppInternalIncludePaths(compilerFromCMake(u"clang++"_s)));
++        // fix: qt.shiboken: x is specified in typesystem, but not defined. This could potentially lead to compilation errors.
++        // PySide requires that Qt headers are not -isystem
++        // https://bugreports.qt.io/browse/PYSIDE-787
++        const HeaderPaths clangPaths = gppInternalIncludePaths(compilerFromCMake(u"clang++"_qs));
++        for (const HeaderPath &h : clangPaths) {
++            auto match = qtHeaderRegex.match(QString::fromUtf8(h.path));
++            if (!match.hasMatch()) {
++                if (isNixDebug)
++                    qDebug() << "shiboken compilersupport.cpp: found non-qt header: " << h.path;
++                // add using -isystem
++                headerPaths.append(h);
++            } else {
++                if (isNixDebug)
++                    qDebug() << "shiboken compilersupport.cpp: found qt header: " << h.path;
++                headerPaths.append({h.path, HeaderType::Standard});
++            }
++        }
+         result.append(noStandardIncludeOption());
+         break;
++    }
+     case Compiler::Gpp:
+         if (needsClangBuiltinIncludes())
+             appendClangBuiltinIncludes(&headerPaths);
+@@ -363,8 +392,20 @@ QByteArrayList emulatedCompilerOptions()
+         // <type_traits> etc (g++ 11.3).
+         const HeaderPaths gppPaths = gppInternalIncludePaths(compilerFromCMake(u"g++"_qs));
+         for (const HeaderPath &h : gppPaths) {
+-            if (h.path.contains("c++") || h.path.contains("sysroot"))
++            // fix: qt.shiboken: x is specified in typesystem, but not defined. This could potentially lead to compilation errors.
++            // PySide requires that Qt headers are not -isystem
++            // https://bugreports.qt.io/browse/PYSIDE-787
++            auto match = qtHeaderRegex.match(QString::fromUtf8(h.path));
++            if (!match.hasMatch()) {
++                if (isNixDebug)
++                    qDebug() << "shiboken compilersupport.cpp: found non-qt header: " << h.path;
++                // add using -isystem
+                 headerPaths.append(h);
++            } else {
++                if (isNixDebug)
++                    qDebug() << "shiboken compilersupport.cpp: found qt header: " << h.path;
++                headerPaths.append({h.path, HeaderType::Standard});
++            }
+         }
+         break;
+     }
+-- 
+2.39.0

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -10901,6 +10901,10 @@ self: super: with self; {
     inherit (pkgs) cmake llvmPackages qt5;
   });
 
+  shiboken6 = toPythonModule (callPackage ../development/python-modules/shiboken6 {
+    inherit (pkgs) cmake llvmPackages qt6;
+  });
+
   shippai = callPackage ../development/python-modules/shippai { };
 
   shiv = callPackage ../development/python-modules/shiv { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -9133,6 +9133,10 @@ self: super: with self; {
     inherit (pkgs) cmake ninja qt5;
   });
 
+  pyside6 = toPythonModule (callPackage ../development/python-modules/pyside6 {
+    inherit (pkgs) cmake ninja qt6;
+  });
+
   pyside = callPackage ../development/python-modules/pyside {
     inherit (pkgs) mesa;
   };


### PR DESCRIPTION
###### Description of changes

Fixes #216510

Seems to work, tested using SyncPlay 1.7.0 using PySide6 instead of PySide2

Based on the work by @milahu

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).