### PR TITLE
bintools-wrapper: support `lld`'s `-flavor` argument

### DIFF
--- a/pkgs/build-support/bintools-wrapper/default.nix
+++ b/pkgs/build-support/bintools-wrapper/default.nix
@@ -8,6 +8,7 @@
 { name ? ""
 , lib
 , stdenvNoCC
+, testers ? {}
 , bintools ? null, libc ? null, coreutils ? null, shell ? stdenvNoCC.shell, gnugrep ? null
 , netbsd ? null, netbsdCross ? null
 , sharedLibraryLoader ?
@@ -100,7 +101,7 @@ let
 
 in
 
-stdenv.mkDerivation {
+stdenv.mkDerivation (finalAttrs: {
   pname = targetPrefix
     + (if name != "" then name else "${bintoolsName}-wrapper");
   version = if bintools == null then "" else bintoolsVersion;
@@ -112,6 +113,11 @@ stdenv.mkDerivation {
   passthru = {
     inherit targetPrefix suffixSalt;
     inherit bintools libc nativeTools nativeLibc nativePrefix isGNU isLLVM;
+
+    tests = import ./tests.nix {
+      inherit lib stdenvNoCC testers;
+      inherit (finalAttrs) finalPackage;
+    };
 
     emacsBufferSetup = pkgs: ''
       ; We should handle propagation here too
@@ -397,4 +403,4 @@ stdenv.mkDerivation {
   } // optionalAttrs useMacosReexportHack {
     platforms = lib.platforms.darwin;
   };
-}
+})

--- a/pkgs/build-support/bintools-wrapper/ld-wrapper.sh
+++ b/pkgs/build-support/bintools-wrapper/ld-wrapper.sh
@@ -20,6 +20,8 @@ if [ -z "${NIX_BINTOOLS_WRAPPER_FLAGS_SET_@suffixSalt@:-}" ]; then
     source @out@/nix-support/add-flags.sh
 fi
 
+extraAfter=()
+extraBefore=()
 expandResponseParams "$@"
 
 # NIX_LINK_TYPE is set if ld has been called through our cc wrapper. We take
@@ -29,6 +31,21 @@ if [[ -n "${NIX_LINK_TYPE_@suffixSalt@:-}" ]]; then
     linkType=$NIX_LINK_TYPE_@suffixSalt@
 else
     linkType=$(checkLinkType "${params[@]}")
+fi
+
+# `lld` supports specifying the linker flavor (i.e. gnu, link, ld64, wasm, etc)
+# via the `-flavor` argument:
+# https://github.com/llvm/llvm-project/blob/1ba9ec0d10c8c95216d8d7fc47f028344c1640bb/lld/tools/lld/lld.cpp#L125-L142
+#
+# However, this must be the *first* argument to `lld`. So, if `-flavor` is the
+# first arg in `params`, we hoist it to the front of `extraBefore`:
+if [[ ${#params[@]} -ge 2 ]] && [[ ${params[0]} == "-flavor" ]]; then
+    # As per the link above, only `-flavor <flavor name>` is supported. Not
+    # `--flavor`, `-flavor=...`, `/flavor:...`, etc.
+    linkFlavor="${params[1]}"
+    extraBefore=(-flavor "$linkFlavor" "${extraBefore[@]}")
+
+    params=("${params[@]:2}")
 fi
 
 # Optionally filter out paths not refering to the store.
@@ -75,8 +92,7 @@ fi
 
 source @out@/nix-support/add-hardening.sh
 
-extraAfter=()
-extraBefore=(${hardeningLDFlags[@]+"${hardeningLDFlags[@]}"})
+extraBefore+=(${hardeningLDFlags[@]+"${hardeningLDFlags[@]}"})
 
 if [ -z "${NIX_LINK_TYPE_@suffixSalt@:-}" ]; then
     extraAfter+=($(filterRpathFlags "$linkType" $NIX_LDFLAGS_@suffixSalt@))

--- a/pkgs/build-support/bintools-wrapper/ld-wrapper.sh
+++ b/pkgs/build-support/bintools-wrapper/ld-wrapper.sh
@@ -20,8 +20,6 @@ if [ -z "${NIX_BINTOOLS_WRAPPER_FLAGS_SET_@suffixSalt@:-}" ]; then
     source @out@/nix-support/add-flags.sh
 fi
 
-
-# Optionally filter out paths not refering to the store.
 expandResponseParams "$@"
 
 # NIX_LINK_TYPE is set if ld has been called through our cc wrapper. We take
@@ -33,6 +31,7 @@ else
     linkType=$(checkLinkType "${params[@]}")
 fi
 
+# Optionally filter out paths not refering to the store.
 if [[ "${NIX_ENFORCE_PURITY:-}" = 1 && -n "${NIX_STORE:-}"
         && ( -z "$NIX_IGNORE_LD_THROUGH_GCC_@suffixSalt@" || -z "${NIX_LINK_TYPE_@suffixSalt@:-}" ) ]]; then
     rest=()

--- a/pkgs/build-support/bintools-wrapper/tests.nix
+++ b/pkgs/build-support/bintools-wrapper/tests.nix
@@ -1,0 +1,17 @@
+{ stdenvNoCC
+, lib
+, finalPackage
+, testers
+}: let
+  testVersion = { binaryName }: testers.testVersion {
+    package = finalPackage;
+    command = "${binaryName} --version";
+  };
+in lib.optionalAttrs finalPackage.isLLVM {
+  # The `lld` package exposes several linker symlinks for its various flavors
+  # (`wasm-ld`, `ld64.lld`, `ld.lld`, `lld-link`) as well as an `lld` binary but
+  # at the moment we only expose `ld.lld` (and `ld`, a symlink) so that's all
+  # we test for here:
+  ldVersion = testVersion { binaryName = "ld"; };
+  ldLldVersion = testVersion { binaryName = "ld.lld"; };
+}

--- a/pkgs/build-support/bintools-wrapper/tests.nix
+++ b/pkgs/build-support/bintools-wrapper/tests.nix
@@ -8,6 +8,41 @@
     command = "${binaryName} --version";
   };
 in lib.optionalAttrs finalPackage.isLLVM {
+  # `lld` supports specifying the linker flavor with `-flavor` but requires that
+  # this be the _first_ argument.
+  flavorArgumentParsed = stdenvNoCC.mkDerivation {
+    name = "bintools-wrapper-lld-flavor-arg-test";
+    nativeBuildInputs = [ finalPackage ];
+    buildCommand = ''
+      # We expect `-flavor` to be moved before `--help`:
+      NIX_LDFLAGS_BEFORE="--help" ld -flavor gnu \
+        | grep "supported targets: elf"
+
+      # If `-flavor` isn't the first arg the wrapper should not move it; i.e.
+      # we expect the below to fail with an error about `-flavor`:
+      { ld --gc-sections -flavor gnu || :; } \
+        |& grep "unknown argument '-flavor'"
+
+      # Note that we allow non-zero exit codes for the other linker flavors;
+      # `ld-wrapper` still injects flags that don't account for the linker
+      # flavor and so arg parsing fails on some hostPlatforms.
+
+      # We should be able to specify the `link` flavor:
+      { NIX_LDFLAGS_BEFORE="/help" ld -flavor link || :; } \
+        | grep "Create a DLL"
+
+      # `ld64`:
+      { NIX_LDFLAGS_BEFORE="--help" ld -flavor ld64 || :; } \
+        | grep "macos, ios"
+    '' + lib.optionalString (lib.versionAtLeast "6.0.0" finalPackage.version) ''
+      # wasm support was added to lld in v6.0:
+      # https://github.com/llvm/llvm-project/commit/c94d393ad52b6698b15400ee7a33a68b4bda274b
+      { NIX_LDFLAGS_BEFORE="--help" ld -flavor wasm || :; } \
+        | grep "OVERVIEW: LLVM Linker"
+    '' + ''
+    '';
+  };
+
   # The `lld` package exposes several linker symlinks for its various flavors
   # (`wasm-ld`, `ld64.lld`, `ld.lld`, `lld-link`) as well as an `lld` binary but
   # at the moment we only expose `ld.lld` (and `ld`, a symlink) so that's all


### PR DESCRIPTION
###### Description of changes

`lld` supports specifying the linker flavor with `-flavor` however this must be the first argument passed. This PR updates `bintools-wrapper`'d `ld-wrapper` to hoist `-flavor` before `NIX_LDFLAGS_BEFORE`/`extraBefore` when passed as the first argument to the wrapped linker.

---

Note: I'm pretty sure this patch does not interact correctly with `cc-wrapper`'s use of `ld-wrapper`; IIUC `cc-wrapper` [will handle `NIX_LDFLAGS_BEFORE` in lieu of `ld-wrapper`](https://github.com/NixOS/nixpkgs/blob/8fb30f6066a87a91c21241f1993a26ff57005486/pkgs/build-support/cc-wrapper/cc-wrapper.sh#L183-L197) which makes it so that we cannot distinguish between "injected" linker args and pre-existing linker args within `ld-wrapper`.

For the use case that prompted this PR (#231951) this isn't an issue (we were only trying to work around linker hardening flags which always get handled by `linker-wrapper` I believe) but this still seems like something we should fix.

If we're okay "incorrectly" hoisting `-flavor` (i.e. when not passed as the first argument) then having `link-wrapper` scan `params` would be an easy fix for this.

I'm still waiting for stuff to rebuild locally so I can test this; marking this PR as a draft for now.

---

cc @RaitoBezarius 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
