### PR TITLE
dbus-broker: Fetch dependencies from tags instead of branches

### DIFF
--- a/pkgs/os-specific/linux/dbus-broker/default.nix
+++ b/pkgs/os-specific/linux/dbus-broker/default.nix
@@ -11,14 +11,13 @@
 }:
 
 let
-  dep = { pname, version, hash, buildInputs ? [ ] }:
+  dep = { pname, version, hash, rev ? version, buildInputs ? [ ] }:
     stdenv.mkDerivation {
       inherit pname version;
       src = fetchFromGitHub {
         owner = "c-util";
         repo = pname;
-        rev = version;
-        inherit hash;
+        inherit hash rev;
       };
       nativeBuildInputs = [ meson ninja pkg-config ];
       inherit buildInputs;
@@ -28,13 +27,14 @@ let
   #
   # If that changes, we can always break them out, but they are essentially
   # part of the dbus-broker project, just in separate repositories.
-  c-dvar = dep { pname = "c-dvar"; version = "v1"; hash = "sha256-P7y7gUHXQn2eyS6IcV7m7yGy4VGtQ2orgBkS7Y729ZY="; buildInputs = [ c-stdaux c-utf8 ]; };
-  c-ini = dep { pname = "c-ini"; version = "v1"; hash = "sha256-VKxoGexMcquakMmiH5IJt0382TjkV1FLncTSyEqf4X0="; buildInputs = [ c-list c-rbtree c-stdaux c-utf8 ]; };
-  c-list = dep { pname = "c-list"; version = "v3"; hash = "sha256-fp3EAqcbFCLaT2EstLSzwP2X13pi2EFpFAullhoCtpw="; };
-  c-rbtree = dep { pname = "c-rbtree"; version = "v3"; hash = "sha256-ExSPgNqhTjSwRgYfZOAyoaehOpFNHKFqPYkcCfptkrs="; buildInputs = [ c-stdaux ]; };
-  c-shquote = dep { pname = "c-shquote"; version = "v1"; hash = "sha256-Ze1enX0VJ6Xi5e4EhWzaiHc7PnuaifrUP+JuJnauv5c="; buildInputs = [ c-stdaux ]; };
-  c-stdaux = dep { pname = "c-stdaux"; version = "v1"; hash = "sha256-/D+IFdqn1XHDfdOsDnLMO5IHQ5B4P4ELyMpRcPBg/4s="; };
-  c-utf8 = dep { pname = "c-utf8"; version = "v1"; hash = "sha256-QEnjmfQ6kxJdsHfyRgXAlP+oGrKLYQ0m9r+D2L+pizI="; buildInputs = [ c-stdaux ]; };
+  c-dvar = dep { pname = "c-dvar"; version = "v1.0.0"; hash = "sha256-P7y7gUHXQn2eyS6IcV7m7yGy4VGtQ2orgBkS7Y729ZY="; buildInputs = [ c-stdaux c-utf8 ]; };
+  c-ini = dep { pname = "c-ini"; version = "v1.0.0"; hash = "sha256-VKxoGexMcquakMmiH5IJt0382TjkV1FLncTSyEqf4X0="; buildInputs = [ c-list c-rbtree c-stdaux c-utf8 ]; };
+  c-list = dep { pname = "c-list"; version = "v3.1.0"; hash = "sha256-fp3EAqcbFCLaT2EstLSzwP2X13pi2EFpFAullhoCtpw="; };
+  # TODO: Fetch c-rbtree from a tag after its next release
+  c-rbtree = dep { pname = "c-rbtree"; version = "unstable-2022-07-07"; rev = "431a4746705223673e43940ca1ad9b5f52473a4b"; hash = "sha256-ExSPgNqhTjSwRgYfZOAyoaehOpFNHKFqPYkcCfptkrs="; buildInputs = [ c-stdaux ]; };
+  c-shquote = dep { pname = "c-shquote"; version = "v1.0.0"; hash = "sha256-Ze1enX0VJ6Xi5e4EhWzaiHc7PnuaifrUP+JuJnauv5c="; buildInputs = [ c-stdaux ]; };
+  c-stdaux = dep { pname = "c-stdaux"; version = "v1.2.0"; hash = "sha256-/D+IFdqn1XHDfdOsDnLMO5IHQ5B4P4ELyMpRcPBg/4s="; };
+  c-utf8 = dep { pname = "c-utf8"; version = "v1.0.0"; hash = "sha256-QEnjmfQ6kxJdsHfyRgXAlP+oGrKLYQ0m9r+D2L+pizI="; buildInputs = [ c-stdaux ]; };
 
 in
 stdenv.mkDerivation rec {


### PR DESCRIPTION
###### Description of changes

- `c-stdaux` has new commits on its "v1" branch, which makes the fetcher fail due to a hash mismatch. Fetch the "v1.2.0" tag instead.
- Also point the other dependencies at git tags instead of branches for consistency and to avoid future problems if they also get new commits.
- The head of the `c-rbtree` "v3" branch has not been tagged yet. Instead of downgrading this package to the "v3.1.0" tag, point the fetcher at the specific git revision.

The fetchers can be tested with
```
nix-build         -E 'with import ./. {}; builtins.map (dep: dep.src) (lib.filter (dep: lib.hasPrefix "c-" dep.pname) dbus-broker.buildInputs)'
nix-build --check -E 'with import ./. {}; builtins.map (dep: dep.src) (lib.filter (dep: lib.hasPrefix "c-" dep.pname) dbus-broker.buildInputs)'
```

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
