### PR TITLE
secretive: init at 2.3.0

### DIFF
--- a/pkgs/build-support/testers/default.nix
+++ b/pkgs/build-support/testers/default.nix
@@ -124,4 +124,6 @@
   hasPkgConfigModule = callPackage ./hasPkgConfigModule/tester.nix { };
 
   testMetaPkgConfig = callPackage ./testMetaPkgConfig/tester.nix { };
+
+  testDarwinCodesign = callPackage ./testDarwinCodesign/tester.nix { };
 }

--- a/pkgs/build-support/testers/testDarwinCodesign/tester.nix
+++ b/pkgs/build-support/testers/testDarwinCodesign/tester.nix
@@ -1,0 +1,38 @@
+{ lib, runCommand }:
+
+# Reference: https://eclecticlight.co/2022/09/17/how-to-check-an-apps-signature
+
+{ package
+, path
+
+# Whether to require the app to be notarized
+, requireNotarization ? false
+
+# The Team ID to expect
+, teamId ? null
+}:
+
+runCommand "${package.name}-test-codesign" {
+  # Unfortunately, we do depend on the system codesign and spctl
+  __noChroot = true;
+
+  meta.platforms = lib.platforms.darwin;
+} (''
+  mkdir -p $out
+  path="${package}/${path}"
+
+  echo "checking that $path is signed..."
+  /usr/bin/codesign -dvvv --requirements - $path 2>&1 | tee $out/codesign.out
+  echo
+'' + lib.optionalString requireNotarization ''
+  echo "checking that $path is notarized..."
+  /usr/sbin/spctl -a -vv $path 2>&1 | tee $out/spctl.out
+  echo
+'' + lib.optionalString (teamId != null) ''
+  echo "checking that $path is signed with the correct Team ID..."
+  teamId=$(grep -E '^TeamIdentifier=' $out/codesign.out | cut -d'=' -f2)
+  if [[ "$teamId" != "${teamId}" ]]; then
+    echo "ERROR: expected ${teamId}, got $teamId"
+    exit 1
+  fi
+'')

--- a/pkgs/os-specific/darwin/secretive/default.nix
+++ b/pkgs/os-specific/darwin/secretive/default.nix
@@ -1,0 +1,57 @@
+{ lib
+, fetchzip
+, stdenvNoCC
+, makeWrapper
+
+, testers
+, secretive
+}:
+
+stdenvNoCC.mkDerivation rec {
+  pname = "secretive";
+  version = "2.3.0";
+
+  src = fetchzip {
+    url = "https://github.com/maxgoedjen/secretive/releases/download/v${version}/Secretive.zip";
+    sha256 = "sha256-ohJNo2XAvT0yfMs06QidDhTa5M6r8BkYYN4HVDU5KYU=";
+    stripRoot = false;
+  };
+
+  dontConfigure = true;
+  dontBuild = true;
+
+  nativeBuildInputs = [
+    makeWrapper
+  ];
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/{Applications,bin}
+    cp -r ./Secretive.app $out/Applications
+
+    makeWrapper $out/Applications/Secretive.app/Contents/MacOS/Secretive $out/bin/Secretive
+
+    runHook postInstall
+  '';
+
+  passthru = {
+    tests.codesign = testers.testDarwinCodesign {
+      package = secretive;
+      path = "Applications/Secretive.app";
+      requireNotarization = true;
+      teamId = "Z72PRUAWF6";
+    };
+  };
+
+  meta = with lib; {
+    description = "Store and manage SSH keys in the Secure Enclave";
+    homepage = "https://github.com/maxgoedjen/secretive";
+    changelog = "https://github.com/maxgoedjen/secretive/releases/tag/v${version}";
+    mainProgram = "Secretive";
+    license = licenses.mit;
+    platforms = platforms.darwin;
+    sourceProvenance = with sourceTypes; [ binaryNativeCode ];
+    maintainers = with maintainers; [ zhaofengli ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -12085,6 +12085,8 @@ with pkgs;
 
   sdl-jstest = callPackage ../tools/misc/sdl-jstest { };
 
+  secretive = callPackage ../os-specific/darwin/secretive { };
+
   senpai = callPackage ../applications/networking/irc/senpai { };
 
   skim = callPackage ../tools/misc/skim { };


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

[Secretive](https://github.com/maxgoedjen/secretive) is a macOS app that stores SSH keys in the Secure Enclave. This is a repack of the upstream binaries (more below).

## `testers.testDarwinCodesign`

We already have several macOS binary packages (`utm`, `swiftbar`, `rectangle`, etc.) because building them from source can be complex. This isn't ideal, but we can take advantage of it and verify that we are shipping untampered copies from their developers.

For Secretive, this is actually critical for its functionality since Keychain Items can only be accessed by apps from the same Team that created them[^1]. Furthermore, we cannot sign it ourselves as adhoc-signed apps do not have the `com.apple.application-identifier` entitlement and thus cannot use the Secure Enclave. Here we use the newly-added `testDarwinCodesign` tester to verify that the app is correctly signed with the expected Team ID.

[^1]: By default, only the app itself is allowed, but Keychain Access Groups and App Groups can be used to [share access among apps](https://developer.apple.com/documentation/security/keychain_services/keychain_items/sharing_access_to_keychain_items_among_a_collection_of_apps) from the same Team.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
