### PR TITLE
minimal-bootstrap.kaem: move runCommand into kaem

### DIFF
--- a/pkgs/os-specific/linux/minimal-bootstrap/default.nix
+++ b/pkgs/os-specific/linux/minimal-bootstrap/default.nix
@@ -25,6 +25,6 @@ lib.makeScope
     tinycc-bootstrappable = callPackage ./tinycc/bootstrappable.nix { };
     tinycc-mes = callPackage ./tinycc/mes.nix { };
 
-    inherit (callPackage ./utils.nix { }) fetchurl derivationWithMeta writeTextFile writeText runCommand;
+    inherit (callPackage ./utils.nix { }) fetchurl derivationWithMeta writeTextFile writeText;
 
   })

--- a/pkgs/os-specific/linux/minimal-bootstrap/gnumake/default.nix
+++ b/pkgs/os-specific/linux/minimal-bootstrap/gnumake/default.nix
@@ -1,6 +1,6 @@
 { lib
-, runCommand
 , fetchurl
+, kaem
 , tinycc
 , gnupatch
 }:
@@ -145,7 +145,7 @@ let
 
   objects = map (x: lib.replaceStrings [".c"] [".o"] (builtins.baseNameOf x)) sources;
 in
-runCommand "${pname}-${version}" {
+kaem.runCommand "${pname}-${version}" {
   inherit pname version;
 
   nativeBuildInputs = [ tinycc gnupatch ];

--- a/pkgs/os-specific/linux/minimal-bootstrap/gnupatch/default.nix
+++ b/pkgs/os-specific/linux/minimal-bootstrap/gnupatch/default.nix
@@ -1,6 +1,6 @@
 { lib
-, runCommand
 , fetchurl
+, kaem
 , tinycc
 }:
 let
@@ -67,7 +67,7 @@ let
 
   objects = map (x: lib.replaceStrings [".c"] [".o"] (builtins.baseNameOf x)) sources;
 in
-runCommand "${pname}-${version}" {
+kaem.runCommand "${pname}-${version}" {
   inherit pname version;
 
   nativeBuildInputs = [ tinycc ];

--- a/pkgs/os-specific/linux/minimal-bootstrap/ln-boot/default.nix
+++ b/pkgs/os-specific/linux/minimal-bootstrap/ln-boot/default.nix
@@ -1,5 +1,5 @@
 { lib
-, runCommand
+, kaem
 , mes
 }:
 let
@@ -8,7 +8,7 @@ let
 
   src = ./ln.c;
 in
-runCommand "${pname}-${version}" {
+kaem.runCommand "${pname}-${version}" {
   inherit pname version;
 
   meta = with lib; {

--- a/pkgs/os-specific/linux/minimal-bootstrap/mes/default.nix
+++ b/pkgs/os-specific/linux/minimal-bootstrap/mes/default.nix
@@ -1,8 +1,8 @@
 { lib
-, runCommand
 , fetchurl
 , writeText
 , callPackage
+, kaem
 , m2libc
 , mescc-tools
 }:
@@ -43,7 +43,7 @@ let
   sourceArchive = out: sources:
     "catm ${out} ${lib.concatMapStringsSep " " (replaceExt ".s") sources}";
 in
-runCommand "${pname}-${version}" {
+kaem.runCommand "${pname}-${version}" {
   inherit pname version;
 
   passthru = { inherit src nyacc; };

--- a/pkgs/os-specific/linux/minimal-bootstrap/mes/libc.nix
+++ b/pkgs/os-specific/linux/minimal-bootstrap/mes/libc.nix
@@ -1,5 +1,5 @@
 { lib
-, runCommand
+, kaem
 , ln-boot
 , mes
 , mes-libc
@@ -21,7 +21,8 @@ let
   # the operation in two
   firstLibc = lib.take 100 libc_gnu_SOURCES;
   lastLibc = lib.drop 100 libc_gnu_SOURCES;
-in runCommand "${pname}-${version}" {
+in
+kaem.runCommand "${pname}-${version}" {
   inherit pname version;
 
   nativeBuildInputs = [ ln-boot ];

--- a/pkgs/os-specific/linux/minimal-bootstrap/mes/nyacc.nix
+++ b/pkgs/os-specific/linux/minimal-bootstrap/mes/nyacc.nix
@@ -1,6 +1,6 @@
 { lib
-, runCommand
 , fetchurl
+, kaem
 , nyacc
 }:
 let
@@ -15,7 +15,7 @@ let
     sha256 = "065ksalfllbdrzl12dz9d9dcxrv97wqxblslngsc6kajvnvlyvpk";
   };
 in
-runCommand "${pname}-${version}" {
+kaem.runCommand "${pname}-${version}" {
   inherit pname version;
 
   passthru.guilePath = "${nyacc}/share/${pname}-${version}/module";

--- a/pkgs/os-specific/linux/minimal-bootstrap/stage0-posix/kaem/default.nix
+++ b/pkgs/os-specific/linux/minimal-bootstrap/stage0-posix/kaem/default.nix
@@ -1,6 +1,9 @@
 { lib
 , derivationWithMeta
+, writeText
+, kaem
 , kaem-unwrapped
+, mescc-tools
 , mescc-tools-extra
 , version
 }:
@@ -22,6 +25,21 @@ derivationWithMeta {
     '')
   ];
   PATH = lib.makeBinPath [ mescc-tools-extra ];
+
+  passthru.runCommand = name: env: buildCommand:
+    derivationWithMeta ({
+      inherit name;
+
+      builder = "${kaem}/bin/kaem";
+      args = [
+        "--verbose"
+        "--strict"
+        "--file"
+        (writeText "${name}-builder" buildCommand)
+      ];
+
+      PATH = lib.makeBinPath ((env.nativeBuildInputs or []) ++ [ kaem mescc-tools mescc-tools-extra ]);
+    } // (builtins.removeAttrs env [ "nativeBuildInputs" ]));
 
   meta = with lib; {
     description = "Minimal build tool for running scripts on systems that lack any shell";

--- a/pkgs/os-specific/linux/minimal-bootstrap/tinycc/bootstrappable.nix
+++ b/pkgs/os-specific/linux/minimal-bootstrap/tinycc/bootstrappable.nix
@@ -8,9 +8,9 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 { lib
-, runCommand
 , callPackage
 , fetchurl
+, kaem
 , mes
 , mes-libc
 }:
@@ -24,7 +24,7 @@ let
     url = "https://gitlab.com/janneke/tinycc/-/archive/${rev}/tinycc-${rev}.tar.gz";
     sha256 = "1a0cw9a62qc76qqn5sjmp3xrbbvsz2dxrw21lrnx9q0s74mwaxbq";
   };
-  src = (runCommand "tinycc-bootstrappable-${version}-source" {} ''
+  src = (kaem.runCommand "tinycc-bootstrappable-${version}-source" {} ''
     ungz --file ${tarball} --output tinycc.tar
     mkdir -p ''${out}
     cd ''${out}
@@ -39,7 +39,7 @@ let
     platforms = [ "i686-linux" ];
   };
 
-  tinycc-boot-mes = runCommand "tinycc-boot-mes-${version}" {} ''
+  tinycc-boot-mes = kaem.runCommand "tinycc-boot-mes-${version}" {} ''
     catm config.h
     ${mes}/bin/mes --no-auto-compile -e main ${mes}/bin/mescc.scm -- \
       -S \

--- a/pkgs/os-specific/linux/minimal-bootstrap/tinycc/common.nix
+++ b/pkgs/os-specific/linux/minimal-bootstrap/tinycc/common.nix
@@ -1,5 +1,5 @@
 { lib
-, runCommand
+, kaem
 , mes-libc
 , ln-boot
 }:
@@ -17,7 +17,7 @@
       options = lib.strings.concatStringsSep " " buildOptions;
       libtccOptions = lib.strings.concatStringsSep " " libtccBuildOptions;
     in
-    runCommand "${pname}-${version}" {
+    kaem.runCommand "${pname}-${version}" {
       inherit pname version meta;
       nativeBuildInputs = [ ln-boot ];
     } ''

--- a/pkgs/os-specific/linux/minimal-bootstrap/tinycc/mes.nix
+++ b/pkgs/os-specific/linux/minimal-bootstrap/tinycc/mes.nix
@@ -5,9 +5,9 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 { lib
-, runCommand
 , fetchurl
 , callPackage
+, kaem
 , tinycc-bootstrappable
 }:
 let
@@ -20,7 +20,7 @@ let
     url = "https://repo.or.cz/tinycc.git/snapshot/${rev}.tar.gz";
     sha256 = "11idrvbwfgj1d03crv994mpbbbyg63j1k64lw1gjy7mkiifw2xap";
   };
-  src = (runCommand "tinycc-${version}-source" {} ''
+  src = (kaem.runCommand "tinycc-${version}-source" {} ''
     ungz --file ${tarball} --output tinycc.tar
     mkdir -p ''${out}
     cd ''${out}
@@ -35,7 +35,7 @@ let
     platforms = [ "i686-linux" ];
   };
 
-  tccdefs = runCommand "tccdefs-${version}" {} ''
+  tccdefs = kaem.runCommand "tccdefs-${version}" {} ''
     mkdir ''${out}
     ${tinycc-bootstrappable}/bin/tcc -static -DC2STR -o c2str ${src}/conftest.c
     ./c2str ${src}/include/tccdefs.h ''${out}/tccdefs_.h

--- a/pkgs/os-specific/linux/minimal-bootstrap/utils.nix
+++ b/pkgs/os-specific/linux/minimal-bootstrap/utils.nix
@@ -2,7 +2,6 @@
 , buildPlatform
 , callPackage
 , kaem
-, mescc-tools
 , mescc-tools-extra
 }:
 
@@ -64,20 +63,5 @@ rec {
     };
 
   writeText = name: text: writeTextFile {inherit name text;};
-
-  runCommand = name: env: buildCommand:
-    derivationWithMeta ({
-      inherit name;
-
-      builder = "${kaem}/bin/kaem";
-      args = [
-        "--verbose"
-        "--strict"
-        "--file"
-        (writeText "${name}-builder" buildCommand)
-      ];
-
-      PATH = lib.makeBinPath ((env.nativeBuildInputs or []) ++ [ kaem mescc-tools mescc-tools-extra ]);
-    } // (builtins.removeAttrs env [ "nativeBuildInputs" ]));
 
 }


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Refactors the `runCommand` utility as `kaem.runCommand`. This makes usages explicitly declare which shell is used which will reduce confusion once `bash` is introduced.

Continues #227914

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
