### PR TITLE
pngcheck: support cross compilation and install man page

### DIFF
--- a/pkgs/tools/graphics/pngcheck/default.nix
+++ b/pkgs/tools/graphics/pngcheck/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchurl, zlib }:
+{ lib, stdenv, fetchurl, zlib, installShellFiles }:
 
 stdenv.mkDerivation rec {
   pname = "pngcheck";
@@ -11,22 +11,27 @@ stdenv.mkDerivation rec {
 
   hardeningDisable = [ "format" ];
 
-  postPatch = lib.optionalString stdenv.isDarwin ''
-    substituteInPlace Makefile.unx --replace "gcc" "clang"
+  postPatch = ''
+    substituteInPlace $makefile \
+      --replace "gcc" "$CC"
   '';
 
   makefile = "Makefile.unx";
   makeFlags = [ "ZPATH=${zlib.static}/lib" ];
 
+  nativeBuildInputs = [ installShellFiles ];
+
   buildInputs = [ zlib ];
 
   installPhase = ''
-    mkdir -p $out/bin/
-    cp pngcheck $out/bin/pngcheck
+    runHook preInstall
+    install -Dm555 -t $out/bin/ pngcheck
+    installManPage $pname.1
+    runHook postInstall
   '';
 
   meta = with lib; {
-    homepage = "http://pmt.sourceforge.net/pngcrush";
+    homepage = "https://pmt.sourceforge.net/pngcrush";
     description = "Verifies the integrity of PNG, JNG and MNG files";
     license = licenses.free;
     platforms = platforms.unix;


### PR DESCRIPTION
###### Description of changes

A test on darwin would be good.

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).