### PR TITLE
minimal-bootstrap: Parallelize + separate compilers & libs

### DIFF
--- a/pkgs/os-specific/linux/minimal-bootstrap/default.nix
+++ b/pkgs/os-specific/linux/minimal-bootstrap/default.nix
@@ -30,6 +30,7 @@ lib.makeScope
     inherit (callPackage ./utils.nix { }) fetchurl derivationWithMeta writeTextFile writeText;
 
     test = kaem.runCommand "minimal-bootstrap-test" {} ''
+      echo ${mes.tests.get-version}
       echo ${tinycc-mes.compiler.tests.chain}
       mkdir ''${out}
     '';

--- a/pkgs/os-specific/linux/minimal-bootstrap/default.nix
+++ b/pkgs/os-specific/linux/minimal-bootstrap/default.nix
@@ -30,7 +30,7 @@ lib.makeScope
     inherit (callPackage ./utils.nix { }) fetchurl derivationWithMeta writeTextFile writeText;
 
     test = kaem.runCommand "minimal-bootstrap-test" {} ''
-      echo ${mes.tests.get-version}
+      echo ${mes.compiler.tests.get-version}
       echo ${tinycc-mes.compiler.tests.chain}
       mkdir ''${out}
     '';

--- a/pkgs/os-specific/linux/minimal-bootstrap/default.nix
+++ b/pkgs/os-specific/linux/minimal-bootstrap/default.nix
@@ -29,4 +29,8 @@ lib.makeScope
 
     inherit (callPackage ./utils.nix { }) fetchurl derivationWithMeta writeTextFile writeText;
 
+    test = kaem.runCommand "minimal-bootstrap-test" {} ''
+      echo ${tinycc-mes.compiler.tests.chain}
+      mkdir ''${out}
+    '';
   })

--- a/pkgs/os-specific/linux/minimal-bootstrap/default.nix
+++ b/pkgs/os-specific/linux/minimal-bootstrap/default.nix
@@ -20,7 +20,9 @@ lib.makeScope
     mes = callPackage ./mes { };
     mes-libc = callPackage ./mes/libc.nix { };
 
-    inherit (callPackage ./stage0-posix { }) kaem m2libc mescc-tools mescc-tools-extra;
+    stage0-posix = callPackage ./stage0-posix { };
+
+    inherit (self.stage0-posix) kaem m2libc mescc-tools mescc-tools-extra;
 
     tinycc-bootstrappable = callPackage ./tinycc/bootstrappable.nix { };
     tinycc-mes = callPackage ./tinycc/mes.nix { };

--- a/pkgs/os-specific/linux/minimal-bootstrap/gnumake/default.nix
+++ b/pkgs/os-specific/linux/minimal-bootstrap/gnumake/default.nix
@@ -45,7 +45,7 @@ let
         ./configure \
           --build i686-pc-linux-gnu \
           --host i686-pc-linux-gnu \
-          CC="${tinycc-mes}/bin/tcc -static" \
+          CC="${tinycc.compiler}/bin/tcc -B ${tinycc.libs}/lib -static" \
           ac_cv_func_dup=no
     - `ac_cv_func_dup` disabled as mes-libc doesn't implement tmpfile()
 
@@ -148,7 +148,7 @@ in
 kaem.runCommand "${pname}-${version}" {
   inherit pname version;
 
-  nativeBuildInputs = [ tinycc gnupatch ];
+  nativeBuildInputs = [ tinycc.compiler gnupatch ];
 
   meta = with lib; {
     description = "A tool to control the generation of non-source files from sources";
@@ -174,7 +174,7 @@ kaem.runCommand "${pname}-${version}" {
   cp lib/fnmatch.in.h lib/fnmatch.h
 
   # Compile
-  alias CC="tcc ${lib.concatStringsSep " " CFLAGS}"
+  alias CC="tcc -B ${tinycc.libs}/lib ${lib.concatStringsSep " " CFLAGS}"
   ${lib.concatMapStringsSep "\n" (f: "CC -c ${f}") sources}
 
   # Link

--- a/pkgs/os-specific/linux/minimal-bootstrap/gnupatch/default.nix
+++ b/pkgs/os-specific/linux/minimal-bootstrap/gnupatch/default.nix
@@ -70,7 +70,7 @@ in
 kaem.runCommand "${pname}-${version}" {
   inherit pname version;
 
-  nativeBuildInputs = [ tinycc ];
+  nativeBuildInputs = [ tinycc.compiler ];
 
   meta = with lib; {
     description = "GNU Patch, a program to apply differences to files";
@@ -91,7 +91,7 @@ kaem.runCommand "${pname}-${version}" {
   catm config.h
 
   # Build
-  alias CC="tcc ${lib.concatStringsSep " " CFLAGS}"
+  alias CC="tcc -B ${tinycc.libs}/lib ${lib.concatStringsSep " " CFLAGS}"
   ${lib.concatMapStringsSep "\n" (f: "CC -c ${f}") sources}
 
   # Link

--- a/pkgs/os-specific/linux/minimal-bootstrap/ln-boot/default.nix
+++ b/pkgs/os-specific/linux/minimal-bootstrap/ln-boot/default.nix
@@ -20,8 +20,8 @@ kaem.runCommand "${pname}-${version}" {
   };
 } ''
   mkdir -p ''${out}/bin
-  ${mes}/bin/mes --no-auto-compile -e main ${mes}/bin/mescc.scm -- \
-    -L ${mes}/lib \
+  ${mes.compiler}/bin/mes --no-auto-compile -e main ${mes.srcPost.bin}/bin/mescc.scm -- \
+    -L ${mes.libs}/lib \
     -lc+tcc \
     -o ''${out}/bin/ln \
     ${src}

--- a/pkgs/os-specific/linux/minimal-bootstrap/ln-boot/default.nix
+++ b/pkgs/os-specific/linux/minimal-bootstrap/ln-boot/default.nix
@@ -21,6 +21,7 @@ kaem.runCommand "${pname}-${version}" {
 } ''
   mkdir -p ''${out}/bin
   ${mes}/bin/mes --no-auto-compile -e main ${mes}/bin/mescc.scm -- \
+    -L ${mes}/lib \
     -lc+tcc \
     -o ''${out}/bin/ln \
     ${src}

--- a/pkgs/os-specific/linux/minimal-bootstrap/mes/default.nix
+++ b/pkgs/os-specific/linux/minimal-bootstrap/mes/default.nix
@@ -6,6 +6,12 @@
 , m2libc
 , mescc-tools
 }:
+
+# Maintenance note:
+# Build steps have been adapted from build-aux/bootstrap.sh.in
+# as well as the live-bootstrap project
+# https://github.com/fosslinux/live-bootstrap/blob/1bc4296091c51f53a5598050c8956d16e945b0f5/sysa/mes-0.24.2/mes-0.24.2.kaem
+
 let
   pname = "mes";
   version = "0.24.2";
@@ -28,26 +34,6 @@ let
   # add symlink() to libc+tcc so we can use it in ln-boot
   libc_tcc_SOURCES = sources.libc_tcc_SOURCES ++ [ "lib/linux/symlink.c" ];
 
-  compile = sources:
-    lib.concatMapStringsSep
-      "\n"
-      (f: ''CC -c ''${MES_PREFIX}/${f}'')
-      sources;
-  replaceExt = ext: source:
-    lib.replaceStrings
-      [ ".c" ]
-      [ ext ]
-      (builtins.baseNameOf source);
-  archive = out: sources:
-    "catm ${out} ${lib.concatMapStringsSep " " (replaceExt ".o") sources}";
-  sourceArchive = out: sources:
-    "catm ${out} ${lib.concatMapStringsSep " " (replaceExt ".s") sources}";
-in
-kaem.runCommand "${pname}-${version}" {
-  inherit pname version;
-
-  passthru = { inherit src nyacc; };
-
   meta = with lib; {
     description = "Scheme interpreter and C compiler for bootstrapping";
     homepage = "https://www.gnu.org/software/mes";
@@ -55,135 +41,188 @@ kaem.runCommand "${pname}-${version}" {
     maintainers = with maintainers; [ emilytrau ];
     platforms = [ "i686-linux" ];
   };
+
+  srcPost = kaem.runCommand "${pname}-src-${version}" {
+    outputs = [ "out" "bin" ];
+    inherit meta;
+  } ''
+    # Unpack source
+    ungz --file ${src} --output mes.tar
+    mkdir ''${out}
+    cd ''${out}
+    untar --non-strict --file ''${NIX_BUILD_TOP}/mes.tar # ignore symlinks
+
+    MES_PREFIX=''${out}/mes-${version}
+
+    cd ''${MES_PREFIX}
+
+    cp ${config_h} include/mes/config.h
+
+    mkdir include/arch
+    cp include/linux/x86/syscall.h include/arch/syscall.h
+    cp include/linux/x86/kernel-stat.h include/arch/kernel-stat.h
+
+    # Remove pregenerated files
+    rm mes/module/mes/psyntax.pp mes/module/mes/psyntax.pp.header
+
+    # These files are symlinked in the repo
+    cp mes/module/srfi/srfi-9-struct.mes mes/module/srfi/srfi-9.mes
+    cp mes/module/srfi/srfi-9/gnu-struct.mes mes/module/srfi/srfi-9/gnu.mes
+
+    # Fixes to support newer M2-Planet
+    catm x86_defs.M1 ${m2libc}/x86/x86_defs.M1 lib/m2/x86/x86_defs.M1
+    cp x86_defs.M1 lib/m2/x86/x86_defs.M1
+    rm x86_defs.M1
+
+    # Remove environment impurities
+    __GUILE_LOAD_PATH="\"''${MES_PREFIX}/mes/module:''${MES_PREFIX}/module:${nyacc.guilePath}\""
+    boot0_scm=mes/module/mes/boot-0.scm
+    guile_mes=mes/module/mes/guile.mes
+    replace --file ''${boot0_scm} --output ''${boot0_scm} --match-on "(getenv \"GUILE_LOAD_PATH\")" --replace-with ''${__GUILE_LOAD_PATH}
+    replace --file ''${guile_mes} --output ''${guile_mes} --match-on "(getenv \"GUILE_LOAD_PATH\")" --replace-with ''${__GUILE_LOAD_PATH}
+
+    module_mescc_scm=module/mescc/mescc.scm
+    replace --file ''${module_mescc_scm} --output ''${module_mescc_scm} --match-on "(getenv \"M1\")" --replace-with "\"${mescc-tools}/bin/M1\""
+    replace --file ''${module_mescc_scm} --output ''${module_mescc_scm} --match-on "(getenv \"HEX2\")" --replace-with "\"${mescc-tools}/bin/hex2\""
+    replace --file ''${module_mescc_scm} --output ''${module_mescc_scm} --match-on "(getenv \"BLOOD_ELF\")" --replace-with "\"${mescc-tools}/bin/blood-elf\""
+    replace --file ''${module_mescc_scm} --output ''${module_mescc_scm} --match-on "(getenv \"srcdest\")" --replace-with "\"''${MES_PREFIX}\""
+
+    mes_c=src/mes.c
+    replace --file ''${mes_c} --output ''${mes_c} --match-on "getenv (\"MES_PREFIX\")" --replace-with "\"''${MES_PREFIX}\""
+    replace --file ''${mes_c} --output ''${mes_c} --match-on "getenv (\"srcdest\")" --replace-with "\"''${MES_PREFIX}\""
+
+    # Increase runtime resource limits
+    gc_c=src/gc.c
+    replace --file ''${gc_c} --output ''${gc_c} --match-on "getenv (\"MES_ARENA\")" --replace-with "\"100000000\""
+    replace --file ''${gc_c} --output ''${gc_c} --match-on "getenv (\"MES_MAX_ARENA\")" --replace-with "\"100000000\""
+    replace --file ''${gc_c} --output ''${gc_c} --match-on "getenv (\"MES_STACK\")" --replace-with "\"6000000\""
+
+    # Create mescc.scm
+    mescc_in=scripts/mescc.scm.in
+    replace --file ''${mescc_in} --output ''${mescc_in} --match-on "(getenv \"MES_PREFIX\")" --replace-with "\"''${MES_PREFIX}\""
+    replace --file ''${mescc_in} --output ''${mescc_in} --match-on "(getenv \"includedir\")" --replace-with "\"''${MES_PREFIX}/include\""
+    replace --file ''${mescc_in} --output ''${mescc_in} --match-on "(getenv \"libdir\")" --replace-with "\"''${MES_PREFIX}/lib\""
+    replace --file ''${mescc_in} --output ''${mescc_in} --match-on @prefix@ --replace-with ''${MES_PREFIX}
+    replace --file ''${mescc_in} --output ''${mescc_in} --match-on @VERSION@ --replace-with ${version}
+    replace --file ''${mescc_in} --output ''${mescc_in} --match-on @mes_cpu@ --replace-with x86
+    replace --file ''${mescc_in} --output ''${mescc_in} --match-on @mes_kernel@ --replace-with linux
+    mkdir -p ''${bin}/bin
+    cp ''${mescc_in} ''${bin}/bin/mescc.scm
+
+    # Build mes-m2
+    mes_cpu=x86
+    stage0_cpu=x86
+    kaem --verbose --strict --file kaem.run
+    cp bin/mes-m2 ''${bin}/bin/mes-m2
+    chmod 555 ''${bin}/bin/mes-m2
+  '';
+
+  srcPrefix = "${srcPost.out}/mes-${version}";
+
+  cc = "${srcPost.bin}/bin/mes-m2";
+  ccArgs = [
+    "-e" "main"
+    "${srcPost.bin}/bin/mescc.scm"
+    "--"
+    "-D" "HAVE_CONFIG_H=1"
+    "-I" "${srcPrefix}/include"
+    "-I" "${srcPrefix}/include/linux/x86"
+  ];
+
+  CC = toString ([ cc ] ++ ccArgs);
+
+  replaceExt = ext: source:
+    lib.replaceStrings
+      [ ".c" ]
+      [ ext ]
+      (builtins.baseNameOf source);
+
+  compile = source: kaem.runCommand (replaceExt "" source) {} ''
+    mkdir ''${out}
+    cd ''${out}
+    ${CC} -c ${srcPrefix}/${source}
+  '';
+
+  crt1 = compile "/lib/linux/x86-mes-mescc/crt1.c";
+
+  getRes = suffix: res: "${res}/${res.name}${suffix}";
+
+  archive = out: sources:
+    "catm ${out} ${lib.concatMapStringsSep " " (getRes ".o") sources}";
+  sourceArchive = out: sources:
+    "catm ${out} ${lib.concatMapStringsSep " " (getRes ".s") sources}";
+
+  mkLib = libname: sources: let
+    os = map compile sources;
+  in kaem.runCommand "${pname}-${libname}-${version}" {
+    inherit meta;
+  } ''
+    LIBDIR=''${out}/lib
+    mkdir -p ''${LIBDIR}
+    cd ''${LIBDIR}
+
+    ${archive "${libname}.a" os}
+    ${sourceArchive "${libname}.s" os}
+  '';
+
+  libc-mini = mkLib "libc-mini" libc_mini_SOURCES;
+  libmescc = mkLib "libmescc" libmescc_SOURCES;
+  libc = mkLib "libc" libc_SOURCES;
+  libc_tcc = mkLib "libc+tcc" libc_tcc_SOURCES;
+
+in kaem.runCommand "${pname}-${version}" {
+  inherit pname version;
+
+  passthru = { inherit src srcPost srcPrefix nyacc; };
+  passthru.tests.get-version = result: kaem.runCommand "${pname}-get-version-${version}" {} ''
+    ${result}/bin/mes --version
+    mkdir ''${out}
+  '';
+
+  inherit meta;
 }
-# Maintenance note:
-# Build steps have been adapted from build-aux/bootstrap.sh.in
-# as well as the live-bootstrap project
-# https://github.com/fosslinux/live-bootstrap/blob/1bc4296091c51f53a5598050c8956d16e945b0f5/sysa/mes-0.24.2/mes-0.24.2.kaem
 ''
-  # Unpack source
-  ungz --file ${src} --output mes.tar
-  mkdir ''${out} ''${out}/bin ''${out}/share
-  cd ''${out}/share
-  untar --non-strict --file ''${NIX_BUILD_TOP}/mes.tar # ignore symlinks
+  LIBDIR=''${out}/lib
+  BINDIR=''${out}/bin
 
-  MES_PREFIX=''${out}/share/mes-${version}
-  LIBDIR=''${MES_PREFIX}/lib
+  mkdir -p ''${out} ''${LIBDIR} ''${BINDIR}
 
-  cd ''${MES_PREFIX}
-
-  cp ${config_h} include/mes/config.h
-
-  mkdir include/arch
-  cp include/linux/x86/syscall.h include/arch/syscall.h
-  cp include/linux/x86/kernel-stat.h include/arch/kernel-stat.h
-
-  # Remove pregenerated files
-  rm mes/module/mes/psyntax.pp mes/module/mes/psyntax.pp.header
-
-  # These files are symlinked in the repo
-  cp mes/module/srfi/srfi-9-struct.mes mes/module/srfi/srfi-9.mes
-  cp mes/module/srfi/srfi-9/gnu-struct.mes mes/module/srfi/srfi-9/gnu.mes
-
-  # Fixes to support newer M2-Planet
-  catm x86_defs.M1 ${m2libc}/x86/x86_defs.M1 lib/m2/x86/x86_defs.M1
-  cp x86_defs.M1 lib/m2/x86/x86_defs.M1
-  rm x86_defs.M1
-
-  # Remove environment impurities
-  __GUILE_LOAD_PATH="\"''${MES_PREFIX}/mes/module:''${MES_PREFIX}/module:${nyacc.guilePath}\""
-  boot0_scm=mes/module/mes/boot-0.scm
-  guile_mes=mes/module/mes/guile.mes
-  replace --file ''${boot0_scm} --output ''${boot0_scm} --match-on "(getenv \"GUILE_LOAD_PATH\")" --replace-with ''${__GUILE_LOAD_PATH}
-  replace --file ''${guile_mes} --output ''${guile_mes} --match-on "(getenv \"GUILE_LOAD_PATH\")" --replace-with ''${__GUILE_LOAD_PATH}
-
-  module_mescc_scm=module/mescc/mescc.scm
-  replace --file ''${module_mescc_scm} --output ''${module_mescc_scm} --match-on "(getenv \"M1\")" --replace-with "\"${mescc-tools}/bin/M1\""
-  replace --file ''${module_mescc_scm} --output ''${module_mescc_scm} --match-on "(getenv \"HEX2\")" --replace-with "\"${mescc-tools}/bin/hex2\""
-  replace --file ''${module_mescc_scm} --output ''${module_mescc_scm} --match-on "(getenv \"BLOOD_ELF\")" --replace-with "\"${mescc-tools}/bin/blood-elf\""
-  replace --file ''${module_mescc_scm} --output ''${module_mescc_scm} --match-on "(getenv \"srcdest\")" --replace-with "\"''${MES_PREFIX}\""
-
-  mes_c=src/mes.c
-  replace --file ''${mes_c} --output ''${mes_c} --match-on "getenv (\"MES_PREFIX\")" --replace-with "\"''${MES_PREFIX}\""
-  replace --file ''${mes_c} --output ''${mes_c} --match-on "getenv (\"srcdest\")" --replace-with "\"''${MES_PREFIX}\""
-
-  # Increase runtime resource limits
-  gc_c=src/gc.c
-  replace --file ''${gc_c} --output ''${gc_c} --match-on "getenv (\"MES_ARENA\")" --replace-with "\"100000000\""
-  replace --file ''${gc_c} --output ''${gc_c} --match-on "getenv (\"MES_MAX_ARENA\")" --replace-with "\"100000000\""
-  replace --file ''${gc_c} --output ''${gc_c} --match-on "getenv (\"MES_STACK\")" --replace-with "\"6000000\""
-
-  # Create mescc.scm
-  mescc_in=scripts/mescc.scm.in
-  replace --file ''${mescc_in} --output ''${mescc_in} --match-on "(getenv \"MES_PREFIX\")" --replace-with "\"''${MES_PREFIX}\""
-  replace --file ''${mescc_in} --output ''${mescc_in} --match-on "(getenv \"includedir\")" --replace-with "\"''${MES_PREFIX}/include\""
-  replace --file ''${mescc_in} --output ''${mescc_in} --match-on "(getenv \"libdir\")" --replace-with "\"''${MES_PREFIX}/lib\""
-  replace --file ''${mescc_in} --output ''${mescc_in} --match-on @prefix@ --replace-with ''${MES_PREFIX}
-  replace --file ''${mescc_in} --output ''${mescc_in} --match-on @VERSION@ --replace-with ${version}
-  replace --file ''${mescc_in} --output ''${mescc_in} --match-on @mes_cpu@ --replace-with x86
-  replace --file ''${mescc_in} --output ''${mescc_in} --match-on @mes_kernel@ --replace-with linux
-  cp ''${mescc_in} ''${out}/bin/mescc.scm
-
-  # Build mes-m2
-  mes_cpu=x86
-  stage0_cpu=x86
-  kaem --verbose --strict --file kaem.run
-  cp bin/mes-m2 ''${out}/bin/mes-m2
-  chmod 555 ''${out}/bin/mes-m2
-
+  cp ${srcPost.bin}/bin/mescc.scm ''${BINDIR}/mescc.scm
+  cp ${srcPost.bin}/bin/mes-m2 ''${BINDIR}/mes-m2
+  chmod 555 ''${BINDIR}/mes-m2
 
   # Recompile Mes and Mes C library using mes-m2 bootstrapped Mes
-  cd ''${NIX_BUILD_TOP}
-  alias CC="''${out}/bin/mes-m2 -e main ''${out}/bin/mescc.scm -- -D HAVE_CONFIG_H=1 -I ''${MES_PREFIX}/include -I ''${MES_PREFIX}/include/linux/x86"
   mkdir -p ''${LIBDIR}/x86-mes
 
   # crt1.o
-  CC -c ''${MES_PREFIX}/lib/linux/x86-mes-mescc/crt1.c
-  cp crt1.o ''${LIBDIR}/x86-mes
-  cp crt1.s ''${LIBDIR}/x86-mes
+  cp ${crt1}/crt1.o ''${LIBDIR}/x86-mes
+  cp ${crt1}/crt1.s ''${LIBDIR}/x86-mes
 
   # libc-mini.a
-  ${compile libc_mini_SOURCES}
-  ${archive "libc-mini.a" libc_mini_SOURCES}
-  ${sourceArchive "libc-mini.s" libc_mini_SOURCES}
-  cp libc-mini.a ''${LIBDIR}/x86-mes
-  cp libc-mini.s ''${LIBDIR}/x86-mes
+  cp ${libc-mini}/lib/libc-mini.a ''${LIBDIR}/x86-mes
+  cp ${libc-mini}/lib/libc-mini.s ''${LIBDIR}/x86-mes
 
   # libmescc.a
-  ${compile libmescc_SOURCES}
-  ${archive "libmescc.a" libmescc_SOURCES}
-  ${sourceArchive "libmescc.s" libmescc_SOURCES}
-  cp libmescc.a ''${LIBDIR}/x86-mes
-  cp libmescc.s ''${LIBDIR}/x86-mes
+  cp ${libmescc}/lib/libmescc.a ''${LIBDIR}/x86-mes
+  cp ${libmescc}/lib/libmescc.s ''${LIBDIR}/x86-mes
 
   # libc.a
-  ${compile libc_SOURCES}
-  ${archive "libc.a" libc_SOURCES}
-  ${sourceArchive "libc.s" libc_SOURCES}
-  cp libc.a ''${LIBDIR}/x86-mes
-  cp libc.s ''${LIBDIR}/x86-mes
+  cp ${libc}/lib/libc.a ''${LIBDIR}/x86-mes
+  cp ${libc}/lib/libc.s ''${LIBDIR}/x86-mes
 
   # libc+tcc.a
-  # optimisation: don't recompile common libc sources
-  ${compile (lib.subtractLists libc_SOURCES libc_tcc_SOURCES)}
-  ${archive "libc+tcc.a" libc_tcc_SOURCES}
-  ${sourceArchive "libc+tcc.s" libc_tcc_SOURCES}
-  cp libc+tcc.a ''${LIBDIR}/x86-mes
-  cp libc+tcc.s ''${LIBDIR}/x86-mes
+  cp ${libc_tcc}/lib/libc+tcc.a ''${LIBDIR}/x86-mes
+  cp ${libc_tcc}/lib/libc+tcc.s ''${LIBDIR}/x86-mes
 
   # Build mes itself
-  ${compile mes_SOURCES}
   ''${out}/bin/mes-m2 -e main ''${out}/bin/mescc.scm -- \
     --base-address 0x08048000 \
-    -L ''${MES_PREFIX}/lib \
-    -L . \
+    -L ''${srcPrefix}/lib \
+    -L ''${LIBDIR} \
     -lc \
     -lmescc \
     -nostdlib \
     -o ''${out}/bin/mes \
-    crt1.o \
-    ${lib.concatMapStringsSep " " (replaceExt ".o") mes_SOURCES}
-
-  # Check
-  ''${out}/bin/mes --version
+    ''${LIBDIR}/x86-mes/crt1.o \
+    ${lib.concatMapStringsSep " " (getRes ".o") (map compile mes_SOURCES)}
 ''

--- a/pkgs/os-specific/linux/minimal-bootstrap/mes/default.nix
+++ b/pkgs/os-specific/linux/minimal-bootstrap/mes/default.nix
@@ -131,13 +131,13 @@ let
 
   CC = toString ([ cc ] ++ ccArgs);
 
-  replaceExt = ext: source:
+  stripExt = source:
     lib.replaceStrings
       [ ".c" ]
-      [ ext ]
+      [ "" ]
       (builtins.baseNameOf source);
 
-  compile = source: kaem.runCommand (replaceExt "" source) {} ''
+  compile = source: kaem.runCommand (stripExt source) {} ''
     mkdir ''${out}
     cd ''${out}
     ${CC} -c ${srcPrefix}/${source}

--- a/pkgs/os-specific/linux/minimal-bootstrap/mes/libc.nix
+++ b/pkgs/os-specific/linux/minimal-bootstrap/mes/libc.nix
@@ -11,8 +11,6 @@ let
   sources = (import ./sources.nix).x86.linux.gcc;
   inherit (sources) libtcc1_SOURCES libc_gnu_SOURCES;
 
-  prefix = "${mes}/share/mes-${version}";
-
   # Concatenate all source files into a convenient bundle
   # "gcc" variants of source files (eg. "lib/linux/x86-mes-gcc") can also be
   # compiled by tinycc
@@ -37,11 +35,11 @@ kaem.runCommand "${pname}-${version}" {
     platforms = [ "i686-linux" ];
   };
 } ''
-  cd ${prefix}
+  cd ${mes.srcPrefix}
 
   # mescc compiled libc.a
   mkdir -p ''${out}/lib/x86-mes
-  cp lib/x86-mes/libc.a ''${out}/lib/x86-mes
+  cp ${mes}/lib/x86-mes/libc.a ''${out}/lib/x86-mes
 
   # libc.c
   catm ''${TMPDIR}/first.c ${lib.concatStringsSep " " firstLibc}
@@ -59,5 +57,5 @@ kaem.runCommand "${pname}-${version}" {
   cp lib/posix/getopt.c ''${out}/lib/libgetopt.c
 
   # Install headers
-  ln -s ${prefix}/include ''${out}/include
+  ln -s ${mes.srcPrefix}/include ''${out}/include
 ''

--- a/pkgs/os-specific/linux/minimal-bootstrap/mes/libc.nix
+++ b/pkgs/os-specific/linux/minimal-bootstrap/mes/libc.nix
@@ -39,7 +39,6 @@ kaem.runCommand "${pname}-${version}" {
 
   # mescc compiled libc.a
   mkdir -p ''${out}/lib/x86-mes
-  cp ${mes}/lib/x86-mes/libc.a ''${out}/lib/x86-mes
 
   # libc.c
   catm ''${TMPDIR}/first.c ${lib.concatStringsSep " " firstLibc}

--- a/pkgs/os-specific/linux/minimal-bootstrap/mes/libc.nix
+++ b/pkgs/os-specific/linux/minimal-bootstrap/mes/libc.nix
@@ -6,7 +6,7 @@
 }:
 let
   pname = "mes-libc";
-  inherit (mes) version;
+  inherit (mes.compiler) version;
 
   sources = (import ./sources.nix).x86.linux.gcc;
   inherit (sources) libtcc1_SOURCES libc_gnu_SOURCES;

--- a/pkgs/os-specific/linux/minimal-bootstrap/stage0-posix/default.nix
+++ b/pkgs/os-specific/linux/minimal-bootstrap/stage0-posix/default.nix
@@ -12,7 +12,9 @@ lib.makeScope newScope (self: with self; {
   kaem = callPackage ./kaem { };
   kaem-minimal = callPackage ./kaem/minimal.nix { };
 
-  inherit (callPackage ./stage0-posix-x86.nix { }) blood-elf-0 hex2 kaem-unwrapped M1 M2;
+  stage0-posix-x86 = callPackage ./stage0-posix-x86.nix { };
+
+  inherit (self.stage0-posix-x86) blood-elf-0 hex2 kaem-unwrapped M1 M2;
 
   mescc-tools = callPackage ./mescc-tools { };
 

--- a/pkgs/os-specific/linux/minimal-bootstrap/tinycc/bootstrappable.nix
+++ b/pkgs/os-specific/linux/minimal-bootstrap/tinycc/bootstrappable.nix
@@ -15,7 +15,7 @@
 , mes-libc
 }:
 let
-  inherit (callPackage ./common.nix { }) buildTinyccMes;
+  inherit (callPackage ./common.nix { }) buildTinyccMes recompileLibc;
 
   version = "unstable-2023-04-20";
   rev = "80114c4da6b17fbaabb399cc29f427e368309bc8";
@@ -39,50 +39,53 @@ let
     platforms = [ "i686-linux" ];
   };
 
-  tinycc-boot-mes = kaem.runCommand "tinycc-boot-mes-${version}" {} ''
-    catm config.h
-    ${mes}/bin/mes --no-auto-compile -e main ${mes}/bin/mescc.scm -- \
-      -S \
-      -o tcc.s \
-      -I . \
-      -D BOOTSTRAP=1 \
-      -I ${src} \
-      -D TCC_TARGET_I386=1 \
-      -D inline= \
-      -D CONFIG_TCCDIR=\"''${out}/lib\" \
-      -D CONFIG_SYSROOT=\"\" \
-      -D CONFIG_TCC_CRTPREFIX=\"''${out}/lib\" \
-      -D CONFIG_TCC_ELFINTERP=\"/mes/loader\" \
-      -D CONFIG_TCC_SYSINCLUDEPATHS=\"${mes-libc}/include\" \
-      -D TCC_LIBGCC=\"${mes-libc}/lib/x86-mes/libc.a\" \
-      -D CONFIG_TCC_LIBTCC1_MES=0 \
-      -D CONFIG_TCCBOOT=1 \
-      -D CONFIG_TCC_STATIC=1 \
-      -D CONFIG_USE_LIBGCC=1 \
-      -D TCC_MES_LIBC=1 \
-      -D TCC_VERSION=\"${version}\" \
-      -D ONE_SOURCE=1 \
-      ${src}/tcc.c
-    mkdir -p ''${out}/bin
-    ${mes}/bin/mes --no-auto-compile -e main ${mes}/bin/mescc.scm -- \
-      -l c+tcc \
-      -o ''${out}/bin/tcc \
-      tcc.s
+  pname = "tinycc-boot-mes";
 
-    ''${out}/bin/tcc -version
+  tinycc-boot-mes = rec {
+    compiler = kaem.runCommand "${pname}-${version}" {
+      passthru.tests.get-version = result: kaem.runCommand "${pname}-get-version-${version}" {} ''
+        ${result}/bin/tcc -version
+        mkdir ''${out}
+      '';
+    } ''
+      catm config.h
+      ${mes}/bin/mes --no-auto-compile -e main ${mes}/bin/mescc.scm -- \
+        -S \
+        -o tcc.s \
+        -I . \
+        -D BOOTSTRAP=1 \
+        -I ${src} \
+        -D TCC_TARGET_I386=1 \
+        -D inline= \
+        -D CONFIG_TCCDIR=\"\" \
+        -D CONFIG_SYSROOT=\"\" \
+        -D CONFIG_TCC_CRTPREFIX=\"{B}\" \
+        -D CONFIG_TCC_ELFINTERP=\"/mes/loader\" \
+        -D CONFIG_TCC_LIBPATHS=\"{B}\" \
+        -D CONFIG_TCC_SYSINCLUDEPATHS=\"${mes-libc}/include\" \
+        -D TCC_LIBGCC=\"${mes-libc}/lib/x86-mes/libc.a\" \
+        -D CONFIG_TCC_LIBTCC1_MES=0 \
+        -D CONFIG_TCCBOOT=1 \
+        -D CONFIG_TCC_STATIC=1 \
+        -D CONFIG_USE_LIBGCC=1 \
+        -D TCC_MES_LIBC=1 \
+        -D TCC_VERSION=\"${version}\" \
+        -D ONE_SOURCE=1 \
+        ${src}/tcc.c
+      mkdir -p ''${out}/bin
+      ${mes}/bin/mes --no-auto-compile -e main ${mes}/bin/mescc.scm -- \
+        -l c+tcc \
+        -o ''${out}/bin/tcc \
+        tcc.s
+    '';
 
-    # Recompile libc: crt{1,n,i}, libtcc.a, libc.a, libgetopt.a
-    mkdir -p ''${out}/lib
-    ''${out}/bin/tcc ${mes-libc.CFLAGS} -c -o ''${out}/lib/crt1.o ${mes-libc}/lib/crt1.c
-    ''${out}/bin/tcc ${mes-libc.CFLAGS} -c -o ''${out}/lib/crtn.o ${mes-libc}/lib/crtn.c
-    ''${out}/bin/tcc ${mes-libc.CFLAGS} -c -o ''${out}/lib/crti.o ${mes-libc}/lib/crti.c
-    ''${out}/bin/tcc ${mes-libc.CFLAGS} -c -o libc.o ${mes-libc}/lib/libc.c
-    ''${out}/bin/tcc -ar cr ''${out}/lib/libc.a libc.o
-    ''${out}/bin/tcc ${mes-libc.CFLAGS} -c -o libtcc1.o ${mes-libc}/lib/libtcc1.c
-    ''${out}/bin/tcc -ar cr ''${out}/lib/libtcc1.a libtcc1.o
-    ''${out}/bin/tcc ${mes-libc.CFLAGS} -c -o libgetopt.o ${mes-libc}/lib/libgetopt.c
-    ''${out}/bin/tcc -ar cr ''${out}/lib/libgetopt.a libgetopt.o
-  '';
+    libs = recompileLibc {
+      inherit pname version;
+      tcc = compiler;
+      src = mes-libc;
+      libtccOptions = mes-libc.CFLAGS;
+    };
+  };
 
   # Bootstrap stage build flags obtained from
   # https://gitlab.com/janneke/tinycc/-/blob/80114c4da6b17fbaabb399cc29f427e368309bc8/boot.sh

--- a/pkgs/os-specific/linux/minimal-bootstrap/tinycc/bootstrappable.nix
+++ b/pkgs/os-specific/linux/minimal-bootstrap/tinycc/bootstrappable.nix
@@ -49,7 +49,7 @@ let
       '';
     } ''
       catm config.h
-      ${mes}/bin/mes --no-auto-compile -e main ${mes}/bin/mescc.scm -- \
+      ${mes.compiler}/bin/mes --no-auto-compile -e main ${mes.srcPost.bin}/bin/mescc.scm -- \
         -S \
         -o tcc.s \
         -I . \
@@ -73,8 +73,8 @@ let
         -D ONE_SOURCE=1 \
         ${src}/tcc.c
       mkdir -p ''${out}/bin
-      ${mes}/bin/mes --no-auto-compile -e main ${mes}/bin/mescc.scm -- \
-        -L ${mes}/lib \
+      ${mes.compiler}/bin/mes --no-auto-compile -e main ${mes.srcPost.bin}/bin/mescc.scm -- \
+        -L ${mes.libs}/lib \
         -l c+tcc \
         -o ''${out}/bin/tcc \
         tcc.s

--- a/pkgs/os-specific/linux/minimal-bootstrap/tinycc/bootstrappable.nix
+++ b/pkgs/os-specific/linux/minimal-bootstrap/tinycc/bootstrappable.nix
@@ -74,6 +74,7 @@ let
         ${src}/tcc.c
       mkdir -p ''${out}/bin
       ${mes}/bin/mes --no-auto-compile -e main ${mes}/bin/mescc.scm -- \
+        -L ${mes}/lib \
         -l c+tcc \
         -o ''${out}/bin/tcc \
         tcc.s

--- a/pkgs/os-specific/linux/minimal-bootstrap/tinycc/common.nix
+++ b/pkgs/os-specific/linux/minimal-bootstrap/tinycc/common.nix
@@ -3,67 +3,105 @@
 , mes-libc
 , ln-boot
 }:
-{
-  buildTinyccMes = {
-    pname,
-    version,
-    src,
-    prev,
-    buildOptions,
-    libtccBuildOptions,
-    meta
-  }:
+
+rec {
+
+  # Recompile libc: crt{1,n,i}, libtcc.a, libc.a, libgetopt.a
+  recompileLibc =
+    { tcc
+    , pname
+    , version
+    , src
+    , libtccOptions
+    }:
+    let
+
+    crt = kaem.runCommand "crt" {} ''
+      mkdir -p ''${out}/lib
+      ${tcc}/bin/tcc ${mes-libc.CFLAGS} -c -o ''${out}/lib/crt1.o ${mes-libc}/lib/crt1.c
+      ${tcc}/bin/tcc ${mes-libc.CFLAGS} -c -o ''${out}/lib/crtn.o ${mes-libc}/lib/crtn.c
+      ${tcc}/bin/tcc ${mes-libc.CFLAGS} -c -o ''${out}/lib/crti.o ${mes-libc}/lib/crti.c
+    '';
+
+    library = lib: options: source: kaem.runCommand "${lib}.a" {} ''
+      ${tcc}/bin/tcc ${options} -c -o ${lib}.o ${source}
+      ${tcc}/bin/tcc -ar cr ''${out} ${lib}.o
+    '';
+
+    libtcc1 = library "libtcc1" libtccOptions "${src}/lib/libtcc1.c";
+    libc = library "libc" mes-libc.CFLAGS "${mes-libc}/lib/libc.c";
+    libgetopt = library "libgetopt" mes-libc.CFLAGS "${mes-libc}/lib/libgetopt.c";
+  in
+  kaem.runCommand "${pname}-libs-${version}" {} ''
+    mkdir -p ''${out}/lib
+    cp ${crt}/lib/crt1.o ''${out}/lib
+    cp ${crt}/lib/crtn.o ''${out}/lib
+    cp ${crt}/lib/crti.o ''${out}/lib
+    cp ${libtcc1} ''${out}/lib/libtcc1.a
+    cp ${libc} ''${out}/lib/libc.a
+    cp ${libgetopt} ''${out}/lib/libgetopt.a
+  '';
+
+  buildTinyccMes =
+    { pname
+    , version
+    , src
+    , prev
+    , buildOptions
+    , libtccBuildOptions
+    , meta
+    }:
     let
       options = lib.strings.concatStringsSep " " buildOptions;
-      libtccOptions = lib.strings.concatStringsSep " " libtccBuildOptions;
-    in
-    kaem.runCommand "${pname}-${version}" {
-      inherit pname version meta;
-      nativeBuildInputs = [ ln-boot ];
-    } ''
-      catm config.h
-      mkdir -p ''${out}/bin
-      ${prev}/bin/tcc \
-        -g \
-        -v \
-        -static \
-        -o ''${out}/bin/tcc \
-        -D BOOTSTRAP=1 \
-        ${options} \
-        -I . \
-        -I ${src} \
-        -D TCC_TARGET_I386=1 \
-        -D CONFIG_TCCDIR=\"''${out}/lib\" \
-        -D CONFIG_TCC_CRTPREFIX=\"''${out}/lib\" \
-        -D CONFIG_TCC_ELFINTERP=\"\" \
-        -D CONFIG_TCC_LIBPATHS=\"''${out}/lib\" \
-        -D CONFIG_TCC_SYSINCLUDEPATHS=\"${mes-libc}/include:${src}/include\" \
-        -D TCC_LIBGCC=\"libc.a\" \
-        -D TCC_LIBTCC1=\"libtcc1.a\" \
-        -D CONFIG_TCCBOOT=1 \
-        -D CONFIG_TCC_STATIC=1 \
-        -D CONFIG_USE_LIBGCC=1 \
-        -D TCC_MES_LIBC=1 \
-        -D TCC_VERSION=\"${version}\" \
-        -D ONE_SOURCE=1 \
-        -L ${prev}/lib \
-        ${src}/tcc.c
-
-      ''${out}/bin/tcc -v
-
-      # Recompile libc: crt{1,n,i}, libtcc.a, libc.a, libgetopt.a
-      mkdir -p ''${out}/lib
-      ''${out}/bin/tcc ${mes-libc.CFLAGS} -c -o ''${out}/lib/crt1.o ${mes-libc}/lib/crt1.c
-      ''${out}/bin/tcc ${mes-libc.CFLAGS} -c -o ''${out}/lib/crtn.o ${mes-libc}/lib/crtn.c
-      ''${out}/bin/tcc ${mes-libc.CFLAGS} -c -o ''${out}/lib/crti.o ${mes-libc}/lib/crti.c
-      ''${out}/bin/tcc -c -D TCC_TARGET_I386=1 ${libtccOptions} -o libtcc1.o ${src}/lib/libtcc1.c
-      ''${out}/bin/tcc -ar cr ''${out}/lib/libtcc1.a libtcc1.o
-      ''${out}/bin/tcc ${mes-libc.CFLAGS} -c -o libc.o ${mes-libc}/lib/libc.c
-      ''${out}/bin/tcc -ar cr ''${out}/lib/libc.a libc.o
-      ''${out}/bin/tcc ${mes-libc.CFLAGS} -c -o libgetopt.o ${mes-libc}/lib/libgetopt.c
-      ''${out}/bin/tcc -ar cr ''${out}/lib/libgetopt.a libgetopt.o
-
-      # Install headers
-      ln -s ${mes-libc}/include ''${out}/include
-    '';
+      libtccOptions = lib.strings.concatStringsSep " "
+        (["-c" "-D" "TCC_TARGET_I386=1" ] ++ libtccBuildOptions);
+      compiler =  kaem.runCommand "${pname}-${version}" {
+        inherit pname version meta;
+        nativeBuildInputs = [ ln-boot ];
+        passthru.tests = rec {
+          get-version = result: kaem.runCommand "${pname}-get-version-${version}" {} ''
+            ${result}/bin/tcc -version
+            mkdir ''${out}
+          '';
+          chain = result: kaem.runCommand "${pname}-chain-${version}" {} ''
+            echo ${prev.compiler.tests.chain or prev.compiler.tests.get-version};
+            ${result}/bin/tcc -version
+            mkdir ''${out}
+          '';
+        };
+      } ''
+        catm config.h
+        mkdir -p ''${out}/bin
+        ${prev.compiler}/bin/tcc \
+          -B ${prev.libs}/lib \
+          -g \
+          -v \
+          -static \
+          -o ''${out}/bin/tcc \
+          -D BOOTSTRAP=1 \
+          ${options} \
+          -I . \
+          -I ${src} \
+          -D TCC_TARGET_I386=1 \
+          -D CONFIG_TCCDIR=\"\" \
+          -D CONFIG_SYSROOT=\"\" \
+          -D CONFIG_TCC_CRTPREFIX=\"{B}\" \
+          -D CONFIG_TCC_ELFINTERP=\"\" \
+          -D CONFIG_TCC_LIBPATHS=\"{B}\" \
+          -D CONFIG_TCC_SYSINCLUDEPATHS=\"${mes-libc}/include\" \
+          -D TCC_LIBGCC=\"libc.a\" \
+          -D TCC_LIBTCC1=\"libtcc1.a\" \
+          -D CONFIG_TCCBOOT=1 \
+          -D CONFIG_TCC_STATIC=1 \
+          -D CONFIG_USE_LIBGCC=1 \
+          -D TCC_MES_LIBC=1 \
+          -D TCC_VERSION=\"${version}\" \
+          -D ONE_SOURCE=1 \
+          ${src}/tcc.c
+      '';
+    libs = recompileLibc {
+      inherit pname version src libtccOptions;
+      tcc = compiler;
+    };
+  in { inherit prev compiler libs; };
 }

--- a/pkgs/os-specific/linux/minimal-bootstrap/tinycc/mes.nix
+++ b/pkgs/os-specific/linux/minimal-bootstrap/tinycc/mes.nix
@@ -37,7 +37,12 @@ let
 
   tccdefs = kaem.runCommand "tccdefs-${version}" {} ''
     mkdir ''${out}
-    ${tinycc-bootstrappable}/bin/tcc -static -DC2STR -o c2str ${src}/conftest.c
+    ${tinycc-bootstrappable.compiler}/bin/tcc \
+      -B ${tinycc-bootstrappable.libs}/lib \
+      -static \
+      -DC2STR \
+      -o c2str \
+      ${src}/conftest.c
     ./c2str ${src}/include/tccdefs.h ''${out}/tccdefs_.h
   '';
 

--- a/pkgs/os-specific/linux/minimal-bootstrap/utils.nix
+++ b/pkgs/os-specific/linux/minimal-bootstrap/utils.nix
@@ -40,7 +40,7 @@ rec {
     , preferLocalBuild ? true
     }:
     derivationWithMeta {
-      inherit name text executable allowSubstitutes preferLocalBuild;
+      inherit name text allowSubstitutes preferLocalBuild;
       passAsFile = [ "text" ];
 
       builder = "${kaem}/bin/kaem";
@@ -48,20 +48,18 @@ rec {
         "--verbose"
         "--strict"
         "--file"
-        (builtins.toFile "write-text-file.kaem" ''
+        (builtins.toFile "write-text-file.kaem" (''
           target=''${out}''${destination}
-          if match x''${mkdirDestination} x1; then
-            mkdir -p ''${out}''${destinationDir}
-          fi
+        '' + lib.optionalString (builtins.dirOf destination == ".") ''
+          mkdir -p ''${out}''${destinationDir}
+        '' + ''
           cp ''${textPath} ''${target}
-          if match x''${executable} x1; then
-            chmod 555 ''${target}
-          fi
-        '')
+        '' + lib.optionalString executable ''
+          chmod 555 ''${target}
+        ''))
       ];
 
       PATH = lib.makeBinPath [ mescc-tools-extra ];
-      mkdirDestination = if builtins.dirOf destination == "." then "0" else "1";
       destinationDir = builtins.dirOf destination;
       inherit destination;
     };


### PR DESCRIPTION
###### Description of changes

`mes` now builds fast. The only slow step is `mes` building the first `tcc`.

Also, I separated compilers and libs. This is something I generally like to do; it matches Nixpkgs practice; and it will help with cross compilation once we get there.

Similarly, pulled out the `--version` smoke tests, see the new `minimal-bootstrap.test` attribute.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
