### PR TITLE
couchdb3: 3.3.1 -> 3.3.2

### DIFF
--- a/pkgs/servers/http/couchdb/3.nix
+++ b/pkgs/servers/http/couchdb/3.nix
@@ -1,31 +1,55 @@
-{ lib, stdenv, fetchurl, erlang, icu, openssl, spidermonkey_91
-, coreutils, bash, python3, nixosTests }:
+{ lib
+, stdenv
+, fetchurl
+, erlang
+, icu
+, openssl
+, spidermonkey_91
+, python3
+, nixosTests
+}:
 
 stdenv.mkDerivation rec {
   pname = "couchdb";
-  version = "3.3.1";
+  version = "3.3.2";
 
   src = fetchurl {
     url = "mirror://apache/couchdb/source/${version}/apache-${pname}-${version}.tar.gz";
-    sha256 = "sha256-m4nXtU9+9StCvVGmoKLTsbBszjld8smdjx9H+TVeK+4=";
+    hash = "sha256-PWgj1C0Qzw1PhsnE/lnJkyyJ1oV4/LbEtCeNx2kwjao=";
   };
+
+  postPatch = ''
+    substituteInPlace src/couch/rebar.config.script --replace '/usr/include/mozjs-91' "${spidermonkey_91.dev}/include/mozjs-91"
+    substituteInPlace configure --replace '/usr/include/''${SM_HEADERS}' "${spidermonkey_91.dev}/include/mozjs-91"
+    patchShebangs bin/rebar
+  '';
 
   nativeBuildInputs = [
     erlang
   ];
-  buildInputs = [ icu openssl spidermonkey_91 (python3.withPackages(ps: with ps; [ requests ]))];
-  postPatch = ''
-    substituteInPlace src/couch/rebar.config.script --replace '/usr/include/mozjs-91' "${spidermonkey_91.dev}/include/mozjs-91"
-    patchShebangs bin/rebar
-  '';
+
+  buildInputs = [
+    icu
+    openssl
+    spidermonkey_91
+    (python3.withPackages(ps: with ps; [ requests ]))
+  ];
 
   dontAddPrefix= "True";
-  configureFlags = ["--spidermonkey-version=91"];
-  buildFlags = ["release"];
+
+  configureFlags = [
+    "--spidermonkey-version=91"
+  ];
+
+  buildFlags = [
+    "release"
+  ];
 
   installPhase = ''
+    runHook preInstall
     mkdir -p $out
     cp -r rel/couchdb/* $out
+    runHook postInstall
   '';
 
   passthru.tests = {


### PR DESCRIPTION
https://docs.couchdb.org/en/latest/whatsnew/3.3.html#version-3-3-2
https://docs.couchdb.org/en/latest/cve/2023-26268.html

Everywhere I go, CVEs await. Support for Spidermonkey 102 when?

Fixes: CVE-2023-26268

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
