### PR TITLE
mu: generate mu4e-autoloads.el

### DIFF
--- a/pkgs/tools/networking/mu/default.nix
+++ b/pkgs/tools/networking/mu/default.nix
@@ -40,6 +40,8 @@ stdenv.mkDerivation rec {
     find $out/share/emacs -type f -name '*.el' -print0 \
       | xargs -0 -I {} -n 1 -P $NIX_BUILD_CORES sh -c \
           "emacs --batch --eval '(setq large-file-warning-threshold nil)' -f batch-native-compile {} || true"
+  '' + ''
+    emacs --batch -l package --eval "(package-generate-autoloads \"mu4e\" \"$out/share/emacs/site-lisp/mu4e\")"
   '';
 
   buildInputs = [ emacs glib gmime3 texinfo xapian ];


### PR DESCRIPTION
###### Description of changes

* What is autoload?

Basically, it allows you to delay the loading of a package[1].

* What is a name-autoloads.el file?

When installing a package using package.el, Emacs generates[1] a
name-autoloads.el file for that package, which is used to autoload the
principal user commands defined[2][3] in the package.

* What problem does this patch solve?

There are some autoload commands defined[3] by mu4e.  Before, those
autoload commands cannot be autoloaded because of the missing
mu4e-autoloads.el file since mu4e installed from nixpkgs does not use
package.el.  This patch fixes that.

To sum up, with this patch, you can call (mu4e) without
calling (require 'mu4e) first.

* Isn't it better to contribute to the build system of the upstream mu
project to generate that mu4e-autoloads.el file?

It seems impossible[4] to do so.

[1]: https://www.gnu.org/software/emacs/manual/html_node/elisp/Autoload.html
[2]: https://www.gnu.org/software/emacs/manual/html_node/elisp/Packaging-Basics.html
[3]: https://github.com/djcb/mu/blob/581f8d7e92cc71545c0abea2f0e44d2ffe8b351c/mu4e/mu4e.el#L58
[4]: https://github.com/djcb/mu/pull/2313


<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
