### PR TITLE
tree-sitter: Update grammars

### DIFF
--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-c.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-c.json
@@ -1,9 +1,9 @@
 {
   "url": "https://github.com/tree-sitter/tree-sitter-c",
-  "rev": "f35789006ccbe5be8db21d1a2dd4cc0b5a1286f2",
-  "date": "2023-02-22T10:24:35+01:00",
-  "path": "/nix/store/7q7p3iw8dsa5gwvbabnn26w81fkbp46a-tree-sitter-c",
-  "sha256": "0dhl0vz0x0s64n4nq2chnncq89j7xsbg0s73cavpjdq4ajiamdjc",
+  "rev": "424d0145efb0a87927269ab47709f98a564f8c4f",
+  "date": "2023-05-16T21:37:52+02:00",
+  "path": "/nix/store/5a4vk0il946xv8z9k0fv2j35r6ncfxpn-tree-sitter-c",
+  "sha256": "14jnwpphsnkynq7i9a7jxvl6dwkyig0lzanhgcibprjfqw8ilgvj",
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-c.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-c.json
@@ -1,9 +1,9 @@
 {
   "url": "https://github.com/tree-sitter/tree-sitter-c",
-  "rev": "424d0145efb0a87927269ab47709f98a564f8c4f",
-  "date": "2023-05-16T21:37:52+02:00",
-  "path": "/nix/store/5a4vk0il946xv8z9k0fv2j35r6ncfxpn-tree-sitter-c",
-  "sha256": "14jnwpphsnkynq7i9a7jxvl6dwkyig0lzanhgcibprjfqw8ilgvj",
+  "rev": "a015709e7d1bb4f823a2fc53175e0cbee96c1c3e",
+  "date": "2023-05-22T07:31:22+02:00",
+  "path": "/nix/store/mrl2pdg4jxn4hcyz6lpsnl47m0fxqwl8-tree-sitter-c",
+  "sha256": "086cz0ky1f0ds14v9m8nif57cil9ssvqym8c51la7qv4329dgs5b",
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-clojure.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-clojure.json
@@ -1,9 +1,9 @@
 {
   "url": "https://github.com/sogaiu/tree-sitter-clojure",
-  "rev": "421546c2547c74d1d9a0d8c296c412071d37e7ca",
-  "date": "2023-02-25T16:13:05+09:00",
-  "path": "/nix/store/y64fl2527y2d97yl89i62m66dv0n68lq-tree-sitter-clojure",
-  "sha256": "0da18c1kj8pyrzmkg8zv186qy36xyjnmrj8wj7bl4k7gk18xmw0r",
+  "rev": "6e41628e9d18b19caea1cb1d72aae4ccff5bdfe9",
+  "date": "2023-05-05T15:36:48+09:00",
+  "path": "/nix/store/fx50ap0gdspwcpgf0zni4j1pzz29abk5-tree-sitter-clojure",
+  "sha256": "0hcl4svn0q4979mx0nn3hhi27xfxj1lz7g1926lcjx6sv1z4ihmj",
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-comment.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-comment.json
@@ -1,9 +1,9 @@
 {
   "url": "https://github.com/stsewd/tree-sitter-comment",
-  "rev": "a37ca370310ac6f89b6e0ebf2b86b2219780494e",
-  "date": "2022-03-28T20:21:33-05:00",
-  "path": "/nix/store/nbf4bgxb7a15mwbi6lsfn7gbq8x1s3c1-tree-sitter-comment",
-  "sha256": "0y0wqzgrwwg09ipfs6i3bcxm5hbvs938g2ksnygcbgqdwgd5h8f2",
+  "rev": "f08e7d44b2923e9da2bf487a2f365d08677d368e",
+  "date": "2023-04-10T20:11:04-05:00",
+  "path": "/nix/store/swaxl1n782g3gvvbxj0d659krb2zrxaw-tree-sitter-comment",
+  "sha256": "1r9bzf6fxc2cjb8ndrkvirpqgk9wixandcsp2311dxvyfk3phy5z",
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-cpp.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-cpp.json
@@ -1,9 +1,9 @@
 {
   "url": "https://github.com/tree-sitter/tree-sitter-cpp",
-  "rev": "66262d3e76eb2046c76e6d661a6b72664bfb5819",
-  "date": "2023-02-22T10:24:05+01:00",
-  "path": "/nix/store/bairlzwv7gak6wfvk185q1jixncz4wj0-tree-sitter-cpp",
-  "sha256": "09myna6pa1pl0qzj6kfvs4h7jw0fm2mnfnx3lv8r90k6b1vf56ji",
+  "rev": "70aed2e9e83eb7320ab7c454d3084300bf587037",
+  "date": "2023-05-09T10:48:30+02:00",
+  "path": "/nix/store/v44wqlm6vlz3rw9v402hxykz6fvc4n22-tree-sitter-cpp",
+  "sha256": "1h2g7jy0znnzqrfgjnkz33hys4wcgxj6cqk3zcyb1zs77nmwn16y",
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-cuda.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-cuda.json
@@ -1,9 +1,9 @@
 {
   "url": "https://github.com/thehamsta/tree-sitter-cuda",
-  "rev": "9b1f7481a151686fce8af66da147f40388f8ee4d",
-  "date": "2023-02-22T17:21:33-08:00",
-  "path": "/nix/store/d5aqw99m6kgqf56a4sl2h5wcqdmljglh-tree-sitter-cuda",
-  "sha256": "19zn8aqfqg7y225hbb1ag50ma59adlw0l0gjbpjns0f0dbz3qr11",
+  "rev": "a27cb7b9d105c43205fa899f49bc0cc4cf399484",
+  "date": "2023-05-10T17:30:11+02:00",
+  "path": "/nix/store/mhsrib6mf19d36kv9qbc7x0z3mbq95l4-tree-sitter-cuda",
+  "sha256": "1577ld60zw76z283yijrm9zira8bfpg8nyajfxl8q03rn6xbyy9r",
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-cuda.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-cuda.json
@@ -1,9 +1,9 @@
 {
   "url": "https://github.com/thehamsta/tree-sitter-cuda",
-  "rev": "a27cb7b9d105c43205fa899f49bc0cc4cf399484",
-  "date": "2023-05-10T17:30:11+02:00",
-  "path": "/nix/store/mhsrib6mf19d36kv9qbc7x0z3mbq95l4-tree-sitter-cuda",
-  "sha256": "1577ld60zw76z283yijrm9zira8bfpg8nyajfxl8q03rn6xbyy9r",
+  "rev": "9c20a3120c405db9efda9349cd005c29f2aace3c",
+  "date": "2023-05-22T10:54:56+02:00",
+  "path": "/nix/store/zzix5y046a7vj6s16cdkp0v2fhfr24fq-tree-sitter-cuda",
+  "sha256": "0z9va82k7n8rlnk6g9q52sxaw2lcb05arl3l5dqmji5s53sq5q1c",
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-dart.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-dart.json
@@ -1,9 +1,9 @@
 {
   "url": "https://github.com/usernobody14/tree-sitter-dart",
-  "rev": "53485a8f301254e19c518aa20c80f1bcf7cf5c62",
-  "date": "2022-08-11T13:38:34-07:00",
-  "path": "/nix/store/frp77jynv64s1x0l6hix5dk12zlsf5wq-tree-sitter-dart",
-  "sha256": "1ds1hz9gkvc3dp6bz93zlb1rixzhyj8cm6xfpb7cm4a8rhajz1yl",
+  "rev": "d56cc088de91d5a7ef7ec46b5a5ab4aa3fe82409",
+  "date": "2023-05-15T20:25:05-06:00",
+  "path": "/nix/store/2ck1s94hb2ffm6n3f7kfdmhn8m0czm40-tree-sitter-dart",
+  "sha256": "105q2jsh88ykd57j5nqp7lv8nxz63qpasvs90kyz2xxm0bf6y0cs",
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-dart.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-dart.json
@@ -1,9 +1,9 @@
 {
   "url": "https://github.com/usernobody14/tree-sitter-dart",
-  "rev": "d56cc088de91d5a7ef7ec46b5a5ab4aa3fe82409",
-  "date": "2023-05-15T20:25:05-06:00",
-  "path": "/nix/store/2ck1s94hb2ffm6n3f7kfdmhn8m0czm40-tree-sitter-dart",
-  "sha256": "105q2jsh88ykd57j5nqp7lv8nxz63qpasvs90kyz2xxm0bf6y0cs",
+  "rev": "1a525edd89026cc6f0a954b4718ce20fd7e45b15",
+  "date": "2023-05-23T15:35:37-06:00",
+  "path": "/nix/store/kv98km1sar3gxlzi3inyqln7i9701wgi-tree-sitter-dart",
+  "sha256": "0i2d6khh7gv48fpnc0f550gyxpzm328b8065sri7lhab0rjf17ai",
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-devicetree.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-devicetree.json
@@ -1,9 +1,9 @@
 {
   "url": "https://github.com/joelspadin/tree-sitter-devicetree",
-  "rev": "877adbfa0174d25894c40fa75ad52d4515a36368",
-  "date": "2022-03-23T18:25:46-05:00",
-  "path": "/nix/store/q0rqqm39h4dh17nlrr10kbfcqbdfk5kl-tree-sitter-devicetree",
-  "sha256": "1ds7pa4x1yd54xa2mba37vp8lbi8n4l975lps0249x8xw35r0jrl",
+  "rev": "59faca63ab28d8aa8b79416bfcbe5b935f3fa604",
+  "date": "2023-04-23T12:18:55-05:00",
+  "path": "/nix/store/m39bl3vasy0b1r0qzdn8flb480ys8laq-tree-sitter-devicetree",
+  "sha256": "11r46v3zw03p1fldhawn9zwyzpi7h57pjw9sydwq7b1fgdmdxvn7",
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-elisp.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-elisp.json
@@ -1,9 +1,9 @@
 {
   "url": "https://github.com/wilfred/tree-sitter-elisp",
-  "rev": "4b0e4a3891337514126ec72c7af394c0ff2cf48c",
-  "date": "2021-10-02T12:14:40-07:00",
-  "path": "/nix/store/1g3q3xzv5n9wzi84awrlbxwm6q3zh8qz-tree-sitter-elisp",
-  "sha256": "1g6qmpxn1y9hzk2kkpp9gpkphaq9j7vvm4nl5zv8a4wzy3w8p1wv",
+  "rev": "1991465e2722dd36c06e03dc7de6bc5d7da89d51",
+  "date": "2023-03-28T08:47:56-07:00",
+  "path": "/nix/store/mbb6q2yma6vszbzpw5hbpzf0iwg9y7vi-tree-sitter-elisp",
+  "sha256": "1m6lb60mlyk38pizcncp58f69kyf36b47rxnysf1l4193nscjqw6",
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-elixir.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-elixir.json
@@ -1,9 +1,9 @@
 {
   "url": "https://github.com/elixir-lang/tree-sitter-elixir",
-  "rev": "b20eaa75565243c50be5e35e253d8beb58f45d56",
-  "date": "2022-10-16T19:20:07+00:00",
-  "path": "/nix/store/424sg83igjqrkl4yzyiqv0byv4hzii0n-tree-sitter-elixir",
-  "sha256": "1i0c0xki3sv24649p0ws7xs2jagbwg7z7baz1960239bj94nl487",
+  "rev": "869dff3ceb8823ca4b17ca33b663667c8e41e8ba",
+  "date": "2023-03-14T10:58:34+01:00",
+  "path": "/nix/store/d8k07yvr8q14rc21fvhcnqrlpcwhlnmk-tree-sitter-elixir",
+  "sha256": "0m10vykaj36yxk0wwh0vk0pzvpdmac4apgihmxn3j0dwwgirchf0",
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-elm.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-elm.json
@@ -1,9 +1,9 @@
 {
   "url": "https://github.com/elm-tooling/tree-sitter-elm",
-  "rev": "cce0e5938e7779f86cf8bf445eadf7df4b88229d",
-  "date": "2022-09-03T13:02:26+02:00",
-  "path": "/nix/store/scick955z3qrbxmk1jr8cchwsnx4l814-tree-sitter-elm",
-  "sha256": "0b5jpj8bnil1ylisyc4w48j8a30dyf3zylhidj73mlrb8rf7xm2s",
+  "rev": "692c50c0b961364c40299e73c1306aecb5d20f40",
+  "date": "2023-04-15T15:07:51+02:00",
+  "path": "/nix/store/hmjs76plv6a64c2mgfxq79mh0ak2a45a-tree-sitter-elm",
+  "sha256": "0y5mz26ax2gzlv8cbrncn4bip9gin330a2zmynq9f1yfwv4nxfnh",
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-glsl.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-glsl.json
@@ -1,9 +1,9 @@
 {
   "url": "https://github.com/thehamsta/tree-sitter-glsl",
-  "rev": "e2c2214045de2628b81089b1a739962f59654558",
-  "date": "2022-11-24T01:46:06+01:00",
-  "path": "/nix/store/s203fvxw2v3gvbnf5qavms10f308ssl0-tree-sitter-glsl",
-  "sha256": "146v3ki2c2g8grlkz40iay6wi2crkxiy3i3jkcpv096ya9wf3dhs",
+  "rev": "7a005091d3896dab80f34d8dba58935ad7ad6353",
+  "date": "2023-05-17T08:45:20+02:00",
+  "path": "/nix/store/25f7vhw6lqmwzxmq2wk66n7ix58rcigd-tree-sitter-glsl",
+  "sha256": "1ihqxfa5qdr3sg3hak1pvl54lx6a2g8wcz183cyw9ncsfw4mph9g",
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-glsl.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-glsl.json
@@ -1,9 +1,9 @@
 {
   "url": "https://github.com/thehamsta/tree-sitter-glsl",
-  "rev": "7a005091d3896dab80f34d8dba58935ad7ad6353",
-  "date": "2023-05-17T08:45:20+02:00",
-  "path": "/nix/store/25f7vhw6lqmwzxmq2wk66n7ix58rcigd-tree-sitter-glsl",
-  "sha256": "1ihqxfa5qdr3sg3hak1pvl54lx6a2g8wcz183cyw9ncsfw4mph9g",
+  "rev": "190c86e633e6a6dfdb8a96f8b8460e347ff93f1c",
+  "date": "2023-05-20T13:31:53+02:00",
+  "path": "/nix/store/hj5f27mzk311bbjb448azsw2wwrax171-tree-sitter-glsl",
+  "sha256": "0ag7w0cp22253hzlm9017fsxmryhn8b8m0vrpsmh5kd05xss413k",
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-haskell.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-haskell.json
@@ -1,9 +1,9 @@
 {
   "url": "https://github.com/tree-sitter/tree-sitter-haskell",
-  "rev": "3bdba07c7a8eec23f87fa59ce9eb2ea4823348b3",
-  "date": "2023-02-09T02:03:40+01:00",
-  "path": "/nix/store/pv2ar6i072q3i1jy51s0wirarjqsk2ra-tree-sitter-haskell",
-  "sha256": "1hg19af1n510bndf5k5iri7dzb48xb527vispv1aapki4mvr98gx",
+  "rev": "c5cb0c860a399308305f44792bc4853737c40c07",
+  "date": "2023-05-06T16:49:31+02:00",
+  "path": "/nix/store/hh393wfdf43mghdgslq9315cqry1gim6-tree-sitter-haskell",
+  "sha256": "0an4d5q0vjl9amk4cwhs9d9cb3i4d1n20hzda165b88cq720lk7m",
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-html.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-html.json
@@ -1,9 +1,9 @@
 {
   "url": "https://github.com/tree-sitter/tree-sitter-html",
-  "rev": "29f53d8f4f2335e61bf6418ab8958dac3282077a",
-  "date": "2022-05-06T09:01:49-07:00",
-  "path": "/nix/store/w5dy2r99rbzpmg0icwil5j9cp37l9hkk-tree-sitter-html",
-  "sha256": "0wadphmgndj4vq9mg258624pj0klspbpcx8qlc6f8by5xbshvkmz",
+  "rev": "86c253e675e7fdd1c0482efe0706f24bafbc3a7d",
+  "date": "2023-04-17T11:50:54+02:00",
+  "path": "/nix/store/a046axd86r1bd974b7c3ylyni4b90wma-tree-sitter-html",
+  "sha256": "12brygy11q1gkbpj9m4alg91jji6avc5j71lwv3m773c94jpbqlq",
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-http.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-http.json
@@ -1,9 +1,9 @@
 {
   "url": "https://github.com/ntbbloodbath/tree-sitter-http",
-  "rev": "2c6c44574031263326cb1e51658bbc0c084326e7",
-  "date": "2023-01-06T03:29:38+01:00",
-  "path": "/nix/store/p6dxp8z5fyyjs9s0lky651dhmln7ciw0-tree-sitter-http",
-  "sha256": "15spzks4wpd1zvqkaq9irlr5xqk1n144lyxdkijkc9zvyvm6gka7",
+  "rev": "6824a247d1326079aab4fa9f9164e9319678081d",
+  "date": "2023-05-04T18:36:43-04:00",
+  "path": "/nix/store/7d2x9w6nqlhvgk70jahwlp6zg19iriij-tree-sitter-http",
+  "sha256": "0vhipdljx3s2pgzdk2a1zgqf8dd7p3bdbjckcb6z01hdg2p9v121",
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-janet-simple.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-janet-simple.json
@@ -1,9 +1,9 @@
 {
   "url": "https://github.com/sogaiu/tree-sitter-janet-simple",
-  "rev": "c796533cc82ae29d64f13b9a36e715bc02e28e72",
-  "date": "2023-02-25T21:44:49+09:00",
-  "path": "/nix/store/mqc5gh2zfm3vbc63i4pi1mi9xhqpr2ha-tree-sitter-janet-simple",
-  "sha256": "00mnkkmfygfrnx5cjhcll42j3xjy0blj9sisz94s7hkf6x21m9a0",
+  "rev": "bd9cbaf1ea8b942dfd58e68df10c9a378ab3d2b6",
+  "date": "2023-04-29T13:15:11+09:00",
+  "path": "/nix/store/53gscixcapdpckbr4gfx26ax0jk84xcp-tree-sitter-janet-simple",
+  "sha256": "0hy1dm2jzghd7mi74n4b1ac5bhm809mcg3bcl9f300bh5m79qnyq",
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-json.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-json.json
@@ -1,9 +1,9 @@
 {
   "url": "https://github.com/tree-sitter/tree-sitter-json",
-  "rev": "73076754005a460947cafe8e03a8cf5fa4fa2938",
-  "date": "2022-10-03T12:40:23-07:00",
-  "path": "/nix/store/v8s2xfc2jx8wvrfcf0silm5w4gj3m15j-tree-sitter-json",
-  "sha256": "1npf2hrx33jhjpmzcyi7aszg436m4d80sa6h4mhhkmx51q4kpcf1",
+  "rev": "40a81c01a40ac48744e0c8ccabbaba1920441199",
+  "date": "2023-04-21T17:11:30-07:00",
+  "path": "/nix/store/9wcmgficprni47bm3qj9k18bhmjqi6hx-tree-sitter-json",
+  "sha256": "0zji769g3nikqlwn0vb0h93908a7w59da4jf807r9g2s6fvmz4vx",
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-ledger.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-ledger.json
@@ -1,9 +1,9 @@
 {
   "url": "https://github.com/cbarrete/tree-sitter-ledger",
-  "rev": "f787ae635ca79589faa25477b94291a87e2d3e23",
-  "date": "2023-02-16T12:14:48+01:00",
-  "path": "/nix/store/rv2mrwcnjf0q1wxwjsggpkx4a1f5jmbl-tree-sitter-ledger",
-  "sha256": "1r3c5svcrh5bb0i3qn7d2rnppxvqndwnnry918rlb18nhvc3c9zm",
+  "rev": "8a841fb20ce683bfbb3469e6ba67f2851cfdf94a",
+  "date": "2023-05-07T23:13:39-04:00",
+  "path": "/nix/store/hdf6hzhb4h9p28hx26iqqz0cwf471aq8-tree-sitter-ledger",
+  "sha256": "12mfn42nhn0i8gf39aqbqfkccqc1mbn5z1vw5gh98pc9392jccq4",
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-llvm.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-llvm.json
@@ -1,9 +1,9 @@
 {
   "url": "https://github.com/benwilliamgraham/tree-sitter-llvm",
-  "rev": "e9948edc41e9e5869af99dddb2b5ff5cc5581af6",
-  "date": "2022-03-31T23:27:40-04:00",
-  "path": "/nix/store/8nkhzala4wscfip1g0skh1cxvmp3gp8l-tree-sitter-llvm",
-  "sha256": "0d579ylhi3hgzm5wbahs6hci1rhv7q1x6wsav9dbzv1y6np2dfrk",
+  "rev": "d47c95d78ef0e7495a74d214dd6fcddf6e402dfc",
+  "date": "2023-05-03T15:12:41-04:00",
+  "path": "/nix/store/fp1hrlrvj29ndsyp7dbvg4bgmja891s6-tree-sitter-llvm",
+  "sha256": "1d863cy214w26hlj22y60a4nw3j5qmr9a174f8vfgcc0lk9dzbh8",
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-lua.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-lua.json
@@ -1,9 +1,9 @@
 {
   "url": "https://github.com/MunifTanjim/tree-sitter-lua",
-  "rev": "0fc89962b7ff5c7d676b8592c1cbce1ceaa806fd",
-  "date": "2022-12-16T15:23:55+06:00",
-  "path": "/nix/store/cm9ff3d8f48sqgjkrc38sqjg7lbpswz9-tree-sitter-lua",
-  "sha256": "07mj9jydnxmp2dr7ssj58qlwrjx3gp6jnri79wa2jxaaygblzcri",
+  "rev": "dcc44f7473ecec4d7b99af0a9529705d98a769f1",
+  "date": "2023-05-13T02:02:51+06:00",
+  "path": "/nix/store/079khfz0609hqllhwp08c2y96j2jkbwr-tree-sitter-lua",
+  "sha256": "13rmng6y6q653s0yk1ahbppjmxwcbr80h5kgr53q43bq9khjrjxx",
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-markdown.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-markdown.json
@@ -1,9 +1,9 @@
 {
   "url": "https://github.com/MDeiml/tree-sitter-markdown",
-  "rev": "6138ee0c0d0ddafc4bf0e25728b73f902bbf2c98",
-  "date": "2023-02-28T15:28:45+01:00",
-  "path": "/nix/store/i184yz0i3afs1hbw10b3k9i58fxzdzcv-tree-sitter-markdown",
-  "sha256": "1rx6m2qj9a08qzzaxrkij68pcw7m1rl78qggg6k93caskjab461z",
+  "rev": "fa6bfd51727e4bef99f7eec5f43947f73d64ea7d",
+  "date": "2023-03-06T00:22:35+01:00",
+  "path": "/nix/store/8biwal105haahabfl6q01q2dm3danjzn-tree-sitter-markdown",
+  "sha256": "0wryvq7153a3jx9qs1plm5crlgd88sm1ymlqc3gs09mr2n456z9z",
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-nickel.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-nickel.json
@@ -1,9 +1,9 @@
 {
   "url": "https://github.com/nickel-lang/tree-sitter-nickel",
-  "rev": "d6c7eeb751038f934b5b1aa7ff236376d0235c56",
-  "date": "2023-01-27T10:31:38+01:00",
-  "path": "/nix/store/nyv8hdasyh5hgs65r38saxdn2m26b70r-tree-sitter-nickel",
-  "sha256": "1qdhggiprs1z5nnans2a876znfga95az3nafl4qp7j0ngg0m3x0g",
+  "rev": "3a794388773f2424a97b2186828aa3fac4c66ce6",
+  "date": "2023-05-17T14:02:29+02:00",
+  "path": "/nix/store/m4siaf1k6xbr3smyyjm7f047szzp99sw-tree-sitter-nickel",
+  "sha256": "1m28gjdamysxr9grjzwpmj1qiniff4vy1nka9i3zjyskbm71pf1l",
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-nix.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-nix.json
@@ -1,9 +1,9 @@
 {
   "url": "https://github.com/cstrahan/tree-sitter-nix",
-  "rev": "1b69cf1fa92366eefbe6863c184e5d2ece5f187d",
-  "date": "2022-09-29T23:30:43-05:00",
-  "path": "/nix/store/m5g4d7vddlwhhbdmzpwdvisqvb1hbh02-tree-sitter-nix",
-  "sha256": "0ls9djhpbbnjvd6b3166zjy92di0927f70720b57j2d3925538i5",
+  "rev": "02878b40ac77d2889833519c6b6e9e63cfc690e6",
+  "date": "2023-03-11T16:31:57-06:00",
+  "path": "/nix/store/mlasmj51yygqms5fwsd34fjb2h16q8q0-tree-sitter-nix",
+  "sha256": "1y737sif7hjnssif28xn16paf1kpamgsqh82k4j6grzbp11j4kpl",
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-perl.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-perl.json
@@ -1,9 +1,9 @@
 {
   "url": "https://github.com/ganezdragon/tree-sitter-perl",
-  "rev": "c43bae0090cfcfc62d9904312599ded1b645a66d",
-  "date": "2023-02-25T16:52:44+05:30",
-  "path": "/nix/store/k7mnrlm1b2cw17fr1qn2cnip3fhmgqyp-tree-sitter-perl",
-  "sha256": "16bpjnydl1qdiqy6j0ahi0ff9fdsxhmz1n0sni4amn57xky6sxiz",
+  "rev": "60aa138f9e1db15becad53070f4d5898b0e8a98c",
+  "date": "2023-04-13T01:12:55+05:30",
+  "path": "/nix/store/dd6ymbx86sw0g6dp1lns65avs50kr9kr-tree-sitter-perl",
+  "sha256": "1br66y8prhq7k7fi50sl8v51y8s29wf590g44kh5a574dx51960s",
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-php.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-php.json
@@ -1,9 +1,9 @@
 {
   "url": "https://github.com/tree-sitter/tree-sitter-php",
-  "rev": "f860e598194f4a71747f91789bf536b393ad4a56",
-  "date": "2023-02-10T07:41:01+01:00",
-  "path": "/nix/store/dmiqjxsagqmqvsmw9hp4z4wbrp9nsb26-tree-sitter-php",
-  "sha256": "02yc5b3qps8ghsmy4b5m5kldyr5pnqz9yw663v13pnz92r84k14g",
+  "rev": "1a40581b7a899201d7c2b4684ee34490bc306bd6",
+  "date": "2023-03-14T02:52:52-07:00",
+  "path": "/nix/store/nxhb4hdr16bfylq1jkzjznh65bkd0g8x-tree-sitter-php",
+  "sha256": "1hm7mpv0sggqzgbixh4r3bpap3dsh1zsy6msyknhdpkhblch4a5m",
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-query.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-query.json
@@ -1,9 +1,9 @@
 {
   "url": "https://github.com/nvim-treesitter/tree-sitter-query",
-  "rev": "0717de07078a20a8608c98ad5f26c208949d0e15",
-  "date": "2022-12-19T17:53:12+01:00",
-  "path": "/nix/store/gdf77qz6qmfikks2vjqh38wxsvn80r8w-tree-sitter-query",
-  "sha256": "19025zagdmimqixd25gh2rwn5hr9jfr7s08fvil3n5fqr9zshrbm",
+  "rev": "e97504446f14f529d5a8e649667d3d60391e4dfd",
+  "date": "2023-03-09T05:33:03-08:00",
+  "path": "/nix/store/3p8d4hl2bnm1fzn0nx7zc62l73118vm2-tree-sitter-query",
+  "sha256": "0xd00idgmyr55yd10xaxma1pwahlvn7gqy78zf8zknfbqvd3rzqs",
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-rust.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-rust.json
@@ -1,9 +1,9 @@
 {
   "url": "https://github.com/tree-sitter/tree-sitter-rust",
-  "rev": "fbf9e507d09d8b3c0bb9dfc4d46c31039a47dc4a",
-  "date": "2023-02-22T10:25:29+01:00",
-  "path": "/nix/store/90qz5h5a0ikn665d9q1d7nj4wcyyc5km-tree-sitter-rust",
-  "sha256": "1accbzkp6h4c9z7sakqnrjajx08ja5w8p6j17bgnbc9vy50jhsl5",
+  "rev": "0a70e15da977489d954c219af9b50b8a722630ee",
+  "date": "2023-04-25T13:09:18+02:00",
+  "path": "/nix/store/ymkvfvgf2wkxzsffxhyv7m8bq8j2f39f-tree-sitter-rust",
+  "sha256": "0m979bkrb7r58dapnm5plarvk3x3mvn5yyslrnrh6qgci7xmicqa",
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-scala.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-scala.json
@@ -1,9 +1,9 @@
 {
   "url": "https://github.com/tree-sitter/tree-sitter-scala",
-  "rev": "918f0fb948405181707a1772cab639f2d278d384",
-  "date": "2023-01-05T16:03:13-05:00",
-  "path": "/nix/store/38yd5q5d19fdry4icmq5fqz0kkmz3xi3-tree-sitter-scala",
-  "sha256": "0ffcx6lrpvg56wci0a4crk58as8hs8aljrqsim2kqbb171mc4wzy",
+  "rev": "5aefc0ae4c174fa74d6e973faefa28692e081954",
+  "date": "2023-05-23T22:52:07-04:00",
+  "path": "/nix/store/2gag459nfdm3c0p1a79wj9m3mnpzqn83-tree-sitter-scala",
+  "sha256": "064hch4v9pkl2ylkb6imfxz0a5dfl6rc37m76rxcdzmiwcr7fmfw",
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-scheme.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-scheme.json
@@ -1,9 +1,9 @@
 {
   "url": "https://github.com/6cdh/tree-sitter-scheme",
-  "rev": "67b90a365bebf4406af4e5a546d6336de787e135",
-  "date": "2023-01-16T14:32:14+08:00",
-  "path": "/nix/store/vsbfzbn9phgkn008633yjxr3d95zf4y1-tree-sitter-scheme",
-  "sha256": "1pvxckza1kdfwqs78ka3lbwldrwkgymb31f5x1fq5vyawg60wxk8",
+  "rev": "6abcfe33d976ebe3e244ca80273c7e8a070441b5",
+  "date": "2023-04-22T18:14:27+08:00",
+  "path": "/nix/store/18v6jgrcfdl3sgg7p02dpzkc3lj9mpn6-tree-sitter-scheme",
+  "sha256": "0iazh55cmznw2mkffnzwkpq4f8vkb1hxiapkgflmcnaq9wb6jp7a",
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-sql.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-sql.json
@@ -1,9 +1,9 @@
 {
   "url": "https://github.com/derekstride/tree-sitter-sql",
-  "rev": "d4b8be1e52b07b66e5ec62d2f1c0d701dfa85ed9",
-  "date": "2023-03-01T10:01:35-05:00",
-  "path": "/nix/store/sx2ycgc20fw4hqc5vkh2lynl4s947qsg-tree-sitter-sql",
-  "sha256": "04if27bdl03w2fqgyja6aq29hy7j5lb82r5jd5s75am5g1lwiicj",
+  "rev": "ea9ed488823c9a5641254009eb929866050988bc",
+  "date": "2023-05-15T23:17:35+02:00",
+  "path": "/nix/store/rrsipi6gc7ymbqj8f8rkzas3dgp9h8hr-tree-sitter-sql",
+  "sha256": "1xw6j5brdhnjqgn6vd86d5640nr64vi4b3rrmnnv2p7fsb7zbmwl",
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-sql.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-sql.json
@@ -1,9 +1,9 @@
 {
   "url": "https://github.com/derekstride/tree-sitter-sql",
-  "rev": "ea9ed488823c9a5641254009eb929866050988bc",
-  "date": "2023-05-15T23:17:35+02:00",
-  "path": "/nix/store/rrsipi6gc7ymbqj8f8rkzas3dgp9h8hr-tree-sitter-sql",
-  "sha256": "1xw6j5brdhnjqgn6vd86d5640nr64vi4b3rrmnnv2p7fsb7zbmwl",
+  "rev": "63a6bad6d4ca2192cf252e10db73627414546732",
+  "date": "2023-05-23T15:22:05+00:00",
+  "path": "/nix/store/wkbdy34zr3ccs0pf0is1xc5223k3riai-tree-sitter-sql",
+  "sha256": "1g7ldcvwmw5rp97i12drcr26b8biczpphhgl08c4gack787sxgrk",
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-svelte.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-svelte.json
@@ -1,9 +1,9 @@
 {
   "url": "https://github.com/Himujjal/tree-sitter-svelte",
-  "rev": "84c90ee15f851e1541c25c86e8a4338f5b4d5af2",
-  "date": "2022-04-13T11:35:15+05:30",
-  "path": "/nix/store/2miakcpw7xgg2pcwdbcg0kl2djijcfbj-tree-sitter-svelte",
-  "sha256": "0hidafgzbnksyigksab8731jdnvj1vqn7fv0jxsc1yfrwrmai6ls",
+  "rev": "be7f2e7db1fc19f0852265ec60923fc058380739",
+  "date": "2023-04-03T22:59:58+05:30",
+  "path": "/nix/store/lqqls8g9zhiv2v32if429cwycn092zq6-tree-sitter-svelte",
+  "sha256": "1kp91sarydq41zznwxwxdv2i2pflgzhmpfv0iqgq47fma9bcv2wy",
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-tiger.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-tiger.json
@@ -1,9 +1,9 @@
 {
   "url": "https://github.com/ambroisie/tree-sitter-tiger",
-  "rev": "a233ebe360a73a92c50978e5c4e9e471bc59ff42",
-  "date": "2022-11-22T10:59:45+01:00",
-  "path": "/nix/store/30fd7jd6p4rc2x1ahax19jxxa0blz7lq-tree-sitter-tiger",
-  "sha256": "0jv8dawvdjws0klypf80z4fff4va5963vcxdp22rvp3g1n8dc3cm",
+  "rev": "4a099243ed68a4fc72fdad8ea3ce57ec411ebfe3",
+  "date": "2023-04-01T17:11:28+01:00",
+  "path": "/nix/store/f8nmndxp42jf09lp1v2m3grj1h6f447y-tree-sitter-tiger",
+  "sha256": "0riyjsqdk4kiyl58vanfg7k64n55czcncsjx696l3gph2dyfjxnb",
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-tlaplus.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-tlaplus.json
@@ -1,9 +1,9 @@
 {
   "url": "https://github.com/tlaplus-community/tree-sitter-tlaplus",
-  "rev": "c54aebd31e2ac394a0aa70b510724c99144119f1",
-  "date": "2023-02-04T13:10:02-05:00",
-  "path": "/nix/store/p4jybbcwfv9x1s3kxp9bzifl2zsd3nil-tree-sitter-tlaplus",
-  "sha256": "06sshz8ia27ypzbwy5isx7ndyi9sc6x4xyr8r50njcpy3av4d7wn",
+  "rev": "7ba226cf85280c7917d082940022006e6a3b7b6f",
+  "date": "2023-03-28T17:13:15-04:00",
+  "path": "/nix/store/biqm93z4n1ravfi5bs466fbp4bxadjmk-tree-sitter-tlaplus",
+  "sha256": "0md800h54792nv1mfzdw7wyjzz8wx5cvl6mzlb8l70p0ihjfrk1s",
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-typescript.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-typescript.json
@@ -1,9 +1,9 @@
 {
   "url": "https://github.com/tree-sitter/tree-sitter-typescript",
-  "rev": "c6e56d44c686a67c89e29e773e662567285d610f",
-  "date": "2023-02-24T18:42:51+01:00",
-  "path": "/nix/store/m7hqakchzx02kb56d8sf17623jpkp35w-tree-sitter-typescript",
-  "sha256": "1vdqmna7zqs8aw7a87z4pn3ivplbgbn8jqjpyaxx6k5czmnl1ims",
+  "rev": "286e90c32060032225f636a573d0e999f7766c97",
+  "date": "2023-04-21T18:31:50-07:00",
+  "path": "/nix/store/cf6q6c3mclp70bplsdykgxbpjrnb2yh2-tree-sitter-typescript",
+  "sha256": "06kq9c26my2h53fv7qlmkpaia21ahbyd0lsrn9l4hric7b3ca3wn",
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-vim.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-vim.json
@@ -1,9 +1,9 @@
 {
   "url": "https://github.com/vigoux/tree-sitter-viml",
-  "rev": "e39a7bbcfdcfc7900629962b785c7e14503ae590",
-  "date": "2023-02-06T05:55:47+01:00",
-  "path": "/nix/store/haqij5xp39vjwh7p1rzdrzbicscnqx3l-tree-sitter-viml",
-  "sha256": "0p9vkl4z0kvyl3mv71rq57zghddvl2ghxbir2amjgrwb00gh0xbz",
+  "rev": "7c317fbade4b40baa7babcd6c9097c157d148e60",
+  "date": "2023-05-05T08:51:55+02:00",
+  "path": "/nix/store/dazqp112dyrxh96yizdm382fsz1rmsdj-tree-sitter-viml",
+  "sha256": "1fsngbgpvq4mg0qfwkpdn4qqi3djg2kv4a8g49yw2i8a3d88yg7x",
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-zig.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-zig.json
@@ -1,9 +1,9 @@
 {
   "url": "https://github.com/maxxnino/tree-sitter-zig",
-  "rev": "1cd5f339b146b764f39b36bb7be98ca631a2e02a",
-  "date": "2023-02-28T21:37:35+07:00",
-  "path": "/nix/store/hl9gqwnlplia44nkq9mhd2ck3gf0clxy-tree-sitter-zig",
-  "sha256": "1pg17xq7x3m4nlqbnc261zz9603xwl3am82qs21b0wkqc6zs3fyb",
+  "rev": "0d08703e4c3f426ec61695d7617415fff97029bd",
+  "date": "2023-04-25T05:51:06-03:00",
+  "path": "/nix/store/fzz8x1pa11zksamgk199fw0j7dkbsz0s-tree-sitter-zig",
+  "sha256": "0whj44fl6hmcyap5bjqhy90rd6xnnxgsy3vn1z3mvq8d2mwbnxbb",
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,

--- a/pkgs/development/tools/parsing/tree-sitter/update.nix
+++ b/pkgs/development/tools/parsing/tree-sitter/update.nix
@@ -141,6 +141,7 @@ let
     "tree-sitter-sql" = {
       orga = "derekstride";
       repo = "tree-sitter-sql";
+      branch = "gh-pages";
     };
     "tree-sitter-vim" = {
       orga = "vigoux";

--- a/pkgs/development/tools/parsing/tree-sitter/update_impl.py
+++ b/pkgs/development/tools/parsing/tree-sitter/update_impl.py
@@ -3,7 +3,7 @@ import json
 import subprocess as sub
 import os
 import sys
-from typing import Iterator, Any, Literal, TypedDict
+from typing import Iterator, Any, Literal, TypedDict, Optional
 from tempfile import NamedTemporaryFile
 
 debug: bool = True if os.environ.get("DEBUG", False) else False
@@ -106,9 +106,13 @@ def fetchRepo() -> None:
             release: str
             match curl_result(out):
                 case "not found":
-                    # github sometimes returns an empty list even tough there are releases
-                    log(f"uh-oh, latest for {orga}/{repo} is not there, using HEAD")
-                    release = "HEAD"
+                    if "branch" in jsonArg:
+                        branch = jsonArg.get("branch")
+                        release = f"refs/heads/{branch}"
+                    else:
+                        # github sometimes returns an empty list even tough there are releases
+                        log(f"uh-oh, latest for {orga}/{repo} is not there, using HEAD")
+                        release = "HEAD"
                 case {"tag_name": tag_name}:
                     release = tag_name
                 case _:
@@ -171,7 +175,8 @@ Grammar = TypedDict(
     {
         "nixRepoAttrName": str,
         "orga": str,
-        "repo": str
+        "repo": str,
+        "branch": Optional[str]
     }
 )
 


### PR DESCRIPTION
###### Description of changes

This PR updates the grammars as instructed by

https://github.com/NixOS/nixpkgs/blob/41beb4852c2ab44aceeb7ffc6aa9df61040ef613/pkgs/development/tools/parsing/tree-sitter/default.nix#L28-L32

**Update**

It turned out that `tree-sitter-sql` cannot be built anymore. The reason is that maintainers of that repository decided to move generated parser into a separate branch (see for details:https://github.com/DerekStride/tree-sitter-sql/pull/100). 

This PR allows for specifying an optional parameter `branch` when defining the list of tree-sitter grammars that will be used when fetching grammar parser. 

*Details*: If `branch` key is specified then there is an additional call made to github api to fetch latest commit for the provided branch. It is then passed to `nix-prefech-git` as `rev`. Otherwise the behavior remains the same. I couldn't simply alter `nix-prefetch-git` invocation as the `branch-name` argument is only used there to checkout to a specific branch locally (without tracking the upstream). 


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
