### PR TITLE
pbpctrl: unstable-2023-02-07 -> 0.1.3

### DIFF
--- a/pkgs/applications/audio/pbpctrl/default.nix
+++ b/pkgs/applications/audio/pbpctrl/default.nix
@@ -1,25 +1,23 @@
-{ rustPlatform
+{ lib
+, rustPlatform
 , fetchFromGitHub
 , pkg-config
 , dbus
 , protobuf
-, lib
 }:
 
 rustPlatform.buildRustPackage rec {
   pname = "pbpctrl";
-
-  # https://github.com/qzed/pbpctrl/issues/4
-  version = "unstable-2023-02-07";
+  version = "0.1.3";
 
   src = fetchFromGitHub {
     owner = "qzed";
     repo = "${pname}";
-    rev = "9fef4bb88046a9f00719b189f8e378c8dbdb8ee6";
-    hash = "sha256-8YbsBqqITJ9bKzbGX6d/CSBb8wzr6bDzy8vsyntL1CA=";
+    rev = "v${version}";
+    hash = "sha256-CYroQb6x2d4ay3RZUSiSrcGDF0IL3ETZtHAFt18sa5s=";
   };
 
-  cargoHash = "sha256-ZxJjjaT/ZpEPxvO42UWBy3xW/V5dhXGsKn3KmuM89YA==";
+  cargoHash = "sha256-+YtnPKbxZENL6/u36RFFZA6F+19qHDAVx6Q8FSB/LCU=";
 
   nativeBuildInputs = [ pkg-config protobuf ];
   buildInputs = [ dbus ];


### PR DESCRIPTION
###### Description of changes

@VergeDX test you buds, I'm poor

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
