### PR TITLE
flutter: Move artifact installation logic to the wrapper

### DIFF
--- a/pkgs/development/compilers/flutter/default.nix
+++ b/pkgs/development/compilers/flutter/default.nix
@@ -34,15 +34,15 @@ let
         inherit wrapFlutter mkCustomFlutter mkFlutter;
         buildFlutterApplication = callPackage ../../../build-support/flutter {
           # Package a minimal version of Flutter that only uses Linux desktop release artifacts.
-          flutter = wrapFlutter
-            (mkCustomFlutter (args // {
-              includedEngineArtifacts = {
-                common = [ "flutter_patched_sdk_product" ];
-                platform.linux = lib.optionals stdenv.hostPlatform.isLinux
-                  (lib.genAttrs ((lib.optional stdenv.hostPlatform.isx86_64 "x64") ++ (lib.optional stdenv.hostPlatform.isAarch64 "arm64"))
-                    (architecture: [ "release" ]));
-              };
-            }));
+          flutter = (wrapFlutter (mkCustomFlutter args)).override {
+            supportsAndroid = false;
+            includedEngineArtifacts = {
+              common = [ "flutter_patched_sdk_product" ];
+              platform.linux = lib.optionals stdenv.hostPlatform.isLinux
+                (lib.genAttrs ((lib.optional stdenv.hostPlatform.isx86_64 "x64") ++ (lib.optional stdenv.hostPlatform.isAarch64 "arm64"))
+                  (architecture: [ "release" ]));
+            };
+          };
         };
       };
     });

--- a/pkgs/development/compilers/flutter/flutter.nix
+++ b/pkgs/development/compilers/flutter/flutter.nix
@@ -8,13 +8,7 @@
       "flutter_patched_sdk"
       "flutter_patched_sdk_product"
     ];
-    platform = {
-      android = lib.optionalAttrs stdenv.hostPlatform.isx86_64
-        ((lib.genAttrs [ "arm" "arm64" "x64" ] (architecture: [ "profile" "release" ])) // { x86 = [ "jit-release" ]; });
-      linux = lib.optionals stdenv.hostPlatform.isLinux
-        (lib.genAttrs ((lib.optional stdenv.hostPlatform.isx86_64 "x64") ++ (lib.optional stdenv.hostPlatform.isAarch64 "arm64"))
-          (architecture: [ "debug" "profile" "release" ]));
-    };
+    platform = { };
   }
 
 , lib


### PR DESCRIPTION
###### Description of changes

this PR moves the artifacts installation logic to the wrapper, rather than the unwrapped flutter.
This way users will be able to easily decide which parts of flutter they want to install, and `supportsLinuxDesktop` will not only be for dependencies, but also for artifacts.

Previously, to wrap flutter without android artifacts, you'd had to do this:
```nix
pkgs.flutterPackages.wrapFlutter (let
  inherit (pkgs) lib stdenv;
in
  pkgs.flutter-unwrapped.override {
    includedEngineArtifacts = {
      common = [
        "flutter_patched_sdk"
        "flutter_patched_sdk_product"
      ];
      platform = {
        android = {};
        linux =
          lib.optionals stdenv.hostPlatform.isLinux
          (lib.genAttrs ((lib.optional stdenv.hostPlatform.isx86_64 "x64") ++ (lib.optional stdenv.hostPlatform.isAarch64 "arm64"))
            (architecture: ["debug" "profile" "release"]));
      };
    };
  })
```

now it is as simple as:
```nix
pkgs.flutter.override {
  supportsAndroid = false;
  supportsLinuxDesktop = true; # true by default
}
```

And still allows greater control over the artifacts if needed:
```nix
pkgs.flutter.override {
  includedEngineArtifacts = let
    inherit (pkgs) lib stdenv;
  in {
    common = [ "flutter_patched_sdk_product" ];
    platform.linux = lib.optionals stdenv.hostPlatform.isLinux
      (lib.genAttrs ((lib.optional stdenv.hostPlatform.isx86_64 "x64") ++ (lib.optional stdenv.hostPlatform.isAarch64 "arm64"))
        (architecture: [ "release" ]));
  };
}
```

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
