### PR TITLE
hdfview: 3.2.0 -> 3.3.0

### DIFF
--- a/pkgs/tools/misc/hdfview/default.nix
+++ b/pkgs/tools/misc/hdfview/default.nix
@@ -2,16 +2,18 @@
 
 stdenv.mkDerivation rec {
   pname = "hdfview";
-  version = "3.2.0";
+  version = "3.3.0";
 
   src = fetchurl {
     url = "https://support.hdfgroup.org/ftp/HDF5/releases/HDF-JAVA/${pname}-${version}/src/${pname}-${version}.tar.gz";
-    sha256 = "sha256-08De/yy9lZUIxNqccS2nL7IE/2gYo0NPAKcHH46M8rg=";
+    sha256 = "sha256-CRYWGGHCH6jdNUtEW0jv9aU9gKXAs4PnnrZLexCOJDA=";
   };
 
   patches = [
     # Hardcode isUbuntu=false to avoid calling hostname to detect os
     ./0001-Hardcode-isUbuntu-false-to-avoid-hostname-dependency.patch
+    # Disable signing on macOS
+    ./disable-mac-signing.patch
   ];
 
   nativeBuildInputs = [

--- a/pkgs/tools/misc/hdfview/disable-mac-signing.patch
+++ b/pkgs/tools/misc/hdfview/disable-mac-signing.patch
@@ -1,0 +1,26 @@
+diff --git a/build.xml b/build.xml
+index 70ab3e2..9460321 100644
+--- a/build.xml
++++ b/build.xml
+@@ -1802,13 +1802,6 @@
+             description="Create the final package for distribution" />
+ 
+     <target name="createJPackageMac" depends="createJPackageBase" if="${isAppMac}">
+-        <!-- unlock keychain -->
+-        <exec executable="security" dir="${dist.dir}" failonerror="true">
+-            <arg value="unlock-keychain" />
+-            <arg value="-p" />
+-            <arg value="${login.keychain_key}" />
+-            <arg value="login.keychain" />
+-        </exec>
+ 
+         <echo> Create the mac jpackage</echo>
+         <exec executable="${java.home}/bin/jpackage">
+@@ -1864,7 +1857,6 @@
+             <arg value="app-image" />
+             <arg value="--icon" />
+             <arg value="${basedir}/package_files/macosx/HDFView.icns" />
+-            <arg value="--mac-sign" />
+             <arg value="--mac-package-identifier" />
+             <arg value="HDFView.hdfgroup.org" />
+             <arg value="--mac-package-name" />


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Bump hdfview to 3.3.0 and skip signing on macOS.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
