### PR TITLE
cdesktopenv: work around tcl8.6.13 error

### DIFF
--- a/pkgs/desktops/cdesktopenv/default.nix
+++ b/pkgs/desktops/cdesktopenv/default.nix
@@ -3,7 +3,7 @@
 , xorgproto, libX11, bison, ksh, perl, gnum4
 , libXinerama, libXt, libXext, libtirpc, motif, libXft, xbitmaps
 , libjpeg, libXmu, libXdmcp, libXScrnSaver, symlinkJoin, bdftopcf
-, ncompress, mkfontdir, tcl, libXaw, libxcrypt, gcc, glibcLocales
+, ncompress, mkfontdir, tcl-8_5, libXaw, libxcrypt, gcc, glibcLocales
 , autoPatchelfHook, libredirect, makeWrapper, xset, xrdb, fakeroot
 , rpcsvc-proto }:
 
@@ -40,7 +40,7 @@ in stdenv.mkDerivation rec {
 
   buildInputs = [
     libX11 libXinerama libXt libXext libtirpc motif libXft xbitmaps
-    libjpeg libXmu libXdmcp libXScrnSaver tcl libXaw ksh libxcrypt
+    libjpeg libXmu libXdmcp libXScrnSaver tcl-8_5 libXaw ksh libxcrypt
   ];
   nativeBuildInputs = [
     bison ncompress autoPatchelfHook makeWrapper fakeroot
@@ -59,6 +59,9 @@ in stdenv.mkDerivation rec {
     "BOOTSTRAPCFLAGS=-I${xorgproto}/include/X11"
     "IMAKECPP=cpp"
     "LOCALE_ARCHIVE=${glibcLocales}/lib/locale/locale-archive"
+    # Workaround for dtdocbook issue with tcl 8.6.13.
+    # TODO: this might be possible to remove when updating CDE
+    "TCLLIB=-ltcl8.5"
   ];
 
   preConfigure = ''


### PR DESCRIPTION
###### Description of changes
This workaround fixes the CDE build by using Tcl 8.5 instead of 8.6. The build issue seems to have something to do with the es_ES.ISO8859-1 locale (maybe others?) and Tcl 8.6.13. When bisecting the build failure, I found the culprit to be 048bf22a4c1281999528df0ac72a22d4d6fa4e96, but have so far failed to narrow down exactly what happened. It looks like upstream CDE has since migrated the es_ES.ISO8859-1 documentation to use UTF-8 in [`cdesktopenv@9a847f1`](https://sourceforge.net/p/cdesktopenv/code/ci/9a847f1e86d0634a04700e5b4d8b87ab9d2cd1d3/), which might mean that this fix can be removed when CDE is updated (#231519). Unfortunately, I was not able to confirm so far.

Tcl is _only_ used in the `programs/dtdocbook/instant` program used for generating documentation. I was able to confirm using `./result/opt/dt/bin/dthelpview -helpVolume Appmanager` that the documentation still built as-expected on Tcl 8.5. I expect that this should not have any negative consequences on the result.

ZHF: #230712

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
