### PR TITLE
Update configuration-darwin.nix with streamly_0_8_3

### DIFF
--- a/pkgs/development/haskell-modules/configuration-darwin.nix
+++ b/pkgs/development/haskell-modules/configuration-darwin.nix
@@ -35,6 +35,8 @@ self: super: ({
   double-conversion = addExtraLibrary pkgs.libcxx super.double-conversion;
 
   streamly = addBuildDepend darwin.apple_sdk.frameworks.Cocoa super.streamly;
+  
+  streamly_0_8_3 = addBuildDepend darwin.apple_sdk.frameworks.Cocoa super.streamly_0_8_3;
 
   apecs-physics = addPkgconfigDepends [
     darwin.apple_sdk.frameworks.ApplicationServices


### PR DESCRIPTION
###### Description of changes
Extends configuration-darwin.nix to add `streamly_0_8_3` as having a `Cocoa` framework dependency, just like the normal `streamly` package.

`streamly_0_8_3` package fails to build on `aarch64-darwin` at the moment with the truncated error output as follows
```
> error: ld: framework not found Cocoa
> clang-11: error: linker command failed with exit code 1 (use -v to see invocation)
```

but the normal `streamly` package builds fine. I suspected this was the reason and thus submitting a PR for it.

###### Things done

1. Adds Cocoa as a dependency for `streamly_0_8_3`


cc:- @maralorn 
