### PR TITLE
fantasia-archive: init at 0.1.10

### DIFF
--- a/pkgs/applications/office/fantasia-archive/default.nix
+++ b/pkgs/applications/office/fantasia-archive/default.nix
@@ -1,0 +1,30 @@
+{ lib
+, buildNpmPackage
+, fetchFromGitHub
+, nodePackages
+}:
+
+buildNpmPackage rec {
+  pname = "fantasia-archive";
+  version = "0.1.10";
+
+  src = fetchFromGitHub {
+    owner = "Elvanos";
+    repo = "fantasia-archive";
+    rev = "v${version}";
+    hash = "sha256-LOC/LY8ZG9Mtm7nTqqJ0s125NCrY3p3BZ2aw+hClIUg=";
+  };
+
+  nativeBuildInputs = [ nodePackages.node-gyp-build ];
+
+  npmDepsHash = "sha256-6GWEnU5xQPfQbRita4cYR4h6GOgwozj8Yt3VJopU8jU=";
+
+  meta = with lib; {
+    description = "100% free, powerful & feature-rich offline worldbuilding tool that runs on your computer!";
+    homepage = "https://fantasiaarchive.com/";
+    license = licenses.gpl3;
+    maintainers = with maintainers; [ elnudev ];
+    platforms = [ "x86_64-linux" ];
+    sourceProvenance = [ lib.sourceTypes.binaryNativeCode ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -551,6 +551,8 @@ with pkgs;
 
   expressvpn = callPackage ../applications/networking/expressvpn { };
 
+  fantasia-archive = callPackage ../applications/office/fantasia-archive { };
+
   figma-agent = callPackage ../applications/graphics/figma-agent { };
 
   figma-linux = callPackage ../applications/graphics/figma-linux { };


### PR DESCRIPTION
###### Description of changes

Packaged [fantasia-archive](https://github.com/Elvanos/fantasia-archive).

One issue I've encountered is that when I run `fantasia-archive` on my system, it gives the following error:

```
[2:0516/111619.911273:FATAL:gpu_data_manager_impl_private.cc(445)] GPU process isn't usable. Goodbye.
```

From what I've gathered, this is [an issue with Electron on Nvidia GPUs that can be prevented by running with the `--disable-gpu-sandbox` flag](https://github.com/balena-io/etcher/issues/3639#issuecomment-981052011), so I don't believe it's something wrong with my packaging. However, it wouldn't be ideal to have this break the .desktop file and have Fantasia Archive only usable from the terminal, so I've set the execution command of the .desktop file to be `fantasia-archive || fantasia-archive --disable-gpu-sandbox`. This way, if the user has a Nvidia GPU, it can fallback to disabling the GPU sandbox.

In addition, I've put fantasia-archive under the "office" category. Since it's essentially a writing program with a lot of extra bells and whistles, I figured it'd fit there. It might be better-suited to "misc" though, I'm not sure.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
