### PR TITLE
[22.11] frr: add patches for CVE-2022-43681, CVE-2022-40302 & CVE-2022-40318

### DIFF
--- a/pkgs/servers/frr/default.nix
+++ b/pkgs/servers/frr/default.nix
@@ -48,6 +48,21 @@ stdenv.mkDerivation rec {
       url = "https://github.com/FRRouting/frr/commit/ff6db1027f8f36df657ff2e5ea167773752537ed.patch";
       sha256 = "sha256-b3nT6xco620hMSqlj/nTWTJCegf3ARAGaQbii4Yq6Ag=";
     })
+    (fetchpatch {
+      name = "CVE-2022-43681.patch";
+      url = "https://github.com/FRRouting/frr/commit/766eec1b7accffe2c04a5c9ebb14e9f487bb9f78.patch";
+      sha256 = "sha256-3XubiKvQos9QLQ4PaY89LLvLBjfYGoo6prulUgPXRgU=";
+    })
+    (fetchpatch {
+      name = "CVE-2022-40302.patch";
+      url = "https://github.com/FRRouting/frr/commit/3e46b43e3788f0f87bae56a86b54d412b4710286.patch";
+      sha256 = "sha256-GlTJcoPg2BFw3JBSFEQk2CMEGGbYfXOPqsTjIoSe8WY=";
+    })
+    (fetchpatch {
+      name = "CVE-2022-40318.patch";
+      url = "https://github.com/FRRouting/frr/commit/1117baca3c592877a4d8a13ed6a1d9bd83977487.patch";
+      sha256 = "sha256-txvpQZlqOyUl4kQ4VkLCUqSiA0lLdFt3uJdurnpJblM=";
+    })
   ];
 
   nativeBuildInputs = [


### PR DESCRIPTION
###### Description of changes
https://nvd.nist.gov/vuln/detail/CVE-2022-43681
https://nvd.nist.gov/vuln/detail/CVE-2022-40302
https://nvd.nist.gov/vuln/detail/CVE-2022-40318

Patches found via https://github.com/FRRouting/frr/issues/13480#issuecomment-1541380295

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
