### PR TITLE
shantell-sans: init at 1.008

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -1547,6 +1547,12 @@
     githubId = 1060224;
     name = "Alexey Vakhrenev";
   };
+  avanderbergh = {
+    email = "avanderbergh@gmail.com";
+    github = "avanderbergh";
+    githubId = 493849;
+    name = "Adriaan van der Bergh";
+  };
   avaq = {
     email = "nixpkgs@account.avaq.it";
     github = "Avaq";

--- a/pkgs/data/fonts/shantell-sans/default.nix
+++ b/pkgs/data/fonts/shantell-sans/default.nix
@@ -1,0 +1,32 @@
+{ lib, stdenvNoCC, fetchzip }:
+
+stdenvNoCC.mkDerivation rec {
+  pname = "shantell-sans";
+  version = "1.008";
+
+  src = fetchzip {
+    url = "https://github.com/arrowtype/shantell-sans/releases/download/${version}/Shantell_Sans_${version}.zip";
+    hash = "sha256-hC8n2owpQO0OwaBuwMbli3sfcn6RB2rqkLzmSZY3Sks=";
+  };
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p "$out/share/fonts/truetype"
+
+    cd Shantell\ Sans\ ${version}/Desktop
+
+    mv Static $out/share/fonts/opentype
+    mv *.ttf $out/share/fonts/truetype
+
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    description = "A marker-style font built for creative expression, typographic play, and animation.";
+    homepage = "https://github.com/arrowtype/shantell-sans";
+    license = licenses.ofl;
+    maintainers = with maintainers; [ avanderbergh ];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -28576,6 +28576,8 @@ with pkgs;
 
   skeu = callPackage ../data/themes/skeu { };
 
+  shantell-sans = callPackage ../data/fonts/shantell-sans { };
+
   sweet = callPackage ../data/themes/sweet { };
 
   sweet-nova = callPackage ../data/themes/sweet-nova { };


### PR DESCRIPTION
###### Description of changes

Shantell Sans, from [Shantell Martin](https://shantellmartin.art/), is a marker-style font built for creative expression, typographic play, and animation.
https://shantellsans.com/

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
Fixes #231054
