### PR TITLE
clisp: remove broken status on Darwin

### DIFF
--- a/pkgs/development/interpreters/clisp/default.nix
+++ b/pkgs/development/interpreters/clisp/default.nix
@@ -34,7 +34,7 @@ stdenv.mkDerivation rec {
 
   inherit libsigsegv gettext coreutils;
 
-  ffcallAvailable = stdenv.isLinux && (libffcall != null);
+  ffcallAvailable = libffcall != null;
 
   buildInputs = [libsigsegv]
   ++ lib.optional (gettext != null) gettext

--- a/pkgs/development/interpreters/clisp/default.nix
+++ b/pkgs/development/interpreters/clisp/default.nix
@@ -101,8 +101,7 @@ stdenv.mkDerivation rec {
     homepage = "http://clisp.cons.org";
     maintainers = lib.teams.lisp.members;
     platforms = lib.platforms.unix;
-    # problems on Darwin: https://github.com/NixOS/nixpkgs/issues/20062
-    broken = stdenv.hostPlatform.isDarwin || stdenv.hostPlatform.isAarch64;
+    broken = stdenv.hostPlatform.isAarch64;
     license = lib.licenses.gpl2;
   };
 }

--- a/pkgs/development/interpreters/clisp/hg.nix
+++ b/pkgs/development/interpreters/clisp/hg.nix
@@ -93,6 +93,7 @@ stdenv.mkDerivation rec {
     homepage = "http://clisp.cons.org";
     maintainers = lib.teams.lisp.members;
     # problems on Darwin: https://github.com/NixOS/nixpkgs/issues/20062
-    platforms = lib.platforms.linux;
+    platforms = lib.platforms.unix;
+    broken = stdenv.hostPlatform.isDarwin;
   };
 }


### PR DESCRIPTION
###### Description of changes
clisp 2.49 seems to build fine on my Mac, so... it works now?

Edit: and ffcall seems to compile just fine, I have removed the `isLinux` guard in a third commit.

###### Things done
- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [X] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).