### PR TITLE
qt5.qtwebengine: add kerberos support

### DIFF
--- a/pkgs/development/libraries/qt-5/modules/qtwebengine.nix
+++ b/pkgs/development/libraries/qt-5/modules/qtwebengine.nix
@@ -26,6 +26,8 @@
 , pipewireSupport ? stdenv.isLinux
 , pipewire_0_2
 , postPatch ? ""
+, kerberosSupport ? true
+, libkrb5
 }:
 
 qtModule {
@@ -123,7 +125,8 @@ qtModule {
 
   qmakeFlags = [ "--" "-system-ffmpeg" ]
     ++ lib.optional pipewireSupport "-webengine-webrtc-pipewire"
-    ++ lib.optional enableProprietaryCodecs "-proprietary-codecs";
+    ++ lib.optional enableProprietaryCodecs "-proprietary-codecs"
+    ++ lib.optional kerberosSupport "-webengine-kerberos";
 
   propagatedBuildInputs = [
     # Image formats
@@ -159,6 +162,8 @@ qtModule {
   ] ++ lib.optionals pipewireSupport [
     # Pipewire
     pipewire_0_2
+  ] ++ lib.optionals kerberosSupport [
+    libkrb5
   ]
 
   # FIXME These dependencies shouldn't be needed but can't find a way


### PR DESCRIPTION
###### Description of changes

Compile qtwebengine w/ kerberos support.

Tested with qutebrowser.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
