### PR TITLE
clash-verge: 1.3.1 -> 1.3.2, remove bundled clash cores

### DIFF
--- a/pkgs/applications/networking/clash-verge/default.nix
+++ b/pkgs/applications/networking/clash-verge/default.nix
@@ -19,8 +19,6 @@ stdenv.mkDerivation rec {
     hash = "sha256-AEOFMKxrkPditf5ks++tII6zeuH72Fxw/TVtZeXS3v4=";
   };
 
-  unpackPhase = "dpkg-deb -x $src .";
-
   nativeBuildInputs = [
     dpkg
     wrapGAppsHook

--- a/pkgs/applications/networking/clash-verge/default.nix
+++ b/pkgs/applications/networking/clash-verge/default.nix
@@ -4,6 +4,8 @@
 , dpkg
 , wrapGAppsHook
 , autoPatchelfHook
+, clash
+, clash-meta
 , openssl
 , webkitgtk
 , udev
@@ -41,8 +43,14 @@ stdenv.mkDerivation rec {
 
     mkdir -p $out/bin
     mv usr/* $out
+    rm $out/bin/{clash,clash-meta}
 
     runHook postInstall
+  '';
+
+  postFixup = ''
+    ln -s ${lib.getExe clash} $out/bin/clash
+    ln -s ${lib.getExe clash-meta} $out/bin/clash-meta
   '';
 
   meta = with lib; {

--- a/pkgs/applications/networking/clash-verge/default.nix
+++ b/pkgs/applications/networking/clash-verge/default.nix
@@ -14,11 +14,11 @@
 
 stdenv.mkDerivation rec {
   pname = "clash-verge";
-  version = "1.3.1";
+  version = "1.3.2";
 
   src = fetchurl {
     url = "https://github.com/zzzgydi/clash-verge/releases/download/v${version}/clash-verge_${version}_amd64.deb";
-    hash = "sha256-AEOFMKxrkPditf5ks++tII6zeuH72Fxw/TVtZeXS3v4=";
+    hash = "sha256-46+7P9WH85fC3m+5LQHpvZX2ggeH6djoO53fQxQJdYk=";
   };
 
   nativeBuildInputs = [


### PR DESCRIPTION
###### Description of changes

Fixes https://github.com/NixOS/nixpkgs/issues/231778

Also removes the `unpackPhase` that is no longer needed after https://github.com/NixOS/nixpkgs/pull/225504 was merged.

NOTE: This PR replaces the default clash premium core with the opensource version, which may be incompatible with clash configs that rely on "premium" features. In this case, try switching to clash meta core, or override `clash` with `clash-premium` (exists in [linyinfeng's NUR repo](https://nur.nix-community.org/repos/linyinfeng/)).
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
