### PR TITLE
mumble: Fix 32-bit build

### DIFF
--- a/pkgs/applications/networking/mumble/0002-FIX-positional-audio-Force-8-bytes-alignment-for-CCa.patch
+++ b/pkgs/applications/networking/mumble/0002-FIX-positional-audio-Force-8-bytes-alignment-for-CCa.patch
@@ -1,0 +1,31 @@
+From 13c051b36b387356815cff5d685bc628b74ba136 Mon Sep 17 00:00:00 2001
+From: Davide Beatrici <git@davidebeatrici.dev>
+Date: Thu, 1 Sep 2022 23:32:57 +0200
+Subject: [PATCH] FIX(positional-audio): Force 8 bytes alignment for
+ CCameraAngles in GTAV plugin
+
+https://en.cppreference.com/w/cpp/language/alignas
+
+This fixes compilation when the implicit alignment is not 8 bytes.
+
+It can be the case with 32 bit targets.
+---
+ plugins/gtav/structs.h | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/plugins/gtav/structs.h b/plugins/gtav/structs.h
+index 2829dc11e..0e4f76eda 100644
+--- a/plugins/gtav/structs.h
++++ b/plugins/gtav/structs.h
+@@ -118,7 +118,7 @@ struct CCameraManagerAngles {
+ 	ptr_t cameraAngles; // CCameraAngles *
+ };
+ 
+-struct CCameraAngles {
++struct alignas(8) CCameraAngles {
+ 	uint8_t pad1[960];
+ 	ptr_t playerAngles; // CPlayerAngles *
+ 	uint8_t pad2[60];
+-- 
+2.38.5
+

--- a/pkgs/applications/networking/mumble/default.nix
+++ b/pkgs/applications/networking/mumble/default.nix
@@ -22,6 +22,7 @@ let
 
     patches = [
       ./0001-BUILD-crypto-Migrate-to-OpenSSL-3.0-compatible-API.patch
+      ./0002-FIX-positional-audio-Force-8-bytes-alignment-for-CCa.patch
     ];
 
     nativeBuildInputs = [ cmake pkg-config python3 qt5.wrapQtAppsHook qt5.qttools ]


### PR DESCRIPTION
###### Description of changes

32-bit builds fail due to the following error. Apply a patch from master to fix the issue.

```
[ 25%] Building CXX object plugins/gtav/CMakeFiles/gtav.dir/gtav.cpp.o In file included from /build/source/plugins/gtav/Game.h:9,
                 from /build/source/plugins/gtav/gtav.cpp:6:
/build/source/plugins/gtav/structs.h:218:37: error: static assertion failed
  218 | static_assert(sizeof(CCameraAngles) == 0x408, "");
      |               ~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~
/build/source/plugins/gtav/structs.h:218:37: note: the comparison reduces to '(1028 == 1032)'
```

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
