### PR TITLE
minimal-bootstrap.stage0-posix: support x86_64-linux

### DIFF
--- a/pkgs/os-specific/linux/minimal-bootstrap/mes/default.nix
+++ b/pkgs/os-specific/linux/minimal-bootstrap/mes/default.nix
@@ -222,7 +222,6 @@ let
     mkdir -p ''${out}/bin
 
     ${srcPost.bin}/bin/mes-m2 -e main ${srcPost.bin}/bin/mescc.scm -- \
-      --base-address 0x08048000 \
       -L ''${srcPrefix}/lib \
       -L ${libs}/lib \
       -lc \

--- a/pkgs/os-specific/linux/minimal-bootstrap/stage0-posix/bootstrap-sources.nix
+++ b/pkgs/os-specific/linux/minimal-bootstrap/stage0-posix/bootstrap-sources.nix
@@ -9,14 +9,6 @@ rec {
   outputHashAlgo = "sha256";
   outputHash = "sha256-FpMp7z+B3cR3LkQ+PooH/b1/NlxH8NHVJNWifaPWt4U=";
 
-  # This 256 byte seed is the only pre-compiled binary in the bootstrap chain.
-  hex0-seed = import <nix/fetchurl.nix> {
-    name = "hex0-seed-${version}";
-    url = "https://github.com/oriansj/bootstrap-seeds/raw/b1263ff14a17835f4d12539226208c426ced4fba/POSIX/x86/hex0-seed";
-    hash = "sha256-QU3RPGy51W7M2xnfFY1IqruKzusrSLU+L190ztN6JW8=";
-    executable = true;
-  };
-
   /*
   Since `make-minimal-bootstrap-sources` requires nixpkgs and nix it
   will create a circular dependency if it is used in place of the

--- a/pkgs/os-specific/linux/minimal-bootstrap/stage0-posix/default.nix
+++ b/pkgs/os-specific/linux/minimal-bootstrap/stage0-posix/default.nix
@@ -3,21 +3,23 @@
 }:
 
 lib.makeScope newScope (self: with self; {
-  inherit (self.callPackage ./bootstrap-sources.nix {})
-    version hex0-seed minimal-bootstrap-sources;
+  inherit (callPackage ./platforms.nix { }) platforms stage0Arch m2libcArch m2libcOS baseAddress;
+
+  inherit (self.callPackage ./bootstrap-sources.nix {}) version minimal-bootstrap-sources;
 
   src = minimal-bootstrap-sources;
 
   m2libc = src + "/M2libc";
 
   hex0 = callPackage ./hex0.nix { };
+  inherit (self.hex0) hex0-seed;
 
   kaem = callPackage ./kaem { };
   kaem-minimal = callPackage ./kaem/minimal.nix { };
 
-  stage0-posix-x86 = callPackage ./stage0-posix-x86.nix { };
+  mescc-tools-boot = callPackage ./mescc-tools-boot.nix { };
 
-  inherit (self.stage0-posix-x86) blood-elf-0 hex2 kaem-unwrapped M1 M2;
+  inherit (self.mescc-tools-boot) blood-elf-0 hex2 kaem-unwrapped M1 M2;
 
   mescc-tools = callPackage ./mescc-tools { };
 

--- a/pkgs/os-specific/linux/minimal-bootstrap/stage0-posix/hex0.nix
+++ b/pkgs/os-specific/linux/minimal-bootstrap/stage0-posix/hex0.nix
@@ -1,15 +1,33 @@
 { lib
 , derivationWithMeta
-, hex0-seed
+, hostPlatform
 , src
 , version
+, platforms
+, stage0Arch
 }:
+
+let
+  hash = {
+    "x86"   = "sha256-QU3RPGy51W7M2xnfFY1IqruKzusrSLU+L190ztN6JW8=";
+    "AMD64" = "sha256-RCgK9oZRDQUiWLVkcIBSR2HeoB+Bh0czthrpjFEkCaY=";
+  }.${stage0Arch} or (throw "Unsupported system: ${hostPlatform.system}");
+
+  # Pinned from https://github.com/oriansj/stage0-posix/commit/3189b5f325b7ef8b88e3edec7c1cde4fce73c76c
+  # This 256 byte seed is the only pre-compiled binary in the bootstrap chain.
+  hex0-seed = import <nix/fetchurl.nix> {
+    name = "hex0-seed";
+    url = "https://github.com/oriansj/bootstrap-seeds/raw/b1263ff14a17835f4d12539226208c426ced4fba/POSIX/${stage0Arch}/hex0-seed";
+    executable = true;
+    inherit hash;
+  };
+in
 derivationWithMeta {
   inherit version;
   pname = "hex0";
   builder = hex0-seed;
   args = [
-    "${src}/x86/hex0_x86.hex0"
+    "${src}/${stage0Arch}/hex0_${stage0Arch}.hex0"
     (placeholder "out")
   ];
 
@@ -18,11 +36,13 @@ derivationWithMeta {
     homepage = "https://github.com/oriansj/stage0-posix";
     license = licenses.gpl3Plus;
     maintainers = teams.minimal-bootstrap.members;
-    platforms = [ "i686-linux" ];
+    inherit platforms;
   };
+
+  passthru = { inherit hex0-seed; };
 
   # Ensure the untrusted hex0-seed binary produces a known-good hex0
   outputHashMode = "recursive";
   outputHashAlgo = "sha256";
-  outputHash = "sha256-QU3RPGy51W7M2xnfFY1IqruKzusrSLU+L190ztN6JW8=";
+  outputHash = hash;
 }

--- a/pkgs/os-specific/linux/minimal-bootstrap/stage0-posix/kaem/default.nix
+++ b/pkgs/os-specific/linux/minimal-bootstrap/stage0-posix/kaem/default.nix
@@ -6,6 +6,7 @@
 , mescc-tools
 , mescc-tools-extra
 , version
+, platforms
 }:
 
 # Once mescc-tools-extra is available we can install kaem at /bin/kaem
@@ -46,6 +47,6 @@ derivationWithMeta {
     homepage = "https://github.com/oriansj/mescc-tools";
     license = licenses.gpl3Plus;
     maintainers = teams.minimal-bootstrap.members;
-    platforms = [ "i686-linux" ];
+    inherit platforms;
   };
 }

--- a/pkgs/os-specific/linux/minimal-bootstrap/stage0-posix/kaem/minimal.nix
+++ b/pkgs/os-specific/linux/minimal-bootstrap/stage0-posix/kaem/minimal.nix
@@ -3,13 +3,15 @@
 , src
 , hex0
 , version
+, platforms
+, stage0Arch
 }:
 derivationWithMeta {
   inherit version;
   pname = "kaem-minimal";
   builder = hex0;
   args = [
-    "${src}/x86/kaem-minimal.hex0"
+    "${src}/${stage0Arch}/kaem-minimal.hex0"
     (placeholder "out")
   ];
 
@@ -18,7 +20,7 @@ derivationWithMeta {
     homepage = "https://github.com/oriansj/stage0-posix";
     license = licenses.gpl3Plus;
     maintainers = teams.minimal-bootstrap.members;
-    platforms = [ "i686-linux" ];
+    inherit platforms;
   };
 }
 

--- a/pkgs/os-specific/linux/minimal-bootstrap/stage0-posix/mescc-tools-extra/build.kaem
+++ b/pkgs/os-specific/linux/minimal-bootstrap/stage0-posix/mescc-tools-extra/build.kaem
@@ -19,7 +19,7 @@
 ## You should have received a copy of the GNU General Public License
 ## along with mescc-tools.  If not, see <http://www.gnu.org/licenses/>.
 
-alias CC="${mescc-tools}/bin/M2-Mesoplanet --operating-system ${OPERATING_SYSTEM} --architecture ${ARCH} -f"
+alias CC="${mescc-tools}/bin/M2-Mesoplanet --operating-system ${m2libcOS} --architecture ${m2libcArch} -f"
 cd ${src}/mescc-tools-extra
 
 # Create output folder

--- a/pkgs/os-specific/linux/minimal-bootstrap/stage0-posix/mescc-tools-extra/default.nix
+++ b/pkgs/os-specific/linux/minimal-bootstrap/stage0-posix/mescc-tools-extra/default.nix
@@ -4,9 +4,12 @@
 , mescc-tools
 , src
 , version
+, platforms
+, m2libcArch
+, m2libcOS
 }:
 derivationWithMeta {
-  inherit version src mescc-tools;
+  inherit version src mescc-tools m2libcArch m2libcOS;
   pname = "mescc-tools-extra";
   builder = kaem-unwrapped;
   args = [
@@ -16,14 +19,11 @@ derivationWithMeta {
     ./build.kaem
   ];
 
-  ARCH = "x86";
-  OPERATING_SYSTEM = "linux";
-
   meta = with lib; {
     description = "Collection of tools written for use in bootstrapping";
     homepage = "https://github.com/oriansj/mescc-tools-extra";
     license = licenses.gpl3Plus;
     maintainers = teams.minimal-bootstrap.members;
-    platforms = [ "i686-linux" ];
+    inherit platforms;
   };
 }

--- a/pkgs/os-specific/linux/minimal-bootstrap/stage0-posix/mescc-tools/build.kaem
+++ b/pkgs/os-specific/linux/minimal-bootstrap/stage0-posix/mescc-tools/build.kaem
@@ -46,13 +46,13 @@ ${replace} \
 # Phase-12 Build M2-Mesoplanet from M2-Planet #
 ###############################################
 
-${M2} --architecture ${ARCH} \
+${M2} --architecture ${m2libcArch} \
   -f ${m2libc}/sys/types.h \
   -f ${m2libc}/stddef.h \
-  -f ${m2libc}/${ARCH}/linux/fcntl.c \
+  -f ${m2libc}/${m2libcArch}/linux/fcntl.c \
   -f ${m2libc}/fcntl.c \
-  -f ${m2libc}/${ARCH}/linux/unistd.c \
-  -f ${m2libc}/${ARCH}/linux/sys/stat.c \
+  -f ${m2libc}/${m2libcArch}/linux/unistd.c \
+  -f ${m2libc}/${m2libcArch}/linux/sys/stat.c \
   -f ${m2libc}/stdlib.c \
   -f ${m2libc}/stdio.h \
   -f ${m2libc}/stdio.c \
@@ -69,20 +69,20 @@ ${M2} --architecture ${ARCH} \
   --debug \
   -o ./M2-Mesoplanet-1.M1
 
-${blood-elf-0} ${ENDIAN_FLAG} ${BLOOD_FLAG} -f ./M2-Mesoplanet-1.M1 -o ./M2-Mesoplanet-1-footer.M1
+${blood-elf-0} ${endianFlag} ${bloodFlag} -f ./M2-Mesoplanet-1.M1 -o ./M2-Mesoplanet-1-footer.M1
 
-${M1} --architecture ${ARCH} \
-  ${ENDIAN_FLAG} \
-  -f ${m2libc}/${ARCH}/${ARCH}_defs.M1 \
-  -f ${m2libc}/${ARCH}/libc-full.M1 \
+${M1} --architecture ${m2libcArch} \
+  ${endianFlag} \
+  -f ${m2libc}/${m2libcArch}/${m2libcArch}_defs.M1 \
+  -f ${m2libc}/${m2libcArch}/libc-full.M1 \
   -f ./M2-Mesoplanet-1.M1 \
   -f ./M2-Mesoplanet-1-footer.M1 \
   -o ./M2-Mesoplanet-1.hex2
 
-${hex2} --architecture ${ARCH} \
-  ${ENDIAN_FLAG} \
-  --base-address ${BASE_ADDRESS} \
-  -f ${m2libc}/${ARCH}/ELF-${ARCH}-debug.hex2 \
+${hex2} --architecture ${m2libcArch} \
+  ${endianFlag} \
+  --base-address ${baseAddress} \
+  -f ${m2libc}/${m2libcArch}/ELF-${m2libcArch}-debug.hex2 \
   -f ./M2-Mesoplanet-1.hex2 \
   -o ${out}/bin/M2-Mesoplanet
 
@@ -90,12 +90,12 @@ ${hex2} --architecture ${ARCH} \
 # Phase-13 Build final blood-elf from C sources #
 #################################################
 
-${M2} --architecture ${ARCH} \
+${M2} --architecture ${m2libcArch} \
 	-f ${m2libc}/sys/types.h \
 	-f ${m2libc}/stddef.h \
-	-f ${m2libc}/${ARCH}/linux/fcntl.c \
+	-f ${m2libc}/${m2libcArch}/linux/fcntl.c \
 	-f ${m2libc}/fcntl.c \
-	-f ${m2libc}/${ARCH}/linux/unistd.c \
+	-f ${m2libc}/${m2libcArch}/linux/unistd.c \
 	-f ${m2libc}/stdlib.c \
 	-f ${m2libc}/stdio.h \
 	-f ${m2libc}/stdio.c \
@@ -105,19 +105,20 @@ ${M2} --architecture ${ARCH} \
 	--debug \
 	-o ./blood-elf-1.M1
 
-${blood-elf-0} ${BLOOD_FLAG} ${ENDIAN_FLAG} -f ./blood-elf-1.M1 -o ./blood-elf-1-footer.M1
-${M1} --architecture ${ARCH} \
-	${ENDIAN_FLAG} \
-	-f ${m2libc}/${ARCH}/${ARCH}_defs.M1 \
-	-f ${m2libc}/${ARCH}/libc-full.M1 \
+${blood-elf-0} ${endianFlag} ${bloodFlag} -f ./blood-elf-1.M1 -o ./blood-elf-1-footer.M1
+
+${M1} --architecture ${m2libcArch} \
+	${endianFlag} \
+	-f ${m2libc}/${m2libcArch}/${m2libcArch}_defs.M1 \
+	-f ${m2libc}/${m2libcArch}/libc-full.M1 \
 	-f ./blood-elf-1.M1 \
 	-f ./blood-elf-1-footer.M1 \
 	-o ./blood-elf-1.hex2
 
-${hex2} --architecture ${ARCH} \
-	${ENDIAN_FLAG} \
-	--base-address ${BASE_ADDRESS} \
-	-f ${m2libc}/${ARCH}/ELF-${ARCH}-debug.hex2 \
+${hex2} --architecture ${m2libcArch} \
+	${endianFlag} \
+	--base-address ${baseAddress} \
+	-f ${m2libc}/${m2libcArch}/ELF-${m2libcArch}-debug.hex2 \
 	-f ./blood-elf-1.hex2 \
 	-o ${out}/bin/blood-elf
 
@@ -129,11 +130,11 @@ ${hex2} --architecture ${ARCH} \
 # Phase-14 Build get_machine from C sources #
 #############################################
 
-${M2} --architecture ${ARCH} \
+${M2} --architecture ${m2libcArch} \
 	-f ${m2libc}/sys/types.h \
 	-f ${m2libc}/stddef.h \
-	-f ${m2libc}/${ARCH}/linux/unistd.c \
-	-f ${m2libc}/${ARCH}/linux/fcntl.c \
+	-f ${m2libc}/${m2libcArch}/linux/unistd.c \
+	-f ${m2libc}/${m2libcArch}/linux/fcntl.c \
 	-f ${m2libc}/fcntl.c \
 	-f ${m2libc}/stdlib.c \
 	-f ${m2libc}/stdio.h \
@@ -143,20 +144,20 @@ ${M2} --architecture ${ARCH} \
 	--debug \
 	-o get_machine.M1
 
-${out}/bin/blood-elf ${BLOOD_FLAG} ${ENDIAN_FLAG} -f ./get_machine.M1 -o ./get_machine-footer.M1
+${out}/bin/blood-elf ${endianFlag} ${bloodFlag} -f ./get_machine.M1 -o ./get_machine-footer.M1
 
-${M1} --architecture ${ARCH} \
-	${ENDIAN_FLAG} \
-	-f ${m2libc}/${ARCH}/${ARCH}_defs.M1 \
-	-f ${m2libc}/${ARCH}/libc-full.M1 \
+${M1} --architecture ${m2libcArch} \
+	${endianFlag} \
+	-f ${m2libc}/${m2libcArch}/${m2libcArch}_defs.M1 \
+	-f ${m2libc}/${m2libcArch}/libc-full.M1 \
 	-f ./get_machine.M1 \
 	-f ./get_machine-footer.M1 \
 	-o ./get_machine.hex2
 
-${hex2} --architecture ${ARCH} \
-	${ENDIAN_FLAG} \
-	--base-address ${BASE_ADDRESS} \
-	-f ${m2libc}/${ARCH}/ELF-${ARCH}-debug.hex2 \
+${hex2} --architecture ${m2libcArch} \
+	${endianFlag} \
+	--base-address ${baseAddress} \
+	-f ${m2libc}/${m2libcArch}/ELF-${m2libcArch}-debug.hex2 \
 	-f ./get_machine.hex2 \
 	-o ${out}/bin/get_machine
 
@@ -164,11 +165,11 @@ ${hex2} --architecture ${ARCH} \
 # Phase-15 Build M2-Planet from M2-Planet  #
 ############################################
 
-${M2} --architecture ${ARCH} \
+${M2} --architecture ${m2libcArch} \
 	-f ${m2libc}/sys/types.h \
 	-f ${m2libc}/stddef.h \
-	-f ${m2libc}/${ARCH}/linux/unistd.c \
-	-f ${m2libc}/${ARCH}/linux/fcntl.c \
+	-f ${m2libc}/${m2libcArch}/linux/unistd.c \
+	-f ${m2libc}/${m2libcArch}/linux/fcntl.c \
 	-f ${m2libc}/fcntl.c \
 	-f ${m2libc}/stdlib.c \
 	-f ${m2libc}/stdio.h \
@@ -185,20 +186,19 @@ ${M2} --architecture ${ARCH} \
 	--debug \
 	-o ./M2-1.M1
 
-${out}/bin/blood-elf ${ENDIAN_FLAG} ${BLOOD_FLAG} -f ./M2-1.M1 -o ./M2-1-footer.M1
+${out}/bin/blood-elf ${endianFlag} ${bloodFlag} -f ./M2-1.M1 -o ./M2-1-footer.M1
 
-${M1} --architecture ${ARCH} \
-	${ENDIAN_FLAG} \
-	-f ${m2libc}/${ARCH}/${ARCH}_defs.M1 \
-	-f ${m2libc}/${ARCH}/libc-full.M1 \
+${M1} --architecture ${m2libcArch} \
+	${endianFlag} \
+	-f ${m2libc}/${m2libcArch}/${m2libcArch}_defs.M1 \
+	-f ${m2libc}/${m2libcArch}/libc-full.M1 \
 	-f ./M2-1.M1 \
 	-f ./M2-1-footer.M1 \
 	-o ./M2-1.hex2
 
-${hex2} --architecture ${ARCH} \
-	${ENDIAN_FLAG} \
-	--base-address ${BASE_ADDRESS} \
-	-f ${m2libc}/${ARCH}/ELF-${ARCH}-debug.hex2 \
+${hex2} --architecture ${m2libcArch} \
+	${endianFlag} \
+	--base-address ${baseAddress} \
+	-f ${m2libc}/${m2libcArch}/ELF-${m2libcArch}-debug.hex2 \
 	-f ./M2-1.hex2 \
 	-o ${out}/bin/M2-Planet
-

--- a/pkgs/os-specific/linux/minimal-bootstrap/stage0-posix/platforms.nix
+++ b/pkgs/os-specific/linux/minimal-bootstrap/stage0-posix/platforms.nix
@@ -1,0 +1,29 @@
+# Platform specific constants
+{ lib
+, hostPlatform
+}:
+
+rec {
+  # meta.platforms
+  platforms = [
+    "i686-linux"
+    "x86_64-linux"
+  ];
+
+  # system arch as used within the stage0 project
+  stage0Arch = {
+    "i686-linux"   = "x86";
+    "x86_64-linux" = "AMD64";
+  }.${hostPlatform.system} or (throw "Unsupported system: ${hostPlatform.system}");
+
+  # lower-case form is widely used by m2libc
+  m2libcArch = lib.toLower stage0Arch;
+
+  # Passed to M2-Mesoplanet as --operating-system
+  m2libcOS = if hostPlatform.isLinux then "linux" else throw "Unsupported system: ${hostPlatform.system}";
+
+  baseAddress = {
+    "i686-linux"   = "0x08048000";
+    "x86_64-linux" = "0x00600000";
+  }.${hostPlatform.system} or (throw "Unsupported system: ${hostPlatform.system}");
+}


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Add support for building `minimal-bootstrap.stage0-posix.*` packages under `x86_64-linux`. This will generalise well to `aarch64`, `riscv`, and all other platforms supported by `stage0-posix`.

Note that `mes` is currently only able to bootstrap from `M2` on `i686-linux`, however `x86_64-linux` and `riscv` is targetted for the next release :)

Related #227914

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
