### PR TITLE
cbqn: updates and a bugfix

### DIFF
--- a/pkgs/development/interpreters/bqn/cbqn/default.nix
+++ b/pkgs/development/interpreters/bqn/cbqn/default.nix
@@ -50,12 +50,12 @@ stdenv.mkDerivation rec {
 
   makeFlags = [
     "CC=${stdenv.cc.targetPrefix}cc"
-  ]
-  ++ lib.optional enableReplxx "REPLXX=1";
+  ];
 
   buildFlags = [
     # interpreter binary
     (lib.flatten (if enableSingeli then ["o3n-singeli" "f='-mavx2'"] else ["o3"]))
+    "REPLXX=${if enableReplxx then "1" else "0"}"
   ] ++ lib.optionals enableLibcbqn [
     # embeddable interpreter as a shared lib
     "shared-o3"

--- a/pkgs/development/interpreters/bqn/cbqn/replxx.nix
+++ b/pkgs/development/interpreters/bqn/cbqn/replxx.nix
@@ -5,13 +5,13 @@
 
 stdenvNoCC.mkDerivation {
   pname = "replxx";
-  version = "unstable-2023-01-21";
+  version = "unstable-2023-02-26";
 
   src = fetchFromGitHub {
     owner = "dzaima";
     repo = "replxx";
-    rev = "eb6bcecff4ca6051120c99e9dd64c3bd20fcc42f";
-    hash = "sha256-cb486FGF+4sUxgBbRfnbTTnZn2WQ3p93fSwDRCEtFJg=";
+    rev = "1da4681a8814366ec51e7630b76558e53be0997d";
+    hash = "sha256-Zs7ItuK31n0VSxwOsPUdZZLr68PypitZqcydACrx90Q=";
   };
 
   dontConfigure = true;

--- a/pkgs/development/interpreters/bqn/cbqn/singeli.nix
+++ b/pkgs/development/interpreters/bqn/cbqn/singeli.nix
@@ -5,13 +5,13 @@
 
 stdenvNoCC.mkDerivation {
   pname = "singeli";
-  version = "unstable-2023-01-23";
+  version = "unstable-2023-04-12";
 
   src = fetchFromGitHub {
     owner = "mlochbaum";
     repo = "Singeli";
-    rev = "0bc519ccbbe4051204d40bfc861a5bed7132e95f";
-    hash = "sha256-zo4yr9t3hp6BOX1ac3md6R/O+hl5MphZdCmI8nNP9Yc=";
+    rev = "3327956fedfdc6aef12954bc12120f20de2226d0";
+    hash = "sha256-k25hk5zTn0m+2Nh9buTJYhtM98/VRlQ0guoRw9el3VE=";
   };
 
   dontConfigure = true;

--- a/pkgs/development/interpreters/bqn/mlochbaum-bqn/default.nix
+++ b/pkgs/development/interpreters/bqn/mlochbaum-bqn/default.nix
@@ -7,13 +7,13 @@
 
 stdenvNoCC.mkDerivation rec {
   pname = "bqn";
-  version = "0.pre+date=2022-11-24";
+  version = "0.pre+date=2023-05-09";
 
   src = fetchFromGitHub {
     owner = "mlochbaum";
     repo = "BQN";
-    rev = "976bd82fb0e830876cca117c302c8a19048033a4";
-    hash = "sha256:1nhn30ypc2zvq58b3zi66ypc9wv3v8cryn43cqihazc1lq8qxqdw";
+    rev = "656b176c5dc783b038b018f0ed17a5414ea62b4d";
+    hash = "sha256-6r+N0eCvwvaoB84cw+Vtoqa6MXuI0NXLbOPblemY4M8=";
   };
 
   nativeBuildInputs = [ makeWrapper ];


### PR DESCRIPTION
- Update `replxx` and `singeli` submodules to the version that the CBQN repository tag `v0.2.0` has. It is the version currently packaged in nixpkgs.
- Update `mbqn` to the latest version. `mbqn` is used to generate the bytecode in the derivations that do not have `-standalone`.
- Fix a bug where both `cbqn` and `cbqn-replxx` had replxx enabled if `enableSingeli` was true.