### PR TITLE
libei: init at 1.0.0rc1

### DIFF
--- a/pkgs/development/libraries/libei/default.nix
+++ b/pkgs/development/libraries/libei/default.nix
@@ -1,0 +1,71 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, fetchFromGitLab
+, attr
+, libevdev
+, libxkbcommon
+, meson
+, ninja
+, pkg-config
+, protobuf
+, protobufc
+, python3
+, python3Packages
+, systemd
+}:
+let
+  munit = fetchFromGitHub {
+    owner = "nemequ";
+    repo = "munit";
+    rev = "fbbdf1467eb0d04a6ee465def2e529e4c87f2118";
+    hash = "sha256-qm30C++rpLtxBhOABBzo+6WILSpKz2ibvUvoe8ku4ow=";
+  };
+in
+stdenv.mkDerivation rec {
+  pname = "libei";
+  version = "0.99.1";
+
+  src = fetchFromGitLab {
+    domain = "gitlab.freedesktop.org";
+    owner = "libinput";
+    repo = "libei";
+    rev = version;
+    hash = "sha256-r/rkN2d8P30P/IL1YaLWWRbA5s3uVq5Fc/K1vhS31tw=";
+  };
+
+  buildInputs = [
+    libevdev
+    libxkbcommon
+    protobuf
+    protobufc
+    systemd
+  ];
+  nativeBuildInputs = [
+    attr
+    meson
+    ninja
+    pkg-config
+    python3
+  ] ++
+  (with python3Packages; [
+    jinja2
+    pytest
+    python-dbusmock
+    strenum
+    structlog
+  ]);
+
+  postPatch = ''
+    ln -s "${munit}" ./subprojects/munit
+    patchShebangs ./proto/ei-scanner
+  '';
+
+  meta = with lib; {
+    description = "Library for Emulated Input";
+    homepage = "https://gitlab.freedesktop.org/libinput/libei";
+    license = licenses.mit;
+    maintainers = [ maintainers.pedrohlc ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -21643,6 +21643,8 @@ with pkgs;
 
   libedit = callPackage ../development/libraries/libedit { };
 
+  libei = callPackage ../development/libraries/libei { };
+
   libelf = callPackage ../development/libraries/libelf { };
 
   libelfin = callPackage ../development/libraries/libelfin { };


### PR DESCRIPTION
###### Description of changes

> libei is a library for Emulated Input, primarily aimed at the Wayland stack

Release: https://gitlab.freedesktop.org/libinput/libei/-/releases/0.99.1
Note: tag `0.99.1` was released as `1.0.0rc1`

This library will be used in future-releases of `input-leap` (newest fork of `barrier` and `synergy-core`) and can be used to bring flawless Wayland support for the likes of KDE Connect.

###### Things done

I do have `input-leap` working with it in https://github.com/chaotic-cx/nyx, but I'll wait some official tag before submitting it to nixpkgs.

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
