### PR TITLE
kicad-unstable: 2023-04-14 -> 2023-06-24

### DIFF
--- a/pkgs/applications/science/electronics/kicad/versions.nix
+++ b/pkgs/applications/science/electronics/kicad/versions.nix
@@ -25,23 +25,23 @@
   };
   "kicad-unstable" = {
     kicadVersion = {
-      version =			"2023-04-14";
+      version =			"2023-06-24";
       src = {
-        rev =			"4a3f77cd9dac9dc5921eb9beaa63d0d3c9c051e5";
-        sha256 =		"06dsiyvr7zn3cp13w0y63d1qmjlhzsqlvajkximg3pw5mmiljxrr";
+        rev =			"1c1849ec1a6614247abe4c623c086def2b3192e0";
+        sha256 =		"0faf4fw7nrfwdrl4pjqdyfzqbvb9jd4nk4aq83v1w358yqyk7zg9";
       };
     };
     libVersion = {
-      version =			"2023-04-14";
+      version =			"2023-06-24";
       libSources = {
-        symbols.rev =		"38d4e7e1ab6a9b5d9eee85f687e60467753b2135";
-        symbols.sha256 =	"0df6fx9b19v6sxrfyggbisw72y66kiwqi05k8mldsgiw6q55gbkc";
+        symbols.rev =		"43456780d309682f6da4a6f14710355b06fc4c5d";
+        symbols.sha256 =	"1ql2w3q3dv13ascw8s0hzwda486763qma7i2m877jw3p78gjhldr";
         templates.rev =		"867eef383a0f61015cb69677d5c632d78a2ea01a";
         templates.sha256 =	"1qi20mrsfn4fxmr1fyphmil2i9p2nzmwk5rlfchc5aq2194nj3lq";
-        footprints.rev =	"4da055a2d572ff87e7ecea97cf358ed8c1d46dfc";
-        footprints.sha256 =	"1xb84284dmcb7mbvzlrxb4v4km3ih7gq856h8cglf9jn8wzlnvrk";
-        packages3d.rev =	"0f43a0962437feb53bd2083e9f39efffb5a5dd90";
-        packages3d.sha256 =	"1nkk4325jh89vh52ykfnf9pz1k3jk5017gz6r2cia2v4b3jadi31";
+        footprints.rev =	"6a59a2d3940dbab7b3e8254a5b9bf06cc5330301";
+        footprints.sha256 =	"0jlz0ln9vzj1av1fmw8ma8kfqlb8w0r9vrfng19bkc3cgh9lvh9x";
+        packages3d.rev =	"8a2c5c4c85457832f3320902456d066d29561806";
+        packages3d.sha256 =	"0dmssyhqd94d9wj8w7g7xjan560b2rwcs540sgl0rc77cw2jify8";
       };
     };
   };

--- a/pkgs/development/python-modules/diffimg/default.nix
+++ b/pkgs/development/python-modules/diffimg/default.nix
@@ -1,0 +1,43 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, pillow
+, unittestCheckHook
+}:
+
+buildPythonPackage rec {
+  pname = "diffimg";
+  version = "0.3.0"; # github recognized 0.1.3, there's a v0.1.5 tag and setup.py says 0.3.0
+  format = "setuptools";
+
+  src = fetchFromGitHub {
+    owner = "nicolashahn";
+    repo = "diffimg";
+    rev = "b82f0bb416f100f9105ccccf1995872b29302461";
+    hash = "sha256-H/UQsqyfdnlESBe7yRu6nK/0dakQkAfeFaZNwjCMvdM=";
+  };
+
+  # it imports the wrong diff,
+  # fix offered to upstream https://github.com/nicolashahn/diffimg/pull/6
+  postPatch = ''
+    substituteInPlace diffimg/test.py \
+      --replace "from diff import diff" "from diffimg.diff import diff"
+  '';
+
+  propagatedBuildInputs = [
+    pillow
+  ];
+
+  pythonImportsCheck = [ "diffimg" ];
+
+  nativeCheckInputs = [
+    unittestCheckHook
+  ];
+
+  meta = with lib; {
+    description = "Differentiate images in python - get a ratio or percentage difference, and generate a diff image";
+    homepage = "https://github.com/nicolashahn/diffimg";
+    license = licenses.mit;
+    maintainers = with maintainers; [ evils ];
+  };
+}

--- a/pkgs/development/python-modules/image-diff/default.nix
+++ b/pkgs/development/python-modules/image-diff/default.nix
@@ -1,0 +1,39 @@
+{ lib
+, python
+, buildPythonPackage
+, fetchFromGitHub
+, pillow
+, click
+, click-default-group
+, pytestCheckHook
+}:
+
+buildPythonPackage rec {
+  pname = "image-diff";
+  version = "0.2.2";
+  format = "setuptools";
+
+  src = fetchFromGitHub {
+    owner = "simonw";
+    repo = "image-diff";
+    rev = version;
+    hash = "sha256-AQykJNvBgVjmPVTwJOX17eKWelqvZZieq/giid8GYAY=";
+  };
+
+  propagatedBuildInputs = [
+    pillow
+    click
+    click-default-group
+  ];
+
+  pythonImportsCheck = [ "image_diff" ];
+
+  nativeCheckInputs = [ pytestCheckHook ];
+
+  meta = with lib; {
+    description = "CLI tool for comparing images";
+    homepage = "https://github.com/simonw/image-diff";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ evils ];
+  };
+}

--- a/pkgs/development/python-modules/imgdiff/default.nix
+++ b/pkgs/development/python-modules/imgdiff/default.nix
@@ -1,0 +1,39 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, pillow
+, mock
+, unittestCheckHook
+}:
+
+buildPythonPackage rec {
+  pname = "imgdiff";
+  version = "1.7.1";
+  format = "setuptools";
+
+  src = fetchFromGitHub {
+    owner = "mgedmin";
+    repo = "imgdiff";
+    rev = version;
+    hash = "sha256-Y5nUnjihRpVVehhP1LUgfuJN5nCxEJu6P1w99Igpxjs=";
+  };
+
+  propagatedBuildInputs = [
+    pillow
+  ];
+
+  pythonImportsCheck = [ "imgdiff" ];
+
+  nativeCheckInputs = [
+    mock
+    unittestCheckHook
+  ];
+
+  meta = with lib; {
+    description = "Compare two images side-by-side";
+    homepage = "https://github.com/mgedmin/imgdiff";
+    changelog = "https://github.com/mgedmin/imgdiff/blob/${src.rev}/CHANGES.rst";
+    license = licenses.mit;
+    maintainers = with maintainers; [ evils ];
+  };
+}

--- a/pkgs/development/python-modules/pytest-image-diff/default.nix
+++ b/pkgs/development/python-modules/pytest-image-diff/default.nix
@@ -1,0 +1,43 @@
+{ lib
+, python3
+, buildPythonPackage
+, fetchFromGitHub
+, typing-extensions
+, diffimg
+, imgdiff
+, pytestCheckHook
+, recommonmark
+}:
+
+buildPythonPackage rec {
+  pname = "pytest-image-diff";
+  version = "0.0.11";
+  format = "setuptools";
+
+  src = fetchFromGitHub {
+    owner = "Apkawa";
+    repo = "pytest-image-diff";
+    rev = "v${version}";
+    hash = "sha256-7GBwxm0YQNN/Gq1yyBIxCEYbM7hmOFa9kUsfbBKQtBQ=";
+  };
+
+  propagatedBuildInputs = [
+    typing-extensions
+    diffimg
+    imgdiff
+  ];
+
+  pythonImportsCheck = [ "pytest_image_diff" ];
+
+  nativeCheckInputs = [
+    pytestCheckHook
+    recommonmark
+  ];
+
+  meta = with lib; {
+    description = "Pytest helps for compare images and regression";
+    homepage = "https://github.com/Apkawa/pytest-image-diff";
+    license = licenses.mit;
+    maintainers = with maintainers; [ evils ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -9669,6 +9669,8 @@ self: super: with self; {
 
   pytest-httpx = callPackage ../development/python-modules/pytest-httpx { };
 
+  pytest-image-diff = callPackage ../development/python-modules/pytest-image-diff { };
+
   pytest-instafail = callPackage ../development/python-modules/pytest-instafail { };
 
   pytest-isort = callPackage ../development/python-modules/pytest-isort { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2549,6 +2549,8 @@ self: super: with self; {
 
   diff-match-patch = callPackage ../development/python-modules/diff-match-patch { };
 
+  diffimg = callPackage ../development/python-modules/diffimg { };
+
   digital-ocean = callPackage ../development/python-modules/digitalocean { };
 
   digi-xbee = callPackage ../development/python-modules/digi-xbee { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -4887,6 +4887,8 @@ self: super: with self; {
 
   imgaug = callPackage ../development/python-modules/imgaug { };
 
+  imgdiff = callPackage ../development/python-modules/imgdiff { };
+
   imgsize = callPackage ../development/python-modules/imgsize { };
 
   iminuit = callPackage ../development/python-modules/iminuit { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -4865,6 +4865,8 @@ self: super: with self; {
 
   imageio-ffmpeg = callPackage ../development/python-modules/imageio-ffmpeg { };
 
+  image-diff = callPackage ../development/python-modules/image-diff { };
+
   image-go-nord = callPackage ../development/python-modules/image-go-nord { };
 
   imagesize = callPackage ../development/python-modules/imagesize { };


### PR DESCRIPTION
###### Description of changes

bump to latest master commit
which now has `qa_cli` tests, which require `pytest-image-diff`, which requires `imgdiff` and `diffimg`
(i initially packaged `image-diff` instead which is not needed, but it's packaged now...)

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [x] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).