### PR TITLE
ocamlPackages.{zed,charInfo_width}: use Dune 3

### DIFF
--- a/pkgs/development/ocaml-modules/charInfo_width/default.nix
+++ b/pkgs/development/ocaml-modules/charInfo_width/default.nix
@@ -3,7 +3,7 @@
 buildDunePackage rec {
   pname = "charInfo_width";
   version = "1.1.0";
-  useDune2 = true;
+  duneVersion = "3";
   src = fetchzip {
     url = "https://bitbucket.org/zandoye/charinfo_width/get/${version}.tar.bz2";
     sha256 = "19mnq9a1yr16srqs8n6hddahr4f9d2gbpmld62pvlw1ps7nfrp9w";

--- a/pkgs/development/ocaml-modules/zed/default.nix
+++ b/pkgs/development/ocaml-modules/zed/default.nix
@@ -7,14 +7,12 @@ let
       {
         version = "3.2.0";
         sha256 = "sha256-6yKHE30nVFXo8hGdCx+GO4VYYGbi802aMdN2XuYMJ7w=";
-        duneVersion = "3";
         propagatedBuildInputs = [ react result uchar uutf uucp uuseg ];
       }
     else
       {
         version = "3.1.0";
         sha256 = "04vr1a94imsghm98iigc35rhifsz0rh3qz2qm0wam2wvp6vmrx0p";
-        duneVersion = "2";
         propagatedBuildInputs = [ charInfo_width react ];
       };
 in
@@ -22,7 +20,9 @@ in
 buildDunePackage rec {
   pname = "zed";
 
-  inherit (switch) version duneVersion propagatedBuildInputs;
+  inherit (switch) version propagatedBuildInputs;
+
+  duneVersion = "3";
 
   src = fetchFromGitHub {
     owner = "ocaml-community";


### PR DESCRIPTION
Small cleaning.

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

