### PR TITLE
python3Packages.publicsuffix2: restore original version number

### DIFF
--- a/pkgs/development/python-modules/publicsuffix2/default.nix
+++ b/pkgs/development/python-modules/publicsuffix2/default.nix
@@ -4,6 +4,8 @@ let
 in
 buildPythonPackage {
   pname = "publicsuffix2";
+  # tags have dashes, while the library version does not
+  # see https://github.com/nexB/python-publicsuffix2/issues/12
   version = lib.replaceStrings ["-"] [""] tagVersion;
 
   src = fetchFromGitHub {

--- a/pkgs/development/python-modules/publicsuffix2/default.nix
+++ b/pkgs/development/python-modules/publicsuffix2/default.nix
@@ -1,13 +1,15 @@
 { lib, buildPythonPackage, fetchFromGitHub }:
-
-buildPythonPackage rec {
+let
+  tagVersion = "2.2019-12-21";
+in
+buildPythonPackage {
   pname = "publicsuffix2";
-  version = "2.2019-12-21";
+  version = lib.replaceStrings ["-"] [""] tagVersion;
 
   src = fetchFromGitHub {
     owner = "nexB";
     repo = "python-publicsuffix2";
-    rev = "release-${version}";
+    rev = "release-${tagVersion}";
     sha256 = "1dkvfvl0izq9hqzilnw8ipkbgjs9xyad9p21i3864hzinbh0wp9r";
   };
 


### PR DESCRIPTION
###### Description of changes

This is a pretty nit-picky thing to want to fix, but with the following justifications:
* The hyphenated date isn't valid as a component of Python versions, either per my reading of [PEP 440](https://peps.python.org/pep-0440/) or per the implementation in [`packaging.version`](https://github.com/pypa/packaging/blob/main/src/packaging/version.py)
* Consequently, the [PyPI version number](https://pypi.org/project/publicsuffix2/) doesn't use hyphens
* Nor do [most other Linux distributions](https://repology.org/project/python:publicsuffix2/versions)
* To the best of my ability to grep, in Nixpkgs no other Python library uses dates with hyphens in version strings

The version number format was changed in #165402, with what I assume is the goal of reducing duplication; this refinement should preserve that property while restoring the original version number.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
