### PR TITLE
cppfront: init at unstable-2023-05-15

### DIFF
--- a/pkgs/development/compilers/cppfront/default.nix
+++ b/pkgs/development/compilers/cppfront/default.nix
@@ -1,0 +1,43 @@
+{ stdenv
+, fetchFromGitHub
+, lib
+}:
+
+stdenv.mkDerivation {
+  pname = "cppfront";
+  version = "unstable-2023-05-15";
+
+  src = fetchFromGitHub {
+    repo = "cppfront";
+    owner = "hsutter";
+    rev = "ebe5ebc11303b11d29d6d40d498372c2bea07abd";
+    sha256 = "sha256-PtRmN2HsDC6byXWR2iFepvEg1KBNeIsYm/LKqlFlZ7Y=";
+  };
+
+  buildPhase = ''
+    runHook preBuild
+    $CXX source/cppfront.cpp -std=c++20 -o cppfront
+    runHook postBuild
+  '';
+
+  installPhase = ''
+    runHook preInstall
+    install -Dm755 cppfront $out/bin/cppfront
+    cp -r include $out/include
+    runHook postInstall
+  '';
+
+  meta =
+    let
+      inherit (lib) platforms licenses maintainers;
+    in
+    {
+      platforms = platforms.all;
+      description = "An experimental compiler from a potential C++ 'syntax 2' (Cpp2) to today's 'syntax 1' (Cpp1)";
+      homepage = "https://github.com/hsutter/cppfront";
+      license = licenses.cc-by-nc-nd-40;
+      maintainers = [
+        maintainers.adisbladis
+      ];
+    };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -14719,6 +14719,8 @@ with pkgs;
     inherit (darwin.apple_sdk.frameworks) CoreServices;
   };
 
+  cppfront = callPackage ../development/compilers/cppfront { };
+
   inherit (callPackages ../development/compilers/crystal {
     llvmPackages = llvmPackages_13;
     stdenv = if stdenv.isDarwin then darwin.apple_sdk_11_0.stdenv else stdenv;


### PR DESCRIPTION
###### Description of changes

Quoting upstream
> Cppfront is an experimental compiler from a potential C++ 'syntax 2' (Cpp2) to today's 'syntax 1' (Cpp1), to learn some things, prove out some concepts, and share some ideas. This compiler is a work in progress and currently hilariously incomplete... basic functions work, classes will be next, then metaclasses and lightweight exceptions.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
