### PR TITLE
gitea-actions-runner: 0.1.2 -> 0.1.8

### DIFF
--- a/pkgs/development/tools/continuous-integration/gitea-actions-runner/default.nix
+++ b/pkgs/development/tools/continuous-integration/gitea-actions-runner/default.nix
@@ -5,17 +5,17 @@
 
 buildGoModule rec {
   pname = "gitea-actions-runner";
-  version = "0.1.2";
+  version = "0.1.8";
 
   src = fetchFromGitea {
     domain = "gitea.com";
     owner = "gitea";
     repo = "act_runner";
     rev = "v${version}";
-    hash = "sha256-0wLBFZdFaGTselRZIJ809wHQFhAjt4sdmZp12LQOB9I=";
+    hash = "sha256-J67g0jy/5Dfmvu3bSPqH+r9+MuLyl2lZyEZrOovfNJI=";
   };
 
-  vendorHash = "sha256-GBqt5qSM2mDAS7klWdJiC6t5HaVKaP0PjecYnHZBzrc=";
+  vendorHash = "sha256-Ik4n1oB6MWE2djcM5CdDhJKx4IJsZu7eJr5St+T67B4=";
 
   ldflags = [
     "-s"


### PR DESCRIPTION
https://gitea.com/gitea/act_runner/releases/tag/v0.1.3 
https://gitea.com/gitea/act_runner/releases/tag/v0.1.4 
https://gitea.com/gitea/act_runner/releases/tag/v0.1.5 
https://gitea.com/gitea/act_runner/releases/tag/v0.1.6 
https://gitea.com/gitea/act_runner/releases/tag/v0.1.7 
https://gitea.com/gitea/act_runner/releases/tag/v0.1.8

Untested

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
