### PR TITLE
odp-dpdk: Build against openssl3

### DIFF
--- a/pkgs/os-specific/linux/odp-dpdk/default.nix
+++ b/pkgs/os-specific/linux/odp-dpdk/default.nix
@@ -1,25 +1,28 @@
-{ lib, stdenv, fetchurl, autoreconfHook, pkg-config
-, dpdk, libbpf, libconfig, libpcap, numactl, openssl, zlib, libbsd, libelf, jansson
+{ lib
+, stdenv
+, fetchurl
+, autoreconfHook
+, pkg-config
+, dpdk
+, libbpf
+, libconfig
+, libpcap
+, numactl
+, openssl
+, zlib
+, libbsd
+, libelf
+, jansson
 , libnl
-}: let
-  dpdk_19_11 = dpdk.overrideAttrs (old: rec {
-    version = "19.11.12";
-    src = fetchurl {
-      url = "https://fast.dpdk.org/rel/dpdk-${version}.tar.xz";
-      sha256 = "sha256-F9m2+MZi3n0psPIwjWwhiIbbNkoGlxqtru2OlV7TbzQ=";
-    };
-    mesonFlags = old.mesonFlags ++ [
-      "-Denable_docs=false"
-    ];
-  });
+}:
 
-in stdenv.mkDerivation rec {
+stdenv.mkDerivation rec {
   pname = "odp-dpdk";
-  version = "1.37.0.0_DPDK_19.11";
+  version = "1.41.0.0_DPDK_22.11";
 
   src = fetchurl {
     url = "https://git.linaro.org/lng/odp-dpdk.git/snapshot/${pname}-${version}.tar.gz";
-    sha256 = "sha256-Ai6+6eZJeG0BrwNboBPfgDGkUbCC8lcj7+oxmWjWP2k=";
+    hash = "sha256-4p+R+7IeDKQFqBzQTvXfR407exxhoS8pnKxF9Qnr8tw=";
   };
 
   nativeBuildInputs = [
@@ -28,7 +31,7 @@ in stdenv.mkDerivation rec {
   ];
 
   buildInputs = [
-    dpdk_19_11
+    dpdk
     libconfig
     libpcap
     numactl

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -27199,9 +27199,7 @@ with pkgs;
 
   odin = callPackage ../development/compilers/odin { };
 
-  odp-dpdk = callPackage ../os-specific/linux/odp-dpdk {
-    openssl = openssl_1_1;
-  };
+  odp-dpdk = callPackage ../os-specific/linux/odp-dpdk { };
 
   odroid-xu3-bootloader = callPackage ../tools/misc/odroid-xu3-bootloader { };
 


### PR DESCRIPTION
###### Description of changes

https://github.com/OpenDataPlane/odp/releases/tag/v1.38.0.0
https://github.com/OpenDataPlane/odp/releases/tag/v1.39.0.0
https://github.com/OpenDataPlane/odp/releases/tag/v1.40.0.0
https://github.com/OpenDataPlane/odp/releases/tag/v1.41.0.0

#210452 

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
