### PR TITLE
wiki-js: use nodejs18

### DIFF
--- a/nixos/modules/services/web-apps/wiki-js.nix
+++ b/nixos/modules/services/web-apps/wiki-js.nix
@@ -133,7 +133,7 @@ in {
         WorkingDirectory = "/var/lib/${cfg.stateDirectoryName}";
         DynamicUser = true;
         PrivateTmp = true;
-        ExecStart = "${pkgs.nodejs_16}/bin/node ${pkgs.wiki-js}/server";
+        ExecStart = "${pkgs.nodejs_18}/bin/node ${pkgs.wiki-js}/server";
       };
     };
   };

--- a/pkgs/servers/web-apps/wiki-js/default.nix
+++ b/pkgs/servers/web-apps/wiki-js/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, lib, nixosTests }:
+{ stdenv, fetchurl, lib, nixosTests, jq, moreutils }:
 
 stdenv.mkDerivation rec {
   pname = "wiki-js";
@@ -8,6 +8,40 @@ stdenv.mkDerivation rec {
     url = "https://github.com/Requarks/wiki/releases/download/v${version}/${pname}.tar.gz";
     sha256 = "sha256-O7KQ134zh9ullYyQZimmxfdRwXeHkD8aAhy/pRzIjxo=";
   };
+
+  # Implements nodejs 18 support as it's not planned to fix this before
+  # the release of v3[1] which is planned to happen in 2023, but not before
+  # NixOS 23.05. However, in the lifespan of 23.05 v16 will get EOLed, so
+  # we have to hack this on our own.
+  #
+  # The problem we fix here is that `exports."/public/"` in a `package.json`
+  # is prohibited, i.e. you cannot export full directories anymore.
+  #
+  # Unfortunately it's non-trivial to fix this because v10 of `extract-files`
+  # (where the problem is fixed) doesn't work for graphql-tools (which depends
+  # on this). Updating this as well is also quite complex because in later
+  # versions the package was split up into multiple smaller packages and
+  # thus a lot of parts of the code-base would need to be changed accordingly.
+  #
+  # Since this is the only breaking change of nodejs 17/18[2][3], this workaround
+  # will be necessary until we can upgrade to v3.
+  #
+  # [1] https://github.com/requarks/wiki/discussions/6388
+  # [2] https://nodejs.org/en/blog/release/v17.0.0
+  # [3] https://nodejs.org/en/blog/release/v18.0.0
+  nativeBuildInputs = [ jq moreutils ];
+  postPatch = ''
+    # Dirty hack to implement nodejs-18 support.
+    <./node_modules/extract-files/package.json jq '
+      # error out loud if the structure has changed and we need to change
+      # this expression
+      if .exports|has("./public/")|not then
+        halt_error(1)
+      else
+        .exports."./public/*" = "./public/*.js" | del(.exports."./public/")
+      end
+    ' | sponge ./node_modules/extract-files/package.json
+  '';
 
   sourceRoot = ".";
 


### PR DESCRIPTION

###### Description of changes
Part of #229910.

Unfortunately this is a little hacky because upstream doesn't intend to support it for 2.5, but only for 3.0 which isn't out yet, however nodejs-16 will get out of maintenance during the support-span of NixOS 23.05[1].

The only breaking change is that `extract-files` uses a deprecated way of exposing modules, I went through the list of other breaking changes in v17 and v18[2][3] and couldn't spot any usage of removed features, also local testing didn't reveal further issues.

Unfortunately fixing that breakage turned out to be non-trivial. Currently, `extract-files@9.0.0` is used with the problematic portions in its `package.json`, however it's only a transitive dependency of `@graphql-tools/url-loader` & `apollo-upload-client`. Unfortunately, the versions of that in use require v9 and don't work with a newer version of `extract-files` with the problem fixed[4]. Also, upgrading the dependencies in question is not a feasible option because `graphql-tools` was split up into multiple smaller packages in v8 and also some of the APIs in use in `wiki.js` were dropped there[5], so this would also be very time-consuming and non-trivial to fix.

Since this was the only issue, I decided to go down the hacky route and patch the problem in `package.json` of `extract-files` manually during our `patchPhase`.

[1] https://github.com/requarks/wiki/discussions/6388
[2] https://nodejs.org/en/blog/release/v17.0.0
[3] https://nodejs.org/en/blog/release/v18.0.0
[4] Upon local testing, this broke with the following error:

        Error [ERR_PACKAGE_PATH_NOT_EXPORTED]: Package subpath './public/extractFiles' is not defined by "exports" in /wiki/node_modules/extract-files/package.json
[5] For instance `SchemaDirectiveVisitor` in
  `server/graph/directives/auth`.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
