### PR TITLE
Revert #229168 "gnupg: 2.4.0 -> 2.4.1"

### DIFF
--- a/pkgs/tools/security/gnupg/24.nix
+++ b/pkgs/tools/security/gnupg/24.nix
@@ -12,11 +12,11 @@ assert guiSupport -> enableMinimal == false;
 
 stdenv.mkDerivation rec {
   pname = "gnupg";
-  version = "2.4.1";
+  version = "2.4.0";
 
   src = fetchurl {
     url = "mirror://gnupg/gnupg/${pname}-${version}.tar.bz2";
-    hash = "sha256-drceWutEO/2RDOnLyCgbYXyDQWh6+2e65FWHeXK1neg=";
+    hash = "sha256-HXkVjdAdmSQx3S4/rLif2slxJ/iXhOosthDGAPsMFIM=";
   };
 
   depsBuildBuild = [ buildPackages.stdenv.cc ];


### PR DESCRIPTION
It needs some fixes.  See the reverted PR for details:
https://github.com/NixOS/nixpkgs/pull/229168