### PR TITLE
sfwbar: init at v1.0_beta11

### DIFF
--- a/pkgs/applications/misc/sfwbar/default.nix
+++ b/pkgs/applications/misc/sfwbar/default.nix
@@ -1,0 +1,45 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  gtk3,
+  meson,
+  ninja,
+  json_c,
+  pkg-config,
+  gtk-layer-shell,
+  libpulseaudio,
+  libmpdclient,
+  libxkbcommon,
+}:
+stdenv.mkDerivation rec {
+  pname = "sfwbar";
+  version = "v1.0_beta11";
+
+  src = fetchFromGitHub {
+    owner = "LBCrion";
+    repo = pname;
+    rev = version;
+    sha256 = "PmpiO5gvurpaFpoq8bQdZ53FYSVDnyjN8MxDpelMnAU=";
+  };
+
+  nativeBuildInputs = [
+    gtk3
+    meson
+    ninja
+    pkg-config
+    json_c
+    gtk-layer-shell
+    libpulseaudio
+    libmpdclient
+    libxkbcommon
+  ];
+
+  meta = with lib; {
+    inherit (src.meta) homepage;
+    description = "A flexible taskbar application for wayland compositors, designed with a stacking layout in mind";
+    platforms = ["x86_64-linux"];
+    maintainers = with maintainers; [NotAShelf];
+    license = licenses.gpl3;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1121,6 +1121,8 @@ with pkgs;
   closureInfo = callPackage ../build-support/closure-info.nix { };
 
   serverspec = callPackage ../tools/misc/serverspec { };
+  
+  sfwbar = callPckage ../applications/misc/sfwbar { };
 
   setupSystemdUnits = callPackage ../build-support/setup-systemd-units.nix { };
 


### PR DESCRIPTION
###### Description of changes

Adds [sfwbar](https://github.com/LBCrion/sfwbar)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).