### PR TITLE
nixos/tests/systemd-networkd-vrf: fix build & clean up

### DIFF
--- a/nixos/tests/systemd-networkd-vrf.nix
+++ b/nixos/tests/systemd-networkd-vrf.nix
@@ -1,5 +1,26 @@
 import ./make-test-python.nix ({ pkgs, lib, ... }: let
   inherit (import ./ssh-keys.nix pkgs) snakeOilPrivateKey snakeOilPublicKey;
+
+  mkNode = vlan: id: {
+    virtualisation.vlans = [ vlan ];
+    networking = {
+      useDHCP = false;
+      useNetworkd = true;
+    };
+
+    systemd.network = {
+      enable = true;
+
+      networks."10-eth${toString vlan}" = {
+        matchConfig.Name = "eth${toString vlan}";
+        linkConfig.RequiredForOnline = "no";
+        networkConfig = {
+          Address = "192.168.${toString vlan}.${toString id}/24";
+          IPForward = "yes";
+        };
+      };
+    };
+  };
 in {
   name = "systemd-networkd-vrf";
   meta.maintainers = with lib.maintainers; [ ma27 ];
@@ -70,71 +91,16 @@ in {
       };
     };
 
-    node1 = { pkgs, ... }: {
-      virtualisation.vlans = [ 1 ];
-      networking = {
-        useDHCP = false;
-        useNetworkd = true;
-      };
+    node1 = lib.mkMerge [
+      (mkNode 1 2)
+      {
+        services.openssh.enable = true;
+        users.users.root.openssh.authorizedKeys.keys = [ snakeOilPublicKey ];
+      }
+    ];
 
-      services.openssh.enable = true;
-      users.users.root.openssh.authorizedKeys.keys = [ snakeOilPublicKey ];
-
-      systemd.network = {
-        enable = true;
-
-        networks."10-eth1" = {
-          matchConfig.Name = "eth1";
-          linkConfig.RequiredForOnline = "no";
-          networkConfig = {
-            Address = "192.168.1.2/24";
-            IPForward = "yes";
-          };
-        };
-      };
-    };
-
-    node2 = { pkgs, ... }: {
-      virtualisation.vlans = [ 2 ];
-      networking = {
-        useDHCP = false;
-        useNetworkd = true;
-      };
-
-      systemd.network = {
-        enable = true;
-
-        networks."10-eth2" = {
-          matchConfig.Name = "eth2";
-          linkConfig.RequiredForOnline = "no";
-          networkConfig = {
-            Address = "192.168.2.3/24";
-            IPForward = "yes";
-          };
-        };
-      };
-    };
-
-    node3 = { pkgs, ... }: {
-      virtualisation.vlans = [ 2 ];
-      networking = {
-        useDHCP = false;
-        useNetworkd = true;
-      };
-
-      systemd.network = {
-        enable = true;
-
-        networks."10-eth2" = {
-          matchConfig.Name = "eth2";
-          linkConfig.RequiredForOnline = "no";
-          networkConfig = {
-            Address = "192.168.2.4/24";
-            IPForward = "yes";
-          };
-        };
-      };
-    };
+    node2 = mkNode 2 3;
+    node3 = mkNode 2 4;
   };
 
   testScript = ''
@@ -158,22 +124,6 @@ in {
     node1.wait_for_unit("network.target")
     node2.wait_for_unit("network.target")
     node3.wait_for_unit("network.target")
-
-    client_ipv4_table = """
-    192.168.1.2 dev vrf1 proto static metric 100\x20
-    192.168.2.3 dev vrf2 proto static metric 100
-    """.strip()
-    vrf1_table = """
-    192.168.1.0/24 dev eth1 proto kernel scope link src 192.168.1.1\x20
-    local 192.168.1.1 dev eth1 proto kernel scope host src 192.168.1.1\x20
-    broadcast 192.168.1.255 dev eth1 proto kernel scope link src 192.168.1.1
-    """.strip()
-    vrf2_table = """
-    192.168.2.0/24 dev eth2 proto kernel scope link src 192.168.2.1\x20
-    local 192.168.2.1 dev eth2 proto kernel scope host src 192.168.2.1\x20
-    broadcast 192.168.2.255 dev eth2 proto kernel scope link src 192.168.2.1
-    """.strip()
-    # editorconfig-checker-enable
 
     # Check that networkd properly configures the main routing table
     # and the routing tables for the VRF.

--- a/nixos/tests/systemd-networkd-vrf.nix
+++ b/nixos/tests/systemd-networkd-vrf.nix
@@ -54,7 +54,7 @@ in {
           linkConfig.RequiredForOnline = "no";
           networkConfig = {
             VRF = "vrf1";
-            Address = "192.168.1.1";
+            Address = "192.168.1.1/24";
             IPForward = "yes";
           };
         };
@@ -63,7 +63,7 @@ in {
           linkConfig.RequiredForOnline = "no";
           networkConfig = {
             VRF = "vrf2";
-            Address = "192.168.2.1";
+            Address = "192.168.2.1/24";
             IPForward = "yes";
           };
         };
@@ -87,7 +87,7 @@ in {
           matchConfig.Name = "eth1";
           linkConfig.RequiredForOnline = "no";
           networkConfig = {
-            Address = "192.168.1.2";
+            Address = "192.168.1.2/24";
             IPForward = "yes";
           };
         };
@@ -108,7 +108,7 @@ in {
           matchConfig.Name = "eth2";
           linkConfig.RequiredForOnline = "no";
           networkConfig = {
-            Address = "192.168.2.3";
+            Address = "192.168.2.3/24";
             IPForward = "yes";
           };
         };
@@ -129,7 +129,7 @@ in {
           matchConfig.Name = "eth2";
           linkConfig.RequiredForOnline = "no";
           networkConfig = {
-            Address = "192.168.2.4";
+            Address = "192.168.2.4/24";
             IPForward = "yes";
           };
         };


### PR DESCRIPTION
###### Description of changes

For this round of ZHF: #230712
Failing Hydra build: https://hydra.nixos.org/build/219234565

Not sure why this a problem now and not in the past, but routes to
the corresponding `/24`-subnet are only configured if addresses are
specified with the correct CIDR.

Also added a second, small clean-up commit with the following changes:

* Removed unused variables
* Deduplicate config for `node{1..3}`

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
