### PR TITLE
proxysql: 2.5.1 -> 2.5.2

### DIFF
--- a/pkgs/servers/sql/proxysql/default.nix
+++ b/pkgs/servers/sql/proxysql/default.nix
@@ -33,13 +33,13 @@
 
 stdenv.mkDerivation rec {
   pname = "proxysql";
-  version = "2.5.1";
+  version = "2.5.2";
 
   src = fetchFromGitHub {
     owner = "sysown";
     repo = pname;
     rev = version;
-    hash = "sha256-Z85/oSV2TUKEoum09G6OHNw6K/Evt1wMCcleTcc96EY=";
+    hash = "sha256-KPTvFbEreWQBAs5ofcdVzlVqL0t5pM/mMLv4+E4lJ5M=";
   };
 
   patches = [

--- a/pkgs/servers/sql/proxysql/makefiles.patch
+++ b/pkgs/servers/sql/proxysql/makefiles.patch
@@ -1,5 +1,5 @@
 diff --git a/Makefile b/Makefile
-index e7dae058..09c28859 100644
+index df7ed196..3a3b393d 100644
 --- a/Makefile
 +++ b/Makefile
 @@ -57,11 +57,7 @@ endif
@@ -36,7 +36,7 @@ index e7dae058..09c28859 100644
  	install -m 0755 etc/init.d/proxysql /etc/init.d
  ifeq ($(DISTRO),"CentOS Linux")
 diff --git a/deps/Makefile b/deps/Makefile
-index 55a45ba9..8443d439 100644
+index 47c0f3c3..80d33d11 100644
 --- a/deps/Makefile
 +++ b/deps/Makefile
 @@ -66,10 +66,7 @@ endif
@@ -56,28 +56,28 @@ index 55a45ba9..8443d439 100644
  libssl/openssl/libssl.a:
 -	cd libssl && rm -rf openssl-openssl-*/ openssl-3*/ || true
 -	cd libssl && tar -zxf openssl-*.tar.gz
- 	cd libssl/openssl && patch crypto/ec/curve448/curve448.c < ../curve448.c-multiplication-overflow.patch
- 	cd libssl/openssl && patch crypto/asn1/a_time.c < ../a_time.c-multiplication-overflow.patch
+ #	cd libssl/openssl && patch crypto/ec/curve448/curve448.c < ../curve448.c-multiplication-overflow.patch
+ #	cd libssl/openssl && patch crypto/asn1/a_time.c < ../a_time.c-multiplication-overflow.patch
  	cd libssl/openssl && ./config no-ssl3 no-tests
-@@ -95,8 +90,6 @@ libssl: libssl/openssl/libssl.a
- 
+@@ -103,8 +98,6 @@ ifeq ($(MIN_VERSION),$(lastword $(SORTED_VERSIONS)))
+ endif
  
  libhttpserver/libhttpserver/build/src/.libs/libhttpserver.a: libmicrohttpd/libmicrohttpd/src/microhttpd/.libs/libmicrohttpd.a re2/re2/obj/libre2.a
 -	cd libhttpserver && rm -rf libhttpserver-*/ || true
 -	cd libhttpserver && tar -zxf libhttpserver-*.tar.gz
+ #ifeq ($(REQUIRE_PATCH), true)
  	cd libhttpserver/libhttpserver && patch -p1 < ../noexcept.patch
  	cd libhttpserver/libhttpserver && patch -p1 < ../re2_regex.patch
- 	cd libhttpserver/libhttpserver && patch -p1 < ../final_val_post_process.patch
-@@ -112,8 +105,6 @@ libhttpserver: libhttpserver/libhttpserver/build/src/.libs/libhttpserver.a
+@@ -122,8 +115,6 @@ libhttpserver: libhttpserver/libhttpserver/build/src/.libs/libhttpserver.a
  
  
  libev/libev/.libs/libev.a:
 -	cd libev && rm -rf libev-*/ || true
 -	cd libev && tar -zxf libev-*.tar.gz
- #	cd libev/libev && patch ev.c < ../ev.c-multiplication-overflow.patch
+ 	cd libev/libev && patch ev.c < ../ev.c-multiplication-overflow.patch
  	cd libev/libev && ./configure
  	cd libev/libev && CC=${CC} CXX=${CXX} ${MAKE}
-@@ -122,8 +113,6 @@ ev: libev/libev/.libs/libev.a
+@@ -132,8 +123,6 @@ ev: libev/libev/.libs/libev.a
  
  
  curl/curl/lib/.libs/libcurl.a: libssl/openssl/libssl.a
@@ -86,7 +86,7 @@ index 55a45ba9..8443d439 100644
  #	cd curl/curl && ./configure --disable-debug --disable-ftp --disable-ldap --disable-ldaps --disable-rtsp --disable-proxy --disable-dict --disable-telnet --disable-tftp --disable-pop3 --disable-imap --disable-smb --disable-smtp --disable-gopher --disable-manual --disable-ipv6 --disable-sspi --disable-crypto-auth --disable-ntlm-wb --disable-tls-srp --without-nghttp2 --without-libidn2 --without-libssh2 --without-brotli --with-ssl=$(shell pwd)/../../libssl/openssl/ && CC=${CC} CXX=${CXX} ${MAKE}
  #	cd curl/curl && patch configure < ../configure.patch
  	cd curl/curl && autoreconf -fi
-@@ -133,16 +122,6 @@ curl: curl/curl/lib/.libs/libcurl.a
+@@ -143,16 +132,6 @@ curl: curl/curl/lib/.libs/libcurl.a
  
  
  libmicrohttpd/libmicrohttpd/src/microhttpd/.libs/libmicrohttpd.a:
@@ -103,18 +103,16 @@ index 55a45ba9..8443d439 100644
  ifeq ($(UNAME_S),Darwin)
  	cd libmicrohttpd/libmicrohttpd && patch src/microhttpd/mhd_sockets.c < ../mhd_sockets.c-issue-5977.patch
  endif
-@@ -159,10 +138,7 @@ cityhash/cityhash/src/.libs/libcityhash.a:
+@@ -171,8 +150,6 @@ cityhash: cityhash/cityhash/src/.libs/libcityhash.a
  
- cityhash: cityhash/cityhash/src/.libs/libcityhash.a
  
--
  lz4/lz4/lib/liblz4.a:
 -	cd lz4 && rm -rf lz4-*/ || true
 -	cd lz4 && tar -zxf lz4-*.tar.gz
  	cd lz4/lz4 && CC=${CC} CXX=${CXX} ${MAKE}
  
  lz4: lz4/lz4/lib/liblz4.a
-@@ -187,8 +163,6 @@ clickhouse-cpp: clickhouse-cpp/clickhouse-cpp/clickhouse/libclickhouse-cpp-lib-s
+@@ -197,8 +174,6 @@ clickhouse-cpp: clickhouse-cpp/clickhouse-cpp/clickhouse/libclickhouse-cpp-lib-s
  
  
  libdaemon/libdaemon/libdaemon/.libs/libdaemon.a:
@@ -123,7 +121,7 @@ index 55a45ba9..8443d439 100644
  	cd libdaemon/libdaemon && cp ../config.guess . && chmod +x config.guess && cp ../config.sub . && chmod +x config.sub && ./configure --disable-examples
  	cd libdaemon/libdaemon && CC=${CC} CXX=${CXX} ${MAKE}
  
-@@ -265,8 +239,6 @@ sqlite3: sqlite3/sqlite3/sqlite3.o
+@@ -282,8 +257,6 @@ sqlite3: sqlite3/sqlite3/sqlite3.o
  
  
  libconfig/libconfig/lib/.libs/libconfig++.a:
@@ -132,7 +130,7 @@ index 55a45ba9..8443d439 100644
  	cd libconfig/libconfig && ./configure --disable-examples
  	cd libconfig/libconfig && CC=${CC} CXX=${CXX} ${MAKE}
  
-@@ -274,9 +246,6 @@ libconfig: libconfig/libconfig/lib/.libs/libconfig++.a
+@@ -291,9 +264,6 @@ libconfig: libconfig/libconfig/lib/.libs/libconfig++.a
  
  
  prometheus-cpp/prometheus-cpp/lib/libprometheus-cpp-core.a:
@@ -142,7 +140,7 @@ index 55a45ba9..8443d439 100644
  	cd prometheus-cpp/prometheus-cpp && patch -p1 < ../serial_exposer.patch
  	cd prometheus-cpp/prometheus-cpp && patch -p1 < ../registry_counters_reset.patch
  	cd prometheus-cpp/prometheus-cpp && patch -p1 < ../fix_old_distros.patch
-@@ -287,11 +256,6 @@ prometheus-cpp: prometheus-cpp/prometheus-cpp/lib/libprometheus-cpp-core.a
+@@ -304,10 +274,6 @@ prometheus-cpp: prometheus-cpp/prometheus-cpp/lib/libprometheus-cpp-core.a
  
  
  re2/re2/obj/libre2.a:
@@ -150,17 +148,15 @@ index 55a45ba9..8443d439 100644
 -	cd re2 && tar -zxf re2-*.tar.gz
 -#	cd re2/re2 && sed -i -e 's/-O3 -g /-O3 -fPIC /' Makefile
 -#	cd re2/re2 && patch util/mutex.h < ../mutex.h.patch
--#	cd re2/re2 && patch re2/onepass.cc < ../onepass.cc-multiplication-overflow.patch
+ 	cd re2/re2 && patch re2/onepass.cc < ../onepass.cc-multiplication-overflow.patch
  ifeq ($(UNAME_S),Darwin)
  	cd re2/re2 && sed -i '' -e 's/-O3 -g/-O3 -g -std=c++11 -fPIC -DMEMORY_SANITIZER -DRE2_ON_VALGRIND /' Makefile
- #	cd re2/re2 && sed -i '' -e 's/RE2_CXXFLAGS?=-std=c++11 /RE2_CXXFLAGS?=-std=c++11 -fPIC /' Makefile
-@@ -305,9 +269,6 @@ re2: re2/re2/obj/libre2.a
+@@ -322,8 +288,6 @@ re2: re2/re2/obj/libre2.a
  
  
  pcre/pcre/.libs/libpcre.a:
 -	cd pcre && rm -rf pcre-*/ || true
 -	cd pcre && tar -zxf pcre-*.tar.gz
--#	cd pcre/pcre && patch pcretest.c < ../pcretest.c-multiplication-overflow.patch
+ 	cd pcre/pcre && patch pcretest.c < ../pcretest.c-multiplication-overflow.patch
  	cd pcre/pcre && ./configure
  	cd pcre/pcre && CC=${CC} CXX=${CXX} ${MAKE}
- 


### PR DESCRIPTION
###### Description of changes
https://github.com/sysown/proxysql/releases/tag/v2.5.2

###### Things done
- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).