### PR TITLE
fritzing: added meta.mainProgram

### DIFF
--- a/pkgs/applications/science/electronics/fritzing/default.nix
+++ b/pkgs/applications/science/electronics/fritzing/default.nix
@@ -82,4 +82,5 @@ stdenv.mkDerivation rec {
     maintainers = with maintainers; [ robberer muscaln ];
     platforms = platforms.linux;
   };
+  Program = "Fritzing";
 }

--- a/pkgs/applications/science/electronics/fritzing/default.nix
+++ b/pkgs/applications/science/electronics/fritzing/default.nix
@@ -81,6 +81,6 @@ stdenv.mkDerivation rec {
     license = with licenses; [ gpl3 cc-by-sa-30 ];
     maintainers = with maintainers; [ robberer muscaln ];
     platforms = platforms.linux;
+    mainProgram = "Fritzing";
   };
-  Program = "Fritzing";
 }


### PR DESCRIPTION
Added meta.mainProgram as package name is `fritzing` but binary name is `Fritzing`.

###### Description of changes

Added `meta.mainProgram` as package name is `fritzing` but binary name is `Fritzing` (Capital "F"!).
Otherwise fritzing does not launch with `nix run nixpkgs#fritzing`

Everything else left as-is, as it works.  

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin

- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
