### PR TITLE
python3Packages.python-mapnik: fix build on x86_64

### DIFF
--- a/pkgs/development/python-modules/python-mapnik/default.nix
+++ b/pkgs/development/python-modules/python-mapnik/default.nix
@@ -8,7 +8,7 @@
 , pillow
 , pycairo
 , pkg-config
-, boost
+, boost182
 , cairo
 , harfbuzz
 , icu
@@ -60,7 +60,7 @@ buildPythonPackage rec {
 
   buildInputs = [
     mapnik
-    boost
+    boost182
     cairo
     harfbuzz
     icu

--- a/pkgs/development/python-modules/python-mapnik/default.nix
+++ b/pkgs/development/python-modules/python-mapnik/default.nix
@@ -23,6 +23,7 @@
 , sqlite
 , nose
 , pytestCheckHook
+, stdenv
 }:
 
 buildPythonPackage rec {
@@ -98,6 +99,9 @@ buildPythonPackage rec {
   preCheck = ''
     # import from $out
     rm -r mapnik
+  '' + lib.optionalString stdenv.isDarwin ''
+    # Replace the hardcoded /tmp references with $TMPDIR
+    sed -i "s,/tmp,$TMPDIR,g" test/python_tests/*.py
   '';
 
   # https://github.com/mapnik/python-mapnik/issues/255
@@ -129,6 +133,8 @@ buildPythonPackage rec {
     "test_visual_zoom_all_rendering1"
     "test_visual_zoom_all_rendering2"
     "test_wgs84_inverse_forward"
+  ] ++ lib.optional stdenv.isDarwin [
+    "test_passing_pycairo_context_pdf"
   ];
 
   pythonImportsCheck = [ "mapnik" ];

--- a/pkgs/development/python-modules/python-mapnik/default.nix
+++ b/pkgs/development/python-modules/python-mapnik/default.nix
@@ -106,6 +106,7 @@ buildPythonPackage rec {
     "test_compare_map"
     "test_dataraster_coloring"
     "test_dataraster_query_point"
+    "test_geometry_type"
     "test_good_files"
     "test_layer_init"
     "test_load_save_map"

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -9753,7 +9753,7 @@ self: super: with self; {
 
   python-mapnik = callPackage ../development/python-modules/python-mapnik rec {
     inherit (pkgs) pkg-config cairo icu libjpeg libpng libtiff libwebp proj zlib;
-    boost = pkgs.boost.override {
+    boost182 = pkgs.boost182.override {
       enablePython = true;
       inherit python;
     };


### PR DESCRIPTION
###### Description of changes

For Python3.10: disable the OGR test, which fails since a gdal update at af10ec1c5b7af7106a5b5ea2b633275d549d7e8c (Upstream tests are still considered unreliable according to https://github.com/mapnik/python-mapnik/issues/255).

For Python3.11: use the 1.82 version of boost instead of the default 1.79. The import checks didn't pass because of a boost binding problem solved by https://github.com/boostorg/python/pull/385.

ZHF: #230712

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - the few non-disabled tests of the upstream testsuite.
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

###### nixpkgs-review output

Ran `nix run '.#nixpkgs-review' -- rev HEAD --print-result`

Result of `nixpkgs-review` run on x86_64-linux [1](https://github.com/Mic92/nixpkgs-review)
<details>
  <summary>4 packages built:</summary>
  <ul>
    <li>python310Packages.python-mapnik</li>
    <li>python310Packages.python-mapnik.dist</li>
    <li>python311Packages.python-mapnik</li>
    <li>python311Packages.python-mapnik.dist</li>
  </ul>
</details>

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
