### PR TITLE
cmake: remove fixCmakeFiles

### DIFF
--- a/pkgs/applications/audio/munt/libmt32emu.nix
+++ b/pkgs/applications/audio/munt/libmt32emu.nix
@@ -21,8 +21,6 @@ stdenv.mkDerivation rec {
     cmake
   ];
 
-  dontFixCmake = true;
-
   cmakeFlags = [
     "-Dmunt_WITH_MT32EMU_SMF2WAV=OFF"
     "-Dmunt_WITH_MT32EMU_QT=OFF"

--- a/pkgs/applications/audio/munt/mt32emu-qt.nix
+++ b/pkgs/applications/audio/munt/mt32emu-qt.nix
@@ -48,8 +48,6 @@ mkDerivation rec {
   ]
   ++ lib.optional withJack libjack2;
 
-  dontFixCmake = true;
-
   cmakeFlags = [
     "-Dmt32emu-qt_USE_PULSEAUDIO_DYNAMIC_LOADING=OFF"
     "-Dmunt_WITH_MT32EMU_QT=ON"

--- a/pkgs/applications/audio/munt/mt32emu-smf2wav.nix
+++ b/pkgs/applications/audio/munt/mt32emu-smf2wav.nix
@@ -25,8 +25,6 @@ stdenv.mkDerivation rec {
     sed -i -e '/add_subdirectory(mt32emu)/d' CMakeLists.txt
   '';
 
-  dontFixCmake = true;
-
   nativeBuildInputs = [
     cmake
     pkg-config

--- a/pkgs/applications/editors/vim/macvim.nix
+++ b/pkgs/applications/editors/vim/macvim.nix
@@ -95,21 +95,7 @@ stdenv.mkDerivation {
   # passes arguments to ld that it meant for clang.
   + ''
     unset LD
-  ''
-  # When building with nix-daemon, we need to pass -derivedDataPath or else it tries to use
-  # a folder rooted in /var/empty and fails. Unfortunately we can't just pass -derivedDataPath
-  # by itself as this flag requires the use of -scheme or -xctestrun (not sure why), but MacVim
-  # by default just runs `xcodebuild -project src/MacVim/MacVim.xcodeproj`, relying on the default
-  # behavior to build the first target in the project. Experimentally, there seems to be a scheme
-  # called MacVim, so we'll explicitly select that. We also need to specify the configuration too
-  # as the scheme seems to have the wrong default.
-  + ''
-    configureFlagsArray+=(
-      XCODEFLAGS="-scheme MacVim -derivedDataPath $NIX_BUILD_TOP/derivedData"
-      --with-xcodecfg="Release"
-    )
-  ''
-  ;
+  '';
 
   # Because we're building with system clang, this means we're building against Xcode's SDK and
   # linking against system libraries. The configure script is picking up Nix Libsystem (via ruby)

--- a/pkgs/applications/emulators/darling/default.nix
+++ b/pkgs/applications/emulators/darling/default.nix
@@ -149,10 +149,6 @@ in stdenv.mkDerivation {
     stdenv.cc.libc.linuxHeaders
   ];
 
-  # Breaks valid paths like
-  # Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include
-  dontFixCmake = true;
-
   # src/external/objc4 forces OBJC_IS_DEBUG_BUILD=1, which conflicts with NDEBUG
   # TODO: Fix in a better way
   cmakeBuildType = " ";

--- a/pkgs/applications/misc/cubocore-packages/coretoppings/0001-fix-install-phase.patch
+++ b/pkgs/applications/misc/cubocore-packages/coretoppings/0001-fix-install-phase.patch
@@ -1,8 +1,0 @@
---- a/corepkit/CMakeLists.txt	2021-12-25 17:52:20.000000000 +0700
-+++ b/corepkit/CMakeLists.txt	2021-12-29 17:58:09.298024297 +0700
-@@ -32,4 +32,4 @@
- target_link_libraries( corepkit  Qt5::Core )
- 
- install( TARGETS corepkit DESTINATION libexec/coreapps/ )
--install( FILES org.cubocore.coreapps.policy DESTINATION share/polkit-1/actions/ )
-+install( FILES org.cubocore.coreapps.policy DESTINATION ${CMAKE_INSTALL_PREFIX}/usr/share/polkit-1/actions/ )

--- a/pkgs/applications/misc/cubocore-packages/coretoppings/default.nix
+++ b/pkgs/applications/misc/cubocore-packages/coretoppings/default.nix
@@ -39,11 +39,6 @@ mkDerivation rec {
     hash = "sha256-IYUkPGgFGI6889IyromMBobIoqSZtALVsSswQ7O1Bp0=";
   };
 
-  patches = [
-    # Fix file cannot create directory: /var/empty/share/polkit-1/actions
-    ./0001-fix-install-phase.patch
-  ];
-
   nativeBuildInputs = [
     cmake
     ninja

--- a/pkgs/applications/networking/sniffers/wireshark/default.nix
+++ b/pkgs/applications/networking/sniffers/wireshark/default.nix
@@ -149,7 +149,6 @@ stdenv.mkDerivation rec {
   # Avoid referencing -dev paths because of debug assertions.
   env.NIX_CFLAGS_COMPILE = toString [ "-DQT_NO_DEBUG" ];
 
-  dontFixCmake = true;
   dontWrapGApps = true;
 
   shellHook = ''

--- a/pkgs/applications/window-managers/jwm/jwm-settings-manager.nix
+++ b/pkgs/applications/window-managers/jwm/jwm-settings-manager.nix
@@ -33,11 +33,6 @@ stdenv.mkDerivation rec {
       --replace 'DESTINATION usr/share' "DESTINATION share"
   '';
 
-  postConfigure = ''
-    substituteInPlace cmake_install.cmake \
-      --replace "/var/empty" "/usr"
-  '';
-
   meta = with lib; {
     description = "A full configuration manager for JWM";
     homepage = "https://joewing.net/projects/jwm";

--- a/pkgs/by-name/cm/cmake/package.nix
+++ b/pkgs/by-name/cm/cmake/package.nix
@@ -104,7 +104,6 @@ stdenv.mkDerivation (finalAttrs: {
   propagatedBuildInputs = lib.optional stdenv.isDarwin ps;
 
   preConfigure = ''
-    fixCmakeFiles .
     substituteInPlace Modules/Platform/UnixPaths.cmake \
       --subst-var-by libc_bin ${lib.getBin stdenv.cc.libc} \
       --subst-var-by libc_dev ${lib.getDev stdenv.cc.libc} \

--- a/pkgs/by-name/cm/cmake/setup-hook.sh
+++ b/pkgs/by-name/cm/cmake/setup-hook.sh
@@ -2,16 +2,6 @@ addCMakeParams() {
     addToSearchPath CMAKE_PREFIX_PATH $1
 }
 
-fixCmakeFiles() {
-    # Replace occurences of /usr and /opt by /var/empty.
-    echo "fixing cmake files..."
-    find "$1" \( -type f -name "*.cmake" -o -name "*.cmake.in" -o -name CMakeLists.txt \) -print |
-        while read fn; do
-            sed -e 's^/usr\([ /]\|$\)^/var/empty\1^g' -e 's^/opt\([ /]\|$\)^/var/empty\1^g' < "$fn" > "$fn.tmp"
-            mv "$fn.tmp" "$fn"
-        done
-}
-
 cmakeConfigurePhase() {
     runHook preConfigure
 
@@ -21,10 +11,6 @@ cmakeConfigurePhase() {
     export CTEST_OUTPUT_ON_FAILURE=1
     if [ -n "${enableParallelChecking-1}" ]; then
         export CTEST_PARALLEL_LEVEL=$NIX_BUILD_CORES
-    fi
-
-    if [ -z "${dontFixCmake-}" ]; then
-        fixCmakeFiles .
     fi
 
     if [ -z "${dontUseCmakeBuildDir-}" ]; then

--- a/pkgs/by-name/ne/neovim-unwrapped/package.nix
+++ b/pkgs/by-name/ne/neovim-unwrapped/package.nix
@@ -84,8 +84,6 @@ in {
       ./system_rplugin_manifest.patch
     ];
 
-    dontFixCmake = true;
-
     inherit lua;
     treesitter-parsers = treesitter-parsers //
       { markdown = treesitter-parsers.markdown // { location = "tree-sitter-markdown"; }; } //

--- a/pkgs/development/compilers/swift/compiler/default.nix
+++ b/pkgs/development/compilers/swift/compiler/default.nix
@@ -243,8 +243,6 @@ in stdenv.mkDerivation {
     done
   '';
 
-  # We invoke cmakeConfigurePhase multiple times, but only need this once.
-  dontFixCmake = true;
   # We setup custom build directories.
   dontUseCmakeBuildDir = true;
 
@@ -355,12 +353,6 @@ in stdenv.mkDerivation {
     rm swift/test/AutoDiff/compiler_crashers_fixed/issue-56649-missing-debug-scopes-in-pullback-trampoline.swift
 
     patchShebangs .
-
-    ${lib.optionalString (!stdenv.isDarwin) ''
-    # NOTE: This interferes with ABI stability on Darwin, which uses the system
-    # libraries in the hardcoded path /usr/lib/swift.
-    fixCmakeFiles .
-    ''}
   '';
 
   configurePhase = ''

--- a/pkgs/development/compilers/tvm/default.nix
+++ b/pkgs/development/compilers/tvm/default.nix
@@ -13,12 +13,6 @@ stdenv.mkDerivation rec {
   };
 
   nativeBuildInputs = [ cmake ];
-  # TVM CMake build uses some sources in the project's ./src/target/opt/
-  # directory which errneously gets mangled by the eager `fixCmakeFiles`
-  # function in Nix's CMake setup-hook.sh to ./src/target/var/empty/,
-  # which then breaks the build. Toggling this flag instructs Nix to
-  # not mangle the legitimate use of the opt/ folder.
-  dontFixCmake = true;
 
   meta = with lib; {
     homepage = "https://tvm.apache.org/";

--- a/pkgs/development/libraries/irrlicht/mac.nix
+++ b/pkgs/development/libraries/irrlicht/mac.nix
@@ -21,7 +21,6 @@ stdenv.mkDerivation rec {
   '';
 
   patches = [ ./mac_device.patch ];
-  dontFixCmake = true;
 
   cmakeFlags = [
     "-DIRRLICHT_STATIC_LIBRARY=ON"

--- a/pkgs/development/libraries/liboqs/default.nix
+++ b/pkgs/development/libraries/liboqs/default.nix
@@ -29,8 +29,6 @@ stdenv.mkDerivation rec {
     "-DOQS_BUILD_ONLY_LIB=ON"
   ];
 
-  dontFixCmake = true; # fix CMake file will give an error
-
   meta = with lib; {
     description = "C library for prototyping and experimenting with quantum-resistant cryptography";
     homepage = "https://openquantumsafe.org";

--- a/pkgs/kde/lib/mk-kde-derivation.nix
+++ b/pkgs/kde/lib/mk-kde-derivation.nix
@@ -114,7 +114,6 @@ in
       propagatedBuildInputs = deps ++ extraPropagatedBuildInputs;
       strictDeps = true;
 
-      dontFixCmake = true;
       cmakeFlags = ["-DQT_MAJOR_VERSION=6"] ++ extraCmakeFlags;
 
       separateDebugInfo = true;

--- a/pkgs/servers/foundationdb/cmake.nix
+++ b/pkgs/servers/foundationdb/cmake.nix
@@ -43,7 +43,6 @@ let
           ++ lib.optionals useClang [ llvmPackages.lld ];
 
         separateDebugInfo = true;
-        dontFixCmake = true;
 
         cmakeFlags =
           [ (lib.optionalString officialRelease "-DFDB_RELEASE=TRUE")

--- a/pkgs/servers/nosql/arangodb/default.nix
+++ b/pkgs/servers/nosql/arangodb/default.nix
@@ -46,8 +46,6 @@ gcc10Stdenv.mkDerivation rec {
 
   buildInputs = [ openssl zlib snappy lzo ];
 
-  # prevent failing with "cmake-3.13.4/nix-support/setup-hook: line 10: ./3rdParty/rocksdb/RocksDBConfig.cmake.in: No such file or directory"
-  dontFixCmake = true;
   env.NIX_CFLAGS_COMPILE = "-Wno-error";
 
   postPatch = ''

--- a/pkgs/tools/networking/mozillavpn/default.nix
+++ b/pkgs/tools/networking/mozillavpn/default.nix
@@ -142,7 +142,6 @@ stdenv.mkDerivation {
     "-DQT_LUPDATE_EXECUTABLE=${qttools.dev}/bin/lupdate"
     "-DQT_LRELEASE_EXECUTABLE=${qttools.dev}/bin/lrelease"
   ];
-  dontFixCmake = true;
 
   qtWrapperArgs =
     [ "--prefix" "PATH" ":" (lib.makeBinPath [ wireguard-tools ]) ];

--- a/pkgs/tools/package-management/dnf5/default.nix
+++ b/pkgs/tools/package-management/dnf5/default.nix
@@ -103,8 +103,6 @@ stdenv.mkDerivation (finalAttrs: {
       --replace '/etc/bash_completion.d' "$out/etc/bash_completion.d"
   '';
 
-  dontFixCmake = true;
-
   passthru.tests = {
     version = testers.testVersion { package = finalAttrs.finalPackage; };
   };


### PR DESCRIPTION
Rewriting /usr and /opt to /var/empty is no longer necessary since the sandbox was introduced. It also introduced unexpected side effects and changes paths like $out/etc/opt/ to $out/etc/var/empty/

Closes #24215

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
