### PR TITLE
python310Packages.cnvkit: Change to use pytest and build on current master

### DIFF
--- a/pkgs/development/python-modules/apricot-select/default.nix
+++ b/pkgs/development/python-modules/apricot-select/default.nix
@@ -1,0 +1,51 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, numpy
+, scipy
+, tqdm
+, scikit-learn
+, nose
+, numba
+, torch
+, unittestCheckHook
+}:
+
+
+buildPythonPackage rec {
+  pname = "apricot-select";
+  version = "0.6.1";
+  format = "setuptools";
+
+  src = fetchPypi {
+    inherit pname version;
+    hash = "sha256-O/hy1D7pavFByeTEDkNZqmyl4wIq5DsqiqRrJJR7i9g=";
+  };
+
+  propagatedBuildInputs = [
+    numpy
+    scipy
+    tqdm
+    numba
+    torch
+    scikit-learn
+  ];
+
+  postPatch = ''
+    sed -i '/"nose"/d' setup.py
+  '';
+
+  pythonImportsCheck = [ "apricot" ];
+
+  nativeCheckInputs = [
+    nose
+    unittestCheckHook
+  ];
+
+  meta = with lib; {
+    description = "apricot implements submodular optimization for the purpose of selecting subsets of massive data sets to train machine learning models quickly.";
+    homepage = "https://github.com/jmschrei/apricot";
+    license = licenses.mit;
+    maintainers = with maintainers; [ savyajha ];
+  };
+}

--- a/pkgs/development/python-modules/pomegranate/default.nix
+++ b/pkgs/development/python-modules/pomegranate/default.nix
@@ -5,36 +5,67 @@
 , fetchpatch
 , numpy
 , scipy
-, cython
+, torch
 , networkx
-, joblib
-, pandas
+, apricot-select
+, scikit-learn
+, pytestCheckHook
 , nose
-, pyyaml
 }:
 
 
 buildPythonPackage rec {
   pname = "pomegranate";
-  version = "0.14.8";
+  version = "1.0.0";
 
   src = fetchFromGitHub {
     repo = pname;
     owner = "jmschrei";
-    # no tags for recent versions: https://github.com/jmschrei/pomegranate/issues/974
-    rev = "0652e955c400bc56df5661db3298a06854c7cce8";
-    sha256 = "16g49nl2bgnh6nh7bd21s393zbksdvgp9l13ww2diwhplj6hlly3";
+    rev = "v${version}";
+    hash = "sha256-EnxKlRRfsOIDLAhYOq7bUSbI/NvPoSyYCZ9D5VCXFGQ=";
   };
 
-  propagatedBuildInputs = [ numpy scipy cython networkx joblib pyyaml ];
+  propagatedBuildInputs = [
+    numpy
+    scipy
+    torch
+    networkx
+    scikit-learn
+    apricot-select
+  ];
 
-  nativeCheckInputs = [ pandas nose ];  # as of 0.13.5, it depends explicitly on nose, rather than pytest.
+  nativeCheckInputs = [
+    nose
+    pytestCheckHook
+  ];
+
+  # These tests seem to be broken as of 1.0.0
+  disabledTests = [
+    "sample"
+    "test_learn_structure_chow_liu"
+    "test_learn_structure_exact"
+    "test_categorical_chow_liu"
+    "test_categorical_exact"
+    "test_categorical_learn_structure"
+  ];
+
+  pythonImportsCheck = [
+    "pomegranate"
+    "pomegranate.distributions"
+    "pomegranate.gmm"
+    "pomegranate.bayes_classifier"
+    "pomegranate.hmm"
+    "pomegranate.markov_chain"
+    "pomegranate.bayesian_network"
+    "pomegranate.factor_graph"
+  ];
 
   meta = with lib; {
     broken = stdenv.isDarwin;
-    description = "Probabilistic and graphical models for Python, implemented in cython for speed";
+    description = "Fast, flexible and easy to use probabilistic modelling in Python.";
     homepage = "https://github.com/jmschrei/pomegranate";
     license = licenses.mit;
     maintainers = with maintainers; [ rybern ];
+    changelog = "https://github.com/jmschrei/${pname}/releases/tag/v${version}";
   };
 }

--- a/pkgs/development/python-modules/pomegranate/default.nix
+++ b/pkgs/development/python-modules/pomegranate/default.nix
@@ -16,13 +16,13 @@
 
 buildPythonPackage rec {
   pname = "pomegranate";
-  version = "1.0.0";
+  version = "1.0.3";
 
   src = fetchFromGitHub {
     repo = pname;
     owner = "jmschrei";
-    rev = "v${version}";
-    hash = "sha256-EnxKlRRfsOIDLAhYOq7bUSbI/NvPoSyYCZ9D5VCXFGQ=";
+    rev = "f8ed453337fae6b44eddcbfe0d1031d33d8bea76";
+    hash = "sha256-OdXLP/GpBqY28q3tcIfJRQ+nI82BfBwjLfCm1hIjw8U=";
   };
 
   propagatedBuildInputs = [
@@ -39,14 +39,10 @@ buildPythonPackage rec {
     pytestCheckHook
   ];
 
-  # These tests seem to be broken as of 1.0.0
+  # These tests seem to be broken as of 1.0.1
   disabledTests = [
     "sample"
-    "test_learn_structure_chow_liu"
-    "test_learn_structure_exact"
-    "test_categorical_chow_liu"
     "test_categorical_exact"
-    "test_categorical_learn_structure"
   ];
 
   pythonImportsCheck = [

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -566,6 +566,8 @@ self: super: with self; {
 
   appthreat-vulnerability-db = callPackage ../development/python-modules/appthreat-vulnerability-db { };
 
+  apricot-select = callPackage ../development/python-modules/apricot-select { };
+
   aprslib = callPackage ../development/python-modules/aprslib { };
 
   apscheduler = callPackage ../development/python-modules/apscheduler { };


### PR DESCRIPTION
###### Description of changes

python310Packages.cnvkit: Change to use pytest
python310Packages.pomegranate: 0.14.8 -> 1.0.0 (Major breaking change)
~~python310Packages.pysam: 0.20.0 -> 0.21.0 (Bumped version and changed the test suite to use `pytestCheckHook`. Also enabled previously disabled tests.)~~ (Separated out into its own commit)
python310Packages.apricot-select: init (New dependency of pomegranate)

`cnvkit` needs to be updated to use `pomegranate`'s new functionality since the new version is a breaking change. See https://github.com/etal/cnvkit/issues/815 for the first report of the same.

`pomegranate` has some tests disabled. The test suite did not pass on Fedora either for me, so I assume this is a test suite issue.

`apricot-select` is a new dependency of `pomegranate` after the bump to 1.0.0.

Some packages do not build on python 3.11 due to their dependencies not building (specifically the current versions of `numba` and `tensorboard`)

nixpkgs-review output:

```
1 package added:
python310Packages.apricot-select (init at 0.6.1)

9 packages updated:
deepTools python3.10-cnvkit python3.10-htseq python310Packages.pomegranate (0.14.8 → 1.0.0) python310Packages.pysam (0.20.0 → 0.21.0) python3.11-htseq python311Packages.pysam (0.20.0 → 0.21.0) tebreak truvari

2 packages removed:
python3.11-cnvkit (†0.9.10) python3.11-pomegranate (†0.14.8)

20 packages built:
deeptools deeptools.dist python310Packages.apricot-select python310Packages.apricot-select.dist python310Packages.cnvkit python310Packages.cnvkit.dist python310Packages.htseq python310Packages.htseq.dist python310Packages.pomegranate python310Packages.pomegranate.dist python310Packages.pysam python310Packages.pysam.dist python311Packages.htseq python311Packages.htseq.dist python311Packages.pysam python311Packages.pysam.dist tebreak tebreak.dist truvari truvari.dist
```

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [X] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [X] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
