### PR TITLE
electron-fiddle: 0.32.1 → 0.32.6

### DIFF
--- a/pkgs/development/tools/electron-fiddle/default.nix
+++ b/pkgs/development/tools/electron-fiddle/default.nix
@@ -1,12 +1,13 @@
 { buildFHSEnv
-, electron_22
+, electron_24
 , fetchFromGitHub
 , fetchYarnDeps
+, fetchurl
 , fixup_yarn_lock
 , git
 , lib
 , makeDesktopItem
-, nodejs_16
+, nodejs_18
 , stdenvNoCC
 , util-linux
 , zip
@@ -14,21 +15,29 @@
 
 let
   pname = "electron-fiddle";
-  version = "0.32.1";
-  electron = electron_22;
-  nodejs = nodejs_16;
+  version = "0.32.6";
+  electron = electron_24;
+  nodejs = nodejs_18;
 
   src = fetchFromGitHub {
     owner = "electron";
     repo = "fiddle";
     rev = "v${version}";
-    hash = "sha256-k+cbg03mwvobyazIUqm+TO9OMYVFQICy4CtkUZmvkr8=";
+    hash = "sha256-Iuss2xwts1aWy2rKYG7J2EvFdH8Bbedn/uZG2bi9UHw=";
+  };
+
+  # As of https://github.com/electron/fiddle/pull/1316 this is fetched
+  # from the network and has no stable hash.  Grab an old version from
+  # the repository.
+  releasesJson = fetchurl {
+    url = "https://raw.githubusercontent.com/electron/fiddle/v0.32.4~18/static/releases.json";
+    hash = "sha256-1sxd3eJ6/WjXS6XQbrgKUTNUmrhuc1dAvy+VAivGErg=";
   };
 
   inherit (nodejs.pkgs) yarn;
   offlineCache = fetchYarnDeps {
     yarnLock = "${src}/yarn.lock";
-    hash = "sha256-3vM+YPIA3zeWBaEFXU5lFl+VaGmAY0Qdg4pSA6mIKl0=";
+    hash = "sha256-dwhwUWwv6RYKEMdhRBvKVXvM8n1r+Qo0D3/uFsWIOpw=";
   };
 
   electronDummyMirror = "https://electron.invalid/";
@@ -55,6 +64,8 @@ let
       cp -ra '${electron}/lib/electron' "$TMPDIR/electron"
       chmod -R u+w "$TMPDIR/electron"
       (cd "$TMPDIR/electron" && zip -0Xr ~/.cache/electron/${electronDummyHash}/${electronDummyFilename} .)
+
+      ln -s ${releasesJson} static/releases.json
     '';
 
     buildPhase = ''


### PR DESCRIPTION
###### Description of changes

Upgrade Electron Fiddle from 0.32.1 to 0.32.6.

https://github.com/electron/fiddle/releases/tag/v0.32.6
https://github.com/electron/fiddle/compare/v0.32.1...v0.32.6

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
