### PR TITLE
linux: manual-config: use a non-random path for $buildRoot

### DIFF
--- a/pkgs/os-specific/linux/kernel/manual-config.nix
+++ b/pkgs/os-specific/linux/kernel/manual-config.nix
@@ -179,7 +179,8 @@ stdenv.mkDerivation ({
   configurePhase = ''
     runHook preConfigure
 
-    export buildRoot=$(mktemp -d)
+    export buildRoot=$TMPDIR/kernel-buildroot
+    mkdir -p $buildRoot
 
     echo "manual-config configurePhase buildRoot=$buildRoot pwd=$PWD"
 


### PR DESCRIPTION
###### Description of changes

Fixes reproducibility issues with x86/amd64 VDSO ELFs Build-IDs.

The kernel build system tries pretty hard to not leak build file paths in its output. However, the embedded VDSO ELF files are built using slightly different build options that do not include the path mapping options that protect the rest of the kernel against this issue.

This should be fixed upstream eventually, but a lot of this logic is duplicated across architecture, so I don't expect it will be a trivial fix. Instead, make our derivation use a fixed build root directory so this does not impact the build reproducibility.

Fixes #227800.

---------

("Regression" from d75cff2ee3bb6d91c818d43d1ba7603bb6dacd59, so cc-ing the interested parties who authored/reviewed that PR: @alyssais @lovesegfault @Ma27.)

As far as I can tell this is the last reproducibility issue impacting our Linux kernel builds for x86/amd64.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
