### PR TITLE
nixosTests.fcitx5: unbreak, add rest of CJK

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -11235,6 +11235,12 @@
     githubId = 17120571;
     name = "Xinhao Luo";
   };
+  nevivurn = {
+    email = "nevivurn@nevi.dev";
+    github = "nevivurn";
+    githubId = 7698349;
+    name = "Yongun Seong";
+  };
   newam = {
     email = "alex@thinglab.org";
     github = "newAM";

--- a/nixos/tests/fcitx5/profile
+++ b/nixos/tests/fcitx5/profile
@@ -4,11 +4,23 @@ Default Layout=us
 DefaultIM=wbx
 
 [Groups/0/Items/0]
+Name=keyboard-us
+Layout=
+
+[Groups/0/Items/1]
 Name=wbx
 Layout=us
 
-[Groups/0/Items/1]
+[Groups/0/Items/2]
+Name=hangul
+Layout=us
+
+[Groups/0/Items/3]
 Name=m17n_sa_harvard-kyoto
+Layout=us
+
+[Groups/0/Items/4]
+Name=mozc
 Layout=us
 
 [GroupOrder]

--- a/pkgs/tools/inputmethods/fcitx5/default.nix
+++ b/pkgs/tools/inputmethods/fcitx5/default.nix
@@ -31,6 +31,7 @@
 , xcbutilwm
 , xcb-imdkit
 , libxkbfile
+, nixosTests
 }:
 let
   enDictVer = "20121020";
@@ -89,7 +90,12 @@ stdenv.mkDerivation rec {
     libxkbfile
   ];
 
-  passthru.updateScript = ./update.py;
+  passthru = {
+    updateScript = ./update.py;
+    tests = {
+      inherit (nixosTests) fcitx5;
+    };
+  };
 
   meta = with lib; {
     description = "Next generation of fcitx";

--- a/pkgs/tools/inputmethods/fcitx5/fcitx5-hangul.nix
+++ b/pkgs/tools/inputmethods/fcitx5/fcitx5-hangul.nix
@@ -6,6 +6,7 @@
 , gettext
 , fcitx5
 , libhangul
+, nixosTests
 }:
 
 stdenv.mkDerivation rec {
@@ -29,6 +30,10 @@ stdenv.mkDerivation rec {
     fcitx5
     libhangul
   ];
+
+  passthru.tests = {
+    inherit (nixosTests) fcitx5;
+  };
 
   meta = with lib; {
     description = "Hangul wrapper for Fcitx5";

--- a/pkgs/tools/inputmethods/fcitx5/fcitx5-m17n.nix
+++ b/pkgs/tools/inputmethods/fcitx5/fcitx5-m17n.nix
@@ -9,6 +9,7 @@
 , m17n_db
 , gettext
 , fmt
+, nixosTests
 }:
 
 stdenv.mkDerivation rec {
@@ -35,6 +36,10 @@ stdenv.mkDerivation rec {
     m17n_lib
     fmt
   ];
+
+  passthru.tests = {
+    inherit (nixosTests) fcitx5;
+  };
 
   meta = with lib; {
     description = "m17n support for Fcitx5";

--- a/pkgs/tools/inputmethods/fcitx5/fcitx5-mozc.nix
+++ b/pkgs/tools/inputmethods/fcitx5/fcitx5-mozc.nix
@@ -1,6 +1,6 @@
 { lib, clangStdenv, fetchFromGitHub, fetchurl, fetchpatch, fetchgit
 , python3Packages, ninja, pkg-config, protobuf, zinnia, qt5, fcitx5
-, jsoncpp, gtest, which, gtk2, unzip, abseil-cpp, breakpad }:
+, jsoncpp, gtest, which, gtk2, unzip, abseil-cpp, breakpad, nixosTests }:
 let
   inherit (python3Packages) python gyp six;
   utdic = fetchurl {
@@ -114,6 +114,10 @@ in clangStdenv.mkDerivation rec {
   preFixup = ''
     wrapQtApp $out/lib/mozc/mozc_tool
   '';
+
+  passthru.tests = {
+    inherit (nixosTests) fcitx5;
+  };
 
   meta = with lib; {
     description = "Fcitx5 Module of A Japanese Input Method for Chromium OS, Windows, Mac and Linux (the Open Source Edition of Google Japanese Input)";


### PR DESCRIPTION
###### Description of changes

Test was broken in fcitx4 (7e2a357edbea07debf27703d713c900fc6e8654c) even before f95c20d77d5275a0fe4d2809bbb6e10d5492b93f.
According to hydra, it has never succeeded. Also, I added the test to `passthru.tests` for fcitx5 and other engines used in the test.

I also added the rest of CJK.

ZHF: #230712

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
