### PR TITLE
wordpressPackages.plugins: update, wPackages.plugins.wp-swiper: init at 1.0.32

### DIFF
--- a/pkgs/servers/web-apps/wordpress/packages/plugins.json
+++ b/pkgs/servers/web-apps/wordpress/packages/plugins.json
@@ -24,10 +24,10 @@
     "version": "2.21.08.31"
   },
   "breeze": {
-    "path": "breeze/tags/2.0.21",
-    "rev": "2906926",
-    "sha256": "11apjskzfajvz4bm06bva0pjm6z7salvvl024267l6n5hyp924zs",
-    "version": "2.0.21"
+    "path": "breeze/tags/2.0.22",
+    "rev": "2913544",
+    "sha256": "09x5ii2255cj78hamvbkzxfgj917pn7agpl7v8lgpkf0y113lvqi",
+    "version": "2.0.22"
   },
   "co-authors-plus": {
     "path": "co-authors-plus/tags/3.5.10",
@@ -178,6 +178,12 @@
     "rev": "2907012",
     "sha256": "0pb5988x1aqpdkr5ar32zl004c48c6040bvjdws6f3z6vi6i475x",
     "version": "14.1"
+  },
+  "wp-swiper": {
+    "path": "wp-swiper/trunk",
+    "rev": "2905097",
+    "sha256": "0g8m6rar78pwshyk124ww04gy18bz85z8xv0ir8b7lxx8l8rpmvd",
+    "version": "1.0.32"
   },
   "wp-user-avatars": {
     "path": "wp-user-avatars/trunk",

--- a/pkgs/servers/web-apps/wordpress/packages/wordpress-plugins.json
+++ b/pkgs/servers/web-apps/wordpress/packages/wordpress-plugins.json
@@ -29,6 +29,7 @@
 , "wp-gdpr-compliance"
 , "wp-mail-smtp"
 , "wp-statistics"
+, "wp-swiper"
 , "wp-user-avatars"
 , "wpforms-lite"
 ]


### PR DESCRIPTION
###### Description of changes

Update packages and add [wp-swiper](https://wordpress.org/plugins/wp-swiper/) plugin

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
