### PR TITLE
wpsoffice: don't need wrapGAppsHook nor wrapQtAppsHook & use autoPatchelfIgnoreMissingDeps

### DIFF
--- a/pkgs/applications/office/wpsoffice/default.nix
+++ b/pkgs/applications/office/wpsoffice/default.nix
@@ -2,19 +2,22 @@
 , stdenv
 , fetchurl
 , dpkg
-, wrapGAppsHook
-, wrapQtAppsHook
 , autoPatchelfHook
 , alsa-lib
+, at-spi2-core
 , libtool
+, libxkbcommon
 , nspr
 , mesa
 , libtiff
-, cups
+, libxslt
 , udev
+, gtk3
+, gdk-pixbuf
+, qtbase
 , xorg
+, cups
 , pango
-, makeWrapper
 , useChineseVersion ? false
 }:
 
@@ -44,18 +47,33 @@ stdenv.mkDerivation rec {
     rm -r opt/kingsoft/wps-office/office6/addons/wppencoder/libwppencoder.so
   '';
 
-  nativeBuildInputs = [ dpkg wrapGAppsHook wrapQtAppsHook makeWrapper autoPatchelfHook ];
+  nativeBuildInputs = [
+    dpkg
+    autoPatchelfHook
+  ];
 
   buildInputs = [
     alsa-lib
-    xorg.libXdamage
-    xorg.libXtst
+    at-spi2-core
     libtool
+    libxkbcommon
     nspr
     mesa
     libtiff
+    libxslt
     udev
+    gtk3
+    gdk-pixbuf
+    qtbase
+    xorg.libXdamage
+    xorg.libXtst
+    xorg.libXrandr
+    xorg.libXcomposite
+    cups
+    pango
   ];
+
+  dontWrapQtApps = true;
 
   runtimeDependencies = map lib.getLib [
     cups
@@ -79,23 +97,11 @@ stdenv.mkDerivation rec {
     runHook postInstall
   '';
 
-  dontWrapQtApps = true;
-  dontWrapGApps = true;
-
   preFixup = ''
     # The following libraries need libtiff.so.5, but nixpkgs provides libtiff.so.6
     patchelf --replace-needed libtiff.so.5 libtiff.so $out/opt/kingsoft/wps-office/office6/{libpdfmain.so,libqpdfpaint.so,qt/plugins/imageformats/libqtiff.so}
     # dlopen dependency
     patchelf --add-needed libudev.so.1 $out/opt/kingsoft/wps-office/office6/addons/cef/libcef.so
-  '';
-
-  postFixup = ''
-    for f in "$out"/bin/*; do
-      echo "Wrapping $f"
-      wrapProgram "$f" \
-        "''${gappsWrapperArgs[@]}" \
-        "''${qtWrapperArgs[@]}"
-    done
   '';
 
   meta = with lib; {

--- a/pkgs/applications/office/wpsoffice/default.nix
+++ b/pkgs/applications/office/wpsoffice/default.nix
@@ -36,17 +36,6 @@ stdenv.mkDerivation rec {
   unpackCmd = "dpkg -x $src .";
   sourceRoot = ".";
 
-  postUnpack = ''
-    # distribution is missing libkappessframework.so, so we should not let
-    # autoPatchelfHook fail on the following dead libraries
-    rm -r opt/kingsoft/wps-office/office6/addons/pdfbatchcompression
-
-    # Remove the following libraries because they depend on qt4
-    rm -r opt/kingsoft/wps-office/office6/{librpcetapi.so,librpcwpsapi.so,librpcwppapi.so,libavdevice.so.58.10.100,libmediacoder.so}
-    rm -r opt/kingsoft/wps-office/office6/addons/wppcapturer/libwppcapturer.so
-    rm -r opt/kingsoft/wps-office/office6/addons/wppencoder/libwppencoder.so
-  '';
-
   nativeBuildInputs = [
     dpkg
     autoPatchelfHook
@@ -69,6 +58,7 @@ stdenv.mkDerivation rec {
     xorg.libXtst
     xorg.libXrandr
     xorg.libXcomposite
+    xorg.libXv
     cups
     pango
   ];
@@ -78,6 +68,15 @@ stdenv.mkDerivation rec {
   runtimeDependencies = map lib.getLib [
     cups
     pango
+  ];
+
+  autoPatchelfIgnoreMissingDeps = [
+    # distribution is missing libkappessframework.so
+    "libkappessframework.so"
+    # qt4 support is deprecated
+    "libQtCore.so.4"
+    "libQtNetwork.so.4"
+    "libQtXml.so.4"
   ];
 
   installPhase = ''
@@ -99,7 +98,7 @@ stdenv.mkDerivation rec {
 
   preFixup = ''
     # The following libraries need libtiff.so.5, but nixpkgs provides libtiff.so.6
-    patchelf --replace-needed libtiff.so.5 libtiff.so $out/opt/kingsoft/wps-office/office6/{libpdfmain.so,libqpdfpaint.so,qt/plugins/imageformats/libqtiff.so}
+    patchelf --replace-needed libtiff.so.5 libtiff.so $out/opt/kingsoft/wps-office/office6/{libpdfmain.so,libqpdfpaint.so,qt/plugins/imageformats/libqtiff.so,addons/pdfbatchcompression/libpdfbatchcompressionapp.so}
     # dlopen dependency
     patchelf --add-needed libudev.so.1 $out/opt/kingsoft/wps-office/office6/addons/cef/libcef.so
   '';

--- a/pkgs/applications/office/wpsoffice/default.nix
+++ b/pkgs/applications/office/wpsoffice/default.nix
@@ -10,10 +10,8 @@
 , nspr
 , mesa
 , libtiff
-, libxslt
 , udev
 , gtk3
-, gdk-pixbuf
 , qtbase
 , xorg
 , cups
@@ -49,18 +47,12 @@ stdenv.mkDerivation rec {
     nspr
     mesa
     libtiff
-    libxslt
     udev
     gtk3
-    gdk-pixbuf
     qtbase
     xorg.libXdamage
     xorg.libXtst
-    xorg.libXrandr
-    xorg.libXcomposite
     xorg.libXv
-    cups
-    pango
   ];
 
   dontWrapQtApps = true;


### PR DESCRIPTION
###### Description of changes

wrapGAppsHook and wrapQtAppsHook should not be necessary for wpsoffice



<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->



###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
