### PR TITLE
tauri-mobile: unstable-2023-04-25 -> unstable-2023-06-06

### DIFF
--- a/pkgs/development/tools/rust/tauri-mobile/default.nix
+++ b/pkgs/development/tools/rust/tauri-mobile/default.nix
@@ -12,36 +12,36 @@
 let
   inherit (darwin.apple_sdk.frameworks) CoreServices;
   pname = "tauri-mobile";
-  version = "unstable-2023-04-25";
+  version = "unstable-2023-06-06";
 in
 rustPlatform.buildRustPackage {
   inherit pname version;
   src = fetchFromGitHub {
     owner = "tauri-apps";
     repo = pname;
-    rev = "c2abaf54135bf65b1165a38d3b1d84e8d57f5d6c";
-    sha256 = "sha256-WHyiswe64tkNhhgmHquv9YPLQAU1yTJ/KglTqEPBcOM=";
+    rev = "43b2a3ba3a05b9ca3d3c9d8d7eafbeb4f24bf396";
+    hash = "sha256-fVQmhtUn2Lwtr/id/qWtgnHQdXkf0jAOg4apOgnLD4Y=";
   };
 
   # Manually specify the sourceRoot since this crate depends on other crates in the workspace. Relevant info at
   # https://discourse.nixos.org/t/difficulty-using-buildrustpackage-with-a-src-containing-multiple-cargo-workspaces/10202
   # sourceRoot = "source/tooling/cli";
 
-  cargoHash = "sha256-Kc1BikwUYSpPShRtAPbHCdfVzo6zwjiO3QeqRkO+WhY=";
+  cargoHash = "sha256-MtLfcDJcLVhsIGD6pjpomuu9GYGqa7L8xnaQ++f+0H4=";
 
   preBuild = ''
-    export HOME=$(mktemp -d)
+    mkdir -p $out/share/
+    # during the install process tauri-mobile puts templates and commit information in CARGO_HOME
+    export CARGO_HOME=$out/share/
   '';
 
   buildInputs = [ openssl ] ++ lib.optionals stdenv.isDarwin [ CoreServices ];
   nativeBuildInputs = [ pkg-config git makeWrapper ];
 
-  preInstall = ''
-    mkdir -p $out/share/
-    # the directory created in the build process is .tauri-mobile, a hidden directory
-    shopt -s dotglob
-    for temp_dir in $HOME/*; do
-      cp -R $temp_dir $out/share
+  preFixup = ''
+    for bin in $out/bin/cargo-*; do
+      wrapProgram $bin \
+        --set CARGO_HOME "$out/share"
     done
   '';
 


### PR DESCRIPTION
###### Description of changes

Just a draft for now as it doesn't compile since version 0.5.0 has a lockfile not up to date. Rather than updating to another unstable version, I'm leaving this as draft for now.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
