### PR TITLE
bcompare: 4.4.4.27058 -> 4.4.6.27348 https://www.scootersoftware.com/download/v4changelog

### DIFF
--- a/pkgs/applications/version-management/bcompare/default.nix
+++ b/pkgs/applications/version-management/bcompare/default.nix
@@ -16,7 +16,7 @@ let
 
     x86_64-darwin = fetchurl {
       url = "https://www.scootersoftware.com/files/BCompareOSX-${version}.zip";
-      hash = "sha256-HORBhCRyaDwvij79wEkL0q749CLT7ZUuIxm8TTOxkck=";
+      hash = "sha256-hUzJfUgfCuvB6ADHbsgmEXXgntm01hPnfSjwl7jI70c=";
     };
 
     aarch64-darwin = srcs.x86_64-darwin;

--- a/pkgs/applications/version-management/bcompare/default.nix
+++ b/pkgs/applications/version-management/bcompare/default.nix
@@ -11,7 +11,7 @@ let
   srcs = {
     x86_64-linux = fetchurl {
       url = "https://www.scootersoftware.com/files/${pname}-${version}_amd64.deb";
-      hash = "sha256-PdriIn6eh1maESAAGBI+wgc6JVg85ZTZz9gB/+RiDK0=";
+      hash = "sha256-1+f/AfyJ8Z80WR4cs1JDjTquTR1mGAUOd27vniSeA0k=";
     };
 
     x86_64-darwin = fetchurl {

--- a/pkgs/applications/version-management/bcompare/default.nix
+++ b/pkgs/applications/version-management/bcompare/default.nix
@@ -4,19 +4,19 @@
 
 let
   pname = "bcompare";
-  version = "4.4.4.27058";
+  version = "4.4.6.27348";
 
   throwSystem = throw "Unsupported system: ${stdenv.hostPlatform.system}";
 
   srcs = {
     x86_64-linux = fetchurl {
-      url = "https://www.scootersoftware.com/${pname}-${version}_amd64.deb";
-      sha256 = "sha256-8wJzCCfekr/mrDJCDgoIqMRz21wWjfp5c5sPavZma3g=";
+      url = "https://www.scootersoftware.com/files/${pname}-${version}_amd64.deb";
+      hash = "sha256-PdriIn6eh1maESAAGBI+wgc6JVg85ZTZz9gB/+RiDK0=";
     };
 
     x86_64-darwin = fetchurl {
-      url = "https://www.scootersoftware.com/BCompareOSX-${version}.zip";
-      sha256 = "sha256-UopkyKHvbIZb9rNAJ+l3dEmOX33lQwakNypWCgYDT04=";
+      url = "https://www.scootersoftware.com/files/BCompareOSX-${version}.zip";
+      hash = "sha256-HORBhCRyaDwvij79wEkL0q749CLT7ZUuIxm8TTOxkck=";
     };
 
     aarch64-darwin = srcs.x86_64-darwin;


### PR DESCRIPTION
version bump for bcompare
