### PR TITLE
ocf-resource-agents: 4.10.0 -> 4.12.0 (and fix build on i686)

### DIFF
--- a/pkgs/os-specific/linux/ocf-resource-agents/0001-storage_mon-Fix-printf-format-string-on-i686.patch
+++ b/pkgs/os-specific/linux/ocf-resource-agents/0001-storage_mon-Fix-printf-format-string-on-i686.patch
@@ -1,0 +1,34 @@
+From 5ff43935d87b727fdd2a26781f22d6519bfe0fc2 Mon Sep 17 00:00:00 2001
+From: Tobias Markus <tobias@miglix.eu>
+Date: Sat, 20 May 2023 13:53:03 +0200
+Subject: [PATCH] storage_mon: Fix printf format string on i686
+
+---
+ tools/storage_mon.c | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/tools/storage_mon.c b/tools/storage_mon.c
+index f829c508..8af28beb 100644
+--- a/tools/storage_mon.c
++++ b/tools/storage_mon.c
+@@ -67,7 +67,7 @@ static void *test_device(const char *device, int verbose, int inject_error_perce
+ 		goto error;
+ 	}
+ 	if (verbose) {
+-		printf("%s: opened %s O_DIRECT, size=%zu\n", device, (flags & O_DIRECT)?"with":"without", devsize);
++		printf("%s: opened %s O_DIRECT, size=%llu\n", device, (flags & O_DIRECT)?"with":"without", devsize);
+ 	}
+ 
+ 	/* Don't fret about real randomness */
+@@ -120,7 +120,7 @@ static void *test_device(const char *device, int verbose, int inject_error_perce
+ 			goto error;
+ 		}
+ 		if (res < (int)sizeof(buffer)) {
+-			fprintf(stderr, "Failed to read %ld bytes from %s, got %d\n", sizeof(buffer), device, res);
++			fprintf(stderr, "Failed to read %zd bytes from %s, got %d\n", sizeof(buffer), device, res);
+ 			goto error;
+ 		}
+ 	}
+-- 
+2.40.1
+

--- a/pkgs/os-specific/linux/ocf-resource-agents/default.nix
+++ b/pkgs/os-specific/linux/ocf-resource-agents/default.nix
@@ -42,6 +42,11 @@ let
       python3
     ];
 
+    patches = [
+      # See https://github.com/ClusterLabs/resource-agents/pull/1870
+      ./0001-storage_mon-Fix-printf-format-string-on-i686.patch
+    ];
+
     env.NIX_CFLAGS_COMPILE = toString (lib.optionals (stdenv.cc.isGNU && lib.versionAtLeast stdenv.cc.version "12") [
       # Needed with GCC 12 but breaks on darwin (with clang) or older gcc
       "-Wno-error=maybe-uninitialized"

--- a/pkgs/os-specific/linux/ocf-resource-agents/default.nix
+++ b/pkgs/os-specific/linux/ocf-resource-agents/default.nix
@@ -23,13 +23,13 @@ let
 
   resource-agentsForOCF = stdenv.mkDerivation rec {
     pname = "resource-agents";
-    version = "4.10.0";
+    version = "4.12.0";
 
     src = fetchFromGitHub {
       owner = "ClusterLabs";
       repo = pname;
       rev = "v${version}";
-      sha256 = "0haryi3yrszdfpqnkfnppxj1yiy6ipah6m80snvayc7v0ss0wnir";
+      sha256 = "sha256-+UIjmHmCOi1aitJ01tC8k/2/Xb361UhMVtj/9wC/TEE=";
     };
 
     nativeBuildInputs = [

--- a/pkgs/os-specific/linux/ocf-resource-agents/default.nix
+++ b/pkgs/os-specific/linux/ocf-resource-agents/default.nix
@@ -57,7 +57,7 @@ let
       description = "Combined repository of OCF agents from the RHCS and Linux-HA projects";
       license = licenses.gpl2Plus;
       platforms = platforms.linux;
-      maintainers = with maintainers; [ ryantm astro ];
+      maintainers = with maintainers; [ ryantm astro tmarkus ];
     };
   };
 


### PR DESCRIPTION
###### Description of changes

PR contents:
* Update ocf-resouce-agents to 4.12.0
* Fix i686 build failure via patch (PR already submitted upstream: https://github.com/ClusterLabs/resource-agents/pull/1870)
* Add maintainer tmarkus

Part of ZHF (#230712)

Should fix the following Hydra failure:
* https://hydra.nixos.org/build/220102055

<details>
<summary>With this PR, nixosTests.drbd works on i686-linux</summary>

```console
$ nix-build --system i686-linux -A nixosTests.drbd
     1  # This file contains type hints that can be prepended to Nix test scripts so they can be type
     2  # checked.
     3
     4  from test_driver.driver import Driver
     5  from test_driver.vlan import VLan
     6  from test_driver.machine import Machine
     7  from test_driver.logger import Logger
     8  from typing import Callable, Iterator, ContextManager, Optional, List, Dict, Any, Union
     9  from typing_extensions import Protocol
    10  from pathlib import Path
    11
    12
    13  class RetryProtocol(Protocol):
    14      def __call__(self, fn: Callable, timeout: int = 900) -> None:
    15          raise Exception("This is just type information for the Nix test driver")
    16
    17
    18  class PollingConditionProtocol(Protocol):
    19      def __call__(
    20          self,
    21          fun_: Optional[Callable] = None,
    22          *,
    23          seconds_interval: float = 2.0,
    24          description: Optional[str] = None,
    25      ) -> Union[Callable[[Callable], ContextManager], ContextManager]:
    26          raise Exception("This is just type information for the Nix test driver")
    27
    28
    29  start_all: Callable[[], None]
    30  subtest: Callable[[str], ContextManager[None]]
    31  retry: RetryProtocol
    32  test_script: Callable[[], None]
    33  machines: List[Machine]
    34  vlans: List[VLan]
    35  driver: Driver
    36  log: Logger
    37  create_machine: Callable[[Dict[str, Any]], Machine]
    38  run_tests: Callable[[], None]
    39  join_all: Callable[[], None]
    40  serial_stdout_off: Callable[[], None]
    41  serial_stdout_on: Callable[[], None]
    42  polling_condition: PollingConditionProtocol
    43  drbd1: Machine; drbd2: Machine;
    44  vlan1: VLan;
    45  drbd1.start()
    46  drbd2.start()
    47
    48  drbd1.wait_for_unit("network.target")
    49  drbd2.wait_for_unit("network.target")
    50
    51  drbd1.succeed(
    52      "drbdadm create-md r0",
    53      "drbdadm up r0",
    54      "drbdadm primary r0 --force",
    55  )
    56
    57  drbd2.succeed("drbdadm create-md r0", "drbdadm up r0")
    58
    59  drbd1.succeed(
    60      "mkfs.ext4 /dev/drbd0",
    61      "mkdir -p /mnt/drbd",
    62      "mount /dev/drbd0 /mnt/drbd",
    63      "touch /mnt/drbd/hello",
    64      "umount /mnt/drbd",
    65      "drbdadm secondary r0",
    66  )
    67  drbd1.sleep(1)
    68
    69  drbd2.succeed(
    70      "drbdadm primary r0",
    71      "mkdir -p /mnt/drbd",
    72      "mount /dev/drbd0 /mnt/drbd",
    73      "ls /mnt/drbd/hello",
    74  )
Success: no issues found in 1 source file
start all VLans
(finished: start all VLans, in 0.00 seconds)
additionally exposed symbols:
    ,
    ,
    start_all, test_script, machines, vlans, driver, log, os, create_machine, subtest, run_tests, join_all, retry, serial_stdout_off, serial_stdout_on, polling_condition, Machine
building '/nix/store/2yw47dy03w2kkpmaliz8q6z0axnhz22l-vm-test-run-drbd.drv'...
Machine state will be reset. To keep it, pass --keep-vm-state
start all VLans
start vlan
running vlan (pid 5; ctl /build/vde1.ctl)
(finished: start all VLans, in 0.00 seconds)
run the VM test script
additionally exposed symbols:
    drbd1, drbd2,
    vlan1,
    start_all, test_script, machines, vlans, driver, log, os, create_machine, subtest, run_tests, join_all, retry, serial_stdout_off, serial_stdout_on, polling_condition, Machine
drbd1: starting vm
drbd1 # Disk image do not exist, creating the virtualisation disk image...
drbd1 # Formatting '/build/vm-state-drbd1/drbd1.qcow2', fmt=qcow2 cluster_size=65536 extended_l2=off compression_type=zlib size=1073741824 lazy_refcounts=off refcount_bits=16
drbd1 # Virtualisation disk image created.
drbd1 # Formatting 'empty0.qcow2', fmt=qcow2 cluster_size=65536 extended_l2=off compression_type=zlib size=1048576 lazy_refcounts=off refcount_bits=16
drbd1: QEMU running (pid 6)
drbd2: starting vm
drbd2 # Disk image do not exist, creating the virtualisation disk image...
drbd2 # Formatting '/build/vm-state-drbd2/drbd2.qcow2', fmt=qcow2 cluster_size=65536 extended_l2=off compression_type=zlib size=1073741824 lazy_refcounts=off refcount_bits=16
drbd2 # Virtualisation disk image created.
drbd2 # Formatting 'empty0.qcow2', fmt=qcow2 cluster_size=65536 extended_l2=off compression_type=zlib size=1048576 lazy_refcounts=off refcount_bits=16
drbd2: QEMU running (pid 21)
drbd1: waiting for unit network.target
drbd1: waiting for the VM to finish booting
drbd1 # cSeaBIOS (version rel-1.16.2-0-gea1b7a073390-prebuilt.qemu.org)
drbd2 # cSeaBIOS (version rel-1.16.2-0-gea1b7a073390-prebuilt.qemu.org)
drbd1 #
drbd1 #
drbd1 # iPXE (http://ipxe.org) 00:03.0 CA00 PCI2.10 PnP PMM+3EFD0C80+3EF30C80 CA00
drbd1 # Press Ctrl-B to configure iPXE (PCI 00:03.0)...
drbd1 #
drbd1 #
drbd1 #
drbd1 #
drbd1 # iPXE (http://ipxe.org) 00:0A.0 CB00 PCI2.10 PnP PMM 3EFD0C80 3EF30C80 CB00
drbd1 # Press Ctrl-B to configure iPXE (PCI 00:0A.0)...
drbd1 #
drbd1 #
drbd1 # Booting from ROM...
drbd2 #
drbd2 #
drbd2 # iPXE (http://ipxe.org) 00:03.0 CA00 PCI2.10 PnP PMM+3EFD0C80+3EF30C80 CA00
drbd2 # Press Ctrl-B to configure iPXE (PCI 00:03.0)...
drbd2 #
drbd2 #
drbd2 #
drbd2 #
drbd2 # iPXE (http://ipxe.org) 00:0A.0 CB00 PCI2.10 PnP PMM 3EFD0C80 3EF30C80 CB00
drbd2 # Press Ctrl-B to configure iPXE (PCI 00:0A.0)...
drbd2 #
drbd2 #
drbd2 # Booting from ROM...
drbd1 # Probing EDD (edd=off to disable)... ock[    0.000000] Linux version 6.1.29 (nixbld@localhost) (gcc (GCC) 12.2.0, GNU ld (GNU Binutils) 2.40) #1-NixOS SMP PREEMPT_DYNAMIC Wed May 17 09:54:00 UTC 2023
drbd1 # [    0.000000] x86/fpu: x87 FPU will use FXSAVE
drbd1 # [    0.000000] signal: max sigframe size: 1440
drbd1 # [    0.000000] BIOS-provided physical RAM map:
drbd1 # [    0.000000] BIOS-e820: [mem 0x0000000000000000-0x000000000009fbff] usable
drbd1 # [    0.000000] BIOS-e820: [mem 0x000000000009fc00-0x000000000009ffff] reserved
drbd1 # [    0.000000] BIOS-e820: [mem 0x00000000000f0000-0x00000000000fffff] reserved
drbd1 # [    0.000000] BIOS-e820: [mem 0x0000000000100000-0x000000003ffd7fff] usable
drbd1 # [    0.000000] BIOS-e820: [mem 0x000000003ffd8000-0x000000003fffffff] reserved
drbd1 # [    0.000000] BIOS-e820: [mem 0x00000000feffc000-0x00000000feffffff] reserved
drbd1 # [    0.000000] BIOS-e820: [mem 0x00000000fffc0000-0x00000000ffffffff] reserved
drbd1 # [    0.000000] Notice: NX (Execute Disable) protection missing in CPU!
drbd1 # [    0.000000] SMBIOS 2.8 present.
drbd1 # [    0.000000] DMI: QEMU Standard PC (i440FX + PIIX, 1996), BIOS rel-1.16.2-0-gea1b7a073390-prebuilt.qemu.org 04/01/2014
drbd1 # [    0.000000] Hypervisor detected: KVM
drbd1 # [    0.000000] kvm-clock: Using msrs 4b564d01 and 4b564d00
drbd1 # [    0.000001] kvm-clock: using sched offset of 1020244023 cycles
drbd1 # [    0.000004] clocksource: kvm-clock: mask: 0xffffffffffffffff max_cycles: 0x1cd42e4dffb, max_idle_ns: 881590591483 ns
drbd1 # [    0.000008] tsc: Detected 2711.998 MHz processor
drbd1 # [    0.000782] last_pfn = 0x3ffd8 max_arch_pfn = 0x1000000
drbd1 # [    0.000785] Disabled
drbd1 # [    0.000786] x86/PAT: MTRRs disabled, skipping PAT initialization too.
drbd1 # [    0.000788] x86/PAT: Configuration [0-7]: WB  WT  UC- UC  WB  WT  UC- UC
drbd1 # [    0.004212] found SMP MP-table at [mem 0x000f5b40-0x000f5b4f]
drbd1 # [    0.004281] RAMDISK: [mem 0x3f366000-0x3ffcffff]
drbd1 # [    0.004283] Allocated new RAMDISK: [mem 0x36994000-0x375fdca9]
drbd1 # [    0.023624] Move RAMDISK from [mem 0x3f366000-0x3ffcfca9] to [mem 0x36994000-0x375fdca9]
drbd1 # [    0.023631] ACPI: Early table checksum verification disabled
drbd1 # [    0.023635] ACPI: RSDP 0x00000000000F5960 000014 (v00 BOCHS )
drbd1 # [    0.023642] ACPI: RSDT 0x000000003FFE1B88 000034 (v01 BOCHS  BXPC     00000001 BXPC 00000001)
drbd1 # [    0.023648] ACPI: FACP 0x000000003FFE1A3C 000074 (v01 BOCHS  BXPC     00000001 BXPC 00000001)
drbd1 # [    0.023655] ACPI: DSDT 0x000000003FFE0040 0019FC (v01 BOCHS  BXPC     00000001 BXPC 00000001)
drbd1 # [    0.023659] ACPI: FACS 0x000000003FFE0000 000040
drbd1 # [    0.023663] ACPI: APIC 0x000000003FFE1AB0 000078 (v01 BOCHS  BXPC     00000001 BXPC 00000001)
drbd1 # [    0.023666] ACPI: HPET 0x000000003FFE1B28 000038 (v01 BOCHS  BXPC     00000001 BXPC 00000001)
drbd1 # [    0.023670] ACPI: WAET 0x000000003FFE1B60 000028 (v01 BOCHS  BXPC     00000001 BXPC 00000001)
drbd1 # [    0.023672] ACPI: Reserving FACP table memory at [mem 0x3ffe1a3c-0x3ffe1aaf]
drbd1 # [    0.023674] ACPI: Reserving DSDT table memory at [mem 0x3ffe0040-0x3ffe1a3b]
drbd1 # [    0.023675] ACPI: Reserving FACS table memory at [mem 0x3ffe0000-0x3ffe003f]
drbd1 # [    0.023676] ACPI: Reserving APIC table memory at [mem 0x3ffe1ab0-0x3ffe1b27]
drbd1 # [    0.023677] ACPI: Reserving HPET table memory at [mem 0x3ffe1b28-0x3ffe1b5f]
drbd1 # [    0.023677] ACPI: Reserving WAET table memory at [mem 0x3ffe1b60-0x3ffe1b87]
drbd1 # [    0.023712] 137MB HIGHMEM available.
drbd1 # [    0.023714] 885MB LOWMEM available.
drbd1 # [    0.023714]   mapped low ram: 0 - 375fe000
drbd1 # [    0.023715]   low ram: 0 - 375fe000
drbd1 # [    0.023728] Zone ranges:
drbd1 # [    0.023729]   DMA      [mem 0x0000000000001000-0x0000000000ffffff]
drbd1 # [    0.023730]   Normal   [mem 0x0000000001000000-0x00000000375fdfff]
drbd1 # [    0.023732]   HighMem  [mem 0x00000000375fe000-0x000000003ffd7fff]
drbd1 # [    0.023733] Movable zone start for each node
drbd1 # [    0.023734] Early memory node ranges
drbd1 # [    0.023734]   node   0: [mem 0x0000000000001000-0x000000000009efff]
drbd1 # [    0.023735]   node   0: [mem 0x0000000000100000-0x000000003ffd7fff]
drbd1 # [    0.023737] Initmem setup node 0 [mem 0x0000000000001000-0x000000003ffd7fff]
drbd1 # [    0.024313] On node 0, zone DMA: 1 pages in unavailable ranges
drbd1 # [    0.024455] On node 0, zone DMA: 97 pages in unavailable ranges
drbd1 # [    0.036351] Using APIC driver default
drbd1 # [    0.036979] ACPI: PM-Timer IO Port: 0x608
drbd1 # [    0.036988] ACPI: LAPIC_NMI (acpi_id[0xff] dfl dfl lint[0x1])
drbd1 # [    0.037026] IOAPIC[0]: apic_id 0, version 17, address 0xfec00000, GSI 0-23
drbd1 # [    0.037030] ACPI: INT_SRC_OVR (bus 0 bus_irq 0 global_irq 2 dfl dfl)
drbd1 # [    0.037032] ACPI: INT_SRC_OVR (bus 0 bus_irq 5 global_irq 5 high level)
drbd1 # [    0.037033] ACPI: INT_SRC_OVR (bus 0 bus_irq 9 global_irq 9 high level)
drbd1 # [    0.037034] ACPI: INT_SRC_OVR (bus 0 bus_irq 10 global_irq 10 high level)
drbd1 # [    0.037035] ACPI: INT_SRC_OVR (bus 0 bus_irq 11 global_irq 11 high level)
drbd1 # [    0.037039] ACPI: Using ACPI (MADT) for SMP configuration information
drbd1 # [    0.037051] smpboot: Allowing 1 CPUs, 0 hotplug CPUs
drbd1 # [    0.037069] PM: hibernation: Registered nosave memory: [mem 0x00000000-0x00000fff]
drbd1 # [    0.037071] PM: hibernation: Registered nosave memory: [mem 0x0009f000-0x0009ffff]
drbd1 # [    0.037072] PM: hibernation: Registered nosave memory: [mem 0x000a0000-0x000effff]
drbd1 # [    0.037072] PM: hibernation: Registered nosave memory: [mem 0x000f0000-0x000fffff]
drbd1 # [    0.037074] [mem 0x40000000-0xfeffbfff] available for PCI devices
drbd1 # [    0.037075] Booting paravirtualized kernel on KVM
drbd1 # [    0.037077] clocksource: refined-jiffies: mask: 0xffffffff max_cycles: 0xffffffff, max_idle_ns: 1910969940391419 ns
drbd1 # [    0.037082] setup_percpu: NR_CPUS:8 nr_cpumask_bits:1 nr_cpu_ids:1 nr_node_ids:1
drbd1 # [    0.037182] percpu: Embedded 32 pages/cpu s100468 r0 d30604 u131072
drbd1 # [    0.037207] kvm-guest: PV spinlocks disabled, no host support
drbd1 # [    0.037209] Built 1 zonelists, mobility grouping on.  Total pages: 259791
drbd1 # [    0.037211] Kernel command line: console=ttyS0 panic=1 boot.panic_on_fail clock=acpi_pm loglevel=7 net.ifnames=0 init=/nix/store/gxg9szsfkvj2z9iyp306hhfrbqdp11db-nixos-system-drbd1-23.05pre-git/init regInfo=/nix/store/ggi1b613gpnkwbx5y1mymz4x72mv9nq8-closure-info/registration console=ttyS0
drbd1 # [    0.037259] clocksource: clock= boot option is deprecated - use clocksource=xyz
drbd1 # [    0.037328] Unknown kernel command line parameters "regInfo=/nix/store/ggi1b613gpnkwbx5y1mymz4x72mv9nq8-closure-info/registration", will be passed to user space.
drbd1 # [    0.037651] Dentry cache hash table entries: 131072 (order: 7, 524288 bytes, linear)
drbd1 # [    0.037806] Inode-cache hash table entries: 65536 (order: 6, 262144 bytes, linear)
drbd1 # [    0.039026] allocated 1052508 bytes of page_ext
drbd2 # Probing EDD (edd=off to disable)... ock[    0.000000] Linux version 6.1.29 (nixbld@localhost) (gcc (GCC) 12.2.0, GNU ld (GNU Binutils) 2.40) #1-NixOS SMP PREEMPT_DYNAMIC Wed May 17 09:54:00 UTC 2023
drbd2 # [    0.000000] x86/fpu: x87 FPU will use FXSAVE
drbd1 # [    0.039030] mem auto-init: stack:all(zero), heap alloc:off, heap free:off
drbd2 # [    0.000000] signal: max sigframe size: 1440
drbd2 # [    0.000000] BIOS-provided physical RAM map:
drbd1 # [    0.039032] Initializing HighMem for node 0 (000375fe:0003ffd8)
drbd1 # [    0.046063] Initializing Movable for node 0 (00000000:00000000)
drbd2 # [    0.000000] BIOS-e820: [mem 0x0000000000000000-0x000000000009fbff] usable
drbd1 # [    0.048089] Checking if this processor honours the WP bit even in supervisor mode...Ok.
drbd2 # [    0.000000] BIOS-e820: [mem 0x000000000009fc00-0x000000000009ffff] reserved
drbd2 # [    0.000000] BIOS-e820: [mem 0x00000000000f0000-0x00000000000fffff] reserved
drbd1 # [    0.048096] Memory: 1002828K/1048024K available (9355K kernel code, 1608K rwdata, 6776K rodata, 800K init, 604K bss, 45196K reserved, 0K cma-reserved, 141160K highmem)
drbd2 # [    0.000000] BIOS-e820: [mem 0x0000000000100000-0x000000003ffd7fff] usable
drbd1 # [    0.049045] SLUB: HWalign=32, Order=0-3, MinObjects=0, CPUs=1, Nodes=1
drbd2 # [    0.000000] BIOS-e820: [mem 0x000000003ffd8000-0x000000003fffffff] reserved
drbd2 # [    0.000000] BIOS-e820: [mem 0x00000000feffc000-0x00000000feffffff] reserved
drbd1 # [    0.049060] Kernel/User page tables isolation: enabled
drbd1 # [    0.049070] ftrace: allocating 34010 entries in 67 pages
drbd1 # [    0.054544] ftrace: allocated 67 pages with 3 groups
drbd1 # [    0.054677] trace event string verifier disabled
drbd2 # [    0.000000] BIOS-e820: [mem 0x00000000fffc0000-0x00000000ffffffff] reserved
drbd1 # [    0.054713] Dynamic Preempt: voluntary
drbd2 # [    0.000000] Notice: NX (Execute Disable) protection missing in CPU!
drbd1 # [    0.055290] rcu: Preemptible hierarchical RCU implementation.
drbd2 # [    0.000000] SMBIOS 2.8 present.
drbd1 # [    0.055291] rcu:     RCU event tracing is enabled.
drbd1 # [    0.055292] rcu:     RCU restricting CPUs from NR_CPUS=8 to nr_cpu_ids=1.
drbd2 # [    0.000000] DMI: QEMU Standard PC (i440FX + PIIX, 1996), BIOS rel-1.16.2-0-gea1b7a073390-prebuilt.qemu.org 04/01/2014
drbd2 # [    0.000000] Hypervisor detected: KVM
drbd1 # [    0.055293]  Trampoline variant of Tasks RCU enabled.
drbd1 # [    0.055294]  Rude variant of Tasks RCU enabled.
drbd2 # [    0.000000] kvm-clock: Using msrs 4b564d01 and 4b564d00
drbd2 # [    0.000001] kvm-clock: using sched offset of 1045671196 cycles
drbd1 # [    0.055294]  Tracing variant of Tasks RCU enabled.
drbd1 # [    0.055295] rcu: RCU calculated value of scheduler-enlistment delay is 100 jiffies.
drbd2 # [    0.000004] clocksource: kvm-clock: mask: 0xffffffffffffffff max_cycles: 0x1cd42e4dffb, max_idle_ns: 881590591483 ns
drbd1 # [    0.055296] rcu: Adjusting geometry for rcu_fanout_leaf=16, nr_cpu_ids=1
drbd2 # [    0.000008] tsc: Detected 2711.998 MHz processor
drbd1 # [    0.061368] NR_IRQS: 2304, nr_irqs: 256, preallocated irqs: 16
drbd2 # [    0.000774] last_pfn = 0x3ffd8 max_arch_pfn = 0x1000000
drbd1 # [    0.061559] rcu: srcu_init: Setting srcu_struct sizes based on contention.
drbd2 # [    0.000776] Disabled
drbd2 # [    0.000778] x86/PAT: MTRRs disabled, skipping PAT initialization too.
drbd1 # [    0.077115] Console: colour VGA+ 80x25
drbd1 # [    0.225419] printk: console [ttyS0] enabled
drbd2 # [    0.000780] x86/PAT: Configuration [0-7]: WB  WT  UC- UC  WB  WT  UC- UC
drbd1 # [    0.226308] ACPI: Core revision 20220331
drbd1 # [    0.227281] APIC: Switch to symmetric I/O mode setup
drbd2 # [    0.004155] found SMP MP-table at [mem 0x000f5b40-0x000f5b4f]
drbd2 # [    0.004211] RAMDISK: [mem 0x3f366000-0x3ffcffff]
drbd1 # [    0.228367] Enabling APIC mode:  Flat.  Using 1 I/O APICs
drbd2 # [    0.004213] Allocated new RAMDISK: [mem 0x36994000-0x375fdca9]
drbd2 # [    0.024686] Move RAMDISK from [mem 0x3f366000-0x3ffcfca9] to [mem 0x36994000-0x375fdca9]
drbd1 # [    0.231095] ..TIMER: vector=0x30 apic1=0 pin1=2 apic2=-1 pin2=-1
drbd2 # [    0.024695] ACPI: Early table checksum verification disabled
drbd2 # [    0.024699] ACPI: RSDP 0x00000000000F5960 000014 (v00 BOCHS )
drbd1 # [    0.232514] clocksource: tsc-early: mask: 0xffffffffffffffff max_cycles: 0x27178451938, max_idle_ns: 440795251172 ns
drbd2 # [    0.024709] ACPI: RSDT 0x000000003FFE1B88 000034 (v01 BOCHS  BXPC     00000001 BXPC 00000001)
drbd1 # [    0.234882] Calibrating delay loop (skipped) preset value.. 5423.99 BogoMIPS (lpj=2711998)
drbd1 # [    0.236881] pid_max: default: 32768 minimum: 301
drbd2 # [    0.024718] ACPI: FACP 0x000000003FFE1A3C 000074 (v01 BOCHS  BXPC     00000001 BXPC 00000001)
drbd1 # [    0.237986] LSM: Security Framework initializing
drbd1 # [    0.238903] landlock: Up and running.
drbd2 # [    0.024729] ACPI: DSDT 0x000000003FFE0040 0019FC (v01 BOCHS  BXPC     00000001 BXPC 00000001)
drbd1 # [    0.239880] Yama: becoming mindful.
drbd2 # [    0.024736] ACPI: FACS 0x000000003FFE0000 000040
drbd1 # [    0.240920] SELinux:  Initializing.
drbd2 # [    0.024741] ACPI: APIC 0x000000003FFE1AB0 000078 (v01 BOCHS  BXPC     00000001 BXPC 00000001)
drbd1 # [    0.242070] Mount-cache hash table entries: 2048 (order: 1, 8192 bytes, linear)
drbd2 # [    0.024745] ACPI: HPET 0x000000003FFE1B28 000038 (v01 BOCHS  BXPC     00000001 BXPC 00000001)
drbd1 # [    0.243889] Mountpoint-cache hash table entries: 2048 (order: 1, 8192 bytes, linear)
drbd2 # [    0.024751] ACPI: WAET 0x000000003FFE1B60 000028 (v01 BOCHS  BXPC     00000001 BXPC 00000001)
drbd1 # [    0.246418] Last level iTLB entries: 4KB 0, 2MB 0, 4MB 0
drbd2 # [    0.024756] ACPI: Reserving FACP table memory at [mem 0x3ffe1a3c-0x3ffe1aaf]
drbd1 # [    0.246882] Last level dTLB entries: 4KB 0, 2MB 0, 4MB 0, 1GB 0
drbd2 # [    0.024759] ACPI: Reserving DSDT table memory at [mem 0x3ffe0040-0x3ffe1a3b]
drbd1 # [    0.248883] Spectre V1 : Mitigation: usercopy/swapgs barriers and __user pointer sanitization
drbd2 # [    0.024760] ACPI: Reserving FACS table memory at [mem 0x3ffe0000-0x3ffe003f]
drbd1 # [    0.249881] Spectre V2 : Mitigation: Retpolines
drbd2 # [    0.024762] ACPI: Reserving APIC table memory at [mem 0x3ffe1ab0-0x3ffe1b27]
drbd1 # [    0.250879] Spectre V2 : Spectre v2 / SpectreRSB mitigation: Filling RSB on context switch
drbd2 # [    0.024763] ACPI: Reserving HPET table memory at [mem 0x3ffe1b28-0x3ffe1b5f]
drbd1 # [    0.252879] Spectre V2 : Spectre v2 / SpectreRSB : Filling RSB on VMEXIT
drbd2 # [    0.024765] ACPI: Reserving WAET table memory at [mem 0x3ffe1b60-0x3ffe1b87]
drbd1 # [    0.254880] Speculative Store Bypass: Vulnerable
drbd2 # [    0.024806] 137MB HIGHMEM available.
drbd1 # [    0.255883] MDS: Vulnerable: Clear CPU buffers attempted, no microcode
drbd2 # [    0.024808] 885MB LOWMEM available.
drbd1 # [    0.256879] MMIO Stale Data: Unknown: No mitigations
drbd2 # [    0.024809]   mapped low ram: 0 - 375fe000
drbd2 # [    0.024810]   low ram: 0 - 375fe000
drbd2 # [    0.024825] Zone ranges:
drbd2 # [    0.024826]   DMA      [mem 0x0000000000001000-0x0000000000ffffff]
drbd2 # [    0.024829]   Normal   [mem 0x0000000001000000-0x00000000375fdfff]
drbd2 # [    0.024831]   HighMem  [mem 0x00000000375fe000-0x000000003ffd7fff]
drbd2 # [    0.024833] Movable zone start for each node
drbd2 # [    0.024834] Early memory node ranges
drbd1 # [    0.265572] Freeing SMP alternatives memory: 32K
drbd2 # [    0.024834]   node   0: [mem 0x0000000000001000-0x000000000009efff]
drbd2 # [    0.024836]   node   0: [mem 0x0000000000100000-0x000000003ffd7fff]
drbd2 # [    0.024839] Initmem setup node 0 [mem 0x0000000000001000-0x000000003ffd7fff]
drbd2 # [    0.025535] On node 0, zone DMA: 1 pages in unavailable ranges
drbd2 # [    0.025724] On node 0, zone DMA: 97 pages in unavailable ranges
drbd2 # [    0.041304] Using APIC driver default
drbd2 # [    0.041959] ACPI: PM-Timer IO Port: 0x608
drbd2 # [    0.041968] ACPI: LAPIC_NMI (acpi_id[0xff] dfl dfl lint[0x1])
drbd2 # [    0.042007] IOAPIC[0]: apic_id 0, version 17, address 0xfec00000, GSI 0-23
drbd2 # [    0.042011] ACPI: INT_SRC_OVR (bus 0 bus_irq 0 global_irq 2 dfl dfl)
drbd2 # [    0.042013] ACPI: INT_SRC_OVR (bus 0 bus_irq 5 global_irq 5 high level)
drbd2 # [    0.042014] ACPI: INT_SRC_OVR (bus 0 bus_irq 9 global_irq 9 high level)
drbd2 # [    0.042015] ACPI: INT_SRC_OVR (bus 0 bus_irq 10 global_irq 10 high level)
drbd2 # [    0.042016] ACPI: INT_SRC_OVR (bus 0 bus_irq 11 global_irq 11 high level)
drbd2 # [    0.042020] ACPI: Using ACPI (MADT) for SMP configuration information
drbd2 # [    0.042031] smpboot: Allowing 1 CPUs, 0 hotplug CPUs
drbd2 # [    0.042051] PM: hibernation: Registered nosave memory: [mem 0x00000000-0x00000fff]
drbd2 # [    0.042052] PM: hibernation: Registered nosave memory: [mem 0x0009f000-0x0009ffff]
drbd2 # [    0.042053] PM: hibernation: Registered nosave memory: [mem 0x000a0000-0x000effff]
drbd2 # [    0.042054] PM: hibernation: Registered nosave memory: [mem 0x000f0000-0x000fffff]
drbd2 # [    0.042056] [mem 0x40000000-0xfeffbfff] available for PCI devices
drbd2 # [    0.042057] Booting paravirtualized kernel on KVM
drbd2 # [    0.042059] clocksource: refined-jiffies: mask: 0xffffffff max_cycles: 0xffffffff, max_idle_ns: 1910969940391419 ns
drbd2 # [    0.042064] setup_percpu: NR_CPUS:8 nr_cpumask_bits:1 nr_cpu_ids:1 nr_node_ids:1
drbd2 # [    0.042183] percpu: Embedded 32 pages/cpu s100468 r0 d30604 u131072
drbd2 # [    0.042212] kvm-guest: PV spinlocks disabled, no host support
drbd2 # [    0.042214] Built 1 zonelists, mobility grouping on.  Total pages: 259791
drbd2 # [    0.042216] Kernel command line: console=ttyS0 panic=1 boot.panic_on_fail clock=acpi_pm loglevel=7 net.ifnames=0 init=/nix/store/crrvj215mdcki3bzrf4ajd9dwp6h1zbd-nixos-system-drbd2-23.05pre-git/init regInfo=/nix/store/sy7fxgx5qkqn4p5wsydyvq87c6017pw9-closure-info/registration console=ttyS0
drbd2 # [    0.042276] clocksource: clock= boot option is deprecated - use clocksource=xyz
drbd2 # [    0.042365] Unknown kernel command line parameters "regInfo=/nix/store/sy7fxgx5qkqn4p5wsydyvq87c6017pw9-closure-info/registration", will be passed to user space.
drbd2 # [    0.042706] Dentry cache hash table entries: 131072 (order: 7, 524288 bytes, linear)
drbd2 # [    0.042876] Inode-cache hash table entries: 65536 (order: 6, 262144 bytes, linear)
drbd2 # [    0.043807] allocated 1052508 bytes of page_ext
drbd2 # [    0.043811] mem auto-init: stack:all(zero), heap alloc:off, heap free:off
drbd2 # [    0.043814] Initializing HighMem for node 0 (000375fe:0003ffd8)
drbd2 # [    0.053423] Initializing Movable for node 0 (00000000:00000000)
drbd2 # [    0.055601] Checking if this processor honours the WP bit even in supervisor mode...Ok.
drbd2 # [    0.055613] Memory: 1003076K/1048024K available (9355K kernel code, 1608K rwdata, 6776K rodata, 800K init, 604K bss, 44948K reserved, 0K cma-reserved, 141160K highmem)
drbd2 # [    0.056470] SLUB: HWalign=32, Order=0-3, MinObjects=0, CPUs=1, Nodes=1
drbd2 # [    0.056489] Kernel/User page tables isolation: enabled
drbd2 # [    0.056499] ftrace: allocating 34010 entries in 67 pages
drbd2 # [    0.061758] ftrace: allocated 67 pages with 3 groups
drbd2 # [    0.061907] trace event string verifier disabled
drbd2 # [    0.061954] Dynamic Preempt: voluntary
drbd2 # [    0.062184] rcu: Preemptible hierarchical RCU implementation.
drbd2 # [    0.062185] rcu:     RCU event tracing is enabled.
drbd2 # [    0.062186] rcu:     RCU restricting CPUs from NR_CPUS=8 to nr_cpu_ids=1.
drbd2 # [    0.062187]  Trampoline variant of Tasks RCU enabled.
drbd2 # [    0.062188]  Rude variant of Tasks RCU enabled.
drbd2 # [    0.062188]  Tracing variant of Tasks RCU enabled.
drbd2 # [    0.062189] rcu: RCU calculated value of scheduler-enlistment delay is 100 jiffies.
drbd2 # [    0.062190] rcu: Adjusting geometry for rcu_fanout_leaf=16, nr_cpu_ids=1
drbd2 # [    0.069038] NR_IRQS: 2304, nr_irqs: 256, preallocated irqs: 16
drbd2 # [    0.069236] rcu: srcu_init: Setting srcu_struct sizes based on contention.
drbd2 # [    0.094122] Console: colour VGA+ 80x25
drbd2 # [    0.240617] printk: console [ttyS0] enabled
drbd2 # [    0.241600] ACPI: Core revision 20220331
drbd2 # [    0.242630] APIC: Switch to symmetric I/O mode setup
drbd2 # [    0.243597] Enabling APIC mode:  Flat.  Using 1 I/O APICs
drbd2 # [    0.245924] ..TIMER: vector=0x30 apic1=0 pin1=2 apic2=-1 pin2=-1
drbd2 # [    0.246919] clocksource: tsc-early: mask: 0xffffffffffffffff max_cycles: 0x27178451938, max_idle_ns: 440795251172 ns
drbd2 # [    0.249144] Calibrating delay loop (skipped) preset value.. 5423.99 BogoMIPS (lpj=2711998)
drbd2 # [    0.251143] pid_max: default: 32768 minimum: 301
drbd2 # [    0.252248] LSM: Security Framework initializing
drbd2 # [    0.253163] landlock: Up and running.
drbd2 # [    0.254142] Yama: becoming mindful.
drbd2 # [    0.255148] SELinux:  Initializing.
drbd2 # [    0.255890] Mount-cache hash table entries: 2048 (order: 1, 8192 bytes, linear)
drbd2 # [    0.257153] Mountpoint-cache hash table entries: 2048 (order: 1, 8192 bytes, linear)
drbd2 # [    0.258608] Last level iTLB entries: 4KB 0, 2MB 0, 4MB 0
drbd2 # [    0.259149] Last level dTLB entries: 4KB 0, 2MB 0, 4MB 0, 1GB 0
drbd2 # [    0.261145] Spectre V1 : Mitigation: usercopy/swapgs barriers and __user pointer sanitization
drbd2 # [    0.263143] Spectre V2 : Mitigation: Retpolines
drbd2 # [    0.264142] Spectre V2 : Spectre v2 / SpectreRSB mitigation: Filling RSB on context switch
drbd2 # [    0.266141] Spectre V2 : Spectre v2 / SpectreRSB : Filling RSB on VMEXIT
drbd2 # [    0.267142] Speculative Store Bypass: Vulnerable
drbd2 # [    0.268151] MDS: Vulnerable: Clear CPU buffers attempted, no microcode
drbd1 # [    0.368933] smpboot: CPU0: Intel QEMU Virtual CPU version 2.5+ (family: 0x6, model: 0x6, stepping: 0x3)
drbd2 # [    0.269141] MMIO Stale Data: Unknown: No mitigations
drbd1 # [    0.370170] cblist_init_generic: Setting adjustable number of callback queues.
drbd1 # [    0.370880] cblist_init_generic: Setting shift to 0 and lim to 1.
drbd1 # [    0.371931] cblist_init_generic: Setting shift to 0 and lim to 1.
drbd1 # [    0.372924] cblist_init_generic: Setting shift to 0 and lim to 1.
drbd1 # [    0.373976] Performance Events: PMU not available due to virtualization, using software events only.
drbd1 # [    0.374948] rcu: Hierarchical SRCU implementation.
drbd1 # [    0.375807] rcu:     Max phase no-delay instances is 400.
drbd2 # [    0.278873] Freeing SMP alternatives memory: 32K
drbd1 # [    0.376295] smp: Bringing up secondary CPUs ...
drbd1 # [    0.376882] smp: Brought up 1 node, 1 CPU
drbd1 # [    0.377883] smpboot: Max logical packages: 1
drbd1 # [    0.378880] smpboot: Total of 1 processors activated (5423.99 BogoMIPS)
drbd1 # [    0.380896] devtmpfs: initialized
drbd1 # [    0.381954] clocksource: jiffies: mask: 0xffffffff max_cycles: 0xffffffff, max_idle_ns: 1911260446275000 ns
drbd1 # [    0.382881] futex hash table entries: 256 (order: 1, 8192 bytes, linear)
drbd1 # [    0.383948] pinctrl core: initialized pinctrl subsystem
drbd1 # [    0.385501] NET: Registered PF_NETLINK/PF_ROUTE protocol family
drbd1 # [    0.386131] audit: initializing netlink subsys (disabled)
drbd1 # [    0.387909] thermal_sys: Registered thermal governor 'bang_bang'
drbd1 # [    0.387911] thermal_sys: Registered thermal governor 'step_wise'
drbd1 # [    0.388880] thermal_sys: Registered thermal governor 'user_space'
drbd1 # [    0.389934] audit: type=2000 audit(1684585106.190:1): state=initialized audit_enabled=0 res=1
drbd1 # [    0.391897] cpuidle: using governor menu
drbd1 # [    0.393003] acpiphp: ACPI Hot Plug PCI Controller Driver version: 0.5
drbd1 # [    0.394127] PCI: PCI BIOS revision 2.10 entry at 0xfd1ca, last bus=0
drbd1 # [    0.394879] PCI: Using configuration type 1 for base access
drbd1 # [    0.397348] kprobes: kprobe jump-optimization is enabled. All kprobes are optimized if possible.
drbd1 # [    0.421887] HugeTLB: registered 2.00 MiB page size, pre-allocated 0 pages
drbd1 # [    0.422879] HugeTLB: 0 KiB vmemmap can be freed for a 2.00 MiB page
drbd1 # [    0.425238] ACPI: Added _OSI(Module Device)
drbd1 # [    0.425882] ACPI: Added _OSI(Processor Device)
drbd1 # [    0.426880] ACPI: Added _OSI(3.0 _SCP Extensions)
drbd1 # [    0.427883] ACPI: Added _OSI(Processor Aggregator Device)
drbd1 # [    0.430204] ACPI: 1 ACPI AML tables successfully acquired and loaded
drbd1 # [    0.433031] ACPI: Interpreter enabled
drbd1 # [    0.433898] ACPI: PM: (supports S0 S3 S4 S5)
drbd1 # [    0.434880] ACPI: Using IOAPIC for interrupt routing
drbd1 # [    0.435777] PCI: Using host bridge windows from ACPI; if necessary, use "pci=nocrs" and report a bug
drbd1 # [    0.435879] PCI: Using E820 reservations for host bridge windows
drbd1 # [    0.437017] ACPI: Enabled 2 GPEs in block 00 to 0F
drbd1 # [    0.440498] ACPI: PCI Root Bridge [PCI0] (domain 0000 [bus 00-ff])
drbd1 # [    0.441880] acpi PNP0A03:00: _OSC: OS supports [ASPM ClockPM Segments MSI HPX-Type3]
drbd1 # [    0.442881] acpi PNP0A03:00: _OSC: not requesting OS control; OS requires [ExtendedConfig ASPM ClockPM MSI]
drbd1 # [    0.443886] acpi PNP0A03:00: fail to add MMCONFIG information, can't access extended PCI configuration space under this bridge.
drbd1 # [    0.445228] acpiphp: Slot [3] registered
drbd1 # [    0.445912] acpiphp: Slot [4] registered
drbd1 # [    0.446908] acpiphp: Slot [5] registered
drbd1 # [    0.447936] acpiphp: Slot [6] registered
drbd1 # [    0.448914] acpiphp: Slot [7] registered
drbd1 # [    0.449926] acpiphp: Slot [8] registered
drbd1 # [    0.450654] acpiphp: Slot [9] registered
drbd1 # [    0.450913] acpiphp: Slot [10] registered
drbd1 # [    0.451926] acpiphp: Slot [11] registered
drbd1 # [    0.452912] acpiphp: Slot [12] registered
drbd1 # [    0.453909] acpiphp: Slot [13] registered
drbd1 # [    0.454918] acpiphp: Slot [14] registered
drbd1 # [    0.455908] acpiphp: Slot [15] registered
drbd1 # [    0.456834] acpiphp: Slot [16] registered
drbd1 # [    0.456931] acpiphp: Slot [17] registered
drbd1 # [    0.457912] acpiphp: Slot [18] registered
drbd1 # [    0.458903] acpiphp: Slot [19] registered
drbd1 # [    0.459908] acpiphp: Slot [20] registered
drbd1 # [    0.460913] acpiphp: Slot [21] registered
drbd1 # [    0.461911] acpiphp: Slot [22] registered
drbd1 # [    0.462806] acpiphp: Slot [23] registered
drbd1 # [    0.462914] acpiphp: Slot [24] registered
drbd1 # [    0.463914] acpiphp: Slot [25] registered
drbd1 # [    0.464913] acpiphp: Slot [26] registered
drbd1 # [    0.465908] acpiphp: Slot [27] registered
drbd1 # [    0.466935] acpiphp: Slot [28] registered
drbd1 # [    0.467935] acpiphp: Slot [29] registered
drbd1 # [    0.468911] acpiphp: Slot [30] registered
drbd1 # [    0.469908] acpiphp: Slot [31] registered
drbd1 # [    0.470900] PCI host bridge to bus 0000:00
drbd2 # [    0.382283] smpboot: CPU0: Intel QEMU Virtual CPU version 2.5+ (family: 0x6, model: 0x6, stepping: 0x3)
drbd1 # [    0.471831] pci_bus 0000:00: root bus resource [io  0x0000-0x0cf7 window]
drbd2 # [    0.383402] cblist_init_generic: Setting adjustable number of callback queues.
drbd2 # [    0.384142] cblist_init_generic: Setting shift to 0 and lim to 1.
drbd1 # [    0.471882] pci_bus 0000:00: root bus resource [io  0x0d00-0xffff window]
drbd1 # [    0.472881] pci_bus 0000:00: root bus resource [mem 0x000a0000-0x000bffff window]
drbd2 # [    0.386166] cblist_init_generic: Setting shift to 0 and lim to 1.
drbd1 # [    0.473881] pci_bus 0000:00: root bus resource [mem 0x40000000-0xfebfffff window]
drbd2 # [    0.387201] cblist_init_generic: Setting shift to 0 and lim to 1.
drbd1 # [    0.474881] pci_bus 0000:00: root bus resource [mem 0x100000000-0x17fffffff window]
drbd2 # [    0.388216] Performance Events: PMU not available due to virtualization, using software events only.
drbd1 # [    0.475883] pci_bus 0000:00: root bus resource [bus 00-ff]
drbd2 # [    0.389220] rcu: Hierarchical SRCU implementation.
drbd1 # [    0.476972] pci 0000:00:00.0: [8086:1237] type 00 class 0x060000
drbd2 # [    0.390143] rcu:     Max phase no-delay instances is 400.
drbd2 # [    0.391513] smp: Bringing up secondary CPUs ...
drbd2 # [    0.392146] smp: Brought up 1 node, 1 CPU
drbd1 # [    0.479323] pci 0000:00:01.0: [8086:7000] type 00 class 0x060100
drbd2 # [    0.393142] smpboot: Max logical packages: 1
drbd1 # [    0.481593] pci 0000:00:01.1: [8086:7010] type 00 class 0x010180
drbd2 # [    0.394143] smpboot: Total of 1 processors activated (5423.99 BogoMIPS)
drbd2 # [    0.396186] devtmpfs: initialized
drbd2 # [    0.397154] clocksource: jiffies: mask: 0xffffffff max_cycles: 0xffffffff, max_idle_ns: 1911260446275000 ns
drbd2 # [    0.398152] futex hash table entries: 256 (order: 1, 8192 bytes, linear)
drbd2 # [    0.399238] pinctrl core: initialized pinctrl subsystem
drbd1 # [    0.487890] pci 0000:00:01.1: reg 0x20: [io  0xc260-0xc26f]
drbd2 # [    0.401264] NET: Registered PF_NETLINK/PF_ROUTE protocol family
drbd2 # [    0.402337] audit: initializing netlink subsys (disabled)
drbd2 # [    0.403342] thermal_sys: Registered thermal governor 'bang_bang'
drbd2 # [    0.403343] thermal_sys: Registered thermal governor 'step_wise'
drbd1 # [    0.491767] pci 0000:00:01.1: legacy IDE quirk: reg 0x10: [io  0x01f0-0x01f7]
drbd2 # [    0.404143] thermal_sys: Registered thermal governor 'user_space'
drbd1 # [    0.491881] pci 0000:00:01.1: legacy IDE quirk: reg 0x14: [io  0x03f6]
drbd2 # [    0.405204] audit: type=2000 audit(1684585106.299:1): state=initialized audit_enabled=0 res=1
drbd2 # [    0.407164] cpuidle: using governor menu
drbd1 # [    0.492882] pci 0000:00:01.1: legacy IDE quirk: reg 0x18: [io  0x0170-0x0177]
drbd1 # [    0.493881] pci 0000:00:01.1: legacy IDE quirk: reg 0x1c: [io  0x0376]
drbd2 # [    0.408301] acpiphp: ACPI Hot Plug PCI Controller Driver version: 0.5
drbd1 # [    0.496007] pci 0000:00:01.2: [8086:7020] type 00 class 0x0c0300
drbd2 # [    0.409489] PCI: PCI BIOS revision 2.10 entry at 0xfd1ca, last bus=0
drbd2 # [    0.410143] PCI: Using configuration type 1 for base access
drbd2 # [    0.413587] kprobes: kprobe jump-optimization is enabled. All kprobes are optimized if possible.
drbd1 # [    0.501371] pci 0000:00:01.2: reg 0x20: [io  0xc180-0xc19f]
drbd1 # [    0.505112] pci 0000:00:01.3: [8086:7113] type 00 class 0x068000
drbd1 # [    0.507044] pci 0000:00:01.3: quirk: [io  0x0600-0x063f] claimed by PIIX4 ACPI
drbd1 # [    0.507893] pci 0000:00:01.3: quirk: [io  0x0700-0x070f] claimed by PIIX4 SMB
drbd1 # [    0.509195] pci 0000:00:02.0: [1234:1111] type 00 class 0x030000
drbd2 # [    0.438741] HugeTLB: registered 2.00 MiB page size, pre-allocated 0 pages
drbd2 # [    0.439143] HugeTLB: 0 KiB vmemmap can be freed for a 2.00 MiB page
drbd2 # [    0.440624] ACPI: Added _OSI(Module Device)
drbd1 # [    0.512914] pci 0000:00:02.0: reg 0x10: [mem 0xfd000000-0xfdffffff pref]
drbd2 # [    0.441143] ACPI: Added _OSI(Processor Device)
drbd2 # [    0.442144] ACPI: Added _OSI(3.0 _SCP Extensions)
drbd2 # [    0.443145] ACPI: Added _OSI(Processor Aggregator Device)
drbd2 # [    0.444920] ACPI: 1 ACPI AML tables successfully acquired and loaded
drbd2 # [    0.447197] ACPI: Interpreter enabled
drbd2 # [    0.447984] ACPI: PM: (supports S0 S3 S4 S5)
drbd2 # [    0.448144] ACPI: Using IOAPIC for interrupt routing
drbd2 # [    0.449175] PCI: Using host bridge windows from ACPI; if necessary, use "pci=nocrs" and report a bug
drbd2 # [    0.450145] PCI: Using E820 reservations for host bridge windows
drbd1 # [    0.518922] pci 0000:00:02.0: reg 0x18: [mem 0xfebd0000-0xfebd0fff]
drbd2 # [    0.452266] ACPI: Enabled 2 GPEs in block 00 to 0F
drbd2 # [    0.456445] ACPI: PCI Root Bridge [PCI0] (domain 0000 [bus 00-ff])
drbd2 # [    0.457148] acpi PNP0A03:00: _OSC: OS supports [ASPM ClockPM Segments MSI HPX-Type3]
drbd2 # [    0.458144] acpi PNP0A03:00: _OSC: not requesting OS control; OS requires [ExtendedConfig ASPM ClockPM MSI]
drbd2 # [    0.459162] acpi PNP0A03:00: fail to add MMCONFIG information, can't access extended PCI configuration space under this bridge.
drbd2 # [    0.461161] acpiphp: Slot [3] registered
drbd2 # [    0.462077] acpiphp: Slot [4] registered
drbd2 # [    0.462198] acpiphp: Slot [5] registered
drbd2 # [    0.463220] acpiphp: Slot [6] registered
drbd2 # [    0.464175] acpiphp: Slot [7] registered
drbd2 # [    0.465191] acpiphp: Slot [8] registered
drbd2 # [    0.466176] acpiphp: Slot [9] registered
drbd2 # [    0.467179] acpiphp: Slot [10] registered
drbd2 # [    0.468201] acpiphp: Slot [11] registered
drbd2 # [    0.469177] acpiphp: Slot [12] registered
drbd2 # [    0.470180] acpiphp: Slot [13] registered
drbd2 # [    0.470944] acpiphp: Slot [14] registered
drbd2 # [    0.471179] acpiphp: Slot [15] registered
drbd2 # [    0.472197] acpiphp: Slot [16] registered
drbd1 # [    0.528919] pci 0000:00:02.0: reg 0x30: [mem 0xfebc0000-0xfebcffff pref]
drbd2 # [    0.473196] acpiphp: Slot [17] registered
drbd2 # [    0.474178] acpiphp: Slot [18] registered
drbd1 # [    0.531069] pci 0000:00:02.0: Video device with shadowed ROM at [mem 0x000c0000-0x000dffff]
drbd2 # [    0.475175] acpiphp: Slot [19] registered
drbd2 # [    0.476179] acpiphp: Slot [20] registered
drbd1 # [    0.532620] pci 0000:00:03.0: [1af4:1000] type 00 class 0x020000
drbd2 # [    0.477176] acpiphp: Slot [21] registered
drbd2 # [    0.478177] acpiphp: Slot [22] registered
drbd2 # [    0.479222] acpiphp: Slot [23] registered
drbd2 # [    0.480184] acpiphp: Slot [24] registered
drbd2 # [    0.481183] acpiphp: Slot [25] registered
drbd1 # [    0.535884] pci 0000:00:03.0: reg 0x10: [io  0xc1a0-0xc1bf]
drbd2 # [    0.482162] acpiphp: Slot [26] registered
drbd2 # [    0.483010] acpiphp: Slot [27] registered
drbd2 # [    0.483207] acpiphp: Slot [28] registered
drbd2 # [    0.484185] acpiphp: Slot [29] registered
drbd2 # [    0.485189] acpiphp: Slot [30] registered
drbd1 # [    0.538883] pci 0000:00:03.0: reg 0x14: [mem 0xfebd1000-0xfebd1fff]
drbd2 # [    0.486179] acpiphp: Slot [31] registered
drbd2 # [    0.487168] PCI host bridge to bus 0000:00
drbd2 # [    0.488145] pci_bus 0000:00: root bus resource [io  0x0000-0x0cf7 window]
drbd2 # [    0.489144] pci_bus 0000:00: root bus resource [io  0x0d00-0xffff window]
drbd2 # [    0.490147] pci_bus 0000:00: root bus resource [mem 0x000a0000-0x000bffff window]
drbd2 # [    0.491147] pci_bus 0000:00: root bus resource [mem 0x40000000-0xfebfffff window]
drbd2 # [    0.492147] pci_bus 0000:00: root bus resource [mem 0x100000000-0x17fffffff window]
drbd2 # [    0.493150] pci_bus 0000:00: root bus resource [bus 00-ff]
drbd1 # [    0.546885] pci 0000:00:03.0: reg 0x20: [mem 0xfe000000-0xfe003fff 64bit pref]
drbd2 # [    0.494231] pci 0000:00:00.0: [8086:1237] type 00 class 0x060000
drbd2 # [    0.495803] pci 0000:00:01.0: [8086:7000] type 00 class 0x060100
drbd1 # [    0.549882] pci 0000:00:03.0: reg 0x30: [mem 0xfeb40000-0xfeb7ffff pref]
drbd2 # [    0.497241] pci 0000:00:01.1: [8086:7010] type 00 class 0x010180
drbd1 # [    0.553282] pci 0000:00:04.0: [1af4:1005] type 00 class 0x00ff00
drbd1 # [    0.555882] pci 0000:00:04.0: reg 0x10: [io  0xc1c0-0xc1df]
drbd2 # [    0.503673] pci 0000:00:01.1: reg 0x20: [io  0xc260-0xc26f]
drbd1 # [    0.558882] pci 0000:00:04.0: reg 0x14: [mem 0xfebd2000-0xfebd2fff]
drbd2 # [    0.506171] pci 0000:00:01.1: legacy IDE quirk: reg 0x10: [io  0x01f0-0x01f7]
drbd2 # [    0.507147] pci 0000:00:01.1: legacy IDE quirk: reg 0x14: [io  0x03f6]
drbd2 # [    0.508145] pci 0000:00:01.1: legacy IDE quirk: reg 0x18: [io  0x0170-0x0177]
drbd2 # [    0.509144] pci 0000:00:01.1: legacy IDE quirk: reg 0x1c: [io  0x0376]
drbd2 # [    0.510440] pci 0000:00:01.2: [8086:7020] type 00 class 0x0c0300
drbd1 # [    0.566883] pci 0000:00:04.0: reg 0x20: [mem 0xfe004000-0xfe007fff 64bit pref]
drbd2 # [    0.515575] pci 0000:00:01.2: reg 0x20: [io  0xc180-0xc19f]
drbd1 # [    0.572150] pci 0000:00:05.0: [1af4:1009] type 00 class 0x000200
drbd2 # [    0.518352] pci 0000:00:01.3: [8086:7113] type 00 class 0x068000
drbd2 # [    0.520286] pci 0000:00:01.3: quirk: [io  0x0600-0x063f] claimed by PIIX4 ACPI
drbd1 # [    0.574881] pci 0000:00:05.0: reg 0x10: [io  0xc100-0xc13f]
drbd2 # [    0.521158] pci 0000:00:01.3: quirk: [io  0x0700-0x070f] claimed by PIIX4 SMB
drbd2 # [    0.522487] pci 0000:00:02.0: [1234:1111] type 00 class 0x030000
drbd1 # [    0.577881] pci 0000:00:05.0: reg 0x14: [mem 0xfebd3000-0xfebd3fff]
drbd1 # [    0.584882] pci 0000:00:05.0: reg 0x20: [mem 0xfe008000-0xfe00bfff 64bit pref]
drbd2 # [    0.526181] pci 0000:00:02.0: reg 0x10: [mem 0xfd000000-0xfdffffff pref]
drbd1 # [    0.589314] pci 0000:00:06.0: [1af4:1009] type 00 class 0x000200
drbd1 # [    0.592882] pci 0000:00:06.0: reg 0x10: [io  0xc1e0-0xc1ff]
drbd1 # [    0.595891] pci 0000:00:06.0: reg 0x14: [mem 0xfebd4000-0xfebd4fff]
drbd2 # [    0.531181] pci 0000:00:02.0: reg 0x18: [mem 0xfebd0000-0xfebd0fff]
drbd1 # [    0.603700] pci 0000:00:06.0: reg 0x20: [mem 0xfe00c000-0xfe00ffff 64bit pref]
drbd1 # [    0.607678] pci 0000:00:07.0: [1af4:1009] type 00 class 0x000200
drbd1 # [    0.609883] pci 0000:00:07.0: reg 0x10: [io  0xc200-0xc21f]
drbd1 # [    0.612882] pci 0000:00:07.0: reg 0x14: [mem 0xfebd5000-0xfebd5fff]
drbd1 # [    0.620882] pci 0000:00:07.0: reg 0x20: [mem 0xfe010000-0xfe013fff 64bit pref]
drbd1 # [    0.625426] pci 0000:00:08.0: [1af4:1001] type 00 class 0x010000
drbd2 # [    0.541200] pci 0000:00:02.0: reg 0x30: [mem 0xfebc0000-0xfebcffff pref]
drbd2 # [    0.542356] pci 0000:00:02.0: Video device with shadowed ROM at [mem 0x000c0000-0x000dffff]
drbd2 # [    0.544214] pci 0000:00:03.0: [1af4:1000] type 00 class 0x020000
drbd1 # [    0.629883] pci 0000:00:08.0: reg 0x10: [io  0xc000-0xc07f]
drbd2 # [    0.547150] pci 0000:00:03.0: reg 0x10: [io  0xc1a0-0xc1bf]
drbd2 # [    0.550969] pci 0000:00:03.0: reg 0x14: [mem 0xfebd1000-0xfebd1fff]
drbd1 # [    0.632885] pci 0000:00:08.0: reg 0x14: [mem 0xfebd6000-0xfebd6fff]
drbd2 # [    0.557146] pci 0000:00:03.0: reg 0x20: [mem 0xfe000000-0xfe003fff 64bit pref]
drbd2 # [    0.560144] pci 0000:00:03.0: reg 0x30: [mem 0xfeb40000-0xfeb7ffff pref]
drbd2 # [    0.563514] pci 0000:00:04.0: [1af4:1005] type 00 class 0x00ff00
drbd2 # [    0.566144] pci 0000:00:04.0: reg 0x10: [io  0xc1c0-0xc1df]
drbd2 # [    0.568937] pci 0000:00:04.0: reg 0x14: [mem 0xfebd2000-0xfebd2fff]
drbd1 # [    0.640892] pci 0000:00:08.0: reg 0x20: [mem 0xfe014000-0xfe017fff 64bit pref]
drbd2 # [    0.576146] pci 0000:00:04.0: reg 0x20: [mem 0xfe004000-0xfe007fff 64bit pref]
drbd2 # [    0.580644] pci 0000:00:05.0: [1af4:1009] type 00 class 0x000200
drbd1 # [    0.645551] pci 0000:00:09.0: [1af4:1001] type 00 class 0x010000
drbd2 # [    0.583147] pci 0000:00:05.0: reg 0x10: [io  0xc100-0xc13f]
drbd2 # [    0.586144] pci 0000:00:05.0: reg 0x14: [mem 0xfebd3000-0xfebd3fff]
drbd1 # [    0.649885] pci 0000:00:09.0: reg 0x10: [io  0xc080-0xc0ff]
drbd2 # [    0.593146] pci 0000:00:05.0: reg 0x20: [mem 0xfe008000-0xfe00bfff 64bit pref]
drbd2 # [    0.597527] pci 0000:00:06.0: [1af4:1009] type 00 class 0x000200
drbd1 # [    0.652885] pci 0000:00:09.0: reg 0x14: [mem 0xfebd7000-0xfebd7fff]
drbd2 # [    0.600145] pci 0000:00:06.0: reg 0x10: [io  0xc1e0-0xc1ff]
drbd2 # [    0.603145] pci 0000:00:06.0: reg 0x14: [mem 0xfebd4000-0xfebd4fff]
drbd2 # [    0.610145] pci 0000:00:06.0: reg 0x20: [mem 0xfe00c000-0xfe00ffff 64bit pref]
drbd2 # [    0.615404] pci 0000:00:07.0: [1af4:1009] type 00 class 0x000200
drbd2 # [    0.618143] pci 0000:00:07.0: reg 0x10: [io  0xc200-0xc21f]
drbd2 # [    0.621144] pci 0000:00:07.0: reg 0x14: [mem 0xfebd5000-0xfebd5fff]
drbd1 # [    0.660887] pci 0000:00:09.0: reg 0x20: [mem 0xfe018000-0xfe01bfff 64bit pref]
drbd2 # [    0.629144] pci 0000:00:07.0: reg 0x20: [mem 0xfe010000-0xfe013fff 64bit pref]
drbd2 # [    0.634029] pci 0000:00:08.0: [1af4:1001] type 00 class 0x010000
drbd1 # [    0.665301] pci 0000:00:0a.0: [1af4:1000] type 00 class 0x020000
drbd2 # [    0.636149] pci 0000:00:08.0: reg 0x10: [io  0xc000-0xc07f]
drbd1 # [    0.667883] pci 0000:00:0a.0: reg 0x10: [io  0xc220-0xc23f]
drbd1 # [    0.671882] pci 0000:00:0a.0: reg 0x14: [mem 0xfebd8000-0xfebd8fff]
drbd2 # [    0.640149] pci 0000:00:08.0: reg 0x14: [mem 0xfebd6000-0xfebd6fff]
drbd1 # [    0.678882] pci 0000:00:0a.0: reg 0x20: [mem 0xfe01c000-0xfe01ffff 64bit pref]
drbd1 # [    0.681882] pci 0000:00:0a.0: reg 0x30: [mem 0xfeb80000-0xfebbffff pref]
drbd1 # [    0.684706] pci 0000:00:0b.0: [1af4:1052] type 00 class 0x090000
drbd1 # [    0.686882] pci 0000:00:0b.0: reg 0x14: [mem 0xfebd9000-0xfebd9fff]
drbd1 # [    0.691881] pci 0000:00:0b.0: reg 0x20: [mem 0xfe020000-0xfe023fff 64bit pref]
drbd2 # [    0.649147] pci 0000:00:08.0: reg 0x20: [mem 0xfe014000-0xfe017fff 64bit pref]
drbd1 # [    0.696654] pci 0000:00:0c.0: [1af4:1003] type 00 class 0x078000
drbd1 # [    0.699884] pci 0000:00:0c.0: reg 0x10: [io  0xc140-0xc17f]
drbd2 # [    0.654598] pci 0000:00:09.0: [1af4:1001] type 00 class 0x010000
drbd1 # [    0.702885] pci 0000:00:0c.0: reg 0x14: [mem 0xfebda000-0xfebdafff]
drbd2 # [    0.658155] pci 0000:00:09.0: reg 0x10: [io  0xc080-0xc0ff]
drbd1 # [    0.710885] pci 0000:00:0c.0: reg 0x20: [mem 0xfe024000-0xfe027fff 64bit pref]
drbd2 # [    0.661147] pci 0000:00:09.0: reg 0x14: [mem 0xfebd7000-0xfebd7fff]
drbd1 # [    0.716191] pci 0000:00:0d.0: [1af4:1005] type 00 class 0x00ff00
drbd1 # [    0.718882] pci 0000:00:0d.0: reg 0x10: [io  0xc240-0xc25f]
drbd1 # [    0.721883] pci 0000:00:0d.0: reg 0x14: [mem 0xfebdb000-0xfebdbfff]
drbd1 # [    0.728883] pci 0000:00:0d.0: reg 0x20: [mem 0xfe028000-0xfe02bfff 64bit pref]
drbd1 # [    0.733818] ACPI: PCI: Interrupt link LNKA configured for IRQ 10
drbd1 # [    0.734046] ACPI: PCI: Interrupt link LNKB configured for IRQ 10
drbd1 # [    0.735069] ACPI: PCI: Interrupt link LNKC configured for IRQ 11
drbd2 # [    0.670147] pci 0000:00:09.0: reg 0x20: [mem 0xfe018000-0xfe01bfff 64bit pref]
drbd1 # [    0.736048] ACPI: PCI: Interrupt link LNKD configured for IRQ 11
drbd1 # [    0.737012] ACPI: PCI: Interrupt link LNKS configured for IRQ 9
drbd1 # [    0.739138] iommu: Default domain type: Translated
drbd1 # [    0.739880] iommu: DMA domain TLB invalidation policy: lazy mode
drbd1 # [    0.742166] NetLabel: Initializing
drbd1 # [    0.742880] NetLabel:  domain hash size = 128
drbd1 # [    0.743880] NetLabel:  protocols = UNLABELED CIPSOv4 CALIPSO
drbd2 # [    0.676114] pci 0000:00:0a.0: [1af4:1000] type 00 class 0x020000
drbd1 # [    0.744919] NetLabel:  unlabeled traffic allowed by default
drbd1 # [    0.745889] PCI: Using ACPI for IRQ routing
drbd1 # [    0.747437] pci 0000:00:02.0: vgaarb: setting as boot VGA device
drbd2 # [    0.678146] pci 0000:00:0a.0: reg 0x10: [io  0xc220-0xc23f]
drbd1 # [    0.747877] pci 0000:00:02.0: vgaarb: bridge control possible
drbd1 # [    0.747877] pci 0000:00:02.0: vgaarb: VGA device added: decodes=io+mem,owns=io+mem,locks=none
drbd1 # [    0.747887] vgaarb: loaded
drbd1 # [    0.748967] clocksource: Switched to clocksource kvm-clock
drbd2 # [    0.682146] pci 0000:00:0a.0: reg 0x14: [mem 0xfebd8000-0xfebd8fff]
drbd2 # [    0.688145] pci 0000:00:0a.0: reg 0x20: [mem 0xfe01c000-0xfe01ffff 64bit pref]
drbd2 # [    0.692144] pci 0000:00:0a.0: reg 0x30: [mem 0xfeb80000-0xfebbffff pref]
drbd2 # [    0.694753] pci 0000:00:0b.0: [1af4:1052] type 00 class 0x090000
drbd1 # [    0.765754] VFS: Disk quotas dquot_6.6.0
drbd1 # [    0.766853] VFS: Dquot-cache hash table entries: 1024 (order 0, 4096 bytes)
drbd1 # [    0.768526] pnp: PnP ACPI init
drbd1 # [    0.770153] pnp: PnP ACPI: found 6 devices
drbd2 # [    0.700146] pci 0000:00:0b.0: reg 0x14: [mem 0xfebd9000-0xfebd9fff]
drbd2 # [    0.706953] pci 0000:00:0b.0: reg 0x20: [mem 0xfe020000-0xfe023fff 64bit pref]
drbd2 # [    0.711886] pci 0000:00:0c.0: [1af4:1003] type 00 class 0x078000
drbd2 # [    0.714147] pci 0000:00:0c.0: reg 0x10: [io  0xc140-0xc17f]
drbd2 # [    0.718146] pci 0000:00:0c.0: reg 0x14: [mem 0xfebda000-0xfebdafff]
drbd1 # [    0.808568] clocksource: acpi_pm: mask: 0xffffff max_cycles: 0xffffff, max_idle_ns: 2085701024 ns
drbd1 # [    0.810558] clocksource: Switched to clocksource acpi_pm
drbd2 # [    0.727148] pci 0000:00:0c.0: reg 0x20: [mem 0xfe024000-0xfe027fff 64bit pref]
drbd1 # [    0.812241] NET: Registered PF_INET protocol family
drbd1 # [    0.813613] IP idents hash table entries: 16384 (order: 5, 131072 bytes, linear)
drbd1 # [    0.816259] tcp_listen_portaddr_hash hash table entries: 512 (order: 0, 4096 bytes, linear)
drbd1 # [    0.817867] Table-perturb hash table entries: 65536 (order: 6, 262144 bytes, linear)
drbd2 # [    0.733539] pci 0000:00:0d.0: [1af4:1005] type 00 class 0x00ff00
drbd1 # [    0.819880] TCP established hash table entries: 8192 (order: 3, 32768 bytes, linear)
drbd1 # [    0.821798] TCP bind hash table entries: 8192 (order: 5, 131072 bytes, linear)
drbd1 # [    0.823864] TCP: Hash tables configured (established 8192 bind 8192)
drbd2 # [    0.736148] pci 0000:00:0d.0: reg 0x10: [io  0xc240-0xc25f]
drbd1 # [    0.825979] MPTCP token hash table entries: 1024 (order: 2, 16384 bytes, linear)
drbd1 # [    0.827657] UDP hash table entries: 512 (order: 2, 16384 bytes, linear)
drbd1 # [    0.829157] UDP-Lite hash table entries: 512 (order: 2, 16384 bytes, linear)
drbd1 # [    0.830600] NET: Registered PF_UNIX/PF_LOCAL protocol family
drbd2 # [    0.739149] pci 0000:00:0d.0: reg 0x14: [mem 0xfebdb000-0xfebdbfff]
drbd1 # [    0.831943] NET: Registered PF_XDP protocol family
drbd1 # [    0.832917] pci_bus 0000:00: resource 4 [io  0x0000-0x0cf7 window]
drbd1 # [    0.834400] pci_bus 0000:00: resource 5 [io  0x0d00-0xffff window]
drbd1 # [    0.835821] pci_bus 0000:00: resource 6 [mem 0x000a0000-0x000bffff window]
drbd1 # [    0.837417] pci_bus 0000:00: resource 7 [mem 0x40000000-0xfebfffff window]
drbd2 # [    0.746146] pci 0000:00:0d.0: reg 0x20: [mem 0xfe028000-0xfe02bfff 64bit pref]
drbd1 # [    0.839026] pci_bus 0000:00: resource 8 [mem 0x100000000-0x17fffffff window]
drbd1 # [    0.840631] pci 0000:00:01.0: PIIX3: Enabling Passive Release
drbd1 # [    0.841975] pci 0000:00:00.0: Limiting direct PCI/PCI transfers
drbd1 # [    0.843147] pci 0000:00:01.0: Activating ISA DMA hang workarounds
drbd2 # [    0.752192] ACPI: PCI: Interrupt link LNKA configured for IRQ 10
drbd2 # [    0.753300] ACPI: PCI: Interrupt link LNKB configured for IRQ 10
drbd2 # [    0.755160] ACPI: PCI: Interrupt link LNKC configured for IRQ 11
drbd2 # [    0.756293] ACPI: PCI: Interrupt link LNKD configured for IRQ 11
drbd2 # [    0.757278] ACPI: PCI: Interrupt link LNKS configured for IRQ 9
drbd2 # [    0.758667] iommu: Default domain type: Translated
drbd2 # [    0.759142] iommu: DMA domain TLB invalidation policy: lazy mode
drbd2 # [    0.761828] NetLabel: Initializing
drbd2 # [    0.762142] NetLabel:  domain hash size = 128
drbd2 # [    0.763142] NetLabel:  protocols = UNLABELED CIPSOv4 CALIPSO
drbd2 # [    0.764169] NetLabel:  unlabeled traffic allowed by default
drbd2 # [    0.765147] PCI: Using ACPI for IRQ routing
drbd2 # [    0.766618] pci 0000:00:02.0: vgaarb: setting as boot VGA device
drbd2 # [    0.767139] pci 0000:00:02.0: vgaarb: bridge control possible
drbd2 # [    0.767139] pci 0000:00:02.0: vgaarb: VGA device added: decodes=io+mem,owns=io+mem,locks=none
drbd2 # [    0.767145] vgaarb: loaded
drbd2 # [    0.768358] clocksource: Switched to clocksource kvm-clock
drbd1 # [    0.867123] ACPI: \_SB_.LNKD: Enabled at IRQ 11
drbd2 # [    0.783944] VFS: Disk quotas dquot_6.6.0
drbd2 # [    0.784655] VFS: Dquot-cache hash table entries: 1024 (order 0, 4096 bytes)
drbd2 # [    0.786052] pnp: PnP ACPI init
drbd2 # [    0.787221] pnp: PnP ACPI: found 6 devices
drbd1 # [    0.889143] pci 0000:00:01.2: quirk_usb_early_handoff+0x0/0x7f0 took 43728 usecs
drbd1 # [    0.891021] PCI: CLS 0 bytes, default 32
drbd1 # [    0.892079] Trying to unpack rootfs image as initramfs...
drbd1 # [    0.895585] clocksource: tsc: mask: 0xffffffffffffffff max_cycles: 0x27178451938, max_idle_ns: 440795251172 ns
drbd1 # [    0.900699] Initialise system trusted keyrings
drbd1 # [    0.905409] workingset: timestamp_bits=14 max_order=18 bucket_order=4
drbd1 # [    0.910244] zbud: loaded
drbd1 # [    0.913060] Key type asymmetric registered
drbd1 # [    0.916360] Asymmetric key parser 'x509' registered
drbd2 # [    0.824370] clocksource: acpi_pm: mask: 0xffffff max_cycles: 0xffffff, max_idle_ns: 2085701024 ns
drbd2 # [    0.825853] clocksource: Switched to clocksource acpi_pm
drbd2 # [    0.827239] NET: Registered PF_INET protocol family
drbd2 # [    0.828620] IP idents hash table entries: 16384 (order: 5, 131072 bytes, linear)
drbd2 # [    0.830975] tcp_listen_portaddr_hash hash table entries: 512 (order: 0, 4096 bytes, linear)
drbd2 # [    0.832653] Table-perturb hash table entries: 65536 (order: 6, 262144 bytes, linear)
drbd2 # [    0.834315] TCP established hash table entries: 8192 (order: 3, 32768 bytes, linear)
drbd2 # [    0.835931] TCP bind hash table entries: 8192 (order: 5, 131072 bytes, linear)
drbd2 # [    0.837513] TCP: Hash tables configured (established 8192 bind 8192)
drbd2 # [    0.839275] MPTCP token hash table entries: 1024 (order: 2, 16384 bytes, linear)
drbd2 # [    0.840993] UDP hash table entries: 512 (order: 2, 16384 bytes, linear)
drbd2 # [    0.842261] UDP-Lite hash table entries: 512 (order: 2, 16384 bytes, linear)
drbd2 # [    0.843571] NET: Registered PF_UNIX/PF_LOCAL protocol family
drbd2 # [    0.844529] NET: Registered PF_XDP protocol family
drbd2 # [    0.845680] pci_bus 0000:00: resource 4 [io  0x0000-0x0cf7 window]
drbd2 # [    0.846835] pci_bus 0000:00: resource 5 [io  0x0d00-0xffff window]
drbd2 # [    0.848103] pci_bus 0000:00: resource 6 [mem 0x000a0000-0x000bffff window]
drbd2 # [    0.849500] pci_bus 0000:00: resource 7 [mem 0x40000000-0xfebfffff window]
drbd2 # [    0.851085] pci_bus 0000:00: resource 8 [mem 0x100000000-0x17fffffff window]
drbd2 # [    0.852380] pci 0000:00:01.0: PIIX3: Enabling Passive Release
drbd2 # [    0.853416] pci 0000:00:00.0: Limiting direct PCI/PCI transfers
drbd2 # [    0.854870] pci 0000:00:01.0: Activating ISA DMA hang workarounds
drbd2 # [    0.873055] ACPI: \_SB_.LNKD: Enabled at IRQ 11
drbd2 # [    0.891252] pci 0000:00:01.2: quirk_usb_early_handoff+0x0/0x7f0 took 34362 usecs
drbd2 # [    0.892707] PCI: CLS 0 bytes, default 32
drbd2 # [    0.893514] Trying to unpack rootfs image as initramfs...
drbd2 # [    0.897014] clocksource: tsc: mask: 0xffffffffffffffff max_cycles: 0x27178451938, max_idle_ns: 440795251172 ns
drbd2 # [    0.901291] Initialise system trusted keyrings
drbd2 # [    0.904962] workingset: timestamp_bits=14 max_order=18 bucket_order=4
drbd2 # [    0.908934] zbud: loaded
drbd2 # [    0.913468] Key type asymmetric registered
drbd2 # [    0.915945] Asymmetric key parser 'x509' registered
drbd1 # [    1.085213] Freeing initrd memory: 12712K
drbd1 # [    1.086851] alg: self-tests for CTR-KDF (hmac(sha256)) passed
drbd1 # [    1.088290] bounce: pool size: 64 pages
drbd1 # [    1.089177] Block layer SCSI generic (bsg) driver version 0.4 loaded (major 252)
drbd1 # [    1.090669] io scheduler mq-deadline registered
drbd1 # [    1.091493] io scheduler kyber registered
drbd1 # [    1.092820] Serial: 8250/16550 driver, 4 ports, IRQ sharing enabled
drbd1 # [    1.094576] 00:04: ttyS0 at I/O 0x3f8 (irq = 4, base_baud = 115200) is a 16550A
drbd1 # [    1.097018] hpet_acpi_add: no address or irqs in _CRS
drbd1 # [    1.098413] intel_pstate: CPU model not supported
drbd1 # [    1.099620] drop_monitor: Initializing network drop monitor service
drbd1 # [    1.112827] NET: Registered PF_INET6 protocol family
drbd1 # [    1.114970] Segment Routing with IPv6
drbd1 # [    1.115875] In-situ OAM (IOAM) with IPv6
drbd1 # [    1.116833] mce: Unable to init MCE device (rc: -5)
drbd1 # [    1.117784] IPI shorthand broadcast: enabled
drbd1 # [    1.118592] sched_clock: Marking stable (950191419, 168311075)->(1310062739, -191560245)
drbd1 # [    1.120132] registered taskstats version 1
drbd1 # [    1.120848] Loading compiled-in X.509 certificates
drbd1 # [    1.122116] zswap: loaded using pool lzo/zbud
drbd1 # [    1.123355] Key type .fscrypt registered
drbd1 # [    1.124073] Key type fscrypt-provisioning registered
drbd1 # [    1.127351] Freeing unused kernel image (initmem) memory: 800K
drbd1 # [    1.130450] Write protecting kernel text and read-only data: 16132k
drbd1 # [    1.131648] Run /init as init process
drbd1 #
drbd1 # <<< NixOS Stage 1 >>>
drbd1 #
drbd1 # loading module virtio_balloon...
drbd1 # loading module virtio_console...
drbd1 # loading module virtio_rng...
drbd2 # [    1.088019] Freeing initrd memory: 12712K
drbd2 # [    1.089601] alg: self-tests for CTR-KDF (hmac(sha256)) passed
drbd2 # [    1.091054] bounce: pool size: 64 pages
drbd2 # [    1.092061] Block layer SCSI generic (bsg) driver version 0.4 loaded (major 252)
drbd1 # loading module dm_mod...
drbd2 # [    1.093956] io scheduler mq-deadline registered
drbd2 # [    1.095034] io scheduler kyber registered
drbd2 # [    1.096308] Serial: 8250/16550 driver, 4 ports, IRQ sharing enabled
drbd2 # [    1.098097] 00:04: ttyS0 at I/O 0x3f8 (irq = 4, base_baud = 115200) is a 16550A
drbd2 # [    1.100458] hpet_acpi_add: no address or irqs in _CRS
drbd2 # [    1.101767] intel_pstate: CPU model not supported
drbd2 # [    1.103002] drop_monitor: Initializing network drop monitor service
drbd1 # [    1.207716] device-mapper: ioctl: 4.47.0-ioctl (2022-07-28) initialised: dm-devel@redhat.com
drbd1 # running udev...
drbd2 # [    1.116240] NET: Registered PF_INET6 protocol family
drbd2 # [    1.118268] Segment Routing with IPv6
drbd2 # [    1.119172] In-situ OAM (IOAM) with IPv6
drbd2 # [    1.120124] mce: Unable to init MCE device (rc: -5)
drbd2 # [    1.121250] IPI shorthand broadcast: enabled
drbd2 # [    1.122192] sched_clock: Marking stable (946217619, 175883373)->(1312031109, -189930117)
drbd2 # [    1.124267] registered taskstats version 1
drbd2 # [    1.125251] Loading compiled-in X.509 certificates
drbd2 # [    1.126300] zswap: loaded using pool lzo/zbud
drbd2 # [    1.127335] Key type .fscrypt registered
drbd2 # [    1.128062] Key type fscrypt-provisioning registered
drbd1 # Starting systemd-udevd version 253.3
drbd2 # [    1.131312] Freeing unused kernel image (initmem) memory: 800K
drbd2 # [    1.134004] Write protecting kernel text and read-only data: 16132k
drbd2 # [    1.134792] Run /init as init process
drbd2 #
drbd2 # <<< NixOS Stage 1 >>>
drbd2 #
drbd2 # loading module virtio_balloon...
drbd2 # loading module virtio_console...
drbd2 # loading module virtio_rng...
drbd2 # loading module dm_mod...
drbd2 # [    1.207443] device-mapper: ioctl: 4.47.0-ioctl (2022-07-28) initialised: dm-devel@redhat.com
drbd2 # running udev...
drbd2 # Starting systemd-udevd version 253.3
drbd1 # [    1.331424] i8042: PNP: PS/2 Controller [PNP0303:KBD,PNP0f13:MOU] at 0x60,0x64 irq 1,12
drbd1 # [    1.333975] rtc_cmos 00:05: RTC can wake from S4
drbd1 # [    1.340998] rtc_cmos 00:05: registered as rtc0
drbd1 # [    1.342375] serio: i8042 KBD port at 0x60,0x64 irq 1
drbd1 # [    1.343258] serio: i8042 AUX port at 0x60,0x64 irq 12
drbd1 # [    1.345668] rtc_cmos 00:05: alarms up to one day, y3k, 242 bytes nvram
drbd2 # [    1.308521] rtc_cmos 00:05: RTC can wake from S4
drbd2 # [    1.309745] rtc_cmos 00:05: registered as rtc0
drbd2 # [    1.315181] rtc_cmos 00:05: alarms up to one day, y3k, 242 bytes nvram
drbd2 # [    1.322366] i8042: PNP: PS/2 Controller [PNP0303:KBD,PNP0f13:MOU] at 0x60,0x64 irq 1,12
drbd2 # [    1.326692] serio: i8042 KBD port at 0x60,0x64 irq 1
drbd1 # [    1.425489] SCSI subsystem initialized
drbd2 # [    1.331437] serio: i8042 AUX port at 0x60,0x64 irq 12
drbd1 # [    1.444658] ACPI: bus type USB registered
drbd1 # [    1.447969] ACPI: \_SB_.LNKC: Enabled at IRQ 10
drbd1 # [    1.448756] usbcore: registered new interface driver usbfs
drbd1 # [    1.449624] usbcore: registered new interface driver hub
drbd1 # [    1.450352] usbcore: registered new device driver usb
drbd1 # [    1.508383] scsi host0: ata_piix
drbd2 # [    1.415926] SCSI subsystem initialized
drbd1 # [    1.517467] scsi host1: ata_piix
drbd1 # [    1.517936] ata1: PATA max MWDMA2 cmd 0x1f0 ctl 0x3f6 bmdma 0xc260 irq 14
drbd1 # [    1.519188] ata2: PATA max MWDMA2 cmd 0x170 ctl 0x376 bmdma 0xc268 irq 15
drbd2 # [    1.427086] ACPI: \_SB_.LNKC: Enabled at IRQ 10
drbd1 # [    1.526092] uhci_hcd 0000:00:01.2: UHCI Host Controller
drbd2 # [    1.428494] ACPI: bus type USB registered
drbd2 # [    1.429681] usbcore: registered new interface driver usbfs
drbd1 # [    1.528047] uhci_hcd 0000:00:01.2: new USB bus registered, assigned bus number 1
drbd1 # [    1.529533] uhci_hcd 0000:00:01.2: detected 2 ports
drbd1 # [    1.530852] random: crng init done
drbd2 # [    1.435936] usbcore: registered new interface driver hub
drbd2 # [    1.436816] usbcore: registered new device driver usb
drbd1 # [    1.538420] uhci_hcd 0000:00:01.2: irq 11, io port 0x0000c180
drbd1 # [    1.539558] usb usb1: New USB device found, idVendor=1d6b, idProduct=0001, bcdDevice= 6.01
drbd1 # [    1.540961] usb usb1: New USB device strings: Mfr=3, Product=2, SerialNumber=1
drbd1 # [    1.542199] usb usb1: Product: UHCI Host Controller
drbd1 # [    1.543073] usb usb1: Manufacturer: Linux 6.1.29 uhci_hcd
drbd1 # [    1.544004] usb usb1: SerialNumber: 0000:00:01.2
drbd1 # [    1.548913] hub 1-0:1.0: USB hub found
drbd1 # [    1.550377] hub 1-0:1.0: 2 ports detected
drbd1 # [    1.573443] ACPI: \_SB_.LNKA: Enabled at IRQ 10
drbd1 # [    1.605480] ACPI: \_SB_.LNKB: Enabled at IRQ 11
drbd2 # [    1.514952] scsi host0: ata_piix
drbd2 # [    1.522946] scsi host1: ata_piix
drbd2 # [    1.523673] ata1: PATA max MWDMA2 cmd 0x1f0 ctl 0x3f6 bmdma 0xc260 irq 14
drbd2 # [    1.524673] ata2: PATA max MWDMA2 cmd 0x170 ctl 0x376 bmdma 0xc268 irq 15
drbd2 # [    1.539987] uhci_hcd 0000:00:01.2: UHCI Host Controller
drbd2 # [    1.540688] uhci_hcd 0000:00:01.2: new USB bus registered, assigned bus number 1
drbd2 # [    1.542073] uhci_hcd 0000:00:01.2: detected 2 ports
drbd2 # [    1.543224] uhci_hcd 0000:00:01.2: irq 11, io port 0x0000c180
drbd2 # [    1.544477] usb usb1: New USB device found, idVendor=1d6b, idProduct=0001, bcdDevice= 6.01
drbd2 # [    1.545798] usb usb1: New USB device strings: Mfr=3, Product=2, SerialNumber=1
drbd2 # [    1.547062] usb usb1: Product: UHCI Host Controller
drbd2 # [    1.547865] usb usb1: Manufacturer: Linux 6.1.29 uhci_hcd
drbd2 # [    1.548722] usb usb1: SerialNumber: 0000:00:01.2
drbd2 # [    1.549595] random: crng init done
drbd2 # [    1.557416] hub 1-0:1.0: USB hub found
drbd2 # [    1.558139] hub 1-0:1.0: 2 ports detected
drbd2 # [    1.571472] ACPI: \_SB_.LNKA: Enabled at IRQ 10
drbd1 # [    1.678488] ata2: found unknown device (class 0)
drbd1 # [    1.680005] ata2.00: ATAPI: QEMU DVD-ROM, 2.5+, max UDMA/100
drbd1 # [    1.682055] scsi 1:0:0:0: CD-ROM            QEMU     QEMU DVD-ROM     2.5+ PQ: 0 ANSI: 5
drbd2 # [    1.595315] ACPI: \_SB_.LNKB: Enabled at IRQ 11
drbd2 # [    1.678055] ata2: found unknown device (class 0)
drbd2 # [    1.679999] ata2.00: ATAPI: QEMU DVD-ROM, 2.5+, max UDMA/100
drbd2 # [    1.686373] scsi 1:0:0:0: CD-ROM            QEMU     QEMU DVD-ROM     2.5+ PQ: 0 ANSI: 5
drbd1 # [    1.785388] usb 1-1: new full-speed USB device number 2 using uhci_hcd
drbd1 # [    1.875499] input: AT Translated Set 2 keyboard as /devices/platform/i8042/serio0/input/input0
drbd2 # [    1.783922] usb 1-1: new full-speed USB device number 2 using uhci_hcd
drbd1 # [    1.891069] virtio_blk virtio5: 1/0/0 default/read/poll queues
drbd1 # [    1.915300] virtio_blk virtio5: [vda] 2097152 512-byte logical blocks (1.07 GB/1.00 GiB)
drbd1 # [    1.930241] 9pnet: Installing 9P2000 support
drbd1 # [    1.949761] virtio_blk virtio6: 1/0/0 default/read/poll queues
drbd1 # [    1.951517] virtio_blk virtio6: [vdb] 2048 512-byte logical blocks (1.05 MB/1.00 MiB)
drbd2 # [    1.861164] input: AT Translated Set 2 keyboard as /devices/platform/i8042/serio0/input/input0
drbd1 # [    1.964984] usb 1-1: New USB device found, idVendor=0627, idProduct=0001, bcdDevice= 0.00
drbd1 # [    1.966186] usb 1-1: New USB device strings: Mfr=1, Product=3, SerialNumber=10
drbd1 # [    1.967522] usb 1-1: Product: QEMU USB Tablet
drbd1 # [    1.968274] usb 1-1: Manufacturer: QEMU
drbd1 # [    1.968844] usb 1-1: SerialNumber: 28754-0000:00:01.2-1
drbd1 # [    1.972938] sr 1:0:0:0: [sr0] scsi3-mmc drive: 4x/4x cd/rw xa/form2 tray
drbd1 # [    1.974205] cdrom: Uniform CD-ROM driver Revision: 3.20
drbd2 # [    1.880019] virtio_blk virtio5: 1/0/0 default/read/poll queues
drbd2 # [    1.893726] virtio_blk virtio5: [vda] 2097152 512-byte logical blocks (1.07 GB/1.00 GiB)
drbd2 # [    1.910550] 9pnet: Installing 9P2000 support
drbd1 # [    2.012833] hid: raw HID events driver (C) Jiri Kosina
drbd1 # [    2.023289] usbcore: registered new interface driver usbhid
drbd1 # [    2.024264] usbhid: USB HID core driver
drbd1 # [    2.027221] input: QEMU QEMU USB Tablet as /devices/pci0000:00/0000:00:01.2/usb1/1-1/1-1:1.0/0003:0627:0001.0001/input/input2
drbd1 # [    2.030205] hid-generic 0003:0627:0001.0001: input,hidraw0: USB HID v0.01 Mouse [QEMU QEMU USB Tablet] on usb-0000:00:01.2-1/input0
drbd2 # [    1.942217] virtio_blk virtio6: 1/0/0 default/read/poll queues
drbd2 # [    1.943859] virtio_blk virtio6: [vdb] 2048 512-byte logical blocks (1.05 MB/1.00 MiB)
drbd2 # [    1.957467] sr 1:0:0:0: [sr0] scsi3-mmc drive: 4x/4x cd/rw xa/form2 tray
drbd2 # [    1.958478] cdrom: Uniform CD-ROM driver Revision: 3.20
drbd2 # [    1.970364] usb 1-1: New USB device found, idVendor=0627, idProduct=0001, bcdDevice= 0.00
drbd2 # [    1.971964] usb 1-1: New USB device strings: Mfr=1, Product=3, SerialNumber=10
drbd2 # [    1.973119] usb 1-1: Product: QEMU USB Tablet
drbd2 # [    1.973817] usb 1-1: Manufacturer: QEMU
drbd2 # [    1.974382] usb 1-1: SerialNumber: 28754-0000:00:01.2-1
drbd2 # [    2.009692] hid: raw HID events driver (C) Jiri Kosina
drbd2 # [    2.021121] usbcore: registered new interface driver usbhid
drbd2 # [    2.022046] usbhid: USB HID core driver
drbd2 # [    2.025201] input: QEMU QEMU USB Tablet as /devices/pci0000:00/0000:00:01.2/usb1/1-1/1-1:1.0/0003:0627:0001.0001/input/input2
drbd2 # [    2.027496] hid-generic 0003:0627:0001.0001: input,hidraw0: USB HID v0.01 Mouse [QEMU QEMU USB Tablet] on usb-0000:00:01.2-1/input0
drbd1 # kbd_mode: KDSKBMODE: Inappropriate ioctl for device
drbd1 # %Gstarting device mapper and LVM...
drbd1 # mke2fs 1.46.6 (1-Feb-2023)
drbd1 # Discarding device blocks: done
drbd1 # Creating filesystem with 262144 4k blocks and 65536 inodes
drbd1 # Filesystem UUID: 3ed84036-2b7e-4786-bb9f-c80bcaf11ae9
drbd1 # Superblock backups stored on blocks:
drbd1 #         32768, 98304, 163840, 229376
drbd1 #
drbd1 # Allocating group tables: done
drbd1 # Writing inode tables: done
drbd1 # Creating journal (8192 blocks): done
drbd1 # Writing superblocks and filesystem accounting information: done
drbd1 #
drbd2 # kbd_mode: KDSKBMODE: Inappropriate ioctl for device
drbd1 # checking /dev/vda...
drbd2 # %Gstarting device mapper and LVM...
drbd1 # fsck (busybox 1.36.0)
drbd1 # [fsck.ext4 (1) -- /mnt-root/] fsck.ext4 -a /dev/vda
drbd1 # /dev/vda: clean, 11/65536 files, 12955/262144 blocks
drbd1 # mounting /dev/vda on /...
drbd2 # mke2fs 1.46.6 (1-Feb-2023)
drbd2 # Discarding device blocks: done
drbd2 # Creating filesystem with 262144 4k blocks and 65536 inodes
drbd2 # Filesystem UUID: d9f3d3cf-793a-4fd5-a92e-701d03b00324
drbd2 # Superblock backups stored on blocks:
drbd2 #         32768, 98304, 163840, 229376
drbd2 #
drbd2 # Allocating group tables: done
drbd2 # Writing inode tables: done
drbd2 # Creating journal (8192 blocks): done
drbd2 # Writing superblocks and filesystem accounting information: done
drbd2 #
drbd2 # checking /dev/vda...
drbd2 # fsck (busybox 1.36.0)
drbd2 # [fsck.ext4 (1) -- /mnt-root/] fsck.ext4 -a /dev/vda
drbd2 # /dev/vda: clean, 11/65536 files, 12955/262144 blocks
drbd2 # mounting /dev/vda on /...
drbd1 # [    2.456089] EXT4-fs (vda): mounted filesystem with ordered data mode. Quota mode: none.
drbd1 # [    2.459042] EXT4-fs (vda): re-mounted. Quota mode: none.
drbd1 # mounting nix-store on /nix/.ro-store...
drbd1 # [    2.485235] FS-Cache: Loaded
drbd1 # [    2.494722] 9p: Installing v9fs 9p2000 file system support
drbd1 # mounting tmpfs on /nix/.rw-store...
drbd1 # mounting shared on /tmp/shared...
drbd2 # [    2.429763] EXT4-fs (vda): mounted filesystem with ordered data mode. Quota mode: none.
drbd2 # [    2.432707] EXT4-fs (vda): re-mounted. Quota mode: none.
drbd2 # mounting nix-store on /nix/.ro-store...
drbd1 # mounting xchg on /tmp/xchg...
drbd2 # [    2.459467] FS-Cache: Loaded
drbd1 # mounting overlay filesystem on /nix/store...
drbd2 # [    2.469131] 9p: Installing v9fs 9p2000 file system support
drbd2 # mounting tmpfs on /nix/.rw-store...
drbd2 # mounting shared on /tmp/shared...
drbd2 # mounting xchg on /tmp/xchg...
drbd2 # mounting overlay filesystem on /nix/store...
drbd1 #
drbd1 # <<< NixOS Stage 2 >>>
drbd1 #
drbd1 # [    2.751120] EXT4-fs (vda): re-mounted. Quota mode: none.
drbd1 # [    2.754410] booting system configuration /nix/store/gxg9szsfkvj2z9iyp306hhfrbqdp11db-nixos-system-drbd1-23.05pre-git
drbd2 #
drbd2 # <<< NixOS Stage 2 >>>
drbd2 #
drbd1 # running activation script...
drbd2 # [    2.755157] EXT4-fs (vda): re-mounted. Quota mode: none.
drbd2 # [    2.758458] booting system configuration /nix/store/crrvj215mdcki3bzrf4ajd9dwp6h1zbd-nixos-system-drbd2-23.05pre-git
drbd2 # running activation script...
drbd1 # setting up /etc...
drbd2 # setting up /etc...
drbd1 # starting systemd...
drbd2 # starting systemd...
drbd1 # [    5.117876] systemd[1]: Inserted module 'autofs4'
drbd2 # [    5.037868] systemd[1]: Inserted module 'autofs4'
drbd1 # [    5.194831] systemd[1]: systemd 253.3 running in system mode (+PAM +AUDIT -SELINUX +APPARMOR +IMA +SMACK +SECCOMP +GCRYPT -GNUTLS +OPENSSL +ACL +BLKID +CURL +ELFUTILS +FIDO2 +IDN2 -IDN +IPTC +KMOD +LIBCRYPTSETUP +LIBFDISK +PCRE2 -PWQUALITY +P11KIT -QRENCODE +TPM2 +BZIP2 +LZ4 +XZ +ZLIB +ZSTD +BPF_FRAMEWORK -XKBCOMMON +UTMP -SYSVINIT default-hierarchy=unified)
drbd1 # [    5.201238] systemd[1]: Detected virtualization kvm.
drbd1 # [    5.202380] systemd[1]: Detected architecture x86.
drbd2 # [    5.103128] systemd[1]: systemd 253.3 running in system mode (+PAM +AUDIT -SELINUX +APPARMOR +IMA +SMACK +SECCOMP +GCRYPT -GNUTLS +OPENSSL +ACL +BLKID +CURL +ELFUTILS +FIDO2 +IDN2 -IDN +IPTC +KMOD +LIBCRYPTSETUP +LIBFDISK +PCRE2 -PWQUALITY +P11KIT -QRENCODE +TPM2 +BZIP2 +LZ4 +XZ +ZLIB +ZSTD +BPF_FRAMEWORK -XKBCOMMON +UTMP -SYSVINIT default-hierarchy=unified)
drbd1 # [    5.208257] systemd[1]: Initializing machine ID from random generator.
drbd2 # [    5.110522] systemd[1]: Detected virtualization kvm.
drbd2 # [    5.111642] systemd[1]: Detected architecture x86.
drbd2 # [    5.116911] systemd[1]: Initializing machine ID from random generator.
drbd2 # [    5.192092] systemd[1]: bpf-lsm: BPF LSM hook not enabled in the kernel, BPF LSM not supported
drbd1 # [    5.291075] systemd[1]: bpf-lsm: BPF LSM hook not enabled in the kernel, BPF LSM not supported
drbd2 # [    6.232071] systemd[1]: Queued start job for default target Multi-User System.
drbd1 # [    6.331094] systemd[1]: Queued start job for default target Multi-User System.
drbd2 # [    6.243637] systemd[1]: Created slice Slice /system/getty.
drbd1 # [    6.342265] systemd[1]: Created slice Slice /system/getty.
drbd2 # [    6.245752] systemd[1]: Created slice Slice /system/modprobe.
drbd1 # [    6.345032] systemd[1]: Created slice Slice /system/modprobe.
drbd2 # [    6.247842] systemd[1]: Created slice User and Session Slice.
drbd1 # [    6.347240] systemd[1]: Created slice User and Session Slice.
drbd2 # [    6.249180] systemd[1]: Started Dispatch Password Requests to Console Directory Watch.
drbd1 # [    6.348947] systemd[1]: Started Dispatch Password Requests to Console Directory Watch.
drbd2 # [    6.251329] systemd[1]: Started Forward Password Requests to Wall Directory Watch.
drbd1 # [    6.351536] systemd[1]: Started Forward Password Requests to Wall Directory Watch.
drbd2 # [    6.254312] systemd[1]: Reached target Local Encrypted Volumes.
drbd2 # [    6.255538] systemd[1]: Reached target Containers.
drbd1 # [    6.354185] systemd[1]: Reached target Local Encrypted Volumes.
drbd2 # [    6.256752] systemd[1]: Reached target Path Units.
drbd1 # [    6.355739] systemd[1]: Reached target Containers.
drbd2 # [    6.257748] systemd[1]: Reached target Remote File Systems.
drbd1 # [    6.356962] systemd[1]: Reached target Path Units.
drbd2 # [    6.259143] systemd[1]: Reached target Slice Units.
drbd1 # [    6.358189] systemd[1]: Reached target Remote File Systems.
drbd2 # [    6.260402] systemd[1]: Reached target Swaps.
drbd1 # [    6.359785] systemd[1]: Reached target Slice Units.
drbd1 # [    6.361046] systemd[1]: Reached target Swaps.
drbd2 # [    6.269606] systemd[1]: Listening on Process Core Dump Socket.
drbd1 # [    6.370807] systemd[1]: Listening on Process Core Dump Socket.
drbd2 # [    6.272317] systemd[1]: Listening on Journal Socket (/dev/log).
drbd2 # [    6.274193] systemd[1]: Listening on Journal Socket.
drbd1 # [    6.373376] systemd[1]: Listening on Journal Socket (/dev/log).
drbd1 # [    6.375202] systemd[1]: Listening on Journal Socket.
drbd2 # [    6.276470] systemd[1]: Listening on Userspace Out-Of-Memory (OOM) Killer Socket.
drbd1 # [    6.377619] systemd[1]: Listening on Userspace Out-Of-Memory (OOM) Killer Socket.
drbd2 # [    6.280742] systemd[1]: Listening on udev Control Socket.
drbd2 # [    6.282602] systemd[1]: Listening on udev Kernel Socket.
drbd1 # [    6.381735] systemd[1]: Listening on udev Control Socket.
drbd1 # [    6.383972] systemd[1]: Listening on udev Kernel Socket.
drbd1 # [    6.390486] systemd[1]: Mounting Huge Pages File System...
drbd2 # [    6.292187] systemd[1]: Mounting Huge Pages File System...
drbd1 # [    6.395491] systemd[1]: Mounting POSIX Message Queue File System...
drbd2 # [    6.297159] systemd[1]: Mounting POSIX Message Queue File System...
drbd1 # [    6.408534] systemd[1]: Mounting Kernel Debug File System...
drbd2 # [    6.310158] systemd[1]: Mounting Kernel Debug File System...
drbd1 # [    6.423660] systemd[1]: Starting Create List of Static Device Nodes...
drbd2 # [    6.325350] systemd[1]: Starting Create List of Static Device Nodes...
drbd1 # [    6.439576] systemd[1]: Starting Load Kernel Module configfs...
drbd2 # [    6.342556] systemd[1]: Starting Load Kernel Module configfs...
drbd1 # [    6.449671] systemd[1]: Starting Load Kernel Module drm...
drbd2 # [    6.353733] systemd[1]: Starting Load Kernel Module drm...
drbd1 # [    6.462151] systemd[1]: Starting Load Kernel Module efi_pstore...
drbd2 # [    6.365186] systemd[1]: Starting Load Kernel Module efi_pstore...
drbd1 # [    6.476898] systemd[1]: Starting Load Kernel Module fuse...
drbd2 # [    6.386809] systemd[1]: Starting Load Kernel Module fuse...
drbd1 # [    6.495025] systemd[1]: Starting mount-pstore.service...
drbd2 # [    6.402743] systemd[1]: Starting mount-pstore.service...
drbd1 # [    6.503474] systemd[1]: File System Check on Root Device was skipped because of an unmet condition check (ConditionPathIsReadWrite=!/).
drbd2 # [    6.413952] systemd[1]: File System Check on Root Device was skipped because of an unmet condition check (ConditionPathIsReadWrite=!/).
drbd1 # [    6.536118] systemd[1]: Starting Journal Service...
drbd2 # [    6.446083] systemd[1]: Starting Journal Service...
drbd1 # [    6.553670] systemd[1]: Starting Load Kernel Modules...
drbd2 # [    6.461413] systemd[1]: Starting Load Kernel Modules...
drbd1 # [    6.564897] fuse: init (API version 7.37)
drbd2 # [    6.477722] fuse: init (API version 7.37)
drbd1 # [    6.581602] systemd[1]: Starting Remount Root and Kernel File Systems...
drbd2 # [    6.488489] systemd[1]: Starting Remount Root and Kernel File Systems...
drbd1 # [    6.622868] systemd[1]: Starting Coldplug All udev Devices...
drbd2 # [    6.527533] systemd[1]: Starting Coldplug All udev Devices...
drbd2 # [    6.567795] systemd-journald[471]: Collecting audit messages is disabled.
drbd1 # [    6.667752] EXT4-fs (vda): re-mounted. Quota mode: none.
drbd1 # [    6.672448] systemd-journald[471]: Collecting audit messages is disabled.
drbd2 # [    6.588111] systemd[1]: Mounted Huge Pages File System.
drbd1 # [    6.695272] systemd[1]: Mounted Huge Pages File System.
drbd2 # [    6.596726] systemd[1]: Mounted POSIX Message Queue File System.
drbd2 # [    6.601023] EXT4-fs (vda): re-mounted. Quota mode: none.
drbd1 # [    6.703748] systemd[1]: Mounted POSIX Message Queue File System.
drbd2 # [    6.611346] systemd[1]: Mounted Kernel Debug File System.
drbd1 # [    6.712752] systemd[1]: Mounted Kernel Debug File System.
drbd1 # [    6.725493] systemd[1]: Finished Create List of Static Device Nodes.
drbd2 # [    6.628137] systemd[1]: Finished Create List of Static Device Nodes.
drbd1 # [    6.735244] systemd[1]: modprobe@configfs.service: Deactivated successfully.
drbd2 # [    6.642352] systemd[1]: modprobe@configfs.service: Deactivated successfully.
drbd1 # [    6.749086] systemd[1]: Finished Load Kernel Module configfs.
drbd2 # [    6.659017] systemd[1]: Finished Load Kernel Module configfs.
drbd1 # [    6.761601] systemd[1]: modprobe@efi_pstore.service: Deactivated successfully.
drbd2 # [    6.669543] systemd[1]: modprobe@efi_pstore.service: Deactivated successfully.
drbd1 # [    6.776924] systemd[1]: Finished Load Kernel Module efi_pstore.
drbd1 # [    6.781218] systemd[1]: modprobe@fuse.service: Deactivated successfully.
drbd2 # [    6.683106] systemd[1]: Finished Load Kernel Module efi_pstore.
drbd2 # [    6.694773] systemd[1]: modprobe@fuse.service: Deactivated successfully.
drbd1 # [    6.806533] systemd[1]: Finished Load Kernel Module fuse.
drbd1 # [    6.808467] bridge: filtering via arp/ip/ip6tables is no longer available by default. Update your scripts to load br_netfilter if you need this.
drbd2 # [    6.721164] systemd[1]: Finished Load Kernel Module fuse.
drbd2 # [    6.727202] bridge: filtering via arp/ip/ip6tables is no longer available by default. Update your scripts to load br_netfilter if you need this.
drbd1 # [    6.827554] systemd[1]: Finished Remount Root and Kernel File Systems.
drbd2 # [    6.745610] systemd[1]: Finished Remount Root and Kernel File Systems.
drbd1 # [    6.857992] ACPI: bus type drm_connector registered
drbd1 # [    6.862756] systemd[1]: Mounting FUSE Control File System...
drbd2 # [    6.774481] ACPI: bus type drm_connector registered
drbd2 # [    6.783636] systemd[1]: Mounting FUSE Control File System...
drbd1 # [    6.884861] tun: Universal TUN/TAP device driver, 1.6
drbd1 # [    6.896865] systemd[1]: Mounting Kernel Configuration File System...
drbd2 # [    6.806730] tun: Universal TUN/TAP device driver, 1.6
drbd1 # [    6.925515] loop: module loaded
drbd2 # [    6.842122] systemd[1]: Mounting Kernel Configuration File System...
drbd2 # [    6.846402] loop: module loaded
drbd1 # [    6.945758] systemd[1]: Starting Load/Save OS Random Seed...
drbd2 # [    6.870507] systemd[1]: Starting Load/Save OS Random Seed...
drbd1 # [    6.980802] systemd[1]: Starting Create Static Device Nodes in /dev...
drbd2 # [    6.914357] systemd[1]: Starting Create Static Device Nodes in /dev...
drbd1 # [    7.026128] systemd[1]: modprobe@drm.service: Deactivated successfully.
drbd1 # [    7.048438] systemd[1]: Finished Load Kernel Module drm.
drbd1 # [    7.060909] systemd[1]: Mounted FUSE Control File System.
drbd2 # [    6.963423] systemd[1]: modprobe@drm.service: Deactivated successfully.
drbd1 # [    7.070568] systemd[1]: Mounted Kernel Configuration File System.
drbd2 # [    6.977315] systemd[1]: Finished Load Kernel Module drm.
drbd1 # [    7.084117] systemd[1]: Finished Load/Save OS Random Seed.
drbd2 # [    6.991215] systemd[1]: Mounted FUSE Control File System.
drbd2 # [    6.997325] systemd[1]: Mounted Kernel Configuration File System.
drbd2 # [    7.011983] systemd[1]: Finished Load/Save OS Random Seed.
drbd1 # [    7.151521] systemd[1]: Finished Create Static Device Nodes in /dev.
drbd1 # [    7.154004] systemd[1]: Reached target Preparation for Local File Systems.
drbd1 # [    7.161803] systemd[1]: Reached target Local File Systems.
drbd2 # [    7.068026] systemd[1]: Finished Create Static Device Nodes in /dev.
drbd2 # [    7.077844] systemd[1]: Reached target Preparation for Local File Systems.
drbd1 # [    7.183206] systemd[1]: Starting Rule-based Manager for Device Events and Files...
drbd2 # [    7.088450] systemd[1]: Reached target Local File Systems.
drbd1 # [    7.201585] drbd: initialized. Version: 8.4.11 (api:1/proto:86-101)
drbd1 # [    7.202873] drbd: srcversion: 488C1124B879DCE7CD031DA
drbd1 # [    7.203729] drbd: registered as block device major 147
drbd2 # [    7.113084] systemd[1]: Starting Rule-based Manager for Device Events and Files...
drbd2 # [    7.120082] drbd: initialized. Version: 8.4.11 (api:1/proto:86-101)
drbd2 # [    7.121348] drbd: srcversion: 488C1124B879DCE7CD031DA
drbd2 # [    7.122278] drbd: registered as block device major 147
drbd1 # [    7.224825] systemd[1]: Finished Load Kernel Modules.
drbd1 # [    7.235042] systemd[1]: Starting Firewall...
drbd2 # [    7.144258] systemd[1]: Finished Load Kernel Modules.
drbd2 # [    7.157749] systemd[1]: Starting Firewall...
drbd1 # [    7.261807] systemd[1]: Starting Apply Kernel Variables...
drbd2 # [    7.190973] systemd[1]: Starting Apply Kernel Variables...
drbd1 # [    7.402139] systemd[1]: Finished Apply Kernel Variables.
drbd2 # [    7.315194] systemd[1]: Finished Apply Kernel Variables.
drbd2 # [    7.388848] systemd[1]: Started Journal Service.
drbd1 # [    7.497988] systemd[1]: Started Journal Service.
drbd2 # [    7.223266] systemd-modules-load[472]: Inserted module 'bridge'
drbd1 # [    7.340562] systemd-modules-load[472]: Inserted module 'bridge'
drbd2 # [    7.236690] systemd-modules-load[472]: Inserted module 'macvlan'
drbd1 # [    7.355806] systemd-modules-load[472]: Inserted module 'macvlan'
drbd2 # [    7.256401] systemd-modules-load[472]: Inserted module 'tap'
drbd1 # [    7.374764] systemd-modules-load[472]: Inserted module 'tap'
drbd2 # [    7.273821] systemd-modules-load[472]: Inserted module 'tun'
drbd1 # [    7.403529] systemd-modules-load[472]: Inserted module 'tun'
drbd1 # [    7.418574] systemd-modules-load[472]: Inserted module 'loop'
drbd1 # [    7.597968] systemd-journald[471]: Received client request to flush runtime journal.
drbd2 # [    7.500098] systemd-journald[471]: Received client request to flush runtime journal.
drbd2 # [    7.580908] systemd-modules-load[472]: Inserted module 'loop'
drbd1 # [    7.695148] systemd-modules-load[472]: Inserted module 'drbd'
drbd2 # [    7.603935] systemd-modules-load[472]: Inserted module 'drbd'
drbd1 # [    7.721447] systemd-udevd[490]: Using default interface naming scheme 'v253'.
drbd2 # [    7.624333] systemd-udevd[490]: Using default interface naming scheme 'v253'.
drbd1 # [    7.743688] systemd[1]: Starting Flush Journal to Persistent Storage...
drbd1 # [    7.757600] systemd[1]: Started Rule-based Manager for Device Events and Files.
drbd2 # [    7.651960] systemd[1]: Starting Flush Journal to Persistent Storage...
drbd2 # [    7.671475] systemd[1]: Started Rule-based Manager for Device Events and Files.
drbd1 # [    7.788226] systemd[1]: Finished Coldplug All udev Devices.
drbd2 # [    7.694333] systemd[1]: Finished Flush Journal to Persistent Storage.
drbd1 # [    7.809123] systemd[1]: Finished Flush Journal to Persistent Storage.
drbd2 # [    7.719608] systemd[1]: Starting Create Volatile Files and Directories...
drbd1 # [    7.825978] systemd[1]: Starting Create Volatile Files and Directories...
drbd2 # [    7.734688] systemd[1]: Finished Coldplug All udev Devices.
drbd2 # [    7.804658] systemd[1]: Finished Create Volatile Files and Directories.
drbd1 # [    7.910427] systemd[1]: Finished Create Volatile Files and Directories.
drbd1 # [    7.927263] systemd[1]: Starting Rebuild Journal Catalog...
drbd2 # [    7.822243] systemd[1]: Starting Rebuild Journal Catalog...
drbd1 # [    7.972226] systemd[1]: Starting Userspace Out-Of-Memory (OOM) Killer...
drbd2 # [    7.865319] systemd[1]: Starting Userspace Out-Of-Memory (OOM) Killer...
drbd1 # [    8.000668] systemd[1]: Starting Record System Boot/Shutdown in UTMP...
drbd2 # [    7.896577] systemd[1]: Starting Record System Boot/Shutdown in UTMP...
drbd2 # [    7.995865] systemd[1]: Finished Record System Boot/Shutdown in UTMP.
drbd1 # [    8.120532] systemd[1]: Finished Record System Boot/Shutdown in UTMP.
drbd2 # [    8.138185] systemd[1]: Finished Rebuild Journal Catalog.
drbd1 # [    8.252625] systemd[1]: Finished Rebuild Journal Catalog.
drbd2 # [    8.162791] systemd[1]: Starting Update is Completed...
drbd1 # [    8.271623] systemd[1]: Starting Update is Completed...
drbd2 # [    8.232810] systemd[1]: Finished Update is Completed.
drbd1 # [    8.379475] systemd[1]: Finished Update is Completed.
drbd2 # [    8.413190] systemd-oomd[548]: Swap is currently not detected; memory pressure usage will be degraded
drbd2 # [    8.423358] systemd[1]: Started Userspace Out-Of-Memory (OOM) Killer.
drbd1 # [    8.553814] systemd-oomd[551]: Swap is currently not detected; memory pressure usage will be degraded
drbd1 # [    8.562994] systemd[1]: Started Userspace Out-Of-Memory (OOM) Killer.
drbd1 # [    8.669335] systemd[1]: Found device /dev/hvc0.
drbd2 # [    8.564234] systemd[1]: Found device /dev/ttyS0.
drbd1 # [    8.693305] systemd[1]: Found device /dev/ttyS0.
drbd2 # [    8.603860] (udev-worker)[513]: Network interface NamePolicy= disabled on kernel command line.
drbd2 # [    8.610297] systemd[1]: Found device /dev/hvc0.
drbd1 # [    8.763714] (udev-worker)[510]: eth1: Config file /etc/systemd/network/40-eth1.link is applied to device based on potentially unpredictable interface name.
drbd1 # [    8.774790] (udev-worker)[577]: Network interface NamePolicy= disabled on kernel command line.
drbd1 # [    8.782274] (udev-worker)[510]: Network interface NamePolicy= disabled on kernel command line.
drbd2 # [    8.700353] (udev-worker)[580]: eth1: Config file /etc/systemd/network/40-eth1.link is applied to device based on potentially unpredictable interface name.
drbd2 # [    8.707218] (udev-worker)[580]: Network interface NamePolicy= disabled on kernel command line.
drbd1 # [    8.860705] n4yawd1s0b0lgvr7885rdgfbsvi8zmni-mount-pstore.sh[477]: Persistent Storage backend was not registered in time.
drbd1 # [    8.871556] systemd[1]: Finished mount-pstore.service.
drbd2 # [    8.774311] n4yawd1s0b0lgvr7885rdgfbsvi8zmni-mount-pstore.sh[477]: Persistent Storage backend was not registered in time.
drbd1 # [    8.877543] systemd[1]: Platform Persistent Storage Archival was skipped because of an unmet condition check (ConditionDirectoryNotEmpty=/sys/fs/pstore).
drbd2 # [    8.786956] systemd[1]: Finished mount-pstore.service.
drbd1 # [    8.889745] systemd[1]: Reached target System Initialization.
drbd1 # [    8.899878] systemd[1]: Started logrotate.timer.
drbd1 # [    8.908681] systemd[1]: Started Daily Cleanup of Temporary Directories.
drbd2 # [    8.791644] systemd[1]: Platform Persistent Storage Archival was skipped because of an unmet condition check (ConditionDirectoryNotEmpty=/sys/fs/pstore).
drbd2 # [    8.820215] systemd[1]: Reached target System Initialization.
drbd1 # [    8.921616] systemd[1]: Reached target Timer Units.
drbd2 # [    8.828709] systemd[1]: Started logrotate.timer.
drbd1 # [    8.940199] systemd[1]: Listening on D-Bus System Message Bus Socket.
drbd2 # [    8.839896] systemd[1]: Started Daily Cleanup of Temporary Directories.
drbd2 # [    8.854357] systemd[1]: Reached target Timer Units.
drbd1 # [    8.968193] systemd[1]: Listening on Nix Daemon Socket.
drbd2 # [    8.880272] systemd[1]: Listening on D-Bus System Message Bus Socket.
drbd2 # [    8.900736] systemd[1]: Listening on Nix Daemon Socket.
drbd1 # [    9.012500] systemd[1]: Reached target Socket Units.
drbd1 # connecting to host...
drbd2 # connecting to host...
drbd1 # [    9.037443] dhcpcd[603]: dhcpcd-9.4.1 starting
drbd2 # [    8.936804] systemd[1]: Reached target Socket Units.
drbd1 # [    9.048658] 9iwvv5iriqk2cv1px241s960kbi22gik-audit-disable[604]: No rules
drbd1 # [    9.077414] systemd[1]: Reached target Basic System.
drbd2 # [    8.967487] dhcpcd[602]: dhcpcd-9.4.1 starting
drbd2 # [    8.982657] systemd[1]: Reached target Basic System.
drbd2 # [    9.012490] 9iwvv5iriqk2cv1px241s960kbi22gik-audit-disable[605]: No rules
drbd1 # [    9.102229] logrotate[606]: warning: logrotate in debug mode does nothing except printing debug messages!  Consider using verbose mode (-v) instead if this is not what you want.
drbd1 # [    9.137484] logrotate[606]: reading config file /nix/store/0mnkk89wg905a4fhz1kpjwccvanacfik-logrotate.conf
drbd1 # [    9.334952] 8021q: 802.1Q VLAN Support v1.8
drbd1 # [    9.159060] logrotate[606]: note: 'monthly' overrides previously specified 'weekly'
drbd1: Spawning backdoor root shell...

drbd2 # [    9.055727] logrotate[606]: warning: logrotate in debug mode does nothing except printing debug messages!  Consider using verbose mode (-v) instead if this is not what you want.
drbd1 # [    9.187306] logrotate[606]: Reading state from file: /var/lib/logrotate.status
drbd2 # [    9.086650] logrotate[606]: reading config file /nix/store/0mnkk89wg905a4fhz1kpjwccvanacfik-logrotate.conf
drbd1 # [    9.211490] logrotate[606]: state file /var/lib/logrotate.status does not exist
drbd2 # [    9.100722] logrotate[606]: note: 'monthly' overrides previously specified 'weekly'
drbd2 # [    9.112868] logrotate[606]: Reading state from file: /var/lib/logrotate.status
drbd2 # [    9.123491] logrotate[606]: state file /var/lib/logrotate.status does not exist
drbd1 # [    9.225698] logrotate[606]: Allocating hash table for state file, size 64 entries
drbd2 # [    9.321221] 8021q: 802.1Q VLAN Support v1.8
drbd1 # [    9.239746] logrotate[606]: Handling 2 logs
drbd1 # [    9.259707] logrotate[606]: rotating pattern: "/var/log/btmp"  monthly (1 rotations)
drbd2 # [    9.149414] logrotate[606]: Allocating hash table for state file, size 64 entries
drbd1 # [    9.271562] logrotate[606]: empty log files are not rotated, only log files >= 1048576 bytes are rotated, old logs are removed
drbd2 # [    9.163491] logrotate[606]: Handling 2 logs
drbd1 # [    9.286345] logrotate[606]: considering log /var/log/btmp
drbd2 # [    9.174306] logrotate[606]: rotating pattern: "/var/log/btmp"  monthly (1 rotations)
drbd2 # [    9.205843] logrotate[606]: empty log files are not rotated, only log files >= 1048576 bytes are rotated, old logs are removed
drbd1 # [    9.298630] logrotate[606]: Creating new state
drbd1: connected to guest root shell
drbd1: (connecting took 10.68 seconds)
(finished: waiting for the VM to finish booting, in 10.68 seconds)
drbd1 # [    9.319133] logrotate[606]:   Now: 2023-05-20 12:18
drbd2 # [    9.219195] logrotate[606]: considering log /var/log/btmp
drbd2 # [    9.234809] logrotate[606]: Creating new state
drbd1 # [    9.357281] logrotate[606]:   Last rotated at 2023-05-20 12:00
drbd2 # [    9.262237] logrotate[606]:   Now: 2023-05-20 12:18
drbd1 # [    9.376404] logrotate[606]:   log does not need rotating (log has already been rotated)
drbd2 # [    9.276494] logrotate[606]:   Last rotated at 2023-05-20 12:00
drbd1 # [    9.396921] logrotate[606]: rotating pattern: "/var/log/wtmp"  monthly (1 rotations)
drbd2 # [    9.304392] logrotate[606]:   log does not need rotating (log has already been rotated)
drbd1 # [    9.420404] logrotate[606]: empty log files are not rotated, only log files >= 1048576 bytes are rotated, old logs are removed
drbd2 # [    9.331989] logrotate[606]: rotating pattern: "/var/log/wtmp"  monthly (1 rotations)
drbd1 # [    9.459436] logrotate[606]: considering log /var/log/wtmp
drbd2 # [    9.355640] logrotate[606]: empty log files are not rotated, only log files >= 1048576 bytes are rotated, old logs are removed
drbd1 # [    9.471913] logrotate[606]: Creating new state
drbd2 # [    9.373970] logrotate[606]: considering log /var/log/wtmp
drbd1 # [    9.488506] logrotate[606]:   Now: 2023-05-20 12:18
drbd2 # [    9.388319] logrotate[606]: Creating new state
drbd1 # [    9.502582] logrotate[606]:   Last rotated at 2023-05-20 12:00
drbd2 # [    9.403226] logrotate[606]:   Now: 2023-05-20 12:18
drbd1 # [    9.520201] logrotate[606]:   log does not need rotating (log has already been rotated)
drbd2 # [    9.417282] logrotate[606]:   Last rotated at 2023-05-20 12:00
drbd2 # [    9.434381] logrotate[606]:   log does not need rotating (log has already been rotated)
drbd1 # [    9.547553] dhcpcd[611]: dev: loaded udev
drbd2 # [    9.453119] systemd[1]: Starting Kernel Auditing...
drbd1 # [    9.572772] systemd[1]: Starting Kernel Auditing...
drbd2 # [    9.470429] dhcpcd[611]: dev: loaded udev
drbd1 # [    9.601441] systemd[1]: Started backdoor.service.
drbd2 # [    9.490513] systemd[1]: Started backdoor.service.
drbd2 # [    9.517907] systemd[1]: Starting DHCP Client...
drbd1 # [    9.630439] nsncd[618]: May 20 12:18:34.222 INFO started, handoff_timeout: 3s, worker_count: 8, path: "/var/run/nscd/socket"
drbd2 # [    9.538704] nsncd[616]: May 20 12:18:34.145 INFO started, handoff_timeout: 3s, worker_count: 8, path: "/var/run/nscd/socket"
drbd1 # [    9.666702] systemd[1]: Starting DHCP Client...
drbd2 # [    9.569677] systemd[1]: Starting Logrotate configuration check...
drbd1 # [    9.691239] systemd[1]: Starting Logrotate configuration check...
drbd2 # [    9.586647] systemd[1]: Starting Name Service Cache Daemon (nsncd)...
drbd2 # [    9.603648] dbus-daemon[629]: dbus[629]: Unknown username "systemd-timesync" in message bus configuration file
drbd1 # [    9.711495] dbus-daemon[629]: dbus[629]: Unknown username "systemd-timesync" in message bus configuration file
drbd2 # [    9.622707] systemd[1]: Started Reset console on configuration changes.
drbd1 # [    9.731415] systemd[1]: Starting Name Service Cache Daemon (nsncd)...
drbd2 # [    9.641353] systemd[1]: Starting resolvconf update...
drbd1 # [    9.755440] systemd[1]: Started Reset console on configuration changes.
drbd2 # [    9.652677] systemd[1]: Finished Kernel Auditing.
drbd1 # [    9.762535] systemd[1]: Starting resolvconf update...
drbd2 # [    9.665441] systemd[1]: Finished Logrotate configuration check.
drbd1 # [    9.780335] systemd[1]: Finished Kernel Auditing.
drbd2 # [    9.674864] systemd[1]: Starting D-Bus System Message Bus...
drbd1 # [    9.796683] systemd[1]: Finished Logrotate configuration check.
drbd2 # [    9.697557] systemd[1]: Started Name Service Cache Daemon (nsncd).
drbd2 # [    9.714597] systemd[1]: Reached target Host and Network Name Lookups.
drbd2 # [    9.732450] systemd[1]: Reached target User and Group Name Lookups.
drbd2 # [    9.752162] systemd[1]: Starting User Login Management...
drbd2 # [    9.767661] systemd[1]: Started D-Bus System Message Bus.
drbd1 # [    9.810711] systemd[1]: Starting D-Bus System Message Bus...
drbd1 # [    9.891249] systemd[1]: Started Name Service Cache Daemon (nsncd).
drbd1 # [    9.903349] systemd[1]: Reached target Host and Network Name Lookups.
drbd1 # [    9.918234] systemd[1]: Reached target User and Group Name Lookups.
drbd1 # [    9.931916] systemd[1]: Starting User Login Management...
drbd1 # [    9.950879] systemd[1]: Started D-Bus System Message Bus.
drbd2 # [    9.889750] systemd-logind[642]: New seat seat0.
drbd2 # [    9.902685] systemd[1]: Started User Login Management.
drbd2 # [   10.114691] cfg80211: Loading compiled-in X.509 certificates for regulatory database
drbd2 # [    9.958567] systemd[1]: Stopped target Host and Network Name Lookups.
drbd2 # [    9.961151] systemd[1]: Stopping Host and Network Name Lookups...
drbd2 # [    9.975643] systemd[1]: Stopped target User and Group Name Lookups.
drbd1 # [   10.265717] cfg80211: Loading compiled-in X.509 certificates for regulatory database
drbd1 # [   10.110835] systemd-logind[641]: New seat seat0.
drbd2 # [    9.999196] systemd[1]: Stopping User and Group Name Lookups...
drbd1 # [   10.124577] systemd[1]: Stopped target Host and Network Name Lookups.
drbd2 # [   10.014430] systemd[1]: Stopping Name Service Cache Daemon (nsncd)...
drbd2 # [   10.028438] systemd[1]: nscd.service: Deactivated successfully.
drbd1 # [   10.130333] systemd[1]: Stopping Host and Network Name Lookups...
drbd2 # [   10.040620] systemd[1]: Stopped Name Service Cache Daemon (nsncd).
drbd1 # [   10.155517] systemd[1]: Stopped target User and Group Name Lookups.
drbd2 # [   10.239263] cfg80211: Loaded X.509 cert 'sforshee: 00b28ddf47aef9cea7'
drbd2 # [   10.058973] systemd[1]: Found device Virtio network device.[   10.245758] platform regulatory.0: Direct firmware load for regulatory.db failed with error -2
drbd2 # [   10.247416] cfg80211: failed to load regulatory.db
drbd1 # [   10.169372] systemd[1]: Stopping User and Group Name Lookups...
drbd2 #
drbd1 # [   10.188325] systemd[1]: Stopping Name Service Cache Daemon (nsncd)...
drbd2 # [   10.090411] systemd[1]: Finished resolvconf update.
drbd1 # [   10.204470] systemd[1]: Started User Login Management.[   10.376461] cfg80211: Loaded X.509 cert 'sforshee: 00b28ddf47aef9cea7'
drbd1 # [   10.379640] platform regulatory.0: Direct firmware load for regulatory.db failed with error -2
drbd1 # [   10.380973] cfg80211: failed to load regulatory.db
drbd1 #
drbd2 # [   10.102767] systemd[1]: Starting Name Service Cache Daemon (nsncd)...
drbd1 # [   10.231932] systemd[1]: nscd.service: Deactivated successfully.
drbd1 # [   10.246753] systemd[1]: Stopped Name Service Cache Daemon (nsncd).
drbd1 # [   10.261895] systemd[1]: Starting Name Service Cache Daemon (nsncd)...
drbd1 # [   10.292432] systemd[1]: Finished resolvconf update.
drbd2 # [   10.211871] systemd[1]: Started Name Service Cache Daemon (nsncd).
drbd1 # [   10.328197] systemd[1]: Found device Virtio network device.
drbd2 # [   10.226329] systemd[1]: Reached target Host and Network Name Lookups.
drbd1 # [   10.337746] nsncd[695]: May 20 12:18:35.203 INFO started, handoff_timeout: 3s, worker_count: 8, path: "/var/run/nscd/socket"
drbd2 # [   10.232613] nsncd[704]: May 20 12:18:35.127 INFO started, handoff_timeout: 3s, worker_count: 8, path: "/var/run/nscd/socket"
drbd1 # [   10.347815] systemd[1]: Started Name Service Cache Daemon (nsncd).
drbd2 # [   10.251469] systemd[1]: Reached target User and Group Name Lookups.
drbd1 # [   10.381678] systemd[1]: Reached target Host and Network Name Lookups.
drbd1 # [   10.390162] systemd[1]: Reached target User and Group Name Lookups.
drbd2 # [   10.509319] 8021q: adding VLAN 0 to HW filter on device eth0
drbd2 # [   10.338352] dhcpcd[611]: eth0: waiting for carrier
drbd2 # [   10.343670] dhcpcd[611]: eth0: carrier acquired
drbd1 # [   10.645015] 8021q: adding VLAN 0 to HW filter on device eth0
drbd1 # [   10.482346] dhcpcd[611]: eth0: waiting for carrier
drbd1 # [   10.486798] dhcpcd[611]: eth0: carrier acquired
drbd2 # [   10.395356] dhcpcd[611]: DUID 00:01:00:01:2b:fb:77:1b:52:54:00:12:34:56
drbd2 # [   10.400259] dhcpcd[611]: eth0: IAID 00:12:34:56
drbd2 # [   10.404402] dhcpcd[611]: eth0: adding address fe80::5054:ff:fe12:3456
drbd2 # [   10.419174] systemd[1]: Finished Firewall.
drbd2 # [   10.422389] dhcpcd[611]: eth0: IAID 00:12:34:56
drbd2 # [   10.427844] systemd[1]: Reached target Preparation for Network.
drbd1 # [   10.538979] dhcpcd[611]: DUID 00:01:00:01:2b:fb:77:1b:52:54:00:12:34:56
drbd1 # [   10.542213] dhcpcd[611]: eth0: IAID 00:12:34:56
drbd2 # [   10.435962] systemd[1]: Reached target All Network Interfaces (deprecated).
drbd1 # [   10.545217] dhcpcd[611]: eth0: adding address fe80::5054:ff:fe12:3456
drbd2 # [   10.445914] systemd[1]: Starting Address configuration of eth1...
drbd1 # [   10.557169] dhcpcd[611]: eth0: IAID 00:12:34:56
drbd2 # [   10.677436] 8021q: adding VLAN 0 to HW filter on device eth1
drbd2 # [   10.518427] network-addresses-eth1-start[738]: adding address 192.168.1.2/24... done
drbd2 # [   10.541660] systemd[1]: Finished Address configuration of eth1.
drbd2 # [   10.556751] systemd[1]: Starting Networking Setup...
drbd2 # [   10.756346] mousedev: PS/2 mouse device common for all mice
drbd1 # [   10.876242] mousedev: PS/2 mouse device common for all mice
drbd1 # [   10.764980] systemd[1]: Finished Firewall.
drbd1 # [   10.768647] systemd[1]: Reached target Preparation for Network.
drbd1 # [   10.773255] systemd[1]: Reached target All Network Interfaces (deprecated).
drbd1 # [   10.786844] systemd[1]: Starting Address configuration of eth1...
drbd2 # [   10.876843] input: Power Button as /devices/LNXSYSTM:00/LNXPWRBN:00/input/input3
drbd1 # [   10.998090] input: Power Button as /devices/LNXSYSTM:00/LNXPWRBN:00/input/input3
drbd2 # [   10.900402] ACPI: button: Power Button [PWRF]
drbd1 # [   11.007157] 8021q: adding VLAN 0 to HW filter on device eth1
drbd1 # [   10.851516] network-addresses-eth1-start[748]: adding address 192.168.1.1/24... done
drbd1 # [   11.022266] ACPI: button: Power Button [PWRF]
drbd1 # [   10.876991] systemd[1]: Finished Address configuration of eth1.
drbd1 # [   10.892877] systemd[1]: Starting Networking Setup...
drbd2 # [   10.799338] systemd[1]: Finished Networking Setup.
drbd2 # [   10.810395] systemd[1]: Starting Extra networking commands....
drbd2 # [   11.012067] parport_pc 00:03: reported by Plug and Play ACPI
drbd2 # [   10.840884] systemd[1]: Finished Extra networking commands..
drbd2 # [   10.846832] systemd[1]: Reached target Network.
drbd2 # [   10.857616] (drbdadm)[790]: drbd.service: Failed to locate executable /nix/store/7pgn3xdrams9c6y6scbna2xdqg3rhnkl-drbd-9.19.1/sbin/drbdadm: No such file or directory
drbd2 # [   10.867767] (drbdadm)[790]: drbd.service: Failed at step EXEC spawning /nix/store/7pgn3xdrams9c6y6scbna2xdqg3rhnkl-drbd-9.19.1/sbin/drbdadm: No such file or directory
drbd2 # [   10.885461] systemd[1]: Started drbd.service.[   11.064210] parport0: PC-style at 0x378, irq 7 [PCSPP(,...)]
drbd2 #
drbd2 # [   10.892909] systemd[1]: Starting Permit User Sessions...
drbd2 # [   10.911313] systemd[1]: drbd.service: Main process exited, code=exited, status=203/EXEC
drbd1 # [   11.188330] parport_pc 00:03: reported by Plug and Play ACPI
drbd2 # [   10.914669] systemd[1]: drbd.service: Failed with result 'exit-code'.
drbd1 # [   11.194602] Floppy drive(s): fd0 is 2.88M AMI BIOS
drbd2 # [   10.926217] systemd[1]: Finished Permit User Sessions.
drbd1 # [   11.206871] parport0: PC-style at 0x378, irq 7 [PCSPP(,...)]
drbd2 # [   10.934690] systemd[1]: Started Getty on tty1.
drbd2 # [   10.938792] systemd[1]: Reached target Login Prompts.
drbd1 # [   11.217018] FDC 0 is a S82078B
drbd2 # [   11.144492] Floppy drive(s): fd0 is 2.88M AMI BIOS
drbd2 # [   11.164427] FDC 0 is a S82078B
drbd2 # [   11.202199] Linux agpgart interface v0.103
drbd1 # [   11.132275] systemd[1]: Finished Networking Setup.
drbd2 # [   11.203437] piix4_smbus 0000:00:01.3: SMBus Host Controller at 0x700, revision 0
drbd1 # [   11.145672] systemd[1]: Starting Extra networking commands....
drbd1 # [   11.148539] dhcpcd[611]: eth0: soliciting an IPv6 router
drbd1 # [   11.176719] systemd[1]: Finished Extra networking commands..
drbd1 # [   11.182125] systemd[1]: Reached target Network.
drbd1 # [   11.192426] (drbdadm)[796]: drbd.service: Failed to locate executable /nix/store/7pgn3xdrams9c6y6scbna2xdqg3rhnkl-drbd-9.19.1/sbin/drbdadm: No such file or directory
drbd2 # [   11.271520] input: QEMU Virtio Keyboard as /devices/pci0000:00/0000:00:0b.0/virtio8/input/input4
drbd1 # [   11.203830] (drbdadm)[796]: drbd.service: Failed at step EXEC spawning /nix/store/7pgn3xdrams9c6y6scbna2xdqg3rhnkl-drbd-9.19.1/sbin/drbdadm: No such file or directory
drbd2 # [   11.111898] dhcpcd[611]: eth0: soliciting a DHCP lease
drbd1 # [   11.223369] systemd[1]: Started drbd.service.
drbd2 # [   11.123632] dhcpcd[611]: eth0: soliciting an IPv6 router
drbd1 # [   11.230978] systemd[1]: Starting Permit User Sessions...
drbd1 # [   11.242683] systemd[1]: drbd.service: Main process exited, code=exited, status=203/EXEC
drbd2 # [   11.321573] NET: Registered PF_PACKET protocol family
drbd1 # [   11.251784] systemd[1]: drbd.service: Failed with result 'exit-code'.
drbd1 # [   11.427544] Linux agpgart interface v0.103
drbd2 # [   11.155233] dhcpcd[611]: eth0: offered 10.0.2.15 from 10.0.2.2
drbd1 # [   11.262796] systemd[1]: Finished Permit User Sessions.
drbd2 # [   11.158169] dhcpcd[611]: eth0: leased 10.0.2.15 for 86400 seconds
drbd2 # [   11.162607] dhcpcd[611]: eth0: adding route to 10.0.2.0/24
drbd1 # [   11.275605] systemd[1]: Started Getty on tty1.
drbd2 # [   11.170500] dhcpcd[611]: eth0: adding default route via 10.0.2.2
drbd1 # [   11.280669] systemd[1]: Reached target Login Prompts.
drbd1 # [   11.304067] dhcpcd[611]: eth0: soliciting a DHCP lease
drbd1 # [   11.504835] piix4_smbus 0000:00:01.3: SMBus Host Controller at 0x700, revision 0
drbd1 # [   11.506332] NET: Registered PF_PACKET protocol family
drbd1 # [   11.345382] dhcpcd[611]: eth0: offered 10.0.2.15 from 10.0.2.2
drbd1 # [   11.348895] dhcpcd[611]: eth0: leased 10.0.2.15 for 86400 seconds
drbd1 # [   11.359214] dhcpcd[611]: eth0: adding route to 10.0.2.0/24
drbd1 # [   11.360733] dhcpcd[611]: eth0: adding default route via 10.0.2.2
drbd2 # [   11.463939] input: VirtualPS/2 VMware VMMouse as /devices/platform/i8042/serio1/input/input6
drbd2 # [   11.465842] input: VirtualPS/2 VMware VMMouse as /devices/platform/i8042/serio1/input/input5
(finished: waiting for unit network.target, in 12.88 seconds)
drbd2: waiting for unit network.target
drbd2: waiting for the VM to finish booting
drbd2: Spawning backdoor root shell...

drbd2: connected to guest root shell
drbd2: (connecting took 0.00 seconds)
(finished: waiting for the VM to finish booting, in 0.00 seconds)
drbd1 # [   11.690641] input: QEMU Virtio Keyboard as /devices/pci0000:00/0000:00:0b.0/virtio8/input/input4
drbd2 # [   11.438762] systemd[1]: Stopped target Host and Network Name Lookups.
drbd2 # [   11.440910] systemd[1]: Stopping Host and Network Name Lookups...
drbd2 # [   11.447464] systemd[1]: Stopped target User and Group Name Lookups.
drbd2 # [   11.456777] systemd[1]: Stopping User and Group Name Lookups...
drbd2 # [   11.467844] systemd[1]: Stopping Name Service Cache Daemon (nsncd)...
drbd2 # [   11.480801] systemd[1]: nscd.service: Deactivated successfully.
drbd2 # [   11.488748] systemd[1]: Stopped Name Service Cache Daemon (nsncd).
drbd2 # [   11.515539] systemd[1]: Starting Name Service Cache Daemon (nsncd)...
drbd1 # [   11.663549] systemd[1]: Stopped target Host and Network Name Lookups.
drbd1 # [   11.665719] systemd[1]: Stopping Host and Network Name Lookups...
drbd1 # [   11.672869] systemd[1]: Stopped target User and Group Name Lookups.
drbd1 # [   11.690697] systemd[1]: Stopping User and Group Name Lookups...
drbd1 # [   11.703719] systemd[1]: Stopping Name Service Cache Daemon (nsncd)...
drbd1 # [   11.712860] systemd[1]: nscd.service: Deactivated successfully.
drbd2 # [   11.613399] nsncd[850]: May 20 12:18:36.506 INFO started, handoff_timeout: 3s, worker_count: 8, path: "/var/run/nscd/socket"
drbd1 # [   11.721348] systemd[1]: Stopped Name Service Cache Daemon (nsncd).
drbd1 # [   11.730152] systemd[1]: Starting Name Service Cache Daemon (nsncd)...
drbd2 # [   11.622201] systemd[1]: Started Name Service Cache Daemon (nsncd).
drbd2 # [   11.644940] dhcpcd[602]: Failed to reload-or-try-restart ntpd.service: Unit ntpd.service not found.
drbd2 # [   11.648859] dhcpcd[602]: Failed to reload-or-try-restart openntpd.service: Unit openntpd.service not found.
drbd1 # [   11.932106] input: VirtualPS/2 VMware VMMouse as /devices/platform/i8042/serio1/input/input6
drbd1 # [   11.937489] input: VirtualPS/2 VMware VMMouse as /devices/platform/i8042/serio1/input/input5
drbd1 # [   11.803142] systemd[1]: Started Name Service Cache Daemon (nsncd).
drbd1 # [   11.807991] systemd[1]: Reached target Host and Network Name Lookups.
drbd1 # [   11.812896] systemd[1]: Reached target User and Group Name Lookups.
drbd1 # [   11.822928] nsncd[855]: May 20 12:18:36.698 INFO started, handoff_timeout: 3s, worker_count: 8, path: "/var/run/nscd/socket"
drbd1 # [   11.835442] dhcpcd[603]: Failed to reload-or-try-restart ntpd.service: Unit ntpd.service not found.
drbd2 # [   11.733173] systemd[1]: Reached target Host and Network Name Lookups.
drbd1 # [   11.846932] dhcpcd[603]: Failed to reload-or-try-restart openntpd.service: Unit openntpd.service not found.
drbd2 # [   11.738929] dhcpcd[602]: Failed to reload-or-try-restart chronyd.service: Unit chronyd.service not found.
(finished: waiting for unit network.target, in 0.35 seconds)
drbd2 # [   11.755077] systemd[1]: Reached target User and Group Name Lookups.[   11.932667] bochs-drm 0000:00:02.0: vgaarb: deactivate vga console
drbd2 #
drbd1: must succeed: drbdadm create-md r0
drbd2 # [   11.761806] systemd[1]: Listening on Load/Save RF Kill Switch Status /dev/rfkill Watch.
drbd2 # [   11.769464] systemd[1]: Started DHCP Client.
drbd2 # [   11.774184] systemd[1]: Reached target Network is Online.
drbd1 # [   11.856098] dhcpcd[603]: Failed to reload-or-try-restart chronyd.service: Unit chronyd.service not found.
drbd1 # [   11.889674] systemd[1]: Started DHCP Client.
drbd1 # [   11.918234] systemd[1]: Reached target Network is Online.
drbd1 # [   11.921939] systemd[1]: Reached target Multi-User System.
drbd2 # [   11.804763] systemd[1]: Reached target Multi-User System.
drbd1 # [   11.930634] systemd[1]: Startup finished in 4.892s (kernel) + 6.989s (userspace) = 11.881s.
drbd1 # [   11.955713] dhcpcd[611]: eth0: Router Advertisement from fe80::2
drbd1 # [   11.966499] dhcpcd[611]: eth0: adding address fec0::5054:ff:fe12:3456/64
drbd1 # [   11.971675] dhcpcd[611]: eth0: adding route to fec0::/64
drbd1 # [   11.975304] dhcpcd[611]: eth0: adding default route via fe80::2
drbd1 # initializing bitmap (4 KB) to all zero
drbd1 # lk_bdev_save(/var/lib/drbd/drbd-minor-0.lkbd) failed: No such file or directory
drbd1 # lk_bdev_save(/var/lib/drbd/drbd-minor-0.lkbd) failed: No such file or directory
(finished: must succeed: drbdadm create-md r0, in 0.15 seconds)
drbd1: must succeed: drbdadm up r0
drbd2 # [   12.104830] ppdev: user-space parallel port driver
drbd2 # [   12.107104] Console: switching to colour dummy device 80x25
drbd2 # [   11.827719] systemd[1]: Startup finished in 4.812s (kernel) + 6.991s (userspace) = 11.804s.
drbd2 # [   12.122504] [drm] Found bochs VGA, ID 0xb0c5.
drbd2 # [   12.123485] [drm] Framebuffer size 16384 kB @ 0xfd000000, mmio @ 0xfebd0000.
drbd2 # [   11.950389] systemd-logind[642]: Watching system buttons on /dev/input/event0 (AT Translated Set 2 keyboard)
drbd2 # [   11.957951] systemd-logind[642]: Watching system buttons on /dev/input/event2 (Power Button)
drbd1 # [   12.261974] drbd r0: Starting worker thread (from drbdsetup-84 [888])
drbd1 # [   12.265000] bochs-drm 0000:00:02.0: vgaarb: deactivate vga console
drbd1 # [   12.268183] block drbd0: disk( Diskless -> Attaching )
drbd1 # [   12.270229] drbd r0: Method to ensure write ordering: flush
drbd1 # [   12.271473] block drbd0: max BIO size = 4096
drbd1 # [   12.273160] block drbd0: drbd_bm_resize called with capacity == 1968
drbd1 # [   12.276061] block drbd0: resync bitmap: bits=246 words=8 pages=1
drbd1 # [   12.277147] drbd0: detected capacity change from 0 to 1968
drbd1 # [   12.278335] block drbd0: size = 984 KB (984 KB)
drbd2 # [   12.005489] systemd-logind[642]: Watching system buttons on /dev/input/event3 (QEMU Virtio Keyboard)
drbd2 # [   12.012749] dhcpcd[611]: eth0: Router Advertisement from fe80::2[   12.192993] [drm] Found EDID data blob.
drbd2 #
drbd2 # [   12.018675] dhcpcd[611]: eth0: adding address fec0::5054:ff:fe12:3456/64
drbd2 # [   12.020746] dhcpcd[611]: eth0: adding route to fec0::/64
drbd2 # [   12.024555] dhcpcd[611]: eth0: adding default route via fe80::2
drbd2 # [   12.221232] [drm] Initialized bochs-drm 1.0.0 20130925 for 0000:00:02.0 on minor 0
(finished: must succeed: drbdadm up r0, in 0.14 seconds)
drbd1: must succeed: drbdadm primary r0 --force
drbd2 # [   12.263664] fbcon: bochs-drmdrmfb (fb0) is primary device
drbd2 # [   12.276294] Console: switching to colour frame buffer device 160x50
drbd2 # [   12.281981] bochs-drm 0000:00:02.0: [drm] fb0: bochs-drmdrmfb frame buffer device
(finished: must succeed: drbdadm primary r0 --force, in 0.08 seconds)
drbd2: must succeed: drbdadm create-md r0
drbd1 # [   12.308204] block drbd0: Writing the whole bitmap, size changed
drbd1 # [   12.309425] block drbd0: 984 KB (246 bits) marked out-of-sync by on disk bit-map.
drbd1 # [   12.310340] block drbd0: recounting of set bits took additional 0 jiffies
drbd1 # [   12.310344] block drbd0: 984 KB (246 bits) marked out-of-sync by on disk bit-map.
drbd1 # [   12.310358] block drbd0: Suspended AL updates
drbd1 # [   12.310361] block drbd0: disk( Attaching -> Inconsistent )
drbd1 # [   12.310365] block drbd0: attached to UUIDs 0000000000000004:0000000000000000:0000000000000000:0000000000000000
drbd2 # initializing bitmap (4 KB) to all zero
drbd1 # [   12.318967] drbd r0: conn( StandAlone -> Unconnected )
drbd2 # lk_bdev_save(/var/lib/drbd/drbd-minor-0.lkbd) failed: No such file or directory
drbd1 # [   12.319019] drbd r0: Starting receiver thread (from drbd_w_r0 [889])
drbd1 # [   12.320439] drbd r0: receiver (re)started
drbd1 # [   12.320451] drbd r0: conn( Unconnected -> WFConnection )
drbd1 # [   12.403631] block drbd0: role( Secondary -> Primary ) disk( Inconsistent -> UpToDate )
drbd2 # lk_bdev_save(/var/lib/drbd/drbd-minor-0.lkbd) failed: No such file or directory
drbd1 # [   12.404229] block drbd0: Forced to consider local data as UpToDate!
(finished: must succeed: drbdadm create-md r0, in 0.15 seconds)
drbd2: must succeed: drbdadm up r0
drbd1 # [   12.404237] block drbd0: new current UUID 61C2DCF690D54387:0000000000000004:0000000000000000:0000000000000000
drbd1 # [   12.462228] Console: switching to colour dummy device 80x25
drbd1 # [   12.540518] ppdev: user-space parallel port driver
drbd1 # [   12.192616] systemd[1]: Listening on Load/Save RF Kill Switch Status /dev/rfkill Watch.
drbd1 # [   12.602931] [drm] Found bochs VGA, ID 0xb0c5.
drbd1 # [   12.603852] [drm] Framebuffer size 16384 kB @ 0xfd000000, mmio @ 0xfebd0000.
drbd1 # [   12.440472] systemd-logind[641]: Watching system buttons on /dev/input/event0 (AT Translated Set 2 keyboard)
drbd1 # [   12.450987] systemd-logind[641]: Watching system buttons on /dev/input/event2 (Power Button)
drbd1 # [   12.455868] systemd-logind[641]: Watching system buttons on /dev/input/event3 (QEMU Virtio Keyboard)
drbd1 # [   12.668053] [drm] Found EDID data blob.
drbd2 # [   12.576189] drbd r0: Starting worker thread (from drbdsetup-84 [885])
drbd2 # [   12.580908] block drbd0: disk( Diskless -> Attaching )
drbd2 # [   12.582803] drbd r0: Method to ensure write ordering: flush
drbd2 # [   12.584520] block drbd0: max BIO size = 4096
drbd2 # [   12.587702] block drbd0: drbd_bm_resize called with capacity == 1968
drbd2 # [   12.591486] block drbd0: resync bitmap: bits=246 words=8 pages=1
drbd2 # [   12.592783] drbd0: detected capacity change from 0 to 1968
drbd2 # [   12.593728] block drbd0: size = 984 KB (984 KB)
drbd1 # [   12.707023] [drm] Initialized bochs-drm 1.0.0 20130925 for 0000:00:02.0 on minor 0
drbd2 # [   12.609563] block drbd0: Writing the whole bitmap, size changed
drbd2 # [   12.612285] block drbd0: 984 KB (246 bits) marked out-of-sync by on disk bit-map.
drbd2 # [   12.623299] block drbd0: recounting of set bits took additional 0 jiffies
drbd2 # [   12.624304] block drbd0: 984 KB (246 bits) marked out-of-sync by on disk bit-map.
drbd2 # [   12.625374] block drbd0: Suspended AL updates
drbd2 # [   12.626605] block drbd0: disk( Attaching -> Inconsistent )
drbd2 # [   12.627394] block drbd0: attached to UUIDs 0000000000000004:0000000000000000:0000000000000000:0000000000000000
drbd2 # [   12.654330] drbd r0: conn( StandAlone -> Unconnected )
drbd2 # [   12.655408] drbd r0: Starting receiver thread (from drbd_w_r0 [886])
drbd2 # [   12.657692] drbd r0: receiver (re)started
drbd2 # [   12.658916] drbd r0: conn( Unconnected -> WFConnection )
(finished: must succeed: drbdadm up r0, in 0.21 seconds)
drbd1: must succeed: mkfs.ext4 /dev/drbd0
drbd1 # [   12.772970] fbcon: bochs-drmdrmfb (fb0) is primary device
drbd1 # [   12.816053] Console: switching to colour frame buffer device 160x50
drbd1 # [   12.824103] bochs-drm 0000:00:02.0: [drm] fb0: bochs-drmdrmfb frame buffer device
drbd1 # mke2fs 1.46.6 (1-Feb-2023)
drbd1 #
drbd1 # Filesystem too small for a journal
(finished: must succeed: mkfs.ext4 /dev/drbd0, in 0.17 seconds)
drbd1: must succeed: mkdir -p /mnt/drbd
(finished: must succeed: mkdir -p /mnt/drbd, in 0.07 seconds)
drbd1: must succeed: mount /dev/drbd0 /mnt/drbd
drbd1 # [   13.079932] EXT4-fs (drbd0): mounted filesystem without journal. Quota mode: none.
(finished: must succeed: mount /dev/drbd0 /mnt/drbd, in 0.07 seconds)
drbd1: must succeed: touch /mnt/drbd/hello
(finished: must succeed: touch /mnt/drbd/hello, in 0.07 seconds)
drbd1: must succeed: umount /mnt/drbd
drbd1 # [   13.049369] systemd[1]: mnt-drbd.mount: Deactivated successfully.
drbd1 # [   13.223171] EXT4-fs (drbd0): unmounting filesystem.
(finished: must succeed: umount /mnt/drbd, in 0.08 seconds)
drbd1: must succeed: drbdadm secondary r0
drbd2 # [   13.174150] drbd r0: Handshake successful: Agreed network protocol version 101
drbd1 # [   13.272998] drbd r0: Handshake successful: Agreed network protocol version 101
drbd1 # [   13.274386] drbd r0: Feature flags enabled on protocol level: 0xf TRIM THIN_RESYNC WRITE_SAME WRITE_ZEROES.
drbd2 # [   13.175604] drbd r0: Feature flags enabled on protocol level: 0xf TRIM THIN_RESYNC WRITE_SAME WRITE_ZEROES.
drbd2 # [   13.178405] drbd r0: conn( WFConnection -> WFReportParams )
drbd1 # [   13.276709] drbd r0: conn( WFConnection -> WFReportParams )
drbd2 # [   13.179411] drbd r0: Starting ack_recv thread (from drbd_r_r0 [889])
drbd1 # [   13.278126] drbd r0: Starting ack_recv thread (from drbd_r_r0 [891])
drbd2 # [   13.183967] block drbd0: max BIO size = 1048576
drbd2 # [   13.185636] block drbd0: drbd_sync_handshake:
drbd2 # [   13.187068] block drbd0: self 0000000000000004:0000000000000000:0000000000000000:0000000000000000 bits:246 flags:0
drbd2 # [   13.189132] block drbd0: peer 61C2DCF690D54387:0000000000000004:0000000000000000:0000000000000000 bits:246 flags:0
drbd2 # [   13.191153] block drbd0: uuid_compare()=-2 by rule 20
drbd2 # [   13.192634] block drbd0: Becoming sync target due to disk states.
drbd2 # [   13.193908] block drbd0: Writing the whole bitmap, full sync required after drbd_sync_handshake.
drbd1 # [   13.294436] block drbd0: max BIO size = 1048576
drbd1 # [   13.295625] block drbd0: drbd_sync_handshake:
drbd1 # [   13.296618] block drbd0: self 61C2DCF690D54387:0000000000000004:0000000000000000:0000000000000000 bits:246 flags:0
drbd1 # [   13.298574] block drbd0: peer 0000000000000004:0000000000000000:0000000000000000:0000000000000000 bits:246 flags:0
drbd1 # [   13.301079] block drbd0: uuid_compare()=2 by rule 30
drbd1 # [   13.302371] block drbd0: Becoming sync source due to disk states.
drbd1 # [   13.303554] block drbd0: Writing the whole bitmap, full sync required after drbd_sync_handshake.
drbd2 # [   13.211902] block drbd0: 984 KB (246 bits) marked out-of-sync by on disk bit-map.
drbd2 # [   13.215454] block drbd0: peer( Unknown -> Primary ) conn( WFReportParams -> WFBitMapT ) pdsk( DUnknown -> UpToDate )
drbd2 # [   13.217869] block drbd0: Resumed AL updates
drbd1 # [   13.330784] block drbd0: 984 KB (246 bits) marked out-of-sync by on disk bit-map.
drbd1 # [   13.338612] block drbd0: peer( Unknown -> Secondary ) conn( WFReportParams -> WFBitMapS ) pdsk( DUnknown -> Inconsistent )
drbd1 # [   13.340660] block drbd0: Resumed AL updates
drbd1 # [   13.341603] block drbd0: send bitmap stats [Bytes(packets)]: plain 0(0), RLE 19(1), total 19; compression: 70.4%
drbd2 # [   13.247912] block drbd0: receive bitmap stats [Bytes(packets)]: plain 0(0), RLE 19(1), total 19; compression: 70.4%
drbd2 # [   13.250489] block drbd0: send bitmap stats [Bytes(packets)]: plain 0(0), RLE 19(1), total 19; compression: 70.4%
drbd2 # [   13.254794] block drbd0: conn( WFBitMapT -> WFSyncUUID )
drbd1 # [   13.352956] block drbd0: receive bitmap stats [Bytes(packets)]: plain 0(0), RLE 19(1), total 19; compression: 70.4%
drbd1 # [   13.355166] block drbd0: helper command: /run/current-system/sw/bin/drbdadm before-resync-source minor-0
drbd1 # [   13.359511] block drbd0: role( Primary -> Secondary )
drbd2 # [   13.264601] block drbd0: peer( Primary -> Secondary )
(finished: must succeed: drbdadm secondary r0, in 0.14 seconds)
drbd1: must succeed: sleep 1
drbd1 # [   13.398657] block drbd0: helper command: /run/current-system/sw/bin/drbdadm before-resync-source minor-0 exit code 0 (0x0)
drbd1 # [   13.401647] block drbd0: conn( WFBitMapS -> SyncSource )
drbd1 # [   13.403193] block drbd0: Began resync as SyncSource (will sync 984 KB [246 bits set]).
drbd1 # [   13.404933] block drbd0: updated sync UUID 61C2DCF690D54386:E4223995B4AE6586:0000000000000004:0000000000000000
drbd2 # [   13.311924] block drbd0: updated sync uuid E4223995B4AE6586:0000000000000000:0000000000000000:0000000000000000
drbd2 # [   13.315094] block drbd0: helper command: /run/current-system/sw/bin/drbdadm before-resync-target minor-0
drbd2 # [   13.340344] block drbd0: helper command: /run/current-system/sw/bin/drbdadm before-resync-target minor-0 exit code 0 (0x0)
drbd2 # [   13.342624] block drbd0: conn( WFSyncUUID -> SyncTarget )
drbd2 # [   13.343707] block drbd0: Began resync as SyncTarget (will sync 984 KB [246 bits set]).
(finished: must succeed: sleep 1, in 1.10 seconds)
drbd2: must succeed: drbdadm primary r0
drbd1 # [   15.110434] block drbd0: peer( Secondary -> Primary )
drbd2 # [   15.014693] block drbd0: role( Secondary -> Primary )
(finished: must succeed: drbdadm primary r0, in 0.65 seconds)
drbd2: must succeed: mkdir -p /mnt/drbd
(finished: must succeed: mkdir -p /mnt/drbd, in 0.06 seconds)
drbd2: must succeed: mount /dev/drbd0 /mnt/drbd
drbd2 # [   15.128809] EXT4-fs (drbd0): mounted filesystem without journal. Quota mode: none.
(finished: must succeed: mount /dev/drbd0 /mnt/drbd, in 0.05 seconds)
drbd2: must succeed: ls /mnt/drbd/hello
(finished: must succeed: ls /mnt/drbd/hello, in 0.05 seconds)
(finished: run the VM test script, in 16.65 seconds)
test script finished in 16.75s
cleanup
kill machine (pid 6)
drbd1 # qemu-kvm: terminating on signal 15 from pid 4 (/nix/store/mnqhl503ap4djaqifsmw4z0523zbz3j0-python3-3.10.11/bin/python3.10)
kill machine (pid 21)
drbd2 # qemu-kvm: terminating on signal 15 from pid 4 (/nix/store/mnqhl503ap4djaqifsmw4z0523zbz3j0-python3-3.10.11/bin/python3.10)
(finished: cleanup, in 0.16 seconds)
kill vlan (pid 5)
/nix/store/h9ckxi8m4w3h36fmsa1ib060izjp3i43-vm-test-run-drbd
```
</details>

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
