### PR TITLE
python3Packages.qcodes: init at 0.38.1 and added dependencies

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -4928,6 +4928,12 @@
     githubId = 2512008;
     name = "Even Brenden";
   };
+  evilmav = {
+    email = "elenskiy.ilya@gmail.com";
+    github = "evilmav";
+    githubId = 6803717;
+    name = "Ilya Elenskiy";
+  };
   evils = {
     email = "evils.devils@protonmail.com";
     matrix = "@evils:nixos.dev";

--- a/pkgs/development/python-modules/broadbean/default.nix
+++ b/pkgs/development/python-modules/broadbean/default.nix
@@ -1,0 +1,47 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, pythonOlder
+, setuptools
+, versioningit
+, numpy
+, matplotlib
+, schema
+, hypothesis
+, pytestCheckHook
+}:
+
+buildPythonPackage rec {
+  pname = "broadbean";
+  version = "0.11.0";
+  format = "pyproject";
+
+  disabled = pythonOlder "3.7";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "sha256-e+LAcmWxT+SkaWtToPgg+x3QRu5fCSm+w4dLCcyZrw8=";
+  };
+
+  nativeBuildInputs = [ setuptools versioningit ];
+
+  propagatedBuildInputs = [
+    numpy
+    matplotlib
+    schema
+  ];
+
+  nativeCheckInputs = [
+    hypothesis
+    pytestCheckHook
+  ];
+
+  pythonImportsCheck = [ "broadbean" ];
+
+  meta = {
+    homepage = "https://qcodes.github.io/broadbean";
+    description = "A library for making pulses that can be leveraged with QCoDeS";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ evilmav ];
+  };
+}

--- a/pkgs/development/python-modules/hickle/default.nix
+++ b/pkgs/development/python-modules/hickle/default.nix
@@ -12,8 +12,10 @@
 }:
 
 buildPythonPackage rec {
-  pname   = "hickle";
+  pname = "hickle";
   version = "5.0.2";
+  format = "setuptools";
+
   disabled = pythonOlder "3.5";
 
   src = fetchPypi {
@@ -28,10 +30,22 @@ buildPythonPackage rec {
   propagatedBuildInputs = [ h5py numpy dill ];
 
   nativeCheckInputs = [
-    pytestCheckHook scipy pandas astropy
+    pytestCheckHook
+    scipy
+    pandas
+    astropy
   ];
 
   pythonImportsCheck = [ "hickle" ];
+
+  disabledTests = [
+    # broken in 5.0.2 with recent NumPy
+    # see https://github.com/telegraphic/hickle/issues/174
+    "test_scalar_compression"
+    # broken in 5.0.2 with python 3.11
+    # see https://github.com/telegraphic/hickle/issues/169
+    "test_H5NodeFilterProxy"
+  ];
 
   meta = {
     description = "Serialize Python data to HDF5";

--- a/pkgs/development/python-modules/opencensus-ext-azure/default.nix
+++ b/pkgs/development/python-modules/opencensus-ext-azure/default.nix
@@ -1,0 +1,42 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, pythonOlder
+, azure-core
+, azure-identity
+, opencensus
+, psutil
+, requests
+}:
+
+buildPythonPackage rec {
+  pname = "opencensus-ext-azure";
+  version = "1.1.9";
+  format = "setuptools";
+
+  disabled = pythonOlder "3.4";
+
+  src = fetchPypi {
+    inherit pname version;
+    hash = "sha256-UHYIt36djqq2/9X/EbfOuH9U5KapQMS4FDMbTRsDQVE=";
+  };
+
+  propagatedBuildInputs = [
+    azure-core
+    azure-identity
+    opencensus
+    psutil
+    requests
+  ];
+
+  pythonImportsCheck = [ "opencensus.ext.azure" ];
+
+  doCheck = false; # tests are not included in the PyPi tarball
+
+  meta = with lib; {
+    homepage = "https://github.com/census-instrumentation/opencensus-python/tree/master/contrib/opencensus-ext-azure";
+    description = "OpenCensus Azure Monitor Exporter";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ billhuang evilmav ];
+  };
+}

--- a/pkgs/development/python-modules/pyvisa-sim/default.nix
+++ b/pkgs/development/python-modules/pyvisa-sim/default.nix
@@ -1,0 +1,49 @@
+{ lib
+, fetchPypi
+, pythonOlder
+, buildPythonPackage
+, pyvisa
+, pyyaml
+, stringparser
+, typing-extensions
+, pytestCheckHook
+}:
+
+buildPythonPackage rec {
+  pname = "pyvisa-sim";
+  version = "0.5.1";
+  format = "pyproject";
+
+  disabled = pythonOlder "3.8";
+
+  src = fetchPypi {
+    pname = "PyVISA-sim";
+    inherit version;
+    sha256 = "sha256-vWxW941/1e58pqL/Rzq+eoZJpwsvLphgIe48SuJtohY=";
+  };
+
+  propagatedBuildInputs = [
+    pyvisa
+    pyyaml
+    stringparser
+    typing-extensions
+  ];
+
+  nativeCheckInputs = [
+    pytestCheckHook
+  ];
+
+  pythonImportsCheck = [ "pyvisa_sim" ];
+
+  # should be fixed after 0.5.1, remove at next release
+  disabledTestPaths = [
+    "pyvisa_sim/testsuite/test_all.py"
+  ];
+
+  meta = with lib; {
+    description = "Simulated backend for PyVISA implementing TCPIP, GPIB, RS232, and USB resources";
+    homepage = "https://pyvisa.readthedocs.io/projects/pyvisa-sim/en/latest/";
+    license = licenses.mit;
+    maintainers = with maintainers; [ evilmav ];
+  };
+}

--- a/pkgs/development/python-modules/qcodes-contrib-drivers/default.nix
+++ b/pkgs/development/python-modules/qcodes-contrib-drivers/default.nix
@@ -1,0 +1,58 @@
+{ lib
+, fetchFromGitHub
+, pythonOlder
+, buildPythonPackage
+, setuptools
+, versioningit
+, qcodes
+, packaging
+, pytestCheckHook
+, pytest-mock
+, pyvisa-sim
+}:
+
+buildPythonPackage rec {
+  pname = "qcodes-contrib-drivers";
+  version = "0.18.0";
+
+  disabled = pythonOlder "3.8";
+  format = "pyproject";
+
+  src = fetchFromGitHub {
+    owner = "QCoDeS";
+    repo = "Qcodes_contrib_drivers";
+    rev = "v${version}";
+    sha256 = "sha256-hg3jSiuOkiuOInnUzzlKtBeoP5zkCDBQ3xP6KCwq+lU=";
+  };
+
+  nativeBuildInputs = [ setuptools versioningit ];
+
+  propagatedBuildInputs = [
+    qcodes
+    packaging
+  ];
+
+  nativeCheckInputs = [
+    pytestCheckHook
+    pytest-mock
+    pyvisa-sim
+  ];
+
+  pythonImportsCheck = [ "qcodes_contrib_drivers" ];
+
+  # should be fixed starting with 0.19.0, remove at next release
+  disabledTestPaths = [
+    "qcodes_contrib_drivers/tests/test_Keysight_M3201A.py"
+  ];
+
+  postInstall = ''
+    export HOME="$TMPDIR"
+  '';
+
+  meta = with lib; {
+    description = "User contributed drivers for QCoDeS";
+    homepage = "https://github.com/QCoDeS/Qcodes_contrib_drivers";
+    license = licenses.mit;
+    maintainers = with maintainers; [ evilmav ];
+  };
+}

--- a/pkgs/development/python-modules/qcodes-loop/default.nix
+++ b/pkgs/development/python-modules/qcodes-loop/default.nix
@@ -1,0 +1,87 @@
+{ lib
+, fetchPypi
+, pythonOlder
+, buildPythonPackage
+, qcodes
+, h5py
+, lazy-loader
+, matplotlib
+, numpy
+, pandas
+, versioningit
+, xarray
+, hickle
+, ipython
+, slack-sdk
+, hypothesis
+, pytest-xdist
+, pytest-mock
+, pyqtgraph
+, pyqt5
+, pytestCheckHook
+}:
+
+buildPythonPackage rec {
+  pname = "qcodes-loop";
+  version = "0.1.1";
+
+  disabled = pythonOlder "3.8";
+  format = "pyproject";
+
+  src = fetchPypi {
+    inherit version;
+    pname = "qcodes_loop";
+    sha256 = "sha256-pDR0Ws8cYQifftdE9dKcSzMxmouFo4tJmQvNanm6zyM=";
+  };
+
+  nativeBuildInputs = [
+    versioningit
+  ];
+
+  propagatedBuildInputs = [
+    qcodes
+    h5py
+    lazy-loader
+    matplotlib
+    numpy
+    pandas
+    xarray
+    hickle
+    ipython
+  ];
+
+  passthru.optional-dependencies = {
+    qtplot = [
+      pyqtgraph
+    ];
+    slack = [
+      slack-sdk
+    ];
+  };
+
+  nativeCheckInputs = [
+    pytestCheckHook
+    hypothesis
+    pytest-xdist
+    pytest-mock
+    pyqt5
+  ];
+
+  pythonImportsCheck = [ "qcodes_loop" ];
+
+  disabledTestPaths = [
+    # test broken in 0.1.1, see https://github.com/QCoDeS/Qcodes_loop/pull/25
+    "src/qcodes_loop/tests/test_hdf5formatter.py"
+  ];
+
+  postInstall = ''
+    export HOME="$TMPDIR"
+  '';
+
+  meta = with lib; {
+    description = "Features previously in QCoDeS";
+    homepage = "https://github.com/QCoDeS/Qcodes_loop";
+    license = licenses.mit;
+    maintainers = with maintainers; [ evilmav ];
+  };
+}

--- a/pkgs/development/python-modules/qcodes/default.nix
+++ b/pkgs/development/python-modules/qcodes/default.nix
@@ -1,0 +1,133 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, pythonOlder
+, setuptools
+, versioningit
+
+  # mandatory
+, broadbean
+, h5netcdf
+, h5py
+, importlib-metadata
+, importlib-resources
+, ipywidgets
+, ipykernel
+, jsonschema
+, matplotlib
+, numpy
+, opencensus
+, opencensus-ext-azure
+, packaging
+, pandas
+, pyvisa
+, ruamel-yaml
+, tabulate
+, typing-extensions
+, tqdm
+, uncertainties
+, websockets
+, wrapt
+, xarray
+, ipython
+, pillow
+, rsa
+
+  # optional
+, qcodes-loop
+
+  # test
+, pytestCheckHook
+, deepdiff
+, hypothesis
+, lxml
+, pytest-asyncio
+, pytest-mock
+, pytest-rerunfailures
+, pytest-xdist
+, pyvisa-sim
+, sphinx
+}:
+
+buildPythonPackage rec {
+  pname = "qcodes";
+  version = "0.38.1";
+
+  disabled = pythonOlder "3.8";
+  format = "pyproject";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "sha256-whUGkRvYQOdYxWoj7qhv2kiiyTwq3ZLLipI424PBzFg=";
+  };
+
+  nativeBuildInputs = [ setuptools versioningit ];
+
+  propagatedBuildInputs = [
+    broadbean
+    h5netcdf
+    h5py
+    ipywidgets
+    ipykernel
+    jsonschema
+    matplotlib
+    numpy
+    opencensus
+    opencensus-ext-azure
+    packaging
+    pandas
+    pyvisa
+    ruamel-yaml
+    tabulate
+    typing-extensions
+    tqdm
+    uncertainties
+    websockets
+    wrapt
+    xarray
+    ipython
+    pillow
+    rsa
+  ] ++ lib.optionals (pythonOlder "3.10") [
+    importlib-metadata
+  ] ++ lib.optionals (pythonOlder "3.9") [
+    importlib-resources
+  ];
+
+  passthru.optional-dependencies = {
+    loop = [
+      qcodes-loop
+    ];
+  };
+
+  nativeCheckInputs = [
+    pytestCheckHook
+    deepdiff
+    hypothesis
+    lxml
+    pytest-asyncio
+    pytest-mock
+    pytest-rerunfailures
+    pytest-xdist
+    pyvisa-sim
+    sphinx
+  ];
+
+  disabledTestPaths = [
+    # depends on qcodes-loop, causing a cyclic dependency
+    "qcodes/tests/dataset/measurement/test_load_legacy_data.py"
+  ];
+
+  pythonImportsCheck = [ "qcodes" ];
+
+  postInstall = ''
+    export HOME="$TMPDIR"
+  '';
+
+  meta = {
+    homepage = "https://qcodes.github.io/Qcodes/";
+    description = "Python-based data acquisition framework";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ evilmav ];
+  };
+}

--- a/pkgs/development/python-modules/stringparser/default.nix
+++ b/pkgs/development/python-modules/stringparser/default.nix
@@ -1,0 +1,36 @@
+{ lib
+, buildPythonPackage
+, pythonOlder
+, fetchFromGitHub
+, setuptools
+, setuptools-scm
+, pytestCheckHook
+}:
+
+buildPythonPackage rec {
+  pname = "stringparser";
+  version = "0.6";
+  format = "setuptools";
+
+  disabled = pythonOlder "3.5";
+
+  src = fetchFromGitHub {
+    owner = "hgrecco";
+    repo = pname;
+    rev = version;
+    sha256 = "sha256-uyeHuH0UfpZqh7sMRI6+fR/Rr2jSzdR+5O/MtzslO5w=";
+  };
+
+  nativeBuildInputs = [ setuptools setuptools-scm ];
+
+  pythonImportsCheck = [ "stringparser" ];
+
+  nativeCheckInputs = [ pytestCheckHook ];
+
+  meta = with lib; {
+    description = "Easy to use pattern matching and information extraction";
+    homepage = "https://github.com/hgrecco/stringparser";
+    license = licenses.bsd3;
+    maintainers = with maintainers; [ evilmav ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1485,6 +1485,8 @@ self: super: with self; {
 
   brian2 = callPackage ../development/python-modules/brian2 { };
 
+  broadbean = callPackage ../development/python-modules/broadbean { };
+
   broadlink = callPackage ../development/python-modules/broadlink { };
 
   brother = callPackage ../development/python-modules/brother { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -7036,6 +7036,8 @@ self: super: with self; {
 
   opencensus-context = callPackage ../development/python-modules/opencensus-context { };
 
+  opencensus-ext-azure = callPackage ../development/python-modules/opencensus-ext-azure { };
+
   opencontainers = callPackage ../development/python-modules/opencontainers { };
 
   opencv3 = toPythonModule (pkgs.opencv3.override {

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -10206,6 +10206,8 @@ self: super: with self; {
 
   qcodes = callPackage ../development/python-modules/qcodes { };
 
+  qcodes-contrib-drivers = callPackage ../development/python-modules/qcodes-contrib-drivers { };
+
   qcodes-loop = callPackage ../development/python-modules/qcodes-loop { };
 
   qcs-api-client = callPackage ../development/python-modules/qcs-api-client { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -10204,6 +10204,10 @@ self: super: with self; {
 
   qcengine = callPackage ../development/python-modules/qcengine { };
 
+  qcodes = callPackage ../development/python-modules/qcodes { };
+
+  qcodes-loop = callPackage ../development/python-modules/qcodes-loop { };
+
   qcs-api-client = callPackage ../development/python-modules/qcs-api-client { };
 
   qdarkstyle = callPackage ../development/python-modules/qdarkstyle { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -10110,6 +10110,8 @@ self: super: with self; {
 
   pyvisa-py = callPackage ../development/python-modules/pyvisa-py { };
 
+  pyvisa-sim = callPackage ../development/python-modules/pyvisa-sim { };
+
   pyvista = callPackage ../development/python-modules/pyvista { };
 
   pyviz-comms = callPackage ../development/python-modules/pyviz-comms { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -11681,6 +11681,8 @@ self: super: with self; {
 
   stringly = callPackage ../development/python-modules/stringly { };
 
+  stringparser = callPackage ../development/python-modules/stringparser { };
+
   stripe = callPackage ../development/python-modules/stripe { };
 
   striprtf = callPackage ../development/python-modules/striprtf { };


### PR DESCRIPTION
###### Description of changes

[QcoDeS](https://qcodes.github.io/Qcodes/) is a Python-based data acquisition framework developed by the Copenhagen / Delft / Sydney / Microsoft quantum computing consortium. 

The framework depends on some packages not previously in `nixpkgs`, as well as being extended by `qcodes-loop` and `qcodes-contrib-drivers`. `zhinst-qcodes` would have been nice, but I am yet to find out how to package `zhinst-core` properly and therefore will leave it to a later PR. The missing packages have been added as individual commits in an order that should allow for building after each of these. Furthermore, `hickle` checkPhase issue has been fixed as it was failing the dependencies of the new packages. 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
