### PR TITLE
tilix: fix build issue with ldc 1.31+

### DIFF
--- a/pkgs/applications/terminal-emulators/tilix/default.nix
+++ b/pkgs/applications/terminal-emulators/tilix/default.nix
@@ -16,6 +16,7 @@
 , libunwind
 , appstream
 , nixosTests
+, fetchpatch
 }:
 
 stdenv.mkDerivation rec {
@@ -53,6 +54,15 @@ stdenv.mkDerivation rec {
     gtkd
     libsecret
     libunwind
+  ];
+
+  patches = [
+    # https://github.com/gnunn1/tilix/issues/2151
+    (fetchpatch {
+      name = "tilix-replace-std-xml-with-gmarkup.patch";
+      url = "https://github.com/gnunn1/tilix/commit/b02779737997a02b98b690e6f8478d28d5e931a5.patch";
+      hash = "sha256-6p+DomJEZ/hCW8RTjttKsTDsgHZ6eFKj/71TU5O/Ysg=";
+    })
   ];
 
   postPatch = ''


### PR DESCRIPTION
###### Description of changes

Merging #218905 caused tilix to stop building, due to the `std.xml` module being removed from the D standard library.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
