### PR TITLE
m17n_lib: 1.8.0 -> 1.8.2

### DIFF
--- a/pkgs/tools/inputmethods/m17n-lib/default.nix
+++ b/pkgs/tools/inputmethods/m17n-lib/default.nix
@@ -1,23 +1,19 @@
-{ lib, stdenv, fetchurl, fetchpatch, m17n_db, autoreconfHook, pkg-config }:
+{ lib
+, stdenv
+, fetchurl
+, fetchpatch
+, m17n_db
+, autoreconfHook
+, pkg-config
+}:
 stdenv.mkDerivation rec {
   pname = "m17n-lib";
-  version = "1.8.0";
+  version = "1.8.2";
 
   src = fetchurl {
     url = "https://download.savannah.gnu.org/releases/m17n/m17n-lib-${version}.tar.gz";
-    sha256 = "0jp61y09xqj10mclpip48qlfhniw8gwy8b28cbzxy8hq8pkwmfkq";
+    hash = "sha256-5bA0SvnxFdlJV6P5ud68T45nG2n4wf1eC2iKeU16J/I=";
   };
-
-  patches = [
-    (fetchpatch {
-      # Patch pending upstream inclusion:
-      #   https://savannah.nongnu.org/bugs/index.php?61377
-      name = "parallel-build.patch";
-      url = "https://savannah.nongnu.org/bugs/download.php?file_id=53704";
-      hash = "sha256-1smKSIFVRJZSwCv0NiUsnndxKcPnJ/wqzH8+ka6nfNM=";
-      excludes = [ "src/ChangeLog" ];
-    })
-  ];
 
   strictDeps = true;
 


### PR DESCRIPTION
The main change is drop of the upstream patch that fixes parallel build failures.

Changes: https://lists.nongnu.org/archive/html/m17n-list/2023-05/msg00002.html

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
