### PR TITLE
linux: patch to fix MAP_32BIT crashes, e.g. Haskell

### DIFF
--- a/pkgs/os-specific/linux/kernel/patches.nix
+++ b/pkgs/os-specific/linux/kernel/patches.nix
@@ -58,6 +58,15 @@
     patch = ./export-rt-sched-migrate.patch;
   };
 
+  make-maple-state-reusable-after-mas_empty_area = rec {
+    name = "make-maple-state-reusable-after-mas_empty_area";
+    patch = fetchpatch {
+      name = name + ".patch";
+      url = "https://git.kernel.org/pub/scm/linux/kernel/git/akpm/mm.git/patch/?id=39bf07d812b888b23983a9443ad967ca9b61551d";
+      hash = "sha256-JHEFq+Gw8Dtl0M8pXcKXpwkaHhbbl5NwTSzvV5qP4hk=";
+    };
+  };
+
   fix-em-ice-bonding = {
     name = "fix-em-ice-bonding";
     patch = ./fix-em-ice-bonding.patch;

--- a/pkgs/top-level/linux-kernels.nix
+++ b/pkgs/top-level/linux-kernels.nix
@@ -174,6 +174,7 @@ in {
       kernelPatches = [
         kernelPatches.bridge_stp_helper
         kernelPatches.request_key_helper
+        kernelPatches.make-maple-state-reusable-after-mas_empty_area
         kernelPatches.fix-em-ice-bonding
         kernelPatches.CVE-2023-32233
       ];
@@ -183,6 +184,7 @@ in {
       kernelPatches = [
         kernelPatches.bridge_stp_helper
         kernelPatches.request_key_helper
+        kernelPatches.make-maple-state-reusable-after-mas_empty_area
         kernelPatches.fix-em-ice-bonding
         kernelPatches.export-rt-sched-migrate
         kernelPatches.CVE-2023-32233
@@ -193,6 +195,7 @@ in {
       kernelPatches = [
         kernelPatches.bridge_stp_helper
         kernelPatches.request_key_helper
+        kernelPatches.make-maple-state-reusable-after-mas_empty_area
         kernelPatches.fix-em-ice-bonding
         kernelPatches.CVE-2023-32233
       ];
@@ -202,6 +205,7 @@ in {
       kernelPatches = [
         kernelPatches.bridge_stp_helper
         kernelPatches.request_key_helper
+        kernelPatches.make-maple-state-reusable-after-mas_empty_area
         kernelPatches.fix-em-ice-bonding
         kernelPatches.CVE-2023-32233
       ];
@@ -212,6 +216,7 @@ in {
         kernelPatches = [
           kernelPatches.bridge_stp_helper
           kernelPatches.request_key_helper
+          kernelPatches.make-maple-state-reusable-after-mas_empty_area
         ];
       };
       latest = packageAliases.linux_latest.kernel;


### PR DESCRIPTION
###### Description of changes

Revert a supposed fix the causes a second regression of memory allocation in
the "32 bit" zone.
Such allocations are performed by the GHC RTS linker and some other software.
This regression has particularly affected hercules-ci-agent and nix-serve-ng.
See https://github.com/hercules-ci/hercules-ci-agent/issues/514

I've asked the mailing list whether this is reasonably safe to revert, but the test results speak for themselves as far as the mentioned problem goes.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux (though rebuilding due to superficial change)
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - This regression does not have a suitable test and I consider this kind of problem infeasible to test for, or too high cost to benefit. I have tested the patch using the hercules-ci-agent flake's `checks.x86_64-linux.agent-functional-test` attribute after extending it to include the patch; see https://github.com/hercules-ci/hercules-ci-agent/issues/514
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
