### PR TITLE
mpvScripts.thumbfast: init at unstable-2023-05-12

### DIFF
--- a/pkgs/applications/video/mpv/scripts/thumbfast.nix
+++ b/pkgs/applications/video/mpv/scripts/thumbfast.nix
@@ -1,0 +1,38 @@
+{ lib, stdenvNoCC, fetchFromGitHub, mpv-unwrapped }:
+
+stdenvNoCC.mkDerivation {
+  name = "mpv-thumbfast";
+  version = "unstable-2023-05-12";
+
+  src = fetchFromGitHub {
+    owner = "po5";
+    repo = "thumbfast";
+    rev = "10e9f6133d4ea88e3e5d154969abfaee17173570";
+    hash = "sha256-3fzkAR/itgheXQHTr30XPQR3NpYpIVeZfkcBxEoAnGg=";
+  };
+
+  postPatch = ''
+    substituteInPlace thumbfast.lua \
+      --replace 'mpv_path = "mpv"' 'mpv_path = "${lib.getBin mpv-unwrapped}/bin/mpv"'
+  '';
+
+  dontBuild = true;
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/share/mpv/scripts
+    cp -r thumbfast.lua $out/share/mpv/scripts/thumbfast.lua
+
+    runHook postInstall
+  '';
+
+  passthru.scriptName = "thumbfast.lua";
+
+  meta = {
+    description = "High-performance on-the-fly thumbnailer for mpv";
+    homepage = "https://github.com/po5/thumbfast";
+    license = lib.licenses.unfree; # no explicit licensing information available at this time
+    maintainers = with lib.maintainers; [ apfelkuchen6 ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -32489,6 +32489,7 @@ with pkgs;
     mpvacious = callPackage ../applications/video/mpv/scripts/mpvacious.nix { };
     simple-mpv-webui = callPackage ../applications/video/mpv/scripts/simple-mpv-webui.nix { };
     sponsorblock = callPackage ../applications/video/mpv/scripts/sponsorblock.nix { };
+    thumbfast = callPackage ../applications/video/mpv/scripts/thumbfast.nix { };
     thumbnail = callPackage ../applications/video/mpv/scripts/thumbnail.nix { };
     uosc = callPackage ../applications/video/mpv/scripts/uosc.nix { };
     vr-reversal = callPackage ../applications/video/mpv/scripts/vr-reversal.nix { };


### PR DESCRIPTION
###### Description of changes

#231469 

Can be run with
```
NIXPKGS_ALLOW_UNFREE=1 nix build -I nixpkgs=flake:github:apfelkuchen6/nixpkgs/mpv-thumbfast --impure \
    --expr 'with import <nixpkgs> {};
    pkgs.wrapMpv pkgs.mpv-unwrapped {
      scripts = [ pkgs.mpvScripts.uosc pkgs.mpvScripts.thumbfast ];
    }'
./result/bin/mpv /path/to/test/file.mkv
```

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
