### PR TITLE
lib/options: nullable mkPackageOption

### DIFF
--- a/lib/tests/modules.sh
+++ b/lib/tests/modules.sh
@@ -182,6 +182,11 @@ checkConfigOutput '^true$' config.enableAlias ./alias-with-priority.nix
 checkConfigOutput '^false$' config.enable ./alias-with-priority-can-override.nix
 checkConfigOutput '^false$' config.enableAlias ./alias-with-priority-can-override.nix
 
+# Check mkPackageOption
+checkConfigOutput '^"hello"$' config.package.pname ./declare-mkPackageOption.nix
+checkConfigError 'The option .undefinedPackage. is used but not defined' config.undefinedPackage ./declare-mkPackageOption.nix
+checkConfigOutput '^null$' config.nullablePackage ./declare-mkPackageOption.nix
+
 # submoduleWith
 
 ## specialArgs should work

--- a/lib/tests/modules/declare-mkPackageOption.nix
+++ b/lib/tests/modules/declare-mkPackageOption.nix
@@ -1,0 +1,19 @@
+{ lib, ... }: let
+  pkgs.hello = {
+    type = "derivation";
+    pname = "hello";
+  };
+in {
+  options = {
+    package = lib.mkPackageOption pkgs "hello" { };
+
+    undefinedPackage = lib.mkPackageOption pkgs "hello" {
+      default = null;
+    };
+
+    nullablePackage = lib.mkPackageOption pkgs "hello" {
+      nullable = true;
+      default = null;
+    };
+  };
+}


### PR DESCRIPTION
It is sometimes useful to allow setting a package option to `null` to skip installing the package. See https://github.com/nix-community/home-manager/pull/3668#issuecomment-1554044171 for example.

No manualHTML diff, haven't tested beyond that.