### PR TITLE
gmime3: 3.2.12 -> 3.2.13

### DIFF
--- a/pkgs/development/libraries/gmime/3.nix
+++ b/pkgs/development/libraries/gmime/3.nix
@@ -1,14 +1,37 @@
-{ lib, stdenv, fetchurl, pkg-config, glib, zlib, gnupg, gpgme, libidn2, libunistring, gobject-introspection
-, vala }:
+{ lib
+, stdenv
+, fetchurl
+, fetchpatch
+, pkg-config
+, glib
+, zlib
+, gnupg
+, gpgme
+, libidn2
+, libunistring
+, gobject-introspection
+, vala
+}:
 
 stdenv.mkDerivation rec {
-  version = "3.2.12";
+  version = "3.2.13";
   pname = "gmime";
 
-  src = fetchurl { # https://github.com/jstedfast/gmime/releases
+  src = fetchurl {
+    # https://github.com/jstedfast/gmime/releases
     url = "https://github.com/jstedfast/gmime/releases/download/${version}/gmime-${version}.tar.xz";
-    sha256 = "sha256-OPm3aBgjQsSExBIobbjVgRaX/4FiQ3wFea3w0G4icFs=";
+    hash = "sha256-LhClTUgh2vixbAGa1dVn4PuOdm+P/l/sPUxqNzc9ZAY=";
   };
+
+  # remove with version 3.2.14 or later
+  patches = [
+    # https://github.com/jstedfast/gmime/issues/133
+    (fetchpatch {
+      url = "https://github.com/jstedfast/gmime/commit/1a33a55baafc73b0a6d7f83cf4c30ad9e169669f.patch";
+      hash = "sha256-1sDVoXkNpT+UBBnQt66lCQqd+wk1asO8q29GFwJU1Cs=";
+      name = "fix_for_issue_133.patch";
+    })
+  ];
 
   outputs = [ "out" "dev" ];
 


### PR DESCRIPTION
###### Description of changes

Also include a fix for https://github.com/jstedfast/gmime/issues/133 that affects =mu=.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
