### PR TITLE
exiv2: 0.27.6 -> 0.28.0

### DIFF
--- a/pkgs/development/libraries/exiv2/default.nix
+++ b/pkgs/development/libraries/exiv2/default.nix
@@ -1,30 +1,33 @@
-{ lib, stdenv
+{ lib
+, stdenv
 , fetchFromGitHub
-, zlib
-, expat
 , cmake
-, which
-, libxml2
-, python3
-, gettext
 , doxygen
+, gettext
 , graphviz
 , libxslt
-, libiconv
 , removeReferencesTo
+, libiconv
+, brotli
+, expat
+, inih
+, zlib
+, libxml2
+, python3
+, which
 }:
 
 stdenv.mkDerivation rec {
   pname = "exiv2";
-  version = "0.27.7";
+  version = "0.28.0";
 
-  outputs = [ "out" "lib" "dev" "doc" "man" "static" ];
+  outputs = [ "out" "lib" "dev" "doc" "man" ];
 
   src = fetchFromGitHub {
     owner = "exiv2";
-    repo  = "exiv2";
+    repo = "exiv2";
     rev = "v${version}";
-    sha256 = "sha256-xytVGrLDS22n2/yydFTT6CsDESmhO9mFbPGX4yk+b6g=";
+    hash = "sha256-nEoLJWxSJmAonCbW/iZKjLrKMj09mwEaSUXUcUu8GxU=";
   };
 
   nativeBuildInputs = [
@@ -36,10 +39,14 @@ stdenv.mkDerivation rec {
     removeReferencesTo
   ];
 
-  buildInputs = lib.optional stdenv.isDarwin libiconv;
+  buildInputs = lib.optionals stdenv.isDarwin [
+    libiconv
+  ];
 
   propagatedBuildInputs = [
+    brotli
     expat
+    inih
     zlib
   ];
 
@@ -60,67 +67,33 @@ stdenv.mkDerivation rec {
     "doc"
   ];
 
-  doCheck = true;
+  # https://github.com/Exiv2/exiv2/issues/2762
+  doCheck = lib.versionOlder brotli.version "1.1.0";
 
   preCheck = ''
     patchShebangs ../test/
     mkdir ../test/tmp
-
-    ${lib.optionalString stdenv.hostPlatform.isAarch ''
-      # Fix tests on arm
-      # https://github.com/Exiv2/exiv2/issues/933
-      rm -f ../tests/bugfixes/github/test_CVE_2018_12265.py
-    ''}
-
-    ${lib.optionalString stdenv.isDarwin ''
-      export DYLD_LIBRARY_PATH=$DYLD_LIBRARY_PATH''${DYLD_LIBRARY_PATH:+:}$PWD/lib
-      # Removing tests depending on charset conversion
-      substituteInPlace ../test/Makefile --replace "conversions.sh" ""
-      rm -f ../tests/bugfixes/redmine/test_issue_460.py
-      rm -f ../tests/bugfixes/redmine/test_issue_662.py
-      rm -f ../tests/bugfixes/github/test_issue_1046.py
-
-      rm ../tests/bugfixes/redmine/test_issue_683.py
-
-      # disable tests that requires loopback networking
-      substituteInPlace  ../tests/bash_tests/testcases.py \
-        --replace "def io_test(self):" "def io_disabled(self):"
-     ''}
-  '' + lib.optionalString (stdenv.isDarwin && stdenv.isAarch64) ''
+  '' + lib.optionalString stdenv.hostPlatform.isAarch32 ''
+    # Fix tests on arm
+    # https://github.com/Exiv2/exiv2/issues/933
+    rm -f ../tests/bugfixes/github/test_CVE_2018_12265.py
+  '' + lib.optionalString stdenv.isDarwin ''
+    export DYLD_LIBRARY_PATH=$DYLD_LIBRARY_PATH''${DYLD_LIBRARY_PATH:+:}$PWD/lib
     export LC_ALL=C
-  '' + lib.optionalString stdenv.isAarch32 ''
-    # these tests are fixed in 0.28, remove when updating to 0.28
-    rm -f ../tests/bugfixes/github/test_issue_1503.py
-    rm -f ../tests/bugfixes/github/test_pr1475_AVIF.py
-    rm -f ../tests/bugfixes/github/test_pr1475_HEIC.py
-    rm -f ../tests/bugfixes/github/test_pr1475_HIF.py
+
+    # disable tests that requires loopback networking
+    substituteInPlace  ../tests/bash_tests/testcases.py \
+      --replace "def io_test(self):" "def io_disabled(self):"
   '';
 
-  # With CMake we have to enable samples or there won't be
-  # a tests target. This removes them.
-  postInstall = ''
-    ( cd "$out/bin"
-      mv exiv2 .exiv2
-      rm *
-      mv .exiv2 exiv2
-    )
-
-    mkdir -p $static/lib
-    mv $lib/lib/*.a $static/lib/
-
+  preFixup = ''
     remove-references-to -t ${stdenv.cc.cc} $lib/lib/*.so.*.*.* $out/bin/exiv2 $static/lib/*.a
   '';
 
-  postFixup = ''
-    substituteInPlace "$dev"/lib/cmake/exiv2/exiv2Config.cmake --replace \
-      "set(_IMPORT_PREFIX \"$out\")" \
-      "set(_IMPORT_PREFIX \"$static\")"
-    substituteInPlace "$dev"/lib/cmake/exiv2/exiv2Config-*.cmake --replace \
-      "$lib/lib/libexiv2-xmp.a" \
-      "$static/lib/libexiv2-xmp.a"
-  '';
-
   disallowedReferences = [ stdenv.cc.cc ];
+
+  # causes redefinition of _FORTIFY_SOURCE
+  hardeningDisable = [ "fortify3" ];
 
   meta = with lib; {
     homepage = "https://exiv2.org";


### PR DESCRIPTION
###### Description of changes

From https://packages.gentoo.org/packages/media-gfx/exiv2:
> A major reverse depndency (kde-apps/libkexiv2) does not yet build against this so mask for now, see bug #906087 and bug #906090.

https://archlinux.org/todo/exiv2-028/

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
