### PR TITLE
minissdpd: fix build

### DIFF
--- a/pkgs/tools/networking/minissdpd/default.nix
+++ b/pkgs/tools/networking/minissdpd/default.nix
@@ -10,6 +10,10 @@ stdenv.mkDerivation rec {
     name = "${pname}-${version}.tar.gz";
   };
 
+  patches = [
+    ./makefile-install-dir.patch
+  ];
+
   buildInputs = [ libnfnetlink ];
 
   installFlags = [ "PREFIX=$(out)" "INSTALLPREFIX=$(out)" ];

--- a/pkgs/tools/networking/minissdpd/makefile-install-dir.patch
+++ b/pkgs/tools/networking/minissdpd/makefile-install-dir.patch
@@ -1,0 +1,15 @@
+diff --git a/Makefile b/Makefile
+index b14e2fa..4472598 100644
+--- a/Makefile
++++ b/Makefile
+@@ -74,8 +74,8 @@ install:	minissdpd
+ 	$(INSTALL) -d $(DESTDIR)$(MANINSTALLDIR)/man1
+ 	$(INSTALL) minissdpd.1 $(DESTDIR)$(MANINSTALLDIR)/man1/minissdpd.1
+ ifeq (, $(findstring darwin, $(OS)))
+-	$(INSTALL) -d $(DESTDIR)/etc/init.d
+-	$(INSTALL) minissdpd.init.d.script $(DESTDIR)/etc/init.d/minissdpd
++	$(INSTALL) -d $(DESTDIR)$(INSTALLPREFIX)/etc/init.d
++	$(INSTALL) minissdpd.init.d.script $(DESTDIR)$(INSTALLPREFIX)/etc/init.d/minissdpd
+ endif
+ 
+ check:	validateminissdpd validatecodelength


### PR DESCRIPTION
###### Description of changes
Adjusted make variable values to get the desired directory layout, as the makefile was attempting to install files to `/etc`

ZHF: #230712

Result of `nixpkgs-review` run on x86_64-linux [1](https://github.com/Mic92/nixpkgs-review)
<details>
  <summary>1 package built:</summary>
  <ul>
    <li>minissdpd</li>
  </ul>
</details>

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
