### PR TITLE
flutter: Install Android variant artifacts in platform subdirectories

### DIFF
--- a/pkgs/development/compilers/flutter/engine-artifacts/default.nix
+++ b/pkgs/development/compilers/flutter/engine-artifacts/default.nix
@@ -80,7 +80,7 @@ let
       };
     };
 
-  mkArtifactDerivation = { platform ? null, variant ? null, archive, ... }@args:
+  mkArtifactDerivation = { platform ? null, variant ? null, subdirectory ? null, archive, ... }@args:
     let
       artifactDirectory = if platform == null then null else "${platform}${lib.optionalString (variant != null) "-${variant}"}";
       archiveBasename = lib.removeSuffix ".${(lib.last (lib.splitString "." archive))}" archive;
@@ -97,7 +97,14 @@ let
 
       nativeBuildInputs = [ autoPatchelfHook ];
 
-      installPhase = "cp -r . $out";
+      installPhase =
+        let
+          destination = "$out/${if subdirectory == true then archiveBasename else if subdirectory != null then subdirectory else "."}";
+        in
+        ''
+          mkdir -p "${destination}"
+          cp -r . "${destination}"
+        '';
     } // args);
 
   artifactDerivations = {

--- a/pkgs/development/compilers/flutter/engine-artifacts/default.nix
+++ b/pkgs/development/compilers/flutter/engine-artifacts/default.nix
@@ -30,7 +30,7 @@ let
                 variants = lib.genAttrs [ "profile" "release" ]
                   (variant: [
                     { archive = "artifacts.zip"; }
-                    { archive = "${lib.toLower hostPlatform.uname.system}-x64.zip"; }
+                    { subdirectory = true; archive = "${lib.toLower hostPlatform.uname.system}-x64.zip"; }
                   ]);
               })) //
           {


### PR DESCRIPTION
###### Description of changes

This fixes the installation location of build-variant-specific Android engine artifacts in the Flutter SDK.

Closes #231247.

(CC: @NixOS/flutter)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
