### PR TITLE
isabelle-linter: unstable-2022-09-05 -> 1.2.1

### DIFF
--- a/pkgs/applications/science/logic/isabelle/components/isabelle-linter.nix
+++ b/pkgs/applications/science/logic/isabelle/components/isabelle-linter.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation rec {
   pname = "isabelle-linter";
-  version = "unstable-2022-09-05";
+  version = "1.2.1";
 
   src = fetchFromGitHub {
     owner = "isabelle-prover";
     repo = "isabelle-linter";
-    rev = "0424fc05426d5f7a23adf19ad08c690c17184e86";
-    sha256 = "02afbgmi195ibichjkpni2wjgjkszv7i6qkmmprwrmb4jd2wdvd5";
+    rev = "Isabelle2022-v${version}";
+    sha256 = "sha256-qlojNCsm3/49TtAVq6J31BbQipdIoDcn71pBotZyquY=";
   };
 
   nativeBuildInputs = [ isabelle ];


### PR DESCRIPTION
###### Description of changes
unstable-2022-09-05 -> 1.1.0: [Changelog](https://github.com/isabelle-prover/isabelle-linter/releases/tag/Isabelle2022-v1.1.0)
1.1.0 -> 1.1.1: [Changelog](https://github.com/isabelle-prover/isabelle-linter/releases/tag/Isabelle2022-v1.1.1)
1.1.1 -> 1.2.0: [Changelog](https://github.com/isabelle-prover/isabelle-linter/releases/tag/Isabelle2022-v1.2.0)
1.2.0 -> 1.2.1: [Changelog](https://github.com/isabelle-prover/isabelle-linter/releases/tag/Isabelle2022-v1.2.1)
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
