### PR TITLE
gcc: fix cross build with different gcc version

### DIFF
--- a/pkgs/development/compilers/gcc/common/configure-flags.nix
+++ b/pkgs/development/compilers/gcc/common/configure-flags.nix
@@ -24,7 +24,7 @@
 , langObjC
 , langObjCpp
 , langJit
-, disableBootstrap ? stdenv.targetPlatform != stdenv.hostPlatform
+, disableBootstrap ? true
 }:
 
 assert !enablePlugin -> disableGdbPlugin;
@@ -45,7 +45,13 @@ let
     buildPlatform hostPlatform targetPlatform;
 
   # See https://github.com/NixOS/nixpkgs/pull/209870#issuecomment-1500550903
-  disableBootstrap' = disableBootstrap && !langFortran && !langGo;
+  disableBootstrap' = disableBootstrap
+     # Local libraries always have to be built with inplace gcc.
+     # Otherwise we risk using wrong gcc version that does not support
+     # required features.
+     && (stdenv.buildPlatform == stdenv.hostPlatform && stdenv.hostPlatform == stdenv.targetPlatform)
+     && !langFortran
+     && !langGo;
 
   crossMingw = targetPlatform != hostPlatform && targetPlatform.libc == "msvcrt";
   crossDarwin = targetPlatform != hostPlatform && targetPlatform.libc == "libSystem";


### PR DESCRIPTION
gcc: fix cross build with different gcc version

Without the change we pass --disable-bootstrap` and try to build runtime
libraries like `libgomp` or `libgcc` by non-local compiler for cases.

This causes build failures when host compiler does not support target's
required features added in target's gcc version. An example is:

  --host=x86_64 --{build,target}=aarch64:

    gcc-aarch64-unknown-linux-gnu> ../../../gcc-13.1.0/libgcc/soft-fp/brain.h:62:1: error: unable to emulate 'BF'
    gcc-aarch64-unknown-linux-gnu>    62 | typedef float BFtype __attribute__ ((mode (BF)));

The change flips back to more conservative setup: do not disable
bootstrap if it's not a native build. If we want to skip the bootstrap
here we will need to add precise compiler version checks in respective
toolchains.

This fixes an example build of aarch64-gcc-13 with x86_64-gcc-12.

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
