### PR TITLE
_90secondportraits: use copyDesktopItems

### DIFF
--- a/pkgs/games/90secondportraits/default.nix
+++ b/pkgs/games/90secondportraits/default.nix
@@ -1,51 +1,44 @@
-{ lib, stdenv, fetchurl, love, lua, makeWrapper, makeDesktopItem }:
+{ lib, stdenv, fetchurl, love, makeWrapper, makeDesktopItem, copyDesktopItems }:
 
 let
   pname = "90secondportraits";
-  version = "1.01b";
 
   icon = fetchurl {
     url = "http://tangramgames.dk/img/thumb/90secondportraits.png";
     sha256 = "13k6cq8s7jw77j81xfa5ri41445m778q6iqbfplhwdpja03c6faw";
   };
 
-  desktopItem = makeDesktopItem {
-    name = "90secondportraits";
-    exec = pname;
-    icon = icon;
-    comment = "A silly speed painting game";
-    desktopName = "90 Second Portraits";
-    genericName = "90secondportraits";
-    categories = [ "Game" ];
-  };
+  desktopItems = [
+    (makeDesktopItem {
+      name = "90secondportraits";
+      exec = pname;
+      icon = icon;
+      comment = "A silly speed painting game";
+      desktopName = "90 Second Portraits";
+      genericName = "90secondportraits";
+      categories = [ "Game" ];
+    })
+  ];
 
-in
-
-stdenv.mkDerivation {
-  name = "${pname}-${version}";
+in stdenv.mkDerivation rec {
+  inherit pname desktopItems;
+  version = "1.01b";
 
   src = fetchurl {
     url = "https://github.com/SimonLarsen/90-Second-Portraits/releases/download/${version}/${pname}-${version}.love";
     sha256 = "0jj3k953r6vb02212gqcgqpb4ima87gnqgls43jmylxq2mcm33h5";
   };
 
-  nativeBuildInputs = [ makeWrapper ];
-  buildInputs = [ lua love ];
+  nativeBuildInputs = [ makeWrapper copyDesktopItems ];
 
   dontUnpack = true;
 
-  installPhase =
-  ''
-    mkdir -p $out/bin
-    mkdir -p $out/share/games/lovegames
-
-    cp -v $src $out/share/games/lovegames/${pname}.love
-
-    makeWrapper ${love}/bin/love $out/bin/${pname} --add-flags $out/share/games/lovegames/${pname}.love
-
-    chmod +x $out/bin/${pname}
-    mkdir -p $out/share/applications
-    ln -s ${desktopItem}/share/applications/* $out/share/applications/
+  installPhase = ''
+    runHook preInstall
+    install -Dm444 $src $out/share/games/lovegames/${pname}.love
+    makeWrapper ${love}/bin/love $out/bin/${pname} \
+      --add-flags $out/share/games/lovegames/${pname}.love
+    runHook postInstall
   '';
 
   meta = with lib; {


### PR DESCRIPTION
###### Description of changes



###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).