### PR TITLE
Revert "shadowsocks-v2ray-plugin: mark as broken"

### DIFF
--- a/pkgs/tools/networking/shadowsocks-v2ray-plugin/default.nix
+++ b/pkgs/tools/networking/shadowsocks-v2ray-plugin/default.nix
@@ -23,7 +23,6 @@ buildGoModule rec {
     license = licenses.mit;
     maintainers = [ maintainers.ahrzb ];
     mainProgram = "v2ray-plugin";
-    broken = true; # build fails with go > 1.17
   };
 }
 


### PR DESCRIPTION
Reverts NixOS/nixpkgs#231507

ZHF: https://github.com/NixOS/nixpkgs/issues/230712

https://github.com/NixOS/nixpkgs/pull/231507#issuecomment-1549267137

cc @mweinelt @hmenke 