### PR TITLE
python3Packages.cantools: init at 38.0.2

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -6333,6 +6333,12 @@
     githubId = 4656860;
     name = "Gaute Ravndal";
   };
+  gray-heron = {
+    email = "ave+nix@cezar.info";
+    github = "gray-heron";
+    githubId = 7032646;
+    name = "Cezary Siwek";
+  };
   graysonhead = {
     email = "grayson@graysonhead.net";
     github = "graysonhead";

--- a/pkgs/development/python-modules/cantools/default.nix
+++ b/pkgs/development/python-modules/cantools/default.nix
@@ -1,0 +1,58 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, setuptools-scm
+, argparse-addons
+, bitstruct
+, can
+, crccheck
+, diskcache
+, matplotlib
+, parameterized
+, pytestCheckHook
+, pythonOlder
+, textparser
+}:
+
+buildPythonPackage rec {
+  pname = "cantools";
+  version = "38.0.2";
+  format = "setuptools";
+
+  disabled = pythonOlder "3.7";
+
+  src = fetchPypi {
+    inherit pname version;
+    hash = "sha256-k7/m9L1lLzaXY+qRYrAnpi9CSoQA8kI9QRN5GM5oxo4=";
+  };
+
+  nativeBuildInputs = [
+    setuptools-scm
+  ];
+
+  propagatedBuildInputs = [
+    argparse-addons
+    bitstruct
+    can
+    crccheck
+    diskcache
+    matplotlib
+    textparser
+  ];
+
+  nativeCheckInputs = [
+    parameterized
+    pytestCheckHook
+  ];
+
+  pythonImportsCheck = [
+    "cantools"
+  ];
+
+  meta = with lib; {
+    homepage = "https://github.com/cantools/cantools";
+    description = "CAN bus tools.";
+    license = licenses.mit;
+    maintainers = with maintainers; [ gray-heron ];
+  };
+}

--- a/pkgs/development/python-modules/textparser/default.nix
+++ b/pkgs/development/python-modules/textparser/default.nix
@@ -1,0 +1,39 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, setuptools-scm
+, pytestCheckHook
+, pythonOlder
+}:
+
+buildPythonPackage rec {
+  pname = "textparser";
+  version = "0.24.0";
+  format = "setuptools";
+
+  disabled = pythonOlder "3.7";
+
+  src = fetchPypi {
+    inherit pname version;
+    hash = "sha256-VvcI51qp0AKtt22CO6bvFm1+zsHj5MpMHKED+BdWgzU=";
+  };
+
+  nativeBuildInputs = [
+    setuptools-scm
+  ];
+
+  nativeCheckInputs = [
+    pytestCheckHook
+  ];
+
+  pythonImportsCheck = [
+    "textparser"
+  ];
+
+  meta = with lib; {
+    homepage = "https://github.com/eerimoq/textparser";
+    description = "A text parser";
+    license = licenses.mit;
+    maintainers = with maintainers; [ gray-heron ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1685,6 +1685,8 @@ self: super: with self; {
 
   canopen = callPackage ../development/python-modules/canopen { };
 
+  cantools = callPackage ../development/python-modules/cantools { };
+
   camelot = callPackage ../development/python-modules/camelot { };
 
   capstone = callPackage ../development/python-modules/capstone {

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -12472,6 +12472,8 @@ self: super: with self; {
 
   textile = callPackage ../development/python-modules/textile { };
 
+  textparser = callPackage ../development/python-modules/textparser { };
+
   textual = callPackage ../development/python-modules/textual { };
 
   textual-universal-directorytree = callPackage ../development/python-modules/textual-universal-directorytree { };


### PR DESCRIPTION
###### Description of changes

 - Added python-based utilities for the CAN bus: https://github.com/cantools/cantools
 - Added textparser python packge (https://github.com/eerimoq/textparser), as `cantools`  depends on it.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
