### PR TITLE
treewide: update broken `src.fedoraproject.org/cgit/` patch URLs

### DIFF
--- a/pkgs/applications/version-management/monotone-viz/default.nix
+++ b/pkgs/applications/version-management/monotone-viz/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchurl, ocamlPackages, gnome2, pkg-config, makeWrapper, glib
+{ lib, stdenv, fetchurl, fetchpatch, ocamlPackages, gnome2, pkg-config, makeWrapper, glib
 , libtool, libpng, bison, expat, fontconfig, gd, pango, libjpeg, libwebp, libX11, libXaw
 }:
 # We need an old version of Graphviz for format compatibility reasons.
@@ -23,17 +23,17 @@ stdenv.mkDerivation rec {
   prePatch="ln -s . a; ln -s . b";
   patchFlags = ["-p0"];
   patches = [
-    (fetchurl {
-      url = "https://src.fedoraproject.org/cgit/rpms/monotone-viz.git/plain/monotone-viz-1.0.2-dot.patch";
-      sha256 = "0risfy8iqmkr209hmnvpv57ywbd3rvchzzd0jy2lfyqrrrm6zknw";
+    (fetchpatch {
+      url = "https://src.fedoraproject.org/rpms/monotone-viz/raw/c9f4c1bebe01bb471df05d8a37ca4b6d630574ec/f/monotone-viz-1.0.2-dot.patch";
+      hash = "sha256-e348703+IzM4m/3cpe6Z9VebZgTK8+3lRLdaTfXHwSI=";
     })
-    (fetchurl {
-      url = "https://src.fedoraproject.org/cgit/rpms/monotone-viz.git/plain/monotone-viz-1.0.2-new-stdio.patch";
-      sha256 = "16bj0ppzqd45an154dr7sifjra7lv4m9anxfw3c56y763jq7fafa";
+    (fetchpatch {
+      url = "https://src.fedoraproject.org/rpms/monotone-viz/raw/c9f4c1bebe01bb471df05d8a37ca4b6d630574ec/f/monotone-viz-1.0.2-new-stdio.patch";
+      hash = "sha256-9xQzJ+oYz06fDFOe1YOOisEZnwiwShqr2Rt7IXiu6Zo=";
     })
-    (fetchurl {
-      url = "https://src.fedoraproject.org/cgit/rpms/monotone-viz.git/plain/monotone-viz-1.0.2-typefix.patch";
-      sha256 = "1gfp82rc7pawb5x4hh2wf7xh1l1l54ib75930xgd1y437la4703r";
+    (fetchpatch {
+      url = "https://src.fedoraproject.org/rpms/monotone-viz/raw/c9f4c1bebe01bb471df05d8a37ca4b6d630574ec/f/monotone-viz-1.0.2-typefix.patch";
+      hash = "sha256-52VGXDJKx4ZGvZRO8QCXdTGsWR0m1pqQnEOby7PMQdg=";
     })
   ];
 

--- a/pkgs/development/libraries/SDL/default.nix
+++ b/pkgs/development/libraries/SDL/default.nix
@@ -89,7 +89,7 @@ stdenv.mkDerivation rec {
     # Ticket: https://bugs.freedesktop.org/show_bug.cgi?id=27222
     (fetchpatch {
       name = "SDL_SetGamma.patch";
-      url = "https://src.fedoraproject.org/cgit/rpms/SDL.git/plain/SDL-1.2.15-x11-Bypass-SetGammaRamp-when-changing-gamma.patch?id=04a3a7b1bd88c2d5502292fad27e0e02d084698d";
+      url = "https://src.fedoraproject.org/rpms/SDL/raw/7a07323e5cec08bea6f390526f86a1ce5341596d/f/SDL-1.2.15-x11-Bypass-SetGammaRamp-when-changing-gamma.patch";
       sha256 = "0x52s4328kilyq43i7psqkqg7chsfwh0aawr50j566nzd7j51dlv";
     })
     # Fix a build failure on OS X Mavericks

--- a/pkgs/development/libraries/dbus-cplusplus/default.nix
+++ b/pkgs/development/libraries/dbus-cplusplus/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchurl, dbus, glib, pkg-config, expat }:
+{ lib, stdenv, fetchurl, fetchpatch, dbus, glib, pkg-config, expat }:
 
 stdenv.mkDerivation rec {
   pname = "dbus-cplusplus";
@@ -17,23 +17,20 @@ stdenv.mkDerivation rec {
           + "dbus-c++/files/dbus-c++-0.9.0-gcc-4.7.patch";
       sha256 = "0rwcz9pvc13b3yfr0lkifnfz0vb5q6dg240bzgf37ni4s8rpc72g";
     })
-    (fetchurl {
+    (fetchpatch {
       name = "writechar.patch"; # since gcc7
-      url = "https://src.fedoraproject.org/cgit/rpms/dbus-c++.git/plain/"
-          + "dbus-c++-writechar.patch?id=7f371172f5c";
+      url = "https://src.fedoraproject.org/rpms/dbus-c++/raw/9f515ace0594c8b2b9f0d41ffe71bc5b78d30eee/f/dbus-c++-writechar.patch";
       sha256 = "1kkg4gbpm4hp87l25zw2a3r9c58g7vvgzcqgiman734i66zsbb9l";
     })
-    (fetchurl {
+    (fetchpatch {
       name = "threading.patch"; # since gcc7
-      url = "https://src.fedoraproject.org/cgit/rpms/dbus-c++.git/plain/"
-          + "dbus-c++-threading.patch?id=7f371172f5c";
+      url = "https://src.fedoraproject.org/rpms/dbus-c++/raw/9f515ace0594c8b2b9f0d41ffe71bc5b78d30eee/f/dbus-c++-threading.patch";
       sha256 = "1h362anx3wyxm5lq0v8girmip1jmkdbijrmbrq7k5pp47zkhwwrq";
     })
-    (fetchurl {
+    (fetchpatch {
       name = "template-operators.patch"; # since gcc12
-      url = "https://src.fedoraproject.org/cgit/rpms/dbus-c++.git/plain/"
-          + "dbus-c++-template-operators.patch?id=d3f0d8bb519c0af";
-      sha256 = "N25Y7jXDbr0qb7MfRr2yz3zRySppgGOe+oCfNQhRvVc=";
+      url = "https://src.fedoraproject.org/rpms/dbus-c++/raw/9f515ace0594c8b2b9f0d41ffe71bc5b78d30eee/f/dbus-c++-template-operators.patch";
+      hash = "sha256-B8S7z/YH2YEQgaRsBJBBVTx8vHQhHW7z171TZmogpL8=";
     })
   ];
 

--- a/pkgs/development/libraries/openslp/default.nix
+++ b/pkgs/development/libraries/openslp/default.nix
@@ -12,12 +12,12 @@ stdenv.mkDerivation rec {
   patches = [
     (fetchpatch {
       name = "openslp-2.0.0-null-pointer-deref.patch";
-      url = "https://src.fedoraproject.org/cgit/rpms/openslp.git/plain/openslp-2.0.0-null-pointer-deref.patch";
+      url = "https://src.fedoraproject.org/rpms/openslp/raw/696fd55ae4fcea7beda0a25131dca8bfb14bbdf9/f/openslp-2.0.0-null-pointer-deref.patch";
       sha256 = "186f3rj3z2lf5h1lpbhqk0szj2a9far1p3mjqg6422f29yjfnz6a";
     })
     (fetchpatch {
       name = "openslp-2.0.0-CVE-2016-7567.patch";
-      url = "https://src.fedoraproject.org/cgit/rpms/openslp.git/plain/openslp-2.0.0-cve-2016-7567.patch";
+      url = "https://src.fedoraproject.org/rpms/openslp/raw/696fd55ae4fcea7beda0a25131dca8bfb14bbdf9/f/openslp-2.0.0-cve-2016-7567.patch";
       sha256 = "0zp61axx93b7nrbsyhn2x4dnw7n9y6g4rys21hyqxk4khrnc2yr9";
     })
     ./CVE-2016-4912.patch


### PR DESCRIPTION
###### Description of changes

https://src.fedoraproject.org/cgit/ patch URLs are broken, and therefore patches fetched from these URLs cannot be rebuilt anymore without access to cache.nixos.org.

This PR updates all affected patch URLs to their new location, and replaces `fetchurl` with `fetchpatch` where neccessary. I've verified that the patches for which the hash changed are semantically identical.

To test whether all patches can be fetched successfuly, use
```bash
nix-build         -E 'with import ./. {}; lib.filter lib.isDerivation (dbus_cplusplus.patches ++ monotoneViz.patches ++ SDL_classic.patches ++ openslp.patches)'
nix-build --check -E 'with import ./. {}; lib.filter lib.isDerivation (dbus_cplusplus.patches ++ monotoneViz.patches ++ SDL_classic.patches ++ openslp.patches)'
```

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
