### PR TITLE
docs: Reference packages directly in `allowUnfreePredicate`

### DIFF
--- a/doc/using/configuration.chapter.md
+++ b/doc/using/configuration.chapter.md
@@ -100,14 +100,14 @@ There are several ways to tweak how Nix handles a package which has been marked 
     }
     ```
 
-    For a more useful example, try the following. This configuration only allows unfree packages named roon-server and visual studio code:
+    For a more useful example, try the following. This configuration only allows two specific unfree packages, "roon-server" and "vscode-fhs":
 
     ```nix
     {
-      allowUnfreePredicate = pkg: builtins.elem (lib.getName pkg) [
-        "roon-server"
-        "vscode"
-      ];
+      allowUnfreePredicate = pkg: builtins.elem (lib.getName pkg) (map lib.getName [
+        roon-server
+        vscode-fhs
+      ]);
     }
     ```
 

--- a/doc/using/configuration.chapter.md
+++ b/doc/using/configuration.chapter.md
@@ -100,7 +100,7 @@ There are several ways to tweak how Nix handles a package which has been marked 
     }
     ```
 
-    For a more useful example, try the following. This configuration only allows two specific unfree packages, "roon-server" and "vscode-fhs":
+    The following example only allows two specific unfree packages:
 
     ```nix
     {

--- a/pkgs/stdenv/generic/check-meta.nix
+++ b/pkgs/stdenv/generic/check-meta.nix
@@ -144,9 +144,9 @@ let
     ''
 
       Alternatively you can configure a predicate to allow specific packages:
-        { nixpkgs.config.${predicateConfigAttr} = pkg: builtins.elem (lib.getName pkg) [
+        { nixpkgs.config.${predicateConfigAttr} = pkg: builtins.elem (lib.getName pkg) (map lib.getName [
             "${lib.getName attrs}"
-          ];
+          ]);
         }
     '';
 


### PR DESCRIPTION
This makes the connection from the predicate to the package explicit, avoiding confusion when `pkg.name != pkgs."${pkg.name}".name`.

The new example demonstrates the subtle difference. To install the Visual Studio Code package in an FHS-compatible environment, we have to include nixpkgs' `vscode-fhs` property. But
`pkgs.vscode-fhs.name == "code"`, so `allowUnfreePredicate` ends up looking like this:

```nix
{
  allowUnfreePredicate = pkg: builtins.elem (lib.getName pkg) [
    "code"
  ];
}
```

By linking to the package explicitly we can instead do this:

```nix
{
  allowUnfreePredicate = pkg: builtins.elem (lib.getName pkg) (map lib.getName [
    vscode-fhs
  ]);
}
```

The result is less confusing in case of package names being different from the field name in nixpkgs.

[Example in the wild](https://gitlab.com/engmark/root/-/blob/29ca73fec94b5190c069aa0c42861c948f3b55a8/configuration.nix#L239-250)

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
