### PR TITLE
[staging-22.11] curl: backport 8.1.0 security fixes

### DIFF
--- a/pkgs/tools/networking/curl/CVE-2023-28320.patch
+++ b/pkgs/tools/networking/curl/CVE-2023-28320.patch
@@ -1,0 +1,83 @@
+From bbb74dee738c1b1f655b086f580a58d472496ef6 Mon Sep 17 00:00:00 2001
+From: Harry Sintonen <sintonen@iki.fi>
+Date: Tue, 25 Apr 2023 09:22:26 +0200
+Subject: [PATCH 14/16] hostip: add locks around use of global buffer for
+ alarm()
+
+When building with the sync name resolver and timeout ability we now
+require thread-safety to be present to enable it.
+
+Closes #11030
+---
+ lib/hostip.c | 19 +++++++++++++++----
+ 1 file changed, 15 insertions(+), 4 deletions(-)
+
+diff --git a/lib/hostip.c b/lib/hostip.c
+index 941ecacf4..071c3a9ac 100644
+--- a/lib/hostip.c
++++ b/lib/hostip.c
+@@ -74,12 +74,19 @@
+ #include <SystemConfiguration/SCDynamicStoreCopySpecific.h>
+ #endif
+ 
+-#if defined(CURLRES_SYNCH) && \
+-    defined(HAVE_ALARM) && defined(SIGALRM) && defined(HAVE_SIGSETJMP)
++#if defined(CURLRES_SYNCH) &&                   \
++  defined(HAVE_ALARM) &&                        \
++  defined(SIGALRM) &&                           \
++  defined(HAVE_SIGSETJMP) &&                    \
++  defined(GLOBAL_INIT_IS_THREADSAFE)
+ /* alarm-based timeouts can only be used with all the dependencies satisfied */
+ #define USE_ALARM_TIMEOUT
+ #endif
+ 
++#ifdef USE_ALARM_TIMEOUT
++#include "easy_lock.h"
++#endif
++
+ #define MAX_HOSTCACHE_LEN (255 + 7) /* max FQDN + colon + port number + zero */
+ 
+ /*
+@@ -251,11 +258,12 @@ void Curl_hostcache_prune(struct Curl_easy *data)
+     Curl_share_unlock(data, CURL_LOCK_DATA_DNS);
+ }
+ 
+-#ifdef HAVE_SIGSETJMP
++#ifdef USE_ALARM_TIMEOUT
+ /* Beware this is a global and unique instance. This is used to store the
+    return address that we can jump back to from inside a signal handler. This
+    is not thread-safe stuff. */
+ sigjmp_buf curl_jmpenv;
++curl_simple_lock curl_jmpenv_lock;
+ #endif
+ 
+ /* lookup address, returns entry if found and not stale */
+@@ -822,7 +830,6 @@ enum resolve_t Curl_resolv(struct Curl_easy *data,
+ static
+ void alarmfunc(int sig)
+ {
+-  /* this is for "-ansi -Wall -pedantic" to stop complaining!   (rabe) */
+   (void)sig;
+   siglongjmp(curl_jmpenv, 1);
+ }
+@@ -902,6 +909,8 @@ enum resolve_t Curl_resolv_timeout(struct Curl_easy *data,
+      This should be the last thing we do before calling Curl_resolv(),
+      as otherwise we'd have to worry about variables that get modified
+      before we invoke Curl_resolv() (and thus use "volatile"). */
++  curl_simple_lock_lock(&curl_jmpenv_lock);
++
+   if(sigsetjmp(curl_jmpenv, 1)) {
+     /* this is coming from a siglongjmp() after an alarm signal */
+     failf(data, "name lookup timed out");
+@@ -970,6 +979,8 @@ clean_up:
+ #endif
+ #endif /* HAVE_SIGACTION */
+ 
++  curl_simple_lock_unlock(&curl_jmpenv_lock);
++
+   /* switch back the alarm() to either zero or to what it was before minus
+      the time we spent until now! */
+   if(prev_alarm) {
+-- 
+2.40.1
+

--- a/pkgs/tools/networking/curl/CVE-2023-28321.patch
+++ b/pkgs/tools/networking/curl/CVE-2023-28321.patch
@@ -1,0 +1,295 @@
+From ce423227ddc951251a480b55d55740c9a625b0bf Mon Sep 17 00:00:00 2001
+From: Daniel Stenberg <daniel@haxx.se>
+Date: Mon, 24 Apr 2023 21:07:02 +0200
+Subject: [PATCH 15/16] hostcheck: fix host name wildcard checking
+
+The leftmost "label" of the host name can now only match against single
+'*'. Like the browsers have worked for a long time.
+
+- extended unit test 1397 for this
+- move some SOURCE variables from unit/Makefile.am to unit/Makefile.inc
+
+Reported-by: Hiroki Kurosawa
+Closes #11018
+---
+ lib/vtls/hostcheck.c  |  50 +++++++---------
+ tests/data/test1397   |  10 ++--
+ tests/unit/unit1397.c | 134 ++++++++++++++++++++++++++----------------
+ 3 files changed, 108 insertions(+), 86 deletions(-)
+
+diff --git a/lib/vtls/hostcheck.c b/lib/vtls/hostcheck.c
+index 2a648f20a..fa66e272e 100644
+--- a/lib/vtls/hostcheck.c
++++ b/lib/vtls/hostcheck.c
+@@ -71,7 +71,12 @@ static bool pmatch(const char *hostname, size_t hostlen,
+  * apparent distinction between a name and an IP. We need to detect the use of
+  * an IP address and not wildcard match on such names.
+  *
++ * Only match on "*" being used for the leftmost label, not "a*", "a*b" nor
++ * "*b".
++ *
+  * Return TRUE on a match. FALSE if not.
++ *
++ * @unittest: 1397
+  */
+ 
+ static bool hostmatch(const char *hostname,
+@@ -79,53 +84,42 @@ static bool hostmatch(const char *hostname,
+                       const char *pattern,
+                       size_t patternlen)
+ {
+-  const char *pattern_label_end, *wildcard, *hostname_label_end;
+-  size_t prefixlen, suffixlen;
++  const char *pattern_label_end;
+ 
+-  /* normalize pattern and hostname by stripping off trailing dots */
++  DEBUGASSERT(pattern);
+   DEBUGASSERT(patternlen);
++  DEBUGASSERT(hostname);
++  DEBUGASSERT(hostlen);
++
++  /* normalize pattern and hostname by stripping off trailing dots */
+   if(hostname[hostlen-1]=='.')
+     hostlen--;
+   if(pattern[patternlen-1]=='.')
+     patternlen--;
+ 
+-  wildcard = memchr(pattern, '*', patternlen);
+-  if(!wildcard)
++  if(strncmp(pattern, "*.", 2))
+     return pmatch(hostname, hostlen, pattern, patternlen);
+ 
+   /* detect IP address as hostname and fail the match if so */
+-  if(Curl_host_is_ipnum(hostname))
++  else if(Curl_host_is_ipnum(hostname))
+     return FALSE;
+ 
+   /* We require at least 2 dots in the pattern to avoid too wide wildcard
+      match. */
+   pattern_label_end = memchr(pattern, '.', patternlen);
+   if(!pattern_label_end ||
+-     (memrchr(pattern, '.', patternlen) == pattern_label_end) ||
+-     strncasecompare(pattern, "xn--", 4))
++     (memrchr(pattern, '.', patternlen) == pattern_label_end))
+     return pmatch(hostname, hostlen, pattern, patternlen);
+-
+-  hostname_label_end = memchr(hostname, '.', hostlen);
+-  if(!hostname_label_end)
+-    return FALSE;
+   else {
+-    size_t skiphost = hostname_label_end - hostname;
+-    size_t skiplen = pattern_label_end - pattern;
+-    if(!pmatch(hostname_label_end, hostlen - skiphost,
+-               pattern_label_end, patternlen - skiplen))
+-      return FALSE;
++    const char *hostname_label_end = memchr(hostname, '.', hostlen);
++    if(hostname_label_end) {
++      size_t skiphost = hostname_label_end - hostname;
++      size_t skiplen = pattern_label_end - pattern;
++      return pmatch(hostname_label_end, hostlen - skiphost,
++                    pattern_label_end, patternlen - skiplen);
++    }
+   }
+-  /* The wildcard must match at least one character, so the left-most
+-     label of the hostname is at least as large as the left-most label
+-     of the pattern. */
+-  if(hostname_label_end - hostname < pattern_label_end - pattern)
+-    return FALSE;
+-
+-  prefixlen = wildcard - pattern;
+-  suffixlen = pattern_label_end - (wildcard + 1);
+-  return strncasecompare(pattern, hostname, prefixlen) &&
+-    strncasecompare(wildcard + 1, hostname_label_end - suffixlen,
+-                    suffixlen) ? TRUE : FALSE;
++  return FALSE;
+ }
+ 
+ /*
+diff --git a/tests/data/test1397 b/tests/data/test1397
+index 84f962abe..f31b2c2a3 100644
+--- a/tests/data/test1397
++++ b/tests/data/test1397
+@@ -2,8 +2,7 @@
+ <info>
+ <keywords>
+ unittest
+-ssl
+-wildcard
++Curl_cert_hostcheck
+ </keywords>
+ </info>
+ 
+@@ -16,9 +15,8 @@ none
+ <features>
+ unittest
+ </features>
+- <name>
+-Check wildcard certificate matching function Curl_cert_hostcheck
+- </name>
++<name>
++Curl_cert_hostcheck unit tests
++</name>
+ </client>
+-
+ </testcase>
+diff --git a/tests/unit/unit1397.c b/tests/unit/unit1397.c
+index 90ec31c68..0f27fa3d3 100644
+--- a/tests/unit/unit1397.c
++++ b/tests/unit/unit1397.c
+@@ -23,7 +23,6 @@
+  ***************************************************************************/
+ #include "curlcheck.h"
+ 
+-#include "vtls/hostcheck.h" /* from the lib dir */
+ 
+ static CURLcode unit_setup(void)
+ {
+@@ -32,63 +31,94 @@ static CURLcode unit_setup(void)
+ 
+ static void unit_stop(void)
+ {
+-  /* done before shutting down and exiting */
+ }
+ 
+-UNITTEST_START
+-
+ /* only these backends define the tested functions */
+-#if defined(USE_OPENSSL) || defined(USE_GSKIT)
+-
+-  /* here you start doing things and checking that the results are good */
++#if defined(USE_OPENSSL) || defined(USE_GSKIT) || defined(USE_SCHANNEL)
++#include "vtls/hostcheck.h"
++struct testcase {
++  const char *host;
++  const char *pattern;
++  bool match;
++};
+ 
+-fail_unless(Curl_cert_hostcheck(STRCONST("www.example.com"),
+-                                STRCONST("www.example.com")), "good 1");
+-fail_unless(Curl_cert_hostcheck(STRCONST("*.example.com"),
+-                                STRCONST("www.example.com")),
+-            "good 2");
+-fail_unless(Curl_cert_hostcheck(STRCONST("xxx*.example.com"),
+-                                STRCONST("xxxwww.example.com")), "good 3");
+-fail_unless(Curl_cert_hostcheck(STRCONST("f*.example.com"),
+-                                STRCONST("foo.example.com")), "good 4");
+-fail_unless(Curl_cert_hostcheck(STRCONST("192.168.0.0"),
+-                                STRCONST("192.168.0.0")), "good 5");
++static struct testcase tests[] = {
++  {"", "", FALSE},
++  {"a", "", FALSE},
++  {"", "b", FALSE},
++  {"a", "b", FALSE},
++  {"aa", "bb", FALSE},
++  {"\xff", "\xff", TRUE},
++  {"aa.aa.aa", "aa.aa.bb", FALSE},
++  {"aa.aa.aa", "aa.aa.aa", TRUE},
++  {"aa.aa.aa", "*.aa.bb", FALSE},
++  {"aa.aa.aa", "*.aa.aa", TRUE},
++  {"192.168.0.1", "192.168.0.1", TRUE},
++  {"192.168.0.1", "*.168.0.1", FALSE},
++  {"192.168.0.1", "*.0.1", FALSE},
++  {"h.ello", "*.ello", FALSE},
++  {"h.ello.", "*.ello", FALSE},
++  {"h.ello", "*.ello.", FALSE},
++  {"h.e.llo", "*.e.llo", TRUE},
++  {"h.e.llo", " *.e.llo", FALSE},
++  {" h.e.llo", "*.e.llo", TRUE},
++  {"h.e.llo.", "*.e.llo", TRUE},
++  {"*.e.llo.", "*.e.llo", TRUE},
++  {"************.e.llo.", "*.e.llo", TRUE},
++  {"AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
++   "BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB"
++   "CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC"
++   "DDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDD"
++   "EEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEE"
++   ".e.llo.", "*.e.llo", TRUE},
++  {"\xfe\xfe.e.llo.", "*.e.llo", TRUE},
++  {"h.e.llo.", "*.e.llo.", TRUE},
++  {"h.e.llo", "*.e.llo.", TRUE},
++  {".h.e.llo", "*.e.llo.", FALSE},
++  {"h.e.llo", "*.*.llo.", FALSE},
++  {"h.e.llo", "h.*.llo", FALSE},
++  {"h.e.llo", "h.e.*", FALSE},
++  {"hello", "*.ello", FALSE},
++  {"hello", "**llo", FALSE},
++  {"bar.foo.example.com", "*.example.com", FALSE},
++  {"foo.example.com", "*.example.com", TRUE},
++  {"baz.example.net", "b*z.example.net", FALSE},
++  {"foobaz.example.net", "*baz.example.net", FALSE},
++  {"xn--l8j.example.local", "x*.example.local", FALSE},
++  {"xn--l8j.example.net", "*.example.net", TRUE},
++  {"xn--l8j.example.net", "*j.example.net", FALSE},
++  {"xn--l8j.example.net", "xn--l8j.example.net", TRUE},
++  {"xn--l8j.example.net", "xn--l8j.*.net", FALSE},
++  {"xl8j.example.net", "*.example.net", TRUE},
++  {"fe80::3285:a9ff:fe46:b619", "*::3285:a9ff:fe46:b619", FALSE},
++  {"fe80::3285:a9ff:fe46:b619", "fe80::3285:a9ff:fe46:b619", TRUE},
++  {NULL, NULL, FALSE}
++};
+ 
+-fail_if(Curl_cert_hostcheck(STRCONST("xxx.example.com"),
+-                            STRCONST("www.example.com")), "bad 1");
+-fail_if(Curl_cert_hostcheck(STRCONST("*"),
+-                            STRCONST("www.example.com")),"bad 2");
+-fail_if(Curl_cert_hostcheck(STRCONST("*.*.com"),
+-                            STRCONST("www.example.com")), "bad 3");
+-fail_if(Curl_cert_hostcheck(STRCONST("*.example.com"),
+-                            STRCONST("baa.foo.example.com")), "bad 4");
+-fail_if(Curl_cert_hostcheck(STRCONST("f*.example.com"),
+-                            STRCONST("baa.example.com")), "bad 5");
+-fail_if(Curl_cert_hostcheck(STRCONST("*.com"),
+-                            STRCONST("example.com")), "bad 6");
+-fail_if(Curl_cert_hostcheck(STRCONST("*fail.com"),
+-                            STRCONST("example.com")), "bad 7");
+-fail_if(Curl_cert_hostcheck(STRCONST("*.example."),
+-                            STRCONST("www.example.")), "bad 8");
+-fail_if(Curl_cert_hostcheck(STRCONST("*.example."),
+-                            STRCONST("www.example")), "bad 9");
+-fail_if(Curl_cert_hostcheck(STRCONST(""), STRCONST("www")), "bad 10");
+-fail_if(Curl_cert_hostcheck(STRCONST("*"), STRCONST("www")), "bad 11");
+-fail_if(Curl_cert_hostcheck(STRCONST("*.168.0.0"),
+-                            STRCONST("192.168.0.0")), "bad 12");
+-fail_if(Curl_cert_hostcheck(STRCONST("www.example.com"),
+-                            STRCONST("192.168.0.0")), "bad 13");
+-
+-#ifdef ENABLE_IPV6
+-fail_if(Curl_cert_hostcheck(STRCONST("*::3285:a9ff:fe46:b619"),
+-                            STRCONST("fe80::3285:a9ff:fe46:b619")), "bad 14");
+-fail_unless(Curl_cert_hostcheck(STRCONST("fe80::3285:a9ff:fe46:b619"),
+-                                STRCONST("fe80::3285:a9ff:fe46:b619")),
+-            "good 6");
+-#endif
++UNITTEST_START
++{
++  int i;
++  for(i = 0; tests[i].host; i++) {
++    if(tests[i].match != Curl_cert_hostcheck(tests[i].pattern,
++                                             strlen(tests[i].pattern),
++                                             tests[i].host,
++                                             strlen(tests[i].host))) {
++      fprintf(stderr,
++              "HOST: %s\n"
++              "PTRN: %s\n"
++              "did %sMATCH\n",
++              tests[i].host,
++              tests[i].pattern,
++              tests[i].match ? "NOT ": "");
++      unitfail++;
++    }
++  }
++}
+ 
+-#endif
++UNITTEST_STOP
++#else
+ 
+-  /* you end the test code like this: */
++UNITTEST_START
+ 
+ UNITTEST_STOP
++#endif
+-- 
+2.40.1
+

--- a/pkgs/tools/networking/curl/CVE-2023-28322.patch
+++ b/pkgs/tools/networking/curl/CVE-2023-28322.patch
@@ -1,0 +1,440 @@
+From d71e01c1599a9519d52a4ffaf1ed0f444624d459 Mon Sep 17 00:00:00 2001
+From: Daniel Stenberg <daniel@haxx.se>
+Date: Tue, 25 Apr 2023 08:28:01 +0200
+Subject: [PATCH 16/16] lib: unify the upload/method handling
+
+By making sure we set state.upload based on the set.method value and not
+independently as set.upload, we reduce confusion and mixup risks, both
+internally and externally.
+
+Closes #11017
+---
+ lib/curl_rtmp.c    | 4 ++--
+ lib/file.c         | 4 ++--
+ lib/ftp.c          | 8 ++++----
+ lib/http.c         | 4 ++--
+ lib/imap.c         | 6 +++---
+ lib/rtsp.c         | 4 ++--
+ lib/setopt.c       | 6 ++----
+ lib/smb.c          | 9 +++++++--
+ lib/smtp.c         | 4 ++--
+ lib/tftp.c         | 8 ++++----
+ lib/transfer.c     | 4 ++--
+ lib/urldata.h      | 5 ++++-
+ lib/vssh/libssh.c  | 6 +++---
+ lib/vssh/libssh2.c | 6 +++---
+ lib/vssh/wolfssh.c | 2 +-
+ 15 files changed, 43 insertions(+), 37 deletions(-)
+
+diff --git a/lib/curl_rtmp.c b/lib/curl_rtmp.c
+index b0c371041..47333d187 100644
+--- a/lib/curl_rtmp.c
++++ b/lib/curl_rtmp.c
+@@ -231,7 +231,7 @@ static CURLcode rtmp_connect(struct Curl_easy *data, bool *done)
+   /* We have to know if it's a write before we send the
+    * connect request packet
+    */
+-  if(data->set.upload)
++  if(data->state.upload)
+     r->Link.protocol |= RTMP_FEATURE_WRITE;
+ 
+   /* For plain streams, use the buffer toggle trick to keep data flowing */
+@@ -263,7 +263,7 @@ static CURLcode rtmp_do(struct Curl_easy *data, bool *done)
+   if(!RTMP_ConnectStream(r, 0))
+     return CURLE_FAILED_INIT;
+ 
+-  if(data->set.upload) {
++  if(data->state.upload) {
+     Curl_pgrsSetUploadSize(data, data->state.infilesize);
+     Curl_setup_transfer(data, -1, -1, FALSE, FIRSTSOCKET);
+   }
+diff --git a/lib/file.c b/lib/file.c
+index d82d57b46..6a68385a6 100644
+--- a/lib/file.c
++++ b/lib/file.c
+@@ -229,7 +229,7 @@ static CURLcode file_connect(struct Curl_easy *data, bool *done)
+   file->freepath = real_path; /* free this when done */
+ 
+   file->fd = fd;
+-  if(!data->set.upload && (fd == -1)) {
++  if(!data->state.upload && (fd == -1)) {
+     failf(data, "Couldn't open file %s", data->state.up.path);
+     file_done(data, CURLE_FILE_COULDNT_READ_FILE, FALSE);
+     return CURLE_FILE_COULDNT_READ_FILE;
+@@ -411,7 +411,7 @@ static CURLcode file_do(struct Curl_easy *data, bool *done)
+ 
+   Curl_pgrsStartNow(data);
+ 
+-  if(data->set.upload)
++  if(data->state.upload)
+     return file_upload(data);
+ 
+   file = data->req.p.file;
+diff --git a/lib/ftp.c b/lib/ftp.c
+index 9e8ccd54d..d27951347 100644
+--- a/lib/ftp.c
++++ b/lib/ftp.c
+@@ -1380,7 +1380,7 @@ static CURLcode ftp_state_prepare_transfer(struct Curl_easy *data)
+                                data->set.str[STRING_CUSTOMREQUEST]?
+                                data->set.str[STRING_CUSTOMREQUEST]:
+                                (data->state.list_only?"NLST":"LIST"));
+-      else if(data->set.upload)
++      else if(data->state.upload)
+         result = Curl_pp_sendf(data, &ftpc->pp, "PRET STOR %s",
+                                conn->proto.ftpc.file);
+       else
+@@ -3379,7 +3379,7 @@ static CURLcode ftp_done(struct Curl_easy *data, CURLcode status,
+     /* the response code from the transfer showed an error already so no
+        use checking further */
+     ;
+-  else if(data->set.upload) {
++  else if(data->state.upload) {
+     if((-1 != data->state.infilesize) &&
+        (data->state.infilesize != data->req.writebytecount) &&
+        !data->set.crlf &&
+@@ -3656,7 +3656,7 @@ static CURLcode ftp_do_more(struct Curl_easy *data, int *completep)
+                            connected back to us */
+       }
+     }
+-    else if(data->set.upload) {
++    else if(data->state.upload) {
+       result = ftp_nb_type(data, conn, data->state.prefer_ascii,
+                            FTP_STOR_TYPE);
+       if(result)
+@@ -4245,7 +4245,7 @@ CURLcode ftp_parse_url_path(struct Curl_easy *data)
+     ftpc->file = NULL; /* instead of point to a zero byte,
+                             we make it a NULL pointer */
+ 
+-  if(data->set.upload && !ftpc->file && (ftp->transfer == PPTRANSFER_BODY)) {
++  if(data->state.upload && !ftpc->file && (ftp->transfer == PPTRANSFER_BODY)) {
+     /* We need a file name when uploading. Return error! */
+     failf(data, "Uploading to a URL without a file name");
+     free(rawPath);
+diff --git a/lib/http.c b/lib/http.c
+index 45bb25a2f..5e328edeb 100644
+--- a/lib/http.c
++++ b/lib/http.c
+@@ -2089,7 +2089,7 @@ void Curl_http_method(struct Curl_easy *data, struct connectdata *conn,
+   Curl_HttpReq httpreq = (Curl_HttpReq)data->state.httpreq;
+   const char *request;
+   if((conn->handler->protocol&(PROTO_FAMILY_HTTP|CURLPROTO_FTP)) &&
+-     data->set.upload)
++     data->state.upload)
+     httpreq = HTTPREQ_PUT;
+ 
+   /* Now set the 'request' pointer to the proper request string */
+@@ -2406,7 +2406,7 @@ CURLcode Curl_http_body(struct Curl_easy *data, struct connectdata *conn,
+     if((conn->handler->protocol & PROTO_FAMILY_HTTP) &&
+        (((httpreq == HTTPREQ_POST_MIME || httpreq == HTTPREQ_POST_FORM) &&
+          http->postsize < 0) ||
+-        ((data->set.upload || httpreq == HTTPREQ_POST) &&
++        ((data->state.upload || httpreq == HTTPREQ_POST) &&
+          data->state.infilesize == -1))) {
+       if(conn->bits.authneg)
+         /* don't enable chunked during auth neg */
+diff --git a/lib/imap.c b/lib/imap.c
+index ffa08bf7a..15f16009c 100644
+--- a/lib/imap.c
++++ b/lib/imap.c
+@@ -1507,11 +1507,11 @@ static CURLcode imap_done(struct Curl_easy *data, CURLcode status,
+     result = status;         /* use the already set error code */
+   }
+   else if(!data->set.connect_only && !imap->custom &&
+-          (imap->uid || imap->mindex || data->set.upload ||
++          (imap->uid || imap->mindex || data->state.upload ||
+           data->set.mimepost.kind != MIMEKIND_NONE)) {
+     /* Handle responses after FETCH or APPEND transfer has finished */
+ 
+-    if(!data->set.upload && data->set.mimepost.kind == MIMEKIND_NONE)
++    if(!data->state.upload && data->set.mimepost.kind == MIMEKIND_NONE)
+       state(data, IMAP_FETCH_FINAL);
+     else {
+       /* End the APPEND command first by sending an empty line */
+@@ -1577,7 +1577,7 @@ static CURLcode imap_perform(struct Curl_easy *data, bool *connected,
+     selected = TRUE;
+ 
+   /* Start the first command in the DO phase */
+-  if(data->set.upload || data->set.mimepost.kind != MIMEKIND_NONE)
++  if(data->state.upload || data->set.mimepost.kind != MIMEKIND_NONE)
+     /* APPEND can be executed directly */
+     result = imap_perform_append(data);
+   else if(imap->custom && (selected || !imap->mailbox))
+diff --git a/lib/rtsp.c b/lib/rtsp.c
+index 6d3bf97e6..ba3096c42 100644
+--- a/lib/rtsp.c
++++ b/lib/rtsp.c
+@@ -511,7 +511,7 @@ static CURLcode rtsp_do(struct Curl_easy *data, bool *done)
+      rtspreq == RTSPREQ_SET_PARAMETER ||
+      rtspreq == RTSPREQ_GET_PARAMETER) {
+ 
+-    if(data->set.upload) {
++    if(data->state.upload) {
+       putsize = data->state.infilesize;
+       data->state.httpreq = HTTPREQ_PUT;
+ 
+@@ -530,7 +530,7 @@ static CURLcode rtsp_do(struct Curl_easy *data, bool *done)
+         result =
+           Curl_dyn_addf(&req_buffer,
+                         "Content-Length: %" CURL_FORMAT_CURL_OFF_T"\r\n",
+-                        (data->set.upload ? putsize : postsize));
++                        (data->state.upload ? putsize : postsize));
+         if(result)
+           return result;
+       }
+diff --git a/lib/setopt.c b/lib/setopt.c
+index dd80b7017..d87ee1776 100644
+--- a/lib/setopt.c
++++ b/lib/setopt.c
+@@ -320,8 +320,8 @@ CURLcode Curl_vsetopt(struct Curl_easy *data, CURLoption option, va_list param)
+      * We want to sent data to the remote host. If this is HTTP, that equals
+      * using the PUT request.
+      */
+-    data->set.upload = (0 != va_arg(param, long)) ? TRUE : FALSE;
+-    if(data->set.upload) {
++    arg = va_arg(param, long);
++    if(arg) {
+       /* If this is HTTP, PUT is what's needed to "upload" */
+       data->set.method = HTTPREQ_PUT;
+       data->set.opt_no_body = FALSE; /* this is implied */
+@@ -651,7 +651,6 @@ CURLcode Curl_vsetopt(struct Curl_easy *data, CURLoption option, va_list param)
+     }
+     else
+       data->set.method = HTTPREQ_GET;
+-    data->set.upload = FALSE;
+     break;
+ 
+ #ifndef CURL_DISABLE_MIME
+@@ -882,7 +881,6 @@ CURLcode Curl_vsetopt(struct Curl_easy *data, CURLoption option, va_list param)
+      */
+     if(va_arg(param, long)) {
+       data->set.method = HTTPREQ_GET;
+-      data->set.upload = FALSE; /* switch off upload */
+       data->set.opt_no_body = FALSE; /* this is implied */
+     }
+     break;
+diff --git a/lib/smb.c b/lib/smb.c
+index dbab485c5..85d415edb 100644
+--- a/lib/smb.c
++++ b/lib/smb.c
+@@ -535,7 +535,7 @@ static CURLcode smb_send_open(struct Curl_easy *data)
+   byte_count = strlen(req->path);
+   msg.name_length = smb_swap16((unsigned short)byte_count);
+   msg.share_access = smb_swap32(SMB_FILE_SHARE_ALL);
+-  if(data->set.upload) {
++  if(data->state.upload) {
+     msg.access = smb_swap32(SMB_GENERIC_READ | SMB_GENERIC_WRITE);
+     msg.create_disposition = smb_swap32(SMB_FILE_OVERWRITE_IF);
+   }
+@@ -768,6 +768,11 @@ static CURLcode smb_request_state(struct Curl_easy *data, bool *done)
+   void *msg = NULL;
+   const struct smb_nt_create_response *smb_m;
+ 
++  if(data->state.upload && (data->state.infilesize < 0)) {
++    failf(data, "SMB upload needs to know the size up front");
++    return CURLE_SEND_ERROR;
++  }
++
+   /* Start the request */
+   if(req->state == SMB_REQUESTING) {
+     result = smb_send_tree_connect(data);
+@@ -814,7 +819,7 @@ static CURLcode smb_request_state(struct Curl_easy *data, bool *done)
+     smb_m = (const struct smb_nt_create_response*) msg;
+     req->fid = smb_swap16(smb_m->fid);
+     data->req.offset = 0;
+-    if(data->set.upload) {
++    if(data->state.upload) {
+       data->req.size = data->state.infilesize;
+       Curl_pgrsSetUploadSize(data, data->req.size);
+       next_state = SMB_UPLOAD;
+diff --git a/lib/smtp.c b/lib/smtp.c
+index 6ebb41af6..fa70cefff 100644
+--- a/lib/smtp.c
++++ b/lib/smtp.c
+@@ -1413,7 +1413,7 @@ static CURLcode smtp_done(struct Curl_easy *data, CURLcode status,
+     result = status;         /* use the already set error code */
+   }
+   else if(!data->set.connect_only && data->set.mail_rcpt &&
+-          (data->set.upload || data->set.mimepost.kind)) {
++          (data->state.upload || data->set.mimepost.kind)) {
+     /* Calculate the EOB taking into account any terminating CRLF from the
+        previous line of the email or the CRLF of the DATA command when there
+        is "no mail data". RFC-5321, sect. 4.1.1.4.
+@@ -1506,7 +1506,7 @@ static CURLcode smtp_perform(struct Curl_easy *data, bool *connected,
+   smtp->eob = 2;
+ 
+   /* Start the first command in the DO phase */
+-  if((data->set.upload || data->set.mimepost.kind) && data->set.mail_rcpt)
++  if((data->state.upload || data->set.mimepost.kind) && data->set.mail_rcpt)
+     /* MAIL transfer */
+     result = smtp_perform_mail(data);
+   else
+diff --git a/lib/tftp.c b/lib/tftp.c
+index 9e6d9490e..8faec9fe6 100644
+--- a/lib/tftp.c
++++ b/lib/tftp.c
+@@ -369,7 +369,7 @@ static CURLcode tftp_parse_option_ack(struct tftp_state_data *state,
+ 
+       /* tsize should be ignored on upload: Who cares about the size of the
+          remote file? */
+-      if(!data->set.upload) {
++      if(!data->state.upload) {
+         if(!tsize) {
+           failf(data, "invalid tsize -:%s:- value in OACK packet", value);
+           return CURLE_TFTP_ILLEGAL;
+@@ -450,7 +450,7 @@ static CURLcode tftp_send_first(struct tftp_state_data *state,
+       return result;
+     }
+ 
+-    if(data->set.upload) {
++    if(data->state.upload) {
+       /* If we are uploading, send an WRQ */
+       setpacketevent(&state->spacket, TFTP_EVENT_WRQ);
+       state->data->req.upload_fromhere =
+@@ -485,7 +485,7 @@ static CURLcode tftp_send_first(struct tftp_state_data *state,
+     if(!data->set.tftp_no_options) {
+       char buf[64];
+       /* add tsize option */
+-      if(data->set.upload && (data->state.infilesize != -1))
++      if(data->state.upload && (data->state.infilesize != -1))
+         msnprintf(buf, sizeof(buf), "%" CURL_FORMAT_CURL_OFF_T,
+                   data->state.infilesize);
+       else
+@@ -539,7 +539,7 @@ static CURLcode tftp_send_first(struct tftp_state_data *state,
+     break;
+ 
+   case TFTP_EVENT_OACK:
+-    if(data->set.upload) {
++    if(data->state.upload) {
+       result = tftp_connect_for_tx(state, event);
+     }
+     else {
+diff --git a/lib/transfer.c b/lib/transfer.c
+index 4ab72f45a..56ce51188 100644
+--- a/lib/transfer.c
++++ b/lib/transfer.c
+@@ -1392,6 +1392,7 @@ void Curl_init_CONNECT(struct Curl_easy *data)
+ {
+   data->state.fread_func = data->set.fread_func_set;
+   data->state.in = data->set.in_set;
++  data->state.upload = (data->state.httpreq == HTTPREQ_PUT);
+ }
+ 
+ /*
+@@ -1824,7 +1825,6 @@ CURLcode Curl_follow(struct Curl_easy *data,
+          data->state.httpreq != HTTPREQ_POST_MIME) ||
+         !(data->set.keep_post & CURL_REDIR_POST_303))) {
+       data->state.httpreq = HTTPREQ_GET;
+-      data->set.upload = false;
+       infof(data, "Switch to %s",
+             data->set.opt_no_body?"HEAD":"GET");
+     }
+@@ -1862,7 +1862,7 @@ CURLcode Curl_retry_request(struct Curl_easy *data, char **url)
+ 
+   /* if we're talking upload, we can't do the checks below, unless the protocol
+      is HTTP as when uploading over HTTP we will still get a response */
+-  if(data->set.upload &&
++  if(data->state.upload &&
+      !(conn->handler->protocol&(PROTO_FAMILY_HTTP|CURLPROTO_RTSP)))
+     return CURLE_OK;
+ 
+diff --git a/lib/urldata.h b/lib/urldata.h
+index aaae3d8d8..85d6d8e39 100644
+--- a/lib/urldata.h
++++ b/lib/urldata.h
+@@ -1522,6 +1522,10 @@ struct UrlState {
+   BIT(url_alloc);   /* URL string is malloc()'ed */
+   BIT(referer_alloc); /* referer string is malloc()ed */
+   BIT(wildcard_resolve); /* Set to true if any resolve change is a wildcard */
++  BIT(rewindbeforesend);/* TRUE when the sending couldn't be stopped even
++                           though it will be discarded. We must call the data
++                           rewind callback before trying to send again. */
++  BIT(upload);         /* upload request */
+ };
+ 
+ /*
+@@ -1886,7 +1890,6 @@ struct UserDefined {
+   BIT(http_auto_referer); /* set "correct" referer when following
+                              location: */
+   BIT(opt_no_body);    /* as set with CURLOPT_NOBODY */
+-  BIT(upload);         /* upload request */
+   BIT(verbose);        /* output verbosity */
+   BIT(krb);            /* Kerberos connection requested */
+   BIT(reuse_forbid);   /* forbidden to be reused, close after use */
+diff --git a/lib/vssh/libssh.c b/lib/vssh/libssh.c
+index 0105e4079..004f1d1a4 100644
+--- a/lib/vssh/libssh.c
++++ b/lib/vssh/libssh.c
+@@ -1214,7 +1214,7 @@ static CURLcode myssh_statemach_act(struct Curl_easy *data, bool *block)
+     }
+ 
+     case SSH_SFTP_TRANS_INIT:
+-      if(data->set.upload)
++      if(data->state.upload)
+         state(data, SSH_SFTP_UPLOAD_INIT);
+       else {
+         if(protop->path[strlen(protop->path)-1] == '/')
+@@ -1827,7 +1827,7 @@ static CURLcode myssh_statemach_act(struct Curl_easy *data, bool *block)
+       /* Functions from the SCP subsystem cannot handle/return SSH_AGAIN */
+       ssh_set_blocking(sshc->ssh_session, 1);
+ 
+-      if(data->set.upload) {
++      if(data->state.upload) {
+         if(data->state.infilesize < 0) {
+           failf(data, "SCP requires a known file size for upload");
+           sshc->actualcode = CURLE_UPLOAD_FAILED;
+@@ -1932,7 +1932,7 @@ static CURLcode myssh_statemach_act(struct Curl_easy *data, bool *block)
+         break;
+       }
+     case SSH_SCP_DONE:
+-      if(data->set.upload)
++      if(data->state.upload)
+         state(data, SSH_SCP_SEND_EOF);
+       else
+         state(data, SSH_SCP_CHANNEL_FREE);
+diff --git a/lib/vssh/libssh2.c b/lib/vssh/libssh2.c
+index 5a2c0f8bb..5747dd79f 100644
+--- a/lib/vssh/libssh2.c
++++ b/lib/vssh/libssh2.c
+@@ -2004,7 +2004,7 @@ static CURLcode ssh_statemach_act(struct Curl_easy *data, bool *block)
+     }
+ 
+     case SSH_SFTP_TRANS_INIT:
+-      if(data->set.upload)
++      if(data->state.upload)
+         state(data, SSH_SFTP_UPLOAD_INIT);
+       else {
+         if(sshp->path[strlen(sshp->path)-1] == '/')
+@@ -2677,7 +2677,7 @@ static CURLcode ssh_statemach_act(struct Curl_easy *data, bool *block)
+         break;
+       }
+ 
+-      if(data->set.upload) {
++      if(data->state.upload) {
+         if(data->state.infilesize < 0) {
+           failf(data, "SCP requires a known file size for upload");
+           sshc->actualcode = CURLE_UPLOAD_FAILED;
+@@ -2817,7 +2817,7 @@ static CURLcode ssh_statemach_act(struct Curl_easy *data, bool *block)
+     break;
+ 
+     case SSH_SCP_DONE:
+-      if(data->set.upload)
++      if(data->state.upload)
+         state(data, SSH_SCP_SEND_EOF);
+       else
+         state(data, SSH_SCP_CHANNEL_FREE);
+diff --git a/lib/vssh/wolfssh.c b/lib/vssh/wolfssh.c
+index c2f85f3fe..36ccb1bf9 100644
+--- a/lib/vssh/wolfssh.c
++++ b/lib/vssh/wolfssh.c
+@@ -556,7 +556,7 @@ static CURLcode wssh_statemach_act(struct Curl_easy *data, bool *block)
+       }
+       break;
+     case SSH_SFTP_TRANS_INIT:
+-      if(data->set.upload)
++      if(data->state.upload)
+         state(data, SSH_SFTP_UPLOAD_INIT);
+       else {
+         if(sftp_scp->path[strlen(sftp_scp->path)-1] == '/')
+-- 
+2.40.1
+

--- a/pkgs/tools/networking/curl/default.nix
+++ b/pkgs/tools/networking/curl/default.nix
@@ -73,6 +73,10 @@ stdenv.mkDerivation (finalAttrs: {
     ./CVE-2023-27536.patch
     ./CVE-2023-27537.patch
     ./CVE-2023-27538.patch
+    # curl 8.1.0 fixes
+    ./CVE-2023-28320.patch
+    ./CVE-2023-28321.patch
+    ./CVE-2023-28322.patch    
   ];
 
   outputs = [ "bin" "dev" "out" "man" "devdoc" ];


### PR DESCRIPTION
https://curl.se/docs/CVE-2023-28320.html
https://curl.se/docs/CVE-2023-28321.html
https://curl.se/docs/CVE-2023-28322.html

Fixes: CVE-2023-28320, CVE-2023-28321, CVE-2023-28322

Related: #232531 

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
