### PR TITLE
nerdfix: 0.3.0 -> 0.3.1

### DIFF
--- a/pkgs/tools/text/nerdfix/default.nix
+++ b/pkgs/tools/text/nerdfix/default.nix
@@ -1,30 +1,20 @@
 { lib
 , rustPlatform
 , fetchFromGitHub
-, fetchpatch
 }:
 
 rustPlatform.buildRustPackage rec {
   pname = "nerdfix";
-  version = "0.3.0";
+  version = "0.3.1";
 
   src = fetchFromGitHub {
     owner = "loichyan";
     repo = "nerdfix";
     rev = "v${version}";
-    hash = "sha256-71P0ESPLTUq8z0mSU4v8KmS069DNUi5fPHz01Kg3aKg=";
+    hash = "sha256-cqTaup/MrtLcBIoY+1vQLLlU+Cmu3iODH4jmZImjGrg=";
   };
 
-  cargoHash = "sha256-XAelHpTVvz+jsDzfB+jsEuUdB0hN7c+hVDvCyOixx9E=";
-
-  patches = [
-    # fixes failing tests due to outdated snapshots
-    (fetchpatch {
-      name = "test-cli-udpate-stdout.patch";
-      url = "https://github.com/loichyan/nerdfix/commit/4070f9e894337ca7d3f7641258428ad6d7cd6332.patch";
-      hash = "sha256-oDuHKgoMcOaO1mtBbT1Uwn5ZUp/FvqsD4S+A1LdOhcE=";
-    })
-  ];
+  cargoHash = "sha256-V/M70ARqOyN0f/uudWPHc4bGc3WXK3PpcM8r2MBEWAs=";
 
   meta = with lib; {
     description = "Nerdfix helps you to find/fix obsolete nerd font icons in your project";


### PR DESCRIPTION
Diff: https://github.com/loichyan/nerdfix/compare/v0.3.0...v0.3.1

Changelog: https://github.com/loichyan/nerdfix/blob/v0.3.1/CHANGELOG.md

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
