### PR TITLE
cargo-docset: init at 0.3.1

### DIFF
--- a/pkgs/development/tools/rust/cargo-docset/default.nix
+++ b/pkgs/development/tools/rust/cargo-docset/default.nix
@@ -1,0 +1,34 @@
+{ lib
+, fetchFromGitHub
+, gitUpdater
+, rustPlatform
+, sqlite
+}:
+
+rustPlatform.buildRustPackage rec {
+  pname = "cargo-docset";
+  version = "0.3.1";
+
+  src = fetchFromGitHub {
+    owner = "Robzz";
+    repo = pname;
+    rev = "v${version}";
+    hash = "sha256-o2CSQiU9fEoS3eRmwphtYGZTwn3mstRm2Tlvval83+U=";
+  };
+
+  cargoHash = "sha256-YHrSvfHfQ7kbVeCOgggYf3E7gHq+RhVKZrzP8LqX5I0=";
+
+  buildInputs = [ sqlite ];
+
+  passthru.updateScript = gitUpdater {
+    rev-prefix = "v";
+  };
+
+  meta = with lib; {
+    description = "Cargo subcommand to generate a Dash/Zeal docset for your Rust packages";
+    homepage = "https://github.com/Robzz/cargo-docset";
+    changelog = "https://github.com/Robzz/cargo-docset/blob/${version}/CHANGELOG.md";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ colinsane ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -16187,6 +16187,7 @@ with pkgs;
   };
   cargo-deb = callPackage ../development/tools/rust/cargo-deb { };
   cargo-deps = callPackage ../development/tools/rust/cargo-deps { };
+  cargo-docset = callPackage ../development/tools/rust/cargo-docset { };
   cargo-edit = callPackage ../development/tools/rust/cargo-edit {
     inherit (darwin.apple_sdk.frameworks) Security;
   };


### PR DESCRIPTION
###### Description of changes

cargo-docset is useful in combination with the existing `zeal` documentation viewer in nixpkgs. here's how one could build API docs for some rust/Cargo project and view them locally:
```sh
# cd into any Cargo project, or clone this one as an example:
~$ git clone https://github.com/Robzz/cargo-docset.git
~$ cd cargo-docset

# build the docs
~/cargo-docset$ nix-shell -p cargo cargo-docset --run "cargo docset"

# view the docs in zeal
~/cargo-docset$ mkdir -p ~/.local/share/Zeal/Zeal/docsets
~/cargo-docset$ cp -R target/docset/* ~/.local/share/Zeal/Zeal/docsets/
~/cargo-docset$ nix-shell -p zeal-qt5 --run zeal
```

---- 
those who want to install docsets system-wide (as one would with manpages) may additionally find this [cargoDocsetHook](https://git.uninsane.org/colin/nix-files/src/commit/d661a0776a518ad6fe7692c958dd0b3b52bcadbd/pkgs/additional/cargo-docset/hook.nix) setup hook of use. one could add `cargoDocsetHook` into the `nativeBuildDependencies` for any rust packages they use (via `overrideAttrs` inside an overlay, say) and then configure `environment.pathsToLink = ["/share/docset"]`and direct zeal to `/run/current-system/sw/share/docset`.

for now i'm leaving `cargoDocsetHook` out of this PR because it's a bit more niche than any existing setup hook i could find in nixpkgs. it's available via [NUR](https://github.com/nix-community/NUR) for those who want it.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
