### PR TITLE
vlang: update to latest

### DIFF
--- a/pkgs/development/compilers/tinycc/default.nix
+++ b/pkgs/development/compilers/tinycc/default.nix
@@ -75,7 +75,9 @@ stdenv.mkDerivation rec {
 
   outputs = [ "out" "info" "man" ];
 
-  doCheck = true;
+  # Test segfault for static build
+  doCheck = !stdenv.hostPlatform.isStatic;
+
   checkTarget = "test";
   # https://www.mail-archive.com/tinycc-devel@nongnu.org/msg10142.html
   preCheck = lib.optionalString (stdenv.isDarwin && stdenv.isx86_64) ''


### PR DESCRIPTION
###### Description of changes

I had a go at an update of vlang.
here is where I am at.
On darwin, I've got a failure almost immediately with
```
vlang> cc  -std=gnu99 -w -o v1.exe /nix/store/2pn7pylgi3lhjjkp64456j5afdlv93r0-source/v.c -lm -lpthread
vlang> In file included from /nix/store/2pn7pylgi3lhjjkp64456j5afdlv93r0-source/v.c:1986:
vlang> /nix/store/c834w8pg8ypl9lcaxqgj2bpsxbv518rn-Libsystem-1238.60.2/include/sys/ptrace.h:99:38: error:
unknown type name 'caddr_t'
vlang> int     ptrace(int _request, pid_t _pid, caddr_t _addr, int _data);
vlang>                                          ^
vlang> 1 error generated.
vlang> make: *** [GNUmakefile:113: all] Error 1
```

on linux, I get the thing to compilation to finish, but upon the ldd step I get a
```
> cc  -std=gnu99 -w -o v1.exe /nix/store/2pn7pylgi3lhjjkp64456j5afdlv93r0-source/v.c -lm -lpthread
vlang> ./v1.exe -no-parallel -o v2.exe  cmd/v
vlang> ./v2.exe -nocache -o ./v  cmd/v
vlang> rm -rf v1.exe v2.exe
vlang> ==================
vlang> tcc: error: file '/build/source/thirdparty/tcc/lib/libgc.a' not found
vlang> ...
vlang> ==================
vlang> (Use `v -cg` to print the entire error message)
vlang>
vlang> builder error:
vlang> ==================
vlang>
vlang> This is a compiler bug, please report it using `v bug file.v`.
vlang>
vlang> https://github.com/vlang/v/issues/new/choose
vlang>
vlang> You can also use #help on Discord: https://discord.gg/vlang
vlang>
vlang> make: *** [GNUmakefile:117: all] Error 1
```

@Madouura I know you've worked on this before, you might have a better idea than me.
I originally thought it was a missing libgc library, so I pulled that repo and built it, but it doesn't provide libgc.a file, not in the normal derivation nor in the dev version. So not sure how to continue ther.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
