### PR TITLE
python3.pkgs.aiosql: init at 8.0

### DIFF
--- a/pkgs/development/python-modules/aiosql/default.nix
+++ b/pkgs/development/python-modules/aiosql/default.nix
@@ -1,0 +1,40 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, poetry-core
+, pytestCheckHook
+, sphinxHook
+, sphinx-rtd-theme
+}:
+
+buildPythonPackage rec {
+  pname = "aiosql";
+  version = "8.0";
+  outputs = [ "out" "doc" ];
+  format = "pyproject";
+
+  src = fetchFromGitHub {
+    owner = "nackjicholson";
+    repo = "aiosql";
+    rev = "refs/tags/${version}";
+    hash = "sha256-cE89w1CbDqlkryRr3yAdSxAtWzV1+O+n41ihTwYWelE=";
+  };
+
+  sphinxRoot = "docs/source";
+
+  nativeBuildInputs = [
+    pytestCheckHook
+    sphinxHook
+    poetry-core
+    sphinx-rtd-theme
+  ];
+
+  pythonImportsCheck = [ "aiosql" ];
+
+  meta = with lib; {
+    description = "Simple SQL in Python";
+    homepage = "https://nackjicholson.github.io/aiosql/";
+    license = with licenses; [ bsd2 ];
+    maintainers = with maintainers; [ kaction ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -328,6 +328,8 @@ self: super: with self; {
 
   aiosasl = callPackage ../development/python-modules/aiosasl { };
 
+  aiosql = callPackage ../development/python-modules/aiosql { };
+
   aiosenseme = callPackage ../development/python-modules/aiosenseme { };
 
   aiosenz = callPackage ../development/python-modules/aiosenz { };


### PR DESCRIPTION
# python3.pkgs.aiosql: init at 8.0

```
python3.pkgs.aiosql: init at 8.0
```

## Build info of packages affected directly
### python3.pkgs.aiosql

<details><summary>content of python3.pkgs.aiosql.dist</summary>

```
/nix/store/hfjpw05linnib7mgdcjq9fj14hniyvx6-python3.10-aiosql-8.0-dist
└── aiosql-8.0-py3-none-any.whl

0 directories, 1 file
```
</details>

<details><summary>content of python3.pkgs.aiosql.doc</summary>

```
/nix/store/x3lxk3j64q9f6hdbhkf24jvwmz3dpjpd-python3.10-aiosql-8.0-doc
└── share
    └── doc
        └── python3.10-aiosql-8.0
            └── html
                ├── _static
                │   ├── _sphinx_javascript_frameworks_compat.js
                │   ├── basic.css
                │   ├── css
                │   │   ├── badge_only.css
                │   │   ├── fonts
                │   │   │   ├── Roboto-Slab-Bold.woff
                │   │   │   ├── Roboto-Slab-Bold.woff2
                │   │   │   ├── Roboto-Slab-Regular.woff
                │   │   │   ├── Roboto-Slab-Regular.woff2
                │   │   │   ├── fontawesome-webfont.eot
                │   │   │   ├── fontawesome-webfont.svg
                │   │   │   ├── fontawesome-webfont.ttf
                │   │   │   ├── fontawesome-webfont.woff
                │   │   │   ├── fontawesome-webfont.woff2
                │   │   │   ├── lato-bold-italic.woff
                │   │   │   ├── lato-bold-italic.woff2
                │   │   │   ├── lato-bold.woff
                │   │   │   ├── lato-bold.woff2
                │   │   │   ├── lato-normal-italic.woff
                │   │   │   ├── lato-normal-italic.woff2
                │   │   │   ├── lato-normal.woff
                │   │   │   └── lato-normal.woff2
                │   │   └── theme.css
                │   ├── doctools.js
                │   ├── documentation_options.js
                │   ├── file.png
                │   ├── jquery-3.6.0.js
                │   ├── jquery.js
                │   ├── js
                │   │   ├── badge_only.js
                │   │   ├── html5shiv-printshiv.min.js
                │   │   ├── html5shiv.min.js
                │   │   └── theme.js
                │   ├── language_data.js
                │   ├── minus.png
                │   ├── plus.png
                │   ├── pygments.css
                │   ├── searchtools.js
                │   ├── sphinx_highlight.js
                │   ├── underscore-1.13.1.js
                │   └── underscore.js
                ├── advanced-topics.html
                ├── contributing.html
                ├── database-driver-adapters.html
                ├── defining-sql-queries.html
                ├── genindex.html
                ├── getting-started.html
                ├── index.html
                ├── objects.inv
                ├── search.html
                └── searchindex.js

8 directories, 48 files
```
</details>

<details><summary>content of python3.pkgs.aiosql.out</summary>

```
/nix/store/kwnqajfrkb5x3l1mnk5xg5xivcn7lgh7-python3.10-aiosql-8.0
├── lib
│   └── python3.10
│       └── site-packages
│           ├── aiosql
│           │   ├── __init__.py
│           │   ├── __pycache__
│           │   │   ├── __init__.cpython-310.pyc
│           │   │   ├── aiosql.cpython-310.pyc
│           │   │   ├── queries.cpython-310.pyc
│           │   │   ├── query_loader.cpython-310.pyc
│           │   │   ├── types.cpython-310.pyc
│           │   │   └── utils.cpython-310.pyc
│           │   ├── adapters
│           │   │   ├── __init__.py
│           │   │   ├── __pycache__
│           │   │   │   ├── __init__.cpython-310.pyc
│           │   │   │   ├── aiosqlite.cpython-310.pyc
│           │   │   │   ├── asyncpg.cpython-310.pyc
│           │   │   │   ├── generic.cpython-310.pyc
│           │   │   │   ├── mysql.cpython-310.pyc
│           │   │   │   ├── pg8000.cpython-310.pyc
│           │   │   │   ├── pyformat.cpython-310.pyc
│           │   │   │   └── sqlite3.cpython-310.pyc
│           │   │   ├── aiosqlite.py
│           │   │   ├── asyncpg.py
│           │   │   ├── generic.py
│           │   │   ├── mysql.py
│           │   │   ├── pg8000.py
│           │   │   ├── pyformat.py
│           │   │   └── sqlite3.py
│           │   ├── aiosql.py
│           │   ├── py.typed
│           │   ├── queries.py
│           │   ├── query_loader.py
│           │   ├── types.py
│           │   └── utils.py
│           └── aiosql-8.0.dist-info
│               ├── INSTALLER
│               ├── LICENSE
│               ├── METADATA
│               ├── RECORD
│               ├── REQUESTED
│               ├── WHEEL
│               └── direct_url.json
└── nix-support
    └── propagated-build-inputs

9 directories, 37 files
```
</details>

<details><summary>build log of python3.pkgs.aiosql</summary>

```
Sourcing python-remove-tests-dir-hook
Sourcing python-catch-conflicts-hook.sh
Sourcing python-remove-bin-bytecode-hook.sh
Sourcing pip-build-hook
Using pipBuildPhase
Using pipShellHook
Sourcing pip-install-hook
Using pipInstallPhase
Sourcing python-imports-check-hook.sh
Using pythonImportsCheckPhase
Sourcing python-namespaces-hook
Sourcing python-catch-conflicts-hook.sh
Sourcing pytest-check-hook
Using pytestCheckPhase
Sourcing sphinx-hook
@nix { "action": "setPhase", "phase": "unpackPhase" }
unpacking sources
unpacking source archive /nix/store/8v9iw9b4xgv72dqpwacq0bsdvyvh6w25-source
source root is source
setting SOURCE_DATE_EPOCH to timestamp 315619200 of file source/tests/wait.py
@nix { "action": "setPhase", "phase": "patchPhase" }
patching sources
@nix { "action": "setPhase", "phase": "configurePhase" }
configuring
no configure script, doing nothing
@nix { "action": "setPhase", "phase": "buildPhase" }
building
Executing pipBuildPhase
Creating a wheel...
WARNING: The directory '/homeless-shelter/.cache/pip' or its parent directory is not owned or is not writable by the current user. The cache has been disabled. Check the permissions and owner of that directory. If executing pip with sudo, you should use sudo's -H flag.
Processing /build/source
  Running command Preparing metadata (pyproject.toml)
  Preparing metadata (pyproject.toml) ... done
Building wheels for collected packages: aiosql
  Running command Building wheel for aiosql (pyproject.toml)
  Building wheel for aiosql (pyproject.toml) ... done
  Created wheel for aiosql: filename=aiosql-8.0-py3-none-any.whl size=19245 sha256=eb869e703f178fe26e3dcc743e98a72f83b423a4712504e546e886d76521097f
  Stored in directory: /build/pip-ephem-wheel-cache-d_kfrd5_/wheels/79/4b/9b/fc24941d75fdb959a71ee80195b2c89d6ae9389f9f0f80fb22
Successfully built aiosql
Finished creating a wheel...
Finished executing pipBuildPhase
@nix { "action": "setPhase", "phase": "installPhase" }
installing
Executing pipInstallPhase
/build/source/dist /build/source
Processing ./aiosql-8.0-py3-none-any.whl
Requirement already satisfied: setuptools in /nix/store/grmg5nql6x31n8vfiqcka7cp081p324x-python3.10-setuptools-67.4.0/lib/python3.10/site-packages (from aiosql==8.0) (67.4.0.post0)
Installing collected packages: aiosql
Successfully installed aiosql-8.0
/build/source
Finished executing pipInstallPhase
@nix { "action": "setPhase", "phase": "pythonOutputDistPhase" }
pythonOutputDistPhase
Executing pythonOutputDistPhase
Finished executing pythonOutputDistPhase
@nix { "action": "setPhase", "phase": "fixupPhase" }
post-installation fixup
shrinking RPATHs of ELF executables and libraries in /nix/store/kwnqajfrkb5x3l1mnk5xg5xivcn7lgh7-python3.10-aiosql-8.0
checking for references to /build/ in /nix/store/kwnqajfrkb5x3l1mnk5xg5xivcn7lgh7-python3.10-aiosql-8.0...
patching script interpreter paths in /nix/store/kwnqajfrkb5x3l1mnk5xg5xivcn7lgh7-python3.10-aiosql-8.0
stripping (with command strip and flags -S -p) in  /nix/store/kwnqajfrkb5x3l1mnk5xg5xivcn7lgh7-python3.10-aiosql-8.0/lib
shrinking RPATHs of ELF executables and libraries in /nix/store/hfjpw05linnib7mgdcjq9fj14hniyvx6-python3.10-aiosql-8.0-dist
checking for references to /build/ in /nix/store/hfjpw05linnib7mgdcjq9fj14hniyvx6-python3.10-aiosql-8.0-dist...
patching script interpreter paths in /nix/store/hfjpw05linnib7mgdcjq9fj14hniyvx6-python3.10-aiosql-8.0-dist
Executing pythonRemoveTestsDir
Finished executing pythonRemoveTestsDir
@nix { "action": "setPhase", "phase": "installCheckPhase" }
running install tests
no Makefile or custom installCheckPhase, doing nothing
@nix { "action": "setPhase", "phase": "pythonCatchConflictsPhase" }
pythonCatchConflictsPhase
@nix { "action": "setPhase", "phase": "pythonRemoveBinBytecodePhase" }
pythonRemoveBinBytecodePhase
@nix { "action": "setPhase", "phase": "pythonImportsCheckPhase" }
pythonImportsCheckPhase
Executing pythonImportsCheckPhase
Check whether the following modules can be imported: aiosql
@nix { "action": "setPhase", "phase": "pytestCheckPhase" }
pytestCheckPhase
Executing pytestCheckPhase
============================= test session starts ==============================
platform linux -- Python 3.10.11, pytest-7.2.1, pluggy-1.0.0
rootdir: /build/source
collecting ... 
collected 32 items / 11 skipped                                                

tests/test_loading.py ..............                                     [ 43%]
tests/test_patterns.py .....                                             [ 59%]
tests/test_sqlite3.py .............                                      [100%]

=============================== warnings summary ===============================
tests/test_loading.py:14
  /build/source/tests/test_loading.py:14: PytestUnknownMarkWarning: Unknown pytest.mark.misc - is this a typo?  You can register custom marks to avoid this warning - for details, see https://docs.pytest.org/en/stable/how-to/mark.html
    pytest.mark.misc,

tests/test_patterns.py:6
  /build/source/tests/test_patterns.py:6: PytestUnknownMarkWarning: Unknown pytest.mark.misc - is this a typo?  You can register custom marks to avoid this warning - for details, see https://docs.pytest.org/en/stable/how-to/mark.html
    pytest.mark.misc,

tests/test_sqlite3.py:6
  /build/source/tests/test_sqlite3.py:6: PytestUnknownMarkWarning: Unknown pytest.mark.sqlite3 - is this a typo?  You can register custom marks to avoid this warning - for details, see https://docs.pytest.org/en/stable/how-to/mark.html
    pytestmark = [pytest.mark.sqlite3]

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
================== 32 passed, 11 skipped, 3 warnings in 0.39s ==================
Finished executing pytestCheckPhase
@nix { "action": "setPhase", "phase": "pytestcachePhase" }
pytestcachePhase
@nix { "action": "setPhase", "phase": "pytestRemoveBytecodePhase" }
pytestRemoveBytecodePhase
@nix { "action": "setPhase", "phase": "buildSphinxPhase" }
buildSphinxPhase
Executing buildSphinxPhase
Executing sphinx-build with html builder
Running Sphinx v5.3.0
making output directory... done
WARNING: html_static_path entry '_static' does not exist
locale_dir /build/source/docs/source/locales/en/LC_MESSAGES does not exists
locale_dir /build/source/docs/source/locales/en/LC_MESSAGES does not exists
building [mo]: targets for 0 po files that are out of date
building [html]: targets for 6 source files that are out of date
updating environment: locale_dir /build/source/docs/source/locales/en/LC_MESSAGES does not exists
[new config] 6 added, 0 changed, 0 removed
reading sources... [ 16%] advanced-topics
reading sources... [ 33%] contributing
reading sources... [ 50%] database-driver-adapters
reading sources... [ 66%] defining-sql-queries
reading sources... [ 83%] getting-started
reading sources... [100%] index

/build/source/docs/source/index.rst:232: WARNING: toctree contains reference to nonexisting document 'pydoc/modules'
looking for now-outdated files... none found
pickling environment... done
checking consistency... done
preparing documents... done
writing output... [ 16%] advanced-topics
writing output... [ 33%] contributing
writing output... [ 50%] database-driver-adapters
writing output... [ 66%] defining-sql-queries
writing output... [ 83%] getting-started
writing output... [100%] index

/build/source/docs/source/defining-sql-queries.rst:35: WARNING: Pygments lexer name 'ipython' is not known
/build/source/docs/source/getting-started.rst:156: WARNING: undefined label: 'subdirectories'
/build/source/docs/source/getting-started.rst:204: WARNING: undefined label: 'leveraging-driver-specific-features'
/build/source/docs/source/getting-started.rst:210: WARNING: Pygments lexer name 'ipython' is not known
generating indices... genindex done
writing additional pages... search done
copying static files... done
copying extra files... done
dumping search index in English (code: en)... done
dumping object inventory... done
build succeeded, 6 warnings.

The HTML pages are in .sphinx/html/html.
@nix { "action": "setPhase", "phase": "installSphinxPhase" }
installSphinxPhase
Executing installSphinxPhase
```
</details>
