### PR TITLE
nushellPlugins.gstat: init

### DIFF
--- a/pkgs/shells/nushell/plugins/default.nix
+++ b/pkgs/shells/nushell/plugins/default.nix
@@ -1,5 +1,6 @@
 { lib, newScope, IOKit, CoreFoundation }:
 
 lib.makeScope newScope (self: with self; {
+  gstat = callPackage ./gstat.nix { };
   query = callPackage ./query.nix { inherit IOKit CoreFoundation; };
 })

--- a/pkgs/shells/nushell/plugins/gstat.nix
+++ b/pkgs/shells/nushell/plugins/gstat.nix
@@ -1,0 +1,28 @@
+{ stdenv
+, lib
+, rustPlatform
+, openssl
+, nushell
+, pkg-config
+}:
+
+let
+  pname = "nushell_plugin_gstat";
+in
+rustPlatform.buildRustPackage {
+  inherit pname;
+  version = nushell.version;
+  src = nushell.src;
+  cargoHash = "sha256-+RFCkM++6DgrwFjTr3JlCgh9FqDBUOQsOucbZAi+V/k=";
+  nativeBuildInputs = [ pkg-config ];
+  buildInputs = [ openssl ];
+  cargoBuildFlags = [ "--package nu_plugin_gstat" ];
+  doCheck = false; # some tests fail
+  meta = with lib; {
+    description = "A git status plugin for Nushell";
+    homepage = "https://github.com/nushell/nushell/tree/main/crates/nu_plugin_gstat";
+    license = licenses.mpl20;
+    maintainers = with maintainers; [ mrkkrp ];
+    platforms = with platforms; all;
+  };
+}


### PR DESCRIPTION
###### Description of changes

Added `nushellPlugins.gstat`.

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

