### PR TITLE
paperless-ngx: 1.14.4 -> 1.16.1, python3Packages.python-ipware: init at 0.9.0,  python3Packages.tika-client: init at 0.1.0

### DIFF
--- a/pkgs/applications/office/paperless-ngx/default.nix
+++ b/pkgs/applications/office/paperless-ngx/default.nix
@@ -17,13 +17,13 @@
 }:
 
 let
-  version = "1.14.4";
+  version = "1.16.1";
 
   src = fetchFromGitHub {
     owner = "paperless-ngx";
     repo = "paperless-ngx";
     rev = "refs/tags/v${version}";
-    hash = "sha256-9+8XqENpSdsND6g59oJkVoCe5tJ1Pwo8HD7Cszv/t7o=";
+    hash = "sha256-KmCUViKyjS/1+PL48TOeamYjSkg4J6ywvHgcIhNtVss=";
   };
 
   # Use specific package versions required by paperless-ngx
@@ -31,38 +31,15 @@ let
     packageOverrides = self: super: {
       django = super.django_4;
 
-      aioredis = super.aioredis.overridePythonAttrs (oldAttrs: rec {
-        version = "1.3.1";
+      # Paperless tests fail with tika-client==0.1.0. Upstream WIP fix is at
+      # https://github.com/paperless-ngx/paperless-ngx/pull/3617
+      tika-client = super.tika-client.overridePythonAttrs (oldAttrs: rec {
+        version = "0.0.3";
         src = oldAttrs.src.override {
-          inherit version;
-          sha256 = "0fi7jd5hlx8cnv1m97kv9hc4ih4l8v15wzkqwsp73is4n0qazy0m";
-        };
-      });
-
-      channels = super.channels.overridePythonAttrs (oldAttrs: rec {
-        version = "3.0.5";
-        pname = "channels";
-        src = fetchFromGitHub {
-          owner = "django";
-          repo = pname;
           rev = version;
-          sha256 = "sha256-bKrPLbD9zG7DwIYBst1cb+zkDsM8B02wh3D80iortpw=";
-        };
-        propagatedBuildInputs = oldAttrs.propagatedBuildInputs ++ [ self.daphne ];
-        pytestFlagsArray = [ "--asyncio-mode=auto" ];
-      });
-
-      daphne = super.daphne.overridePythonAttrs (oldAttrs: rec {
-        version = "3.0.2";
-        pname = "daphne";
-        src = fetchFromGitHub {
-          owner = "django";
-          repo = pname;
-          rev = version;
-          hash = "sha256-KWkMV4L7bA2Eo/u4GGif6lmDNrZAzvYyDiyzyWt9LeI=";
+          hash = "sha256-IKPTQ4n/j/W292F0JpSEUC0X8E1tr961WEcNCN5ymoU=";
         };
       });
-
     };
   };
 
@@ -82,7 +59,7 @@ let
     pname = "paperless-ngx-frontend";
     inherit version src;
 
-    npmDepsHash = "sha256-XTk4DpQAU/rI2XoUvLm0KVjuXFWdz2wb2EAg8EBVEdU=";
+    npmDepsHash = "sha256-GDdHlrU1x/uxDy4mwK7G4F9b7AJat3nhQESUpfDdKeE=";
 
     nativeBuildInputs = [
       python3
@@ -118,7 +95,6 @@ python.pkgs.buildPythonApplication rec {
   ];
 
   propagatedBuildInputs = with python.pkgs; [
-    aioredis
     amqp
     anyio
     asgiref
@@ -142,7 +118,6 @@ python.pkgs.buildPythonApplication rec {
     concurrent-log-handler
     constantly
     cryptography
-    daphne
     dateparser
     django-celery-results
     django-cors-headers
@@ -150,7 +125,6 @@ python.pkgs.buildPythonApplication rec {
     django-extensions
     django-filter
     django-guardian
-    django-ipware
     django
     djangorestframework-guardian2
     djangorestframework
@@ -174,12 +148,10 @@ python.pkgs.buildPythonApplication rec {
     msgpack
     mysqlclient
     nltk
-    numpy
     ocrmypdf
     packaging
     pathvalidate
     pdf2image
-    pdfminer-six
     pikepdf
     pillow
     pluggy
@@ -192,6 +164,7 @@ python.pkgs.buildPythonApplication rec {
     pyopenssl
     python-dateutil
     python-dotenv
+    python-ipware
     python-gnupg
     python-magic
     pytz
@@ -209,7 +182,7 @@ python.pkgs.buildPythonApplication rec {
     sniffio
     sqlparse
     threadpoolctl
-    tika
+    tika-client
     tornado
     tqdm
     twisted
@@ -266,12 +239,16 @@ python.pkgs.buildPythonApplication rec {
   '';
 
   nativeCheckInputs = with python.pkgs; [
+    daphne
     factory_boy
     imagehash
+    pdfminer-six
     pytest-django
     pytest-env
+    pytest-httpx
     pytest-xdist
     pytestCheckHook
+    reportlab
   ];
 
   pytestFlagsArray = [

--- a/pkgs/development/python-modules/python-ipware/default.nix
+++ b/pkgs/development/python-modules/python-ipware/default.nix
@@ -1,0 +1,35 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, pythonOlder
+, unittestCheckHook
+}:
+buildPythonPackage rec {
+  pname = "python-ipware";
+  version = "0.9.0";
+  format = "setuptools";
+
+  disabled = pythonOlder "3.7";
+
+  src = fetchFromGitHub {
+    owner = "un33k";
+    repo = "python-ipware";
+    rev = "v${version}";
+    hash = "sha256-RK624ktIzoLBD/2mB65zcYZ+o8axDE16bJpB6TwG4h4=";
+  };
+
+  pythonImportsCheck = [
+    "ipware"
+  ];
+  nativeCheckInputs = [
+    unittestCheckHook
+  ];
+
+  meta = with lib; {
+    description = "A python package for server applications to retrieve client's IP address";
+    homepage = "https://github.com/un33k/python-ipware";
+    changelog = "https://github.com/un33k/python-ipware/blob/v${version}/CHANGELOG.md";
+    license = licenses.mit;
+    maintainers = with maintainers; [ e1mo ];
+  };
+}

--- a/pkgs/development/python-modules/tika-client/default.nix
+++ b/pkgs/development/python-modules/tika-client/default.nix
@@ -1,0 +1,42 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, pythonOlder
+, hatchling
+, httpx
+}:
+buildPythonPackage rec {
+  pname = "tika-client";
+  version = "0.1.0";
+  format = "pyproject";
+
+  disabled = pythonOlder "3.8";
+
+  src = fetchFromGitHub {
+    owner = "stumpylog";
+    repo = "tika-client";
+    rev = version;
+    hash = "sha256-c/4zoXxxrKA5uIz0esdNBmX1DYOiXrkCH1ePGUpEXRY=";
+  };
+
+  propagatedBuildInputs = [
+    hatchling
+    httpx
+  ];
+  pythonImportsCheck = [
+    "tika_client"
+  ];
+  # Almost all of the tests (all except one in 0.1.0) fail since there
+  # is no tika http API endpoint reachable. Since tika is not yet
+  # packaged for nixpkgs, it seems like an unreasonable amount of effort
+  # fixing these tests.
+  doChecks = false;
+
+  meta = with lib; {
+    description = "A modern Python REST client for Apache Tika server";
+    homepage = "https://github.com/stumpylog/tika-client";
+    changelog = "https://github.com/stumpylog/tika-client/blob/${version}/CHANGELOG.md";
+    license = licenses.gpl3;
+    maintainers = with maintainers; [ e1mo ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -12097,6 +12097,8 @@ self: super: with self; {
 
   tika = callPackage ../development/python-modules/tika { };
 
+  tika-client = callPackage ../development/python-modules/tika-client { };
+
   tiktoken = callPackage ../development/python-modules/tiktoken { };
 
   tikzplotlib = callPackage ../development/python-modules/tikzplotlib { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -7756,6 +7756,8 @@ self: super: with self; {
 
   python-ipmi = callPackage ../development/python-modules/python-ipmi { };
 
+  python-ipware = callPackage ../development/python-modules/python-ipware { };
+
   python-ironicclient = callPackage ../development/python-modules/python-ironicclient { };
 
   python-izone = callPackage ../development/python-modules/python-izone { };


### PR DESCRIPTION
###### Description of changes

Various smaller new features (quick filters from document detail, explanations for relative dates, pagination for tasks) and various other bug fixes and minor enhancements. Especially noteworthy for v1.14.5 seems a security fix around the display of texts in the frontend[^1].

Full changelog available at
https://github.com/paperless-ngx/paperless-ngx/releases/tag/v1.14.5
https://github.com/paperless-ngx/paperless-ngx/releases/tag/v1.15.0
https://github.com/paperless-ngx/paperless-ngx/releases/tag/v1.15.1
https://github.com/paperless-ngx/paperless-ngx/releases/tag/v1.16.0
  https://github.com/paperless-ngx/paperless-ngx/releases/tag/v1.16.1


[^1]: Since the [bug report](https://huntr.dev/bounties/94517f3f-ed86-4d88-bce1-6e9ba11fe1c2/) is not yet public, it's not possible to judge the severity of it.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
