### PR TITLE
yubikey-touch-detector: add icon

### DIFF
--- a/pkgs/tools/security/yubikey-touch-detector/default.nix
+++ b/pkgs/tools/security/yubikey-touch-detector/default.nix
@@ -1,4 +1,4 @@
-{ lib, libnotify, buildGoModule, fetchFromGitHub, pkg-config }:
+{ lib, libnotify, buildGoModule, fetchFromGitHub, fetchurl, pkg-config, iconColor ? "#84bd00" }:
 
 buildGoModule rec {
   pname = "yubikey-touch-detector";
@@ -12,12 +12,30 @@ buildGoModule rec {
   };
   vendorHash = "sha256-OitI9Yp4/mRMrNH4yrWSL785+3mykPkvzarrc6ipOeg=";
 
+  iconSrc = fetchurl {
+    url = "https://github.com/Yubico/yubioath-flutter/raw/yubioath-desktop-5.0.0/images/touch.svg";
+    hash = "sha256-+jC9RKjl1uMBaNqLX5WXN+E4CuOcIEx5IGXWxgxzA/k=";
+  };
+
   nativeBuildInputs = [ pkg-config ];
 
   buildInputs = [ libnotify ];
 
+  postPatch = ''
+    cp $iconSrc yubikey-touch-detector.svg
+    substituteInPlace yubikey-touch-detector.svg \
+      --replace '#284c61' ${lib.escapeShellArg iconColor}
+
+    substituteInPlace notifier/libnotify.go \
+      --replace \
+        'AppIcon: "yubikey-touch-detector"' \
+        "AppIcon: \"$out/share/icons/yubikey-touch-detector.svg\""
+  '';
+
   postInstall = ''
     install -Dm444 -t $out/share/doc/${pname} *.md
+
+    install -Dm444 -t $out/share/icons yubikey-touch-detector.svg
 
     install -Dm444 -t $out/lib/systemd/user *.{service,socket}
 
@@ -29,7 +47,7 @@ buildGoModule rec {
     description = "A tool to detect when your YubiKey is waiting for a touch (to send notification or display a visual indicator on the screen).";
     homepage = "https://github.com/maximbaz/yubikey-touch-detector";
     maintainers = with maintainers; [ sumnerevans ];
-    license = licenses.isc;
+    license = with licenses; [ bsd2 isc ];
     platforms = platforms.linux;
   };
 }


### PR DESCRIPTION
###### Description of changes

As explained in maximbaz/yubikey-touch-detector#25, YubiKey touch detector doesn't include an icon but is intended to be paired with one by the user or packager.

Following the example of alpinelinux/aports@1f596c2, this derives an icon from the assets of [Yubico Authenticator](https://github.com/Yubico/yubioath-flutter/tree/yubioath-desktop-5.0.0):

> <img src="https://github.com/NixOS/nixpkgs/assets/1844746/12d71f6d-aec4-49b8-b16a-d8e376f2e79a" width="559" alt="screenshot" />

I’m not sure if this is the right way to package this.

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`?
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests)
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`.
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
