### PR TITLE
crossfire-server: Use python39 instead of python3

### DIFF
--- a/pkgs/games/crossfire/crossfire-server.nix
+++ b/pkgs/games/crossfire/crossfire-server.nix
@@ -1,6 +1,21 @@
-{ stdenv, lib, fetchsvn, autoreconfHook,
-  autoconf, automake, libtool, flex, perl, check, pkg-config, python3,
-  version, rev, sha256, maps, arch }:
+{ stdenv
+, lib
+, fetchsvn
+, autoreconfHook
+, autoconf
+, automake
+, libtool
+, flex
+, perl
+, check
+, pkg-config
+, python39 # crossfire-server relies on a parser wich was removed in python >3.9
+, version
+, rev
+, sha256
+, maps
+, arch
+}:
 
 stdenv.mkDerivation rec {
   pname = "crossfire-server";
@@ -12,7 +27,7 @@ stdenv.mkDerivation rec {
     rev = "r${rev}";
   };
 
-  nativeBuildInputs = [ autoconf automake libtool flex perl check pkg-config python3 ];
+  nativeBuildInputs = [ autoconf automake libtool flex perl check pkg-config python39 ];
   hardeningDisable = [ "format" ];
 
   preConfigure = ''
@@ -21,7 +36,7 @@ stdenv.mkDerivation rec {
     sh autogen.sh
   '';
 
-  configureFlags = [ "--with-python=${python3}" ];
+  configureFlags = [ "--with-python=${python39}" ];
 
   postInstall = ''
     ln -s ${maps} "$out/share/crossfire/maps"


### PR DESCRIPTION
Apperently the parser used by crossfire was remove in python 3.10.

https://bugs.python.org/issue40939

ZHF: #230712

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
