### PR TITLE
ocamlPackages: default to version 3 of Dune

### DIFF
--- a/pkgs/build-support/ocaml/dune.nix
+++ b/pkgs/build-support/ocaml/dune.nix
@@ -3,7 +3,7 @@
 { pname, version, nativeBuildInputs ? [], enableParallelBuilding ? true, ... }@args:
 
 let Dune =
-  let dune-version = args.duneVersion or "2"; in
+  let dune-version = args.duneVersion or "3"; in
   { "1" = dune_1; "2" = dune_2; "3" = dune_3; }."${dune-version}"
 ; in
 

--- a/pkgs/development/ocaml-modules/dune-build-info/default.nix
+++ b/pkgs/development/ocaml-modules/dune-build-info/default.nix
@@ -1,17 +1,15 @@
-{ lib, buildDunePackage, dune_2, dune-action-plugin }:
+{ lib, buildDunePackage, dune-action-plugin }:
 
 buildDunePackage rec {
   pname = "dune-build-info";
-  inherit (dune_2) src version patches;
-
-  useDune2 = true;
+  inherit (dune-action-plugin) src version preBuild;
 
   dontAddPrefix = true;
 
   buildInputs = [ dune-action-plugin ];
 
   meta = with lib; {
-    inherit (dune_2.meta) homepage;
+    inherit (dune-action-plugin.meta) homepage;
     description = "Embed build information inside executables";
     maintainers = [ maintainers.bcdarwin ];
     license = licenses.mit;

--- a/pkgs/development/ocaml-modules/dune-configurator/default.nix
+++ b/pkgs/development/ocaml-modules/dune-configurator/default.nix
@@ -1,17 +1,20 @@
-{ lib, buildDunePackage, dune_2, csexp, result }:
+{ lib, buildDunePackage, dune_3, csexp }:
 
 buildDunePackage rec {
   pname = "dune-configurator";
 
-  inherit (dune_2) src version patches;
+  inherit (dune_3) src version patches;
 
-  duneVersion = "2";
+  # This fixes finding csexp
+  postPatch = ''
+    rm -rf vendor/pp vendor/csexp
+  '';
 
-  minimalOCamlVersion = "4.03";
+  minimalOCamlVersion = "4.05";
 
   dontAddPrefix = true;
 
-  propagatedBuildInputs = [ csexp result ];
+  propagatedBuildInputs = [ csexp ];
 
   meta = with lib; {
     description = "Helper library for gathering system configuration";

--- a/pkgs/development/ocaml-modules/lame/default.nix
+++ b/pkgs/development/ocaml-modules/lame/default.nix
@@ -4,7 +4,7 @@ buildDunePackage rec {
   pname = "lame";
   version = "0.3.6";
 
-  minimalOCamlVersion = "4.03";
+  minimalOCamlVersion = "4.06";
 
   src = fetchFromGitHub {
     owner = "savonet";

--- a/pkgs/development/ocaml-modules/lo/default.nix
+++ b/pkgs/development/ocaml-modules/lo/default.nix
@@ -4,6 +4,8 @@ buildDunePackage rec {
   pname = "lo";
   version = "0.2.0";
 
+  minimalOCamlVersion = "4.06";
+
   src = fetchFromGitHub {
     owner = "savonet";
     repo = "ocaml-lo";

--- a/pkgs/development/ocaml-modules/ocaml-gettext/stub.nix
+++ b/pkgs/development/ocaml-modules/ocaml-gettext/stub.nix
@@ -6,6 +6,8 @@ buildDunePackage rec {
 
   inherit (ocaml_gettext) src version;
 
+  minimalOCamlVersion = "4.06";
+
   buildInputs = [ dune-configurator ];
 
   propagatedBuildInputs = [ ocaml_gettext ];

--- a/pkgs/development/ocaml-modules/ounit2/default.nix
+++ b/pkgs/development/ocaml-modules/ounit2/default.nix
@@ -1,12 +1,10 @@
 { lib, ocaml, buildDunePackage, fetchurl, seq, stdlib-shims, ncurses }:
 
-buildDunePackage rec {
+buildDunePackage (rec {
   minimalOCamlVersion = "4.04";
 
   pname = "ounit2";
   version = "2.2.6";
-
-  duneVersion = if lib.versionAtLeast ocaml.version "4.08" then "2" else "1";
 
   src = fetchurl {
     url = "https://github.com/gildor478/ounit/releases/download/v${version}/ounit-${version}.tbz";
@@ -24,4 +22,6 @@ buildDunePackage rec {
     license = licenses.mit;
     maintainers = with maintainers; [ sternenseemann ];
   };
-}
+} // lib.optionalAttrs (!lib.versionAtLeast ocaml.version "4.08") {
+  duneVersion = "1";
+})

--- a/pkgs/development/ocaml-modules/ringo/default.nix
+++ b/pkgs/development/ocaml-modules/ringo/default.nix
@@ -10,7 +10,7 @@ buildDunePackage rec {
     sha256 = "sha256-9HW3M27BxrEPbF8cMHwzP8FmJduUInpQQAE2672LOuU=";
   };
 
-  minimalOCamlVersion = "4.05";
+  minimalOCamlVersion = "4.08";
 
   doCheck = true;
 

--- a/pkgs/development/ocaml-modules/shine/default.nix
+++ b/pkgs/development/ocaml-modules/shine/default.nix
@@ -4,8 +4,6 @@ buildDunePackage rec {
   pname = "shine";
   version = "0.2.3";
 
-  duneVersion = "2";
-
   src = fetchFromGitHub {
     owner = "savonet";
     repo = "ocaml-shine";

--- a/pkgs/development/tools/ocaml/js_of_ocaml/ocamlbuild.nix
+++ b/pkgs/development/tools/ocaml/js_of_ocaml/ocamlbuild.nix
@@ -6,7 +6,7 @@ buildDunePackage rec {
   pname = "js_of_ocaml-ocamlbuild";
   version = "5.0";
 
-  minimalOCamlVersion = "4.02";
+  minimalOCamlVersion = "4.03";
 
   src = fetchurl {
     url = "https://github.com/ocsigen/js_of_ocaml-ocamlbuild/releases/download/${version}/js_of_ocaml-ocamlbuild-${version}.tbz";


### PR DESCRIPTION
###### Description of changes

Updates `dune-configurator` as in #223745 and makes `dune_3` the default as in #223751.
cc @ulrikstrid.

The fix to `ringo` is unrelated.

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
