### PR TITLE
ftxui: 3.0.0 -> 4.1.0

### DIFF
--- a/pkgs/development/libraries/ftxui/default.nix
+++ b/pkgs/development/libraries/ftxui/default.nix
@@ -1,31 +1,23 @@
 { lib
 , stdenv
 , fetchFromGitHub
-, fetchpatch
 , cmake
 , doxygen
+, gbenchmark
 , graphviz
+, gtest
 }:
 
 stdenv.mkDerivation rec {
   pname = "ftxui";
-  version = "3.0.0";
+  version = "4.1.0";
 
   src = fetchFromGitHub {
     owner = "ArthurSonzogni";
     repo = "ftxui";
     rev = "v${version}";
-    sha256 = "sha256-2pCk4drYIprUKcjnrlX6WzPted7MUAp973EmAQX3RIE=";
+    sha256 = "sha256-6uPlJXuWcTUnpk+xe6EWDYvDLsfy7hGkEMO/2j3Dz0o=";
   };
-
-  patches = [
-    # Can be removed once https://github.com/ArthurSonzogni/FTXUI/pull/403 hits a stable release
-    (fetchpatch {
-      name = "fix-postevent-segfault.patch";
-      url = "https://github.com/ArthurSonzogni/FTXUI/commit/f9256fa132e9d3c50ef1e1eafe2774160b38e063.patch";
-      sha256 = "sha256-0040/gJcCXzL92FQLhZ2dNMJhNqXXD+UHFv4Koc07K0=";
-    })
-  ];
 
   nativeBuildInputs = [
     cmake
@@ -33,12 +25,18 @@ stdenv.mkDerivation rec {
     graphviz
   ];
 
-  cmakeFlags = [
-    "-DFTXUI_BUILD_EXAMPLES=OFF"
+  nativeCheckInputs = [
+    gbenchmark
+    gtest
   ];
 
-  # gtest and gbenchmark don't seem to generate any binaries
-  doCheck = false;
+  cmakeFlags = [
+    "-DFTXUI_BUILD_EXAMPLES=OFF"
+    "-DFTXUI_BUILD_DOCS=ON"
+    "-DFTXUI_BUILD_TESTS=ON"
+  ];
+
+  doCheck = true;
 
   meta = with lib; {
     homepage = "https://github.com/ArthurSonzogni/FTXUI";
@@ -46,6 +44,6 @@ stdenv.mkDerivation rec {
     description = "Functional Terminal User Interface library for C++";
     license = licenses.mit;
     maintainers = [ maintainers.ivar ];
-    platforms = platforms.unix;
+    platforms = platforms.all;
   };
 }


### PR DESCRIPTION
###### Description of changes

Update of ftxui to version already released back in February.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
