### PR TITLE
python3Packages.hikari: init at 2.0.0.dev124

### DIFF
--- a/pkgs/development/python-modules/hikari/default.nix
+++ b/pkgs/development/python-modules/hikari/default.nix
@@ -1,0 +1,80 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, pytestCheckHook
+, pythonOlder
+, pythonRelaxDepsHook
+, pytest-runner
+, aiohttp
+, attrs
+, multidict
+, colorlog
+, pynacl
+, pytest-cov
+, pytest-randomly
+, pytest-asyncio
+, mock
+}:
+buildPythonPackage rec {
+  pname = "hikari";
+  version = "2.0.0.dev124";
+
+  src = fetchFromGitHub {
+    owner = "hikari-py";
+    repo = "hikari";
+    rev = version;
+    hash = "sha256-zDgU3Ol/I3YNnwXm+aBh20KwonW746p5TObuwuWORog=";
+    # The git commit is part of the `hikari.__git_sha1__` original output;
+    # leave that output the same in nixpkgs. Use the `.git` directory
+    # to retrieve the commit SHA, and remove the directory afterwards,
+    # since it is not needed after that.
+    leaveDotGit = true;
+    postFetch = ''
+      cd "$out"
+      git rev-parse HEAD > $out/COMMIT
+      find "$out" -name .git -print0 | xargs -0 rm -rf
+    '';
+  };
+
+  nativeBuildInputs = [
+    pythonRelaxDepsHook
+  ];
+
+  propagatedBuildInputs = [
+    aiohttp
+    attrs
+    multidict
+    colorlog
+  ];
+
+  pythonRelaxDeps = true;
+
+  passthru.optional-dependencies = {
+    server = [ pynacl ];
+  };
+
+  nativeCheckInputs = [
+    pytestCheckHook
+    pytest-runner
+    pytest-asyncio
+    pytest-cov
+    pytest-randomly
+    mock
+  ];
+
+  pythonImportChecks = [ "hikari" ];
+
+  disabled = pythonOlder "3.7";
+
+  postPatch = ''
+    substituteInPlace hikari/_about.py --replace "__git_sha1__: typing.Final[str] = \"HEAD\"" "__git_sha1__: typing.Final[str] = \"$(cat $src/COMMIT)\""
+  '';
+
+  meta = with lib; {
+    description = "Discord API wrapper for Python written with asyncio";
+    homepage = "https://www.hikari-py.dev/";
+    changelog = "https://github.com/hikari-py/hikari/releases/tag/${version}";
+    license = licenses.mit;
+    maintainers = with maintainers; [ tomodachi94 ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5297,6 +5297,8 @@ self: super: with self; {
 
   hijri-converter = callPackage ../development/python-modules/hijri-converter { };
 
+  hikari = callPackage ../development/python-modules/hikari { };
+
   hikvision = callPackage ../development/python-modules/hikvision { };
 
   hiredis = callPackage ../development/python-modules/hiredis { };


### PR DESCRIPTION
###### Description of changes
Add new package.

[Hikari](https://hikari-py.dev) is an asynchronous Discord API wrapper for Python.

I'm adding this library so I can package other libraries that depend on this package, such as `hikari-lightbulb`/`tanjun`/`crescent`.
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
