### PR TITLE
emacsPackages.prolog-mode: use trivialBuild

### DIFF
--- a/pkgs/applications/editors/emacs/elisp-packages/manual-packages/prolog/default.nix
+++ b/pkgs/applications/editors/emacs/elisp-packages/manual-packages/prolog/default.nix
@@ -1,18 +1,13 @@
-{ lib, stdenv, fetchurl }:
+{ lib, trivialBuild, fetchurl }:
 
-stdenv.mkDerivation {
+trivialBuild {
   pname = "prolog-mode";
   version = "1.28";
 
   src = fetchurl {
-    url = "http://bruda.ca/_media/emacs/prolog.el";
+    url = "https://bruda.ca/_media/emacs/prolog.el";
     sha256 = "ZzIDFQWPq1vI9z3btgsHgn0axN6uRQn9Tt8TnqGybOk=";
   };
-
-  buildCommand = ''
-    mkdir -p $out/share/emacs/site-lisp/
-    cp $src $out/share/emacs/site-lisp/prolog.el
-  '';
 
   meta = {
     homepage = "https://bruda.ca/emacs/prolog_mode_for_emacs/";


### PR DESCRIPTION
###### Description of changes



###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).