### PR TITLE
betterlockscreen: make dunst optional

### DIFF
--- a/pkgs/misc/screensavers/betterlockscreen/default.nix
+++ b/pkgs/misc/screensavers/betterlockscreen/default.nix
@@ -7,6 +7,7 @@
 , bc
 , coreutils
 , dbus
+, withDunst ? true
 , dunst
 , i3lock-color
 , gawk
@@ -16,6 +17,12 @@
 , procps
 , xorg
 }:
+
+let
+  runtimeDeps =
+    [ bc coreutils dbus i3lock-color gawk gnugrep gnused imagemagick procps xorg.xdpyinfo xorg.xrandr xorg.xset ]
+    ++ lib.optionals withDunst [ dunst ];
+in
 
 stdenv.mkDerivation rec {
   pname = "betterlockscreen";
@@ -36,7 +43,7 @@ stdenv.mkDerivation rec {
     mkdir -p $out/bin
     cp betterlockscreen $out/bin/betterlockscreen
     wrapProgram "$out/bin/betterlockscreen" \
-      --prefix PATH : "$out/bin:${lib.makeBinPath [ bc coreutils dbus dunst i3lock-color gawk gnugrep gnused imagemagick procps xorg.xdpyinfo xorg.xrandr xorg.xset ]}"
+      --prefix PATH : "$out/bin:${lib.makeBinPath runtimeDeps}"
 
     runHook postInstall
   '';


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

When `dunst` is detected *and* awesomeWM is used (its internal notification system to be exact)
then b`etterlockscreen` waits for dunst to reply on the DBus. Due to `dunstctl` being in PATH
through the wrapper, `dunst` will always be tried to reach.

None of the workarounds mentioned in the awesome and betterlockscreen repos do not work with
this version, as dunstctl is always called and has to time out first.

In the current master of BLS there is a change that makes BLS check and env-var first, and
would ignore any dunstctl in PATH.

Once the new release happened this could still be used to reduce the closure size.

* Commit with extra env-var: https://github.com/betterlockscreen/betterlockscreen/commit/2a63fab54c9eccdcb81da78d781fb75ebc284b2d
* Issue on BLS: https://github.com/betterlockscreen/betterlockscreen/issues/284
* Issue on AwesomeWM: https://github.com/awesomeWM/awesome/issues/1285

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

