### PR TITLE
bfscripts: init at unstable-2023-05-15

### DIFF
--- a/pkgs/tools/misc/bfscripts/default.nix
+++ b/pkgs/tools/misc/bfscripts/default.nix
@@ -1,0 +1,63 @@
+{ stdenv
+, fetchFromGitHub
+, lib
+, python3
+}:
+
+let
+  # Most of the binaries are not really useful because they have hardcoded
+  # paths that only make sense when you're running the stock BlueField OS on
+  # your BlueField. These might be patched in the future with resholve
+  # (https://github.com/abathur/resholve). If there is one that makes sense
+  # without resholving it, it can simply be uncommented and will be included in
+  # the output.
+  binaries = [
+    # "bfacpievt"
+    # "bfbootmgr"
+    # "bfcfg"
+    # "bfcpu-freq"
+    # "bfdracut"
+    # "bffamily"
+    # "bfgrubcheck"
+    # "bfhcafw"
+    # "bfinst"
+    # "bfpxe"
+    # "bfrec"
+    "bfrshlog"
+    # "bfsbdump"
+    # "bfsbkeys"
+    # "bfsbverify"
+    # "bfver"
+    # "bfvcheck"
+    "mlx-mkbfb"
+    "bfup"
+  ];
+in
+stdenv.mkDerivation rec {
+  pname = "bfscripts";
+  version = "unstable-2023-05-15";
+
+  src = fetchFromGitHub {
+    owner = "Mellanox";
+    repo = pname;
+    rev = "1da79f3ece7cdf99b2571c00e8b14d2e112504a4";
+    hash = "sha256-pTubrnZKEFmtAj/omycFYeYwrCog39zBDEszoCrsQNQ=";
+  };
+
+  buildInputs = [
+    python3
+  ];
+
+  installPhase = ''
+    ${lib.concatStringsSep "\n" (map (b: "install -D ${b} $out/bin/${b}") binaries)}
+  '';
+
+  meta = with lib;
+    {
+      description = "Collection of scripts used for BlueField SoC system management";
+      homepage = "https://github.com/Mellanox/bfscripts";
+      license = licenses.bsd2;
+      platforms = platforms.linux;
+      maintainers = with maintainers; [ nikstur ];
+    };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3858,6 +3858,8 @@ with pkgs;
 
   bfr = callPackage ../tools/misc/bfr { };
 
+  bfscripts = callPackage ../tools/misc/bfscripts { };
+
   bibtool = callPackage ../tools/misc/bibtool { };
 
   bibutils = callPackage ../tools/misc/bibutils { };


### PR DESCRIPTION
###### Description of changes

Add bfscripts a collection of tools for BlueField development. Notably this includes mlx-mkbfb which allows to create bootstreams a format to install a new operating system onto a BlueField. Hopefully, NixOS can be installed via a bootstream soon ;)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
