### PR TITLE
python311Packages.boto: add a patch to fix a test

### DIFF
--- a/pkgs/development/python-modules/boto/0005-Don-t-mock-list-subclass.patch
+++ b/pkgs/development/python-modules/boto/0005-Don-t-mock-list-subclass.patch
@@ -1,0 +1,21 @@
+From: Jochen Sprickerhof <jspricke@debian.org>
+Date: Thu, 15 Dec 2022 07:44:54 +0100
+Subject: Don't mock list subclass
+
+---
+ tests/unit/ec2/test_volume.py | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/tests/unit/ec2/test_volume.py b/tests/unit/ec2/test_volume.py
+index 81d7f55..d4d8e4f 100644
+--- a/tests/unit/ec2/test_volume.py
++++ b/tests/unit/ec2/test_volume.py
+@@ -55,7 +55,7 @@ class VolumeTests(unittest.TestCase):
+     @mock.patch("boto.resultset.ResultSet")
+     def test_startElement_with_name_tagSet_calls_ResultSet(self, ResultSet, startElement):
+         startElement.return_value = None
+-        result_set = mock.Mock(ResultSet([("item", Tag)]))
++        result_set = ResultSet([("item", Tag)])
+         volume = Volume()
+         volume.tags = result_set
+         retval = volume.startElement("tagSet", None, None)

--- a/pkgs/development/python-modules/boto/default.nix
+++ b/pkgs/development/python-modules/boto/default.nix
@@ -22,6 +22,9 @@ buildPythonPackage rec {
     # fixes hmac tests
     # https://sources.debian.org/src/python-boto/2.49.0-4/debian/patches/bug-953970_python3.8-compat.patch/
     ./bug-953970_python3.8-compat.patch
+    # fixes test_startElement_with_name_tagSet_calls_ResultSet
+    # https://sources.debian.org/src/python-boto/2.49.0-4.1/debian/patches/0005-Don-t-mock-list-subclass.patch/
+    ./0005-Don-t-mock-list-subclass.patch
   ];
 
   # boto is deprecated by upstream as of 2021-05-27 (https://github.com/boto/boto/commit/4980ac58764c3d401cb0b9552101f9c61c18f445)


### PR DESCRIPTION
###### Description of changes

Add 0005-Don-t-mock-list-subclass.patch Debian patch to fix a unit test

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
