### PR TITLE
libcpr: init at 1.10.2

### DIFF
--- a/pkgs/development/libraries/libcpr/default.nix
+++ b/pkgs/development/libraries/libcpr/default.nix
@@ -1,0 +1,43 @@
+{ lib, stdenv, fetchFromGitHub, cmake, curl }:
+
+let version = "1.10.2"; in
+stdenv.mkDerivation {
+  pname = "libcpr";
+  inherit version;
+
+  outputs = [ "out" "dev" ];
+
+  src = fetchFromGitHub {
+    owner = "libcpr";
+    repo = "cpr";
+    rev = "1.10.2";
+    hash = "sha256-F+ZIyFwWHn2AcVnKOaRlB7DjZzfmn8Iat/m3uknC8uA=";
+  };
+
+  nativeBuildInputs = [ cmake ];
+
+  buildInputs = [ curl ];
+
+  cmakeFlags = [
+    "-DCPR_USE_SYSTEM_CURL=ON"
+  ];
+
+  postPatch = ''
+    # Linking with stdc++fs is no longer necessary.
+    sed -i '/stdc++fs/d' include/CMakeLists.txt
+  '';
+
+  postInstall = ''
+    substituteInPlace "$out/lib/cmake/cpr/cprTargets.cmake" \
+      --replace "_IMPORT_PREFIX \"$out\"" \
+                "_IMPORT_PREFIX \"$dev\""
+  '';
+
+  meta = with lib; {
+    description = "C++ wrapper around libcurl";
+    homepage = "https://docs.libcpr.org/";
+    license = licenses.mit;
+    maintainers = with maintainers; [ rycee ];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -21404,6 +21404,8 @@ with pkgs;
 
   libcollectdclient = callPackage ../development/libraries/libcollectdclient { };
 
+  libcpr = callPackage ../development/libraries/libcpr { };
+
   libcredis = callPackage ../development/libraries/libcredis { };
 
   libctb = callPackage ../development/libraries/libctb { };


### PR DESCRIPTION
###### Description of changes

Add package for [libcpr](https://docs.libcpr.org/).

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).