### PR TITLE
m/x32edit: fix source urls

### DIFF
--- a/pkgs/applications/audio/midas/generic.nix
+++ b/pkgs/applications/audio/midas/generic.nix
@@ -14,7 +14,7 @@ stdenv.mkDerivation rec {
 
   installPhase = ''
     mkdir -p $out/bin
-    cp ${pname} $out/bin
+    cp ${type}-Edit $out/bin/${pname}
   '';
   preFixup = let
     # we prepare our library path in the let clause to avoid it become part of the input of mkDerivation

--- a/pkgs/applications/audio/midas/m32edit.nix
+++ b/pkgs/applications/audio/midas/m32edit.nix
@@ -4,7 +4,7 @@ callPackage ./generic.nix (args // rec {
   brand = "Midas";
   type = "M32";
   version = "4.1";
-  url = "https://mediadl.musictribe.com/download/software/midas_${type}/${type}-Edit_LINUX_64-Bit_${version}.tar.gz";
+  url = "https://mediadl.musictribe.com/download/software/midas_${type}/${type}-Edit_LINUX_${version}.tar.gz";
   sha256 = "0aqhdrxqa49liyvbbw5x32kwk0h1spzvmizmdxklrfs64vvr9bvh";
   homepage = "https://midasconsoles.com/midas/product?modelCode=P0B3I";
 })

--- a/pkgs/applications/audio/midas/x32edit.nix
+++ b/pkgs/applications/audio/midas/x32edit.nix
@@ -4,7 +4,7 @@ callPackage ./generic.nix (args // rec {
   brand = "Behringer";
   type = "X32";
   version = "4.1";
-  url = "https://mediadl.musictribe.com/download/software/behringer/${type}/${type}-Edit_LINUX_64-Bit_${version}.tar.gz";
+  url = "https://mediadl.musictribe.com/download/software/behringer/${type}/${type}-Edit_LINUX_${version}.tar.gz";
   sha256 = "0zsw7qfmcci87skkpq8vx5zxk35phn8y4byispvki9ascifnnb33";
   homepage = "https://www.behringer.com/behringer/product?modelCode=P0ASF";
 })


### PR DESCRIPTION
###### Description of changes
Behringer changed the URL paths to its package sources of m/x32edit and changed the names of the provided binaries to include uppercase letters.

This pr fixes the urls and changes the binary names back to its lowercase equivalent.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
