### PR TITLE
kubo: 0.19.2 -> 0.20.0

### DIFF
--- a/nixos/modules/services/network-filesystems/kubo.nix
+++ b/nixos/modules/services/network-filesystems/kubo.nix
@@ -172,8 +172,8 @@ in
 
       emptyRepo = mkOption {
         type = types.bool;
-        default = false;
-        description = lib.mdDoc "If set to true, the repo won't be initialized with help files";
+        default = true;
+        description = lib.mdDoc "If set to false, the repo will be initialized with help files";
       };
 
       settings = mkOption {
@@ -331,7 +331,7 @@ in
 
       preStart = ''
         if [[ ! -f "$IPFS_PATH/config" ]]; then
-          ipfs init ${optionalString cfg.emptyRepo "-e"}
+          ipfs init --empty-repo=${lib.boolToString cfg.emptyRepo}
         else
           # After an unclean shutdown this file may exist which will cause the config command to attempt to talk to the daemon. This will hang forever if systemd is holding our sockets open.
           rm -vf "$IPFS_PATH/api"

--- a/pkgs/applications/networking/kubo/default.nix
+++ b/pkgs/applications/networking/kubo/default.nix
@@ -2,7 +2,7 @@
 
 buildGoModule rec {
   pname = "kubo";
-  version = "0.19.2"; # When updating, also check if the repo version changed and adjust repoVersion below
+  version = "0.20.0"; # When updating, also check if the repo version changed and adjust repoVersion below
   rev = "v${version}";
 
   passthru.repoVersion = "13"; # Also update kubo-migrator when changing the repo version
@@ -10,7 +10,7 @@ buildGoModule rec {
   # Kubo makes changes to it's source tarball that don't match the git source.
   src = fetchurl {
     url = "https://github.com/ipfs/kubo/releases/download/${rev}/kubo-source.tar.gz";
-    hash = "sha256-HPhlKAavINaN0SJHWmeJRx43jfeHeYDZb3/dZ55kMLI=";
+    hash = "sha256-3Oj/x3EkceNO8/Ik7+U43wi1aL0lYJi1FA0AjtdJRDI=";
   };
 
   # tarball contains multiple files/directories


### PR DESCRIPTION
###### Description of changes
https://github.com/ipfs/kubo/releases/tag/v0.20.0

When creating a repository with `ipfs init`, `--empty-repo=true` is now the default according to the changelog. Modify the NixOS module to reflect this change and fix the `emptyRepo` setting to work with this change.

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).