### PR TITLE
cbqn: 0.2.0 -> 0.3.0

### DIFF
--- a/pkgs/development/interpreters/bqn/cbqn/cbqn-bytecode.nix
+++ b/pkgs/development/interpreters/bqn/cbqn/cbqn-bytecode.nix
@@ -5,13 +5,13 @@
 
 stdenvNoCC.mkDerivation {
   pname = "cbqn-bytecode";
-  version = "unstable-2023-04-19";
+  version = "unstable-2023-05-17";
 
   src = fetchFromGitHub {
     owner = "dzaima";
     repo = "cbqnBytecode";
-    rev = "78ed4102f914eb5fa490d76d4dcd4f8be6e53417";
-    hash = "sha256-IOhxcfGmpARiTdFMSpc+Rh8VXtasZdfP6vKJzULNxAg=";
+    rev = "32db4dfbfc753835bf112f3d8ae2991d8aebbe3d";
+    hash = "sha256-9uBPrEESn/rB9u0xXwKaQ7ABveQWPc8LRMPlnI/79kg=";
   };
 
   dontConfigure = true;
@@ -20,7 +20,7 @@ stdenvNoCC.mkDerivation {
   installPhase = ''
     runHook preInstall
 
-    install -D $src/gen/{compiles,explain,formatter,runtime0,runtime1,src} -t $out/dev
+    install -D $src/gen/{compiles,explain,formatter,runtime0,runtime1,runtime1x,src} -t $out/dev
 
     runHook postInstall
   '';

--- a/pkgs/development/interpreters/bqn/cbqn/default.nix
+++ b/pkgs/development/interpreters/bqn/cbqn/default.nix
@@ -6,7 +6,7 @@
 , fixDarwinDylibNames
 , genBytecode ? false
 , bqn-path ? null
-, mbqn-source ? null
+, mbqn-source
 , enableReplxx ? false
 , enableSingeli ? stdenv.hostPlatform.avx2Support
 , enableLibcbqn ? ((stdenv.hostPlatform.isLinux || stdenv.hostPlatform.isDarwin) && !enableReplxx)
@@ -42,6 +42,7 @@ stdenv.mkDerivation rec {
   ];
 
   dontConfigure = true;
+  doInstallCheck = true;
 
   postPatch = ''
     sed -i '/SHELL =.*/ d' makefile
@@ -100,6 +101,26 @@ stdenv.mkDerivation rec {
     runHook postInstall
   '';
 
+  installCheckPhase = ''
+    runHook preInstallCheck
+
+    # main test suite from mlochbaum/BQN
+    $out/bin/BQN ${mbqn-source}/test/this.bqn
+
+    # CBQN tests that do not require compiling with test-only flags
+    $out/bin/BQN test/cmp.bqn
+    $out/bin/BQN test/equal.bqn
+    $out/bin/BQN test/copy.bqn
+    $out/bin/BQN test/bit.bqn
+    $out/bin/BQN test/hash.bqn
+    $out/bin/BQN test/squeezeValid.bqn
+    $out/bin/BQN test/squeezeExact.bqn
+    $out/bin/BQN test/various.bqn
+    $out/bin/BQN test/random.bqn
+
+    runHook postInstallCheck
+  '';
+
   meta = with lib; {
     homepage = "https://github.com/dzaima/CBQN/";
     description = "BQN implementation in C";
@@ -108,4 +129,3 @@ stdenv.mkDerivation rec {
     platforms = platforms.all;
   };
 }
-# TODO: test suite

--- a/pkgs/development/interpreters/bqn/cbqn/singeli.nix
+++ b/pkgs/development/interpreters/bqn/cbqn/singeli.nix
@@ -5,13 +5,13 @@
 
 stdenvNoCC.mkDerivation {
   pname = "singeli";
-  version = "unstable-2023-04-12";
+  version = "unstable-2023-04-27";
 
   src = fetchFromGitHub {
     owner = "mlochbaum";
     repo = "Singeli";
-    rev = "3327956fedfdc6aef12954bc12120f20de2226d0";
-    hash = "sha256-k25hk5zTn0m+2Nh9buTJYhtM98/VRlQ0guoRw9el3VE=";
+    rev = "853ab1a06ae8d8603f228d8e784fa319cc401459";
+    hash = "sha256-X/NnufvakihJAE9H7geuuDS7Tv9l7tgLKdRgXC4ZX4A=";
   };
 
   dontConfigure = true;

--- a/pkgs/development/interpreters/bqn/mlochbaum-bqn/default.nix
+++ b/pkgs/development/interpreters/bqn/mlochbaum-bqn/default.nix
@@ -7,13 +7,13 @@
 
 stdenvNoCC.mkDerivation rec {
   pname = "bqn";
-  version = "0.pre+date=2023-05-09";
+  version = "unstable-2023-05-17";
 
   src = fetchFromGitHub {
     owner = "mlochbaum";
     repo = "BQN";
-    rev = "656b176c5dc783b038b018f0ed17a5414ea62b4d";
-    hash = "sha256-6r+N0eCvwvaoB84cw+Vtoqa6MXuI0NXLbOPblemY4M8=";
+    rev = "070bd07dc10c291695215265218ec0ff856ce457";
+    hash = "sha256-GRIIzJwlJ+JTBHXZjoX/9vLFbAC7zyeuqVcrA/Jm/NA=";
   };
 
   nativeBuildInputs = [ makeWrapper ];

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -16752,17 +16752,15 @@ with pkgs;
     mbqn-source = buildPackages.mbqn.src;
 
     phase0 = callPackage ../development/interpreters/bqn/cbqn {
-      inherit (cbqn-bootstrap) stdenv;
+      inherit (cbqn-bootstrap) mbqn-source stdenv;
       genBytecode = false;
       bqn-path = null;
-      mbqn-source = null;
     };
 
     phase0-replxx = callPackage ../development/interpreters/bqn/cbqn {
-      inherit (cbqn-bootstrap) stdenv;
+      inherit (cbqn-bootstrap) mbqn-source stdenv;
       genBytecode = false;
       bqn-path = null;
-      mbqn-source = null;
       enableReplxx = true;
     };
 


### PR DESCRIPTION
Singeli is now enabled by default for `o3` builds in upstream, thus we need to always have `build/singeliLocal` present.

`mbqn-source` is needed for the installCheckPhase.