### PR TITLE
gphotos-sync: 3.04 -> 3.1.2

### DIFF
--- a/pkgs/tools/backup/gphotos-sync/default.nix
+++ b/pkgs/tools/backup/gphotos-sync/default.nix
@@ -1,27 +1,13 @@
 { lib
+, pkgs
 , fetchFromGitHub
 , fetchpatch
 , python3
 , ffmpeg
 }:
-let
-  py = python3.override {
-    packageOverrides = self: super: {
-      google-auth-oauthlib = super.google-auth-oauthlib.overridePythonAttrs (oldAttrs: rec {
-        version = "0.5.2b1";
-        src = fetchFromGitHub {
-          owner = "gilesknap";
-          repo = "google-auth-library-python-oauthlib";
-          rev = "v${version}";
-          hash = "sha256-o4Jakm/JgLszumrSoTTnU+nc79Ei70abjpmn614qGyc=";
-        };
-      });
-    };
-  };
-in
-py.pkgs.buildPythonApplication rec {
+python3.pkgs.buildPythonApplication rec {
   pname = "gphotos-sync";
-  version = "3.04";
+  version = "3.1.2";
   format = "pyproject";
 
   SETUPTOOLS_SCM_PRETEND_VERSION = version;
@@ -30,36 +16,37 @@ py.pkgs.buildPythonApplication rec {
     owner = "gilesknap";
     repo = "gphotos-sync";
     rev = version;
-    sha256 = "0mnlnqmlh3n1b6fjwpx2byl1z41vgghjb95598kz5gvdi95iirrs";
+    hash = "sha256-lLw450Rk7tIENFTZWHoinkhv3VtctDv18NKxhox+NgI=";
   };
 
   patches = [
     ./skip-network-tests.patch
   ];
 
-  propagatedBuildInputs = with py.pkgs; [
+  nativeBuildInputs = [ python3.pkgs.pythonRelaxDepsHook ];
+  pythonRelaxDeps = [
+    "psutil"
+    "exif"
+  ];
+
+  propagatedBuildInputs = with python3.pkgs; [
     appdirs
     attrs
     exif
     google-auth-oauthlib
     psutil
     pyyaml
+    psutil
     requests-oauthlib
     types-pyyaml
     types-requests
   ];
 
-  postPatch = ''
-    # this is a patched release that we include via packageOverrides above
-    substituteInPlace setup.cfg \
-      --replace " @ https://github.com/gilesknap/google-auth-library-python-oauthlib/archive/refs/tags/v0.5.2b1.zip" ""
-  '';
-
   buildInputs = [
     ffmpeg
   ];
 
-  nativeCheckInputs = with py.pkgs; [
+  nativeCheckInputs = with python3.pkgs; [
     mock
     pytestCheckHook
     setuptools-scm


### PR DESCRIPTION
###### Description of changes
Patched google-auth library is no longer needed, so this package could be simplified a bit.

Changelog: https://github.com/gilesknap/gphotos-sync/compare/3.04...3.1.2

Just used the result to complete the authentication flow and already running a backup, so appears to be working.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
