### PR TITLE
[22.11] dokuwiki: Backport xss vulnerability fix

### DIFF
--- a/pkgs/servers/web-apps/dokuwiki/backport-rss-xss-fix.patch
+++ b/pkgs/servers/web-apps/dokuwiki/backport-rss-xss-fix.patch
@@ -1,0 +1,39 @@
+diff --git a/inc/parser/xhtml.php b/inc/parser/xhtml.php
+index 4c2cb78b4..6cc7a9263 100644
+--- a/inc/parser/xhtml.php
++++ b/inc/parser/xhtml.php
+@@ -1347,15 +1347,11 @@ class Doku_Renderer_xhtml extends Doku_Renderer {
+                 $this->doc .= '<li><div class="li">';
+                 // support feeds without links
+                 $lnkurl = $item->get_permalink();
++                $title = html_entity_decode($item->get_title(), ENT_QUOTES, 'UTF-8');
+                 if($lnkurl) {
+-                    // title is escaped by SimplePie, we unescape here because it
+-                    // is escaped again in externallink() FS#1705
+-                    $this->externallink(
+-                        $item->get_permalink(),
+-                        html_entity_decode($item->get_title(), ENT_QUOTES, 'UTF-8')
+-                    );
++                    $this->externallink($item->get_permalink(), $title);
+                 } else {
+-                    $this->doc .= ' '.$item->get_title();
++                    $this->doc .= ' '.hsc($item->get_title());
+                 }
+                 if($params['author']) {
+                     $author = $item->get_author(0);
+@@ -1369,11 +1365,14 @@ class Doku_Renderer_xhtml extends Doku_Renderer {
+                     $this->doc .= ' ('.$item->get_local_date($conf['dformat']).')';
+                 }
+                 if($params['details']) {
++                    $desc = $item->get_description();
++                    $desc = strip_tags($desc);
++                    $desc = html_entity_decode($desc, ENT_QUOTES, 'UTF-8');
+                     $this->doc .= '<div class="detail">';
+                     if($conf['htmlok']) {
+                         $this->doc .= $item->get_description();
+                     } else {
+-                        $this->doc .= strip_tags($item->get_description());
++                        $this->doc .= hsc($desc);
+                     }
+                     $this->doc .= '</div>';
+                 }

--- a/pkgs/servers/web-apps/dokuwiki/default.nix
+++ b/pkgs/servers/web-apps/dokuwiki/default.nix
@@ -11,6 +11,15 @@ stdenv.mkDerivation rec {
     sha256 = "sha256-gtWEtc3kbMokKycTx71XXblkDF39i926uN2kU3oOeVw=";
   };
 
+  patches = [
+    # Manually backported fix for a high severity vulnerability, allowing to inject
+    # arbitrary HTML and thus cross site scripting via RSS feeds.
+    # For reference see:
+    # https://github.com/dokuwiki/dokuwiki/commit/53df38b0e4465894a67a5890f74a6f5f82e827de
+    # https://huntr.dev/bounties/c6119106-1a5c-464c-94dd-ee7c5d0bece0/
+    ./backport-rss-xss-fix.patch
+  ];
+
   preload = writeText "preload.php" ''
   <?php
 


### PR DESCRIPTION
###### Description of changes

The original update containing the fix was in #232160. Manually creating the patch since the upstream patch is only for 2023-04-04 and does not apply to 2022-07-31-31a.

Upstream changes and bug report:
- https://github.com/dokuwiki/dokuwiki/commit/53df38b0e4465894a67a5890f74a6f5f82e827de
- https://huntr.dev/bounties/c6119106-1a5c-464c-94dd-ee7c5d0bece0/

Note: I decided to not escape anything from the description of `htmlok` is set (https://github.com/dokuwiki/dokuwiki/blob/1e4e47625a7c46816aa6070feafa9e423046e6fc/inc/parser/xhtml.php#L1371-L1379) since this, by definition, allows for arbitrary HTML and JS to be passed (since this option was removed in 2023-04-04, just doing what upstream was doing is not possible).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
