### PR TITLE
ios-webkit-debug-proxy: init at 1.9.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -302,6 +302,12 @@
     githubId = 2321000;
     name = "Ruslan Babayev";
   };
+  abustany = {
+    email = "adrien@bustany.org";
+    github = "abustany";
+    githubId = 2526296;
+    name = "Adrien Bustany";
+  };
   acairncross = {
     email = "acairncross@gmail.com";
     github = "acairncross";

--- a/pkgs/development/mobile/ios-webkit-debug-proxy/0001-Don-t-compile-examples.patch
+++ b/pkgs/development/mobile/ios-webkit-debug-proxy/0001-Don-t-compile-examples.patch
@@ -1,0 +1,23 @@
+diff --git a/Makefile.am b/Makefile.am
+index 52dc7a8..407c056 100644
+--- a/Makefile.am
++++ b/Makefile.am
+@@ -2,4 +2,4 @@
+ # Copyright 2012 Google Inc. wrightt@google.com
+ 
+ AUTOMAKE_OPTIONS = foreign
+-SUBDIRS = src include examples
++SUBDIRS = src include
+diff --git a/configure.ac b/configure.ac
+index ac2a278..a4104b7 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -82,7 +82,7 @@ fi
+ 
+ AC_CHECK_FUNCS([memmove memset regcomp select socket strcasecmp strncasecmp strchr strdup strndup strrchr strstr strtol strcasestr getline])
+ 
+-AC_CONFIG_FILES([Makefile src/Makefile include/Makefile examples/Makefile])
++AC_CONFIG_FILES([Makefile src/Makefile include/Makefile])
+ 
+ CFLAGS="${CFLAGS} -Wall -Werror"
+ 

--- a/pkgs/development/mobile/ios-webkit-debug-proxy/default.nix
+++ b/pkgs/development/mobile/ios-webkit-debug-proxy/default.nix
@@ -1,0 +1,57 @@
+{ stdenv
+, autoconf
+, automake
+, fetchFromGitHub
+, fetchpatch
+, lib
+, libimobiledevice
+, libusb1
+, libplist
+, libtool
+, openssl
+, pkg-config
+}:
+
+stdenv.mkDerivation rec {
+  pname = "ios-webkit-debug-proxy";
+  version = "1.9.0";
+
+  src = fetchFromGitHub {
+    owner = "google";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "sha256-cZ/p/aWET/BXKDrD+qgR+rfTISd+4jPNQFuV8klSLUo=";
+  };
+
+  patches = [
+    # OpenSSL 3.0 compatibility
+    (fetchpatch {
+      url = "https://github.com/google/ios-webkit-debug-proxy/commit/5ba30a2a67f39d25025cadf37c0eafb2e2d2d0a8.patch";
+      sha256 = "sha256-2b9BjG9wkqO+ZfoBYYJvD2Db5Kr0F/MxKMTRsI0ea3s=";
+    })
+    # Examples compilation breaks with --disable-static, see https://github.com/google/ios-webkit-debug-proxy/issues/399
+    ./0001-Don-t-compile-examples.patch
+  ];
+
+  outputs = [ "out" "dev" ];
+
+  nativeBuildInputs = [ autoconf automake libtool pkg-config ];
+  buildInputs = [ libimobiledevice libusb1 libplist openssl ];
+
+  preConfigure = ''
+    NOCONFIGURE=1 ./autogen.sh
+  '';
+  enableParallelBuilding = true;
+
+  meta = with lib; {
+    description = "A DevTools proxy (Chrome Remote Debugging Protocol) for iOS devices (Safari Remote Web Inspector).";
+    longDescription = ''
+      The ios_webkit_debug_proxy (aka iwdp) proxies requests from usbmuxd
+      daemon over a websocket connection, allowing developers to send commands
+      to MobileSafari and UIWebViews on real and simulated iOS devices.
+    '';
+    homepage = "https://github.com/google/ios-webkit-debug-proxy";
+    license = licenses.bsd3;
+    maintainers = [ maintainers.abustany ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3676,6 +3676,8 @@ with pkgs;
 
   xc = callPackage ../development/tools/xc { };
 
+  ios-webkit-debug-proxy = callPackage ../development/mobile/ios-webkit-debug-proxy { };
+
   xcodeenv = callPackage ../development/mobile/xcodeenv { };
 
   gomobile = callPackage ../development/mobile/gomobile { };


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Add package to connect to iOS Safari/webviews from Linux.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [x] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
