### PR TITLE
[22.11] libreswan: add patch for CVE-2023-30570

### DIFF
--- a/pkgs/tools/networking/libreswan/default.nix
+++ b/pkgs/tools/networking/libreswan/default.nix
@@ -59,6 +59,11 @@ stdenv.mkDerivation rec {
       url = "https://libreswan.org/security/CVE-2023-23009/CVE-2023-23009-libreswan-4.4-4.9.patch";
       sha256 = "sha256-HJyp7y7ROfMVg5/e/JyOHlXTyVkw0dAVmNHwTAqlFmQ=";
     })
+    (fetchpatch {
+      name = "CVE-2023-30570.patch";
+      url = "https://libreswan.org/security/CVE-2023-30570/CVE-2023-30570-libreswan-4.x.patch";
+      sha256 = "sha256-/GeD1REob9cNwAJm7twxC4hhfT+nXq5m3lG82Ztl/5w=";
+    })
   ];
 
   strictDeps = true;


### PR DESCRIPTION
###### Description of changes

Fix for [CVE-2023-30570](https://libreswan.org/security/CVE-2023-30570/CVE-2023-30570.txt).

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested via `libreswan.tests`
- [x] Tested compilation of all packages that depend on this change
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
