### PR TITLE
darling: unstable-2023-05-02 -> unstable-2023-05-14

### DIFF
--- a/pkgs/applications/emulators/darling/default.nix
+++ b/pkgs/applications/emulators/darling/default.nix
@@ -3,7 +3,6 @@
 , runCommandWith
 , writeShellScript
 , fetchFromGitHub
-, fetchpatch
 
 , freetype
 , libjpeg
@@ -107,14 +106,14 @@ let
   ];
 in stdenv.mkDerivation {
   pname = "darling";
-  version = "unstable-2023-05-02";
+  version = "unstable-2023-05-14";
 
   src = fetchFromGitHub {
     owner = "darlinghq";
     repo = "darling";
-    rev = "557e7e9dece394a3f623825679474457e5b64fd0";
+    rev = "dec20ddf3892ff35f0a688a047d8931faf4471c4";
     fetchSubmodules = true;
-    hash = "sha256-SOoLaV7wg33qRHPQXkdMvrY++CvoG85kwd6IU6DkYa0=";
+    hash = "sha256-ofoS+JiUhtTn9NPCsYyHXucWlxQ20D60wnNAM9GwdPg=";
   };
 
   outputs = [ "out" "sdk" ];
@@ -130,6 +129,9 @@ in stdenv.mkDerivation {
 
     substituteInPlace src/startup/CMakeLists.txt --replace SETUID ""
     substituteInPlace src/external/basic_cmds/CMakeLists.txt --replace SETGID ""
+
+    # https://github.com/darlinghq/darling-wtf/pull/3
+    rm src/external/WTF/darling/include/wtf/mac/AppKitCompatibilityDeclarations.h
   '';
 
   nativeBuildInputs = [


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

The macOS 11 update has been [merged](https://github.com/darlinghq/darling/pull/1369) to master:

```
                    c.'          zhaofeng@malus 
                 ,xNMM.          -------------- 
               .OMMMMo           OS: macOS Big Sur 11.7.4 Darling x86_64 
               lMM"              Kernel: 20.6.0 
     .;loddo:.  .olloddol;.      Uptime: 108 days, 21 hours, 39 mins 
   cKMMMMMMMMMMNWMMMMMMMMMM0:    Shell: fish
 .KMMMMMMMMMMMMMMMMMMMMMMMWd.    DE: Aqua 
 XMMMMMMMMMMMMMMMMMMMMMMMX.      WM: Quartz Compositor 
;MMMMMMMMMMMMMMMMMMMMMMMM:       WM Theme: Blue (Print: Entry, AppleInterfaceStyle, Does Not Exist Cannot Write File) 
:MMMMMMMMMMMMMMMMMMMMMMMM:       Terminal: /dev/pts/144 
.MMMMMMMMMMMMMMMMMMMMMMMMX.      Memory: 21082MiB / 32034MiB 
 kMMMMMMMMMMMMMMMMMMMMMMMMWd.
 'XMMMMMMMMMMMMMMMMMMMMMMMMMMk                           
  'XMMMMMMMMMMMMMMMMMMMMMMMMK.                           
    kMMMMMMMMMMMMMMMMMMMMMMd
     ;KMMMMMMMWXXWMMMMMMMk.
       "cooc*"    "*coo'"

```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
