### PR TITLE
python311Packages.brian2: add patch to fix deprecated numpy types

### DIFF
--- a/pkgs/development/python-modules/brian2/default.nix
+++ b/pkgs/development/python-modules/brian2/default.nix
@@ -22,6 +22,12 @@ buildPythonPackage rec {
     hash = "sha256-x1EcS7PFCsjPYsq3Lt87SJRW4J5DE/OfdFs3NuyHiLw=";
   };
 
+  patches = [
+    # Fix deprecated numpy types
+    # https://sources.debian.org/data/main/b/brian/2.5.1-3/debian/patches/numpy1.24.patch
+    ./numpy1.24.patch
+  ];
+
   propagatedBuildInputs = [
     cython
     jinja2

--- a/pkgs/development/python-modules/brian2/numpy1.24.patch
+++ b/pkgs/development/python-modules/brian2/numpy1.24.patch
@@ -1,0 +1,18 @@
+Description: Remove deprecated use of np.float
+Author: Marcel Stimberg <marcel.stimberg@inserm.fr>
+Bug-Debian: https://bugs.debian.org/1027193
+Applied-Upstream: 61ef84b316a3d0a892298adf51abd8ac50900758
+Last-Update: 2023-01-06
+---
+This patch header follows DEP-3: http://dep.debian.net/deps/dep3/
+--- brian.orig/brian2/units/fundamentalunits.py
++++ brian/brian2/units/fundamentalunits.py
+@@ -1597,7 +1597,7 @@
+         unitless = np.array(self / best_unit, copy=False)
+         threshold = np.get_printoptions()['threshold'] // 100
+         if unitless.ndim == 0:
+-            sympy_quantity = np.float(unitless)
++            sympy_quantity = float(unitless)
+         elif unitless.ndim == 1:
+             array_str = np.array2string(unitless, separator=" & ", threshold=threshold,
+                                         max_line_width=sys.maxsize)


### PR DESCRIPTION
###### Description of changes

Add a Debian patch to fix deprecated numpy types

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
