### PR TITLE
autodock-vina: init at 1.2.3

### DIFF
--- a/pkgs/applications/science/chemistry/autodock-vina/default.nix
+++ b/pkgs/applications/science/chemistry/autodock-vina/default.nix
@@ -1,0 +1,57 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, boost
+, glibc
+}:
+let
+  boost' = boost.override {
+    enableShared = false;
+  };
+in
+stdenv.mkDerivation (finalAttrs: {
+  pname = "autodock-vina";
+  version = "1.2.3";
+
+  src = fetchFromGitHub {
+    owner = "ccsb-scripps";
+    repo = "autodock-vina";
+    rev = "refs/tags/v${finalAttrs.version}";
+    hash = "sha256-oOpwhRmpS5WfnuqxkjxGsGtrofPxUt8bH9ggzm5rrR8=";
+  };
+
+  sourceRoot =
+    if stdenv.isDarwin
+    then "source/build/mac/release"
+    else "source/build/linux/release";
+
+  buildInputs = [
+    boost'
+  ] ++ lib.optionals stdenv.isLinux [
+    glibc.static
+  ];
+
+  makeFlags = [
+    "GPP=${stdenv.cc.targetPrefix}c++"
+    "BASE=${boost'}"
+    "BOOST_INCLUDE=${lib.getDev boost'}/include"
+  ];
+
+  installPhase = ''
+    runHook preInstall
+
+    install -Dm755 vina vina_split -t $out/bin/
+
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    description = "One of the fastest and most widely used open-source docking engines";
+    homepage = "https://vina.scripps.edu/";
+    changelog = "https://github.com/ccsb-scripps/AutoDock-Vina/releases/tag/v${finalAttrs.version}";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ natsukium ];
+    platforms = platforms.unix;
+    mainProgram = "vina";
+  };
+})

--- a/pkgs/applications/science/chemistry/autodock-vina/python-bindings.nix
+++ b/pkgs/applications/science/chemistry/autodock-vina/python-bindings.nix
@@ -1,0 +1,56 @@
+{ lib
+, buildPythonPackage
+, autodock-vina
+, boost
+, swig
+, setuptools
+, numpy
+}:
+
+buildPythonPackage {
+  inherit (autodock-vina) pname version src meta;
+
+  format = "pyproject";
+
+  sourceRoot = "source/build/python";
+
+  postPatch = ''
+    # wildcards are not allowed
+    # https://github.com/ccsb-scripps/AutoDock-Vina/issues/176
+    substituteInPlace setup.py \
+      --replace "python_requires='>=3.5.*'" "python_requires='>=3.5'"
+
+    # setupPyBuildFlags are not applied with `format = "pyproject"`
+    substituteInPlace setup.py \
+      --replace "= locate_boost()" "= '${lib.getDev boost}/include', '${boost}/lib'"
+
+    # this line attempts to delete the source code
+    substituteInPlace setup.py \
+      --replace "shutil.rmtree('src')" "..."
+
+    # np.int is deprecated
+    # https://github.com/ccsb-scripps/AutoDock-Vina/pull/167 and so on
+    substituteInPlace vina/vina.py \
+      --replace "np.int" "int"
+  '';
+
+  nativeBuildInputs = [
+    setuptools
+    swig
+  ];
+
+  buildInputs = [
+    boost
+  ];
+
+  propagatedBuildInputs = [
+    numpy
+  ];
+
+  # upstrem has no tests
+  doCheck = false;
+
+  pythonImportsCheck = [
+    "vina"
+  ];
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -37332,6 +37332,8 @@ with pkgs;
     gstreamerSupport = true;
   };
 
+  autodock-vina = callPackage ../applications/science/chemistry/autodock-vina { };
+
   dkh = callPackage ../applications/science/chemistry/dkh { };
 
   openmolcas = callPackage ../applications/science/chemistry/openmolcas { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -12673,6 +12673,8 @@ self: super: with self; {
 
   vilfo-api-client = callPackage ../development/python-modules/vilfo-api-client { };
 
+  vina = callPackage ../applications/science/chemistry/autodock-vina/python-bindings.nix { };
+
   vincenty = callPackage ../development/python-modules/vincenty { };
 
   vine = callPackage ../development/python-modules/vine { };


### PR DESCRIPTION
###### Description of changes

AutoDock Vina is an open-source program for doing [molecular docking](http://en.wikipedia.org/wiki/Docking_(molecular)).

homepage: https://vina.scripps.edu/
source: https://github.com/ccsb-scripps/AutoDock-Vina

I have confirmed that [this tutorial](https://autodock-vina.readthedocs.io/en/latest/docking_basic.html#running-autodock-vina) works on "x86_64-linux" and "aarch64-darwin".
I have also checked the python-bindings on python310 and python311 as well.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
