### PR TITLE
ch9344: fix build on Linux 6.3

### DIFF
--- a/pkgs/os-specific/linux/ch9344/default.nix
+++ b/pkgs/os-specific/linux/ch9344/default.nix
@@ -13,6 +13,9 @@ stdenv.mkDerivation rec {
   patches = lib.optionals (lib.versionAtLeast kernel.modDirVersion "6.1") [
     # https://github.com/torvalds/linux/commit/a8c11c1520347be74b02312d10ef686b01b525f1
     ./fix-incompatible-pointer-types.patch
+  ] ++ lib.optionals (lib.versionAtLeast kernel.modDirVersion "6.3") [
+    # https://github.com/torvalds/linux/commit/5d420399073770134d2b03e004b2c0201c7fa26f
+    ./fix-incompatible-pointer-types_6_3.patch
   ];
 
   sourceRoot = "${src.name}/driver";

--- a/pkgs/os-specific/linux/ch9344/fix-incompatible-pointer-types_6_3.patch
+++ b/pkgs/os-specific/linux/ch9344/fix-incompatible-pointer-types_6_3.patch
@@ -1,0 +1,13 @@
+diff --git a/ch9344.c b/ch9344.c
+index a16af82..8922ed9 100644
+--- a/ch9344.c
++++ b/ch9344.c
+@@ -774,7 +774,7 @@ static inline void *tty_get_portdata(struct ch9344_ttyport *port)
+     return (port->portdata);
+ }
+ 
+-static void ch9344_port_dtr_rts(struct tty_port *port, int raise)
++static void ch9344_port_dtr_rts(struct tty_port *port, bool raise)
+ {
+     struct ch9344_ttyport *ttyport = container_of(port, struct ch9344_ttyport, port);
+     struct ch9344 *ch9344 = tty_get_portdata(ttyport);


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Fix `ch9344` build on Linux 6.3+.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
