### PR TITLE
intel-one-mono: init at 1.0.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -4121,6 +4121,13 @@
       fingerprint = "4749 0887 CF3B 85A1 6355  C671 78C7 DD40 DF23 FB16";
     }];
   };
+  dpc = {
+    name = "Dawid Ciężarkiewicz";
+    email = "dpc@dpc.pw";
+    matrix = "@dpc:matrix.org";
+    github = "dpc";
+    githubId = 9209;
+  };
   DPDmancul = {
     name = "Davide Peressoni";
     email = "davide.peressoni@tuta.io";

--- a/pkgs/data/fonts/intel-one-mono/default.nix
+++ b/pkgs/data/fonts/intel-one-mono/default.nix
@@ -1,0 +1,46 @@
+{ lib, stdenvNoCC, fetchurl, unzip }:
+
+stdenvNoCC.mkDerivation rec {
+  pname = "intel-one-mono";
+  version = "1.0.0";
+
+  # v1.0.0 tag actually doesn't have any files, so using release archives
+  srcs = [
+    (fetchurl {
+      url = "https://github.com/intel/intel-one-mono/releases/download/V${version}/otf.zip";
+      sha256 = "sha256-RxvLuWZiX4ojjw1jjLyWIqwW1RMGShJBlnmPYrxMgaw=";
+    })
+    (fetchurl {
+      url = "https://github.com/intel/intel-one-mono/releases/download/V${version}/ttf.zip";
+      sha256 = "sha256-skcETQOniKCHhfaj9RKOHxvDKmC93Aj9cudLG7K83bE=";
+    })
+  ];
+
+
+  nativeBuildInputs = [
+    unzip
+  ];
+
+  unpackCmd = ''
+    for src in $srcs; do
+      unzip -o $src -d src
+    done
+  '';
+
+  installPhase = ''
+    runHook preInstall
+    install -Dm644 -t $out/share/fonts/truetype/ ttf/*.ttf
+    install -Dm644 -t $out/share/fonts/opentype/ otf/*.otf
+    runHook postInstall
+  '';
+
+
+  meta = with lib; {
+    description = "Intel One Mono Typeface";
+    homepage = "https://github.com/intel/intel-one-mono";
+    changelog = "https://github.com/intel/intel-one-mono/releases/tag/V${version}";
+    license = licenses.ofl;
+    maintainers = [ maintainers.dpc ];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -28167,6 +28167,8 @@ with pkgs;
 
   input-fonts = callPackage ../data/fonts/input-fonts { };
 
+  intel-one-mono = callPackage ../data/fonts/intel-one-mono { };
+
   inriafonts = callPackage ../data/fonts/inriafonts { };
 
   iosevka = callPackage ../data/fonts/iosevka { };


### PR DESCRIPTION
###### Description of changes

https://github.com/intel/intel-one-mono/tree/main

> Introducing Intel One Mono, an expressive monospaced font family that’s built with clarity, legibility, and the needs of developers in mind.
>
> It’s easier to read, and available for free, with an open-source font license.
>
> Intel One Mono also covers a wide range of over 200 languages using the Latin script. The Intel One Mono fonts are provided in four weights — Light, Regular, Medium, and Bold — with matching italics, and we are happy to share both an oﬃcial release of fonts ready to use as well as editable sources.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

