### PR TITLE
rustfmt: fix on darwin

### DIFF
--- a/pkgs/development/compilers/rust/rustfmt.nix
+++ b/pkgs/development/compilers/rust/rustfmt.nix
@@ -15,6 +15,17 @@ rustPlatform.buildRustPackage rec {
     rustPlatform.rust.rustc.llvm
   ] ++ lib.optional stdenv.isDarwin Security;
 
+  # rustfmt uses the rustc_driver and std private libraries, and Rust's build process forces them to have
+  # an install name of `@rpath/...` [0] [1] instead of the standard on macOS, which is an absolute path
+  # to itself.
+  #
+  # [0]: https://github.com/rust-lang/rust/blob/f77f4d55bdf9d8955d3292f709bd9830c2fdeca5/src/bootstrap/builder.rs#L1543
+  # [1]: https://github.com/rust-lang/rust/blob/f77f4d55bdf9d8955d3292f709bd9830c2fdeca5/compiler/rustc_codegen_ssa/src/back/linker.rs#L323-L331
+  preFixup = lib.optionalString stdenv.isDarwin ''
+    install_name_tool -add_rpath "${rustPlatform.rust.rustc}/lib" "$out/bin/rustfmt"
+    install_name_tool -add_rpath "${rustPlatform.rust.rustc}/lib" "$out/bin/git-rustfmt"
+  '';
+
   # As of 1.0.0 and rustc 1.30 rustfmt requires a nightly compiler
   RUSTC_BOOTSTRAP = 1;
 


### PR DESCRIPTION
###### Description of changes
Without this patch rustfmt installs successfully but upon running it it throws the following error

```
  $ rustfmt
  dyld[68147]: Library not loaded: @rpath/librustc_driver-c577224f5690b349.dylib
    Referenced from: <no uuid> /nix/store/w46inc6cad6xg2kw09v9n629iqb7aqrw-rustfmt-1.69.0/bin/rustfmt
    Reason: tried: '/nix/store/ih18sy1kcbl5kdgq2l8l1lm70ai6aybj-apple-framework-CoreFoundation-11.0.0/Library/Frameworks/librustc_driver-c577224f5690b349.dylib' (no such file), '/System/Volumes/Preboot/Cryptexes/OS/nix/store/ih18sy1kcbl5kdgq2l8l1lm70ai6aybj-apple-framework-CoreFoundation-11.0.0/Library/Frameworks/librustc_driver-c577224f5690b349.dylib' (no such file), '/nix/store/ih18sy1kcbl5kdgq2l8l1lm70ai6aybj-apple-framework-CoreFoundation-11.0.0/Library/Frameworks/librustc_driver-c577224f5690b349.dylib' (no such file), '/System/Volumes/Preboot/Cryptexes/OS/nix/store/ih18sy1kcbl5kdgq2l8l1lm70ai6aybj-apple-framework-CoreFoundation-11.0.0/Library/Frameworks/librustc_driver-c577224f5690b349.dylib' (no such file), '/usr/local/lib/librustc_driver-c577224f5690b349.dylib' (no such file), '/usr/lib/librustc_driver-c577224f5690b349.dylib' (no such file, not in dyld cache)
  Abort trap: 6
```

Reading this [rust-issue] it seems that we have to link against rustc_driver. The [clippy.nix] expression already does something similar

Of the 4 executables found in the result of building rustfmt only rustfmt and git-rustfmt needed to be linked. The other worked without linking to rustc_driver.

[rust-issue]: https://github.com/rust-lang/rust/pull/105609
[clippy.nix]: https://github.com/NixOS/nixpkgs/blob/c8cf570dae9b41f30395b71f9b432418b4ff0ebc/pkgs/development/compilers/rust/clippy.nix#L27-L36

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [X] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
