### PR TITLE
python310Packages.monai-deploy: init at 0.5.0

### DIFF
--- a/pkgs/development/python-modules/monai-deploy/default.nix
+++ b/pkgs/development/python-modules/monai-deploy/default.nix
@@ -1,0 +1,57 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, pythonOlder
+, pytestCheckHook
+, pytest-lazy-fixture
+, numpy
+, networkx
+, pydicom
+, colorama
+, typeguard
+, versioneer
+}:
+
+buildPythonPackage rec {
+  pname = "monai";
+  version = "0.5.0";
+  format = "pyproject";
+
+  disabled = pythonOlder "3.7";
+
+  src = fetchFromGitHub {
+    owner = "Project-MONAI";
+    repo = "monai-deploy-app-sdk";
+    rev = "refs/tags/${version}";
+    hash = "sha256-oaNZ0US0YR/PSwAZ5GfRpAW+HRYVhdCZI83fC00rgok=";
+  };
+
+  nativeBuildInputs = [ versioneer ];
+
+  propagatedBuildInputs = [
+    numpy
+    networkx
+    colorama
+    typeguard
+  ];
+
+  nativeCheckInputs = [ pytestCheckHook pytest-lazy-fixture ];
+  disabledTests = [
+    # requires Docker daemon:
+    "test_packager"
+  ];
+  pythonImportsCheck = [
+    "monai.deploy"
+    "monai.deploy.core"
+    # "monai.deploy.operators" should be imported as well but
+    # requires some "optional" dependencies
+    # like highdicom (which is not packaged yet) and pydicom
+  ];
+
+  meta = with lib; {
+    description = "Framework and tools to design, develop and verify AI applications in healthcare imaging";
+    homepage = "https://monai.io/deploy.html";
+    license = licenses.asl20;
+    maintainers = [ maintainers.bcdarwin ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -6275,6 +6275,8 @@ self: super: with self; {
 
   monai = callPackage ../development/python-modules/monai { };
 
+  monai-deploy = callPackage ../development/python-modules/monai-deploy { };
+
   monero = callPackage ../development/python-modules/monero { };
 
   mongomock = callPackage ../development/python-modules/mongomock { };


### PR DESCRIPTION
###### Description of changes

Add the MONAI Deploy App SDK, part of the NVIDIA's MONAI framework for deep learning in medical imaging.

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
