### PR TITLE
lldap: frontend: replace vendor download with wasm build from source

### DIFF
--- a/pkgs/servers/ldap/lldap/default.nix
+++ b/pkgs/servers/ldap/lldap/default.nix
@@ -1,68 +1,115 @@
-{ fetchFromGitHub
+{ binaryen
+, fetchFromGitHub
+, fetchpatch
 , fetchzip
 , lib
 , lldap
 , nixosTests
 , rustPlatform
+, stdenv
+, wasm-bindgen-cli
+, wasm-pack
+, which
 }:
 
 let
-  # We cannot build the wasm frontend from source, as the
-  # wasm32-unknown-unknown rustc target isn't available in nixpkgs yet.
-  # Tracking issue: https://github.com/NixOS/nixpkgs/issues/89426
-  frontend = fetchzip {
-    url = "https://github.com/lldap/lldap/releases/download/v${lldap.version}/amd64-lldap.tar.gz";
-    hash = "sha256-/Ml4L5Gxpnmt1pLSiLNuxtzQYjTCatsVe/hE+Btl8BI=";
-    name = "lldap-frontend-${lldap.version}";
-    postFetch = ''
-      mv $out $TMPDIR/extracted
-      mv $TMPDIR/extracted/app $out
+
+  # version of wasm-opt, with https://github.com/rustwasm/wasm-pack/pull/1257 backported
+  wasm-pack-git = wasm-pack.overrideAttrs (oldAttrs: {
+    version = oldAttrs.version + "-git";
+    patches = [(fetchpatch {
+      url = "https://patch-diff.githubusercontent.com/raw/rustwasm/wasm-pack/pull/1257.patch";
+      sha256 = "sha256-npi9ewh0NaD67crTcje9AYxaLLOJOMzqjqEJXZF2LbQ=";
+    })];
+  });
+
+  # replace with upstream wasm rustc, after resolution of
+  # https://github.com/NixOS/nixpkgs/issues/89426
+  rustc-wasm = (rustPlatform.rust.rustc.override {
+    stdenv = stdenv.override {
+      targetPlatform = stdenv.targetPlatform // {
+        parsed = {
+          cpu.name = "wasm32";
+          vendor.name = "unknown";
+          kernel.name = "unknown";
+          abi.name = "unknown";
+        };
+      };
+    };
+  }).overrideAttrs (attrs: {
+    configureFlags = attrs.configureFlags ++ ["--set=build.docs=false"];
+  });
+
+  commonDerivationAttrs = rec {
+    pname = "lldap";
+    version = "0.4.3";
+
+    src = fetchFromGitHub {
+      owner = "lldap";
+      repo = "lldap";
+      rev = "v${version}";
+      hash = "sha256-FAUTykFh2eGVpx6LrCjV9xWbBPH8pCgAJv3vOXFMFZ4=";
+    };
+
+    postPatch = ''
+      ln -s --force ${./Cargo.lock} Cargo.lock
     '';
-  };
-in
-rustPlatform.buildRustPackage rec {
-  pname = "lldap";
-  version = "0.4.3";
 
-  src = fetchFromGitHub {
-    owner = "lldap";
-    repo = "lldap";
-    rev = "v${version}";
-    hash = "sha256-FAUTykFh2eGVpx6LrCjV9xWbBPH8pCgAJv3vOXFMFZ4=";
-  };
-
-  # `Cargo.lock` has git dependencies, meaning can't use `cargoHash`
-  cargoLock = {
-    # 0.4.3 has been tagged before the actual Cargo.lock bump, resulting in an inconsitent lock file.
-    # To work around this, the Cargo.lock below is from the commit right after the tag:
-    # https://github.com/lldap/lldap/commit/7b4188a376baabda48d88fdca3a10756da48adda
-    lockFile = ./Cargo.lock;
-    outputHashes = {
-      "lber-0.4.1" = "sha256-2rGTpg8puIAXggX9rEbXPdirfetNOHWfFc80xqzPMT4=";
-      "opaque-ke-0.6.1" = "sha256-99gaDv7eIcYChmvOKQ4yXuaGVzo2Q6BcgSQOzsLF+fM=";
-      "yew_form-0.1.8" = "sha256-1n9C7NiFfTjbmc9B5bDEnz7ZpYJo9ZT8/dioRXJ65hc=";
+    # `Cargo.lock` has git dependencies, meaning can't use `cargoHash`
+    cargoLock = {
+      # 0.4.3 has been tagged before the actual Cargo.lock bump, resulting in an inconsitent lock file.
+      # To work around this, the Cargo.lock below is from the commit right after the tag:
+      # https://github.com/lldap/lldap/commit/7b4188a376baabda48d88fdca3a10756da48adda
+      lockFile = ./Cargo.lock;
+      outputHashes = {
+        "lber-0.4.1" = "sha256-2rGTpg8puIAXggX9rEbXPdirfetNOHWfFc80xqzPMT4=";
+        "opaque-ke-0.6.1" = "sha256-99gaDv7eIcYChmvOKQ4yXuaGVzo2Q6BcgSQOzsLF+fM=";
+        "yew_form-0.1.8" = "sha256-1n9C7NiFfTjbmc9B5bDEnz7ZpYJo9ZT8/dioRXJ65hc=";
+      };
     };
   };
 
+  frontend = rustPlatform.buildRustPackage (commonDerivationAttrs // {
+    pname = commonDerivationAttrs.pname + "-frontend";
+
+    nativeBuildInputs = [
+      wasm-pack-git wasm-bindgen-cli binaryen which rustc-wasm rustc-wasm.llvmPackages.lld
+    ];
+
+    buildPhase = ''
+      HOME=`pwd` RUSTFLAGS="-C linker=lld" ./app/build.sh
+    '';
+
+    installPhase = ''
+      mkdir -p $out
+      cp -R app/{index.html,pkg,static} $out/
+    '';
+
+    doCheck = false;
+  });
+
+in rustPlatform.buildRustPackage (commonDerivationAttrs // {
   patches = [
     ./static-frontend-path.patch
   ];
 
-  postPatch = ''
-    ln -s --force ${./Cargo.lock} Cargo.lock
+  postPatch = commonDerivationAttrs.postPatch + ''
     substituteInPlace server/src/infra/tcp_server.rs --subst-var-by frontend '${frontend}'
   '';
 
-  passthru.tests = {
-    inherit (nixosTests) lldap;
+  passthru = {
+    inherit frontend;
+    tests = {
+      inherit (nixosTests) lldap;
+    };
   };
 
   meta = with lib; {
     description = "A lightweight authentication server that provides an opinionated, simplified LDAP interface for authentication";
     homepage = "https://github.com/lldap/lldap";
-    changelog = "https://github.com/lldap/lldap/blob/v${version}/CHANGELOG.md";
+    changelog = "https://github.com/lldap/lldap/blob/v${lldap.version}/CHANGELOG.md";
     license = licenses.gpl3Only;
     platforms = platforms.linux;
-    maintainers = with maintainers; [ indeednotjames ];
+    maintainers = with maintainers; [ indeednotjames bendlas ];
   };
-}
+})


### PR DESCRIPTION
###### Description of changes

Use a custom wasm rustc toolchain, in order to build the frontend, even before https://github.com/NixOS/nixpkgs/issues/89426 is resolved.

~WIP for testing and~ one potential issue with fonts:

Binary vendor package has
```
    ├── fonts
    │   ├── bootstrap-icons.woff2
    │   ├── fonts.txt
    │   ├── JTUSjIg69CK48gW7PXoo9Wdhyzbi.woff2
    │   └── JTUSjIg69CK48gW7PXoo9Wlhyw.woff2

```

where as this build has
```
    ├── fonts
    │   └── fonts.txt
```


###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

