### PR TITLE
vlang: improve darwin situation

### DIFF
--- a/pkgs/development/compilers/vlang/default.nix
+++ b/pkgs/development/compilers/vlang/default.nix
@@ -2,12 +2,29 @@
 
 let
   version = "weekly.2023.19";
+  ptraceSubstitution = ''
+    #include <sys/types.h>
+    #include <sys/ptrace.h>
+  '';
   # Required for bootstrap.
-  vc = fetchFromGitHub {
-    owner = "vlang";
-    repo = "vc";
-    rev = "f7c2b5f2a0738d0d236161c9de9f31dd0280ac86";
-    sha256 = "sha256-xU3TvyNgc0o4RCsHtoC6cZTNaue2yuAiolEOvP37TKA=";
+  vc = stdenv.mkDerivation {
+    pname = "v.c";
+    version = "unstable-2023-05-14";
+    src = fetchFromGitHub {
+      owner = "vlang";
+      repo = "vc";
+      rev = "f7c2b5f2a0738d0d236161c9de9f31dd0280ac86";
+      sha256 = "sha256-xU3TvyNgc0o4RCsHtoC6cZTNaue2yuAiolEOvP37TKA=";
+    };
+
+    # patch the ptrace reference for darwin
+    installPhase = lib.optionalString stdenv.isDarwin ''
+      substituteInPlace v.c \
+        --replace "#include <sys/ptrace.h>" "${ptraceSubstitution}"
+    '' + ''
+      mkdir -p $out
+      cp v.c $out/
+    '';
   };
   # Required for vdoc.
   markdown = fetchFromGitHub {
@@ -38,11 +55,15 @@ stdenv.mkDerivation {
   ];
 
   env.VC = vc;
-  # libX11.dev and xorg.xorgproto are needed because of
-  # builder error: Header file <X11/Xlib.h>, needed for module `clipboard.x11` was not found. Please install a package with the X11 development headers, for example: `apt-get install libx11-dev`.
-  # libXau, libxcb, libXdmcp need to be static if you use static gcc otherwise
-  # /nix/store/xnk2z26fqy86xahiz3q797dzqx96sidk-glibc-2.37-8/lib/libc.so.6: undefined reference to `_rtld_glob al_ro@GLIBC_PRIVATE'
-  env.VFLAGS = "-cc ${pkgsStatic.gcc}/bin/gcc -no-retry-compilation -cflags -I${xorg.libX11.dev}/include -cflags -I${xorg.xorgproto}/include -ldflags -L${binaryen}/lib -ldflags -L${pkgsStatic.xorg.libX11}/lib -ldflags -L${pkgsStatic.xorg.libxcb}/lib -ldflags -lxcb -ldflags -L${pkgsStatic.xorg.libXau}/lib -ldflags -lXau -ldflags -L${pkgsStatic.xorg.libXdmcp}/lib -ldflags -lXdmcp";
+  env.VFLAGS = if stdenv.isDarwin then
+    # on darwin we need to add a manual link to libgc since it doesn't have a libgc.a
+    "-cg -cc ${pkgsStatic.clang}/bin/clang -no-retry-compilation -ldflags -L${pkgsStatic.boehmgc}/lib -ldflags -lgc -ldflags -L${binaryen}/lib"
+  else
+    # libX11.dev and xorg.xorgproto are needed because of
+    # builder error: Header file <X11/Xlib.h>, needed for module `clipboard.x11` was not found. Please install a package with the X11 development headers, for example: `apt-get install libx11-dev`.
+    # libXau, libxcb, libXdmcp need to be static if you use static gcc otherwise
+    # /nix/store/xnk2z26fqy86xahiz3q797dzqx96sidk-glibc-2.37-8/lib/libc.so.6: undefined reference to `_rtld_glob al_ro@GLIBC_PRIVATE'
+    "-cc ${pkgsStatic.gcc}/bin/gcc -no-retry-compilation -cflags -I${xorg.libX11.dev}/include -cflags -I${xorg.xorgproto}/include -ldflags -L${binaryen}/lib -ldflags -L${pkgsStatic.xorg.libX11}/lib -ldflags -L${pkgsStatic.xorg.libxcb}/lib -ldflags -lxcb -ldflags -L${pkgsStatic.xorg.libXau}/lib -ldflags -lXau -ldflags -L${pkgsStatic.xorg.libXdmcp}/lib -ldflags -lXdmcp";
 
   preBuild = ''
     export HOME=$(mktemp -d)
@@ -51,6 +72,11 @@ stdenv.mkDerivation {
     # we don't use tcc at all since it fails on a missing libatomic
     ln -s ${pkgsStatic.tinycc}/bin/tcc ./thirdparty/tcc/tcc.exe
     cp -r ${pkgsStatic.boehmgc}/lib/* ./thirdparty/tcc/lib
+  '' + lib.optionalString stdenv.isDarwin ''
+    # this file isn't used by clang, but it's just to silence a warning
+    # the compiler complains on an empty file, so this makes it "close" to real
+    substituteInPlace vlib/builtin/builtin_d_gcboehm.c.v \
+        --replace "libgc.a" "libgc.la"
   '';
 
   # vcreate_test.v requires git, so we must remove it when building the tools.


### PR DESCRIPTION
###### Description of changes

The darwin compilation still fails, but it's down to one single tool that fails, vshare.
it's failing on a missing Cocoa.h header, I've tried everything to pass that header, it just doesn't want to find it.

I'll wait for the ci to verify I haven't screwed anything up on linux and will merge. If anyone ever sees this and has an epiphany, feel free to let me know.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
