### PR TITLE
pufferpanel: fix build on i686-linux

### DIFF
--- a/pkgs/servers/pufferpanel/bump-sha1cd.patch
+++ b/pkgs/servers/pufferpanel/bump-sha1cd.patch
@@ -1,0 +1,28 @@
+diff --git a/go.mod b/go.mod
+index 107660ef..8efd7ebf 100644
+--- a/go.mod
++++ b/go.mod
+@@ -128,7 +128,7 @@ require (
+ 	github.com/pelletier/go-toml v1.9.5 // indirect
+ 	github.com/pelletier/go-toml/v2 v2.0.6 // indirect
+ 	github.com/pierrec/lz4/v4 v4.1.2 // indirect
+-	github.com/pjbgf/sha1cd v0.2.0 // indirect
++	github.com/pjbgf/sha1cd v0.3.0 // indirect
+ 	github.com/pmezard/go-difflib v1.0.0 // indirect
+ 	github.com/robfig/cron/v3 v3.0.1 // indirect
+ 	github.com/rogpeppe/go-internal v1.9.0 // indirect
+diff --git a/go.sum b/go.sum
+index 021d3ab9..13592e36 100644
+--- a/go.sum
++++ b/go.sum
+@@ -485,8 +485,9 @@ github.com/pelletier/go-toml/v2 v2.0.6 h1:nrzqCb7j9cDFj2coyLNLaZuJTLjWjlaz6nvTvI
+ github.com/pelletier/go-toml/v2 v2.0.6/go.mod h1:eumQOmlWiOPt5WriQQqoM5y18pDHwha2N+QD+EUNTek=
+ github.com/pierrec/lz4/v4 v4.1.2 h1:qvY3YFXRQE/XB8MlLzJH7mSzBs74eA2gg52YTk6jUPM=
+ github.com/pierrec/lz4/v4 v4.1.2/go.mod h1:gZWDp/Ze/IJXGXf23ltt2EXimqmTUXEy0GFuRQyBid4=
+-github.com/pjbgf/sha1cd v0.2.0 h1:gIsJVwjbRviE4gydidGztxH1IlJQoYBcCrwG4Dz8wvM=
+ github.com/pjbgf/sha1cd v0.2.0/go.mod h1:HOK9QrgzdHpbc2Kzip0Q1yi3M2MFGPADtR6HjG65m5M=
++github.com/pjbgf/sha1cd v0.3.0 h1:4D5XXmUUBUl/xQ6IjCkEAbqXskkq/4O7LmGn0AqMDs4=
++github.com/pjbgf/sha1cd v0.3.0/go.mod h1:nZ1rrWOcGJ5uZgEEVL1VUM9iRQiZvWdbZjkKyFzPPsI=
+ github.com/pkg/browser v0.0.0-20210115035449-ce105d075bb4/go.mod h1:N6UoU20jOqggOuDwUaBQpluzLNDqif3kq9z2wpdYEfQ=
+ github.com/pkg/browser v0.0.0-20210911075715-681adbf594b8/go.mod h1:HKlIX3XHQyzLZPlr7++PzdhaXEj94dEiJgZDTsxEqUI=
+ github.com/pkg/diff v0.0.0-20210226163009-20ebb0f2a09e/go.mod h1:pJLUxLENpZxwdsKMEsNbx1VGcRFpLqf3715MtcvvzbA=

--- a/pkgs/servers/pufferpanel/default.nix
+++ b/pkgs/servers/pufferpanel/default.nix
@@ -5,6 +5,7 @@
 , fetchzip
 , fetchpatch
 , pathDeps ? [ ]
+, nixosTests
 }:
 
 buildGoModule rec {
@@ -13,18 +14,19 @@ buildGoModule rec {
 
   patches = [
     # Bump go-sqlite3 version to avoid a GNU C compiler error.
-    # See https://github.com/PufferPanel/PufferPanel/pull/1240
     (fetchpatch {
-      url = "https://github.com/PufferPanel/PufferPanel/pull/1240/commits/3065dca2d9b05a56789971ccf0f43a7079a390b8.patch";
+      url = "https://github.com/PufferPanel/PufferPanel/commit/dd7fc80c33c7618c98311af09c78c25b77658aef.patch";
       hash = "sha256-ygMrhJoba8swoRBBii7BEiLihqOebLUtSH7os7W3s+k=";
     })
 
     # Fix errors in tests.
-    # See https://github.com/PufferPanel/PufferPanel/pull/1241
     (fetchpatch {
-      url = "https://github.com/PufferPanel/PufferPanel/pull/1241/commits/ffd21bce4bff3040c8e3e783e5b4779222e7a3a5.patch";
+      url = "https://github.com/PufferPanel/PufferPanel/commit/ad6ab4b4368e1111292fadfb3d9f058fa399fa21.patch";
       hash = "sha256-BzGfcWhzRrCHKkAhWf0uvXiiiutWqthn/ed7bN2hR8U=";
     })
+
+    # Bump sha1cd package, otherwise i686-linux fails to build.
+    ./bump-sha1cd.patch
 
     # Seems to be an anti-feature. Startup is the only place where user/group is
     # hardcoded and checked.
@@ -68,7 +70,7 @@ buildGoModule rec {
 
   nativeBuildInputs = [ makeWrapper ];
 
-  vendorHash = "sha256-fB8MxSl9E2W+BdO6i+drbCe9Z3bPHPi0MvpJEomU9co=";
+  vendorHash = "sha256-Esfk7SvqiWeiobXSI+4wYVEH9yVkB+rO7bxUQ5TzvG4=";
   proxyVendor = true;
 
   postFixup = ''
@@ -89,6 +91,10 @@ buildGoModule rec {
       --set-default PUFFER_PANEL_WEB_FILES $out/share/pufferpanel/www \
       --prefix PATH : ${lib.escapeShellArg (lib.makeBinPath pathDeps)}
   '';
+
+  passthru.tests = {
+    inherit (nixosTests) pufferpanel;
+  };
 
   meta = with lib; {
     description = "A free, open source game management panel";


### PR DESCRIPTION
###### Description of changes

This change adds a patch to bump `github.com/pjbgf/sha1cd` Go module dependency of the `pufferpanel` package to the version that builds for `i686-linux` system.

ZHF: #230712

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
