### PR TITLE
catppuccin-plymouth: init at unstable-2022-12-10

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -14782,6 +14782,12 @@
     githubId = 2825204;
     name = "Steven Pease";
   };
+  spectre256 = {
+    name = "Ellis Gibbons";
+    email = "egibbons256@gmail.com";
+    github = "spectre256";
+    githubId = 72505298;
+  };
   spencerjanssen = {
     email = "spencerjanssen@gmail.com";
     matrix = "@sjanssen:matrix.org";

--- a/pkgs/data/themes/catppuccin-plymouth/default.nix
+++ b/pkgs/data/themes/catppuccin-plymouth/default.nix
@@ -1,0 +1,43 @@
+{ stdenvNoCC
+, lib
+, fetchFromGitHub
+, variant ? "macchiato"
+}:
+
+let
+  pname = "catppuccin-plymouth";
+  validVariants = [ "latte" "frappe" "macchiato" "mocha" ];
+in
+lib.checkListOfEnum "${pname}: color variant" validVariants [ variant ]
+
+stdenvNoCC.mkDerivation rec {
+  inherit pname;
+  version = "unstable-2022-12-10";
+
+  src = fetchFromGitHub {
+    owner = "catppuccin";
+    repo = "plymouth";
+    rev = "d4105cf336599653783c34c4a2d6ca8c93f9281c";
+    hash = "sha256-quBSH8hx3gD7y1JNWAKQdTk3CmO4t1kVo4cOGbeWlNE=";
+  };
+
+  sourceRoot = "source/themes/catppuccin-${variant}";
+
+  installPhase = ''
+    runHook preInstall
+
+    sed -i 's:\(^ImageDir=\)/usr:\1'"$out"':' catppuccin-${variant}.plymouth
+    mkdir -p $out/share/plymouth/themes/catppuccin-${variant}
+    cp * $out/share/plymouth/themes/catppuccin-${variant}
+
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    description = "Soothing pastel theme for Plymouth";
+    homepage = "https://github.com/catppuccin/plymouth";
+    license = licenses.mit;
+    platforms = platforms.linux;
+    maintainers = [ maintainers.spectre256 ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -399,6 +399,8 @@ with pkgs;
 
   catppuccin-papirus-folders = callPackage ../data/icons/catppuccin-papirus-folders { };
 
+  catppuccin-plymouth = callPackage ../data/themes/catppuccin-plymouth { };
+
   btdu = callPackage ../tools/misc/btdu { };
 
   ccal = callPackage ../tools/misc/ccal { };


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Added package for the Catppuccin plymouth theme: https://github.com/catppuccin/plymouth


Can be used in a NixOS configuration as shown below:

```nix
{
  boot.plymouth = {
    enable = true;
    themePackages = [ pkgs.catppuccin-plymouth ];
    theme = "catppuccin-macchiato";
  };
}
```

Or with a different variant:

```nix
{
  boot.plymouth = {
    enable = true;
    themePackages = [ (pkgs.catppuccin-plymouth.override { variant = "frappe"; }) ];
    theme = "catppuccin-frappe";
  };
}
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
