### PR TITLE
init backgroundremover at 0.2.1

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -7076,6 +7076,12 @@
     githubId = 5579359;
     name = "Jason Yundt";
   };
+  jayrovacsek = {
+    email = "nixpkgs@jay.rovacsek.com";
+    name = "Jay Rovacsek";
+    github = "JayRovacsek";
+    githubId = 29395089;
+  };
   jb55 = {
     email = "jb55@jb55.com";
     github = "jb55";

--- a/pkgs/development/python-modules/backgroundremover/default.nix
+++ b/pkgs/development/python-modules/backgroundremover/default.nix
@@ -1,0 +1,53 @@
+{ buildPythonPackage, fetchPypi, lib, certifi, charset-normalizer, ffmpeg-python
+, filelock, filetype, hsh, idna, more-itertools, moviepy, numpy, pillow
+, pymatting, pysocks, requests, scikitimage, scipy, six, torch, torchvision
+, tqdm, urllib3, waitress, gdown }:
+buildPythonPackage rec {
+  pname = "backgroundremover";
+  name = pname;
+  version = "0.2.1";
+
+  meta = with lib; {
+    description =
+      "BackgroundRemover is a command line tool to remove background from image and video, made by nadermx to power https://BackgroundRemoverAI.com";
+    platforms = platforms.all;
+    homepage = "https://github.com/nadermx/backgroundremover";
+    downloadPage = "https://github.com/nadermx/backgroundremover/releases";
+    license = licenses.mit;
+    maintainers = with maintainers; [ jayrovacsek ];
+  };
+
+  propagatedBuildInputs = [
+    certifi
+    charset-normalizer
+    ffmpeg-python
+    filelock
+    filetype
+    hsh
+    idna
+    more-itertools
+    moviepy
+    numpy
+    pillow
+    pymatting
+    pysocks
+    requests
+    scikitimage
+    scipy
+    six
+    torch
+    torchvision
+    tqdm
+    urllib3
+    waitress
+    gdown
+  ];
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "sha256-hh+NSFy2NgvgpsnTcFORzFfW4ZxX96nP4u9O+OpZw7Y=";
+  };
+
+  doCheck = false;
+
+}

--- a/pkgs/development/python-modules/commandlines/default.nix
+++ b/pkgs/development/python-modules/commandlines/default.nix
@@ -1,0 +1,21 @@
+{ buildPythonPackage, fetchPypi, lib }:
+buildPythonPackage rec {
+  pname = "commandlines";
+  name = pname;
+  version = "0.4.1";
+
+  meta = with lib; {
+    description =
+      "Commandlines is a Python library for command line application development that supports command line argument parsing";
+    platforms = platforms.all;
+    homepage = "https://github.com/chrissimpkins/commandlines";
+    downloadPage = "https://github.com/chrissimpkins/commandlines/releases";
+    license = licenses.mit;
+    maintainers = with maintainers; [ jayrovacsek ];
+  };
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "sha256-hrZQt4RwrJWWbXsanSFcFlkbzLNLKK4ruQJsO0Fm/WQ=";
+  };
+}

--- a/pkgs/development/python-modules/hsh/default.nix
+++ b/pkgs/development/python-modules/hsh/default.nix
@@ -1,0 +1,23 @@
+{ buildPythonPackage, fetchPypi, lib, commandlines }:
+buildPythonPackage rec {
+  pname = "hsh";
+  name = pname;
+  version = "1.1.0";
+
+  meta = with lib; {
+    description =
+      "hsh is a cross-platform command line application that generates file hash digests and performs file integrity checks via file hash digest comparisons.";
+    platforms = platforms.all;
+    homepage = "https://github.com/chrissimpkins/hsh";
+    downloadPage = "https://github.com/chrissimpkins/hsh/releases";
+    license = licenses.mit;
+    maintainers = with maintainers; [ jayrovacsek ];
+  };
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "sha256-wE5DrFOP6vsCnbo8SXIgenBPX83w7icevd3QPZa134U=";
+  };
+
+  propagatedBuildInputs = [ commandlines ];
+}

--- a/pkgs/development/python-modules/pymatting/default.nix
+++ b/pkgs/development/python-modules/pymatting/default.nix
@@ -1,0 +1,26 @@
+{ buildPythonPackage, fetchPypi, lib, numpy
+, pillow, numba, scipy }:
+buildPythonPackage rec {
+  pname = "PyMatting";
+  name = pname;
+  version = "1.1.8";
+
+  meta = with lib; {
+    description = "PyMatting: A Python Library for Alpha Matting";
+    platforms = platforms.all;
+    homepage = "https://github.com/pymatting/pymatting";
+    downloadPage = "https://github.com/pymatting/pymatting/releases";
+    license = licenses.mit;
+    maintainers = with maintainers; [ jayrovacsek ];
+  };
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "sha256-pzUI7wh0mWgx39KE47xjFRoJSE14n9EO3AP0mzFTKsw=";
+  };
+
+  doCheck = false;
+
+  propagatedBuildInputs = [ numpy pillow numba scipy ];
+
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1135,6 +1135,8 @@ self: super: with self; {
 
   bambi = callPackage ../development/python-modules/bambi { };
 
+  backgroundremover = callPackage ../development/python-modules/backgroundremover { };
+
   pad4pi = callPackage ../development/python-modules/pad4pi { };
 
   pulumi = callPackage ../development/python-modules/pulumi { inherit (pkgs) pulumi; };
@@ -1994,6 +1996,8 @@ self: super: with self; {
   cometblue-lite = callPackage ../development/python-modules/cometblue-lite { };
 
   comm = callPackage ../development/python-modules/comm { };
+
+  commandlines = callPackage ../development/python-modules/commandlines { };
 
   commandparse = callPackage ../development/python-modules/commandparse { };
 
@@ -4574,6 +4578,8 @@ self: super: with self; {
   hs-dbus-signature = callPackage ../development/python-modules/hs-dbus-signature { };
 
   hsaudiotag3k = callPackage ../development/python-modules/hsaudiotag3k { };
+
+  hsh = callPackage ../development/python-modules/hsh { };
 
   hsluv = callPackage ../development/python-modules/hsluv { };
 
@@ -8700,6 +8706,8 @@ self: super: with self; {
   pymatgen = callPackage ../development/python-modules/pymatgen { };
 
   pymatgen-lammps = callPackage ../development/python-modules/pymatgen-lammps { };
+
+  pymatting = callPackage ../development/python-modules/pymatting { };
 
   pymaven-patch = callPackage ../development/python-modules/pymaven-patch { };
 


### PR DESCRIPTION
###### Description of changes

This change set implements the backgroundremover python package and requisite dependencies that do not currently exist within nixpkgs.
Backgroundremover is a package to remove backgrounds from images and video and the homepage can be found [here](https://github.com/nadermx/backgroundremover)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [X] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [X] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [X] Tested, as applicable:
- [X] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

Result of `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"` run on x86-linux [1](https://github.com/Mic92/nixpkgs-review)

<details><summary>6 packages added:</summary><p>

- python3.10-backgroundremover
- python3.10-commandlines
- python3.10-hsh
- python3.10-PyMatting
- python3.11-commandlines
- python3.11-hsh

</p></details>

<details><summary>12 packages built:</summary><p>

- python310Packages.backgroundremover
- python310Packages.backgroundremover.dist
- python310Packages.commandlines
- python310Packages.commandlines.dist
- python310Packages.hsh
- python310Packages.hsh.dist
- python310Packages.pymatting
- python310Packages.pymatting.dist
- python311Packages.commandlines
- python311Packages.commandlines.dist
- python311Packages.hsh
- python311Packages.hsh.dist

</p></details>

Result of `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"` run on aarch64-linux [1](https://github.com/Mic92/nixpkgs-review) - note this is under remote builders

<details><summary>6 packages added:</summary><p>

- python3.10-backgroundremover
- python3.10-commandlines
- python3.10-hsh
- python3.10-PyMatting
- python3.11-commandlines
- python3.11-hsh

</p></details>

<details><summary>12 packages built:</summary><p>

- python310Packages.backgroundremover
- python310Packages.backgroundremover.dist
- python310Packages.commandlines
- python310Packages.commandlines.dist
- python310Packages.hsh
- python310Packages.hsh.dist
- python310Packages.pymatting
- python310Packages.pymatting.dist
- python311Packages.commandlines
- python311Packages.commandlines.dist
- python311Packages.hsh
- python311Packages.hsh.dist

</p></details>

Will add nixpkgs-review outputs from aarch64 and x86_64 darwin as soon as I can