### PR TITLE
bpftrace: 0.17.1 -> 0.18.0

### DIFF
--- a/pkgs/os-specific/linux/bpftrace/default.nix
+++ b/pkgs/os-specific/linux/bpftrace/default.nix
@@ -1,42 +1,56 @@
-{ lib, stdenv, fetchFromGitHub
-, cmake, pkg-config, flex, bison
-, llvmPackages, elfutils
-, libbfd, libbpf, libopcodes, bcc
+{ lib, stdenv, fetchFromGitHub, fetchpatch
+, llvmPackages, elfutils, bcc
+, libbpf, libbfd, libopcodes
 , cereal, asciidoctor
-, nixosTests
+, cmake, pkg-config, flex, bison
 , util-linux
+, nixosTests
 }:
 
 stdenv.mkDerivation rec {
   pname = "bpftrace";
-  version = "0.17.1";
+  version = "0.18.0";
 
   src = fetchFromGitHub {
-    owner  = "iovisor";
-    repo   = "bpftrace";
-    rev    = "v${version}";
-    sha256 = "sha256-dEchHXZPWc+/Dui6P65EqxB8O/M7F47PZVsKSp80oXE=";
+    owner = "iovisor";
+    repo  = "bpftrace";
+    rev   = "v${version}";
+    hash  = "sha256-+SBLcMyOf1gZN8dG5xkNLsqIcK1eVlswjY1GRXepFVg=";
   };
 
-  buildInputs = with llvmPackages;
-    [ llvm libclang
-      elfutils bcc
-      libbpf libbfd libopcodes
-      cereal asciidoctor
-    ];
+  patches = [
+    # fails to build - https://github.com/iovisor/bpftrace/issues/2598
+    (fetchpatch {
+      name = "link-binaries-against-zlib";
+      url = "https://github.com/iovisor/bpftrace/commit/a60b171eb288250c3f1d6f065b05d8a87aff3cdd.patch";
+      hash = "sha256-b/0pKDjolo2RQ/UGjEfmWdG0tnIiFX8PJHhRCXvzyxA=";
+    })
+  ];
 
-  nativeBuildInputs = [ cmake pkg-config flex bison llvmPackages.llvm.dev util-linux ];
+  buildInputs = with llvmPackages; [
+    llvm libclang
+    elfutils bcc
+    libbpf libbfd libopcodes
+    cereal asciidoctor
+  ];
+
+  nativeBuildInputs = [
+    cmake pkg-config flex bison
+    llvmPackages.llvm.dev
+    util-linux
+  ];
 
   # tests aren't built, due to gtest shenanigans. see:
   #
   #     https://github.com/iovisor/bpftrace/issues/161#issuecomment-453606728
   #     https://github.com/iovisor/bpftrace/pull/363
   #
-  cmakeFlags =
-    [ "-DBUILD_TESTING=FALSE"
-      "-DLIBBCC_INCLUDE_DIRS=${bcc}/include"
-      "-DINSTALL_TOOL_DOCS=off"
-    ];
+  cmakeFlags = [
+    "-DBUILD_TESTING=FALSE"
+    "-DLIBBCC_INCLUDE_DIRS=${bcc}/include"
+    "-DINSTALL_TOOL_DOCS=OFF"
+    "-DUSE_SYSTEM_BPF_BCC=ON"
+  ];
 
   # Pull BPF scripts into $PATH (next to their bcc program equivalents), but do
   # not move them to keep `${pkgs.bpftrace}/share/bpftrace/tools/...` working.


### PR DESCRIPTION
###### Description of changes

- release notes: https://github.com/iovisor/bpftrace/releases/tag/v0.18.0
- Add patch to fix build
- While we're here uniformize style a bit, so there's lot of fluff, but it's really just version bump + patch...

I don't mind if this goes in after the 23.05 branch out, but it's minor enough to me and does fix a couple of bugs so probably ought to be backported after branch out if we wait anyway

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
