### PR TITLE
linuxKernel.kernels: update

### DIFF
--- a/pkgs/os-specific/linux/kernel/hardened/patches.json
+++ b/pkgs/os-specific/linux/kernel/hardened/patches.json
@@ -22,12 +22,12 @@
     "5.10": {
         "patch": {
             "extra": "-hardened1",
-            "name": "linux-hardened-5.10.178-hardened1.patch",
-            "sha256": "142ym9z6c9bcq2hpv2ik6xsjlvyyvw3vx8ggp4a67zwv6apg48v3",
-            "url": "https://github.com/anthraxx/linux-hardened/releases/download/5.10.178-hardened1/linux-hardened-5.10.178-hardened1.patch"
+            "name": "linux-hardened-5.10.179-hardened1.patch",
+            "sha256": "0mjfk6b6wvr6646sbl47rhs5jjbmnhfx9wkw44apy92l7mnk983r",
+            "url": "https://github.com/anthraxx/linux-hardened/releases/download/5.10.179-hardened1/linux-hardened-5.10.179-hardened1.patch"
         },
-        "sha256": "1bx8wws9gvksg1c1af29nm03jjz2f5a5sq9hzc00ymjyf7isvkqs",
-        "version": "5.10.178"
+        "sha256": "0abylcqbzpxxh45kmvd9i2cig64aajz87j5c8vm3w1ab2mf49g8v",
+        "version": "5.10.179"
     },
     "5.15": {
         "patch": {

--- a/pkgs/os-specific/linux/kernel/hardened/patches.json
+++ b/pkgs/os-specific/linux/kernel/hardened/patches.json
@@ -32,12 +32,12 @@
     "5.15": {
         "patch": {
             "extra": "-hardened1",
-            "name": "linux-hardened-5.15.108-hardened1.patch",
-            "sha256": "1qfmx640b2s10q3sz0lcn1fsfbhklg8l4bzahrsdq6gkvsy9lyxn",
-            "url": "https://github.com/anthraxx/linux-hardened/releases/download/5.15.108-hardened1/linux-hardened-5.15.108-hardened1.patch"
+            "name": "linux-hardened-5.15.110-hardened1.patch",
+            "sha256": "1kfad446bnkmsssvhn5w30v3qi4ysja6vgfa01jzwvlnvzizfy0c",
+            "url": "https://github.com/anthraxx/linux-hardened/releases/download/5.15.110-hardened1/linux-hardened-5.15.110-hardened1.patch"
         },
-        "sha256": "1fj38bvsyr9g89qr8pcjrp0kaq44g301x46gyjibq73gljnnkswb",
-        "version": "5.15.108"
+        "sha256": "0nqbhgafl513pdfn55j608829bsw8kn0v616gblxqy4rgg3zqacq",
+        "version": "5.15.110"
     },
     "5.4": {
         "patch": {

--- a/pkgs/os-specific/linux/kernel/hardened/patches.json
+++ b/pkgs/os-specific/linux/kernel/hardened/patches.json
@@ -12,12 +12,12 @@
     "4.19": {
         "patch": {
             "extra": "-hardened1",
-            "name": "linux-hardened-4.19.281-hardened1.patch",
-            "sha256": "0qhf0835zwmj0z2654bhyc6zww68g8ng4ghg5ivw2zcfv6yssv17",
-            "url": "https://github.com/anthraxx/linux-hardened/releases/download/4.19.281-hardened1/linux-hardened-4.19.281-hardened1.patch"
+            "name": "linux-hardened-4.19.282-hardened1.patch",
+            "sha256": "1zy3hk5aykyw8nngzjb46i6q1i4sll5qhskycdhji9ga3wbl4z97",
+            "url": "https://github.com/anthraxx/linux-hardened/releases/download/4.19.282-hardened1/linux-hardened-4.19.282-hardened1.patch"
         },
-        "sha256": "13nwzsh3h634450k37pxdca5j8vr3qswx7k79bs2999xp2js9pf0",
-        "version": "4.19.281"
+        "sha256": "02z20879xl4ya957by1p35vi1a7myzxwiqd9cnvm541sgnci99a3",
+        "version": "4.19.282"
     },
     "5.10": {
         "patch": {

--- a/pkgs/os-specific/linux/kernel/hardened/patches.json
+++ b/pkgs/os-specific/linux/kernel/hardened/patches.json
@@ -2,12 +2,12 @@
     "4.14": {
         "patch": {
             "extra": "-hardened1",
-            "name": "linux-hardened-4.14.313-hardened1.patch",
-            "sha256": "0qpf9chiydj6dcka1lf6qdx462wq0salxac3kkl32l33karax292",
-            "url": "https://github.com/anthraxx/linux-hardened/releases/download/4.14.313-hardened1/linux-hardened-4.14.313-hardened1.patch"
+            "name": "linux-hardened-4.14.314-hardened1.patch",
+            "sha256": "08d0mkkc22apdy0m0z5qkkl4xb8d9is0ip3v8rb47bqybmxx879h",
+            "url": "https://github.com/anthraxx/linux-hardened/releases/download/4.14.314-hardened1/linux-hardened-4.14.314-hardened1.patch"
         },
-        "sha256": "0k2j856niappvkp9m1wxr87xvbwdzdy03mbcj827kmpjd9gdca76",
-        "version": "4.14.313"
+        "sha256": "0lwiykv2ci7lrjvvykbiqavzzizdkf8xxqlybixi9l1as7q02v47",
+        "version": "4.14.314"
     },
     "4.19": {
         "patch": {

--- a/pkgs/os-specific/linux/kernel/hardened/patches.json
+++ b/pkgs/os-specific/linux/kernel/hardened/patches.json
@@ -42,12 +42,12 @@
     "5.4": {
         "patch": {
             "extra": "-hardened1",
-            "name": "linux-hardened-5.4.241-hardened1.patch",
-            "sha256": "1nksqvc1ql42v92bfp26yyczvzslzl73mhnfc83j6cayqx8dw59z",
-            "url": "https://github.com/anthraxx/linux-hardened/releases/download/5.4.241-hardened1/linux-hardened-5.4.241-hardened1.patch"
+            "name": "linux-hardened-5.4.242-hardened1.patch",
+            "sha256": "1g2szikq3ac3gshvglvda6chirv2al43sq6byach1hg2sddbxsx0",
+            "url": "https://github.com/anthraxx/linux-hardened/releases/download/5.4.242-hardened1/linux-hardened-5.4.242-hardened1.patch"
         },
-        "sha256": "0z7api3qcjrd6w7fva7k6fj4zx17mg5ibn28a6qbgy27dyny1h7z",
-        "version": "5.4.241"
+        "sha256": "0a7wfi84p74qsnbj1vamz4qxzp94v054jp1csyfl0blz3knrlbql",
+        "version": "5.4.242"
     },
     "6.1": {
         "patch": {

--- a/pkgs/os-specific/linux/kernel/hardened/patches.json
+++ b/pkgs/os-specific/linux/kernel/hardened/patches.json
@@ -52,11 +52,11 @@
     "6.1": {
         "patch": {
             "extra": "-hardened1",
-            "name": "linux-hardened-6.1.25-hardened1.patch",
-            "sha256": "1s9fx4nznmabg7b19qm7nwhpgdvin4f2gxd8f27zh7anbv9na4x7",
-            "url": "https://github.com/anthraxx/linux-hardened/releases/download/6.1.25-hardened1/linux-hardened-6.1.25-hardened1.patch"
+            "name": "linux-hardened-6.1.27-hardened1.patch",
+            "sha256": "0bg149qx7nwpxhajn6283cfgrp151477xpbl5rqhcfk47w3alnk4",
+            "url": "https://github.com/anthraxx/linux-hardened/releases/download/6.1.27-hardened1/linux-hardened-6.1.27-hardened1.patch"
         },
-        "sha256": "149h95r5msvqah868zd36y92ls9h41cr1rb5vzinl20mxdn46wnb",
-        "version": "6.1.25"
+        "sha256": "01grx5y48scyyihpj176knn5yvgpxv2gfkli03rwj31xvnb4pdy2",
+        "version": "6.1.27"
     }
 }

--- a/pkgs/os-specific/linux/kernel/linux-5.15.nix
+++ b/pkgs/os-specific/linux/kernel/linux-5.15.nix
@@ -3,7 +3,7 @@
 with lib;
 
 buildLinux (args // rec {
-  version = "5.15.110";
+  version = "5.15.111";
 
   # modDirVersion needs to be x.y.z, will automatically add .0 if needed
   modDirVersion = versions.pad 3 version;
@@ -13,6 +13,6 @@ buildLinux (args // rec {
 
   src = fetchurl {
     url = "mirror://kernel/linux/kernel/v5.x/linux-${version}.tar.xz";
-    sha256 = "0nqbhgafl513pdfn55j608829bsw8kn0v616gblxqy4rgg3zqacq";
+    sha256 = "1hmfvii77w70dx1lsfigc7nmjblvs1q131q48didsn01khjymkkp";
   };
 } // (args.argsOverride or { }))

--- a/pkgs/os-specific/linux/kernel/linux-6.1.nix
+++ b/pkgs/os-specific/linux/kernel/linux-6.1.nix
@@ -3,7 +3,7 @@
 with lib;
 
 buildLinux (args // rec {
-  version = "6.1.27";
+  version = "6.1.28";
 
   # modDirVersion needs to be x.y.z, will automatically add .0 if needed
   modDirVersion = versions.pad 3 version;
@@ -13,7 +13,7 @@ buildLinux (args // rec {
 
   src = fetchurl {
     url = "mirror://kernel/linux/kernel/v6.x/linux-${version}.tar.xz";
-    sha256 = "01grx5y48scyyihpj176knn5yvgpxv2gfkli03rwj31xvnb4pdy2";
+    sha256 = "1w56qgf1vgk3dmh4xw6699kjm5pdqvyfzr19ah5yy3xj50a4q2bs";
   };
   # TODO: possible to remove after any rebuild, e.g. after update.
   extraConfig = lib.optionalString (buildPackages.stdenv.system == "x86_64-linux") "\n";

--- a/pkgs/os-specific/linux/kernel/linux-6.2.nix
+++ b/pkgs/os-specific/linux/kernel/linux-6.2.nix
@@ -3,7 +3,7 @@
 with lib;
 
 buildLinux (args // rec {
-  version = "6.2.14";
+  version = "6.2.15";
 
   # modDirVersion needs to be x.y.z, will automatically add .0 if needed
   modDirVersion = versions.pad 3 version;
@@ -13,6 +13,6 @@ buildLinux (args // rec {
 
   src = fetchurl {
     url = "mirror://kernel/linux/kernel/v6.x/linux-${version}.tar.xz";
-    sha256 = "0ab756x6baza5wmi0r836g7z0hkvby65g0k6n1sd95nl16irzg0f";
+    sha256 = "1hcgxmwp1977wkj2ylxzbfqj5qwjc6czvd9yvdm0qrj422939ylz";
   };
 } // (args.argsOverride or { }))

--- a/pkgs/os-specific/linux/kernel/linux-6.3.nix
+++ b/pkgs/os-specific/linux/kernel/linux-6.3.nix
@@ -3,7 +3,7 @@
 with lib;
 
 buildLinux (args // rec {
-  version = "6.3.1";
+  version = "6.3.2";
 
   # modDirVersion needs to be x.y.z, will automatically add .0 if needed
   modDirVersion = versions.pad 3 version;
@@ -13,6 +13,6 @@ buildLinux (args // rec {
 
   src = fetchurl {
     url = "mirror://kernel/linux/kernel/v6.x/linux-${version}.tar.xz";
-    sha256 = "0aizkgwdmdjrgab67yjfaqcmvfh7wb3b3mdq9qfxpq6mlys0yqkq";
+    sha256 = "0a2kki763lrlafh6kf9ca8nxrdrk5043k7vdzy4pjgyahbrfq4mn";
   };
 } // (args.argsOverride or { }))

--- a/pkgs/os-specific/linux/kernel/linux-rt-5.15.nix
+++ b/pkgs/os-specific/linux/kernel/linux-rt-5.15.nix
@@ -6,7 +6,7 @@
 , ... } @ args:
 
 let
-  version = "5.15.107-rt62"; # updated by ./update-rt.sh
+  version = "5.15.111-rt63"; # updated by ./update-rt.sh
   branch = lib.versions.majorMinor version;
   kversion = builtins.elemAt (lib.splitString "-" version) 0;
 in buildLinux (args // {
@@ -18,14 +18,14 @@ in buildLinux (args // {
 
   src = fetchurl {
     url = "mirror://kernel/linux/kernel/v5.x/linux-${kversion}.tar.xz";
-    sha256 = "1a5gqpxmzls5mp4a0cw10ldrps4pvbn19nzfri91ys25j1v0wdqr";
+    sha256 = "1hmfvii77w70dx1lsfigc7nmjblvs1q131q48didsn01khjymkkp";
   };
 
   kernelPatches = let rt-patch = {
     name = "rt";
     patch = fetchurl {
       url = "mirror://kernel/linux/kernel/projects/rt/${branch}/older/patch-${version}.patch.xz";
-      sha256 = "0w7ksdv3xpzqiwfxc007k496ghklblb7kglswxhn7y1yqn6pgqzs";
+      sha256 = "1jixgqzyns56804dsjkg9n04mbaqrgwvsbgv5jxi2mip1p8spm8s";
     };
   }; in [ rt-patch ] ++ kernelPatches;
 

--- a/pkgs/os-specific/linux/kernel/linux-rt-5.4.nix
+++ b/pkgs/os-specific/linux/kernel/linux-rt-5.4.nix
@@ -6,7 +6,7 @@
 , ... } @ args:
 
 let
-  version = "5.4.230-rt80"; # updated by ./update-rt.sh
+  version = "5.4.242-rt81"; # updated by ./update-rt.sh
   branch = lib.versions.majorMinor version;
   kversion = builtins.elemAt (lib.splitString "-" version) 0;
 in buildLinux (args // {
@@ -14,14 +14,14 @@ in buildLinux (args // {
 
   src = fetchurl {
     url = "mirror://kernel/linux/kernel/v5.x/linux-${kversion}.tar.xz";
-    sha256 = "0bz6hfhsahymys2g9s4nzf862z0zfq4346577cpvf98hrhnd6kx7";
+    sha256 = "0a7wfi84p74qsnbj1vamz4qxzp94v054jp1csyfl0blz3knrlbql";
   };
 
   kernelPatches = let rt-patch = {
     name = "rt";
     patch = fetchurl {
       url = "mirror://kernel/linux/kernel/projects/rt/${branch}/older/patch-${version}.patch.xz";
-      sha256 = "19vcalg76vi66g3rk56ky873276is4r67sz2i4vympjq9bskrwrz";
+      sha256 = "1wszhzw9ic018x3jiz8x1ffxxg30wpy4db7hja44b661p9fjm1dc";
     };
   }; in [ rt-patch ] ++ kernelPatches;
 

--- a/pkgs/os-specific/linux/kernel/linux-rt-6.1.nix
+++ b/pkgs/os-specific/linux/kernel/linux-rt-6.1.nix
@@ -6,7 +6,7 @@
 , ... } @ args:
 
 let
-  version = "6.1.19-rt8"; # updated by ./update-rt.sh
+  version = "6.1.26-rt8"; # updated by ./update-rt.sh
   branch = lib.versions.majorMinor version;
   kversion = builtins.elemAt (lib.splitString "-" version) 0;
 in buildLinux (args // {
@@ -18,14 +18,14 @@ in buildLinux (args // {
 
   src = fetchurl {
     url = "mirror://kernel/linux/kernel/v6.x/linux-${kversion}.tar.xz";
-    sha256 = "0iw6b9gmhpk6r1asds5kfg6drqvaxy15xicqx9ga873cbxp1r6cy";
+    sha256 = "0461ckgh9qm1pj9xyi61cvawqpavn2sb44wjx5g4mmkrm11w3p6z";
   };
 
   kernelPatches = let rt-patch = {
     name = "rt";
     patch = fetchurl {
       url = "mirror://kernel/linux/kernel/projects/rt/${branch}/older/patch-${version}.patch.xz";
-      sha256 = "1nd3x7rgssf3f9vxsplnp5zg0cbixm9lf6sswlnl6pcvj4adagg1";
+      sha256 = "1nwbj6cx2sa74f772wxmm5czd6c8v3s2f6919qri19xpm6kndkda";
     };
   }; in [ rt-patch ] ++ kernelPatches;
 

--- a/pkgs/top-level/linux-kernels.nix
+++ b/pkgs/top-level/linux-kernels.nix
@@ -174,7 +174,6 @@ in {
         kernelPatches.bridge_stp_helper
         kernelPatches.request_key_helper
         kernelPatches.fix-em-ice-bonding
-        kernelPatches.CVE-2023-32233
       ];
     };
 

--- a/pkgs/top-level/linux-kernels.nix
+++ b/pkgs/top-level/linux-kernels.nix
@@ -158,7 +158,6 @@ in {
         kernelPatches.bridge_stp_helper
         kernelPatches.request_key_helper
         kernelPatches.fix-em-ice-bonding
-        kernelPatches.CVE-2023-32233
       ];
     };
 

--- a/pkgs/top-level/linux-kernels.nix
+++ b/pkgs/top-level/linux-kernels.nix
@@ -200,7 +200,6 @@ in {
         kernelPatches.bridge_stp_helper
         kernelPatches.request_key_helper
         kernelPatches.fix-em-ice-bonding
-        kernelPatches.CVE-2023-32233
       ];
     };
 

--- a/pkgs/top-level/linux-kernels.nix
+++ b/pkgs/top-level/linux-kernels.nix
@@ -54,6 +54,11 @@ let
       };
       kernelPatches = kernel.kernelPatches ++ [
         kernelPatches.hardened.${kernel.meta.branch}
+      ] ++ lib.optionals (lib.versionAtLeast version "5.15") [
+        # Needed as long as hardened kernels are behind the first patch release
+        # containing the fix for CVE-2023-32233. Can most likely be removed after the
+        # next hardened kernel update.
+        kernelPatches.CVE-2023-32233
       ];
       isHardened = true;
   };

--- a/pkgs/top-level/linux-kernels.nix
+++ b/pkgs/top-level/linux-kernels.nix
@@ -192,7 +192,6 @@ in {
         kernelPatches.bridge_stp_helper
         kernelPatches.request_key_helper
         kernelPatches.fix-em-ice-bonding
-        kernelPatches.CVE-2023-32233
       ];
     };
 


### PR DESCRIPTION
- linux: 5.15.110 -> 5.15.111
- linux: 6.1.27 -> 6.1.28
- linux: 6.2.14 -> 6.2.15
- linux: 6.3.1 -> 6.3.2
- linux-rt_5_15: 5.15.107-rt62 -> 5.15.111-rt63
- linux-rt_5_4: 5.4.230-rt80 -> 5.4.242-rt81
- linux-rt_6_1: 6.1.19-rt8 -> 6.1.26-rt8
- linux/hardened/patches/4.14: 4.14.313-hardened1 -> 4.14.314-hardened1
- linux/hardened/patches/4.19: 4.19.281-hardened1 -> 4.19.282-hardened1
- linux/hardened/patches/5.10: 5.10.178-hardened1 -> 5.10.179-hardened1
- linux/hardened/patches/5.15: 5.15.108-hardened1 -> 5.15.110-hardened1
- linux/hardened/patches/5.4: 5.4.241-hardened1 -> 5.4.242-hardened1
- linux/hardened/patches/6.1: 6.1.25-hardened1 -> 6.1.27-hardened1

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
