### PR TITLE
NixOS tests: resolve aliases

### DIFF
--- a/nixos/tests/docker-tools.nix
+++ b/nixos/tests/docker-tools.nix
@@ -11,7 +11,7 @@ let
       # Rootfs diffs for layers 1 and 2 are identical (and empty)
       layer1 = pkgs.dockerTools.buildImage {  name = "empty";  };
       layer2 = layer1.overrideAttrs (_: { fromImage = layer1; });
-      repeatedRootfsDiffs = pkgs.runCommandNoCC "image-with-links.tar" {
+      repeatedRootfsDiffs = pkgs.runCommand "image-with-links.tar" {
         nativeBuildInputs = [pkgs.jq];
       } ''
         mkdir contents

--- a/nixos/tests/iodine.nix
+++ b/nixos/tests/iodine.nix
@@ -45,7 +45,7 @@ import ./make-test-python.nix (
               "f /root/pw 0666 root root - ${password}"
             ];
             environment.systemPackages = [
-              pkgs.nagiosPluginsOfficial
+              pkgs.monitoring-plugins
             ];
           };
 

--- a/nixos/tests/lvm2/default.nix
+++ b/nixos/tests/lvm2/default.nix
@@ -38,7 +38,7 @@ lib.listToAttrs (
         v' = lib.replaceStrings [ "." ] [ "_" ] version;
       in
       lib.flip lib.mapAttrsToList tests (name: t:
-        lib.nameValuePair "lvm-${name}-linux-${v'}" (lib.optionalAttrs (builtins.elem version (t.kernelFilter kernelVersionsToTest)) (t.test ({ kernelPackages = pkgs."linuxPackages_${v'}"; } // builtins.removeAttrs t [ "test" "kernelFilter" ])))
+        lib.nameValuePair "lvm-${name}-linux-${v'}" (lib.optionalAttrs (builtins.elem version (t.kernelFilter kernelVersionsToTest)) (t.test ({ kernelPackages = pkgs.linuxKernel.packages."linux_${v'}"; } // builtins.removeAttrs t [ "test" "kernelFilter" ])))
       )
     )
   )

--- a/nixos/tests/memcached.nix
+++ b/nixos/tests/memcached.nix
@@ -8,7 +8,7 @@ import ./make-test-python.nix ({ pkgs, ... }: {
 
   testScript = let
     testScript = pkgs.writers.writePython3 "test_memcache" {
-      libraries = with pkgs.python3Packages; [ memcached ];
+      libraries = with pkgs.python3Packages; [ python-memcached ];
     } ''
       import memcache
       c = memcache.Client(['localhost:11211'])

--- a/nixos/tests/pgjwt.nix
+++ b/nixos/tests/pgjwt.nix
@@ -1,6 +1,8 @@
 import ./make-test-python.nix ({ pkgs, lib, ...}:
-
-with pkgs; {
+let
+  inherit (pkgs.postgresqlPackages) pgjwt pgtap;
+in
+{
   name = "pgjwt";
   meta = with lib.maintainers; {
     maintainers = [ spinus willibutz ];
@@ -18,7 +20,7 @@ with pkgs; {
 
   testScript = { nodes, ... }:
   let
-    sqlSU = "${nodes.master.config.services.postgresql.superUser}";
+    sqlSU = "${nodes.master.services.postgresql.superUser}";
     pgProve = "${pkgs.perlPackages.TAPParserSourceHandlerpgTAP}";
   in
   ''

--- a/nixos/tests/powerdns.nix
+++ b/nixos/tests/powerdns.nix
@@ -24,7 +24,7 @@ import ./make-test-python.nix ({ pkgs, lib, ... }: {
     };
 
     environment.systemPackages = with pkgs;
-      [ dnsutils powerdns mariadb ];
+      [ dnsutils pdns mariadb ];
   };
 
   testScript = ''
@@ -37,7 +37,7 @@ import ./make-test-python.nix ({ pkgs, lib, ... }: {
     with subtest("Loading the MySQL schema works"):
         server.succeed(
             "sudo -u pdns mysql -u pdns -D powerdns <"
-            "${pkgs.powerdns}/share/doc/pdns/schema.mysql.sql"
+            "${pkgs.pdns}/share/doc/pdns/schema.mysql.sql"
         )
 
     with subtest("PowerDNS server starts"):

--- a/nixos/tests/systemd-machinectl.nix
+++ b/nixos/tests/systemd-machinectl.nix
@@ -18,7 +18,7 @@ import ./make-test-python.nix ({ pkgs, ... }:
     };
 
     containerSystem = (import ../lib/eval-config.nix {
-      inherit (pkgs) system;
+      inherit (pkgs.stdenv.hostPlatform) system;
       modules = [ container ];
     }).config.system.build.toplevel;
 

--- a/nixos/tests/terminal-emulators.nix
+++ b/nixos/tests/terminal-emulators.nix
@@ -51,9 +51,9 @@ let tests = {
 
       kermit.pkg = p: p.kermit-terminal;
 
-      kgx.pkg = p: p.kgx;
-      kgx.cmd = "kgx -e $command";
-      kgx.kill = true;
+      gnome-console.pkg = p: p.gnome-console;
+      gnome-console.cmd = "kgx -e $command";
+      gnome-console.kill = true;
 
       kitty.pkg = p: p.kitty;
       kitty.cmd = "kitty $command";
@@ -118,7 +118,7 @@ in mapAttrs (name: { pkg, executable ? name, cmd ? "SHELL=$command ${executable}
     maintainers = [ jjjollyjim ];
   };
 
-  machine = { pkgsInner, ... }:
+  nodes.machine = { pkgsInner, ... }:
 
   {
     imports = [ ./common/x11.nix ./common/user-account.nix ];

--- a/nixos/tests/wireguard/default.nix
+++ b/nixos/tests/wireguard/default.nix
@@ -22,7 +22,7 @@ listToAttrs (
       v' = replaceStrings [ "." ] [ "_" ] version;
     in
     flip mapAttrsToList tests (name: test:
-      nameValuePair "wireguard-${name}-linux-${v'}" (test { kernelPackages = pkgs."linuxPackages_${v'}"; })
+      nameValuePair "wireguard-${name}-linux-${v'}" (test { kernelPackages = pkgs.linuxKernel.packages."linux_${v'}"; })
     )
   )
 )

--- a/pkgs/applications/terminal-emulators/gnome-console/default.nix
+++ b/pkgs/applications/terminal-emulators/gnome-console/default.nix
@@ -48,7 +48,7 @@ stdenv.mkDerivation rec {
     };
   };
 
-  passthru.tests.test = nixosTests.terminal-emulators.kgx;
+  passthru.tests.test = nixosTests.terminal-emulators.gnome-console;
 
   meta = with lib; {
     description = "Simple user-friendly terminal emulator for the GNOME desktop";


### PR DESCRIPTION
###### Description of changes

Found while working on #230523. 
~Depends on other PRs, so draft for now. Will rebase not to include commits from #230523.
Depends on a decision to be made for #231285.~
Excludes linux kernel packages alias. Does not disable aliases in tests.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
