### PR TITLE
[22.11] pmbootstrap: 1.45.0 -> 1.50.1

### DIFF
--- a/pkgs/tools/misc/pmbootstrap/default.nix
+++ b/pkgs/tools/misc/pmbootstrap/default.nix
@@ -1,13 +1,23 @@
-{ stdenv, lib, git, openssl, makeWrapper, buildPythonApplication, pytestCheckHook, ps
-, fetchPypi, fetchFromGitLab, sudo }:
-
+{ stdenv
+, lib
+, git
+, openssl
+, makeWrapper
+, buildPythonApplication
+, pytestCheckHook
+, ps
+, fetchPypi
+, fetchFromGitLab
+, sudo
+,
+}:
 buildPythonApplication rec {
   pname = "pmbootstrap";
-  version = "1.45.0";
+  version = "1.50.1";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "sha256-75ZFzhRsczkwhiUl1upKjSvmqN0RkXaM8cKr4zLgi4w=";
+    sha256 = "sha256-2S3I3J3wmRkVSUshyQCUTuYgHLsDMnXZQHt7KySBzIY=";
   };
 
   repo = fetchFromGitLab {
@@ -15,10 +25,13 @@ buildPythonApplication rec {
     owner = "postmarketOS";
     repo = pname;
     rev = version;
-    sha256 = "sha256-tG1+vUJW9JIdYpcRn8J0fCIZh29hYo8wSlBKwTUxyMU=";
+    sha256 = "sha256-UkgCNob4nazFO8xXyosV+11Sj4yveYBfgh7aw+/6Rlg=";
   };
 
   pmb_test = "${repo}/test";
+
+  # Tests depend on sudo
+  doCheck = stdenv.isLinux;
 
   checkInputs = [ pytestCheckHook git openssl ps sudo ];
 
@@ -86,14 +99,12 @@ buildPythonApplication rec {
     "test_version"
   ];
 
-  makeWrapperArgs = [ "--prefix PATH : ${lib.makeBinPath [ git openssl ]}" ];
+  makeWrapperArgs = [ "--prefix PATH : ${lib.makeBinPath [git openssl]}" ];
 
   meta = with lib; {
     description = "Sophisticated chroot/build/flash tool to develop and install postmarketOS";
     homepage = "https://gitlab.com/postmarketOS/pmbootstrap";
     license = licenses.gpl3Plus;
     maintainers = with maintainers; [ onny ];
-    # https://github.com/NixOS/nixpkgs/pull/146576#issuecomment-974267651
-    broken = stdenv.isDarwin && stdenv.isAarch64;
   };
 }


### PR DESCRIPTION
(cherry picked from commit 0d5cfedbe4f572360093ca449ac96517d17c0069)

###### Description of changes
[1.50.0 -> 1.50.1](https://gitlab.com/postmarketOS/pmbootstrap/-/tags/1.50.1)
```
Fixes:
- pmb/parse/arch.py: add arm64 -> aarch64 to mapping
- pmb.parse.kconfig: update version for MEMCG_SWAP change

Other:
- pmb.config.apk_tools_min_version: add alpine 3.17
```

[1.49.0 -> 1.50.0](https://gitlab.com/postmarketOS/pmbootstrap/-/tags/1.50.0)
```
Features:
- pmb.parse.kconfig: add wireguard, filesystems & more to community check
- pmb.parse.kconfig: don't enforce non-core checks for testing devices
- pmb ci: add --fast argument

Fixes:
- pmb: sideload: wait for apk database lock
- flasher: heimdall: take depends from pmaports.cfg
- pmb ci: fix arg desc for --all
- pmb ci: error on using --all with script names
- pmb.qemu.run: stop forcing bios for riscv64
- pmb ci: fix typo in URL

Other:
- CI: fix typo in pmOS CI url
```

[1.48.0 -> 1.49.0](https://gitlab.com/postmarketOS/pmbootstrap/-/tags/1.49.0)
```

Features:
* build: envkernel: support packaging kernels that were built on the host (MR 2175)
* pmb.parse.build: mention host compiled kernels in envkenel help (MR 2175)
* pmb: enable riscv64 architecture (MR 2215)
* pmbootstrap log: show testsuite log too
* pmbootstrap ci: new command
* pmb.qemu.run: support riscv64
* envkernel: add dependencies for running 'make dtbs_check'

Fixes:
* pmb.config: add missing pmb:kconfigcheck-* for lint (MR 2214)
* pmb: build: envkernel: Fix bind mount detection (MR 2217)
* pmb.parse.kconfig: fix container check for kernels >= 6.1 (MR 2220)
* pmb.parse.kconfig: drop remaining "_rc1" references (MR 2220)
* helpers/envkernel.sh: return 0 from fish_compat if --fish is not present (MR 2221)
* pmb.parse.kconfig: explicitly add dependency on SWAP
* pmb.qemu.run: replace -nic option with -netdev and -device
* aportgen: don't fail if binary ver < APKBUILD ver
* helpers/envkernel.sh: rename yaml-lint to yamllint
* pmbootstrap ci: fix error with deleted files
* pmb.config.required_programs: add tar
* flasher: fastboot: take depends from pmaports.cfg

Other:
* CI: replace gitlab CI with sourcehut CI
* CI: add note about running scripts locally
* README: remove outdated information
* README: add line breaks
* README: update development section
* README: add new line
* README: add link to issues
* README: add ML subscribe link
* build.yml: add missing sources line
* README: Document git commands for setting the git-send-email defaults
* b4-config: new file
* b4-config: linkmask: encode < and > chars
* CI: flake8: remove ignore for W605
* pmb.flasher.init.install_depends: new function

Between this release and the previous one, pmbootstrap.git was migrated to sourcehut:
https://gitlab.com/postmarketOS/pmbootstrap/-/issues/2181
```

[1.47.1 -> 1.48.0](https://gitlab.com/postmarketOS/pmbootstrap/-/tags/1.48.0)
```
Feature:
* pmb.chroot.root: set PYTHONUNBUFFERED=1 (MR 2209)

Fixes:
* pmb.build._package: update isl workaround (MR 2213)

Other:
* pmb.chroot.root: order env vars alphabetically (MR 2209)
* pmb.aportgen.device: no depend on mesa-dri-gallium (MR 2210)
```

[1.47.0 -> 1.47.1](https://gitlab.com/postmarketOS/pmbootstrap/-/tags/1.47.1)
```
Fixes:
- pmb.aportgen.gcc: remove !tracedeps option
- pmb.build.package: add workaround for missing isl
```

[1.46.0 -> 1.47.0](https://gitlab.com/postmarketOS/pmbootstrap/-/tags/1.47.0)
```
Features:
* pmb.helpers.run: only pass stdin where useful (MR 2197)
* pmb: sideload: Handle ssh_install_apks() errors (MR 2195)
* pmb.chroot.root: preserve proxy environment variables (MR 2201)
* pmb.config.apkbuild_package_attributes: + triggers (MR 2202)
* pmb.parse.kconfig: add 'community' option (MR 2204)
* pmb.config.apkbuild_attributes: Add _pkgbase and _pkgsnap (MR 2208)

Fixes:
* Fix wrong output of pmbootstrap bootimg_analyze (MR 2198)
* aportgen binutils: modernize (MR 2199)
* pmb.parse.kconfig: fix containers check for x86 (MR 2204)
* pmb.aportgen.gcc: remove isl from depends (MR 2203)
* pmb.aportgen.gcc: set libgcc=false (MR 2203)
* pmb.aportgen.gcc: add subpkg libstdc++-dev-$arch (MR 2207)

Other:
* treewide: fix various lint errors (MR 2197)
* test/testdata/aportgen: upgrade binutils to 2.39 (MR 2199)
* pmb.parse.kconfig: remove apparmor check (MR 2200)
* pmb.parse.kconfig: rename anbox check to waydroid (MR 2204)
* test_kconfig_check: modify nokia-n900 test (MR 2204)
* testdata/gcc: upgrade to 12.1.1_git20220630-r5 (MR 2203)
* testdata/gcc: upgrade to 12.2.1_git20220924-r1 (MR 2208)
```

[1.45.0 -> 1.46.0](https://gitlab.com/postmarketOS/pmbootstrap/-/tags/1.46.0)
```
Features:
- pmb.parse.bootimg: Add preliminary support for header v2 (MR 2194)
- pmb.aportgen.device: Generate appropriate header v2 deviceinfo (MR 2194)
- pmb.aportgen.linux: Install DTBs on header v2 (MR 2194)

Fixes:
- helpers/envkernel.sh: disable ccache (MR 2189)
- Revert "helpers/envkernel.sh: add gawk when initialising chroot (MR 2186)" (MR 2188)
- pmb.qemu.run: drop removed depedency (MR 2196)

Other:
- test: Add boot.img header v2 testcase (MR 2194)
```

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
