### PR TITLE
python311Packages.transforms3d: unstable-2019-12-17 -> 0.4.1; unbreak

### DIFF
--- a/pkgs/development/python-modules/transforms3d/default.nix
+++ b/pkgs/development/python-modules/transforms3d/default.nix
@@ -1,8 +1,8 @@
 { lib
 , buildPythonPackage
 , fetchFromGitHub
-, isPy27
-, pytest
+, pythonOlder
+, pytestCheckHook
 , numpy
 , scipy
 , sympy
@@ -10,22 +10,22 @@
 
 buildPythonPackage rec {
   pname = "transforms3d";
-  version = "unstable-2019-12-17";
+  version = "0.4.1";
+  format = "setuptools";
 
-  disabled = isPy27;
+  disabled = pythonOlder "3.7";
 
-  # no Git tag or PyPI release in some time
   src = fetchFromGitHub {
     owner = "matthew-brett";
     repo = pname;
-    rev = "6b20250c610249914ca5e3a3a2964c36ca35c19a";
-    sha256 = "1z789hgk71a6rj6mqp9srpzamg06g58hs2p1l1p344cfnkj5a4kc";
+    rev = "refs/tags/${version}";
+    hash = "sha256-GgnjvwAfyxnDfBGvgMFIPPbR88BWFiNGrScVORygq94=";
   };
 
   propagatedBuildInputs = [ numpy sympy ];
 
-  nativeCheckInputs = [ pytest scipy ];
-  checkPhase = "pytest transforms3d";
+  nativeCheckInputs = [ pytestCheckHook scipy ];
+  pythonImportsCheck = [ "transforms3d" ];
 
   meta = with lib; {
     homepage = "https://matthew-brett.github.io/transforms3d";


### PR DESCRIPTION
###### Description of changes

Update the package to a recent version, unbreaking it.

For ZHF (#230712).

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
