### PR TITLE
python310Packages.nox: 2022.11.21 -> 2023.04.22

### DIFF
--- a/pkgs/development/python-modules/nox/default.nix
+++ b/pkgs/development/python-modules/nox/default.nix
@@ -3,8 +3,7 @@
 , buildPythonPackage
 , colorlog
 , fetchFromGitHub
-, fetchpatch
-, setuptools
+, hatchling
 , importlib-metadata
 , jinja2
 , packaging
@@ -17,7 +16,7 @@
 
 buildPythonPackage rec {
   pname = "nox";
-  version = "2022.11.21";
+  version = "2023.04.22";
   format = "pyproject";
 
   disabled = pythonOlder "3.7";
@@ -26,20 +25,11 @@ buildPythonPackage rec {
     owner = "wntrblm";
     repo = pname;
     rev = "refs/tags/${version}";
-    hash = "sha256-N70yBZyrtdQvgaJzkskG3goHit8eH0di9jHycuAwzfU=";
+    hash = "sha256-WuyNp3jxIktI72zbk+1CK8xflTKrYE5evn/gVdMx+cQ=";
   };
 
-  patches = [
-    # Remove rogue mocking of py._path, https://github.com/wntrblm/nox/pull/677
-    (fetchpatch {
-      name = "remove-py-pyth.patch";
-      url = "https://github.com/wntrblm/nox/commit/44d06b679761e21d76bb96b2b8ffe0ffbe3d4fd0.patch";
-      hash = "sha256-KRDVwbBMBd4GdiAcGJyS7DTNUw3Pumt0JO1igx6npnc=";
-    })
-  ];
-
   nativeBuildInputs = [
-    setuptools
+    hatchling
   ];
 
   propagatedBuildInputs = [
@@ -51,7 +41,6 @@ buildPythonPackage rec {
     typing-extensions
     importlib-metadata
   ];
-
 
   checkInputs = [
     jinja2


### PR DESCRIPTION
Changelog: https://github.com/wntrblm/nox/blob/2023.04.22/CHANGELOG.md

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
