### PR TITLE
libopus: 1.3.1 -> 1.4

### DIFF
--- a/pkgs/development/libraries/libopus/default.nix
+++ b/pkgs/development/libraries/libopus/default.nix
@@ -32,6 +32,10 @@ stdenv.mkDerivation rec {
     (lib.mesonEnable "docs" false)
   ];
 
+  preBuild = ''
+    patchShebangs meson/get-version.py
+  '';
+
   doCheck = !stdenv.isi686 && !stdenv.isAarch32; # test_unit_LPC_inv_pred_gain fails
 
   meta = with lib; {

--- a/pkgs/development/libraries/libopus/default.nix
+++ b/pkgs/development/libraries/libopus/default.nix
@@ -1,26 +1,45 @@
-{ lib, stdenv, fetchurl
-, fixedPoint ? false, withCustomModes ? true }:
+{ lib
+, stdenv
+, fetchurl
+, meson
+, python3
+, ninja
+, fixedPoint ? false
+, withCustomModes ? true
+}:
 
 stdenv.mkDerivation rec {
   pname = "libopus";
-  version = "1.3.1";
+  version = "1.4";
 
   src = fetchurl {
-    url = "mirror://mozilla/opus/opus-${version}.tar.gz";
-    sha256 = "17gz8kxs4i7icsc1gj713gadiapyklynlwqlf0ai98dj4lg8xdb5";
+    url = "https://downloads.xiph.org/releases/opus/opus-${version}.tar.gz";
+    sha256 = "sha256-ybMrQlO+WuY9H/Fu6ga5S18PKVG3oCrO71jjo85JxR8=";
   };
 
   outputs = [ "out" "dev" ];
 
-  configureFlags = lib.optional fixedPoint "--enable-fixed-point"
-                ++ lib.optional withCustomModes "--enable-custom-modes";
+  nativeBuildInputs = [
+    meson
+    python3
+    ninja
+  ];
+
+  mesonFlags = [
+    (lib.mesonBool "fixed-point" fixedPoint)
+    (lib.mesonBool "custom-modes" withCustomModes)
+    (lib.mesonEnable "asm" stdenv.hostPlatform.isAarch)
+    (lib.mesonEnable "docs" false)
+  ];
 
   doCheck = !stdenv.isi686 && !stdenv.isAarch32; # test_unit_LPC_inv_pred_gain fails
 
   meta = with lib; {
     description = "Open, royalty-free, highly versatile audio codec";
-    license = lib.licenses.bsd3;
-    homepage = "https://www.opus-codec.org/";
+    homepage = "https://opus-codec.org/";
+    changelog = "https://gitlab.xiph.org/xiph/opus/-/releases/v${version}";
+    license = licenses.bsd3;
     platforms = platforms.all;
+    maintainers = [ ];
   };
 }


### PR DESCRIPTION

###### Description of changes
https://gitlab.xiph.org/xiph/opus/-/releases/v1.4

Fixes https://github.com/NixOS/nixpkgs/issues/231613
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
