### PR TITLE
aws-secretsmanager-caching: init at 1.1.1.5

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -15901,6 +15901,12 @@
     githubId = 8577941;
     name = "Kevin Rauscher";
   };
+  tomaskala = {
+    email = "public+nixpkgs@tomaskala.com";
+    github = "tomaskala";
+    githubId = 7727887;
+    name = "Tomas Kala";
+  };
   tomberek = {
     email = "tomberek@gmail.com";
     matrix = "@tomberek:matrix.org";

--- a/pkgs/development/python-modules/aws-secretsmanager-caching/default.nix
+++ b/pkgs/development/python-modules/aws-secretsmanager-caching/default.nix
@@ -1,0 +1,63 @@
+{ lib
+, buildPythonPackage
+, pythonOlder
+, fetchPypi
+, setuptools-scm
+, botocore
+, pytestCheckHook
+}:
+
+buildPythonPackage rec {
+  pname = "aws_secretsmanager_caching";
+  version = "1.1.1.5";
+  format = "setuptools";
+
+  disabled = pythonOlder "3.7";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "5cee2762bb89b72f3e5123feee8e45fbe44ffe163bfca08b28f27b2e2b7772e1";
+  };
+
+  nativeBuildInputs = [
+    setuptools-scm
+  ];
+
+  propagatedBuildInputs = [
+    botocore
+  ];
+
+  patches = [
+    # Remove coverage tests from the pytest invocation in setup.cfg.
+    ./remove-coverage-tests.patch
+  ];
+
+  postPatch = ''
+    substituteInPlace setup.py \
+      --replace "'pytest-runner'," ""
+  '';
+
+  nativeCheckInputs = [
+    pytestCheckHook
+  ];
+
+  disabledTestPaths = [
+    # Integration tests require networking.
+    "test/integ"
+  ];
+
+  pythonImportsCheck = [
+    "aws_secretsmanager_caching"
+  ];
+
+  meta = with lib; {
+    description = "Client-side AWS secrets manager caching library";
+    homepage = "https://github.com/aws/aws-secretsmanager-caching-python";
+    changelog = "https://github.com/aws/aws-secretsmanager-caching-python/releases/tag/v${version}";
+    longDescription = ''
+      The AWS Secrets Manager Python caching client enables in-process caching of secrets for Python applications.
+    '';
+    license = licenses.asl20;
+    maintainers = with maintainers; [ tomaskala ];
+  };
+}

--- a/pkgs/development/python-modules/aws-secretsmanager-caching/remove-coverage-tests.patch
+++ b/pkgs/development/python-modules/aws-secretsmanager-caching/remove-coverage-tests.patch
@@ -1,0 +1,14 @@
+diff --git a/setup.cfg b/setup.cfg
+index 5aa81b2..0c02ded 100644
+--- a/setup.cfg
++++ b/setup.cfg
+@@ -3,9 +3,6 @@ xfail_strict = true
+ addopts = 
+ 	--verbose
+ 	--doctest-modules
+-	--cov aws_secretsmanager_caching
+-	--cov-fail-under 90
+-	--cov-report term-missing
+ 	--ignore doc/
+ 
+ [aliases]

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -869,6 +869,8 @@ self: super: with self; {
 
   aws-sam-translator = callPackage ../development/python-modules/aws-sam-translator { };
 
+  aws-secretsmanager-caching = callPackage ../development/python-modules/aws-secretsmanager-caching { };
+
   aws-xray-sdk = callPackage ../development/python-modules/aws-xray-sdk { };
 
   awscrt = callPackage ../development/python-modules/awscrt {


### PR DESCRIPTION
###### Description of changes

The AWS Secrets Manager Python caching client enables in-process caching of secrets for Python applications. 

I disabled running integration tests, since they require networking. This reduces the test suite size from 39 integration and unit tests to 33 unit tests.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
