### PR TITLE
bazel_6: fix darwin build

### DIFF
--- a/pkgs/development/tools/build-managers/bazel/bazel_6/default.nix
+++ b/pkgs/development/tools/build-managers/bazel/bazel_6/default.nix
@@ -394,6 +394,7 @@ stdenv.mkDerivation rec {
       for wrapper in "''${wrappers[@]}"; do
         sed -i -e "s,/usr/bin/gcc,${stdenv.cc}/bin/clang,g" $wrapper
         sed -i -e "s,/usr/bin/install_name_tool,${cctools}/bin/install_name_tool,g" $wrapper
+        sed -i -e "s,/usr/bin/xcrun install_name_tool,${cctools}/bin/install_name_tool,g" $wrapper
       done
     '';
 


### PR DESCRIPTION
###### Description of changes

Since bazel 6.1.0 there was a change in `install_name_tool` invocation on darwin: `/usr/bin/install_name_tool` -> `/usr/bin/xcrun install_name_tool` https://github.com/bazelbuild/bazel/pull/17253

So interception of `install_name_tool` broke and build in nixpkgs became less hermetic. It was either picking up host `xcode` or failing if xcode isn't installed.

Let's update patching script in nixpkgs.

For errors like https://hydra.nixos.org/build/219158800/nixlog/3
```
ERROR: /private/tmp/nix-build-bazel-6.1.2.drv-0/bazel_src/examples/cpp/BUILD:13:8: Linking examples/cpp/hello-success_test failed: (Exit 1): cc_wrapper.sh failed: error executing command (from target //examples/cpp:hello-success_test)
  (cd /private/tmp/nix-build-bazel-6.1.2.drv-0/_bazel__nixbld12/bee562cde99c3bcadaa4e82f18c698fe/sandbox/processwrapper-sandbox/44/execroot/io_bazel && \
  exec env - \
    PATH=/nix/store/v6f6y9mwmqj9v1jffiy4g96ili4pj5la-python3-3.10.11/bin:/nix/store/mda7jac839k0z33n80pglkhfk3s8panz-unzip-6.0/bin:/nix/store/r9ynkgvbn9lp0x3dvrhr0dskss8wwhc2-which-2.21/bin:/nix/store/1jfsv6gcw2lzzavr3jhydzlmpy3iw9b7-zip-3.0/bin:/nix/store/w66qbvdwgpgbn3ikwyxkhpx1zwaw5rln-cctools-port-973.0.1/bin:/nix/store/99xl1hg0pvscfn7aszp0df034jnprn0j-clang-wrapper-11.1.0/bin:/nix/store/ngbj0z5mr5z7dhi0q11csq1k7rxvfcf7-clang-11.1.0/bin:/nix/store/lhbkcjmrv547plyiybfxqddlpn2l13yl-coreutils-9.1/bin:/nix/store/72fxghdpx8732zizx6jg5d74kblpz7ic-cctools-binutils-darwin-wrapper-973.0.1/bin:/nix/store/qm48dbbhmqk70hm35s9hzbmgvwd6slvs-cctools-binutils-darwin-973.0.1/bin:/nix/store/dv87q4384pyhg8f0hkw3l4lgkiqxwk94-zulu11.48.21-ca-jdk-11.0.11/bin:/nix/store/1alnbw2p2s4wfk3j52mxrbwvcrwh8c1b-bash-5.2-p15/bin:/nix/store/shzh26kvfirgl441lkv7vcw9lgylrgy7-file-5.44/bin:/nix/store/4dzdpald6db495rflbwfldvzn0vaqp7k-findutils-4.9.0/bin:/nix/store/2k3k7wg1azk8mr3393aj8xxj5pv3098r-gawk-5.2.1/bin:/nix/store/3whcyzf1r7cvjx30mfdy6h3krnvfd176-gnugrep-3.7/bin:/nix/store/8j0jryir74m945154zxw3zs17ig51v89-gnused-4.9/bin:/nix/store/0zy67qd1vd6643p0p6hw93kikz11lbml-gnutar-1.34/bin:/nix/store/79617rkc430q3rm6v4c5fs2raixq43qi-gzip-1.12/bin:/nix/store/lhbkcjmrv547plyiybfxqddlpn2l13yl-coreutils-9.1/bin:/nix/store/4dzdpald6db495rflbwfldvzn0vaqp7k-findutils-4.9.0/bin:/nix/store/6fx4a1125c3xfs7alrr0jlyh5cwkshz8-diffutils-3.9/bin:/nix/store/8j0jryir74m945154zxw3zs17ig51v89-gnused-4.9/bin:/nix/store/3whcyzf1r7cvjx30mfdy6h3krnvfd176-gnugrep-3.7/bin:/nix/store/2k3k7wg1azk8mr3393aj8xxj5pv3098r-gawk-5.2.1/bin:/nix/store/ym7jyaml2zj2x6y6mriyh6ch8z5abqr1-gnutar-1.34/bin:/nix/store/79617rkc430q3rm6v4c5fs2raixq43qi-gzip-1.12/bin:/nix/store/m8yqab399pakajchm99nq42qdcxiw1n0-bzip2-1.0.8-bin/bin:/nix/store/iiasa4fvs0d5ijj0qbj9nl7p31bznxah-gnumake-4.4.1/bin:/nix/store/1alnbw2p2s4wfk3j52mxrbwvcrwh8c1b-bash-5.2-p15/bin:/nix/store/w9x4wz6i8y7cy8hfvp5is86fyh2bh6cp-patch-2.7.6/bin:/nix/store/kx2n8m3j2pfq0v9jydav1qpdy1fd22im-xz-5.4.2-bin/bin:/nix/store/41qmp6qwwz3vvf94pccqnvcx1zdp5z9i-file-5.44/bin \
    PWD=/proc/self/cwd \
  external/local_config_cc/cc_wrapper.sh @bazel-out/darwin-fastbuild/bin/examples/cpp/hello-success_test-2.params)

Use --sandbox_debug to see verbose messages from the sandbox and retain the sandbox build root for debugging
xcode-select: error: No developer tools were found and no install could be requested (perhaps no UI is present).
If developer tools are located at a non-default location on disk, use `sudo xcode-select --switch path/to/Xcode.app` to specify the Xcode that you wish to use for command line developer tools.
Use `xcode-select --install` to install the standalone command line developer tools, or visit http://adc.apple.com to download Xcode or the standalone command line tools installation package.
See `man xcode-select` for more details.
```

ZHF: #230712

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [X] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
