### PR TITLE
muso: avoid build failure using an updated lockfile

### DIFF
--- a/pkgs/applications/audio/muso/default.nix
+++ b/pkgs/applications/audio/muso/default.nix
@@ -4,13 +4,13 @@
 
 rustPlatform.buildRustPackage rec {
   pname = "muso";
-  version = "2.0.0";
+  version = "unstable-2021-09-02";
 
   src = fetchFromGitHub {
     owner = "quebin31";
     repo = pname;
-    rev = "68cc90869bcc0f202830a318fbfd6bb9bdb75a39";
-    sha256 = "1dnfslliss173igympl7h1zc0qz0g10kf96dwrcj6aglmvvw426p";
+    rev = "6dd1c6d3a82b21d4fb2606accf2f26179eb6eaf9";
+    hash = "sha256-09DWUER0ZWQuwfE3sjov2GjJNI7coE3D3E5iUy9mlSE=";
   };
 
   nativeBuildInputs = [ pkg-config wrapGAppsHook ];
@@ -26,7 +26,7 @@ rustPlatform.buildRustPackage rec {
     cp share/* $out/share/muso/
   '';
 
-  cargoSha256 = "1hgdzyz005244f2mh97js9ga0a6s2hcd6iydz07f1hmhsh1j2bwy";
+  cargoHash = "sha256-+UVUejKCfjC6zdW315wmu7f3A5GmnoQ3rIk8SK6LIRI=";
 
   meta = with lib; {
     broken = (stdenv.isLinux && stdenv.isAarch64) || stdenv.isDarwin;

--- a/pkgs/applications/audio/muso/default.nix
+++ b/pkgs/applications/audio/muso/default.nix
@@ -29,7 +29,7 @@ rustPlatform.buildRustPackage rec {
   cargoHash = "sha256-+UVUejKCfjC6zdW315wmu7f3A5GmnoQ3rIk8SK6LIRI=";
 
   meta = with lib; {
-    broken = (stdenv.isLinux && stdenv.isAarch64) || stdenv.isDarwin;
+    broken = stdenv.isDarwin;
     description = "An automatic music sorter (based on ID3 tags)";
     homepage = "https://github.com/quebin31/muso";
     license = with licenses; [ gpl3Plus ];


### PR DESCRIPTION
###### Description of changes

Muso 2.0.0 has an outdated lock file that doesn't build with newer Rust versions anymore.

This was fixed by quebin31/muso#14. To avoid increasing the complexity of this derivation (as we need to swap the lock file here), I went ahead and changed the source revision to the latest `main` commit.

Looking at the diff (https://github.com/quebin31/muso/compare/68cc90869bcc0f202830a318fbfd6bb9bdb75a39...6dd1c6d3a82b21d4fb2606accf2f26179eb6eaf9) shows that the only significant change was this updated lock file, so this is effectively a backport.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->