### PR TITLE
fiano: init at 1.2.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -7490,6 +7490,12 @@
     githubId = 8900;
     name = "Johan Magnus Jonsson";
   };
+  jmbaur = {
+    email = "jaredbaur@fastmail.com";
+    github = "jmbaur";
+    githubId = 45740526;
+    name = "Jared Baur";
+  };
   jmc-figueira = {
     email = "business+nixos@jmc-figueira.dev";
     github = "jmc-figueira";

--- a/pkgs/tools/misc/fiano/default.nix
+++ b/pkgs/tools/misc/fiano/default.nix
@@ -1,0 +1,39 @@
+{ lib
+, buildGoModule
+, fetchFromGitHub
+}:
+
+buildGoModule rec {
+  pname = "fiano";
+
+  version = "1.2.0";
+
+  src = fetchFromGitHub {
+    owner = "linuxboot";
+    repo = "fiano";
+    rev = "v${version}";
+    hash = "sha256-QX0XMec99YbYWyfRThhwDaNjKstkUEz6wsisBynprmg=";
+  };
+
+  subPackages = [
+    "cmds/cbfs"
+    "cmds/create-ffs"
+    "cmds/fmap"
+    "cmds/fspinfo"
+    "cmds/glzma"
+    "cmds/guid2english"
+    "cmds/microcode"
+    "cmds/utk"
+  ];
+
+  vendorHash = "sha256-00ZSAVEmk2pNjv6fo++gnpIheK8lo4AVWf+ghXappnI=";
+
+  ldflags = [ "-s" "-w" ];
+
+  meta = with lib; {
+    description = "Go-based tools for modifying UEFI firmware";
+    homepage = "https://github.com/linuxboot/fiano";
+    changelog = "https://github.com/linuxboot/fiano/blob/v${version}/RELEASES.md";
+    license = licenses.bsd3;
+  };
+}

--- a/pkgs/tools/misc/fiano/default.nix
+++ b/pkgs/tools/misc/fiano/default.nix
@@ -35,5 +35,6 @@ buildGoModule rec {
     homepage = "https://github.com/linuxboot/fiano";
     changelog = "https://github.com/linuxboot/fiano/blob/v${version}/RELEASES.md";
     license = licenses.bsd3;
+    maintainers = [ maintainers.jmbaur ];
   };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4819,6 +4819,8 @@ with pkgs;
 
   fetch-scm = callPackage ../tools/misc/fetch-scm { };
 
+  fiano = callPackage ../tools/misc/fiano { };
+
   filebench = callPackage ../tools/misc/filebench { };
 
   filebot = callPackage ../applications/video/filebot { };


### PR DESCRIPTION
###### Description of changes

Fiano is a suite of Go-based tools for modifying UEFI firmware.

This initial inclusion of fiano omits one package called `fittool`, since this
tool has a separate `modRoot` than the rest and its `go.sum` is not up to date,
so it does not build. I will be working with upstream to get this fixed.

I also added myself as a maintainer of this package, and thus adding myself to
the maintainer list as well.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See
      [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests)
    (look inside
    [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or
    [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in
    [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or
    [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are
    [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking)
    to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using
      `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all
      changes have to be committed, also see
      [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in
      `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or
        breaking
  - [ ] (Module updates) Added a release notes entry if the change is
        significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS
        module
- [x] Fits
      [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
