### PR TITLE
python.pipInstallHook: avoid producing wrong direct_url.json file

### DIFF
--- a/pkgs/development/interpreters/python/hooks/pip-install-hook.sh
+++ b/pkgs/development/interpreters/python/hooks/pip-install-hook.sh
@@ -10,9 +10,7 @@ pipInstallPhase() {
     mkdir -p "$out/@pythonSitePackages@"
     export PYTHONPATH="$out/@pythonSitePackages@:$PYTHONPATH"
 
-    pushd dist || return 1
-    @pythonInterpreter@ -m pip install ./*.whl --no-index --no-warn-script-location --prefix="$out" --no-cache $pipInstallFlags
-    popd || return 1
+    @pythonInterpreter@ -m pip install $pname --find-links dist --no-index --no-warn-script-location --prefix="$out" --no-cache $pipInstallFlags
 
     runHook postInstall
     echo "Finished executing pipInstallPhase"

--- a/pkgs/development/interpreters/python/hooks/pip-install-hook.sh
+++ b/pkgs/development/interpreters/python/hooks/pip-install-hook.sh
@@ -9,8 +9,13 @@ pipInstallPhase() {
 
     mkdir -p "$out/@pythonSitePackages@"
     export PYTHONPATH="$out/@pythonSitePackages@:$PYTHONPATH"
+    local _wheelPname="${wheelPname-$pname}"
 
-    @pythonInterpreter@ -m pip install $pname --find-links dist --no-index --no-warn-script-location --prefix="$out" --no-cache $pipInstallFlags
+    if ! @pythonInterpreter@ -m pip install "${_wheelPname}" --find-links dist --no-index --no-warn-script-location --prefix="$out" --no-cache $pipInstallFlags; then
+        echo "Pip install failed, probably because no wheel was found. Change pname or add wheelPname."
+        echo "Current value: $_wheelPname. Available wheels: $(ls dist)"
+        exit 1
+    fi
 
     runHook postInstall
     echo "Finished executing pipInstallPhase"

--- a/pkgs/development/interpreters/python/hooks/pip-install-hook.sh
+++ b/pkgs/development/interpreters/python/hooks/pip-install-hook.sh
@@ -20,3 +20,20 @@ if [ -z "${dontUsePipInstall-}" ] && [ -z "${installPhase-}" ]; then
     echo "Using pipInstallPhase"
     installPhase=pipInstallPhase
 fi
+
+
+pipAuditTmpdir() {
+    local dir="$out/@pythonSitePackages@"
+
+    echo "checking for references to $TMPDIR/ in $dir..."
+
+    # OK if no files are found, or they don't have forbidden references
+    if grep "$TMPDIR/" "$dir"/*/direct_url.json; then
+        echo "direct_url.json contains a forbidden reference to $TMPDIR/"
+        exit 1
+    fi
+}
+
+if [[ -z "${noAuditTmpdir-}" ]]; then
+    fixupOutputHooks+=(pipAuditTmpdir)
+fi

--- a/pkgs/development/python-modules/bootstrapped-pip/default.nix
+++ b/pkgs/development/python-modules/bootstrapped-pip/default.nix
@@ -56,7 +56,8 @@ stdenv.mkDerivation rec {
     echo "Building pip wheel..."
     pushd pip
     rm pyproject.toml
-    ${python.pythonForBuild.interpreter} -m pip install --no-build-isolation --no-index --prefix=$out  --ignore-installed --no-dependencies --no-cache .
+    ${python.pythonForBuild.interpreter} -m pip wheel --wheel-dir dist --no-build-isolation --no-index --no-dependencies --no-cache .
+    ${python.pythonForBuild.interpreter} -m pip install pip --find-links dist --no-build-isolation --no-index --prefix=$out --ignore-installed --no-dependencies --no-cache
     popd
   '';
 

--- a/pkgs/development/python-modules/lz4/default.nix
+++ b/pkgs/development/python-modules/lz4/default.nix
@@ -10,7 +10,7 @@
 }:
 
 buildPythonPackage rec {
-  pname = "python-lz4";
+  pname = "lz4";
   version = "4.3.2";
   format = "setuptools";
 

--- a/pkgs/development/python-modules/twisted/default.nix
+++ b/pkgs/development/python-modules/twisted/default.nix
@@ -48,11 +48,12 @@ buildPythonPackage rec {
   pname = "twisted";
   version = "22.10.0";
   format = "setuptools";
+  wheelPname = "Twisted";
 
   disabled = pythonOlder "3.6";
 
   src = fetchPypi {
-    pname = "Twisted";
+    pname = wheelPname;
     inherit version;
     extension = "tar.gz";
     hash = "sha256-Mqy9QKlPX0bntCwQm/riswIlCUVWF4Oot6BZBI8tTTE=";


### PR DESCRIPTION
Fix problem detected in https://github.com/NixOS/nixpkgs/pull/229472#issuecomment-1544410416.

Since bff6c67911ed74cf560bd2b00fb1da32bd2fed63, now pname is expected to match the name of the package that is built by Python standard tools.

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
