### PR TITLE
python311Packages.pymedio: unbreak; enable tests

### DIFF
--- a/pkgs/development/python-modules/pymedio/default.nix
+++ b/pkgs/development/python-modules/pymedio/default.nix
@@ -3,7 +3,11 @@
 , fetchFromGitHub
 , pythonOlder
 , pytestCheckHook
+, cryptography
+, nibabel
 , numpy
+, pydicom
+, simpleitk
 }:
 
 buildPythonPackage rec {
@@ -18,14 +22,20 @@ buildPythonPackage rec {
     hash = "sha256-iHbClOrtYkHT1Nar+5j/ig4Krya8LdQdFB4Mmm5B9bg=";
   };
 
-  # relax Python dep to work with 3.10.x
+  # relax Python dep to work with 3.10.x and 3.11.x
   postPatch = ''
-    substituteInPlace setup.cfg --replace "!=3.10.*," ""
+    substituteInPlace setup.cfg --replace "!=3.10.*," "" --replace "!=3.11.*" ""
   '';
 
   propagatedBuildInputs = [ numpy ];
 
-  doCheck = false;  # requires SimpleITK python package (not in Nixpkgs)
+  nativeCheckInputs = [
+    pytestCheckHook
+    cryptography
+    nibabel
+    pydicom
+    simpleitk
+  ];
 
   pythonImportsCheck = [
     "pymedio"


### PR DESCRIPTION
###### Description of changes

Unbreak with Python 3.11 (by lifting an upper bound in setup.cfg); enable tests as needed packages are now all present in Nixpkgs.

For ZHF (#230712).

###### Things done


- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

