### PR TITLE
opera-dev: init at 101.0.4822.0

### DIFF
--- a/pkgs/applications/networking/browsers/opera/browser.nix
+++ b/pkgs/applications/networking/browsers/opera/browser.nix
@@ -1,0 +1,154 @@
+{ channel, channelRoot, version, sha256 }:
+
+{ alsa-lib
+, atk
+, cairo
+, cups
+, curl
+, dbus
+, dpkg
+, expat
+, fetchurl
+, fontconfig
+, freetype
+, gdk-pixbuf
+, glib
+, gtk3
+, gtk4
+, icu
+, lib
+, libX11
+, libxcb
+, libXScrnSaver
+, libXcomposite
+, libXcursor
+, libXdamage
+, libXext
+, libXfixes
+, libXi
+, libXrandr
+, libXrender
+, libXtst
+, libdrm
+, libnotify
+, libpulseaudio
+, libuuid
+, libxshmfence
+, mesa
+, nspr
+, nss
+, pango
+, stdenv
+, systemd
+, at-spi2-atk
+, at-spi2-core
+, autoPatchelfHook
+, wrapGAppsHook
+, qt5
+, proprietaryCodecs ? false
+, vivaldi-ffmpeg-codecs
+}:
+
+let
+  baseName = "opera";
+
+  longName = if channel == "stable"
+             then baseName
+             else baseName + "-" + channel;
+
+  mirror = "https://get.geo.opera.com/pub/";
+in
+stdenv.mkDerivation rec {
+  pname = longName;
+  inherit version;
+
+  src = fetchurl {
+    url = "${mirror}/${channelRoot}/${version}/linux/${baseName}-${channel}_${version}_amd64.deb";
+    inherit sha256;
+  };
+
+  unpackPhase = "dpkg-deb -x $src .";
+
+  nativeBuildInputs = [
+    dpkg
+    autoPatchelfHook
+    wrapGAppsHook
+    qt5.wrapQtAppsHook
+  ];
+
+  buildInputs = [
+    alsa-lib
+    at-spi2-atk
+    at-spi2-core
+    atk
+    cairo
+    cups
+    curl
+    dbus
+    expat
+    fontconfig.lib
+    freetype
+    gdk-pixbuf
+    glib
+    gtk3
+    libX11
+    libXScrnSaver
+    libXcomposite
+    libXcursor
+    libXdamage
+    libXext
+    libXfixes
+    libXi
+    libXrandr
+    libXrender
+    libXtst
+    libdrm
+    libnotify
+    libuuid
+    libxcb
+    libxshmfence
+    mesa
+    nspr
+    nss
+    pango
+    stdenv.cc.cc.lib
+  ];
+
+  runtimeDependencies = [
+    # Works fine without this except there is no sound.
+    libpulseaudio.out
+
+    # This is a little tricky. Without it the app starts then crashes. Then it
+    # brings up the crash report, which also crashes. `strace -f` hints at a
+    # missing libudev.so.0.
+    (lib.getLib systemd)
+
+    # Fix startup crash/corruption error on v100 +
+    icu
+
+    # Error at startup:
+    # "Illegal instruction (core dumped)"
+    gtk3
+    gtk4
+  ] ++ lib.optionals proprietaryCodecs [
+    vivaldi-ffmpeg-codecs
+  ];
+
+  dontWrapQtApps = true;
+
+  installPhase = ''
+    mkdir -p $out/bin
+    cp -r usr $out
+    cp -r usr/share $out/share
+    ln -s $out/usr/bin/${longName} $out/bin/
+  '';
+
+  meta = with lib; {
+    homepage = "https://www.opera.com";
+    description = "Faster, safer and smarter web browser";
+    platforms = [ "x86_64-linux" ];
+    license = licenses.unfree;
+    sourceProvenance = with sourceTypes; [ binaryNativeCode ];
+    maintainers = with maintainers; [ kindrowboat m1cr0man ];
+  };
+}

--- a/pkgs/applications/networking/browsers/opera/default.nix
+++ b/pkgs/applications/networking/browsers/opera/default.nix
@@ -1,142 +1,20 @@
-{ alsa-lib
-, atk
-, cairo
-, cups
-, curl
-, dbus
-, dpkg
-, expat
-, fetchurl
-, fontconfig
-, freetype
-, gdk-pixbuf
-, glib
-, gtk3
-, gtk4
-, lib
-, libX11
-, libxcb
-, libXScrnSaver
-, libXcomposite
-, libXcursor
-, libXdamage
-, libXext
-, libXfixes
-, libXi
-, libXrandr
-, libXrender
-, libXtst
-, libdrm
-, libnotify
-, libpulseaudio
-, libuuid
-, libxshmfence
-, mesa
-, nspr
-, nss
-, pango
-, stdenv
-, systemd
-, at-spi2-atk
-, at-spi2-core
-, autoPatchelfHook
-, wrapGAppsHook
-, qt5
-, proprietaryCodecs ? false
-, vivaldi-ffmpeg-codecs
-}:
-
-let
-  mirror = "https://get.geo.opera.com/pub/opera/desktop";
-in
-stdenv.mkDerivation rec {
-  pname = "opera";
-  version = "100.0.4815.21";
-
-  src = fetchurl {
-    url = "${mirror}/${version}/linux/${pname}-stable_${version}_amd64.deb";
-    hash = "sha256-bDCj4ZtULO1JkuAsqy2ppcWOshgGRG03qlb3KV3CtSE=";
+{
+  stable = import ./browser.nix {
+    channel = "stable";
+    channelRoot = "opera/desktop";
+    version = "100.0.4815.30";
+    sha256 = "sha256-7JWN6SAqkrQeYAFU9IAgyr4kjS7FkTpX+qnn6wnfc7Q=";
   };
-
-  unpackPhase = "dpkg-deb -x $src .";
-
-  nativeBuildInputs = [
-    dpkg
-    autoPatchelfHook
-    wrapGAppsHook
-    qt5.wrapQtAppsHook
-  ];
-
-  buildInputs = [
-    alsa-lib
-    at-spi2-atk
-    at-spi2-core
-    atk
-    cairo
-    cups
-    curl
-    dbus
-    expat
-    fontconfig.lib
-    freetype
-    gdk-pixbuf
-    glib
-    gtk3
-    libX11
-    libXScrnSaver
-    libXcomposite
-    libXcursor
-    libXdamage
-    libXext
-    libXfixes
-    libXi
-    libXrandr
-    libXrender
-    libXtst
-    libdrm
-    libnotify
-    libuuid
-    libxcb
-    libxshmfence
-    mesa
-    nspr
-    nss
-    pango
-    stdenv.cc.cc.lib
-  ];
-
-  runtimeDependencies = [
-    # Works fine without this except there is no sound.
-    libpulseaudio.out
-
-    # This is a little tricky. Without it the app starts then crashes. Then it
-    # brings up the crash report, which also crashes. `strace -f` hints at a
-    # missing libudev.so.0.
-    (lib.getLib systemd)
-
-    # Error at startup:
-    # "Illegal instruction (core dumped)"
-    gtk3
-    gtk4
-  ] ++ lib.optionals proprietaryCodecs [
-    vivaldi-ffmpeg-codecs
-  ];
-
-  dontWrapQtApps = true;
-
-  installPhase = ''
-    mkdir -p $out/bin
-    cp -r usr $out
-    cp -r usr/share $out/share
-    ln -s $out/usr/bin/opera $out/bin/opera
-  '';
-
-  meta = with lib; {
-    homepage = "https://www.opera.com";
-    description = "Faster, safer and smarter web browser";
-    platforms = [ "x86_64-linux" ];
-    license = licenses.unfree;
-    sourceProvenance = with sourceTypes; [ binaryNativeCode ];
-    maintainers = with maintainers; [ kindrowboat ];
+  beta = import ./browser.nix {
+    channel = "beta";
+    channelRoot = "opera-beta";
+    version = "101.0.4843.5";
+    sha256 = "sha256-/ZzhfPtMB+cAPiQ8PnIJDlJU8kkAZ2Qi2LXHQj1arog=";
+  };
+  developer = import ./browser.nix {
+    channel = "developer";
+    channelRoot = "opera-developer";
+    version = "101.0.4843.0";
+    sha256 = "sha256-F31ybVEOQ6tJtsnZfQ9zi+Lphdw67s7SF1MRjwPBWdI=";
   };
 }

--- a/pkgs/applications/networking/browsers/opera/update.py
+++ b/pkgs/applications/networking/browsers/opera/update.py
@@ -1,0 +1,87 @@
+#! /usr/bin/env nix-shell
+#! nix-shell -i python3 -p python3Packages.packaging
+import base64
+from pathlib import Path
+import sys
+from urllib import request
+from http.client import HTTPResponse
+from re import compile
+import textwrap
+
+from packaging.version import Version, InvalidVersion
+
+# Name -> channel root
+CHANNELS: dict[str, str] = {
+    "stable": "opera/desktop",
+    "beta": "opera-beta",
+    "developer": "opera-developer",
+}
+
+MIRROR_URL = "https://get.geo.opera.com/pub"
+
+# versions expected to be > 5 characters
+VERSION_EXTRACTOR = compile(r'.*href="([\d\.]{5,})/"')
+
+
+def get_latest_version(channel_root: str) -> Version:
+    # Mirror returns an autoindex of the directory tree.
+    # Parses the version numbers from the names of the subdirectories.
+    url = f"{MIRROR_URL}/{channel_root}/"
+    handle: HTTPResponse
+    version = Version("0.0.0")
+    with request.urlopen(url=url) as handle:
+        for line in handle.readlines():
+            raw_version = VERSION_EXTRACTOR.match(line.decode())
+            if raw_version:
+                try:
+                    new_version = Version(raw_version.group(1))
+                except InvalidVersion:
+                    continue
+                if new_version > version:
+                    version = new_version
+    return version
+
+
+def get_version_sha256(channel: str, channel_root: str, version: str) -> str:
+    pkg = f"opera-{channel}_{version}_amd64.deb"
+    url = f"{MIRROR_URL}/{channel_root}/{version}/linux/{pkg}.sha256sum"
+    handle: HTTPResponse
+    with request.urlopen(url=url) as handle:
+        sha256sum = handle.read().decode().strip()
+        return "sha256-" + base64.b64encode(bytes.fromhex(sha256sum)).decode("ascii")
+
+
+def generate_nix(
+    channel: str,
+    channel_root: str,
+    version: Version,
+    sha256sum: str,
+) -> str:
+    return textwrap.dedent(
+        f"""\
+        {channel} = import ./browser.nix {{
+          channel = "{channel}";
+          channelRoot = "{channel_root}";
+          version = "{version}";
+          sha256 = "{sha256sum}";
+        }};"""
+    )
+
+
+def main() -> int:
+    output: list[str] = ["{"]
+    for channel, channel_root in CHANNELS.items():
+        version = get_latest_version(channel_root)
+        sha256sum = get_version_sha256(channel, channel_root, str(version))
+        print(channel, version, sha256sum)
+        output.append(
+            textwrap.indent(
+                generate_nix(channel, channel_root, version, sha256sum), "  "
+            ),
+        )
+    Path("default.nix").write_text("\n".join(output) + "\n}\n", newline="\n")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -33716,7 +33716,9 @@ with pkgs;
 
   openvi = darwin.apple_sdk_11_0.callPackage ../applications/editors/openvi { };
 
-  opera = callPackage ../applications/networking/browsers/opera { };
+  opera = callPackage (import ../applications/networking/browsers/opera).stable { };
+  opera-beta = callPackage (import ../applications/networking/browsers/opera).beta { };
+  opera-dev = callPackage (import ../applications/networking/browsers/opera).developer { };
 
   oranda = callPackage ../applications/misc/oranda { };
 


### PR DESCRIPTION
###### Description of changes

opera-beta: init at 100.0.4815.2

opera: 99.0.4788.31 -> 99.0.4788.47

Added an update.py and split the default.nix into a browser.nix so that all 3 versions can be built the same way chromium and microsoft-edge are handled.

Added icu as a runtime dependency to get opera-dev working.

I tried to minimise the diff but Git refused to accept that I just renamed default.nix to browser.nix.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [X] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
