### PR TITLE
clickhouse: 22.8.5.29 -> 23.3.1.2823, clean up

### DIFF
--- a/pkgs/servers/clickhouse/default.nix
+++ b/pkgs/servers/clickhouse/default.nix
@@ -1,32 +1,35 @@
-{ lib, stdenv, fetchFromGitHub, cmake, libtool, llvm-bintools, ninja
-, boost, brotli, capnproto, cctz, clang-unwrapped, double-conversion
-, icu, jemalloc, libcpuid, libxml2, lld, llvm, lz4, libmysqlclient, openssl, perl
-, poco, protobuf, python3, rapidjson, re2, rdkafka, readline, sparsehash, unixODBC
-, xxHash, zstd
+{ lib
+, stdenv
+, fetchFromGitHub
+, cmake
+, ninja
+, python3
+, perl
+, yasm
 , nixosTests
 }:
 
 stdenv.mkDerivation rec {
   pname = "clickhouse";
-  version = "22.8.16.32";
-
-  broken = stdenv.buildPlatform.is32bit; # not supposed to work on 32-bit https://github.com/ClickHouse/ClickHouse/pull/23959#issuecomment-835343685
+  version = "23.3.2.37";
 
   src = fetchFromGitHub {
-    owner  = "ClickHouse";
-    repo   = "ClickHouse";
-    rev    = "v${version}-lts";
+    owner = "ClickHouse";
+    repo = "ClickHouse";
+    rev = "v${version}-lts";
     fetchSubmodules = true;
-    sha256 = "sha256-LArHbsu2iaEP+GrCxdTrfpGDDfwcg1mlvbAceXNZyz8=";
+    sha256 = "sha256-t6aW3wYmD4UajVaUhIE96wCqr6JbOtoBt910nD9IVsk=";
   };
 
-  nativeBuildInputs = [ cmake libtool llvm-bintools ninja ];
-  buildInputs = [
-    boost brotli capnproto cctz clang-unwrapped double-conversion
-    icu jemalloc libxml2 lld llvm lz4 libmysqlclient openssl perl
-    poco protobuf python3 rapidjson re2 rdkafka readline sparsehash unixODBC
-    xxHash zstd
-  ] ++ lib.optional stdenv.hostPlatform.isx86 libcpuid;
+  strictDeps = true;
+  nativeBuildInputs = [
+    cmake
+    ninja
+    python3
+    perl
+  ] ++ lib.optionals stdenv.isx86_64 [
+    yasm
+  ];
 
   postPatch = ''
     patchShebangs src/
@@ -47,7 +50,7 @@ stdenv.mkDerivation rec {
     "-DENABLE_TESTS=OFF"
     "-DENABLE_CCACHE=0"
     "-DENABLE_EMBEDDED_COMPILER=ON"
-    "-USE_INTERNAL_LLVM_LIBRARY=OFF"
+    "-DWERROR=OFF"
   ];
 
   postInstall = ''
@@ -61,8 +64,6 @@ stdenv.mkDerivation rec {
       --replace "<level>trace</level>" "<level>warning</level>"
   '';
 
-  hardeningDisable = [ "format" ];
-
   # Builds in 7+h with 2 cores, and ~20m with a big-parallel builder.
   requiredSystemFeatures = [ "big-parallel" ];
 
@@ -73,6 +74,9 @@ stdenv.mkDerivation rec {
     description = "Column-oriented database management system";
     license = licenses.asl20;
     maintainers = with maintainers; [ orivej ];
-    platforms = platforms.linux;
+
+    # not supposed to work on 32-bit https://github.com/ClickHouse/ClickHouse/pull/23959#issuecomment-835343685
+    platforms = lib.filter (x: (lib.systems.elaborate x).is64bit) platforms.linux;
+    broken = stdenv.buildPlatform != stdenv.hostPlatform;
   };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -25123,10 +25123,7 @@ with pkgs;
   clamsmtp = callPackage ../servers/mail/clamsmtp { };
 
   clickhouse = callPackage ../servers/clickhouse {
-    # upstream requires llvm12 as of v22.3.2.2
-    inherit (llvmPackages_14) clang-unwrapped lld llvm;
-    llvm-bintools = llvmPackages_14.bintools;
-    stdenv = llvmPackages_14.stdenv;
+    stdenv = llvmPackages_15.stdenv;
   };
 
   clickhouse-cli = with python3Packages; toPythonApplication clickhouse-cli;


### PR DESCRIPTION
Continuation of #227520 

Closes #227435

###### Description of changes

While upgrading clickhouse I noticed the buildInputs are actually not used, because clickhouse vendors _everything_ unconditionally.

In [the build log](https://hydra.nixos.org/log/07clvych4k2hjkdhq0rg2dkswp3b1icw-clickhouse-22.8.16.32.drv) one can also see that all the buildInputs (llvm, capnproto) are being built again from the contrib modules.

The inputs were mostly supposed to be linked as shared libraries, but a `nix-store -qR ./result` reveals the output does not reference any of them.

Building clickhouse with system libraries properly would require _a ton_ of patching around in their build system.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
