### PR TITLE
Revert "python311Packages.google-auth: 2.17.3 -> 2.18.1"

### DIFF
--- a/pkgs/development/python-modules/google-auth/default.nix
+++ b/pkgs/development/python-modules/google-auth/default.nix
@@ -27,14 +27,14 @@
 
 buildPythonPackage rec {
   pname = "google-auth";
-  version = "2.18.1";
+  version = "2.17.3";
   format = "setuptools";
 
   disabled = pythonOlder "3.6";
 
   src = fetchPypi {
     inherit pname version;
-    hash = "sha256-16MkkCfn9GT7v9fugxmgitCdLupRV4V1xL02D/oEnMs=";
+    hash = "sha256-zjEeK8WLEw/d8xbfV8mzlDwqe09uwx3pZjqTM+QGTvw=";
   };
 
   propagatedBuildInputs = [


### PR DESCRIPTION
Reverts NixOS/nixpkgs#232663

Breaking change during the breaking changes freeze.

https://github.com/NixOS/nixpkgs/pull/232663#issuecomment-1554046979