### PR TITLE
tartan: unstable-2021-12-23 → unstable-2023-05-15

### DIFF
--- a/pkgs/development/tools/analysis/tartan/default.nix
+++ b/pkgs/development/tools/analysis/tartan/default.nix
@@ -4,7 +4,7 @@
 , meson
 , ninja
 , pkg-config
-, llvmPackages
+, llvmPackages_16
 , gobject-introspection
 , glib
 , unstableGitUpdater
@@ -12,14 +12,14 @@
 
 stdenv.mkDerivation rec {
   pname = "tartan";
-  version = "unstable-2021-12-23";
+  version = "unstable-2023-05-15";
 
   src = fetchFromGitLab {
     domain = "gitlab.freedesktop.org";
     owner = "tartan";
     repo = "tartan";
-    rev = "bd4ea95d8b3ce1258491e9fac7fcc37d2b241a16";
-    sha256 = "l3duPt8Kh/JljzOV+Dm26XbS7gZ+mmFfYUYofWSJRyo=";
+    rev = "6757cd29b5a33cf9496664cb03c6f4e61f150f19";
+    sha256 = "f3I12zjkF7pfVCE+TTJMWh3Jg6fHFwjDcp2AWtmTpao=";
   };
 
   nativeBuildInputs = [
@@ -31,8 +31,8 @@ stdenv.mkDerivation rec {
   buildInputs = [
     gobject-introspection
     glib
-    llvmPackages.libclang
-    llvmPackages.libllvm
+    llvmPackages_16.libclang
+    llvmPackages_16.libllvm
   ];
 
   passthru = {
@@ -40,6 +40,8 @@ stdenv.mkDerivation rec {
       # The updater tries src.url by default, which does not exist for fetchFromGitLab (fetchurl).
       url = "https://gitlab.freedesktop.org/tartan/tartan.git";
     };
+
+    llvmPackages = llvmPackages_16;
   };
 
   meta = with lib; {


### PR DESCRIPTION
###### Description of changes

Fix build.

https://gitlab.freedesktop.org/tartan/tartan/-/compare/bd4ea95d8b3ce1258491e9fac7fcc37d2b241a16...6757cd29b5a33cf9496664cb03c6f4e61f150f19

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
