### PR TITLE
Revert "clisp: remove broken status on Darwin"

### DIFF
--- a/pkgs/development/interpreters/clisp/default.nix
+++ b/pkgs/development/interpreters/clisp/default.nix
@@ -34,7 +34,7 @@ stdenv.mkDerivation rec {
 
   inherit libsigsegv gettext coreutils;
 
-  ffcallAvailable = libffcall != null;
+  ffcallAvailable = stdenv.isLinux && (libffcall != null);
 
   buildInputs = [libsigsegv]
   ++ lib.optional (gettext != null) gettext
@@ -101,7 +101,8 @@ stdenv.mkDerivation rec {
     homepage = "http://clisp.cons.org";
     maintainers = lib.teams.lisp.members;
     platforms = lib.platforms.unix;
-    broken = stdenv.hostPlatform.isAarch64;
+    # problems on Darwin: https://github.com/NixOS/nixpkgs/issues/20062
+    broken = stdenv.hostPlatform.isDarwin || stdenv.hostPlatform.isAarch64;
     license = lib.licenses.gpl2;
   };
 }

--- a/pkgs/development/interpreters/clisp/hg.nix
+++ b/pkgs/development/interpreters/clisp/hg.nix
@@ -93,7 +93,6 @@ stdenv.mkDerivation rec {
     homepage = "http://clisp.cons.org";
     maintainers = lib.teams.lisp.members;
     # problems on Darwin: https://github.com/NixOS/nixpkgs/issues/20062
-    platforms = lib.platforms.unix;
-    broken = stdenv.hostPlatform.isDarwin;
+    platforms = lib.platforms.linux;
   };
 }


### PR DESCRIPTION
So `clisp` does not build *on Hydra*. Of course it was all too easy. Reverting in a rush before 23.05.

Log: https://hydra.nixos.org/build/220107513/nixlog/3/tail