### PR TITLE
[22.11] Backport the chromium{Beta,Dev} updates

### DIFF
--- a/pkgs/applications/networking/browsers/chromium/upstream-info.json
+++ b/pkgs/applications/networking/browsers/chromium/upstream-info.json
@@ -19,9 +19,9 @@
     }
   },
   "beta": {
-    "version": "111.0.5563.41",
-    "sha256": "0yx5zywbkvdp589906hbwhc2ivzfzd9zvahaxhh8zrh2ar7vqxay",
-    "sha256bin64": "0vnj0422dvpp42w8vgmip4k8c8k6hpvc84cdfvyhipas47dxvh6w",
+    "version": "111.0.5563.50",
+    "sha256": "1iygqlgr7qqac489kb0s4z5mwvchhi7wkibj84ziqcxlbqlfrmni",
+    "sha256bin64": "0pgrqb18hbp1q54flg0c63v85bi11m4rc6f25f0h0x90lvl65d05",
     "deps": {
       "gn": {
         "version": "2022-12-12",

--- a/pkgs/applications/networking/browsers/chromium/upstream-info.json
+++ b/pkgs/applications/networking/browsers/chromium/upstream-info.json
@@ -32,9 +32,9 @@
     }
   },
   "dev": {
-    "version": "111.0.5563.8",
-    "sha256": "0gflrk5i6dr5vrywhxab73044gryxj49px59blgl6nyphw7swpwy",
-    "sha256bin64": "1dgfjz9pnziy1zymk7g15i5zdb002g77q8kqhkwgi4m0fndknpmj",
+    "version": "111.0.5563.19",
+    "sha256": "0hrapzi45jpkb1b87nzlb896jd2h2jbz1mq91md5r2y6ag6fc55w",
+    "sha256bin64": "02aaqny23dcdp611n6jr7swkjnx1wd0lb8dgxq53b806f0s374cp",
     "deps": {
       "gn": {
         "version": "2022-12-12",

--- a/pkgs/applications/networking/browsers/chromium/upstream-info.json
+++ b/pkgs/applications/networking/browsers/chromium/upstream-info.json
@@ -32,15 +32,15 @@
     }
   },
   "dev": {
-    "version": "112.0.5582.0",
-    "sha256": "139g5cpqxvh6bf2x3aqs4md379rwrx143f8lcsym8hgpqdwq5sfk",
-    "sha256bin64": "1npksnnxcni62wx517xy64ysk3ja868gw48vgx4q8xc93g15n89c",
+    "version": "112.0.5596.2",
+    "sha256": "03s6phrqv3a6vdkig9npkvnpgc8hcfb6fqgxlmlcmhrf9cszvycg",
+    "sha256bin64": "1an3gmxcfkzfx30ympli8r7p3xp93i8zmvrayvgddvb8xszrbc3c",
     "deps": {
       "gn": {
-        "version": "2023-01-30",
+        "version": "2023-02-07",
         "url": "https://gn.googlesource.com/gn",
-        "rev": "84c8431f3e03cc6226c59dd49637c15ea31169a1",
-        "sha256": "15dqiy1bf1cixqg23bqpfb8mrlcxqbarjwzajc5hjmivykrjn2s3"
+        "rev": "edf6ef4b06b42c58292faea78498aff76bdf68ed",
+        "sha256": "1l3wz5rxg6q4923gxwx7hrrbx8123i7iniw8ihajp7v4qz27xbcp"
       }
     }
   },

--- a/pkgs/applications/networking/browsers/chromium/upstream-info.json
+++ b/pkgs/applications/networking/browsers/chromium/upstream-info.json
@@ -32,15 +32,15 @@
     }
   },
   "dev": {
-    "version": "112.0.5596.2",
-    "sha256": "03s6phrqv3a6vdkig9npkvnpgc8hcfb6fqgxlmlcmhrf9cszvycg",
-    "sha256bin64": "1an3gmxcfkzfx30ympli8r7p3xp93i8zmvrayvgddvb8xszrbc3c",
+    "version": "112.0.5615.12",
+    "sha256": "1kkpfaqr3rzxlj7kn2l8gchvq17w03mcf3aajqv193jazcb083ci",
+    "sha256bin64": "1ci3vmr6q665rp8h7b1y7gmkv4zczjw5ryf0yycwfcll087ym6g6",
     "deps": {
       "gn": {
-        "version": "2023-02-07",
+        "version": "2023-02-17",
         "url": "https://gn.googlesource.com/gn",
-        "rev": "edf6ef4b06b42c58292faea78498aff76bdf68ed",
-        "sha256": "1l3wz5rxg6q4923gxwx7hrrbx8123i7iniw8ihajp7v4qz27xbcp"
+        "rev": "b25a2f8c2d33f02082f0f258350f5e22c0973108",
+        "sha256": "075p4jwk1apvwmqmvhwfw5f669ci7nxwjq9mz5aa2g5lz4fkdm4c"
       }
     }
   },

--- a/pkgs/applications/networking/browsers/chromium/upstream-info.json
+++ b/pkgs/applications/networking/browsers/chromium/upstream-info.json
@@ -32,9 +32,9 @@
     }
   },
   "dev": {
-    "version": "113.0.5668.0",
-    "sha256": "0rp43m8n26rs2hiysavr0w65x27i6n94jghx81w92fxbfjkc0qp3",
-    "sha256bin64": "1xnx8pg0xhbw2va8bm97x092andzzvqxcm9ydi7d6qadhwqam1br",
+    "version": "113.0.5672.12",
+    "sha256": "1h0mll8xq096jzqg4hhwcaxg12j5pinjjyicm276f7r5m12l1c1x",
+    "sha256bin64": "1ffyhigs4x3c1cr4r8pv5jjg6qx9pxwy0hmyp9a1196jxkh65kpy",
     "deps": {
       "gn": {
         "version": "2023-03-18",

--- a/pkgs/applications/networking/browsers/chromium/upstream-info.json
+++ b/pkgs/applications/networking/browsers/chromium/upstream-info.json
@@ -19,9 +19,9 @@
     }
   },
   "beta": {
-    "version": "111.0.5563.50",
-    "sha256": "1iygqlgr7qqac489kb0s4z5mwvchhi7wkibj84ziqcxlbqlfrmni",
-    "sha256bin64": "0pgrqb18hbp1q54flg0c63v85bi11m4rc6f25f0h0x90lvl65d05",
+    "version": "111.0.5563.64",
+    "sha256": "0x20zqwq051a5j76q1c3m0ddf1hhcm6fgz3b7rqrfamjppia0p3x",
+    "sha256bin64": "1cl7zbsl0ndp5x1g0p1q511mn72iy72sqxycmlrccs9j8jmaiqgw",
     "deps": {
       "gn": {
         "version": "2022-12-12",

--- a/pkgs/applications/networking/browsers/chromium/upstream-info.json
+++ b/pkgs/applications/networking/browsers/chromium/upstream-info.json
@@ -19,9 +19,9 @@
     }
   },
   "beta": {
-    "version": "112.0.5615.20",
-    "sha256": "0qxifnc2xk2zkmpzc1pzd95ym3i829qzgzd83qh7ah9p64c76f9y",
-    "sha256bin64": "11c7k87fnfhaynhpp2rjzpzydrl096fjx3gw589nvq1lckbg9nsd",
+    "version": "112.0.5615.29",
+    "sha256": "0k9dn1gzfr2j353ppza1nypj0a4b27p9n742cms3z8583da8kw6p",
+    "sha256bin64": "04m77ndsfygpb1g11iyscvfszgykbr5n3s6bh1shnpkpdbvx3dki",
     "deps": {
       "gn": {
         "version": "2023-02-17",

--- a/pkgs/applications/networking/browsers/chromium/upstream-info.json
+++ b/pkgs/applications/networking/browsers/chromium/upstream-info.json
@@ -32,9 +32,9 @@
     }
   },
   "dev": {
-    "version": "113.0.5638.0",
-    "sha256": "0v4hminx765swv0iakg5qw7rk6zc67cn5p9x625jaizz50ahpfib",
-    "sha256bin64": "07snjlizj30mzcm5fbsg6ibd4jqmcwiykdwrpqmdqq902c3gwc3r",
+    "version": "113.0.5653.0",
+    "sha256": "1s1as01javi8z4sax70rx4cn03lwfis75rkv58yk7sfhj3qafzhk",
+    "sha256bin64": "1i1zkdq8qzm8r5lg10qmqaycx45m2qc9fzjql0si0amy81sdkfsn",
     "deps": {
       "gn": {
         "version": "2023-02-24",

--- a/pkgs/applications/networking/browsers/chromium/upstream-info.json
+++ b/pkgs/applications/networking/browsers/chromium/upstream-info.json
@@ -19,15 +19,15 @@
     }
   },
   "beta": {
-    "version": "111.0.5563.64",
-    "sha256": "0x20zqwq051a5j76q1c3m0ddf1hhcm6fgz3b7rqrfamjppia0p3x",
-    "sha256bin64": "1cl7zbsl0ndp5x1g0p1q511mn72iy72sqxycmlrccs9j8jmaiqgw",
+    "version": "112.0.5615.20",
+    "sha256": "0qxifnc2xk2zkmpzc1pzd95ym3i829qzgzd83qh7ah9p64c76f9y",
+    "sha256bin64": "11c7k87fnfhaynhpp2rjzpzydrl096fjx3gw589nvq1lckbg9nsd",
     "deps": {
       "gn": {
-        "version": "2022-12-12",
+        "version": "2023-02-17",
         "url": "https://gn.googlesource.com/gn",
-        "rev": "5e19d2fb166fbd4f6f32147fbb2f497091a54ad8",
-        "sha256": "1b5fwldfmkkbpp5x63n1dxv0nc965hphc8rm8ah7zg44zscm9z30"
+        "rev": "b25a2f8c2d33f02082f0f258350f5e22c0973108",
+        "sha256": "075p4jwk1apvwmqmvhwfw5f669ci7nxwjq9mz5aa2g5lz4fkdm4c"
       }
     }
   },

--- a/pkgs/applications/networking/browsers/chromium/upstream-info.json
+++ b/pkgs/applications/networking/browsers/chromium/upstream-info.json
@@ -19,9 +19,9 @@
     }
   },
   "beta": {
-    "version": "111.0.5563.19",
-    "sha256": "0hrapzi45jpkb1b87nzlb896jd2h2jbz1mq91md5r2y6ag6fc55w",
-    "sha256bin64": "1mjrp13xf913xhm9hz6yg595g0jg2afmwvzxzpw79y4snaf2ihza",
+    "version": "111.0.5563.33",
+    "sha256": "19qgmhws90z11mg2vniq9qkppp10qw30hbj9b0nw7n8ca2pm3a71",
+    "sha256bin64": "1lv4ixcjcdwzjv5q1iys55lfhiha4vn6609kdxnhr9jamksp827g",
     "deps": {
       "gn": {
         "version": "2022-12-12",

--- a/pkgs/applications/networking/browsers/chromium/upstream-info.json
+++ b/pkgs/applications/networking/browsers/chromium/upstream-info.json
@@ -32,15 +32,15 @@
     }
   },
   "dev": {
-    "version": "114.0.5696.0",
-    "sha256": "0hcf971azy3jjsl211qk53b6nk0f4pzf2dwfv3rjh4f6fa3nbwai",
-    "sha256bin64": "1ssj633vdg3ghd87az28q262ly1fk7rc3k70l1531xvj2030ijrl",
+    "version": "114.0.5720.4",
+    "sha256": "1q9r4m1gda1mq0nwi00yfpxsqdghd0qb3k7a0xa9py8l6jcv8ifa",
+    "sha256bin64": "15ss5xix773yn4g24ww9bw38g7wxgwhdqbgmwy44yvp0yl824czb",
     "deps": {
       "gn": {
-        "version": "2023-03-18",
+        "version": "2023-04-07",
         "url": "https://gn.googlesource.com/gn",
-        "rev": "41fef642de70ecdcaaa26be96d56a0398f95abd4",
-        "sha256": "12w4g2dl58283allclpi1c4i6ih9v2xvdb9hpbmfda12v8lizmlq"
+        "rev": "ffeea1b1fd070cb6a8d47154a03f8523486b50a7",
+        "sha256": "0xpwh06a82nb4j9ifr878rij97dikfcjfbc08cnkmxrx7hs1sjdw"
       }
     }
   },

--- a/pkgs/applications/networking/browsers/chromium/upstream-info.json
+++ b/pkgs/applications/networking/browsers/chromium/upstream-info.json
@@ -19,9 +19,9 @@
     }
   },
   "beta": {
-    "version": "111.0.5563.33",
-    "sha256": "19qgmhws90z11mg2vniq9qkppp10qw30hbj9b0nw7n8ca2pm3a71",
-    "sha256bin64": "1lv4ixcjcdwzjv5q1iys55lfhiha4vn6609kdxnhr9jamksp827g",
+    "version": "111.0.5563.41",
+    "sha256": "0yx5zywbkvdp589906hbwhc2ivzfzd9zvahaxhh8zrh2ar7vqxay",
+    "sha256bin64": "0vnj0422dvpp42w8vgmip4k8c8k6hpvc84cdfvyhipas47dxvh6w",
     "deps": {
       "gn": {
         "version": "2022-12-12",

--- a/pkgs/applications/networking/browsers/chromium/upstream-info.json
+++ b/pkgs/applications/networking/browsers/chromium/upstream-info.json
@@ -32,15 +32,15 @@
     }
   },
   "dev": {
-    "version": "111.0.5563.19",
-    "sha256": "0hrapzi45jpkb1b87nzlb896jd2h2jbz1mq91md5r2y6ag6fc55w",
-    "sha256bin64": "02aaqny23dcdp611n6jr7swkjnx1wd0lb8dgxq53b806f0s374cp",
+    "version": "112.0.5582.0",
+    "sha256": "139g5cpqxvh6bf2x3aqs4md379rwrx143f8lcsym8hgpqdwq5sfk",
+    "sha256bin64": "1npksnnxcni62wx517xy64ysk3ja868gw48vgx4q8xc93g15n89c",
     "deps": {
       "gn": {
-        "version": "2022-12-12",
+        "version": "2023-01-30",
         "url": "https://gn.googlesource.com/gn",
-        "rev": "5e19d2fb166fbd4f6f32147fbb2f497091a54ad8",
-        "sha256": "1b5fwldfmkkbpp5x63n1dxv0nc965hphc8rm8ah7zg44zscm9z30"
+        "rev": "84c8431f3e03cc6226c59dd49637c15ea31169a1",
+        "sha256": "15dqiy1bf1cixqg23bqpfb8mrlcxqbarjwzajc5hjmivykrjn2s3"
       }
     }
   },

--- a/pkgs/applications/networking/browsers/chromium/upstream-info.json
+++ b/pkgs/applications/networking/browsers/chromium/upstream-info.json
@@ -32,9 +32,9 @@
     }
   },
   "dev": {
-    "version": "113.0.5672.12",
-    "sha256": "1h0mll8xq096jzqg4hhwcaxg12j5pinjjyicm276f7r5m12l1c1x",
-    "sha256bin64": "1ffyhigs4x3c1cr4r8pv5jjg6qx9pxwy0hmyp9a1196jxkh65kpy",
+    "version": "113.0.5672.24",
+    "sha256": "1z7yv5lqi1n4ycymkf0kz1v8ig06n430a37ik8hri3a6db8r9lv8",
+    "sha256bin64": "0byksvk781gmh5fmjmc77jh19gvkzadf78yr9b4c42las44g4pn4",
     "deps": {
       "gn": {
         "version": "2023-03-18",

--- a/pkgs/applications/networking/browsers/chromium/upstream-info.json
+++ b/pkgs/applications/networking/browsers/chromium/upstream-info.json
@@ -19,9 +19,9 @@
     }
   },
   "beta": {
-    "version": "113.0.5672.37",
-    "sha256": "0hmn7h5l8q161f6hwp5g7zbxfdsplwqh5j3yby56qgljgca8pj7f",
-    "sha256bin64": "0j4hl2sbh8cig00rpn4ssxi2087wr33749b5sdcrk93kfzqinrix",
+    "version": "113.0.5672.53",
+    "sha256": "0k91xx3fm0kywjn00s9b7p776882b1mfajf2ig0iz3jac6rprh56",
+    "sha256bin64": "1pzpigz8l6hsddb7v2g9m5d32hlq979l1cpj2yfnc6dixjs8x053",
     "deps": {
       "gn": {
         "version": "2023-03-18",

--- a/pkgs/applications/networking/browsers/chromium/upstream-info.json
+++ b/pkgs/applications/networking/browsers/chromium/upstream-info.json
@@ -19,15 +19,15 @@
     }
   },
   "beta": {
-    "version": "112.0.5615.49",
-    "sha256": "0hgzbbmz40235binfn3vkkxzvwxilaxg04dclqrz980z7hvkgzfx",
-    "sha256bin64": "146gd9csj08d1ygwwh6gyqqbi7d34mhv3vv7wv4a8z9hn7jhdifg",
+    "version": "113.0.5672.24",
+    "sha256": "1z7yv5lqi1n4ycymkf0kz1v8ig06n430a37ik8hri3a6db8r9lv8",
+    "sha256bin64": "1y9jaw47dgphqr2l8yc36s7k9lf4qrbmfll1d2d1zdjd5ma3slab",
     "deps": {
       "gn": {
-        "version": "2023-02-17",
+        "version": "2023-03-18",
         "url": "https://gn.googlesource.com/gn",
-        "rev": "b25a2f8c2d33f02082f0f258350f5e22c0973108",
-        "sha256": "075p4jwk1apvwmqmvhwfw5f669ci7nxwjq9mz5aa2g5lz4fkdm4c"
+        "rev": "41fef642de70ecdcaaa26be96d56a0398f95abd4",
+        "sha256": "12w4g2dl58283allclpi1c4i6ih9v2xvdb9hpbmfda12v8lizmlq"
       }
     }
   },

--- a/pkgs/applications/networking/browsers/chromium/upstream-info.json
+++ b/pkgs/applications/networking/browsers/chromium/upstream-info.json
@@ -19,9 +19,9 @@
     }
   },
   "beta": {
-    "version": "113.0.5672.53",
-    "sha256": "0k91xx3fm0kywjn00s9b7p776882b1mfajf2ig0iz3jac6rprh56",
-    "sha256bin64": "1pzpigz8l6hsddb7v2g9m5d32hlq979l1cpj2yfnc6dixjs8x053",
+    "version": "113.0.5672.63",
+    "sha256": "07pf28yy5c4xw1xkycgzq53zbj14zvhh00sv601nggisq4fw3kkn",
+    "sha256bin64": "1n1bcim5wfafa3bl9grp3ckmnbi1mzhdxz8pim408wz892da34zl",
     "deps": {
       "gn": {
         "version": "2023-03-18",

--- a/pkgs/applications/networking/browsers/chromium/upstream-info.json
+++ b/pkgs/applications/networking/browsers/chromium/upstream-info.json
@@ -32,15 +32,15 @@
     }
   },
   "dev": {
-    "version": "113.0.5653.0",
-    "sha256": "1s1as01javi8z4sax70rx4cn03lwfis75rkv58yk7sfhj3qafzhk",
-    "sha256bin64": "1i1zkdq8qzm8r5lg10qmqaycx45m2qc9fzjql0si0amy81sdkfsn",
+    "version": "113.0.5668.0",
+    "sha256": "0rp43m8n26rs2hiysavr0w65x27i6n94jghx81w92fxbfjkc0qp3",
+    "sha256bin64": "1xnx8pg0xhbw2va8bm97x092andzzvqxcm9ydi7d6qadhwqam1br",
     "deps": {
       "gn": {
-        "version": "2023-02-24",
+        "version": "2023-03-18",
         "url": "https://gn.googlesource.com/gn",
-        "rev": "fe330c0ae1ec29db30b6f830e50771a335e071fb",
-        "sha256": "0fj8kfck53hbfz30m8p0mfcqbjs9cjrlfzi03l3h7n7yd88js8i4"
+        "rev": "41fef642de70ecdcaaa26be96d56a0398f95abd4",
+        "sha256": "12w4g2dl58283allclpi1c4i6ih9v2xvdb9hpbmfda12v8lizmlq"
       }
     }
   },

--- a/pkgs/applications/networking/browsers/chromium/upstream-info.json
+++ b/pkgs/applications/networking/browsers/chromium/upstream-info.json
@@ -19,9 +19,9 @@
     }
   },
   "beta": {
-    "version": "113.0.5672.24",
-    "sha256": "1z7yv5lqi1n4ycymkf0kz1v8ig06n430a37ik8hri3a6db8r9lv8",
-    "sha256bin64": "1y9jaw47dgphqr2l8yc36s7k9lf4qrbmfll1d2d1zdjd5ma3slab",
+    "version": "113.0.5672.37",
+    "sha256": "0hmn7h5l8q161f6hwp5g7zbxfdsplwqh5j3yby56qgljgca8pj7f",
+    "sha256bin64": "0j4hl2sbh8cig00rpn4ssxi2087wr33749b5sdcrk93kfzqinrix",
     "deps": {
       "gn": {
         "version": "2023-03-18",

--- a/pkgs/applications/networking/browsers/chromium/upstream-info.json
+++ b/pkgs/applications/networking/browsers/chromium/upstream-info.json
@@ -19,9 +19,9 @@
     }
   },
   "beta": {
-    "version": "112.0.5615.39",
-    "sha256": "12q4wxlgcqqflsxvcbx00228l1hjzb940ichywhiwmndxjjdvrgg",
-    "sha256bin64": "0b5c02wlmywhkxgdlnwys1djknicvqxcichxgazgpxbjmr8mmzwv",
+    "version": "112.0.5615.49",
+    "sha256": "0hgzbbmz40235binfn3vkkxzvwxilaxg04dclqrz980z7hvkgzfx",
+    "sha256bin64": "146gd9csj08d1ygwwh6gyqqbi7d34mhv3vv7wv4a8z9hn7jhdifg",
     "deps": {
       "gn": {
         "version": "2023-02-17",

--- a/pkgs/applications/networking/browsers/chromium/upstream-info.json
+++ b/pkgs/applications/networking/browsers/chromium/upstream-info.json
@@ -32,9 +32,9 @@
     }
   },
   "dev": {
-    "version": "112.0.5615.12",
-    "sha256": "1kkpfaqr3rzxlj7kn2l8gchvq17w03mcf3aajqv193jazcb083ci",
-    "sha256bin64": "1ci3vmr6q665rp8h7b1y7gmkv4zczjw5ryf0yycwfcll087ym6g6",
+    "version": "112.0.5615.20",
+    "sha256": "0qxifnc2xk2zkmpzc1pzd95ym3i829qzgzd83qh7ah9p64c76f9y",
+    "sha256bin64": "0yvgwh8mmm42jp2cgi3kz9mq7gdcna3cf61ripgpqd8bf34fb6rx",
     "deps": {
       "gn": {
         "version": "2023-02-17",

--- a/pkgs/applications/networking/browsers/chromium/upstream-info.json
+++ b/pkgs/applications/networking/browsers/chromium/upstream-info.json
@@ -32,15 +32,15 @@
     }
   },
   "dev": {
-    "version": "114.0.5720.4",
-    "sha256": "1q9r4m1gda1mq0nwi00yfpxsqdghd0qb3k7a0xa9py8l6jcv8ifa",
-    "sha256bin64": "15ss5xix773yn4g24ww9bw38g7wxgwhdqbgmwy44yvp0yl824czb",
+    "version": "114.0.5735.6",
+    "sha256": "0wxlfqxrawk77yzm00hb1fbssrycl4mha53wm4y5mlb8warqs5jk",
+    "sha256bin64": "0vlb6zr50kn7i0rfvy3yvwzcffpg5ki7is8i3ck43b1gr1bsmgmb",
     "deps": {
       "gn": {
-        "version": "2023-04-07",
+        "version": "2023-04-19",
         "url": "https://gn.googlesource.com/gn",
-        "rev": "ffeea1b1fd070cb6a8d47154a03f8523486b50a7",
-        "sha256": "0xpwh06a82nb4j9ifr878rij97dikfcjfbc08cnkmxrx7hs1sjdw"
+        "rev": "5a004f9427a050c6c393c07ddb85cba8ff3849fa",
+        "sha256": "01xrh9m9m6x8lz0vxwdw2mrhrvnw93zpg09hwdhqakj06agf4jjk"
       }
     }
   },

--- a/pkgs/applications/networking/browsers/chromium/upstream-info.json
+++ b/pkgs/applications/networking/browsers/chromium/upstream-info.json
@@ -32,15 +32,15 @@
     }
   },
   "dev": {
-    "version": "112.0.5615.20",
-    "sha256": "0qxifnc2xk2zkmpzc1pzd95ym3i829qzgzd83qh7ah9p64c76f9y",
-    "sha256bin64": "0yvgwh8mmm42jp2cgi3kz9mq7gdcna3cf61ripgpqd8bf34fb6rx",
+    "version": "113.0.5638.0",
+    "sha256": "0v4hminx765swv0iakg5qw7rk6zc67cn5p9x625jaizz50ahpfib",
+    "sha256bin64": "07snjlizj30mzcm5fbsg6ibd4jqmcwiykdwrpqmdqq902c3gwc3r",
     "deps": {
       "gn": {
-        "version": "2023-02-17",
+        "version": "2023-02-24",
         "url": "https://gn.googlesource.com/gn",
-        "rev": "b25a2f8c2d33f02082f0f258350f5e22c0973108",
-        "sha256": "075p4jwk1apvwmqmvhwfw5f669ci7nxwjq9mz5aa2g5lz4fkdm4c"
+        "rev": "fe330c0ae1ec29db30b6f830e50771a335e071fb",
+        "sha256": "0fj8kfck53hbfz30m8p0mfcqbjs9cjrlfzi03l3h7n7yd88js8i4"
       }
     }
   },

--- a/pkgs/applications/networking/browsers/chromium/upstream-info.json
+++ b/pkgs/applications/networking/browsers/chromium/upstream-info.json
@@ -19,9 +19,9 @@
     }
   },
   "beta": {
-    "version": "110.0.5481.77",
-    "sha256": "1kl1k29sr5qw8pg7shvizw4b37fxjlgah56p57kq641iqhnsnj73",
-    "sha256bin64": "0wnzgvwbpmb5ja4ba5mjk4bk0aaxzbw4zi509vw96q6mbqmr4iwr",
+    "version": "111.0.5563.19",
+    "sha256": "0hrapzi45jpkb1b87nzlb896jd2h2jbz1mq91md5r2y6ag6fc55w",
+    "sha256bin64": "1mjrp13xf913xhm9hz6yg595g0jg2afmwvzxzpw79y4snaf2ihza",
     "deps": {
       "gn": {
         "version": "2022-12-12",

--- a/pkgs/applications/networking/browsers/chromium/upstream-info.json
+++ b/pkgs/applications/networking/browsers/chromium/upstream-info.json
@@ -32,9 +32,9 @@
     }
   },
   "dev": {
-    "version": "113.0.5672.24",
-    "sha256": "1z7yv5lqi1n4ycymkf0kz1v8ig06n430a37ik8hri3a6db8r9lv8",
-    "sha256bin64": "0byksvk781gmh5fmjmc77jh19gvkzadf78yr9b4c42las44g4pn4",
+    "version": "114.0.5696.0",
+    "sha256": "0hcf971azy3jjsl211qk53b6nk0f4pzf2dwfv3rjh4f6fa3nbwai",
+    "sha256bin64": "1ssj633vdg3ghd87az28q262ly1fk7rc3k70l1531xvj2030ijrl",
     "deps": {
       "gn": {
         "version": "2023-03-18",

--- a/pkgs/applications/networking/browsers/chromium/upstream-info.json
+++ b/pkgs/applications/networking/browsers/chromium/upstream-info.json
@@ -19,9 +19,9 @@
     }
   },
   "beta": {
-    "version": "112.0.5615.29",
-    "sha256": "0k9dn1gzfr2j353ppza1nypj0a4b27p9n742cms3z8583da8kw6p",
-    "sha256bin64": "04m77ndsfygpb1g11iyscvfszgykbr5n3s6bh1shnpkpdbvx3dki",
+    "version": "112.0.5615.39",
+    "sha256": "12q4wxlgcqqflsxvcbx00228l1hjzb940ichywhiwmndxjjdvrgg",
+    "sha256bin64": "0b5c02wlmywhkxgdlnwys1djknicvqxcichxgazgpxbjmr8mmzwv",
     "deps": {
       "gn": {
         "version": "2023-02-17",


### PR DESCRIPTION
###### Description of changes

Not really required but let's get these in as well before backporting M113 (normally we irregularly backport those to keep the diff small/manageable but the diff already got out of hand - luckily NixOS 23.05 will be out soon :smile:).
~~Only https://github.com/NixOS/nixpkgs/commit/1926f85b685103d07b54e8fe68a45ab9440d389f makes a difference for `chromium` and `ungoogled-chromium`.~~ Nvm, I just dropped that commit since I already backported 175a86d3b654afcfb6d98598c3abca5f436f35fb without the LLVM change.
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
