### PR TITLE
wapp: init at 1.0

### DIFF
--- a/pkgs/development/libraries/wapp/default.nix
+++ b/pkgs/development/libraries/wapp/default.nix
@@ -1,0 +1,32 @@
+{ lib, fetchurl, tcl }:
+
+tcl.mkTclDerivation {
+  pname = "wapp";
+  version = "unstable-2023-05-05";
+
+  src = fetchurl {
+    url = "https://wapp.tcl-lang.org/home/raw/72d0d081e3e6a4aea91ddf429a85cbdf40f9a32d46cccfe81bb75ee50e6cf9cf?at=wapp.tcldir?ci=9d3368116c59ef16";
+    hash = "sha256-poG7dvaiOXMi4oWMQ5t3v7SYEqZLUY/TsWXrTL62xd0=";
+  };
+
+  dontUnpack = true;
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/lib/wapp
+    cp $src $out/lib/wapp/wapp.tcl
+    cat <<EOF > $out/lib/wapp/pkgIndex.tcl
+    package ifneeded wapp 1.0 [list source [file join \$dir wapp.tcl]]
+    EOF
+
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    homepage = "https://wapp.tcl-lang.org/home/doc/trunk/README.md";
+    description = "A framework for writing web applications in Tcl";
+    license = licenses.bsd2;
+    maintainers = with maintainers; [ nat-418 ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -24312,6 +24312,8 @@ with pkgs;
 
   wangle = callPackage ../development/libraries/wangle { };
 
+  wapp = callPackage ../development/libraries/wapp { };
+
   wavpack = callPackage ../development/libraries/wavpack { };
 
   wayland = darwin.apple_sdk_11_0.callPackage ../development/libraries/wayland { };


### PR DESCRIPTION
###### Description of changes

Wapp is a framework for writing web applications in Tcl

Homepage: https://wapp.tcl-lang.org/home/doc/trunk/README.md

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

