### PR TITLE
python310Packages.qrcode: propagate setuptools

### DIFF
--- a/pkgs/development/python-modules/qrcode/default.nix
+++ b/pkgs/development/python-modules/qrcode/default.nix
@@ -7,6 +7,8 @@
 , typing-extensions
 , mock
 , pytestCheckHook
+, testers
+, qrcode
 }:
 
 buildPythonPackage rec {
@@ -26,6 +28,8 @@ buildPythonPackage rec {
   propagatedBuildInputs = [
     typing-extensions
     pypng
+    # imports pkg_resouces in console_scripts.py
+    setuptools
   ];
 
   passthru.optional-dependencies.pil = [
@@ -36,6 +40,13 @@ buildPythonPackage rec {
     mock
     pytestCheckHook
   ] ++ passthru.optional-dependencies.pil;
+
+  passthru.tests = {
+    version = testers.testVersion {
+      package = qrcode;
+      command = "qr --version";
+    };
+  };
 
   meta = with lib; {
     description = "Python QR Code image generator";


### PR DESCRIPTION
The console script imports pkg_resources at runtime.

```
 ❯ ./result/bin/qr
Traceback (most recent call last):
  File "/nix/store/k8vp1p35bgafm9g85ff9vzcvn7871g2z-python3.10-qrcode-7.4.2/bin/.qr-wrapped", line 9, in <module>
    sys.exit(main())
  File "/nix/store/k8vp1p35bgafm9g85ff9vzcvn7871g2z-python3.10-qrcode-7.4.2/lib/python3.10/site-packages/qrcode/console_scripts.py", line 43, in main
    from pkg_resources import get_distribution
ModuleNotFoundError: No module named 'pkg_resources'
```

ZHF #230712 

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
