### PR TITLE
infamousPlugins: fix build on glibc-2.36

### DIFF
--- a/pkgs/applications/audio/infamousPlugins/default.nix
+++ b/pkgs/applications/audio/infamousPlugins/default.nix
@@ -1,4 +1,19 @@
-{ lib, stdenv, fetchFromGitHub, fetchpatch, pkg-config, cairomm, cmake, lv2, libpthreadstubs, libXdmcp, libXft, ntk, pcre, fftwFloat, zita-resampler }:
+{ lib
+, stdenv
+, fetchFromGitHub
+, fetchpatch
+, pkg-config
+, cairomm
+, cmake
+, lv2
+, libpthreadstubs
+, libXdmcp
+, libXft
+, ntk
+, pcre
+, fftwFloat
+, zita-resampler
+}:
 
 stdenv.mkDerivation rec {
   pname = "infamousPlugins";
@@ -15,6 +30,13 @@ stdenv.mkDerivation rec {
     (fetchpatch {
       url = "https://github.com/ssj71/infamousPlugins/commit/06dd967b4736ea886dc1dc07f882cb1563961582.patch";
       sha256 = "08xwh6px13y1gykaw103nhvjms7vgbgkcm0avh9f5d2d7aadq0l2";
+    })
+
+    # glibx-2.36 upstream fix: https://github.com/ssj71/infamousPlugins/pull/52
+    (fetchpatch {
+      name = "glibc-2.36.patch";
+      url = "https://github.com/ssj71/infamousPlugins/commit/eb4fd9af25362fdd006549c471f4cf0427816dd5.patch";
+      hash = "sha256-kBB2meQYVoVSTHIG77M8Fmeve87JBIUjpWCP6oiOkKI=";
     })
   ];
   nativeBuildInputs = [ pkg-config cmake ];


### PR DESCRIPTION
Without the change build fails as:

    src/casynth/casynth_ui_main.cxx:47:27: error: 'time' was not declared in this scope
    and ((unsigned int) time (NULL));
                        ^~~~
    src/casynth/casynth_ui_main.cxx:9:1: note: 'time' is defined in header '<ctime>'; did you forget to '#include <ctime>'?
        8 | #include "casynth_ui.h"
      +++ |+#include <ctime>
        9 | #include "lv2/lv2plug.in/ns/extensions/ui/ui.h"

Full build log: https://hydra.nixos.org/log/dh6qh731kjkizpymf8qpbi33pwq7bg9v-infamousPlugins-0.3.0.drv

ZHF: #230712

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
