### PR TITLE
nix-output-monitor: 2.0.0.5 -> 2.0.0.6

### DIFF
--- a/pkgs/tools/nix/nix-output-monitor/default.nix
+++ b/pkgs/tools/nix/nix-output-monitor/default.nix
@@ -20,15 +20,11 @@
       chmod a+x $out/bin/nom-build
       installShellCompletion --zsh --name _nom-build completions/completion.zsh
     '';
-    mainProgram = "nom";
   };
-  nom-pkg = haskellPackages.callPackage ./generated-package.nix { };
-  nom-pkg-with-scope = nom-pkg.overrideScope (hfinal: hprev: {
-    hermes-json = hfinal.hermes-json_0_2_0_1;
-  });
+  raw-pkg = haskellPackages.callPackage ./generated-package.nix {};
 in
-lib.pipe
-  nom-pkg-with-scope
+  lib.pipe
+  raw-pkg
   [
     (overrideCabal overrides)
     justStaticExecutables

--- a/pkgs/tools/nix/nix-output-monitor/default.nix
+++ b/pkgs/tools/nix/nix-output-monitor/default.nix
@@ -1,14 +1,18 @@
 {
   haskell,
-  expect,
   haskellPackages,
   installShellFiles,
-  lib
+  lib,
 }: let
   inherit (haskell.lib.compose) justStaticExecutables overrideCabal;
+
   overrides = {
     passthru.updateScript = ./update.sh;
+
+    # nom has unit-tests and golden-tests
+    # golden-tests call nix and thus can’t be run in a nix build.
     testTarget = "unit-tests";
+
     buildTools = [installShellFiles];
     postInstall = ''
       ln -s nom "$out/bin/nom-build"

--- a/pkgs/tools/nix/nix-output-monitor/generated-package.nix
+++ b/pkgs/tools/nix/nix-output-monitor/generated-package.nix
@@ -26,7 +26,7 @@
   relude,
   safe,
   stm,
-  streamly,
+  streamly-core,
   strict,
   strict-types,
   terminal-size,
@@ -38,10 +38,10 @@
 }:
 mkDerivation {
   pname = "nix-output-monitor";
-  version = "2.0.0.5";
+  version = "2.0.0.6";
   src = fetchzip {
-    url = "https://github.com/maralorn/nix-output-monitor/archive/refs/tags/v2.0.0.5.tar.gz";
-    sha256 = "02xrbf2nr64yfny3idkjb1xbd97wl8m5viifrwjf4hi6ivs5bl18";
+    url = "https://github.com/maralorn/nix-output-monitor/archive/refs/tags/v2.0.0.6.tar.gz";
+    sha256 = "1adxg2bws7fqbmzfna5hr28fh8j10gvf57j6b0xbkhh4hgj4h9xd";
   };
   isLibrary = true;
   isExecutable = true;
@@ -66,7 +66,7 @@ mkDerivation {
     relude
     safe
     stm
-    streamly
+    streamly-core
     strict
     strict-types
     terminal-size
@@ -96,7 +96,7 @@ mkDerivation {
     relude
     safe
     stm
-    streamly
+    streamly-core
     strict
     strict-types
     terminal-size
@@ -129,7 +129,7 @@ mkDerivation {
     relude
     safe
     stm
-    streamly
+    streamly-core
     strict
     strict-types
     terminal-size
@@ -142,5 +142,6 @@ mkDerivation {
   homepage = "https://github.com/maralorn/nix-output-monitor";
   description = "Parses output of nix-build to show additional information";
   license = lib.licenses.agpl3Plus;
-  maintainers = with lib.maintainers; [maralorn];
+  mainProgram = "nom";
+  maintainers = [lib.maintainers.maralorn];
 }


### PR DESCRIPTION
- nix-output-monitor: comment and cleanup
- nix-output-monitor: 2.0.0.5 -> 2.0.0.6

CHANGELOG:

* Small improvements in error reporting.
* Significant performance improvements.

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
