### PR TITLE
tideways-daemon: init at 1.8.28

### DIFF
--- a/pkgs/development/tools/misc/tideways/cli.nix
+++ b/pkgs/development/tools/misc/tideways/cli.nix
@@ -3,11 +3,32 @@
 , fetchurl
 }:
 
-stdenvNoCC.mkDerivation rec {
-  pname = "tideways-cli";
+let
   version = "1.0.6";
+  sources = {
+    "x86_64-linux" = fetchurl {
+      url = "https://s3-eu-west-1.amazonaws.com/tideways/cli/${version}/tideways-cli_linux_amd64-${version}.tar.gz";
+      hash = "sha256-ZCYR4ewzsgV5SonpdCrk+qcFNRPt+GDXHAmvJxsCUxI=";
+    };
+    "aarch64-linux" = fetchurl {
+      url = "https://s3-eu-west-1.amazonaws.com/tideways/cli/${version}/tideways-cli_linux_arm64-${version}.tar.gz";
+      hash = "sha256-Ru87Iwwaqv3lLtyRYV7RZFlCrnguNbpMqQQYvKLeO7E=";
+    };
+    "x86_64-darwin" = fetchurl {
+      url = "https://s3-eu-west-1.amazonaws.com/tideways/cli/${version}/tideways-cli_macos_amd64-${version}.tar.gz";
+      hash = "sha256-92kj2sSzChgmzpA1ZzHLAl31jACddBnOId2sJ5A8E9w=";
+    };
+    "aarch64-darwin" = fetchurl {
+      url = "https://s3-eu-west-1.amazonaws.com/tideways/cli/${version}/tideways-cli_macos_arm64-${version}.tar.gz";
+      hash = "sha256-cAjAzKAZIv92SGsgwOkoTt6tA3W93B4pDHnwTEGWt1A=";
+    };
+  };
+in
+stdenvNoCC.mkDerivation (finalAttrs: {
+  pname = "tideways-cli";
+  inherit version;
 
-  src = passthru.sources.${stdenvNoCC.hostPlatform.system} or (throw "Unsupported platform for tideways-cli: ${stdenvNoCC.hostPlatform.system}");
+  src = sources.${stdenvNoCC.hostPlatform.system} or (throw "Unsupported platform for tideways-cli: ${stdenvNoCC.hostPlatform.system}");
 
   installPhase = ''
     runHook preInstall
@@ -19,27 +40,6 @@ stdenvNoCC.mkDerivation rec {
     runHook postInstall
   '';
 
-  passthru = {
-    sources = {
-      "x86_64-linux" = fetchurl {
-        url = "https://s3-eu-west-1.amazonaws.com/tideways/cli/${version}/tideways-cli_linux_amd64-${version}.tar.gz";
-        hash = "sha256-ZCYR4ewzsgV5SonpdCrk+qcFNRPt+GDXHAmvJxsCUxI=";
-      };
-      "aarch64-linux" = fetchurl {
-        url = "https://s3-eu-west-1.amazonaws.com/tideways/cli/${version}/tideways-cli_linux_arm64-${version}.tar.gz";
-        hash = "sha256-Ru87Iwwaqv3lLtyRYV7RZFlCrnguNbpMqQQYvKLeO7E=";
-      };
-      "x86_64-darwin" = fetchurl {
-        url = "https://s3-eu-west-1.amazonaws.com/tideways/cli/${version}/tideways-cli_macos_amd64-${version}.tar.gz";
-        hash = "sha256-92kj2sSzChgmzpA1ZzHLAl31jACddBnOId2sJ5A8E9w=";
-      };
-      "aarch64-darwin" = fetchurl {
-        url = "https://s3-eu-west-1.amazonaws.com/tideways/cli/${version}/tideways-cli_macos_arm64-${version}.tar.gz";
-        hash = "sha256-cAjAzKAZIv92SGsgwOkoTt6tA3W93B4pDHnwTEGWt1A=";
-      };
-    };
-  };
-
   meta = with lib; {
     description = "Tideways Profiler CLI";
     homepage = "https://tideways.com/";
@@ -48,4 +48,4 @@ stdenvNoCC.mkDerivation rec {
     maintainers = with maintainers; [ shyim ];
     platforms = [ "x86_64-linux" "aarch64-linux" "x86_64-darwin" "aarch64-darwin" ];
   };
-}
+})

--- a/pkgs/development/tools/misc/tideways/cli.nix
+++ b/pkgs/development/tools/misc/tideways/cli.nix
@@ -1,0 +1,51 @@
+{ stdenvNoCC
+, lib
+, fetchurl
+}:
+
+stdenvNoCC.mkDerivation rec {
+  pname = "tideways-cli";
+  version = "1.0.6";
+
+  src = passthru.sources.${stdenvNoCC.hostPlatform.system} or (throw "Unsupported platform for tideways-cli: ${stdenvNoCC.hostPlatform.system}");
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/bin
+    cp tideways $out/bin/tideways
+    chmod +x $out/bin/tideways
+
+    runHook postInstall
+  '';
+
+  passthru = {
+    sources = {
+      "x86_64-linux" = fetchurl {
+        url = "https://s3-eu-west-1.amazonaws.com/tideways/cli/${version}/tideways-cli_linux_amd64-${version}.tar.gz";
+        hash = "sha256-ZCYR4ewzsgV5SonpdCrk+qcFNRPt+GDXHAmvJxsCUxI=";
+      };
+      "aarch64-linux" = fetchurl {
+        url = "https://s3-eu-west-1.amazonaws.com/tideways/cli/${version}/tideways-cli_linux_arm64-${version}.tar.gz";
+        hash = "sha256-Ru87Iwwaqv3lLtyRYV7RZFlCrnguNbpMqQQYvKLeO7E=";
+      };
+      "x86_64-darwin" = fetchurl {
+        url = "https://s3-eu-west-1.amazonaws.com/tideways/cli/${version}/tideways-cli_macos_amd64-${version}.tar.gz";
+        hash = "sha256-92kj2sSzChgmzpA1ZzHLAl31jACddBnOId2sJ5A8E9w=";
+      };
+      "aarch64-darwin" = fetchurl {
+        url = "https://s3-eu-west-1.amazonaws.com/tideways/cli/${version}/tideways-cli_macos_arm64-${version}.tar.gz";
+        hash = "sha256-cAjAzKAZIv92SGsgwOkoTt6tA3W93B4pDHnwTEGWt1A=";
+      };
+    };
+  };
+
+  meta = with lib; {
+    description = "Tideways Profiler CLI";
+    homepage = "https://tideways.com/";
+    sourceProvenance = with sourceTypes; [ binaryNativeCode ];
+    license = licenses.unfree;
+    maintainers = with maintainers; [ shyim ];
+    platforms = [ "x86_64-linux" "aarch64-linux" "x86_64-darwin" "aarch64-darwin" ];
+  };
+}

--- a/pkgs/development/tools/misc/tideways/daemon.nix
+++ b/pkgs/development/tools/misc/tideways/daemon.nix
@@ -1,0 +1,47 @@
+{ stdenvNoCC
+, lib
+, fetchurl
+}:
+
+stdenvNoCC.mkDerivation rec {
+  pname = "tideways-daemon";
+  version = "1.8.28";
+
+  src = passthru.sources.${stdenvNoCC.hostPlatform.system} or (throw "Unsupported platform for tideways-daemon: ${stdenvNoCC.hostPlatform.system}");
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/bin
+    cp tideways-daemon $out/bin/tideways-daemon
+    chmod +x $out/bin/tideways-daemon
+
+    runHook postInstall
+  '';
+
+  passthru = {
+    sources = {
+      "x86_64-linux" = fetchurl {
+        url = "https://s3-eu-west-1.amazonaws.com/tideways/daemon/${version}/tideways-daemon_linux_amd64-${version}.tar.gz";
+        hash = "sha256-t84FP09LqmZbaJF4Jbd9bzcXt2G9uhY/ITeV5F3TWCY=";
+      };
+      "aarch64-linux" = fetchurl {
+        url = "https://s3-eu-west-1.amazonaws.com/tideways/daemon/${version}/tideways-daemon_linux_aarch64-${version}.tar.gz";
+        hash = "sha256-gMn9wXg2s8lFkhgDbajbCDvlIDwB0Sz1PcS/KOIzE28=";
+      };
+      "aarch64-darwin" = fetchurl {
+        url = "https://s3-eu-west-1.amazonaws.com/tideways/daemon/${version}/tideways-daemon_macos_arm64-${version}.tar.gz";
+        hash = "sha256-p+WKdBG1K3apeXfSqnpd2yGj87MWVTd5oJoFTIZAGL8=";
+      };
+    };
+  };
+
+  meta = with lib; {
+    description = "Tideways Profiler daemon";
+    homepage = "https://tideways.com/";
+    sourceProvenance = with sourceTypes; [ binaryNativeCode ];
+    license = licenses.unfree;
+    maintainers = with maintainers; [ shyim ];
+    platforms = [ "x86_64-linux" "aarch64-linux" "aarch64-darwin" ];
+  };
+}

--- a/pkgs/development/tools/misc/tideways/daemon.nix
+++ b/pkgs/development/tools/misc/tideways/daemon.nix
@@ -3,11 +3,28 @@
 , fetchurl
 }:
 
-stdenvNoCC.mkDerivation rec {
-  pname = "tideways-daemon";
+let
   version = "1.8.28";
+  sources = {
+    "x86_64-linux" = fetchurl {
+      url = "https://s3-eu-west-1.amazonaws.com/tideways/daemon/${version}/tideways-daemon_linux_amd64-${version}.tar.gz";
+      hash = "sha256-t84FP09LqmZbaJF4Jbd9bzcXt2G9uhY/ITeV5F3TWCY=";
+    };
+    "aarch64-linux" = fetchurl {
+      url = "https://s3-eu-west-1.amazonaws.com/tideways/daemon/${version}/tideways-daemon_linux_aarch64-${version}.tar.gz";
+      hash = "sha256-gMn9wXg2s8lFkhgDbajbCDvlIDwB0Sz1PcS/KOIzE28=";
+    };
+    "aarch64-darwin" = fetchurl {
+      url = "https://s3-eu-west-1.amazonaws.com/tideways/daemon/${version}/tideways-daemon_macos_arm64-${version}.tar.gz";
+      hash = "sha256-p+WKdBG1K3apeXfSqnpd2yGj87MWVTd5oJoFTIZAGL8=";
+    };
+  };
+in
+stdenvNoCC.mkDerivation (finalAttrs: {
+  pname = "tideways-daemon";
+  inherit version;
 
-  src = passthru.sources.${stdenvNoCC.hostPlatform.system} or (throw "Unsupported platform for tideways-daemon: ${stdenvNoCC.hostPlatform.system}");
+  src = sources.${stdenvNoCC.hostPlatform.system} or (throw "Unsupported platform for tideways-daemon: ${stdenvNoCC.hostPlatform.system}");
 
   installPhase = ''
     runHook preInstall
@@ -19,23 +36,6 @@ stdenvNoCC.mkDerivation rec {
     runHook postInstall
   '';
 
-  passthru = {
-    sources = {
-      "x86_64-linux" = fetchurl {
-        url = "https://s3-eu-west-1.amazonaws.com/tideways/daemon/${version}/tideways-daemon_linux_amd64-${version}.tar.gz";
-        hash = "sha256-t84FP09LqmZbaJF4Jbd9bzcXt2G9uhY/ITeV5F3TWCY=";
-      };
-      "aarch64-linux" = fetchurl {
-        url = "https://s3-eu-west-1.amazonaws.com/tideways/daemon/${version}/tideways-daemon_linux_aarch64-${version}.tar.gz";
-        hash = "sha256-gMn9wXg2s8lFkhgDbajbCDvlIDwB0Sz1PcS/KOIzE28=";
-      };
-      "aarch64-darwin" = fetchurl {
-        url = "https://s3-eu-west-1.amazonaws.com/tideways/daemon/${version}/tideways-daemon_macos_arm64-${version}.tar.gz";
-        hash = "sha256-p+WKdBG1K3apeXfSqnpd2yGj87MWVTd5oJoFTIZAGL8=";
-      };
-    };
-  };
-
   meta = with lib; {
     description = "Tideways Profiler daemon";
     homepage = "https://tideways.com/";
@@ -44,4 +44,4 @@ stdenvNoCC.mkDerivation rec {
     maintainers = with maintainers; [ shyim ];
     platforms = [ "x86_64-linux" "aarch64-linux" "aarch64-darwin" ];
   };
-}
+})

--- a/pkgs/development/tools/misc/tideways/php-probe.nix
+++ b/pkgs/development/tools/misc/tideways/php-probe.nix
@@ -1,0 +1,57 @@
+{ stdenvNoCC
+, lib
+, fetchurl
+, autoPatchelfHook
+, php
+}:
+
+let
+  soFile = {
+    "8.0" = "tideways-php-8.0.so";
+    "8.1" = "tideways-php-8.1.so";
+    "8.2" = "tideways-php-8.2.so";
+  }.${lib.versions.majorMinor php.version} or (throw "Unsupported PHP version.");
+  version = "5.5.18";
+  sources = {
+    "x86_64-linux" = fetchurl {
+      url = "https://s3-eu-west-1.amazonaws.com/tideways/extension/${version}/tideways-php-${version}-x86_64.tar.gz";
+      hash = "sha256-ZKx9sVaz+XFz8fYRgYXXg6ggwfjT7LqrFaSQuSaPLSw=";
+    };
+    "aarch64-linux" = fetchurl {
+      url = "https://s3-eu-west-1.amazonaws.com/tideways/extension/${version}/tideways-php-${version}-arm64.tar.gz";
+      hash = "sha256-dX9fSUM0DIAIr1EITsRPx2GZ8zmGSaGn+IZqSQWn66M=";
+    };
+    "aarch64-darwin" = fetchurl {
+      url = "https://s3-eu-west-1.amazonaws.com/tideways/extension/${version}/tideways-php-${version}-macos-arm.tar.gz";
+      hash = "sha256-cDYkd1aP047bwBeJeEgbb+7QSwuNNGZ7d+8BTdMDMBA=";
+    };
+  };
+in
+stdenvNoCC.mkDerivation (finalAttrs: {
+  pname = "tideways-php";
+  extensionName = "tideways";
+  inherit version;
+
+  src = sources.${stdenvNoCC.hostPlatform.system} or (throw "Unsupported platform for tideways-cli: ${stdenvNoCC.hostPlatform.system}");
+
+  nativeBuildInputs = lib.optionals stdenvNoCC.isLinux [
+    autoPatchelfHook
+  ];
+
+  installPhase = ''
+    runHook preInstall
+
+    install -D ${soFile} $out/lib/php/extensions/tideways.so
+
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    description = "Tideways PHP Probe";
+    homepage = "https://tideways.com/";
+    sourceProvenance = with sourceTypes; [ binaryNativeCode ];
+    license = licenses.unfree;
+    maintainers = with maintainers; [ shyim ];
+    platforms = [ "x86_64-linux" "aarch64-linux" "aarch64-darwin" ];
+  };
+})

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -19263,6 +19263,8 @@ with pkgs;
 
   tideways-daemon = callPackage ../development/tools/misc/tideways/daemon.nix { };
 
+  tideways-cli = callPackage ../development/tools/misc/tideways/cli.nix { };
+
   tcptrack = callPackage ../development/tools/misc/tcptrack { };
 
   teensyduino = arduino-core.override { withGui = true; withTeensyduino = true; };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -19261,6 +19261,8 @@ with pkgs;
     inherit (darwin.apple_sdk.frameworks) Security;
   };
 
+  tideways-daemon = callPackage ../development/tools/misc/tideways/daemon.nix { };
+
   tcptrack = callPackage ../development/tools/misc/tcptrack { };
 
   teensyduino = arduino-core.override { withGui = true; withTeensyduino = true; };

--- a/pkgs/top-level/php-packages.nix
+++ b/pkgs/top-level/php-packages.nix
@@ -292,6 +292,8 @@ lib.makeScope pkgs.newScope (self: with self; {
 
     swoole = callPackage ../development/php-packages/swoole { };
 
+    tideways = pkgs.callPackage ../development/tools/misc/tideways/php-probe.nix { inherit php; };
+
     xdebug = callPackage ../development/php-packages/xdebug { };
 
     yaml = callPackage ../development/php-packages/yaml { };


### PR DESCRIPTION
###### Description of changes

Packaged the [Tideways](https://tideways.com) Daemon/CLI/PHP-Probe for Nix.
So it's possible to Profile a PHP application with an Tideways subscription.

###### Things done

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [X] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [X] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [X] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

