### PR TITLE
nixos/config/swap: resolve swapfile issue !232229

### DIFF
--- a/nixos/modules/config/swap.nix
+++ b/nixos/modules/config/swap.nix
@@ -275,12 +275,11 @@ in
                 ''}
                 ${optionalString sw.randomEncryption.enable ''
                   cryptsetup plainOpen -c ${sw.randomEncryption.cipher} -d ${sw.randomEncryption.source} \
-                '' + concatMapStrings (arg: arg + " \\\n") (flatten [
-                  (optional (sw.randomEncryption.sectorSize != null) "--sector-size=${toString sw.randomEncryption.sectorSize}")
-                  (optional (sw.randomEncryption.keySize != null) "--key-size=${toString sw.randomEncryption.keySize}")
-                  (optional sw.randomEncryption.allowDiscards "--allow-discards")
-                ]) + ''
-                  ${sw.device} ${sw.deviceName}
+                  ${concatStringsSep " \\\n" (flatten [
+                    (optional (sw.randomEncryption.sectorSize != null) "--sector-size=${toString sw.randomEncryption.sectorSize}")
+                    (optional (sw.randomEncryption.keySize != null) "--key-size=${toString sw.randomEncryption.keySize}")
+                    (optional sw.randomEncryption.allowDiscards "--allow-discards")
+                  ])} ${sw.device} ${sw.deviceName}
                   mkswap ${sw.realDevice}
                 ''}
               '';

--- a/nixos/tests/swap-file-btrfs.nix
+++ b/nixos/tests/swap-file-btrfs.nix
@@ -32,6 +32,8 @@ import ./make-test-python.nix ({ lib, ... }:
 
   testScript = ''
     machine.wait_for_unit('var-swapfile.swap')
+    # Ensure the swap file creation script ran to completion without failing when creating the swap file
+    machine.fail("systemctl is-failed --quiet mkswap-var-swapfile.service")
     machine.succeed("stat --file-system --format=%T /var/swapfile | grep btrfs")
     # First run. Auto creation.
     machine.succeed("swapon --show | grep /var/swapfile")
@@ -41,6 +43,8 @@ import ./make-test-python.nix ({ lib, ... }:
 
     # Second run. Use it as-is.
     machine.wait_for_unit('var-swapfile.swap')
+    # Ensure the swap file creation script ran to completion without failing when the swap file already exists
+    machine.fail("systemctl is-failed --quiet mkswap-var-swapfile.service")
     machine.succeed("swapon --show | grep /var/swapfile")
   '';
 })


### PR DESCRIPTION
###### Description of changes

Remove spurious template output responsible for !232339

###### Things done

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [X] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - 
        /nix/store/c9fbfjnv8ljk2sgvcvxh7fbycjavzlgi-vm-test-run-hibernate
        /nix/store/wvh8wz4q8g068n2kj61xhf3900pqar81-vm-test-run-swap-ab_and_ctrl-as-shift
        /nix/store/p6af9yvqklrg4q6xcyvf32j29dnxkv58-vm-test-run-misc
        /nix/store/q7z7ld7six2m1pjgc8vgpps88r8hvx7c-vm-test-run-swap-file-btrfs
        /nix/store/36zpk6yba07m27lhpj9plshxgg2jpz77-vm-test-run-swap-partition
        /nix/store/syp5c5p5vdg8d5vsf5srvfjmnmd05hqk-vm-test-run-swap-random-encryption
        /nix/store/2y0bd20b1n8sjskl5giys0a5vd4jb922-vm-test-run-zram-generator
  - ~~and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)~~
  - ~~or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)~~
  - ~~made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages~~
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- ~~[23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)~~
  - [ ] ~~(Package updates) Added a release notes entry if the change is major or breaking~~
  - [ ] ~~(Module updates) Added a release notes entry if the change is significant~~
    
    No change to visible module interface, this change corrects a defect in the original implementation.

  - [ ] ~~(Module addition) Added a release notes entry if adding a new NixOS module~~
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
