### PR TITLE
python310Packages.intensity-normalization: unbreak

### DIFF
--- a/pkgs/development/python-modules/intensity-normalization/default.nix
+++ b/pkgs/development/python-modules/intensity-normalization/default.nix
@@ -3,13 +3,17 @@
 , fetchPypi
 , pythonOlder
 , pytestCheckHook
+, pythonRelaxDepsHook
 , matplotlib
 , nibabel
 , numpy
+, pydicom
+, pymedio
 , scikit-fuzzy
 , scikitimage
 , scikit-learn
 , scipy
+, simpleitk
 , statsmodels
 }:
 
@@ -26,25 +30,32 @@ buildPythonPackage rec {
     hash = "sha256-Yjd4hXmbT87xNKSqc6zkKNisOVhQzQAUZI5wBiI/UBk=";
   };
 
+  postPatch = ''
+    substituteInPlace setup.cfg --replace "!=3.10.*," "" --replace "!=3.11.*" ""
+    substituteInPlace setup.cfg --replace "pytest-runner" ""
+  '';
+
+  nativeBuildInputs = [ pythonRelaxDepsHook ];
+  pythonRelaxDeps = [ "nibabel" ];
+
   propagatedBuildInputs = [
     matplotlib
     nibabel
     numpy
+    pydicom
+    pymedio
     scikit-fuzzy
     scikitimage
     scikit-learn
     scipy
+    simpleitk
     statsmodels
   ];
 
   nativeCheckInputs = [
     pytestCheckHook
   ];
-
-  postPatch = ''
-    substituteInPlace setup.cfg \
-      --replace "pytest-runner" ""
-  '';
+  pytestFlagsArray = [ "tests" ];
 
   pythonImportsCheck = [
     "intensity_normalization"
@@ -53,12 +64,11 @@ buildPythonPackage rec {
     "intensity_normalization.util"
   ];
 
+
   meta = with lib; {
     homepage = "https://github.com/jcreinhold/intensity-normalization";
     description = "MRI intensity normalization tools";
     maintainers = with maintainers; [ bcdarwin ];
     license = licenses.asl20;
-    # depends on simpleitk python wrapper which is not packaged yet
-    broken = true;
   };
 }


### PR DESCRIPTION
###### Description of changes

Added missing dependencies and fixed test collection.

###### Things done


- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).