### PR TITLE
ossutil: 1.7.6 -> 1.7.16

### DIFF
--- a/pkgs/tools/admin/ossutil/default.nix
+++ b/pkgs/tools/admin/ossutil/default.nix
@@ -1,32 +1,25 @@
 { lib, buildGoModule, fetchFromGitHub, fetchpatch }:
 
 buildGoModule rec {
-  version = "1.7.6";
+  version = "1.7.16";
   pname = "ossutil";
 
   src = fetchFromGitHub {
     owner = "aliyun";
     repo = "ossutil";
-    rev = version;
-    sha256 = "1hkdk0hidnm7vz320i7s4z7jngx2j70acc93agii2b3r2bb91l3d";
+    rev = "refs/tags/v${version}";
+    hash = "sha256-J6t8QoyCvbGrUX2AkdqugztchP7Cc0jZsrn1+OB2hVY=";
   };
 
-  # this patch is required to add go mods to fetch dependencies
-  patches = [
-    (fetchpatch {
-      url = "https://github.com/aliyun/ossutil/commit/64067e979fb24ffb198a0c4eca718e81b63f514e.patch";
-      sha256 = "2pn0BcbNNL+iMema54LRpG/ca5kyDugLIZQ/TMhYG/8=";
-    })
-  ];
-
-  vendorSha256 = "lem9Jg4Ywv3qcIwhiZHNi1VH5HxxNr6mnefOLCzPL70=";
+  vendorSha256 = "sha256-oxhi27Zt91S2RwidM+BPati/HWuP8FrZs1X2R2Px5hI=";
 
   # don't run tests as they require secret access keys that only travis has
   doCheck = false;
 
   meta = with lib; {
-    homepage = "https://github.com/aliyun/ossutil";
     description = "A user friendly command line tool to access Alibaba Cloud OSS";
+    homepage = "https://github.com/aliyun/ossutil";
+    changelog = "https://github.com/aliyun/ossutil/blob/v${version}/CHANGELOG.md";
     license = licenses.mit;
     maintainers = with maintainers; [ jpetrucciani ];
   };


### PR DESCRIPTION
###### Description of changes

This updates [ossutil](https://github.com/aliyun/ossutil) to the latest release, and removes the old patches that were required to get it building!

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [X] x86_64-darwin
  - [X] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

