### PR TITLE
envoy: 1.25.1 -> 1.26.1

### DIFF
--- a/pkgs/servers/http/envoy/0001-nixpkgs-use-system-Python.patch
+++ b/pkgs/servers/http/envoy/0001-nixpkgs-use-system-Python.patch
@@ -1,6 +1,6 @@
-From 329ad7cb56e66464e5570bbb51dea0fd56c4d9ae Mon Sep 17 00:00:00 2001
+From 1b6ad143c0f5f96c42f603bb93a72f788b88b622 Mon Sep 17 00:00:00 2001
 From: Luke Granger-Brown <git@lukegb.com>
-Date: Sun, 19 Feb 2023 17:40:50 +0000
+Date: Fri, 12 May 2023 08:12:04 +0100
 Subject: [PATCH 1/2] nixpkgs: use system Python
 
 ---
@@ -9,11 +9,11 @@ Subject: [PATCH 1/2] nixpkgs: use system Python
  2 files changed, 1 insertion(+), 16 deletions(-)
 
 diff --git a/bazel/python_dependencies.bzl b/bazel/python_dependencies.bzl
-index a5c3283d0a..1c2c31ebf2 100644
+index 37c0183664..0bee5feb7e 100644
 --- a/bazel/python_dependencies.bzl
 +++ b/bazel/python_dependencies.bzl
-@@ -1,10 +1,8 @@
- load("@rules_python//python:pip.bzl", "pip_install", "pip_parse")
+@@ -1,24 +1,20 @@
+ load("@rules_python//python:pip.bzl", "pip_parse")
 -load("@python3_10//:defs.bzl", "interpreter")
  
  def envoy_python_dependencies():
@@ -23,13 +23,12 @@ index a5c3283d0a..1c2c31ebf2 100644
          requirements_lock = "@envoy//tools/base:requirements.txt",
          extra_pip_args = ["--require-hashes"],
      )
-@@ -12,14 +10,12 @@ def envoy_python_dependencies():
-     # TODO(phlax): switch to `pip_parse`
-     pip_install(
-         # Note: dev requirements do *not* check hashes
--        python_interpreter_target = interpreter,
+ 
+     pip_parse(
          name = "dev_pip3",
-         requirements = "@envoy//tools/dev:requirements.txt",
+-        python_interpreter_target = interpreter,
+         requirements_lock = "@envoy//tools/dev:requirements.txt",
+         extra_pip_args = ["--require-hashes"],
      )
  
      pip_parse(
@@ -68,5 +67,5 @@ index 9d1b31c5d6..ac5605eb30 100644
 -
      aspect_bazel_lib_dependencies()
 -- 
-2.39.1
+2.40.0
 

--- a/pkgs/servers/http/envoy/0002-nixpkgs-use-system-Go.patch
+++ b/pkgs/servers/http/envoy/0002-nixpkgs-use-system-Go.patch
@@ -1,19 +1,18 @@
-From 31d864a3b6a1a3455191e87ff680eb812f77dc3c Mon Sep 17 00:00:00 2001
+From 30e059d652bd4e352e2c1dc3c44d03a1e42ff912 Mon Sep 17 00:00:00 2001
 From: Luke Granger-Brown <git@lukegb.com>
-Date: Sun, 19 Feb 2023 17:43:03 +0000
+Date: Fri, 12 May 2023 08:13:21 +0100
 Subject: [PATCH 2/2] nixpkgs: use system Go
 
 ---
- bazel/dependency_imports.bzl   | 29 +----------------------------
- bazel/repositories.bzl         |  3 ---
- bazel/repository_locations.bzl |  4 ++--
- 3 files changed, 3 insertions(+), 33 deletions(-)
+ bazel/dependency_imports.bzl | 29 +----------------------------
+ bazel/repositories.bzl       |  3 ---
+ 2 files changed, 1 insertion(+), 31 deletions(-)
 
 diff --git a/bazel/dependency_imports.bzl b/bazel/dependency_imports.bzl
-index 7dbdb0174e..e73662ed79 100644
+index 681617f1b8..a10c560baf 100644
 --- a/bazel/dependency_imports.bzl
 +++ b/bazel/dependency_imports.bzl
-@@ -15,7 +15,7 @@ load("@aspect_bazel_lib//lib:repositories.bzl", "register_jq_toolchains", "regis
+@@ -17,7 +17,7 @@ load("@aspect_bazel_lib//lib:repositories.bzl", "register_jq_toolchains", "regis
  load("@com_google_cel_cpp//bazel:deps.bzl", "parser_deps")
  
  # go version for rules_go
@@ -22,7 +21,7 @@ index 7dbdb0174e..e73662ed79 100644
  
  JQ_VERSION = "1.6"
  YQ_VERSION = "4.24.4"
-@@ -25,7 +25,6 @@ def envoy_dependency_imports(go_version = GO_VERSION, jq_version = JQ_VERSION, y
+@@ -27,7 +27,6 @@ def envoy_dependency_imports(go_version = GO_VERSION, jq_version = JQ_VERSION, y
      rules_foreign_cc_dependencies(register_default_tools = False, register_built_tools = False)
      go_rules_dependencies()
      go_register_toolchains(go_version)
@@ -30,7 +29,7 @@ index 7dbdb0174e..e73662ed79 100644
      gazelle_dependencies(go_sdk = "go_sdk")
      apple_rules_dependencies()
      pip_dependencies()
-@@ -134,29 +133,3 @@ def envoy_dependency_imports(go_version = GO_VERSION, jq_version = JQ_VERSION, y
+@@ -146,29 +145,3 @@ def envoy_dependency_imports(go_version = GO_VERSION, jq_version = JQ_VERSION, y
          # use_category = ["api"],
          # source = "https://github.com/bufbuild/protoc-gen-validate/blob/v0.6.1/dependencies.bzl#L23-L28"
      )
@@ -61,10 +60,10 @@ index 7dbdb0174e..e73662ed79 100644
 -        version = go_version,
 -    )
 diff --git a/bazel/repositories.bzl b/bazel/repositories.bzl
-index fca05b6062..a2f60014cb 100644
+index 6d2cf2014c..a8375bcdef 100644
 --- a/bazel/repositories.bzl
 +++ b/bazel/repositories.bzl
-@@ -115,9 +115,6 @@ def _go_deps(skip_targets):
+@@ -196,9 +196,6 @@ def _go_deps(skip_targets):
      if "io_bazel_rules_go" not in skip_targets:
          external_http_archive(
              name = "io_bazel_rules_go",
@@ -74,21 +73,6 @@ index fca05b6062..a2f60014cb 100644
          )
          external_http_archive("bazel_gazelle")
  
-diff --git a/bazel/repository_locations.bzl b/bazel/repository_locations.bzl
-index e4e89d281a..fb62c4f8f3 100644
---- a/bazel/repository_locations.bzl
-+++ b/bazel/repository_locations.bzl
-@@ -878,8 +878,8 @@ REPOSITORY_LOCATIONS_SPEC = dict(
-         project_name = "Go rules for Bazel",
-         project_desc = "Bazel rules for the Go language",
-         project_url = "https://github.com/bazelbuild/rules_go",
--        version = "0.36.0",
--        sha256 = "ae013bf35bd23234d1dea46b079f1e05ba74ac0321423830119d3e787ec73483",
-+        version = "0.38.1",
-+        sha256 = "dd926a88a564a9246713a9c00b35315f54cbd46b31a26d5d8fb264c07045f05d",
-         urls = ["https://github.com/bazelbuild/rules_go/releases/download/v{version}/rules_go-v{version}.zip"],
-         use_category = ["build", "api"],
-         release_date = "2022-11-23",
 -- 
-2.39.1
+2.40.0
 

--- a/pkgs/servers/http/envoy/default.nix
+++ b/pkgs/servers/http/envoy/default.nix
@@ -1,5 +1,5 @@
 { lib
-, bazel_5
+, bazel_6
 , bazel-gazelle
 , buildBazelPackage
 , fetchFromGitHub
@@ -24,19 +24,19 @@ let
     # However, the version string is more useful for end-users.
     # These are contained in a attrset of their own to make it obvious that
     # people should update both.
-    version = "1.25.1";
-    rev = "bae2e9d642a6a8ae6c5d3810f77f3e888f0d97da";
+    version = "1.26.1";
+    rev = "c7e8e7356d3a969c1b8e4e1f2687699acd91c6a1";
   };
 in
 buildBazelPackage rec {
   pname = "envoy";
   inherit (srcVer) version;
-  bazel = bazel_5;
+  bazel = bazel_6;
   src = fetchFromGitHub {
     owner = "envoyproxy";
     repo = "envoy";
     inherit (srcVer) rev;
-    sha256 = "sha256-qA3+bta2vXGtAYX3mg+CmSIEitk4576JQB/QLPsj9Vc=";
+    sha256 = "sha256-WHedup6z/9t/Jg6CBrwtDy9xv6IwO3gUuBqos4h+k2s=";
 
     postFetch = ''
       chmod -R +w $out
@@ -80,8 +80,8 @@ buildBazelPackage rec {
 
   fetchAttrs = {
     sha256 = {
-      x86_64-linux = "sha256-koz08NWUq5Fkca++1G7WEmg24G6FuMQOgRN3+HBtNIk=";
-      aarch64-linux = "sha256-oSybAw58yK0BUhS8MU2Y9hRo0mU/7xT7VKU3tDW4xN0=";
+      x86_64-linux = "sha256-jx8RavJKlBtZQtZf4GrUkOlhM6qI4LO5lK3HRgn1vzE=";
+      aarch64-linux = "sha256-toEPrGVh61sHsVbhsideMmnX8uXIN+2x8LuZpczTEdw=";
     }.${stdenv.system} or (throw "unsupported system ${stdenv.system}");
     dontUseCmakeConfigure = true;
     dontUseGnConfigure = true;
@@ -176,13 +176,5 @@ buildBazelPackage rec {
     license = licenses.asl20;
     maintainers = with maintainers; [ lukegb ];
     platforms = [ "x86_64-linux" "aarch64-linux" ];
-    knownVulnerabilities = [
-      "CVE-2023-27487"
-      "CVE-2023-27488"
-      "CVE-2023-27491"
-      "CVE-2023-27492"
-      "CVE-2023-27493"
-      "CVE-2023-27496"
-    ];
   };
 }


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

https://github.com/envoyproxy/envoy/compare/v1.25.1...v1.26.1

* v1.25.2 (https://www.envoyproxy.io/docs/envoy/v1.26.1/version_history/v1.25/v1.25.2)
  * dependency: update Kafka to resolve CVE-2023-25194.
  * docker: unify published images as tag variants. For example, envoyproxy/envoy-dev is now available as envoyproxy/envoy:dev
  * ext_authz: deprecated (1.25.0) [ext_authz.v3.AuthorizationRequest.allowed_headers](https://www.envoyproxy.io/docs/envoy/v1.25.6/api-v3/extensions/filters/http/ext_authz/v3/ext_authz.proto#envoy-v3-api-field-extensions-filters-http-ext-authz-v3-authorizationrequest-allowed-headers) in favour of [ext_authz.v3.ExtAuthz.allowed_headers](https://www.envoyproxy.io/docs/envoy/v1.25.6/api-v3/extensions/filters/http/ext_authz/v3/ext_authz.proto#envoy-v3-api-field-extensions-filters-http-ext-authz-v3-extauthz-allowed-headers).
* v1.25.3 (https://www.envoyproxy.io/docs/envoy/v1.26.1/version_history/v1.25/v1.25.3)
  * dependency: update Wasmtime -> 6.0.1, to resolve CVE-2023-26489, CVE-2023-27477.
* v1.25.4 (https://www.envoyproxy.io/docs/envoy/v1.26.1/version_history/v1.25/v1.25.4)
  * http: Validate upstream request header names and values. The new runtime flag envoy.reloadable_features.validate_upstream_headers can be used for revert this behavior.
  * grpc: when Envoy was configured to use ext_authz, ext_proc, tap, ratelimit filters, and grpc access log service and an http header with non-UTF-8 data was received, Envoy would generate an invalid protobuf message and send it to the configured service. The receiving service would typically generate an error when decoding the protobuf message. For ext_authz that was configured with failure_mode_allow: true, the request would have been allowed in this case. For the other services, this could have resulted in other unforseen errors such as a lack of visibility into requests (eg request not logged). Envoy will now by default sanitize the values sent in gRPC service calls to be valid UTF-8, replacing data that is not valid UTF-8 with a ‘!’ character. This behavioral change can be temporarily reverted by setting runtime guard envoy.reloadable_features.service_sanitize_non_utf8_strings to false.
  * http: fixed a bug where x-envoy-original-path was not being sanitized when sent from untrusted users. This behavioral change can be temporarily reverted by setting envoy.reloadable_features.sanitize_original_path to false.
  * http: stop forwarding :method value which is not a valid token defined in https://www.rfc-editor.org/rfc/rfc9110#section-5.6.2. Also, reject :method and :scheme headers with multiple values.
  * http3: reject pseudo headers violating RFC 9114. Specifically, pseudo-header fields with more than one value for the :method (non-CONNECT), :scheme, and :path; or pseudo-header fields after regular header fields; or undefined pseudo-headers.
  * lua: lua coroutine should not execute after local reply is sent.
  * oauth2: fixed a bug where the oauth2 filter would crash if it received a redirect URL without a state query param set. 
* v1.25.5 (https://www.envoyproxy.io/docs/envoy/v1.26.1/version_history/v1.25/v1.25.5)
  * dependency: update Curl -> 8.0.1 to resolve CVE-2023-27535, CVE-2023-27536, CVE-2023-27538. 
  * http: amend the fix for x-envoy-original-path so it removes the header only at edge. Previously this would also remove the header at any Envoy instance upstream of an external request, including an Envoy instance that added the header.
* v1.25.6 (https://www.envoyproxy.io/docs/envoy/v1.26.1/version_history/v1.25/v1.25.6)
  * tls: Fix build FIPS compliance when using both FIPS mode and Wasm extensions (--define boringssl=fips and --define wasm=v8).
* v1.26.0 (https://www.envoyproxy.io/docs/envoy/v1.26.1/version_history/v1.26/v1.26.0)
  * many
* v1.26.1 (https://www.envoyproxy.io/docs/envoy/v1.26.1/version_history/v1.26/v1.26.1)
  * tls: Fix build FIPS compliance when using both FIPS mode and Wasm extensions (--define boringssl=fips and --define wasm=v8).
 
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
