### PR TITLE
flutter: 3.7.12 -> 3.10.0

### DIFF
--- a/pkgs/applications/misc/yubioath-flutter/default.nix
+++ b/pkgs/applications/misc/yubioath-flutter/default.nix
@@ -1,5 +1,5 @@
 { lib
-, flutter
+, flutter37
 , python3
 , fetchFromGitHub
 , pcre2
@@ -8,7 +8,7 @@
 , removeReferencesTo
 }:
 
-flutter.buildFlutterApplication rec {
+flutter37.buildFlutterApplication rec {
   pname = "yubioath-flutter";
   version = "6.1.0";
 
@@ -62,7 +62,7 @@ flutter.buildFlutterApplication rec {
       --replace "@EXEC_PATH/linux_support/com.yubico.yubioath.png" "$out/share/icons/com.yubico.yubioath.png"
 
     # Remove unnecessary references to Flutter.
-    remove-references-to -t ${flutter.unwrapped} $out/app/data/flutter_assets/shaders/ink_sparkle.frag
+    remove-references-to -t ${flutter37.unwrapped} $out/app/data/flutter_assets/shaders/ink_sparkle.frag
   '';
 
   nativeBuildInputs = [
@@ -75,8 +75,8 @@ flutter.buildFlutterApplication rec {
   ];
 
   disallowedReferences = [
-    flutter
-    flutter.unwrapped
+    flutter37
+    flutter37.unwrapped
   ];
 
   meta = with lib; {

--- a/pkgs/applications/networking/instant-messengers/fluffychat/default.nix
+++ b/pkgs/applications/networking/instant-messengers/fluffychat/default.nix
@@ -1,11 +1,11 @@
 { lib
 , fetchFromGitLab
 , imagemagick
-, flutter
+, flutter37
 , makeDesktopItem
 }:
 
-flutter.buildFlutterApplication rec {
+flutter37.buildFlutterApplication rec {
   version = "1.11.0";
   name = "fluffychat";
 

--- a/pkgs/build-support/dart/build-dart-application/hooks/dart-config-hook.sh
+++ b/pkgs/build-support/dart/build-dart-application/hooks/dart-config-hook.sh
@@ -4,7 +4,7 @@ dartConfigHook() {
     echo "Executing dartConfigHook"
 
     echo "Installing dependencies"
-    eval "$pubGetScript" --offline
+    eval doPubGet "$pubGetScript" --offline
 
     echo "Finished dartConfigHook"
 }

--- a/pkgs/build-support/dart/fetch-dart-deps/default.nix
+++ b/pkgs/build-support/dart/fetch-dart-deps/default.nix
@@ -160,7 +160,7 @@ let
 
     configurePhase = ''
       runHook preConfigure
-      dart pub get --offline
+      doPubGet dart pub get --offline
       runHook postConfigure
     '';
 

--- a/pkgs/build-support/dart/fetch-dart-deps/default.nix
+++ b/pkgs/build-support/dart/fetch-dart-deps/default.nix
@@ -169,7 +169,7 @@ let
       dart pub deps --json | jq .packages > $out
       runHook postBuild
     '';
-  } // buildDrvInheritArgs);
+  } // (removeAttrs buildDrvInheritArgs [ "name" "pname" ]));
 
   # As of Dart 3.0.0, Pub checks the revision of cached Git-sourced packages.
   # Git must be wrapped to return a positive result, as the real .git directory is wiped

--- a/pkgs/build-support/dart/fetch-dart-deps/default.nix
+++ b/pkgs/build-support/dart/fetch-dart-deps/default.nix
@@ -1,6 +1,7 @@
 { stdenvNoCC
 , lib
 , makeSetupHook
+, writeShellScriptBin
 , dart
 , git
 , cacert
@@ -170,12 +171,26 @@ let
     '';
   } // buildDrvInheritArgs);
 
+  # As of Dart 3.0.0, Pub checks the revision of cached Git-sourced packages.
+  # Git must be wrapped to return a positive result, as the real .git directory is wiped
+  # to produce a deteministic dependency derivation output.
+  # https://github.com/dart-lang/pub/pull/3791/files#diff-1639c4669c428c26e68cfebd5039a33f87ba568795f2c058c303ca8528f62b77R631
+  gitSourceWrapper = writeShellScriptBin "git" ''
+    args=("$@")
+    if [[ "''${args[0]}" == "rev-list" && "''${args[1]}" == "--max-count=1" ]]; then
+      revision="''${args[''${#args[@]}-1]}"
+      echo "$revision"
+    else
+      ${git}/bin/git "''${args[@]}"
+    fi
+  '';
+
   hook = (makeSetupHook {
     # The setup hook should not be part of the fixed-output derivation.
     # Updates to the hook script should not change vendor hashes, and it won't
     # work at all anyway due to https://github.com/NixOS/nix/issues/6660.
     name = "${name}-dart-deps-setup-hook";
-    substitutions = { inherit deps; };
+    substitutions = { inherit gitSourceWrapper deps; };
     propagatedBuildInputs = [ dart git ];
     passthru = {
       files = deps.outPath;

--- a/pkgs/build-support/dart/fetch-dart-deps/setup-hook.sh
+++ b/pkgs/build-support/dart/fetch-dart-deps/setup-hook.sh
@@ -39,3 +39,8 @@ _setupPubCache() {
         exit 1
     fi
 }
+
+# Performs the given pub get command with an appropriate environment.
+doPubGet() {
+    PATH="@gitSourceWrapper@/bin:$PATH" "$@"
+}

--- a/pkgs/build-support/flutter/default.nix
+++ b/pkgs/build-support/flutter/default.nix
@@ -76,7 +76,7 @@ let
 
       mkdir -p build/flutter_assets/fonts
 
-      flutter packages get --offline -v
+      doPubGet flutter pub get --offline -v
       flutter build linux -v --release --split-debug-info="$debug" ${builtins.concatStringsSep " " (map (flag: "\"${flag}\"") finalAttrs.flutterBuildFlags)}
 
       runHook postBuild

--- a/pkgs/development/compilers/dart/sources.nix
+++ b/pkgs/development/compilers/dart/sources.nix
@@ -1,24 +1,24 @@
-let version = "2.19.6"; in
+let version = "3.0.0"; in
 { fetchurl }: {
   versionUsed = version;
   "${version}-x86_64-darwin" = fetchurl {
     url = "https://storage.googleapis.com/dart-archive/channels/stable/release/${version}/sdk/dartsdk-macos-x64-release.zip";
-    sha256 = "1nlmzappjk1f85iajlvqkvkqfd8ka7svsmglbh57ivvssvb6d6lr";
+    sha256 = "0aav696x5p6zq6vfmv7zpy9v701dpbk0xwkyv2c2qdmrbb8wljb0";
   };
   "${version}-aarch64-darwin" = fetchurl {
     url = "https://storage.googleapis.com/dart-archive/channels/stable/release/${version}/sdk/dartsdk-macos-arm64-release.zip";
-    sha256 = "1dpd8czllsxqly7hrcazp8g9b5zj6ibs93l5qyykijjbyjv58srw";
+    sha256 = "1l06qk4w03qrrmnflb7a9jcm8ssx0p7b95jkhyvdg878d79zrpb7";
   };
   "${version}-aarch64-linux" = fetchurl {
     url = "https://storage.googleapis.com/dart-archive/channels/stable/release/${version}/sdk/dartsdk-linux-arm64-release.zip";
-    sha256 = "170bzz4505fffz4lbaxif9ryaw8pl8ylgkbjsd0w32xpng0bf4v9";
+    sha256 = "0p15njnry0kp9878lmg86p01bbvin8xm6131r8barzclcj5v3msd";
   };
   "${version}-x86_64-linux" = fetchurl {
     url = "https://storage.googleapis.com/dart-archive/channels/stable/release/${version}/sdk/dartsdk-linux-x64-release.zip";
-    sha256 = "0kvhvwd2q8s7mnjgvhl6gr3y73agcd0y79sm844xd8ybd9gg5pqg";
+    sha256 = "0r96frjcqinhyzq809hv9yggm09clyc712ln3caqxfybcr552mm2";
   };
   "${version}-i686-linux" = fetchurl {
     url = "https://storage.googleapis.com/dart-archive/channels/stable/release/${version}/sdk/dartsdk-linux-ia32-release.zip";
-    sha256 = "02iyzdz9grm3rc2dg7l1clww6n5n4kncv0gg6mlkgvmhk4hn9w1r";
+    sha256 = "16qdcc6ssgh3158fpqld6sai3lxvyimvasjmgqrhfh7h8p0inzfw";
   };
 }

--- a/pkgs/development/compilers/flutter/default.nix
+++ b/pkgs/development/compilers/flutter/default.nix
@@ -6,43 +6,46 @@ let
     let files = builtins.attrNames (builtins.readDir dir);
     in map (f: dir + ("/" + f)) files;
   mkFlutter = { version, engineVersion, dartVersion, hash, dartHash, patches }:
-    let args = {
-      inherit version engineVersion patches;
+    let
+      args = {
+        inherit version engineVersion patches;
 
-      dart = dart.override {
-        version = dartVersion;
-        sources = {
-          "${dartVersion}-x86_64-linux" = fetchzip {
-            url = "https://storage.googleapis.com/dart-archive/channels/stable/release/${dartVersion}/sdk/dartsdk-linux-x64-release.zip";
-            sha256 = dartHash.x86_64-linux;
-          };
-          "${dartVersion}-aarch64-linux" = fetchzip {
-            url = "https://storage.googleapis.com/dart-archive/channels/stable/release/${dartVersion}/sdk/dartsdk-linux-arm64-release.zip";
-            sha256 = dartHash.aarch64-linux;
+        dart = dart.override {
+          version = dartVersion;
+          sources = {
+            "${dartVersion}-x86_64-linux" = fetchzip {
+              url = "https://storage.googleapis.com/dart-archive/channels/stable/release/${dartVersion}/sdk/dartsdk-linux-x64-release.zip";
+              sha256 = dartHash.x86_64-linux;
+            };
+            "${dartVersion}-aarch64-linux" = fetchzip {
+              url = "https://storage.googleapis.com/dart-archive/channels/stable/release/${dartVersion}/sdk/dartsdk-linux-arm64-release.zip";
+              sha256 = dartHash.aarch64-linux;
+            };
           };
         };
+        src = fetchzip {
+          url = "https://storage.googleapis.com/flutter_infra_release/releases/stable/linux/flutter_linux_${version}-stable.tar.xz";
+          sha256 = hash;
+        };
       };
-      src = fetchzip {
-        url = "https://storage.googleapis.com/flutter_infra_release/releases/stable/linux/flutter_linux_${version}-stable.tar.xz";
-        sha256 = hash;
+    in
+    (mkCustomFlutter args).overrideAttrs (prev: next: {
+      passthru = next.passthru // rec {
+        inherit wrapFlutter mkCustomFlutter mkFlutter;
+        buildFlutterApplication = callPackage ../../../build-support/flutter {
+          # Package a minimal version of Flutter that only uses Linux desktop release artifacts.
+          flutter = wrapFlutter
+            (mkCustomFlutter (args // {
+              includedEngineArtifacts = {
+                common = [ "flutter_patched_sdk_product" ];
+                platform.linux = lib.optionals stdenv.hostPlatform.isLinux
+                  (lib.genAttrs ((lib.optional stdenv.hostPlatform.isx86_64 "x64") ++ (lib.optional stdenv.hostPlatform.isAarch64 "arm64"))
+                    (architecture: [ "release" ]));
+              };
+            }));
+        };
       };
-   }; in (mkCustomFlutter args).overrideAttrs (prev: next: {
-    passthru = next.passthru // rec {
-      inherit wrapFlutter mkCustomFlutter mkFlutter;
-      buildFlutterApplication = callPackage ../../../build-support/flutter {
-        # Package a minimal version of Flutter that only uses Linux desktop release artifacts.
-        flutter = wrapFlutter
-          (mkCustomFlutter (args // {
-            includedEngineArtifacts = {
-              common = [ "flutter_patched_sdk_product" ];
-              platform.linux = lib.optionals stdenv.hostPlatform.isLinux
-                (lib.genAttrs ((lib.optional stdenv.hostPlatform.isx86_64 "x64") ++ (lib.optional stdenv.hostPlatform.isAarch64 "arm64"))
-                  (architecture: [ "release" ]));
-            };
-          }));
-      };
-    };
-  });
+    });
 
   flutter2Patches = getPatches ./patches/flutter2;
   flutter3Patches = getPatches ./patches/flutter3;
@@ -50,13 +53,13 @@ in
 {
   inherit wrapFlutter;
   stable = mkFlutter {
-    version = "3.7.12";
-    engineVersion = "1a65d409c7a1438a34d21b60bf30a6fd5db59314";
-    dartVersion = "2.19.6";
-    hash = "sha256-5ExDBQXIpoZ5NwS66seY3m9/V8xDiyq/RdzldAyHdEE=";
+    version = "3.10.0";
+    engineVersion = "d44b5a94c976fbb65815374f61ab5392a220b084";
+    dartVersion = "3.0.0";
+    hash = "sha256-3cRVPNrph9QUUnAdQhd5TOp2i1zFRxJ+OhqxXrJ+ncU=";
     dartHash = {
-      x86_64-linux = "sha256-4ezRuwhQHVCxZg5WbzU/tBUDvZVpfCo6coDE4K0UzXo=";
-      aarch64-linux = "sha256-pYmClIqOo0sRPOkrcF4xQbo0mHlrr1TkhT1fnNyYNck=";
+      x86_64-linux = "sha256-AhvAt2c0URzL+MSIXlwbkuWNuhKbWvUpoyiYf1vXfcc=";
+      aarch64-linux = "sha256-bo4kZtNpj91JaCW8+GD4bQ60oOWQ7daj4C7cAHwLMtw=";
     };
     patches = flutter3Patches;
   };

--- a/pkgs/development/compilers/flutter/default.nix
+++ b/pkgs/development/compilers/flutter/default.nix
@@ -64,6 +64,18 @@ in
     patches = flutter3Patches;
   };
 
+  v37 = mkFlutter {
+    version = "3.7.12";
+    engineVersion = "1a65d409c7a1438a34d21b60bf30a6fd5db59314";
+    dartVersion = "2.19.6";
+    hash = "sha256-5ExDBQXIpoZ5NwS66seY3m9/V8xDiyq/RdzldAyHdEE=";
+    dartHash = {
+      x86_64-linux = "sha256-4ezRuwhQHVCxZg5WbzU/tBUDvZVpfCo6coDE4K0UzXo=";
+      aarch64-linux = "sha256-pYmClIqOo0sRPOkrcF4xQbo0mHlrr1TkhT1fnNyYNck=";
+    };
+    patches = flutter3Patches;
+  };
+
   v2 = mkFlutter {
     version = "2.10.5";
     engineVersion = "57d3bac3dd5cb5b0e464ab70e7bc8a0d8cf083ab";

--- a/pkgs/development/compilers/flutter/engine-artifacts/default.nix
+++ b/pkgs/development/compilers/flutter/engine-artifacts/default.nix
@@ -56,22 +56,23 @@ let
             {
               base = [
                 ({ archive = "artifacts.zip"; } // lib.optionalAttrs (arch == "arm64") {
-                  # For some reason, the arm64 artifacts are missing shader code.
+                  # For some reason, the arm64 artifacts are missing shader code in Flutter < 3.10.0.
                   postPatch = ''
-                    if [ -d shader_lib ]; then
-                      The shader_lib directory has been included in the artifact archive.
-                      This patch should be removed.
+                    if [ ! -d shader_lib ]; then
+                      ln -s ${lib.findSingle
+                        (pkg: lib.getName pkg == "flutter-artifact-linux-x64-artifacts")
+                        (throw "Could not find the x64 artifact archive.")
+                        (throw "Could not find the correct x64 artifact archive.")
+                        artifactDerivations.platform.linux.x64.base
+                      }/shader_lib .
                     fi
-                    ln -s ${lib.findSingle
-                      (pkg: lib.getName pkg == "flutter-artifact-linux-x64-artifacts")
-                      (throw "Could not find the x64 artifact archive.")
-                      (throw "Could not find the correct x64 artifact archive.")
-                      artifactDerivations.platform.linux.x64.base
-                    }/shader_lib .
                   '';
                 })
                 { archive = "font-subset.zip"; }
-                linux-flutter-gtk
+                (linux-flutter-gtk // {
+                  # https://github.com/flutter/flutter/commit/9d94a51b607600a39c14470c35c676eb3e30eed6
+                  variant = "debug";
+                })
               ];
               variants = lib.genAttrs [ "debug" "profile" "release" ] (variant: [
                 linux-flutter-gtk

--- a/pkgs/development/compilers/flutter/engine-artifacts/hashes.nix
+++ b/pkgs/development/compilers/flutter/engine-artifacts/hashes.nix
@@ -1,73 +1,71 @@
 {
-  "1a65d409c7a1438a34d21b60bf30a6fd5db59314" = {
-    "flutter_patched_sdk.zip" = "sha256-Pvsjttm5OwpJ/pW4UQXvvEiJYCM5CoZZfVXz5jef37k=";
-    "flutter_patched_sdk_product.zip" = "sha256-fhj2uUOrLwrzHrM6RNVpPNize5Qu6mLQDcSzLT2TbRA=";
+  "d44b5a94c976fbb65815374f61ab5392a220b084" = {
+    "flutter_patched_sdk.zip" = "sha256-uLMzCF3dsBeSZnoY9YQ2bBQhw+hUAksoDKEWr3TCnhk=";
+    "flutter_patched_sdk_product.zip" = "sha256-0NbvAGSK0VgU6jSyboyhviP9H+wID7JoTS6xMqbZs2w=";
     "android-arm" = {
-      "artifacts.zip" = "sha256-KDMiI6SQoZHfFV5LJJZ7VOGyEKC4UxzRc777j4BbXgM=";
+      "artifacts.zip" = "sha256-NZde8sVeknhR6bxchb/RURNIlKnJw6j5PZAWmmjiZvM=";
     };
     "android-arm-profile" = {
-      "artifacts.zip" = "sha256-MErLoGJWXg4yJ6b6c5bqP8Nat6O7eYSfM71mMNAAQf4=";
-      "linux-x64.zip" = "sha256-0TZQ05HR7NRqHzeoHZ/sOrjKiSvCpMUH85YXXzV4URg=";
+      "artifacts.zip" = "sha256-BTs1tuSdjVP8zAGCxV+uQ7sAAbCt0dML4g7/85IOFEs=";
+      "linux-x64.zip" = "sha256-GpjP5omeAjHBLZjJQdUMUnPoEgYBLppicLPUTY0fHqM=";
     };
     "android-arm-release" = {
-      "artifacts.zip" = "sha256-hU4S4FOqUGokByZ47nzOqQ4A9QFshruqrpJvJUBHUho=";
-      "linux-x64.zip" = "sha256-AqNlqjOht+c2sdW5ReoF66ZJWJl1W4vGKbQ3YyderRY=";
+      "artifacts.zip" = "sha256-ip2GnYkKq8aLWjVPk9no3aOf0c3k1h9foznhgLpZ17U=";
+      "linux-x64.zip" = "sha256-mGnmbraE98rqKRdO6keoITOaNCP0K3iYNRadihwOpxc=";
     };
     "android-arm64" = {
-      "artifacts.zip" = "sha256-ApNg3Uu9gyGNsx7sdpTCz1yADVAI5ZuNHgvgiuH9IpQ=";
+      "artifacts.zip" = "sha256-Sl7S/TNZWrlM4Z9UGN5rgGfpKk4UWKz6CKlQbz1qcZ4=";
     };
     "android-arm64-profile" = {
-      "artifacts.zip" = "sha256-D/8+WKPIkOaV3PwkCHiJROFlokm4lWWmtPQb93Yqwr0=";
-      "linux-x64.zip" = "sha256-S0RHLov6/C22VvGdvZV87Ybaxun8YBrw1gTgNklRcM0=";
+      "artifacts.zip" = "sha256-zNZtTxM8254y+KKSVYlBUYyIV2J04XN1cmnSjkQLJs8=";
+      "linux-x64.zip" = "sha256-M8AbEwFV2zedeqMoNeb+2UbR7i9I9rGh6LXBQcPO4iA=";
     };
     "android-arm64-release" = {
-      "artifacts.zip" = "sha256-OoYqHtwmT+VWJ+G+sMXM5+ux3h1Fnyo9Vj2za9cm5eE=";
-      "linux-x64.zip" = "sha256-NuXclg1a+Ofw5AWJ1tajpn2jYEZw6DluWxrFVL8rPfg=";
+      "artifacts.zip" = "sha256-PdnAIcYccdRs3r6M8rwmgl2x+TsBPMRF/iAEgwLbt/4=";
+      "linux-x64.zip" = "sha256-kmLkKXBj/70B3v5GJ50trTlV8epj16jOlQrh1U4/pVA=";
     };
     "android-x86" = {
-      "artifacts.zip" = "sha256-nN66nIrcbJHq2S4oIT5e2NCv7mS5Kw+HBv3ReHs+d3Y=";
+      "artifacts.zip" = "sha256-J1kgvNvdWo05HMHJMlVFECLMVnoCqUm1oP4K394w+xc=";
     };
     "android-x86-jit-release" = {
-      "artifacts.zip" = "sha256-A8F6K78Ykp1rMsUmjD7B9nFFPAubZnqAqgWSzbNCRwk=";
+      "artifacts.zip" = "sha256-Tz/veYh/73px0eH0FOXbN4G8fVjXmEHv7G8lRm3YLtY=";
     };
     "android-x64" = {
-      "artifacts.zip" = "sha256-hrBvnzCj/24h5kat96avlgXi6WhMsos5aPlkgxOYo8Q=";
+      "artifacts.zip" = "sha256-+WT7oT31XwE+ykLbiAUvnKw+WVR0VeFXPGpcMUHbsTg=";
     };
     "android-x64-profile" = {
-      "artifacts.zip" = "sha256-xzSj/2ah9aQoosaNGkSWFP3bMNJqRSFc0+78XEBHwzM=";
-      "linux-x64.zip" = "sha256-HfBiz1JWlBQ8KEfmf8uDlVzFlDt3+VF2VeY82tsMjHs=";
+      "artifacts.zip" = "sha256-f298VAJoZ2x+w0bxma7wu5h7Bn6+kCdrHh5qtjhhhhc=";
+      "linux-x64.zip" = "sha256-73Br9XgafwmagxAf61NSHn4BHn4q90pHJYEXCfAG8qY=";
     };
     "android-x64-release" = {
-      "artifacts.zip" = "sha256-TcfMeA+8Uf9yRrYdEIsjip0cKmSUm2Ow1tkoE9803XY=";
-      "linux-x64.zip" = "sha256-D6efb6pj9+xjPnJu3O+ZCmwfatBzasuFZEFRntAiU9U=";
+      "artifacts.zip" = "sha256-63hQCvObPmIxTcKyBQlXgGY6FfKp9PrbBY0RkSr1D/U=";
+      "linux-x64.zip" = "sha256-i5WQeePNxUNAbVR06Lz2XCXvZZTJxaFB6txtpVn2h9I=";
     };
     "linux-arm64" = {
-      "artifacts.zip" = "sha256-xyKVaEFb5gVkVrPzDrOql5BmXGO0FnCSeXOoQ10ZFrw=";
-      "font-subset.zip" = "sha256-Ulwb6q2SzB4suMJhAM3zAwWOzlEImlu9Ha+w5u4QqIU=";
-      "linux-arm64-flutter-gtk.zip" = "sha256-SiYOH++py4zeoD3BkNayqy/C9Zz9OiYQ5+u+pDLIpWg=";
+      "artifacts.zip" = "sha256-LTdVexuy7cL6dJqdM14YteI7Jo/z5wYOHakbX/BiV38=";
+      "font-subset.zip" = "sha256-cqLjvl3maO6NpN47/e718xyuSL8L8cHqU6ybuwlD+fA=";
     };
     "linux-arm64-debug" = {
-      "linux-arm64-flutter-gtk.zip" = "sha256-SiYOH++py4zeoD3BkNayqy/C9Zz9OiYQ5+u+pDLIpWg=";
+      "linux-arm64-flutter-gtk.zip" = "sha256-SRlKQllg5UWHk2kOIQ6ZwbqG5FoeFGCl2F9tTI+XVOE=";
     };
     "linux-arm64-profile" = {
-      "linux-arm64-flutter-gtk.zip" = "sha256-xB0eqrBYD7vhOwYUgJwNaBftNZJgdwxA9AUpEfX0iFs=";
+      "linux-arm64-flutter-gtk.zip" = "sha256-4wERBO+eimsSKFt8/P6mQqgzv+HURK+O/YFHAUHpklA=";
     };
     "linux-arm64-release" = {
-      "linux-arm64-flutter-gtk.zip" = "sha256-aHLKV129WIRsLUG6xTMwCKB4eXD3jonqinjI8KSsOus=";
+      "linux-arm64-flutter-gtk.zip" = "sha256-1XHdFiW//1Yd+qOLrRlk0vma99HlGDC/RA0An8db/oY=";
     };
     "linux-x64" = {
-      "artifacts.zip" = "sha256-+zIABFXUpiqn3OMoLcU4NDLxZ1y9z0r46iCTNRHAkz8=";
-      "font-subset.zip" = "sha256-W4SRPvA4rraVqN1ehbY6MFL7ZIWDHVJhjlLtxyUJJKY=";
-      "linux-x64-flutter-gtk.zip" = "sha256-boICnuJF4zqGb7kaN5haO/df9hC9KeJidt3uIK06S7M=";
+      "artifacts.zip" = "sha256-Bl0BRxUfVqNX6y7HdUXu5lIFzMLB2GUJauhOLEeInEE=";
+      "font-subset.zip" = "sha256-v02HV8QOqwdv30RiHpKu8ujTXOQmupGr9HCfpBUvrKM=";
     };
     "linux-x64-debug" = {
-      "linux-x64-flutter-gtk.zip" = "sha256-boICnuJF4zqGb7kaN5haO/df9hC9KeJidt3uIK06S7M=";
+      "linux-x64-flutter-gtk.zip" = "sha256-xjScsvWgPO8qeccw5BGzNrMLNzn5O+CvOpoPkvlrX0o=";
     };
     "linux-x64-profile" = {
-      "linux-x64-flutter-gtk.zip" = "sha256-AnkLMPW3mwiXdiDz3Zo802QZRi+8EMCy4Mx2ODSbMOU=";
+      "linux-x64-flutter-gtk.zip" = "sha256-52nMjoHQZ/ve7yJW9d8YK02U8mowe9xHZpkTwbGq9vU=";
     };
     "linux-x64-release" = {
-      "linux-x64-flutter-gtk.zip" = "sha256-RAsgupVF18IxLaP8tJ7XRQ8y/um46nlpA8fDITPwLqY=";
+      "linux-x64-flutter-gtk.zip" = "sha256-SA7Th1Qasaj4Q5wFr89Rv8PNQx6s6zvHsDxT1EKKZV0=";
     };
   };
   "57d3bac3dd5cb5b0e464ab70e7bc8a0d8cf083ab" = {

--- a/pkgs/development/compilers/flutter/engine-artifacts/hashes.nix
+++ b/pkgs/development/compilers/flutter/engine-artifacts/hashes.nix
@@ -68,6 +68,75 @@
       "linux-x64-flutter-gtk.zip" = "sha256-SA7Th1Qasaj4Q5wFr89Rv8PNQx6s6zvHsDxT1EKKZV0=";
     };
   };
+  "1a65d409c7a1438a34d21b60bf30a6fd5db59314" = {
+    "flutter_patched_sdk.zip" = "sha256-Pvsjttm5OwpJ/pW4UQXvvEiJYCM5CoZZfVXz5jef37k=";
+    "flutter_patched_sdk_product.zip" = "sha256-fhj2uUOrLwrzHrM6RNVpPNize5Qu6mLQDcSzLT2TbRA=";
+    "android-arm" = {
+      "artifacts.zip" = "sha256-KDMiI6SQoZHfFV5LJJZ7VOGyEKC4UxzRc777j4BbXgM=";
+    };
+    "android-arm-profile" = {
+      "artifacts.zip" = "sha256-MErLoGJWXg4yJ6b6c5bqP8Nat6O7eYSfM71mMNAAQf4=";
+      "linux-x64.zip" = "sha256-0TZQ05HR7NRqHzeoHZ/sOrjKiSvCpMUH85YXXzV4URg=";
+    };
+    "android-arm-release" = {
+      "artifacts.zip" = "sha256-hU4S4FOqUGokByZ47nzOqQ4A9QFshruqrpJvJUBHUho=";
+      "linux-x64.zip" = "sha256-AqNlqjOht+c2sdW5ReoF66ZJWJl1W4vGKbQ3YyderRY=";
+    };
+    "android-arm64" = {
+      "artifacts.zip" = "sha256-ApNg3Uu9gyGNsx7sdpTCz1yADVAI5ZuNHgvgiuH9IpQ=";
+    };
+    "android-arm64-profile" = {
+      "artifacts.zip" = "sha256-D/8+WKPIkOaV3PwkCHiJROFlokm4lWWmtPQb93Yqwr0=";
+      "linux-x64.zip" = "sha256-S0RHLov6/C22VvGdvZV87Ybaxun8YBrw1gTgNklRcM0=";
+    };
+    "android-arm64-release" = {
+      "artifacts.zip" = "sha256-OoYqHtwmT+VWJ+G+sMXM5+ux3h1Fnyo9Vj2za9cm5eE=";
+      "linux-x64.zip" = "sha256-NuXclg1a+Ofw5AWJ1tajpn2jYEZw6DluWxrFVL8rPfg=";
+    };
+    "android-x86" = {
+      "artifacts.zip" = "sha256-nN66nIrcbJHq2S4oIT5e2NCv7mS5Kw+HBv3ReHs+d3Y=";
+    };
+    "android-x86-jit-release" = {
+      "artifacts.zip" = "sha256-A8F6K78Ykp1rMsUmjD7B9nFFPAubZnqAqgWSzbNCRwk=";
+    };
+    "android-x64" = {
+      "artifacts.zip" = "sha256-hrBvnzCj/24h5kat96avlgXi6WhMsos5aPlkgxOYo8Q=";
+    };
+    "android-x64-profile" = {
+      "artifacts.zip" = "sha256-xzSj/2ah9aQoosaNGkSWFP3bMNJqRSFc0+78XEBHwzM=";
+      "linux-x64.zip" = "sha256-HfBiz1JWlBQ8KEfmf8uDlVzFlDt3+VF2VeY82tsMjHs=";
+    };
+    "android-x64-release" = {
+      "artifacts.zip" = "sha256-TcfMeA+8Uf9yRrYdEIsjip0cKmSUm2Ow1tkoE9803XY=";
+      "linux-x64.zip" = "sha256-D6efb6pj9+xjPnJu3O+ZCmwfatBzasuFZEFRntAiU9U=";
+    };
+    "linux-arm64" = {
+      "artifacts.zip" = "sha256-xyKVaEFb5gVkVrPzDrOql5BmXGO0FnCSeXOoQ10ZFrw=";
+      "font-subset.zip" = "sha256-Ulwb6q2SzB4suMJhAM3zAwWOzlEImlu9Ha+w5u4QqIU=";
+    };
+    "linux-arm64-debug" = {
+      "linux-arm64-flutter-gtk.zip" = "sha256-SiYOH++py4zeoD3BkNayqy/C9Zz9OiYQ5+u+pDLIpWg=";
+    };
+    "linux-arm64-profile" = {
+      "linux-arm64-flutter-gtk.zip" = "sha256-xB0eqrBYD7vhOwYUgJwNaBftNZJgdwxA9AUpEfX0iFs=";
+    };
+    "linux-arm64-release" = {
+      "linux-arm64-flutter-gtk.zip" = "sha256-aHLKV129WIRsLUG6xTMwCKB4eXD3jonqinjI8KSsOus=";
+    };
+    "linux-x64" = {
+      "artifacts.zip" = "sha256-+zIABFXUpiqn3OMoLcU4NDLxZ1y9z0r46iCTNRHAkz8=";
+      "font-subset.zip" = "sha256-W4SRPvA4rraVqN1ehbY6MFL7ZIWDHVJhjlLtxyUJJKY=";
+    };
+    "linux-x64-debug" = {
+      "linux-x64-flutter-gtk.zip" = "sha256-boICnuJF4zqGb7kaN5haO/df9hC9KeJidt3uIK06S7M=";
+    };
+    "linux-x64-profile" = {
+      "linux-x64-flutter-gtk.zip" = "sha256-AnkLMPW3mwiXdiDz3Zo802QZRi+8EMCy4Mx2ODSbMOU=";
+    };
+    "linux-x64-release" = {
+      "linux-x64-flutter-gtk.zip" = "sha256-RAsgupVF18IxLaP8tJ7XRQ8y/um46nlpA8fDITPwLqY=";
+    };
+  };
   "57d3bac3dd5cb5b0e464ab70e7bc8a0d8cf083ab" = {
     "flutter_patched_sdk.zip" = "sha256-A/y5Y+Aw0CUhXABbdyQcGCSnSbO7Ask+71m8LZDSjH4=";
     "flutter_patched_sdk_product.zip" = "sha256-VPxF4NrTUhFbpztyPnLEiC9Cy0kDDbYvy21kA5ES4HM=";

--- a/pkgs/development/compilers/flutter/wrapper.nix
+++ b/pkgs/development/compilers/flutter/wrapper.nix
@@ -101,9 +101,9 @@ in
   mkdir -p $out/bin
   makeWrapper '${immutableFlutter}' $out/bin/flutter \
     --set-default ANDROID_EMULATOR_USE_SYSTEM_LIBS 1 \
-    --prefix PATH : '${lib.makeBinPath (tools ++ buildTools)}' \
-    --prefix PKG_CONFIG_PATH : "$FLUTTER_PKG_CONFIG_PATH" \
-    --prefix LIBRARY_PATH : '${lib.makeLibraryPath appStaticBuildDeps}' \
+    --suffix PATH : '${lib.makeBinPath (tools ++ buildTools)}' \
+    --suffix PKG_CONFIG_PATH : "$FLUTTER_PKG_CONFIG_PATH" \
+    --suffix LIBRARY_PATH : '${lib.makeLibraryPath appStaticBuildDeps}' \
     --prefix CXXFLAGS "''\t" '${builtins.concatStringsSep " " (includeFlags ++ extraCxxFlags)}' \
     --prefix CFLAGS "''\t" '${builtins.concatStringsSep " " (includeFlags ++ extraCFlags)}' \
     --prefix LDFLAGS "''\t" '${builtins.concatStringsSep " " (map (flag: "-Wl,${flag}") linkerFlags)}'

--- a/pkgs/misc/dart-sass-embedded/default.nix
+++ b/pkgs/misc/dart-sass-embedded/default.nix
@@ -41,7 +41,7 @@ stdenvNoCC.mkDerivation (finalAttrs: {
 
   configurePhase = ''
     runHook preConfigure
-    dart pub get --offline
+    doPubGet dart pub get --offline
     mkdir build
     ln -s ${embedded-protocol} build/embedded-protocol
     runHook postConfigure

--- a/pkgs/os-specific/linux/firmware/firmware-updater/default.nix
+++ b/pkgs/os-specific/linux/firmware/firmware-updater/default.nix
@@ -1,9 +1,9 @@
 { lib
-, flutter
+, flutter37
 , fetchFromGitHub
 }:
 
-flutter.buildFlutterApplication {
+flutter37.buildFlutterApplication {
   pname = "firmware-updater";
   version = "unstable-2023-04-30";
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -14753,8 +14753,10 @@ with pkgs;
   flutterPackages =
     recurseIntoAttrs (callPackage ../development/compilers/flutter { });
   flutter-unwrapped = flutterPackages.stable;
+  flutter37-unwrapped = flutterPackages.v37;
   flutter2-unwrapped = flutterPackages.v2;
   flutter = flutterPackages.wrapFlutter flutter-unwrapped;
+  flutter37 = flutterPackages.wrapFlutter flutter37-unwrapped;
   flutter2 = flutterPackages.wrapFlutter flutter2-unwrapped;
 
   fnm = callPackage ../development/tools/fnm {


### PR DESCRIPTION
###### Description of changes

This PR upgrades Flutter to 3.10.0, but keeps applications on 3.7.12. It depends on #231083.

- Most applications do not yet build on 3.10.0
- Upgrading Flutter changes the dependency list and vendor hash of each derivation using `buildFlutterApplication`, as the Flutter SDK and Dart version effect dependency constraints

The latter point is quite significant. We need to decide on an approach for Flutter upgrades (@NixOS/flutter). Perhaps we can build some sort of system to automate lockfile updates across Nixpkgs? Or, we can decide on a support period after each upgrade during which the previous version will be kept available?

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
