### PR TITLE
python310Packages.paramz: unbreak

### DIFF
--- a/pkgs/development/python-modules/paramz/default.nix
+++ b/pkgs/development/python-modules/paramz/default.nix
@@ -1,4 +1,4 @@
-{ lib, buildPythonPackage, fetchPypi, numpy, scipy, six, decorator, nose }:
+{ lib, buildPythonPackage, fetchpatch, fetchPypi, numpy, scipy, six, decorator, nose }:
 
 buildPythonPackage rec {
   pname = "paramz";
@@ -9,10 +9,19 @@ buildPythonPackage rec {
     sha256 = "0917211c0f083f344e7f1bc997e0d713dbc147b6380bc19f606119394f820b9a";
   };
 
+  patches = [
+    (fetchpatch {
+      name = "remove-deprecated-numpy-uses";
+      url = "https://github.com/sods/paramz/pull/38/commits/a5a0be15b12c5864b438d870b519ad17cc72cd12.patch";
+      hash = "sha256-vj/amEXL9QJ7VdqJmyhv/lj8n+yuiZEARQBYWw6lgBA=";
+    })
+  ];
+
   propagatedBuildInputs = [ numpy scipy six decorator ];
   nativeCheckInputs = [ nose ];
 
-  # Ran 113 tests in 3.082s
+  pythonImportsCheck = [ "paramz" ];
+
   checkPhase = ''
       nosetests -v paramz/tests
   '';


### PR DESCRIPTION
###### Description of changes

Patch out deprecated Numpy API usage.

For ZHF (#230712).

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
