### PR TITLE
ocamlPackages.cmarkit: init at 0.1.0

### DIFF
--- a/pkgs/development/ocaml-modules/cmarkit/default.nix
+++ b/pkgs/development/ocaml-modules/cmarkit/default.nix
@@ -1,0 +1,48 @@
+{ lib
+, stdenv
+, cmdliner
+, fetchurl
+, findlib
+, ocaml
+, ocamlbuild
+, topkg
+}:
+
+if lib.versionOlder ocaml.version "4.14.0"
+then throw "cmarkit is not available for OCaml ${ocaml.version}"
+else
+
+stdenv.mkDerivation rec {
+  pname = "cmarkit";
+  version = "0.1.0";
+
+  src = fetchurl {
+    url = "https://erratique.ch/software/cmarkit/releases/cmarkit-${version}.tbz";
+    hash = "sha256-pLPCLlwJt5W5R92HPY8gGpisyjlbSaaEe0HLuJlkjuY=";
+  };
+
+  nativeBuildInputs = [
+    ocaml
+    findlib
+    ocamlbuild
+    topkg
+  ];
+
+  buildInputs = [
+    topkg
+    cmdliner
+  ];
+
+  strictDeps = true;
+
+  inherit (topkg) buildPhase installPhase;
+
+  meta = with lib; {
+    description = "CommonMark parser and renderer for OCaml";
+    homepage = "https://erratique.ch/software/cmarkit";
+    changelog = "https://github.com/dbuenzli/cmarkit/blob/v${version}/CHANGES.md";
+    license = licenses.isc;
+    maintainers = [ maintainers.marsam ];
+    inherit (ocaml.meta) platforms;
+  };
+}

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -196,6 +196,8 @@ let
 
     class_group_vdf = callPackage ../development/ocaml-modules/class_group_vdf { };
 
+    cmarkit = callPackage ../development/ocaml-modules/cmarkit { };
+
     # The 1.1.0 release broke a lot of packages and is not compatible with
     # OCaml < 4.08.
     cmdliner =


### PR DESCRIPTION
###### Description of changes
Add https://erratique.ch/software/cmarkit
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->