### PR TITLE
mir: Modernise derivation

### DIFF
--- a/pkgs/servers/mir/default.nix
+++ b/pkgs/servers/mir/default.nix
@@ -2,6 +2,7 @@
 , lib
 , fetchFromGitHub
 , gitUpdater
+, testers
 , cmake
 , pkg-config
 , python3
@@ -34,26 +35,17 @@
 , gtest
 , umockdev
 , wlcs
+, validatePkgConfig
 }:
 
-let
-  doCheck = stdenv.buildPlatform.canExecute stdenv.hostPlatform;
-  pythonEnv = python3.withPackages(ps: with ps; [
-    pillow
-  ] ++ lib.optionals doCheck [
-    pygobject3
-    python-dbusmock
-  ]);
-in
-
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "mir";
   version = "2.13.0";
 
   src = fetchFromGitHub {
     owner = "MirServer";
     repo = "mir";
-    rev = "v${version}";
+    rev = "v${finalAttrs.version}";
     hash = "sha256-Ip8p4mjcgmZQJTU4MNvWkTTtSJc+cCL3x1mMDFlZrVY=";
   };
 
@@ -98,7 +90,13 @@ stdenv.mkDerivation rec {
     libxslt
     lttng-ust # lttng-gen-tp
     pkg-config
-    pythonEnv
+    (python3.withPackages (ps: with ps; [
+      pillow
+    ] ++ lib.optionals finalAttrs.doCheck [
+      pygobject3
+      python-dbusmock
+    ]))
+    validatePkgConfig
   ];
 
   buildInputs = [
@@ -127,21 +125,23 @@ stdenv.mkDerivation rec {
     xorg.libXcursor
     xorg.xorgproto
     xwayland
-  ] ++ lib.optionals doCheck [
-    gtest
-    umockdev
-    wlcs
   ];
 
   nativeCheckInputs = [
     dbus
   ];
 
+  checkInputs = [
+    gtest
+    umockdev
+    wlcs
+  ];
+
   buildFlags = [ "all" "doc" ];
 
   cmakeFlags = [
     "-DMIR_PLATFORM='gbm-kms;x11;eglstream-kms;wayland'"
-    "-DMIR_ENABLE_TESTS=${if doCheck then "ON" else "OFF"}"
+    "-DMIR_ENABLE_TESTS=${if finalAttrs.doCheck then "ON" else "OFF"}"
     # BadBufferTest.test_truncated_shm_file *doesn't* throw an error as the test expected, mark as such
     # https://github.com/MirServer/mir/pull/1947#issuecomment-811810872
     "-DMIR_SIGBUS_HANDLER_ENVIRONMENT_BROKEN=ON"
@@ -152,7 +152,7 @@ stdenv.mkDerivation rec {
     "-DMIR_BUILD_PLATFORM_TEST_HARNESS=OFF"
   ];
 
-  inherit doCheck;
+  doCheck = stdenv.buildPlatform.canExecute stdenv.hostPlatform;
 
   preCheck = ''
     # Needs to be exactly /tmp so some failing tests don't get run, don't know why they fail yet
@@ -163,6 +163,7 @@ stdenv.mkDerivation rec {
   outputs = [ "out" "dev" "doc" ];
 
   passthru = {
+    tests.pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
     updateScript = gitUpdater {
       rev-prefix = "v";
     };
@@ -179,8 +180,22 @@ stdenv.mkDerivation rec {
   meta = with lib; {
     description = "A display server and Wayland compositor developed by Canonical";
     homepage = "https://mir-server.io";
+    changelog = "https://github.com/MirServer/mir/releases/tag/v${finalAttrs.version}";
     license = licenses.gpl2Plus;
     maintainers = with maintainers; [ onny OPNA2608 ];
     platforms = platforms.linux;
+    pkgConfigModules = [
+      "miral"
+      "mircommon"
+      "mircookie"
+      "mircore"
+      "miroil"
+      "mirplatform"
+      "mir-renderer-gl-dev"
+      "mirrenderer"
+      "mirserver"
+      "mirtest"
+      "mirwayland"
+    ];
   };
-}
+})


### PR DESCRIPTION
###### Description of changes

- test-related `buildInputs` -> `checkInputs`
- use `finalAttrs`
- set `meta.changelog`
- set `meta.pkgConfigModules`, validate with `validatePkgConfig`

I'm not sure how the Python modules for the `checkPhase` could be handled via `nativeCheckInputs`, so they're still in `nativeBuildInputs`' `python3.withPackages`, behind a `lib.optionals finalAttrs.doCheck` conditional.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
