### PR TITLE
[22.11] nanomq: add CVE-2023-29994, CVE-2023-29995, CVE-2023-29996 & more to `knownVulnerabilities`

### DIFF
--- a/pkgs/servers/mqtt/nanomq/default.nix
+++ b/pkgs/servers/mqtt/nanomq/default.nix
@@ -32,5 +32,11 @@ stdenv.mkDerivation rec {
     license = licenses.mit;
     maintainers = with maintainers; [ sikmir ];
     platforms = platforms.unix;
+    knownVulnerabilities = [
+      "CVE-2023-29994"
+      "CVE-2023-29995"
+      "CVE-2023-29996"
+      "https://github.com/emqx/nanomq/issues/1050"  # not individually assigned CVEs
+    ];
   };
 }


### PR DESCRIPTION
###### Description of changes
https://nvd.nist.gov/vuln/detail/CVE-2023-29994
https://nvd.nist.gov/vuln/detail/CVE-2023-29995
https://nvd.nist.gov/vuln/detail/CVE-2023-29996

CVE-2023-29996 & CVE-2023-29994 are straightforward enough to patch, CVE-2023-29995 less so, but digging in to that leads to https://github.com/emqx/nanomq/issues/1050, which weren't even assigned individual CVEs (and some look more serious)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
