### PR TITLE
ligo: 0.64.2 -> 0.65.0

### DIFF
--- a/pkgs/development/compilers/ligo/default.nix
+++ b/pkgs/development/compilers/ligo/default.nix
@@ -44,7 +44,6 @@ ocamlPackages.buildDunePackage rec {
 
   # The build picks this up for ligo --version
   LIGO_VERSION = version;
-  CHANGELOG_PATH = "./changelog.txt";
 
   # This is a hack to work around the hack used in the dune files
   OPAM_SWITCH_PREFIX = "${tezos-rust-libs}";
@@ -132,13 +131,6 @@ ocamlPackages.buildDunePackage rec {
   ] ++ lib.optionals stdenv.isDarwin [
     darwin.apple_sdk.frameworks.Security
   ];
-
-  preBuild = ''
-    # The scripts use `nix-shell` in the shebang which seems to fail
-    sed -i -e '1,5d' ./scripts/changelog-generation.sh
-    sed -i -e '1,5d' ./scripts/changelog-json.sh
-    ./scripts/changelog-generation.sh
-  '';
 
   nativeCheckInputs = [
     cacert

--- a/pkgs/development/compilers/ligo/default.nix
+++ b/pkgs/development/compilers/ligo/default.nix
@@ -24,6 +24,24 @@ ocamlPackages.buildDunePackage rec {
     fetchSubmodules = true;
   };
 
+  postPatch = ''
+    substituteInPlace "vendors/tezos-ligo/src/lib_hacl/hacl.ml" \
+      --replace \
+        "Hacl.NaCl.Noalloc.Easy.secretbox ~pt:msg ~n:nonce ~key ~ct:cmsg" \
+        "Hacl.NaCl.Noalloc.Easy.secretbox ~pt:msg ~n:nonce ~key ~ct:cmsg ()" \
+      --replace \
+        "Hacl.NaCl.Noalloc.Easy.box_afternm ~pt:msg ~n:nonce ~ck:k ~ct:cmsg" \
+        "Hacl.NaCl.Noalloc.Easy.box_afternm ~pt:msg ~n:nonce ~ck:k ~ct:cmsg ()"
+
+    substituteInPlace "vendors/tezos-ligo/src/lib_crypto/crypto_box.ml" \
+      --replace \
+        "secretbox_open ~key ~nonce ~cmsg ~msg" \
+        "secretbox_open ~key ~nonce ~cmsg ~msg ()" \
+      --replace \
+        "Box.box_open ~k ~nonce ~cmsg ~msg" \
+        "Box.box_open ~k ~nonce ~cmsg ~msg ()"
+  '';
+
   # The build picks this up for ligo --version
   LIGO_VERSION = version;
   CHANGELOG_PATH = "./changelog.txt";

--- a/pkgs/development/compilers/ligo/default.nix
+++ b/pkgs/development/compilers/ligo/default.nix
@@ -15,12 +15,12 @@
 
 ocamlPackages.buildDunePackage rec {
   pname = "ligo";
-  version = "0.64.2";
+  version = "0.65.0";
   src = fetchFromGitLab {
     owner = "ligolang";
     repo = "ligo";
     rev = version;
-    sha256 = "sha256-/XUJFDH1pv65VeZt57P+AiCegTwCn7OWdaa0D8sw7CI=";
+    sha256 = "sha256-vBvgagXK9lOXRI+iBwkPKmUvncZjrqHpKI3UAqOzHvc=";
     fetchSubmodules = true;
   };
 


### PR DESCRIPTION
###### Description of changes 

Update ligo version to latest one 

###### Things done 

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
