### PR TITLE
Python package set bootstrap update

### DIFF
--- a/pkgs/development/python-modules/bootstrapped-pip/default.nix
+++ b/pkgs/development/python-modules/bootstrapped-pip/default.nix
@@ -65,5 +65,6 @@ stdenv.mkDerivation rec {
     description = "Version of pip used for bootstrapping";
     license = lib.unique (pip.meta.license ++ setuptools.meta.license ++ wheel.meta.license);
     homepage = pip.meta.homepage;
+    maintainers = lib.teams.python.members;
   };
 }

--- a/pkgs/development/python-modules/bootstrapped-pip/default.nix
+++ b/pkgs/development/python-modules/bootstrapped-pip/default.nix
@@ -43,14 +43,14 @@ stdenv.mkDerivation rec {
     # $out is where we are installing to and takes precedence
     export PYTHONPATH="$out/${python.sitePackages}:$(pwd)/pip/src:$(pwd)/setuptools:$(pwd)/setuptools/pkg_resources:$(pwd)/wheel:$(pwd)/flit/flit_core:$PYTHONPATH"
 
-    echo "Building setuptools wheel..."
-    pushd setuptools
-    rm pyproject.toml
+    echo "Building wheel wheel..."
+    pushd wheel
     ${python.pythonForBuild.interpreter} -m pip install --no-build-isolation --no-index --prefix=$out  --ignore-installed --no-dependencies --no-cache .
     popd
 
-    echo "Building wheel wheel..."
-    pushd wheel
+    echo "Building setuptools wheel..."
+    pushd setuptools
+    rm pyproject.toml
     ${python.pythonForBuild.interpreter} -m pip install --no-build-isolation --no-index --prefix=$out  --ignore-installed --no-dependencies --no-cache .
     popd
 

--- a/pkgs/development/python-modules/bootstrapped-pip/default.nix
+++ b/pkgs/development/python-modules/bootstrapped-pip/default.nix
@@ -1,7 +1,7 @@
 { lib, stdenv, python, makeWrapper, unzip
 , pipInstallHook
 , setuptoolsBuildHook
-, wheel, pip, setuptools
+, wheel, pip, setuptools, flit
 }:
 
 stdenv.mkDerivation rec {
@@ -9,7 +9,7 @@ stdenv.mkDerivation rec {
   inherit (pip) version;
   name = "${python.libPrefix}-bootstrapped-${pname}-${version}";
 
-  srcs = [ wheel.src pip.src setuptools.src ];
+  srcs = [ wheel.src pip.src setuptools.src flit.src ];
   sourceRoot = ".";
 
   dontUseSetuptoolsBuild = true;
@@ -38,9 +38,10 @@ stdenv.mkDerivation rec {
     mv pip* pip
     mv setuptools* setuptools
     mv wheel* wheel
+    mv flit* flit
     # Set up PYTHONPATH. The above folders need to be on PYTHONPATH
     # $out is where we are installing to and takes precedence
-    export PYTHONPATH="$out/${python.sitePackages}:$(pwd)/pip/src:$(pwd)/setuptools:$(pwd)/setuptools/pkg_resources:$(pwd)/wheel:$PYTHONPATH"
+    export PYTHONPATH="$out/${python.sitePackages}:$(pwd)/pip/src:$(pwd)/setuptools:$(pwd)/setuptools/pkg_resources:$(pwd)/wheel:$(pwd)/flit/flit_core:$PYTHONPATH"
 
     echo "Building setuptools wheel..."
     pushd setuptools

--- a/pkgs/development/python-modules/click/default.nix
+++ b/pkgs/development/python-modules/click/default.nix
@@ -2,6 +2,7 @@
 , buildPythonPackage
 , pythonOlder
 , fetchPypi
+, fetchpatch
 , importlib-metadata
 , pytestCheckHook
 
@@ -22,6 +23,15 @@ buildPythonPackage rec {
     inherit pname version;
     hash = "sha256-doLcivswKXABZ0V16gDRgU2AjWo2r0Fagr1IHTe6e44=";
   };
+
+  patches = [
+    (fetchpatch {
+      # pytest 7.3.0 compat
+      name = "click-pytest-7.3.0-compat.patch";
+      url = "https://github.com/pallets/click/commit/0f5fbb7e4d893945b4c07cfe4f81cd82fb2900ed.patch";
+      hash = "sha256-Xgkrn81K9Qzz1T3lfGHCm6rIl/omG+DhmCa6jj7cauw=";
+    })
+  ];
 
   propagatedBuildInputs = lib.optionals (pythonOlder "3.8") [
     importlib-metadata

--- a/pkgs/development/python-modules/flit/default.nix
+++ b/pkgs/development/python-modules/flit/default.nix
@@ -25,6 +25,7 @@ buildPythonPackage rec {
     repo = "flit";
     rev = version;
     hash = "sha256-iXf9K/xI4u+dDV0Zf6S08nbws4NqycrTEW0B8/qCjQc=";
+    name = "${pname}-${version}-source";
   };
 
   nativeBuildInputs = [

--- a/pkgs/development/python-modules/installer/default.nix
+++ b/pkgs/development/python-modules/installer/default.nix
@@ -1,36 +1,64 @@
 { lib
 , buildPythonPackage
-, pythonOlder
 , fetchFromGitHub
-, pytestCheckHook
+
+# bootstrap
 , flit-core
+, python
+
+# tests
+, installer
 , mock
+, pytestCheckHook
 }:
 
 buildPythonPackage rec {
   pname = "installer";
   version = "0.7.0";
-  format = "pyproject";
+  format = "other";
 
   src = fetchFromGitHub {
     owner = "pradyunsg";
-    repo = pname;
-    rev = version;
+    repo = "installer";
+    rev = "refs/tags/${version}";
     hash = "sha256-thHghU+1Alpay5r9Dc3v7ATRFfYKV8l9qR0nbGOOX/A=";
   };
 
-  nativeBuildInputs = [ flit-core ];
+  nativeBuildInputs = [
+    flit-core
+  ];
+
+  dontBuild = true;
+
+  installPhase = ''
+    runHook preInstall
+    ls -lah
+    mkdir -p $out/${python.sitePackages}
+    cp -a src/installer* $out/${python.sitePackages}
+    ${python.interpreter} -m compileall $out/${python.sitePackages}
+    runHook postInstall
+  '';
+
+  pythonImportsCheck = [
+    "installer"
+  ];
+
+  doCheck = false;
 
   nativeCheckInputs = [
-    pytestCheckHook
     mock
+    pytestCheckHook
   ];
+
+  passthru.tests = {
+    pytest = installer.overridePythonAttrs (oldAttrs: { doCheck = true; });
+  };
 
   meta = with lib; {
     changelog = "https://github.com/pypa/installer/blob/${src.rev}/docs/changelog.md";
     homepage = "https://github.com/pradyunsg/installer";
     description = "A low-level library for installing a Python package from a wheel distribution";
     license = licenses.mit;
-    maintainers = with maintainers; [ cpcloud fridh ];
+    maintainers = teams.python.members;
   };
 }

--- a/pkgs/development/python-modules/pip/default.nix
+++ b/pkgs/development/python-modules/pip/default.nix
@@ -14,14 +14,14 @@
 
 buildPythonPackage rec {
   pname = "pip";
-  version = "23.0.1";
+  version = "23.1.2";
   format = "other";
 
   src = fetchFromGitHub {
     owner = "pypa";
     repo = pname;
     rev = "refs/tags/${version}";
-    hash = "sha256-BSonlwKmegrlrQTTIL0avPi61/TY2M0f7kOZpSzPRQk=";
+    hash = "sha256-bnvpSV6KSY+c3w7FSgTTgBXjBp2/RYbpCBC8DvzYPwY=";
     name = "${pname}-${version}-source";
   };
 
@@ -49,5 +49,6 @@ buildPythonPackage rec {
     homepage = "https://pip.pypa.io/";
     changelog = "https://pip.pypa.io/en/stable/news/#v${lib.replaceStrings [ "." ] [ "-" ] version}";
     priority = 10;
+    maintainers = lib.teams.python.members;
   };
 }

--- a/pkgs/development/python-modules/pytest/default.nix
+++ b/pkgs/development/python-modules/pytest/default.nix
@@ -21,12 +21,12 @@
 
 buildPythonPackage rec {
   pname = "pytest";
-  version = "7.2.1";
+  version = "7.3.1";
   format = "pyproject";
 
   src = fetchPypi {
     inherit pname version;
-    hash = "sha256-1F4JUvNyckGRi4/Q83b1/2swHMB3fG+aVWk1yS2KfUI=";
+    hash = "sha256-Q0r6/Xix147Qrd8WCtK3ejDTXUvfivI0/mIZGdntFeM=";
   };
 
   outputs = [

--- a/pkgs/development/python-modules/setuptools/default.nix
+++ b/pkgs/development/python-modules/setuptools/default.nix
@@ -10,7 +10,7 @@
 
 let
   pname = "setuptools";
-  version = "67.4.0";
+  version = "67.7.2";
 
   # Create an sdist of setuptools
   sdist = stdenv.mkDerivation rec {
@@ -20,7 +20,7 @@ let
       owner = "pypa";
       repo = pname;
       rev = "refs/tags/v${version}";
-      hash = "sha256-QDHycUFA2VRUE9alan8rF0efZTNV3Jt0CskjkCc+in0=";
+      hash = "sha256-O67HK7hFp4WCqZh15xRtieEcfAcyeZhBqgI8WnZyuzs=";
       name = "${pname}-${version}-source";
     };
 

--- a/pkgs/development/python-modules/wheel/default.nix
+++ b/pkgs/development/python-modules/wheel/default.nix
@@ -1,20 +1,25 @@
 { lib
 , buildPythonPackage
 , fetchFromGitHub
-, bootstrapped-pip
-, setuptools
+
+# build
+, flit-core
+, python
+
+# install
+, installer
 }:
 
 buildPythonPackage rec {
   pname = "wheel";
-  version = "0.38.4";
+  version = "0.40.0";
   format = "other";
 
   src = fetchFromGitHub {
     owner = "pypa";
     repo = pname;
     rev = version;
-    hash = "sha256-yZLU0t/nz6kfnnoLL15bybOxN4+SJUaTJsCpGffl1QU=";
+    hash = "sha256-WZ0KUy2Y6uWoalwQ1jxipo2XvLHlxMoCqbpNWW6H4PQ=";
     name = "${pname}-${version}-source";
     postFetch = ''
       cd $out
@@ -25,9 +30,21 @@ buildPythonPackage rec {
   };
 
   nativeBuildInputs = [
-    bootstrapped-pip
-    setuptools
+    flit-core
+    installer
   ];
+
+  buildPhase = ''
+    runHook preBuild
+    ${python.interpreter} -m flit_core.wheel
+    runHook postBuild
+  '';
+
+  installPhase = ''
+    runHook preInstall
+    ${python.interpreter} -m installer --prefix "$out" dist/*.whl
+    runHook postInstall
+  '';
 
   # No tests in archive
   doCheck = false;
@@ -52,6 +69,6 @@ buildPythonPackage rec {
       and as such there is no stable, public API.
     '';
     license = with licenses; [ mit ];
-    maintainers = with maintainers; [ siriobalmelli ];
+    maintainers = teams.python.members;
   };
 }

--- a/pkgs/development/tools/poetry2nix/poetry2nix/overrides/default.nix
+++ b/pkgs/development/tools/poetry2nix/poetry2nix/overrides/default.nix
@@ -2670,7 +2670,7 @@ lib.composeManyExtensions [
           python = self.python;
         }
       ).wheel.override {
-        inherit (self) buildPythonPackage bootstrapped-pip setuptools;
+        inherit (self) buildPythonPackage bootstrapped-pip;
       }).overrideAttrs (old: {
         inherit (super.wheel) pname name version src;
       });


### PR DESCRIPTION
As more and more low-level packages are moving towards `flit-core`,
we need to bootstrap it and other packages to escape infinite recursion
scenarios at the base of our package set.

Next packages like [build](https://pypa-build.readthedocs.io/en/latest/) and [installer](https://installer.pypa.io/en/stable/) should be made more lean, so they
can be used in our build and install phase hooks for [pyproject](https://pip.pypa.io/en/stable/reference/build-system/pyproject-toml/) based builds.

Taking the chance to also adopt a few core packages to the python team.

The changes already build, but I'm very much open to discussion of how
I solved things.

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
