### PR TITLE
[Backport 22.11] linux: patch to fix MAP_32BIT crashes, e.g. Haskell

### DIFF
--- a/pkgs/os-specific/linux/kernel/make-maple-state-reusable-after-mas_empty_area.patch
+++ b/pkgs/os-specific/linux/kernel/make-maple-state-reusable-after-mas_empty_area.patch
@@ -1,0 +1,21 @@
+--- a/lib/maple_tree.c
++++ b/lib/maple_tree.c
+@@ -5317,15 +5317,9 @@
+ 
+ 	mt = mte_node_type(mas->node);
+ 	pivots = ma_pivots(mas_mn(mas), mt);
+-	if (offset)
+-		mas->min = pivots[offset - 1] + 1;
+-
+-	if (offset < mt_pivots[mt])
+-		mas->max = pivots[offset];
+-
+-	if (mas->index < mas->min)
+-		mas->index = mas->min;
+-
++	min = mas_safe_min(mas, pivots, offset);
++	if (mas->index < min)
++		mas->index = min;
+ 	mas->last = mas->index + size - 1;
+ 	return 0;
+ }

--- a/pkgs/os-specific/linux/kernel/patches.nix
+++ b/pkgs/os-specific/linux/kernel/patches.nix
@@ -58,13 +58,10 @@
     patch = ./export-rt-sched-migrate.patch;
   };
 
-  make-maple-state-reusable-after-mas_empty_area = rec {
+  # https://git.kernel.org/pub/scm/linux/kernel/git/akpm/mm.git/patch/?id=39bf07d812b888b23983a9443ad967ca9b61551d
+  make-maple-state-reusable-after-mas_empty_area = {
     name = "make-maple-state-reusable-after-mas_empty_area";
-    patch = fetchpatch {
-      name = name + ".patch";
-      url = "https://git.kernel.org/pub/scm/linux/kernel/git/akpm/mm.git/patch/?id=39bf07d812b888b23983a9443ad967ca9b61551d";
-      hash = "sha256-JHEFq+Gw8Dtl0M8pXcKXpwkaHhbbl5NwTSzvV5qP4hk=";
-    };
+    patch = ./make-maple-state-reusable-after-mas_empty_area.patch;
   };
 
   fix-em-ice-bonding = {

--- a/pkgs/os-specific/linux/kernel/patches.nix
+++ b/pkgs/os-specific/linux/kernel/patches.nix
@@ -58,6 +58,15 @@
     patch = ./export-rt-sched-migrate.patch;
   };
 
+  make-maple-state-reusable-after-mas_empty_area = rec {
+    name = "make-maple-state-reusable-after-mas_empty_area";
+    patch = fetchpatch {
+      name = name + ".patch";
+      url = "https://git.kernel.org/pub/scm/linux/kernel/git/akpm/mm.git/patch/?id=39bf07d812b888b23983a9443ad967ca9b61551d";
+      hash = "sha256-JHEFq+Gw8Dtl0M8pXcKXpwkaHhbbl5NwTSzvV5qP4hk=";
+    };
+  };
+
   fix-em-ice-bonding = {
     name = "fix-em-ice-bonding";
     patch = ./fix-em-ice-bonding.patch;

--- a/pkgs/top-level/linux-kernels.nix
+++ b/pkgs/top-level/linux-kernels.nix
@@ -168,6 +168,7 @@ in {
       kernelPatches = [
         kernelPatches.bridge_stp_helper
         kernelPatches.request_key_helper
+        kernelPatches.make-maple-state-reusable-after-mas_empty_area
         kernelPatches.fix-em-ice-bonding
         kernelPatches.CVE-2023-32233
       ];
@@ -177,6 +178,7 @@ in {
       kernelPatches = [
         kernelPatches.bridge_stp_helper
         kernelPatches.request_key_helper
+        kernelPatches.make-maple-state-reusable-after-mas_empty_area
         kernelPatches.fix-em-ice-bonding
         kernelPatches.CVE-2023-32233
       ];
@@ -186,6 +188,7 @@ in {
       kernelPatches = [
         kernelPatches.bridge_stp_helper
         kernelPatches.request_key_helper
+        kernelPatches.make-maple-state-reusable-after-mas_empty_area
         kernelPatches.fix-em-ice-bonding
         kernelPatches.CVE-2023-32233
       ];
@@ -196,6 +199,7 @@ in {
         kernelPatches = [
           kernelPatches.bridge_stp_helper
           kernelPatches.request_key_helper
+          kernelPatches.make-maple-state-reusable-after-mas_empty_area
         ];
       };
       latest = packageAliases.linux_latest.kernel;


### PR DESCRIPTION
Manual backport of #231393 and #232072

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
