### PR TITLE
ocamlPackages: prepare for Dune 3

### DIFF
--- a/pkgs/development/ocaml-modules/odoc/default.nix
+++ b/pkgs/development/ocaml-modules/odoc/default.nix
@@ -13,8 +13,7 @@ buildDunePackage rec {
     sha256 = "sha256-9XTb0ozQ/DorlVJcS7ld320fZAi7T+EhV/pTeIT5h/0=";
   };
 
-  # dune 3 is required for tests to pass
-  duneVersion = if doCheck then "3" else "2";
+  duneVersion = "3";
 
   nativeBuildInputs = [ cppo ];
   buildInputs = [ astring cmdliner fpath result tyxml odoc-parser fmt ];

--- a/pkgs/development/tools/ocaml/cppo/default.nix
+++ b/pkgs/development/tools/ocaml/cppo/default.nix
@@ -23,7 +23,7 @@ buildDunePackage rec {
   inherit pname;
   version = "1.6.9";
 
-  useDune2 = true;
+  duneVersion = "3";
 
   src = fetchFromGitHub {
     owner = "ocaml-community";

--- a/pkgs/development/tools/ocaml/cppo/ocamlbuild.nix
+++ b/pkgs/development/tools/ocaml/cppo/ocamlbuild.nix
@@ -4,10 +4,13 @@ if lib.versionOlder (lib.getVersion cppo) "1.6"
 then cppo
 else
 
-buildDunePackage rec {
+buildDunePackage {
   pname = "cppo_ocamlbuild";
 
-  inherit (cppo) version useDune2 src;
+  inherit (cppo) version src;
+
+  minimalOCamlVersion = "4.03";
+  duneVersion = "3";
 
   propagatedBuildInputs = [ ocamlbuild ];
 

--- a/pkgs/development/tools/ocaml/merlin/dot-merlin-reader.nix
+++ b/pkgs/development/tools/ocaml/merlin/dot-merlin-reader.nix
@@ -1,15 +1,18 @@
-{ lib, fetchurl, yojson, csexp, buildDunePackage, merlin-lib, merlin }:
+{ lib, fetchurl, yojson, csexp, findlib, buildDunePackage, merlin-lib, merlin }:
 
 buildDunePackage rec {
   pname = "dot-merlin-reader";
+
+  duneVersion = "3";
 
   inherit (merlin) version src;
 
   minimalOCamlVersion = "4.06";
 
-  buildInputs = if lib.versionAtLeast version "4.7-414"
+  buildInputs = [ findlib ]
+  ++ (if lib.versionAtLeast version "4.7-414"
   then [ merlin-lib ]
-  else [ yojson csexp ];
+  else [ yojson csexp ]);
 
   meta = with lib; {
     description = "Reads config files for merlin";


### PR DESCRIPTION
###### Description of changes

Small fixes for compatibility with Dune 3

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
