### PR TITLE
tuxedo-rs: init at 0.2.2

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -11835,6 +11835,13 @@
     githubId = 2072185;
     name = "Marc Scholten";
   };
+  mrcjkb = {
+    email = "marc@jakobi.dev";
+    matrix = "@mrcjk:matrix.org";
+    name = "Marc Jakobi";
+    github = "mrcjkb";
+    githubId = 12857160;
+  };
   mredaelli = {
     email = "massimo@typish.io";
     github = "mredaelli";

--- a/nixos/doc/manual/release-notes/rl-2311.section.md
+++ b/nixos/doc/manual/release-notes/rl-2311.section.md
@@ -80,6 +80,8 @@
 
 - [NNCP](http://www.nncpgo.org/). Added nncp-daemon and nncp-caller services. Configuration is set with [programs.nncp.settings](#opt-programs.nncp.settings) and the daemons are enabled at [services.nncp](#opt-services.nncp.caller.enable).
 
+- [tuxedo-rs](https://github.com/AaronErhardt/tuxedo-rs), Rust utilities for interacting with hardware from TUXEDO Computers.
+
 ## Backward Incompatibilities {#sec-release-23.11-incompatibilities}
 
 - The `boot.loader.raspberryPi` options have been marked deprecated, with intent for removal for NixOS 24.11. They had a limited use-case, and do not work like people expect. They required either very old installs ([before mid-2019](https://github.com/NixOS/nixpkgs/pull/62462)) or customized builds out of scope of the standard and generic AArch64 support. That option set never supported the Raspberry Pi 4 family of devices.

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -541,6 +541,7 @@
   ./services/hardware/tlp.nix
   ./services/hardware/trezord.nix
   ./services/hardware/triggerhappy.nix
+  ./services/hardware/tuxedo-rs.nix
   ./services/hardware/udev.nix
   ./services/hardware/udisks2.nix
   ./services/hardware/undervolt.nix

--- a/nixos/modules/services/hardware/tuxedo-rs.nix
+++ b/nixos/modules/services/hardware/tuxedo-rs.nix
@@ -1,0 +1,49 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+  cfg = config.hardware.tuxedo-rs;
+
+in
+{
+  options = {
+    hardware.tuxedo-rs = {
+      enable = mkEnableOption (lib.mdDoc "Rust utilities for interacting with hardware from TUXEDO Computers.");
+
+      tailor-gui.enable = mkEnableOption (lib.mdDoc "Alternative to TUXEDO Control Center, written in Rust.");
+    };
+  };
+
+  config = mkIf cfg.enable (mkMerge [
+    {
+      hardware.tuxedo-keyboard.enable = true;
+
+      systemd = {
+        services.tailord = {
+          enable = true;
+          description = "Tuxedo Tailor hardware control service";
+          after = [ "systemd-logind.service" ];
+          wantedBy = [ "multi-user.target" ];
+
+          serviceConfig = {
+            Type = "dbus";
+            BusName = "com.tux.Tailor";
+            ExecStart = "${pkgs.tuxedo-rs}/bin/tailord";
+            Environment = "RUST_BACKTRACE=1";
+            Restart = "on-failure";
+          };
+        };
+      };
+
+      services.dbus.packages = [ pkgs.tuxedo-rs ];
+
+      environment.systemPackages = [ pkgs.tuxedo-rs ];
+    }
+    (mkIf cfg.tailor-gui.enable {
+      environment.systemPackages = [ pkgs.tailor-gui ];
+    })
+  ]);
+
+  meta.maintainers = with maintainers; [ mrcjkb ];
+}

--- a/pkgs/os-specific/linux/tailor-gui/default.nix
+++ b/pkgs/os-specific/linux/tailor-gui/default.nix
@@ -1,0 +1,60 @@
+{ stdenv
+, lib
+, rustPlatform
+, cargo
+, rustc
+, pkg-config
+, desktop-file-utils
+, appstream-glib
+, wrapGAppsHook4
+, meson
+, ninja
+, libadwaita
+, gtk4
+, tuxedo-rs
+}:
+let
+  src = tuxedo-rs.src;
+  sourceRoot = "source/tailor_gui";
+  pname = "tailor_gui";
+  version = tuxedo-rs.version;
+in
+stdenv.mkDerivation {
+
+  inherit src sourceRoot pname version;
+
+  cargoDeps = rustPlatform.fetchCargoTarball {
+    inherit src sourceRoot;
+    name = "${pname}-${version}";
+    hash = "sha256-DUaSLv1V6skWXQ7aqD62uspq+I9KiWmjlwwxykVve5A=";
+  };
+
+  nativeBuildInputs = [
+    rustPlatform.cargoSetupHook
+    pkg-config
+    desktop-file-utils
+    appstream-glib
+    wrapGAppsHook4
+  ];
+
+  buildInputs = [
+    cargo
+    rustc
+    meson
+    ninja
+    libadwaita
+    gtk4
+  ];
+
+  meta = with lib; {
+    description = "Rust GUI for interacting with hardware from TUXEDO Computers";
+    longDescription = ''
+      An alternative to the TUXEDO Control Center (https://www.tuxedocomputers.com/en/TUXEDO-Control-Center.tuxedo),
+      written in Rust.
+    '';
+    homepage = "https://github.com/AaronErhardt/tuxedo-rs";
+    license = licenses.gpl2Plus;
+    maintainers = with maintainers; [ mrcjkb ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/os-specific/linux/tuxedo-rs/default.nix
+++ b/pkgs/os-specific/linux/tuxedo-rs/default.nix
@@ -1,0 +1,47 @@
+{ lib
+, fetchFromGitHub
+, rustPlatform
+}:
+let
+
+  # NOTE: This src is shared with tailor-gui.
+  # When updating, the tailor-gui.cargoDeps hash needs to be updated.
+  src = fetchFromGitHub {
+    owner = "AaronErhardt";
+    repo = "tuxedo-rs";
+    rev = "a77a9f6c64e6dd1ede3511934392cbc16271ef6b";
+    hash = "sha256-bk17vI1gLHayvCWfmZdCMqgmbJFOTDaaCaHcj9cLpMY=";
+  };
+
+in
+rustPlatform.buildRustPackage {
+  pname = "tuxedo-rs";
+  version = "0.2.2";
+
+  inherit src;
+
+  # Some of the tests are impure and rely on files in /etc/tailord
+  doCheck = false;
+
+  cargoHash = "sha256-vuXqab9W8NSD5U9dk15xM4fM/vd/fGgGdsvReMncWHg=";
+
+  postInstall = ''
+    install -Dm444 tailord/com.tux.Tailor.conf -t $out/share/dbus-1/system.d
+  '';
+
+  meta = with lib; {
+    description = "Rust utilities for interacting with hardware from TUXEDO Computers";
+    longDescription = ''
+      An alternative to the TUXEDO Control Center daemon.
+
+      Contains the following binaries:
+      - tailord: Daemon handling fan, keyboard and general HW support for Tuxedo laptops
+      - tailor: CLI
+    '';
+    homepage = "https://github.com/AaronErhardt/tuxedo-rs";
+    license = licenses.gpl2Plus;
+    maintainers = with maintainers; [ mrcjkb ];
+    platforms = platforms.linux;
+  };
+}
+

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -35862,6 +35862,8 @@ with pkgs;
 
   tailor = callPackage ../applications/version-management/tailor { };
 
+  tailor-gui = callPackage ../os-specific/linux/tailor-gui { };
+
   taizen = callPackage ../applications/misc/taizen { };
 
   talosctl = callPackage ../applications/networking/cluster/talosctl { };
@@ -36191,6 +36193,8 @@ with pkgs;
   };
 
   tut = callPackage ../applications/misc/tut { };
+
+  tuxedo-rs = callPackage ../os-specific/linux/tuxedo-rs { };
 
   tuxguitar = callPackage ../applications/editors/music/tuxguitar {
     jre = jre8;


### PR DESCRIPTION
###### Description of changes

This adds [tuxedo-rs](https://github.com/AaronErhardt/tuxedo-rs), which consists of:

* A dbus daemon as well as a simple CLI for interacting with the hardware of TUXEDO computers
* A GUI (tailor_gui), which can be used to manage power/keyboard-led/fan profiles.

tuxedo-rs is an alternative to the [TUXEDO Control Center (TCC)](https://www.tuxedocomputers.com/en/TUXEDO-Control-Center.tuxedo), for which there exists a packaging request: #132206.

Note that if the packaging request for TCC is fulfilled, the daemons will conflict with each other, so the respective modules should ensure that the other one is disabled.

I had previously contributed [a flake](https://github.com/AaronErhardt/tuxedo-rs/blob/main/flake.nix) to tuxedo-rs, on which I have based this PR - with a small change to the module (`options.services` -> `options.hardware`).
If this is merged, I plan to rewrite the module in the flake to use this one and override the package `src`.
I have been using the tuxedo-rs module on my device for a few weeks now.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [x] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
