### PR TITLE
pahole: patch to force single-threaded mode if reproducibility is desired

### DIFF
--- a/pkgs/development/tools/misc/pahole/default.nix
+++ b/pkgs/development/tools/misc/pahole/default.nix
@@ -26,6 +26,8 @@ stdenv.mkDerivation rec {
     musl-obstack
   ];
 
+  patches = [ ./threading-reproducibility.patch ];
+
   # Put libraries in "lib" subdirectory, not top level of $out
   cmakeFlags = [ "-D__LIB=lib" "-DLIBBPF_EMBEDDED=OFF" ];
 

--- a/pkgs/development/tools/misc/pahole/threading-reproducibility.patch
+++ b/pkgs/development/tools/misc/pahole/threading-reproducibility.patch
@@ -1,0 +1,18 @@
+diff --git a/pahole.c b/pahole.c
+index 6fc4ed6..a4e306f 100644
+--- a/pahole.c
++++ b/pahole.c
+@@ -1687,8 +1687,11 @@ static error_t pahole__options_parser(int key, char *arg,
+ 		  class_name = arg;			break;
+ 	case 'j':
+ #if _ELFUTILS_PREREQ(0, 178)
+-		  conf_load.nr_jobs = arg ? atoi(arg) :
+-					    sysconf(_SC_NPROCESSORS_ONLN) * 1.1;
++		  // Force single thread if reproducibility is desirable.
++		  if (!getenv("SOURCE_DATE_EPOCH")) {
++			  conf_load.nr_jobs = arg ? atoi(arg) :
++						    sysconf(_SC_NPROCESSORS_ONLN) * 1.1;
++		  }
+ #else
+ 		  fputs("pahole: Multithreading requires elfutils >= 0.178. Continuing with a single thread...\n", stderr);
+ #endif


### PR DESCRIPTION
###### Description of changes

#223584 #227800

pahole processes DWARF -> BTF in a pseudo-random order if multi
threading is enabled (default in the Linux kernel). This can be fixed in dependent
derivation by making sure users don't ever pass "-j" or "-j N", but it
seems easier and safer to just detect whether reprodubility is desired
(by proxy: if SOURCE_DATE_EPOCH is set) and ignore the multi-threading
flag.

Tested with a zfs --check build, it passes with this patch applied!

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
