### PR TITLE
python311Packages.torchaudio: 2.0.1 -> 2.0.2

### DIFF
--- a/pkgs/development/python-modules/tensorboard/default.nix
+++ b/pkgs/development/python-modules/tensorboard/default.nix
@@ -2,7 +2,6 @@
 , fetchPypi
 , buildPythonPackage
 , pythonOlder
-, pythonAtLeast
 , pythonRelaxDepsHook
 , numpy
 , wheel
@@ -26,7 +25,7 @@ buildPythonPackage rec {
   pname = "tensorboard";
   version = "2.11.0";
   format = "wheel";
-  disabled = pythonOlder "3.6" || pythonAtLeast "3.11";
+  disabled = pythonOlder "3.6";
 
   src = fetchPypi {
     inherit pname version format;

--- a/pkgs/development/python-modules/torchaudio/default.nix
+++ b/pkgs/development/python-modules/torchaudio/default.nix
@@ -1,24 +1,25 @@
 { lib
 , buildPythonPackage
+, config
 , fetchFromGitHub
 , cmake
 , pkg-config
 , ninja
 , pybind11
 , torch
-, cudaSupport ? false
+, cudaSupport ? config.cudaSupport or false
 , cudaPackages
 }:
 
 buildPythonPackage rec {
   pname = "torchaudio";
-  version = "2.0.1";
+  version = "2.0.2";
 
   src = fetchFromGitHub {
     owner = "pytorch";
     repo = "audio";
     rev = "v${version}";
-    hash = "sha256-qrDWFY+6eVV9prUzUzb5yzyFYtEvaSyEW0zeKqAg2Vk=";
+    hash = "sha256-9lB4gLXq0nXHT1+DNOlbJQqNndt2I6kVoNwhMO/2qlE=";
   };
 
   postPatch = ''
@@ -37,6 +38,7 @@ buildPythonPackage rec {
   buildInputs = [
     pybind11
   ] ++ lib.optionals cudaSupport [
+    cudaPackages.cuda_cudart
     cudaPackages.cudnn
   ];
   propagatedBuildInputs = [


### PR DESCRIPTION
python311Packages.torchaudio: 2.0.1 -> 2.0.2
    
Release: https://github.com/pytorch/audio/releases/tag/v2.0.2
    
* By default inherits "config.cudaSupport" configuration.
* Fixes build error for lack of cuda_cudart.

CC @NixOS/cuda-maintainers 

Depends on: #231669

Cherry-picks:
* 81cbc9f10699f2d083a22351d5222aeadf05ecb8