### PR TITLE
python3.pkgs.wrapt: build offline documentation

### DIFF
--- a/pkgs/development/python-modules/wrapt/default.nix
+++ b/pkgs/development/python-modules/wrapt/default.nix
@@ -2,11 +2,14 @@
 , buildPythonPackage
 , fetchFromGitHub
 , pytestCheckHook
+, sphinxHook
+, sphinx-rtd-theme
 }:
 
 buildPythonPackage rec {
   pname = "wrapt";
   version = "1.14.1";
+  outputs = [ "out" "doc" ];
   format = "setuptools";
 
   src = fetchFromGitHub {
@@ -18,6 +21,11 @@ buildPythonPackage rec {
 
   nativeCheckInputs = [
     pytestCheckHook
+  ];
+
+  nativeBuildInputs = [
+    sphinxHook
+    sphinx-rtd-theme
   ];
 
   pythonImportsCheck = [


### PR DESCRIPTION
python3.pkgs.wrapt: build offline documentationX-Reverse-Dependencies: python3.pkgs.deprecated```

## Build info of packages affected directly

### python3.pkgs.wrapt

<details><summary>content of python3.pkgs.wrapt.dist</summary>

```
/nix/store/5cfi6y6mxg7p9hz2nc9k3pyrr6n09fvw-python3.10-wrapt-1.14.1-dist
└── wrapt-1.14.1-cp310-cp310-linux_x86_64.whl

0 directories, 1 file
```

</details>

<details><summary>content of python3.pkgs.wrapt.doc</summary>

```
/nix/store/bz9r7xda3yvhhixj1ziksx21cb3wvi11-python3.10-wrapt-1.14.1-doc
└── share
    └── doc
        └── python3.10-wrapt-1.14.1
            └── html
                ├── _static
                │   ├── _sphinx_javascript_frameworks_compat.js
                │   ├── basic.css
                │   ├── css
                │   │   ├── badge_only.css
                │   │   ├── fonts
                │   │   │   ├── Roboto-Slab-Bold.woff
                │   │   │   ├── Roboto-Slab-Bold.woff2
                │   │   │   ├── Roboto-Slab-Regular.woff
                │   │   │   ├── Roboto-Slab-Regular.woff2
                │   │   │   ├── fontawesome-webfont.eot
                │   │   │   ├── fontawesome-webfont.svg
                │   │   │   ├── fontawesome-webfont.ttf
                │   │   │   ├── fontawesome-webfont.woff
                │   │   │   ├── fontawesome-webfont.woff2
                │   │   │   ├── lato-bold-italic.woff
                │   │   │   ├── lato-bold-italic.woff2
                │   │   │   ├── lato-bold.woff
                │   │   │   ├── lato-bold.woff2
                │   │   │   ├── lato-normal-italic.woff
                │   │   │   ├── lato-normal-italic.woff2
                │   │   │   ├── lato-normal.woff
                │   │   │   └── lato-normal.woff2
                │   │   └── theme.css
                │   ├── doctools.js
                │   ├── documentation_options.js
                │   ├── file.png
                │   ├── jquery-3.6.0.js
                │   ├── jquery.js
                │   ├── js
                │   │   ├── badge_only.js
                │   │   ├── html5shiv-printshiv.min.js
                │   │   ├── html5shiv.min.js
                │   │   └── theme.js
                │   ├── language_data.js
                │   ├── minus.png
                │   ├── plus.png
                │   ├── pygments.css
                │   ├── searchtools.js
                │   ├── sphinx_highlight.js
                │   ├── underscore-1.13.1.js
                │   └── underscore.js
                ├── benchmarks.html
                ├── changes.html
                ├── decorators.html
                ├── examples.html
                ├── genindex.html
                ├── index.html
                ├── issues.html
                ├── objects.inv
                ├── quick-start.html
                ├── search.html
                ├── searchindex.js
                ├── testing.html
                └── wrappers.html

8 directories, 51 files
```

</details>

<details><summary>content of python3.pkgs.wrapt.out</summary>

```
/nix/store/lpqms90yinf47y5nyxhy08s1y17nlllw-python3.10-wrapt-1.14.1
├── lib
│   └── python3.10
│       └── site-packages
│           ├── wrapt
│           │   ├── __init__.py
│           │   ├── __pycache__
│           │   │   ├── __init__.cpython-310.pyc
│           │   │   ├── arguments.cpython-310.pyc
│           │   │   ├── decorators.cpython-310.pyc
│           │   │   ├── importer.cpython-310.pyc
│           │   │   └── wrappers.cpython-310.pyc
│           │   ├── _wrappers.cpython-310-x86_64-linux-gnu.so
│           │   ├── arguments.py
│           │   ├── decorators.py
│           │   ├── importer.py
│           │   └── wrappers.py
│           └── wrapt-1.14.1.dist-info
│               ├── INSTALLER
│               ├── LICENSE
│               ├── METADATA
│               ├── RECORD
│               ├── REQUESTED
│               ├── WHEEL
│               └── top_level.txt
└── nix-support
    └── propagated-build-inputs

7 directories, 19 files
```

</details>

<details><summary>build log of python3.pkgs.wrapt</summary>

```
Sourcing python-remove-tests-dir-hook
Sourcing python-catch-conflicts-hook.sh
Sourcing python-remove-bin-bytecode-hook.sh
Sourcing setuptools-build-hook
Using setuptoolsBuildPhase
Using setuptoolsShellHook
Sourcing pip-install-hook
Using pipInstallPhase
Sourcing python-imports-check-hook.sh
Using pythonImportsCheckPhase
Sourcing python-namespaces-hook
Sourcing python-catch-conflicts-hook.sh
Sourcing sphinx-hook
Sourcing setuptools-check-hook
Using setuptoolsCheckPhase
Sourcing pytest-check-hook
Using pytestCheckPhase
Removing setuptoolsCheckPhase
@nix { "action": "setPhase", "phase": "unpackPhase" }
unpacking sources
unpacking source archive /nix/store/j74nvhjns4nvsp41xj7901018gfrwps4-source
source root is source
setting SOURCE_DATE_EPOCH to timestamp 315619200 of file source/tests/test_weak_function_proxy.py
@nix { "action": "setPhase", "phase": "patchPhase" }
patching sources
@nix { "action": "setPhase", "phase": "configurePhase" }
configuring
no configure script, doing nothing
@nix { "action": "setPhase", "phase": "buildPhase" }
building
Executing setuptoolsBuildPhase
/nix/store/grzwjq98dl1n8d4gj7w7qbimbav4464l-python3.10-setuptools-67.4.0/lib/python3.10/site-packages/setuptools/config/setupcfg.py:520: SetuptoolsDeprecationWarning: The license_file parameter is deprecated, use license_files instead.
  warnings.warn(msg, warning_class)
/nix/store/grzwjq98dl1n8d4gj7w7qbimbav4464l-python3.10-setuptools-67.4.0/lib/python3.10/site-packages/setuptools/__init__.py:85: _DeprecatedInstaller: setuptools.installer and fetch_build_eggs are deprecated. Requirements should be satisfied by a PEP 517 installer. If you are using pip, you can try `pip install --use-pep517`.
  dist.fetch_build_eggs(dist.setup_requires)
/nix/store/grzwjq98dl1n8d4gj7w7qbimbav4464l-python3.10-setuptools-67.4.0/lib/python3.10/site-packages/setuptools/config/setupcfg.py:520: SetuptoolsDeprecationWarning: The license_file parameter is deprecated, use license_files instead.
  warnings.warn(msg, warning_class)
running bdist_wheel
running build
running build_py
creating build
creating build/lib.linux-x86_64-cpython-310
creating build/lib.linux-x86_64-cpython-310/wrapt
copying src/wrapt/__init__.py -> build/lib.linux-x86_64-cpython-310/wrapt
copying src/wrapt/decorators.py -> build/lib.linux-x86_64-cpython-310/wrapt
copying src/wrapt/importer.py -> build/lib.linux-x86_64-cpython-310/wrapt
copying src/wrapt/arguments.py -> build/lib.linux-x86_64-cpython-310/wrapt
copying src/wrapt/wrappers.py -> build/lib.linux-x86_64-cpython-310/wrapt
running build_ext
building 'wrapt._wrappers' extension
creating build/temp.linux-x86_64-cpython-310
creating build/temp.linux-x86_64-cpython-310/src
creating build/temp.linux-x86_64-cpython-310/src/wrapt
gcc -Wno-unused-result -Wsign-compare -DNDEBUG -g -fwrapv -O3 -Wall -I/nix/store/fxhq0kn94fi877clk03ksrvxxpv234x8-libxcrypt-4.4.33/include -fPIC -I/nix/store/95cxzy2hpizr23343b8bskl4yacf4b3l-python3-3.10.11/include/python3.10 -c src/wrapt/_wrappers.c -o build/temp.linux-x86_64-cpython-310/src/wrapt/_wrappers.o
src/wrapt/_wrappers.c: In function ‘WraptFunctionWrapperBase_instancecheck’:
src/wrapt/_wrappers.c:2550:15: warning: unused variable ‘object’ [8;;https://gcc.gnu.org/onlinedocs/gcc/Warning-Options.html#index-Wunused-variable-Wunused-variable8;;]
 2550 |     PyObject *object = NULL;
      |               ^~~~~~
gcc -shared -L/nix/store/eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee-zlib-1.2.13/lib -L/nix/store/eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee-bzip2-1.0.8/lib -L/nix/store/eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee-expat-2.5.0/lib -L/nix/store/eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee-xz-5.4.3/lib -L/nix/store/eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee-libffi-3.4.4/lib -L/nix/store/fxhq0kn94fi877clk03ksrvxxpv234x8-libxcrypt-4.4.33/lib -L/nix/store/eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee-gdbm-1.23/lib -L/nix/store/eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee-sqlite-3.41.2/lib -L/nix/store/eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee-readline-8.2p1/lib -L/nix/store/eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee-ncurses-6.4/lib -L/nix/store/eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee-openssl-3.0.8/lib -L/nix/store/jhgh02lyizd1kyl71brvc01ygsmgi40a-tzdata-2023c/lib -L/nix/store/eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee-zlib-1.2.13/lib -L/nix/store/eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee-bzip2-1.0.8/lib -L/nix/store/eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee-expat-2.5.0/lib -L/nix/store/eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee-xz-5.4.3/lib -L/nix/store/eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee-libffi-3.4.4/lib -L/nix/store/fxhq0kn94fi877clk03ksrvxxpv234x8-libxcrypt-4.4.33/lib -L/nix/store/eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee-gdbm-1.23/lib -L/nix/store/eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee-sqlite-3.41.2/lib -L/nix/store/eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee-readline-8.2p1/lib -L/nix/store/eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee-ncurses-6.4/lib -L/nix/store/eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee-openssl-3.0.8/lib -L/nix/store/jhgh02lyizd1kyl71brvc01ygsmgi40a-tzdata-2023c/lib build/temp.linux-x86_64-cpython-310/src/wrapt/_wrappers.o -L/nix/store/95cxzy2hpizr23343b8bskl4yacf4b3l-python3-3.10.11/lib -o build/lib.linux-x86_64-cpython-310/wrapt/_wrappers.cpython-310-x86_64-linux-gnu.so
/nix/store/grzwjq98dl1n8d4gj7w7qbimbav4464l-python3.10-setuptools-67.4.0/lib/python3.10/site-packages/setuptools/command/install.py:34: SetuptoolsDeprecationWarning: setup.py install is deprecated. Use build and pip and other standards-based tools.
  warnings.warn(
installing to build/bdist.linux-x86_64/wheel
running install
running install_lib
creating build/bdist.linux-x86_64
creating build/bdist.linux-x86_64/wheel
creating build/bdist.linux-x86_64/wheel/wrapt
copying build/lib.linux-x86_64-cpython-310/wrapt/__init__.py -> build/bdist.linux-x86_64/wheel/wrapt
copying build/lib.linux-x86_64-cpython-310/wrapt/_wrappers.cpython-310-x86_64-linux-gnu.so -> build/bdist.linux-x86_64/wheel/wrapt
copying build/lib.linux-x86_64-cpython-310/wrapt/decorators.py -> build/bdist.linux-x86_64/wheel/wrapt
copying build/lib.linux-x86_64-cpython-310/wrapt/importer.py -> build/bdist.linux-x86_64/wheel/wrapt
copying build/lib.linux-x86_64-cpython-310/wrapt/arguments.py -> build/bdist.linux-x86_64/wheel/wrapt
copying build/lib.linux-x86_64-cpython-310/wrapt/wrappers.py -> build/bdist.linux-x86_64/wheel/wrapt
running install_egg_info
running egg_info
creating src/wrapt.egg-info
writing src/wrapt.egg-info/PKG-INFO
writing dependency_links to src/wrapt.egg-info/dependency_links.txt
writing top-level names to src/wrapt.egg-info/top_level.txt
writing manifest file 'src/wrapt.egg-info/SOURCES.txt'
reading manifest file 'src/wrapt.egg-info/SOURCES.txt'
reading manifest template 'MANIFEST.in'
adding license file 'LICENSE'
writing manifest file 'src/wrapt.egg-info/SOURCES.txt'
Copying src/wrapt.egg-info to build/bdist.linux-x86_64/wheel/wrapt-1.14.1-py3.10.egg-info
running install_scripts
creating build/bdist.linux-x86_64/wheel/wrapt-1.14.1.dist-info/WHEEL
creating 'dist/wrapt-1.14.1-cp310-cp310-linux_x86_64.whl' and adding 'build/bdist.linux-x86_64/wheel' to it
adding 'wrapt/__init__.py'
adding 'wrapt/_wrappers.cpython-310-x86_64-linux-gnu.so'
adding 'wrapt/arguments.py'
adding 'wrapt/decorators.py'
adding 'wrapt/importer.py'
adding 'wrapt/wrappers.py'
adding 'wrapt-1.14.1.dist-info/LICENSE'
adding 'wrapt-1.14.1.dist-info/METADATA'
adding 'wrapt-1.14.1.dist-info/WHEEL'
adding 'wrapt-1.14.1.dist-info/top_level.txt'
adding 'wrapt-1.14.1.dist-info/RECORD'
removing build/bdist.linux-x86_64/wheel
Finished executing setuptoolsBuildPhase
@nix { "action": "setPhase", "phase": "installPhase" }
installing
Executing pipInstallPhase
Looking in links: dist
Processing ./dist/wrapt-1.14.1-cp310-cp310-linux_x86_64.whl
Installing collected packages: wrapt
Successfully installed wrapt-1.14.1
Finished executing pipInstallPhase
@nix { "action": "setPhase", "phase": "pythonOutputDistPhase" }
pythonOutputDistPhase
Executing pythonOutputDistPhase
Finished executing pythonOutputDistPhase
@nix { "action": "setPhase", "phase": "fixupPhase" }
post-installation fixup
shrinking RPATHs of ELF executables and libraries in /nix/store/lpqms90yinf47y5nyxhy08s1y17nlllw-python3.10-wrapt-1.14.1
shrinking /nix/store/lpqms90yinf47y5nyxhy08s1y17nlllw-python3.10-wrapt-1.14.1/lib/python3.10/site-packages/wrapt/_wrappers.cpython-310-x86_64-linux-gnu.so
checking for references to /build/ in /nix/store/lpqms90yinf47y5nyxhy08s1y17nlllw-python3.10-wrapt-1.14.1...
patching script interpreter paths in /nix/store/lpqms90yinf47y5nyxhy08s1y17nlllw-python3.10-wrapt-1.14.1
stripping (with command strip and flags -S -p) in  /nix/store/lpqms90yinf47y5nyxhy08s1y17nlllw-python3.10-wrapt-1.14.1/lib
shrinking RPATHs of ELF executables and libraries in /nix/store/5cfi6y6mxg7p9hz2nc9k3pyrr6n09fvw-python3.10-wrapt-1.14.1-dist
checking for references to /build/ in /nix/store/5cfi6y6mxg7p9hz2nc9k3pyrr6n09fvw-python3.10-wrapt-1.14.1-dist...
patching script interpreter paths in /nix/store/5cfi6y6mxg7p9hz2nc9k3pyrr6n09fvw-python3.10-wrapt-1.14.1-dist
Executing pythonRemoveTestsDir
Finished executing pythonRemoveTestsDir
@nix { "action": "setPhase", "phase": "installCheckPhase" }
running install tests
no Makefile or custom installCheckPhase, doing nothing
@nix { "action": "setPhase", "phase": "pythonCatchConflictsPhase" }
pythonCatchConflictsPhase
@nix { "action": "setPhase", "phase": "pythonRemoveBinBytecodePhase" }
pythonRemoveBinBytecodePhase
@nix { "action": "setPhase", "phase": "pythonImportsCheckPhase" }
pythonImportsCheckPhase
Executing pythonImportsCheckPhase
Check whether the following modules can be imported: wrapt
@nix { "action": "setPhase", "phase": "buildSphinxPhase" }
buildSphinxPhase
Executing buildSphinxPhase
Sphinx documentation found in docs
Executing sphinx-build with html builder
Running Sphinx v5.3.0
making output directory... done
locale_dir /build/source/docs/locales/en/LC_MESSAGES does not exists
locale_dir /build/source/docs/locales/en/LC_MESSAGES does not exists
building [mo]: targets for 0 po files that are out of date
building [html]: targets for 9 source files that are out of date
updating environment: locale_dir /build/source/docs/locales/en/LC_MESSAGES does not exists
[new config] 9 added, 0 changed, 0 removed
reading sources... [ 11%] benchmarks
reading sources... [ 22%] changes
reading sources... [ 33%] decorators
reading sources... [ 44%] examples
reading sources... [ 55%] index
reading sources... [ 66%] issues
reading sources... [ 77%] quick-start
reading sources... [ 88%] testing
reading sources... [100%] wrappers

looking for now-outdated files... none found
pickling environment... done
checking consistency... done
preparing documents... done
writing output... [ 11%] benchmarks
writing output... [ 22%] changes
writing output... [ 33%] decorators
writing output... [ 44%] examples
writing output... [ 55%] index
writing output... [ 66%] issues
writing output... [ 77%] quick-start
writing output... [ 88%] testing
writing output... [100%] wrappers

generating indices... genindex done
writing additional pages... search done
copying static files... done
copying extra files... done
dumping search index in English (code: en)... done
dumping object inventory... done
build succeeded.

The HTML pages are in .sphinx/html/html.
@nix { "action": "setPhase", "phase": "installSphinxPhase" }
installSphinxPhase
Executing installSphinxPhase
@nix { "action": "setPhase", "phase": "pytestCheckPhase" }
pytestCheckPhase
Executing pytestCheckPhase
============================= test session starts ==============================
platform linux -- Python 3.10.11, pytest-7.2.1, pluggy-1.0.0
rootdir: /build/source, configfile: setup.cfg
collecting ...
collected 392 items

tests/test_adapter.py ...........                                        [  2%]
tests/test_adapter_py3.py ........                                       [  4%]
tests/test_adapter_py33.py ..                                            [  5%]
tests/test_arguments.py ..                                               [  5%]
tests/test_attribute_wrapper.py .                                        [  6%]
tests/test_callable_object_proxy.py ......                               [  7%]
tests/test_class.py ..                                                   [  8%]
tests/test_class_py37.py ...                                             [  8%]
tests/test_copy.py ....                                                  [  9%]
tests/test_decorators.py .....                                           [ 11%]
tests/test_descriptors_py36.py .                                         [ 11%]
tests/test_formatargspec_py35.py .                                       [ 11%]
tests/test_formatargspec_py38.py .                                       [ 11%]
tests/test_function.py ........                                          [ 14%]
tests/test_function_wrapper.py ..............................            [ 21%]
tests/test_inheritance_py37.py ...                                       [ 22%]
tests/test_inner_classmethod.py ....................                     [ 27%]
tests/test_inner_staticmethod.py ..................                      [ 32%]
tests/test_instancemethod.py .................................           [ 40%]
tests/test_memoize.py ....                                               [ 41%]
tests/test_monkey_patching.py .................                          [ 45%]
tests/test_nested_function.py .......                                    [ 47%]
tests/test_object_proxy.py ............................................. [ 59%]
........................................................................ [ 77%]
..........................                                               [ 84%]
tests/test_outer_classmethod.py ..............                           [ 87%]
tests/test_outer_staticmethod.py ..............                          [ 91%]
tests/test_pickle.py ..                                                  [ 91%]
tests/test_post_import_hooks.py ...                                      [ 92%]
tests/test_synchronized_lock.py .........                                [ 94%]
tests/test_update_attributes.py ..........                               [ 97%]
tests/test_weak_function_proxy.py ..........                             [100%]

=============================== warnings summary ===============================
tests/test_adapter.py:5
  /build/source/tests/test_adapter.py:5: DeprecationWarning: the imp module is deprecated in favour of importlib and slated for removal in Python 3.12; see the module's documentation for alternative uses
    import imp

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
======================== 392 passed, 1 warning in 0.65s ========================
Finished executing pytestCheckPhase
@nix { "action": "setPhase", "phase": "pytestcachePhase" }
pytestcachePhase
@nix { "action": "setPhase", "phase": "pytestRemoveBytecodePhase" }
pytestRemoveBytecodePhase
```

</details>

## Build info of some reverse dependencies

### python3.pkgs.deprecated

<details><summary>content of python3.pkgs.deprecated.dist</summary>

```
/nix/store/p28wxpj9c5w544a1r2s1jfcbcl4pwcbl-python3.10-deprecated-1.2.13-dist
└── Deprecated-1.2.13-py2.py3-none-any.whl

0 directories, 1 file
```

</details>

<details><summary>content of python3.pkgs.deprecated.doc</summary>

```
/nix/store/inwkshzlpxjqqy7dsnzc1qngqnj9q5n2-python3.10-deprecated-1.2.13-doc
└── share
    └── doc
        └── python3.10-deprecated-1.2.13
            └── html
                ├── _images
                │   └── banner.png
                ├── _static
                │   ├── _sphinx_javascript_frameworks_compat.js
                │   ├── alabaster.css
                │   ├── banner.png
                │   ├── basic.css
                │   ├── custom.css
                │   ├── doctools.js
                │   ├── documentation_options.js
                │   ├── file.png
                │   ├── jquery-3.6.0.js
                │   ├── jquery.js
                │   ├── language_data.js
                │   ├── logo-full.png
                │   ├── minus.png
                │   ├── plus.png
                │   ├── pygments.css
                │   ├── searchtools.js
                │   ├── sphinx_highlight.js
                │   ├── title-page.jpg
                │   ├── underscore-1.13.1.js
                │   └── underscore.js
                ├── api.html
                ├── changelog.html
                ├── contributing.html
                ├── genindex.html
                ├── index.html
                ├── installation.html
                ├── introduction.html
                ├── license.html
                ├── objects.inv
                ├── py-modindex.html
                ├── search.html
                ├── searchindex.js
                ├── sphinx_deco.html
                ├── tutorial.html
                └── white_paper.html

6 directories, 36 files
```

</details>

<details><summary>content of python3.pkgs.deprecated.out</summary>

```
/nix/store/34v32p7qcc6qhfjg9dw4jqz37paidvk8-python3.10-deprecated-1.2.13
├── lib
│   └── python3.10
│       └── site-packages
│           ├── Deprecated-1.2.13.dist-info
│           │   ├── INSTALLER
│           │   ├── LICENSE.rst
│           │   ├── METADATA
│           │   ├── RECORD
│           │   ├── REQUESTED
│           │   ├── WHEEL
│           │   └── top_level.txt
│           └── deprecated
│               ├── __init__.py
│               ├── __pycache__
│               │   ├── __init__.cpython-310.pyc
│               │   ├── classic.cpython-310.pyc
│               │   └── sphinx.cpython-310.pyc
│               ├── classic.py
│               └── sphinx.py
└── nix-support
    └── propagated-build-inputs

7 directories, 14 files
```

</details>

<details><summary>build log of python3.pkgs.deprecated</summary>

```
Sourcing python-remove-tests-dir-hook
Sourcing python-catch-conflicts-hook.sh
Sourcing python-remove-bin-bytecode-hook.sh
Sourcing setuptools-build-hook
Using setuptoolsBuildPhase
Using setuptoolsShellHook
Sourcing pip-install-hook
Using pipInstallPhase
Sourcing python-imports-check-hook.sh
Using pythonImportsCheckPhase
Sourcing python-namespaces-hook
Sourcing python-catch-conflicts-hook.sh
Sourcing sphinx-hook
Sourcing setuptools-check-hook
Using setuptoolsCheckPhase
Sourcing pytest-check-hook
Using pytestCheckPhase
Removing setuptoolsCheckPhase
@nix { "action": "setPhase", "phase": "unpackPhase" }
unpacking sources
unpacking source archive /nix/store/zw0grpzvc3rk0c5fkbcx8bcvdj6ippdg-source
source root is source
setting SOURCE_DATE_EPOCH to timestamp 315619200 of file source/tox.ini
@nix { "action": "setPhase", "phase": "patchPhase" }
patching sources
@nix { "action": "setPhase", "phase": "configurePhase" }
configuring
no configure script, doing nothing
@nix { "action": "setPhase", "phase": "buildPhase" }
building
Executing setuptoolsBuildPhase
running bdist_wheel
running build
running build_py
creating build
creating build/lib
creating build/lib/deprecated
copying deprecated/__init__.py -> build/lib/deprecated
copying deprecated/classic.py -> build/lib/deprecated
copying deprecated/sphinx.py -> build/lib/deprecated
running egg_info
creating Deprecated.egg-info
writing Deprecated.egg-info/PKG-INFO
writing dependency_links to Deprecated.egg-info/dependency_links.txt
writing requirements to Deprecated.egg-info/requires.txt
writing top-level names to Deprecated.egg-info/top_level.txt
writing manifest file 'Deprecated.egg-info/SOURCES.txt'
reading manifest file 'Deprecated.egg-info/SOURCES.txt'
reading manifest template 'MANIFEST.in'
warning: no files found matching '.coveragerc'
warning: no files found matching '*.yaml'
warning: no previously-included files matching '*.py[cod]' found anywhere in distribution
warning: no previously-included files matching '__pycache__' found anywhere in distribution
warning: no previously-included files matching '*.so' found anywhere in distribution
warning: no previously-included files matching '*.dylib' found anywhere in distribution
warning: no previously-included files matching '.DS_Store' found anywhere in distribution
adding license file 'LICENSE.rst'
writing manifest file 'Deprecated.egg-info/SOURCES.txt'
/nix/store/grzwjq98dl1n8d4gj7w7qbimbav4464l-python3.10-setuptools-67.4.0/lib/python3.10/site-packages/setuptools/command/install.py:34: SetuptoolsDeprecationWarning: setup.py install is deprecated. Use build and pip and other standards-based tools.
  warnings.warn(
installing to build/bdist.linux-x86_64/wheel
running install
running install_lib
creating build/bdist.linux-x86_64
creating build/bdist.linux-x86_64/wheel
creating build/bdist.linux-x86_64/wheel/deprecated
copying build/lib/deprecated/__init__.py -> build/bdist.linux-x86_64/wheel/deprecated
copying build/lib/deprecated/classic.py -> build/bdist.linux-x86_64/wheel/deprecated
copying build/lib/deprecated/sphinx.py -> build/bdist.linux-x86_64/wheel/deprecated
running install_egg_info
Copying Deprecated.egg-info to build/bdist.linux-x86_64/wheel/Deprecated-1.2.13-py3.10.egg-info
running install_scripts
creating build/bdist.linux-x86_64/wheel/Deprecated-1.2.13.dist-info/WHEEL
creating 'dist/Deprecated-1.2.13-py2.py3-none-any.whl' and adding 'build/bdist.linux-x86_64/wheel' to it
adding 'deprecated/__init__.py'
adding 'deprecated/classic.py'
adding 'deprecated/sphinx.py'
adding 'Deprecated-1.2.13.dist-info/LICENSE.rst'
adding 'Deprecated-1.2.13.dist-info/METADATA'
adding 'Deprecated-1.2.13.dist-info/WHEEL'
adding 'Deprecated-1.2.13.dist-info/top_level.txt'
adding 'Deprecated-1.2.13.dist-info/RECORD'
removing build/bdist.linux-x86_64/wheel
Finished executing setuptoolsBuildPhase
@nix { "action": "setPhase", "phase": "installPhase" }
installing
Executing pipInstallPhase
Looking in links: dist
Processing ./dist/Deprecated-1.2.13-py2.py3-none-any.whl
Requirement already satisfied: wrapt<2,>=1.10 in /nix/store/lpqms90yinf47y5nyxhy08s1y17nlllw-python3.10-wrapt-1.14.1/lib/python3.10/site-packages (from deprecated) (1.14.1)
Installing collected packages: deprecated
Successfully installed deprecated-1.2.13
Finished executing pipInstallPhase
@nix { "action": "setPhase", "phase": "pythonOutputDistPhase" }
pythonOutputDistPhase
Executing pythonOutputDistPhase
Finished executing pythonOutputDistPhase
@nix { "action": "setPhase", "phase": "fixupPhase" }
post-installation fixup
shrinking RPATHs of ELF executables and libraries in /nix/store/34v32p7qcc6qhfjg9dw4jqz37paidvk8-python3.10-deprecated-1.2.13
checking for references to /build/ in /nix/store/34v32p7qcc6qhfjg9dw4jqz37paidvk8-python3.10-deprecated-1.2.13...
patching script interpreter paths in /nix/store/34v32p7qcc6qhfjg9dw4jqz37paidvk8-python3.10-deprecated-1.2.13
stripping (with command strip and flags -S -p) in  /nix/store/34v32p7qcc6qhfjg9dw4jqz37paidvk8-python3.10-deprecated-1.2.13/lib
shrinking RPATHs of ELF executables and libraries in /nix/store/p28wxpj9c5w544a1r2s1jfcbcl4pwcbl-python3.10-deprecated-1.2.13-dist
checking for references to /build/ in /nix/store/p28wxpj9c5w544a1r2s1jfcbcl4pwcbl-python3.10-deprecated-1.2.13-dist...
patching script interpreter paths in /nix/store/p28wxpj9c5w544a1r2s1jfcbcl4pwcbl-python3.10-deprecated-1.2.13-dist
Executing pythonRemoveTestsDir
Finished executing pythonRemoveTestsDir
@nix { "action": "setPhase", "phase": "installCheckPhase" }
running install tests
no Makefile or custom installCheckPhase, doing nothing
@nix { "action": "setPhase", "phase": "pythonCatchConflictsPhase" }
pythonCatchConflictsPhase
@nix { "action": "setPhase", "phase": "pythonRemoveBinBytecodePhase" }
pythonRemoveBinBytecodePhase
@nix { "action": "setPhase", "phase": "pythonImportsCheckPhase" }
pythonImportsCheckPhase
Executing pythonImportsCheckPhase
Check whether the following modules can be imported: deprecated
@nix { "action": "setPhase", "phase": "buildSphinxPhase" }
buildSphinxPhase
Executing buildSphinxPhase
Sphinx documentation found in docs/source
Executing sphinx-build with html builder
Running Sphinx v5.3.0
WARNING: Invalid configuration value found: 'language = None'. Update your configuration to a valid language code. Falling back to 'en' (English).
making output directory... done
locale_dir /build/source/docs/source/locales/en/LC_MESSAGES does not exists
loading intersphinx inventory from https://docs.python.org/3/objects.inv...
loading intersphinx inventory from https://wrapt.readthedocs.io/en/latest/objects.inv...
loading intersphinx inventory from http://flask.pocoo.org/docs/1.0/objects.inv...
loading intersphinx inventory from https://docs.djangoproject.com/en/2.1/_objects/...
WARNING: failed to reach any of the inventories with the following issues:
intersphinx inventory 'https://docs.python.org/3/objects.inv' not fetchable due to <class 'requests.exceptions.ConnectionError'>: HTTPSConnectionPool(host='docs.python.org', port=443): Max retries exceeded with url: /3/objects.inv (Caused by NewConnectionError('<urllib3.connection.HTTPSConnection object at 0x7ffff4f22050>: Failed to establish a new connection: [Errno -3] Temporary failure in name resolution'))
WARNING: failed to reach any of the inventories with the following issues:
intersphinx inventory 'https://wrapt.readthedocs.io/en/latest/objects.inv' not fetchable due to <class 'requests.exceptions.ConnectionError'>: HTTPSConnectionPool(host='wrapt.readthedocs.io', port=443): Max retries exceeded with url: /en/latest/objects.inv (Caused by NewConnectionError('<urllib3.connection.HTTPSConnection object at 0x7ffff4f22770>: Failed to establish a new connection: [Errno -3] Temporary failure in name resolution'))
WARNING: failed to reach any of the inventories with the following issues:
intersphinx inventory 'http://flask.pocoo.org/docs/1.0/objects.inv' not fetchable due to <class 'requests.exceptions.ConnectionError'>: HTTPConnectionPool(host='flask.pocoo.org', port=80): Max retries exceeded with url: /docs/1.0/objects.inv (Caused by NewConnectionError('<urllib3.connection.HTTPConnection object at 0x7ffff4f224d0>: Failed to establish a new connection: [Errno -3] Temporary failure in name resolution'))
WARNING: failed to reach any of the inventories with the following issues:
intersphinx inventory 'https://docs.djangoproject.com/en/2.1/_objects/' not fetchable due to <class 'requests.exceptions.ConnectionError'>: HTTPSConnectionPool(host='docs.djangoproject.com', port=443): Max retries exceeded with url: /en/2.1/_objects/ (Caused by NewConnectionError('<urllib3.connection.HTTPSConnection object at 0x7ffff50cff40>: Failed to establish a new connection: [Errno -3] Temporary failure in name resolution'))
locale_dir /build/source/docs/source/locales/en/LC_MESSAGES does not exists
building [mo]: targets for 0 po files that are out of date
building [html]: targets for 10 source files that are out of date
updating environment: locale_dir /build/source/docs/source/locales/en/LC_MESSAGES does not exists
[new config] 10 added, 0 changed, 0 removed
reading sources... [ 10%] api
reading sources... [ 20%] changelog
reading sources... [ 30%] contributing
reading sources... [ 40%] index
reading sources... [ 50%] installation
reading sources... [ 60%] introduction
reading sources... [ 70%] license
reading sources... [ 80%] sphinx_deco
reading sources... [ 90%] tutorial
reading sources... [100%] white_paper

looking for now-outdated files... none found
pickling environment... done
checking consistency... done
preparing documents... done
writing output... [ 10%] api
writing output... [ 20%] changelog
writing output... [ 30%] contributing
writing output... [ 40%] index
writing output... [ 50%] installation
writing output... [ 60%] introduction
writing output... [ 70%] license
writing output... [ 80%] sphinx_deco
writing output... [ 90%] tutorial
writing output... [100%] white_paper

generating indices... genindex py-modindex done
writing additional pages... search done
copying images... [100%] _static/banner.png

copying static files... done
copying extra files... done
dumping search index in English (code: en)... done
dumping object inventory... done
build succeeded, 5 warnings.

The HTML pages are in .sphinx/html/html.
@nix { "action": "setPhase", "phase": "installSphinxPhase" }
installSphinxPhase
Executing installSphinxPhase
@nix { "action": "setPhase", "phase": "pytestCheckPhase" }
pytestCheckPhase
Executing pytestCheckPhase
============================= test session starts ==============================
platform linux -- Python 3.10.11, pytest-7.2.1, pluggy-1.0.0
rootdir: /build/source, configfile: setup.cfg
collecting ...
collected 159 items

tests/test.py ..                                                         [  1%]
tests/test_deprecated.py .........................................       [ 27%]
tests/test_deprecated_class.py .......                                   [ 31%]
tests/test_deprecated_metaclass.py ....                                  [ 33%]
tests/test_sphinx.py ................................................... [ 66%]
...............................                                          [ 85%]
tests/test_sphinx_adapter.py ............                                [ 93%]
tests/test_sphinx_class.py .......                                       [ 97%]
tests/test_sphinx_metaclass.py ....                                      [100%]

=============================== warnings summary ===============================
tests/test_deprecated_class.py::test_simple_class_deprecation_with_args
  /build/source/tests/test_deprecated_class.py:148: DeprecationWarning: Call to deprecated class MyClass. (kwargs class)
    MyClass(5)

tests/test_sphinx_class.py::test_isinstance_deprecated
  /build/source/tests/test_sphinx_class.py:134: DeprecationWarning: Call to deprecated class DeprecatedChildCls. (some reason) -- Deprecated since version Y.Z.
    instance = DeprecatedChildCls()

tests/test_sphinx_class.py::test_isinstance_deprecated
  /build/source/deprecated/classic.py:173: DeprecationWarning: Call to deprecated class DeprecatedCls. (some reason) -- Deprecated since version X.Y.
    return old_new1(cls, *args, **kwargs)

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
======================= 159 passed, 3 warnings in 0.37s ========================
Finished executing pytestCheckPhase
@nix { "action": "setPhase", "phase": "pytestcachePhase" }
pytestcachePhase
@nix { "action": "setPhase", "phase": "pytestRemoveBytecodePhase" }
pytestRemoveBytecodePhase
```

</details>
