### PR TITLE
libremidi: init at unstable-2023-05-05

### DIFF
--- a/pkgs/development/libraries/libremidi/default.nix
+++ b/pkgs/development/libraries/libremidi/default.nix
@@ -1,0 +1,44 @@
+{ alsa-lib
+, cmake
+, CoreAudio
+, CoreFoundation
+, CoreMIDI
+, CoreServices
+, fetchFromGitHub
+, lib
+, stdenv
+}:
+
+stdenv.mkDerivation {
+  pname = "libremidi";
+  version = "unstable-2023-05-05";
+
+  src = fetchFromGitHub {
+    owner = "jcelerier";
+    repo = "libremidi";
+    rev = "cd2e52d59c8ecc97d751619072c4f4271fa82455";
+    hash = "sha256-CydoCprxqDl5FXjtgT+AckaRTqQAlCDwwrnPDK17A6o=";
+  };
+
+  nativeBuildInputs = [ cmake ];
+
+  buildInputs = lib.optional stdenv.isLinux alsa-lib
+    ++ lib.optionals stdenv.isDarwin [
+    CoreAudio
+    CoreFoundation
+    CoreMIDI
+    CoreServices
+  ];
+
+  postInstall = ''
+    cp -r $src/include $out
+  '';
+
+  meta = {
+    description = "A modern C++ MIDI real-time & file I/O library";
+    homepage = "https://github.com/jcelerier/libremidi";
+    maintainers = [ lib.maintainers.paveloom ];
+    license = lib.licenses.bsd2;
+    platforms = lib.platforms.all;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -22000,6 +22000,14 @@ with pkgs;
 
   librem = callPackage ../development/libraries/librem { };
 
+  libremidi = callPackage ../development/libraries/libremidi {
+      inherit (darwin.apple_sdk.frameworks)
+        CoreAudio
+        CoreFoundation
+        CoreMIDI
+        CoreServices;
+  };
+
   librelp = callPackage ../development/libraries/librelp { };
 
   librepo = callPackage ../tools/package-management/librepo {


### PR DESCRIPTION
###### Description of changes

https://github.com/jcelerier/libremidi

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
