### PR TITLE
mate.mate-utils: 1.26.0 -> 1.26.1

### DIFF
--- a/pkgs/desktops/mate/mate-utils/default.nix
+++ b/pkgs/desktops/mate/mate-utils/default.nix
@@ -1,6 +1,7 @@
 { lib
 , stdenv
 , fetchurl
+, fetchpatch
 , pkg-config
 , gettext
 , itstool
@@ -19,12 +20,23 @@
 
 stdenv.mkDerivation rec {
   pname = "mate-utils";
-  version = "1.26.0";
+  version = "1.26.1";
 
   src = fetchurl {
     url = "https://pub.mate-desktop.org/releases/${lib.versions.majorMinor version}/${pname}-${version}.tar.xz";
-    sha256 = "0bkqj8qwwml9xyvb680yy06lv3dzwkv89yrzz5jamvz88ar6m9bw";
+    sha256 = "L1NHWxoJkd1ak9ndpY/KTkFvJZJTWG2UpbEQjxI3BiA=";
   };
+
+  patches = [
+    # Hopefully helps "libxml2.treeError: xmlSetProp() failed"
+    # This patch is not part of upstream yet.
+    # https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=919058
+    # https://github.com/mate-desktop/mate-utils/issues/210
+    (fetchpatch {
+      url = "https://salsa.debian.org/debian-mate-team/mate-utils/-/raw/2b43d78f3fdbf0aa50716b62bcada2ef015957c6/debian/patches/1001_fix-gsearchtool-pt-help-translation.patch";
+      sha256 = "SZVpdup/bNv+3hEGQ0L13mgXyNm+wRcL53t9/Oi24wA=";
+    })
+  ];
 
   nativeBuildInputs = [
     pkg-config


### PR DESCRIPTION
https://github.com/mate-desktop/mate-utils/compare/v1.26.0...v1.26.1

###### Description of changes

This is originally part of https://github.com/NixOS/nixpkgs/pull/230843, but I decided to separate this since it has flaky build issues and I want to take a look at it.

- https://github.com/mate-desktop/mate-utils/issues/210
- Sample failure: [here](https://logs.ofborg.org/?attempt_id=208ea37c-8bbc-4137-8c91-b349e94ee577&key=nixos%2Fnixpkgs.230843)
- Sample success: [here](https://logs.ofborg.org/?attempt_id=5a686cd3-1d3b-46ff-8852-83e058e80d7f&key=nixos%2Fnixpkgs.230843)

As the last resort we can either try to push this as-is and *restart the build on hydra.nixos.org* :see_no_evil: or disable the pt translations, wow amazing :upside_down_face: 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
