### PR TITLE
shaka-packager: init at 2.6.1

### DIFF
--- a/pkgs/applications/video/shaka-packager/default.nix
+++ b/pkgs/applications/video/shaka-packager/default.nix
@@ -1,0 +1,62 @@
+{ lib
+, stdenv
+, fetchurl
+, runCommand
+, shaka-packager
+}:
+
+let
+  sources = {
+    "x86_64-linux" = {
+      filename = "packager-linux-x64";
+      hash = "sha256-MoMX6PEtvPmloXJwRpnC2lHlT+tozsV4dmbCqweyyI0=";
+    };
+    aarch64-linux = {
+      filename = "packager-linux-arm64";
+      hash = "sha256-6+7SfnwVRsqFwI7/1F7yqVtkJVIoOFUmhoGU3P6gdQ0=";
+    };
+    x86_64-darwin = {
+      filename = "packager-osx-x64";
+      hash = "sha256-fFBtOp/Zb37LP7TWAEB0yp0xM88cMT9QS59EwW4MrAY=";
+    };
+  };
+
+  source = sources."${stdenv.hostPlatform.system}"
+    or (throw "Unsupported system: ${stdenv.hostPlatform.system}");
+in
+stdenv.mkDerivation (finalAttrs: {
+  pname = "shaka-packager";
+  version = "2.6.1";
+
+  src = fetchurl {
+    url = "https://github.com/shaka-project/shaka-packager/releases/download/v${finalAttrs.version}/${source.filename}";
+    inherit (source) hash;
+  };
+
+  dontUnpack = true;
+  sourceRoot = ".";
+
+  installPhase = ''
+    runHook preInstall
+
+    install -m755 -D $src $out/bin/packager
+
+    runHook postInstall
+  '';
+
+  passthru.tests = {
+    simple = runCommand "${finalAttrs.pname}-test" { } ''
+      ${shaka-packager}/bin/packager -version | grep ${finalAttrs.version} > $out
+    '';
+  };
+
+  meta = {
+    description = "Media packaging framework for VOD and Live DASH and HLS applications";
+    homepage = "https://shaka-project.github.io/shaka-packager/html/";
+    license = lib.licenses.bsd3;
+    mainProgram = "packager";
+    maintainers = with lib.maintainers; [ ];
+    platforms = builtins.attrNames sources;
+    sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
+  };
+})

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -34065,6 +34065,8 @@ with pkgs;
     inherit lua;
   };
 
+  shaka-packager = callPackage ../applications/video/shaka-packager { };
+
   # Wraps without triggering a rebuild
   wrapMpv = callPackage ../applications/video/mpv/wrapper.nix { };
   mpv = wrapMpv mpv-unwrapped { };


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Add `shaka-packager` to `nixpkgs`, for media packaging.

https://shaka-project.github.io/shaka-packager/html/

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

