### PR TITLE
subxt: init at 0.31.0

### DIFF
--- a/pkgs/development/tools/subxt/default.nix
+++ b/pkgs/development/tools/subxt/default.nix
@@ -1,0 +1,36 @@
+{ lib
+, stdenv
+, rustPlatform
+, fetchFromGitHub
+, cmake
+}:
+
+rustPlatform.buildRustPackage rec {
+  pname = "subxt";
+  version = "0.31.0";
+
+  src = fetchFromGitHub {
+    owner = "paritytech";
+    repo = "subxt";
+    rev = "v${version}";
+    hash = "sha256-eEsb88f16Ug9h7JNkzwSTxJZEV5r4XmmzsTxTQGk+j8=";
+  };
+
+  cargoHash = "sha256-kcs55NgwsqgZXcx+a6g0o9KdUG4tt0ZBv3dU/Pb0NJk=";
+
+  # Only build the command line client
+  cargoBuildFlags = [ "--bin" "subxt" ];
+
+  # Needed by wabt-sys
+  nativeBuildInputs = [ cmake ];
+
+  # Requires a running substrate node
+  doCheck = false;
+
+  meta = with lib; {
+    homepage = "https://github.com/paritytech/subxt";
+    description = "Submit transactions to a substrate node via RPC.";
+    license = with licenses; [ gpl3Plus asl20 ];
+    maintainers = [ maintainers.FlorianFranzen ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -25218,6 +25218,8 @@ with pkgs;
 
   subtitleeditor = callPackage ../applications/video/subtitleeditor { };
 
+  subxt = callPackage ../development/tools/subxt { };
+
   suil = darwin.apple_sdk_11_0.callPackage ../development/libraries/audio/suil { };
 
   sundials = callPackage ../development/libraries/sundials {


### PR DESCRIPTION
###### Description of changes

This PR adds two popular development tools for substrate development called `subxt` and `subkey`,

Might need some additional work on darwin, but I have no host to test.

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).