### PR TITLE
open62541: 1.3.5 -> 1.3.6

### DIFF
--- a/pkgs/development/libraries/open62541/default.nix
+++ b/pkgs/development/libraries/open62541/default.nix
@@ -31,13 +31,13 @@ in
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "open62541";
-  version = "1.3.5";
+  version = "1.3.6";
 
   src = fetchFromGitHub {
     owner = "open62541";
     repo = "open62541";
     rev = "v${finalAttrs.version}";
-    sha256 = "sha256-X0kdMKSqKAJvmrd1YcYe1mJpFONqPCALA09xwd6o7BQ=";
+    hash = "sha256-cmD01D49pHEHN0QQtE5RXv0YZ/MPIWnubeUY6BH4DrU=";
     fetchSubmodules = true;
   };
 
@@ -90,10 +90,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   preCheck = let
     disabledTests =
-      lib.optionals (withEncryption == "mbedtls") [
-        "encryption_basic128rsa15"
-      ]
-      ++ lib.optionals withPubSub [
+      lib.optionals withPubSub [
         # "Cannot set socket option IP_ADD_MEMBERSHIP"
         "pubsub_publish"
         "check_pubsub_get_state"


### PR DESCRIPTION
###### Description of changes

https://github.com/open62541/open62541/releases/tag/v1.3.6

> The notable changes in this patch release are:
> 
>   * fix(server): Fix a memory-leak in the Browse service with BrowseNext
>   * fix(server): Transfer subscription - fix queued subscription notifications
>   * fix(arch): disable polling for Windows CE
>   * fix(plugin): Forward rng when calling mbedtls_pk_decrypt
>   * fix(build): Explicitly set encoding to UTF-8 when reading statuscodes csv file

For testing, I built it with `$ nix build -f ./ open62541 open62541.tests --no-link`.

Result of `nixpkgs-review` run on x86_64-linux [1](https://github.com/Mic92/nixpkgs-review)
<details>
  <summary>1 package built:</summary>
  <ul>
    <li>open62541</li>
  </ul>
</details>

###### Things done

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [X] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).