### PR TITLE
python310Packages.{shiny, rsconnect_*}: init at 0.3.3

### DIFF
--- a/pkgs/development/libraries/rsconnect-python/default.nix
+++ b/pkgs/development/libraries/rsconnect-python/default.nix
@@ -1,0 +1,66 @@
+{ lib
+, stdenv
+, python3Packages
+, fetchFromGitHub
+, python
+}:
+
+python3Packages.buildPythonApplication rec {
+  pname = "rsconnect-python";
+  version = "1.16.0";
+  format = "pyproject";
+  disabled = python3Packages.pythonOlder "3.7";
+
+  src = fetchFromGitHub {
+    owner = "rstudio";
+    repo = "rsconnect-python";
+    rev = "${version}";
+    hash = "sha256-DWfr2baGfAp6CdDS/cCinG12XBGoViwEFkxW8zPT86Q=";
+  };
+
+  SETUPTOOLS_SCM_PRETEND_VERSION = version;
+
+  postPatch = ''
+    substituteInPlace setup.py --replace 'semver>=2.0.0,<3.0.0' 'semver>=2.0.0'
+  '';
+
+  nativeBuildInputs = with python3Packages; [
+    setuptools
+    setuptools_scm
+    toml
+    wheel
+  ];
+
+  propagatedBuildInputs = with python3Packages; [
+    six
+    click
+    pip
+    semver
+    pyjwt
+  ];
+
+  nativeCheckInputs = with python3Packages; [
+    pytest
+    httpretty
+    nbconvert
+    ipykernel
+  ];
+
+  checkPhase = ''
+    runHook preCheck
+    # Needed to avoid /homeless-shelter error
+    export HOME=$(mktemp -d)
+    pytest tests/
+    runHook postCheck
+  '';
+
+  doCheck = true;
+
+  meta = with lib; {
+    homepage = "https://docs.posit.co/rsconnect-python";
+    description = "The rsconnect-python CLI";
+    license = licenses.gpl2;
+    maintainers = with maintainers; [ nviets ];
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/development/python-modules/contextvars/default.nix
+++ b/pkgs/development/python-modules/contextvars/default.nix
@@ -1,0 +1,59 @@
+{ lib
+, stdenv
+, buildPythonPackage
+, fetchFromGitHub
+, python
+, pythonOlder
+, setuptools
+, immutables
+# Test inputs
+, pytest
+}:
+
+buildPythonPackage rec {
+  pname = "contextvars";
+  version = "2.4";
+  format = "setuptools";
+  disabled = pythonOlder "3.7";
+
+  src = fetchFromGitHub {
+    owner = "MagicStack";
+    repo = "contextvars";
+    rev = "v${version}";
+    hash = "sha256-66VgtTYf4e3+nnH3Xala5+ujIFoSxRWch7azXyLWinM=";
+  };
+
+  nativeBuildInputs = [
+    setuptools
+  ];
+
+  propagatedBuildInputs = [
+    immutables
+  ];
+
+  nativeCheckInputs = [
+    pytest
+  ];
+
+  checkPhase = ''
+    runHook preCheck
+    pytest tests/
+    runHook postCheck
+  '';
+
+  doCheck = true;
+
+  disabledTests = [
+    "test_coro_hybrid_context"
+  ];
+
+  pythonImportsCheck = [ "contextvars" ];
+
+  meta = with lib; {
+    homepage = "https://github.com/MagicStack/contextvars";
+    description = "This package implements a backport of Python 3.7 contextvars module";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ nviets ];
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/development/python-modules/htmltools/default.nix
+++ b/pkgs/development/python-modules/htmltools/default.nix
@@ -1,0 +1,60 @@
+{ lib
+, stdenv
+, buildPythonPackage
+, fetchFromGitHub
+, python
+, pythonOlder
+, typing-extensions
+, packaging
+, setuptools
+# Test inputs
+, pytest
+, snapshottest
+}:
+
+buildPythonPackage rec {
+  pname = "htmltools";
+  version = "0.2.1";
+  format = "setuptools";
+  disabled = pythonOlder "3.7";
+
+  src = fetchFromGitHub {
+    owner = "rstudio";
+    repo = "py-htmltools";
+    rev = "v${version}";
+    hash = "sha256-QH8DPQBmhCOsUY6AE7K/6o9N8rvh45SbwauTSEdzcWk=";
+  };
+
+  nativeBuildInputs = [
+    setuptools
+  ];
+
+  propagatedBuildInputs = [
+    typing-extensions
+    packaging
+  ];
+
+  nativeCheckInputs = [
+    pytest
+    snapshottest
+  ];
+
+  checkPhase = ''
+    runHook preCheck
+    pytest tests/
+    runHook postCheck
+  '';
+
+  doCheck = true;
+
+  pythonImportsCheck = [ "htmltools" ];
+
+  meta = with lib; {
+    homepage = "https://github.com/rstudio/py-htmltools";
+    changelog = "https://github.com/rstudio/py-htmltools/blob/main/CHANGELOG.md";
+    description = "Tools for creating, manipulating, and writing HTML from Python.";
+    license = licenses.mit;
+    maintainers = with maintainers; [ nviets ];
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/development/python-modules/rsconnect-jupyter/default.nix
+++ b/pkgs/development/python-modules/rsconnect-jupyter/default.nix
@@ -1,0 +1,76 @@
+{ lib
+, stdenv
+, rsconnect-python
+, pythonOlder
+, buildPythonPackage
+, fetchFromGitHub
+# setup requires
+, setuptools
+# install requires
+#, rsconnect-python
+, notebook
+, nbformat
+, nbconvert
+, six
+, ipython
+
+# checks require
+, pytest
+, black
+, mock
+, python
+}:
+
+buildPythonPackage rec {
+  pname = "rsconnect-jupyter";
+  version = "1.8.0";
+  format = "setuptools";
+  disabled = pythonOlder "3.7";
+
+  src = fetchFromGitHub {
+    owner = "rstudio";
+    repo = "rsconnect-jupyter";
+    rev = "${version}";
+    hash = "sha256-3x4j9Ud6H0eNgc9bhwbQyBRZgCBb7Fgm0lpJUc1EUSE=";
+  };
+
+  nativeBuildInputs = [
+    setuptools
+  ];
+
+  propagatedBuildInputs = [
+    rsconnect-python
+    notebook
+    nbformat
+    nbconvert
+    six
+    ipython
+  ];
+
+  nativeCheckInputs = [
+    pytest
+    black
+    mock
+  ];
+
+  # Disable test_managers which import asyncmock, now defunct
+  # can reenable once upstream updates
+  checkPhase = ''
+    runHook preCheck
+    pytest tests/ --ignore=tests/test_managers.py
+    runHook postCheck
+  '';
+
+  doCheck = true;
+
+  pythonImportsCheck = [ "rsconnect_jupyter" ];
+
+  meta = with lib; {
+    homepage = "https://github.com/rstudio/py-htmltools";
+    changelog = "https://github.com/rstudio/py-htmltools/blob/main/CHANGELOG.md";
+    description = "Tools for creating, manipulating, and writing HTML from Python.";
+    license = licenses.mit;
+    maintainers = with maintainers; [ nviets ];
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/development/python-modules/shiny/default.nix
+++ b/pkgs/development/python-modules/shiny/default.nix
@@ -1,0 +1,106 @@
+{ lib
+, stdenv
+, buildPythonPackage
+, fetchFromGitHub
+, python
+, pythonOlder
+, setuptools
+# Install requires
+, typing-extensions
+, uvicorn
+, starlette
+, contextvars # weird backport?
+, websockets
+, python-multipart
+, htmltools
+, click
+, markdown-it-py
+, mdit-py-plugins
+, linkify-it-py
+, appdirs
+, asgiref
+, importlib-metadata
+# Test inputs
+, pytest
+, pytest-asyncio
+, pytest-playwright
+, pytest-xdist
+, pytest-timeout
+, psutil
+, astropy
+#, suntime # old package
+, timezonefinder
+#, ipyleaflet # can add this
+#, shinywidgets # can add this
+, seaborn
+, plotnine
+, plotly
+}:
+
+buildPythonPackage rec {
+  pname = "shiny";
+  version = "0.3.3";
+  format = "setuptools";
+  disabled = pythonOlder "3.7";
+
+  src = fetchFromGitHub {
+    owner = "rstudio";
+    repo = "py-shiny";
+    rev = "v${version}";
+    hash = "sha256-xaLVaiVKzCTGzTdRDRCkmCr+ZebYl4OdRihsTh+cd88=";
+  };
+
+  nativeBuildInputs = [
+    setuptools
+  ];
+
+  propagatedBuildInputs = [
+    typing-extensions
+    uvicorn
+    starlette
+    contextvars
+    websockets
+    python-multipart
+    htmltools
+    click
+    markdown-it-py
+    mdit-py-plugins
+    linkify-it-py
+    appdirs
+    asgiref
+    importlib-metadata
+  ];
+
+  nativeCheckInputs = [
+    pytest
+    pytest-asyncio
+    pytest-playwright
+    pytest-xdist
+    pytest-timeout
+    psutil
+    astropy
+    timezonefinder
+    seaborn
+    plotnine
+    plotly
+  ];
+
+  # skip test that has issue with contextvars
+  checkPhase = ''
+    runHook preCheck
+    pytest tests/ -k "not test_coro_hybrid_context"
+    runHook postCheck
+  '';
+
+  doCheck = true;
+
+  pythonImportsCheck = [ "shiny" ];
+
+  meta = with lib; {
+    homepage = "https://shiny.rstudio.com/py/";
+    description = "Shiny for Python";
+    license = licenses.mit;
+    maintainers = with maintainers; [ nviets ];
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -18955,6 +18955,8 @@ with pkgs;
 
   rsass = callPackage ../development/tools/misc/rsass { };
 
+  rsconnect-python = callPackage ../development/libraries/rsconnect-python { };
+
   rsonpath = callPackage ../development/tools/misc/rsonpath { };
 
   rufo = callPackage ../development/tools/rufo { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2049,6 +2049,8 @@ self: super: with self; {
 
   contexttimer = callPackage ../development/python-modules/contexttimer { };
 
+  contextvars = callPackage ../development/python-modules/contextvars { };
+
   contourpy = callPackage ../development/python-modules/contourpy { };
 
   convertdate = callPackage ../development/python-modules/convertdate { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -4569,6 +4569,8 @@ self: super: with self; {
 
   htmlmin = callPackage ../development/python-modules/htmlmin { };
 
+  htmltools = callPackage ../development/python-modules/htmltools { };
+
   html-sanitizer = callPackage ../development/python-modules/html-sanitizer { };
 
   html-text = callPackage ../development/python-modules/html-text { };
@@ -10552,6 +10554,8 @@ self: super: with self; {
 
   rsa = callPackage ../development/python-modules/rsa { };
 
+  rsconnect-jupyter = callPackage ../development/python-modules/rsconnect-jupyter { };
+
   rsskey = callPackage ../development/python-modules/rsskey { };
 
   rst2ansi = callPackage ../development/python-modules/rst2ansi { };
@@ -10904,6 +10908,8 @@ self: super: with self; {
   shiboken2 = toPythonModule (callPackage ../development/python-modules/shiboken2 {
     inherit (pkgs) cmake llvmPackages qt5;
   });
+
+  shiny = callPackage ../development/python-modules/shiny { };
 
   shippai = callPackage ../development/python-modules/shippai { };
 


### PR DESCRIPTION
###### Description of changes

Adding shiny for python, rsconnect_* packages, and related dependencies:
- shiny 0.3.3
- rsconnect-jupyter at 1.8.0
- rsconnect-python at 1.16.0
- htmltools at 0.2.1
- contextvars at 2.4

###### Things done

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
