### PR TITLE
python310Packages.pysam: 0.20.0 -> 0.21.0

### DIFF
--- a/pkgs/development/python-modules/pysam/default.nix
+++ b/pkgs/development/python-modules/pysam/default.nix
@@ -8,14 +8,14 @@
 , htslib
 , libdeflate
 , xz
-, pytest
+, pytestCheckHook
 , samtools
 , zlib
 }:
 
 buildPythonPackage rec {
   pname   = "pysam";
-  version = "0.20.0";
+  version = "0.21.0";
 
   # Fetching from GitHub instead of PyPi cause the 0.13 src release on PyPi is
   # missing some files which cause test failures.
@@ -24,18 +24,20 @@ buildPythonPackage rec {
     owner = "pysam-developers";
     repo = "pysam";
     rev = "refs/tags/v${version}";
-    hash = "sha256-7yEZJ+iIw4qOxsanlKQlqt1bfi8MvyYjGJWiVDmXBrc=";
+    hash = "sha256-C4/AJwcUyLoUEUEnsATLHJb5F8mltP8X2XfktYu0OTo=";
   };
 
   nativeBuildInputs = [ samtools ];
+
   buildInputs = [
     bzip2
     curl
-    cython
     libdeflate
     xz
     zlib
   ];
+
+  propagatedBuildInputs = [ cython ];
 
   # Use nixpkgs' htslib instead of the bundled one
   # See https://pysam.readthedocs.io/en/latest/installation.html#external
@@ -47,53 +49,17 @@ buildPythonPackage rec {
   '';
 
   nativeCheckInputs = [
-    pytest
+    pytestCheckHook
     bcftools
     htslib
   ];
 
-  # See https://github.com/NixOS/nixpkgs/pull/100823 for why we aren't using
-  # disabledTests and pytestFlagsArray through pytestCheckHook
-  checkPhase = ''
-    # Needed to avoid /homeless-shelter error
-    export HOME=$(mktemp -d)
-
-    # To avoid API incompatibilities, these should ideally show the same version
-    echo "> samtools --version"
-    samtools --version
-    echo "> htsfile --version"
-    htsfile --version
-    echo "> bcftools --version"
-    bcftools --version
-
-    # Create auxiliary test data
+  preCheck = ''
+    export HOME=$TMPDIR
     make -C tests/pysam_data
     make -C tests/cbcf_data
-
-    # Delete pysam folder in current directory to avoid importing it during testing
+    make -C tests/tabix_data
     rm -rf pysam
-
-    # Deselect tests that are known to fail due to upstream issues
-    # See https://github.com/pysam-developers/pysam/issues/961
-    py.test \
-      --deselect tests/AlignmentFileHeader_test.py::TestHeaderBAM::test_dictionary_access_works \
-      --deselect tests/AlignmentFileHeader_test.py::TestHeaderBAM::test_header_content_is_as_expected \
-      --deselect tests/AlignmentFileHeader_test.py::TestHeaderCRAM::test_dictionary_access_works \
-      --deselect tests/AlignmentFileHeader_test.py::TestHeaderCRAM::test_header_content_is_as_expected \
-      --deselect tests/AlignmentFile_test.py::TestDeNovoConstruction::testBAMWholeFile \
-      --deselect tests/AlignmentFile_test.py::TestEmptyHeader::testEmptyHeader \
-      --deselect tests/AlignmentFile_test.py::TestHeaderWithProgramOptions::testHeader \
-      --deselect tests/AlignmentFile_test.py::TestIO::testBAM2BAM \
-      --deselect tests/AlignmentFile_test.py::TestIO::testBAM2CRAM \
-      --deselect tests/AlignmentFile_test.py::TestIO::testBAM2SAM \
-      --deselect tests/AlignmentFile_test.py::TestIO::testFetchFromClosedFileObject \
-      --deselect tests/AlignmentFile_test.py::TestIO::testOpenFromFilename \
-      --deselect tests/AlignmentFile_test.py::TestIO::testSAM2BAM \
-      --deselect tests/AlignmentFile_test.py::TestIO::testWriteUncompressedBAMFile \
-      --deselect tests/AlignmentFile_test.py::TestIteratorRowAllBAM::testIterate \
-      --deselect tests/StreamFiledescriptors_test.py::StreamTest::test_text_processing \
-      --deselect tests/compile_test.py::BAMTest::testCount \
-      tests/
   '';
 
   pythonImportsCheck = [


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
Bumped version and changed the test suite to use pytestCheckHook. Also enabled previously disabled tests.

Separated out commit from https://github.com/NixOS/nixpkgs/pull/231118 as requested.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [X] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [X] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
