### PR TITLE
teams-for-linux: 1.0.83 -> 1.0.88

### DIFF
--- a/pkgs/applications/networking/instant-messengers/teams-for-linux/default.nix
+++ b/pkgs/applications/networking/instant-messengers/teams-for-linux/default.nix
@@ -17,13 +17,13 @@
 
 stdenv.mkDerivation rec {
   pname = "teams-for-linux";
-  version = "1.0.83";
+  version = "1.0.88";
 
   src = fetchFromGitHub {
     owner = "IsmaelMartinez";
     repo = pname;
     rev = "v${version}";
-    sha256 = "sha256-2tCBFc4CEgaYJq5fMbHi+M/Cz5Eeo2Slqgu9xUUkUjA=";
+    sha256 = "sha256-eaXW52e+YJbL+0d2Cqrpp6M11rGsyNfIhgjHLzLDbWQ=";
   };
 
   offlineCache = fetchYarnDeps {

--- a/pkgs/applications/networking/instant-messengers/teams-for-linux/screensharing-wayland-hack-fix.patch
+++ b/pkgs/applications/networking/instant-messengers/teams-for-linux/screensharing-wayland-hack-fix.patch
@@ -1,14 +1,14 @@
 diff --git a/app/index.js b/app/index.js
-index 20ccf43..b251f62 100644
+index ea89608..98f4a90 100644
 --- a/app/index.js
 +++ b/app/index.js
 @@ -1,4 +1,4 @@
 -const { app, ipcMain, desktopCapturer, systemPreferences, powerMonitor } = require('electron');
 +const { app, ipcMain, desktopCapturer, nativeImage, systemPreferences, powerMonitor } = require('electron');
  const path = require('path');
+ const fs = require('fs');
  const { LucidLog } = require('lucid-log');
- const isDev = require('electron-is-dev');
-@@ -93,7 +93,16 @@ if (!gotTheLock) {
+@@ -97,7 +97,16 @@ if (!gotTheLock) {
  	ipcMain.handle('getSystemIdleState', handleGetSystemIdleState);
  	ipcMain.handle('getZoomLevel', handleGetZoomLevel);
  	ipcMain.handle('saveZoomLevel', handleSaveZoomLevel);
@@ -23,6 +23,6 @@ index 20ccf43..b251f62 100644
 +			thumbnail: nativeImage.createEmpty()
 +		}])
 +		: desktopCapturer.getSources(opts));
+ 	ipcMain.handle('getCustomBGList', handleGetCustomBGList);
  	ipcMain.on('play-notification-sound', playNotificationSound);
- }
- 
+ 	ipcMain.on('user-status-changed', userStatusChangedHandler);


### PR DESCRIPTION
###### Description of changes

The new releases mostly add custom background stuff (they just never stop making these releases so fast...): https://github.com/ismaelmartinez/teams-for-linux/releases

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).