### PR TITLE
intel-one-mono: init at 1.2.0

### DIFF
--- a/pkgs/data/fonts/intel-one-mono/default.nix
+++ b/pkgs/data/fonts/intel-one-mono/default.nix
@@ -15,9 +15,6 @@ stdenvNoCC.mkDerivation rec {
     })
   ];
 
-  # Multiple packages are download in srcs folder
-  # -> need to specify where the unpack phase will `cd` into
-  # use the `srcs` folder as the Root of the unpack phase
   sourceRoot = ".";
 
   nativeBuildInputs = [

--- a/pkgs/data/fonts/intel-one-mono/default.nix
+++ b/pkgs/data/fonts/intel-one-mono/default.nix
@@ -1,0 +1,42 @@
+{ lib, stdenvNoCC, fetchurl, unzip}:
+
+stdenvNoCC.mkDerivation rec {
+  pname = "intel-one-mono";
+  version = "1.2.0";
+
+  srcs = [
+    (fetchurl {
+      url = "https://github.com/intel/intel-one-mono/releases/download/V${version}/otf.zip";
+      sha256 = "sha256-VnXIaW77dRXvXB1Vr01xRQDMECltwzF/RMqGgAWnu5M=";
+     })
+    (fetchurl {
+      url = "https://github.com/intel/intel-one-mono/releases/download/V${version}/ttf.zip";
+      sha256 = "sha256-kaz0DePeO8nvKVonYJhs5f2+ps/5Xo5psjg1hoxzaiU=";
+    })
+  ];
+
+  # Multiple packages are download in srcs folder
+  # -> need to specify where the unpack phase will `cd` into
+  # use the `srcs` folder as the Root of the unpack phase
+  sourceRoot = ".";
+
+  nativeBuildInputs = [
+    unzip
+  ];
+
+  installPhase = ''
+    runHook preInstall
+    install -Dm644 -t $out/share/fonts/truetype/ ttf/*.ttf
+    install -Dm644 -t $out/share/fonts/opentype/ otf/*.otf
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    description = "Intel One Mono, an expressive monospaced font family that’s built with clarity, legibility, and the needs of developers in mind";
+    homepage = "https://github.com/intel/intel-one-mono";
+    changelog = "https://github.com/intel/intel-one-mono/releases/tag/V${version}";
+    license = licenses.ofl;
+    maintainers = [ maintainers.simoneruffini];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -28207,6 +28207,8 @@ with pkgs;
     fonts = [ "Inconsolata" ];
   };
 
+  intel-one-mono = callPackage ../data/fonts/intel-one-mono {};
+
   input-fonts = callPackage ../data/fonts/input-fonts { };
 
   inriafonts = callPackage ../data/fonts/inriafonts { };


### PR DESCRIPTION
###### Description of changes
Added font `intel-one-mono`

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ x ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
