### PR TITLE
treewide: Reduce jtojnar maintainership

### DIFF
--- a/pkgs/applications/accessibility/contrast/default.nix
+++ b/pkgs/applications/accessibility/contrast/default.nix
@@ -58,7 +58,7 @@ stdenv.mkDerivation rec {
     description = "Checks whether the contrast between two colors meet the WCAG requirements";
     homepage = "https://gitlab.gnome.org/World/design/contrast";
     license = licenses.gpl3Plus;
-    maintainers = with maintainers; [ jtojnar ];
+    maintainers = with maintainers; [ ];
     platforms = platforms.unix;
     # never built on aarch64-darwin, x86_64-darwin since first introduction in nixpkgs
     broken = stdenv.isDarwin;

--- a/pkgs/applications/audio/easyeffects/default.nix
+++ b/pkgs/applications/audio/easyeffects/default.nix
@@ -105,7 +105,7 @@ stdenv.mkDerivation rec {
     description = "Audio effects for PipeWire applications.";
     homepage = "https://github.com/wwmm/easyeffects";
     license = licenses.gpl3Plus;
-    maintainers = with maintainers; [ jtojnar ];
+    maintainers = with maintainers; [ ];
     platforms = platforms.linux;
   };
 }

--- a/pkgs/applications/audio/osdlyrics/default.nix
+++ b/pkgs/applications/audio/osdlyrics/default.nix
@@ -81,7 +81,7 @@ stdenv.mkDerivation rec {
     description = "Standalone lyrics fetcher/displayer";
     homepage = "https://github.com/osdlyrics/osdlyrics";
     license = licenses.gpl3Plus;
-    maintainers = with maintainers; [ jtojnar ];
+    maintainers = with maintainers; [ ];
     platforms = platforms.linux;
   };
 }

--- a/pkgs/applications/editors/sublime/3/common.nix
+++ b/pkgs/applications/editors/sublime/3/common.nix
@@ -130,7 +130,7 @@ in stdenv.mkDerivation (rec {
   meta = with lib; {
     description = "Sophisticated text editor for code, markup and prose";
     homepage = "https://www.sublimetext.com/";
-    maintainers = with maintainers; [ jtojnar wmertens demin-dmitriy zimbatm ];
+    maintainers = with maintainers; [ wmertens demin-dmitriy zimbatm ];
     sourceProvenance = with sourceTypes; [ binaryNativeCode ];
     license = licenses.unfree;
     platforms = [ "x86_64-linux" "i686-linux" ];

--- a/pkgs/applications/graphics/gcolor3/default.nix
+++ b/pkgs/applications/graphics/gcolor3/default.nix
@@ -49,7 +49,7 @@ stdenv.mkDerivation rec {
     description = "A simple color chooser written in GTK3";
     homepage = "https://gitlab.gnome.org/World/gcolor3";
     license = licenses.gpl2Plus;
-    maintainers = with maintainers; [ jtojnar ];
+    maintainers = with maintainers; [ ];
     platforms = platforms.unix;
   };
 }

--- a/pkgs/data/fonts/twitter-color-emoji/default.nix
+++ b/pkgs/data/fonts/twitter-color-emoji/default.nix
@@ -111,6 +111,6 @@ stdenv.mkDerivation rec {
     # In Fedora twitter-twemoji-fonts source
     ## spec files are MIT: https://fedoraproject.org/wiki/Licensing:Main#License_of_Fedora_SPEC_Files
     license = with licenses; [ asl20 ofl cc-by-40 mit ];
-    maintainers = with maintainers; [ jtojnar emily ];
+    maintainers = with maintainers; [ emily ];
   };
 }

--- a/pkgs/development/libraries/flatpak/default.nix
+++ b/pkgs/development/libraries/flatpak/default.nix
@@ -203,7 +203,7 @@ stdenv.mkDerivation (finalAttrs: {
     description = "Linux application sandboxing and distribution framework";
     homepage = "https://flatpak.org/";
     license = licenses.lgpl21Plus;
-    maintainers = with maintainers; [ jtojnar ];
+    maintainers = with maintainers; [ ];
     platforms = platforms.linux;
   };
 })

--- a/pkgs/development/libraries/gthree/default.nix
+++ b/pkgs/development/libraries/gthree/default.nix
@@ -67,7 +67,7 @@ stdenv.mkDerivation rec {
     description = "GObject/GTK port of three.js";
     homepage = "https://github.com/alexlarsson/gthree";
     license = licenses.mit;
-    maintainers = with maintainers; [ jtojnar ];
+    maintainers = with maintainers; [ ];
     platforms = platforms.unix;
     broken = stdenv.isDarwin; # never built on Hydra https://hydra.nixos.org/job/nixpkgs/trunk/gthree.x86_64-darwin
   };

--- a/pkgs/development/libraries/libabigail/default.nix
+++ b/pkgs/development/libraries/libabigail/default.nix
@@ -53,7 +53,7 @@ stdenv.mkDerivation rec {
     description = "ABI Generic Analysis and Instrumentation Library";
     homepage = "https://sourceware.org/libabigail/";
     license = licenses.asl20-llvm;
-    maintainers = with maintainers; [ jtojnar ];
+    maintainers = with maintainers; [ ];
     platforms = platforms.linux;
   };
 }

--- a/pkgs/development/libraries/libhandy/0.x.nix
+++ b/pkgs/development/libraries/libhandy/0.x.nix
@@ -47,7 +47,7 @@ stdenv.mkDerivation rec {
     description = "A library full of GTK widgets for mobile phones";
     homepage = "https://source.puri.sm/Librem5/libhandy";
     license = licenses.lgpl21Plus;
-    maintainers = with maintainers; [ jtojnar ];
+    maintainers = with maintainers; [ ];
     platforms = platforms.unix;
   };
 }

--- a/pkgs/development/libraries/pipewire/default.nix
+++ b/pkgs/development/libraries/pipewire/default.nix
@@ -220,7 +220,7 @@ let
       homepage = "https://pipewire.org/";
       license = licenses.mit;
       platforms = platforms.linux;
-      maintainers = with maintainers; [ jtojnar kranzes k900 ];
+      maintainers = with maintainers; [ kranzes k900 ];
     };
   };
 

--- a/pkgs/development/php-packages/box/default.nix
+++ b/pkgs/development/php-packages/box/default.nix
@@ -30,6 +30,6 @@ mkDerivation {
     description = "An application for building and managing Phars";
     license = licenses.mit;
     homepage = "https://github.com/box-project/box";
-    maintainers = with maintainers; [ jtojnar ] ++ teams.php.members;
+    maintainers = with maintainers; [ ] ++ teams.php.members;
   };
 }

--- a/pkgs/development/php-packages/php-cs-fixer/default.nix
+++ b/pkgs/development/php-packages/php-cs-fixer/default.nix
@@ -30,6 +30,6 @@ mkDerivation {
     description = "A tool to automatically fix PHP coding standards issues";
     license = licenses.mit;
     homepage = "https://cs.symfony.com/";
-    maintainers = with maintainers; [ jtojnar ] ++ teams.php.members;
+    maintainers = with maintainers; [ ] ++ teams.php.members;
   };
 }

--- a/pkgs/development/php-packages/php-parallel-lint/default.nix
+++ b/pkgs/development/php-packages/php-parallel-lint/default.nix
@@ -43,6 +43,6 @@ mkDerivation {
     description = "Tool to check syntax of PHP files faster than serial check with fancier output";
     license = licenses.bsd2;
     homepage = "https://github.com/php-parallel-lint/PHP-Parallel-Lint";
-    maintainers = with maintainers; [ jtojnar ] ++ teams.php.members;
+    maintainers = with maintainers; [ ] ++ teams.php.members;
   };
 }

--- a/pkgs/development/python-modules/babelgladeextractor/default.nix
+++ b/pkgs/development/python-modules/babelgladeextractor/default.nix
@@ -28,6 +28,6 @@ buildPythonPackage rec {
     homepage = "https://github.com/gnome-keysign/babel-glade";
     description = "Babel Glade XML files translatable strings extractor";
     license = licenses.bsd3;
-    maintainers = with maintainers; [ jtojnar ];
+    maintainers = with maintainers; [ ];
   };
 }

--- a/pkgs/development/python-modules/cffsubr/default.nix
+++ b/pkgs/development/python-modules/cffsubr/default.nix
@@ -37,6 +37,6 @@ buildPythonPackage rec {
     description = "Standalone CFF subroutinizer based on AFDKO tx";
     homepage = "https://github.com/adobe-type-tools/cffsubr";
     license = licenses.asl20;
-    maintainers = with maintainers; [ jtojnar ];
+    maintainers = with maintainers; [ ];
   };
 }

--- a/pkgs/development/python-modules/click-configfile/default.nix
+++ b/pkgs/development/python-modules/click-configfile/default.nix
@@ -46,6 +46,6 @@ buildPythonPackage rec {
     description = "Add support for commands that use configuration files to Click";
     homepage = "https://github.com/click-contrib/click-configfile";
     license = licenses.bsd3;
-    maintainers = with maintainers; [ jtojnar ];
+    maintainers = with maintainers; [ ];
   };
 }

--- a/pkgs/development/python-modules/click-spinner/default.nix
+++ b/pkgs/development/python-modules/click-spinner/default.nix
@@ -25,6 +25,6 @@ buildPythonPackage rec {
     description = "Add support for showwing that command line app is active to Click";
     homepage = "https://github.com/click-contrib/click-spinner";
     license = licenses.mit;
-    maintainers = with maintainers; [ jtojnar ];
+    maintainers = with maintainers; [ ];
   };
 }

--- a/pkgs/development/python-modules/cloudsmith-api/default.nix
+++ b/pkgs/development/python-modules/cloudsmith-api/default.nix
@@ -39,6 +39,6 @@ buildPythonPackage rec {
     description = "Cloudsmith API Client";
     homepage = "https://github.com/cloudsmith-io/cloudsmith-api";
     license = licenses.asl20;
-    maintainers = with maintainers; [ jtojnar ];
+    maintainers = with maintainers; [ ];
   };
 }

--- a/pkgs/development/python-modules/compreffor/default.nix
+++ b/pkgs/development/python-modules/compreffor/default.nix
@@ -40,6 +40,6 @@ buildPythonPackage rec {
     description = "CFF table subroutinizer for FontTools";
     homepage = "https://github.com/googlefonts/compreffor";
     license = licenses.asl20;
-    maintainers = with maintainers; [ jtojnar ];
+    maintainers = with maintainers; [ ];
   };
 }

--- a/pkgs/development/python-modules/dogtail/default.nix
+++ b/pkgs/development/python-modules/dogtail/default.nix
@@ -62,6 +62,6 @@ buildPythonPackage {
     description = "GUI test tool and automation framework that uses Accessibility technologies to communicate with desktop applications";
     homepage = "https://gitlab.com/dogtail/dogtail";
     license = lib.licenses.gpl2Only;
-    maintainers = with lib.maintainers; [ jtojnar ];
+    maintainers = with lib.maintainers; [ ];
   };
 }

--- a/pkgs/development/python-modules/lml/default.nix
+++ b/pkgs/development/python-modules/lml/default.nix
@@ -26,6 +26,6 @@ buildPythonPackage rec {
     description = "Load me later. A lazy plugin management system for Python";
     homepage = "http://lml.readthedocs.io/";
     license = lib.licenses.bsd3;
-    maintainers = with lib.maintainers; [ jtojnar ];
+    maintainers = with lib.maintainers; [ ];
   };
 }

--- a/pkgs/development/python-modules/orderedset/default.nix
+++ b/pkgs/development/python-modules/orderedset/default.nix
@@ -13,7 +13,7 @@ buildPythonPackage rec {
     description = "An Ordered Set implementation in Cython";
     homepage = "https://pypi.python.org/pypi/orderedset";
     license = licenses.bsd3;
-    maintainers = [ maintainers.jtojnar ];
+    maintainers = [ ];
     # No support for Python 3.9/3.10
     # https://github.com/simonpercivall/orderedset/issues/36
     broken = true;

--- a/pkgs/development/python-modules/pyexcel-io/default.nix
+++ b/pkgs/development/python-modules/pyexcel-io/default.nix
@@ -29,6 +29,6 @@ buildPythonPackage rec {
     description = "One interface to read and write the data in various excel formats, import the data into and export the data from databases";
     homepage = "http://docs.pyexcel.org/";
     license = lib.licenses.bsd3;
-    maintainers = with lib.maintainers; [ jtojnar ];
+    maintainers = with lib.maintainers; [ ];
   };
 }

--- a/pkgs/development/python-modules/pyexcel-ods/default.nix
+++ b/pkgs/development/python-modules/pyexcel-ods/default.nix
@@ -36,6 +36,6 @@ buildPythonPackage rec {
     description = "Plug-in to pyexcel providing the capbility to read, manipulate and write data in ods formats using odfpy";
     homepage = "http://docs.pyexcel.org/";
     license = lib.licenses.bsd3;
-    maintainers = with lib.maintainers; [ jtojnar ];
+    maintainers = with lib.maintainers; [ ];
   };
 }

--- a/pkgs/development/python-modules/pyexcel-xls/default.nix
+++ b/pkgs/development/python-modules/pyexcel-xls/default.nix
@@ -40,6 +40,6 @@ buildPythonPackage rec {
     description = "A wrapper library to read, manipulate and write data in xls using xlrd and xlwt";
     homepage = "http://docs.pyexcel.org/";
     license = lib.licenses.bsd3;
-    maintainers = with lib.maintainers; [ jtojnar ];
+    maintainers = with lib.maintainers; [ ];
   };
 }

--- a/pkgs/development/python-modules/pyexcel/default.nix
+++ b/pkgs/development/python-modules/pyexcel/default.nix
@@ -38,6 +38,6 @@ buildPythonPackage rec {
     description = "Single API for reading, manipulating and writing data in csv, ods, xls, xlsx and xlsm files";
     homepage = "http://docs.pyexcel.org/";
     license = lib.licenses.bsd3;
-    maintainers = with lib.maintainers; [ jtojnar ];
+    maintainers = with lib.maintainers; [ ];
   };
 }

--- a/pkgs/development/python-modules/statmake/default.nix
+++ b/pkgs/development/python-modules/statmake/default.nix
@@ -65,6 +65,6 @@ buildPythonPackage rec {
     homepage = "https://github.com/daltonmaag/statmake";
     changelog = "https://github.com/daltonmaag/statmake/releases/tag/v${version}";
     license = licenses.mit;
-    maintainers = with maintainers; [ jtojnar ];
+    maintainers = with maintainers; [ ];
   };
 }

--- a/pkgs/development/python-modules/ufo2ft/default.nix
+++ b/pkgs/development/python-modules/ufo2ft/default.nix
@@ -64,6 +64,6 @@ buildPythonPackage rec {
     description = "Bridge from UFOs to FontTools objects";
     homepage = "https://github.com/googlefonts/ufo2ft";
     license = licenses.mit;
-    maintainers = with maintainers; [ jtojnar ];
+    maintainers = with maintainers; [ ];
   };
 }

--- a/pkgs/development/python-modules/ufoLib2/default.nix
+++ b/pkgs/development/python-modules/ufoLib2/default.nix
@@ -49,6 +49,6 @@ buildPythonPackage rec {
     description = "Library to deal with UFO font sources";
     homepage = "https://github.com/fonttools/ufoLib2";
     license = licenses.mit;
-    maintainers = with maintainers; [ jtojnar ];
+    maintainers = with maintainers; [ ];
   };
 }

--- a/pkgs/development/tools/build-managers/meson/default.nix
+++ b/pkgs/development/tools/build-managers/meson/default.nix
@@ -138,7 +138,7 @@ python3.pkgs.buildPythonApplication rec {
       code.
     '';
     license = licenses.asl20;
-    maintainers = with maintainers; [ jtojnar mbe AndersonTorres ];
+    maintainers = with maintainers; [ mbe AndersonTorres ];
     inherit (python3.meta) platforms;
   };
 }

--- a/pkgs/development/tools/cloudsmith-cli/default.nix
+++ b/pkgs/development/tools/cloudsmith-cli/default.nix
@@ -40,7 +40,7 @@ python3.pkgs.buildPythonApplication rec {
     homepage = "https://help.cloudsmith.io/docs/cli/";
     description = "Cloudsmith Command Line Interface";
     changelog = "https://github.com/cloudsmith-io/cloudsmith-cli/blob/v${version}/CHANGELOG.md";
-    maintainers = with maintainers; [ jtojnar ];
+    maintainers = with maintainers; [ ];
     license = licenses.asl20;
     platforms = with platforms; unix;
   };

--- a/pkgs/development/tools/flatpak-builder/default.nix
+++ b/pkgs/development/tools/flatpak-builder/default.nix
@@ -152,7 +152,7 @@ in stdenv.mkDerivation rec {
     description = "Tool to build flatpaks from source";
     homepage = "https://github.com/flatpak/flatpak-builder";
     license = licenses.lgpl21Plus;
-    maintainers = with maintainers; [ jtojnar ];
+    maintainers = with maintainers; [ ];
     platforms = platforms.linux;
   };
 }

--- a/pkgs/development/tools/ofono-phonesim/default.nix
+++ b/pkgs/development/tools/ofono-phonesim/default.nix
@@ -34,7 +34,7 @@ mkDerivation {
     description = "Phone Simulator for modem testing";
     homepage = "https://01.org/ofono";
     license = licenses.gpl2;
-    maintainers = with maintainers; [ jtojnar ];
+    maintainers = with maintainers; [ ];
     platforms = platforms.linux;
   };
 }

--- a/pkgs/games/freedroidrpg/default.nix
+++ b/pkgs/games/freedroidrpg/default.nix
@@ -69,7 +69,7 @@ in stdenv.mkDerivation {
 
     license = licenses.gpl2Plus;
 
-    maintainers = with maintainers; [ jtojnar ];
+    maintainers = with maintainers; [ ];
     platforms = platforms.unix;
     hydraPlatforms = platforms.linux; # sdl-config times out on darwin
   };

--- a/pkgs/games/gnome-hexgl/default.nix
+++ b/pkgs/games/gnome-hexgl/default.nix
@@ -37,7 +37,7 @@ stdenv.mkDerivation rec {
     description = "Gthree port of HexGL";
     homepage = "https://github.com/alexlarsson/gnome-hexgl";
     license = licenses.mit;
-    maintainers = with maintainers; [ jtojnar ];
+    maintainers = with maintainers; [ ];
     platforms = platforms.unix;
   };
 }

--- a/pkgs/os-specific/linux/power-profiles-daemon/default.nix
+++ b/pkgs/os-specific/linux/power-profiles-daemon/default.nix
@@ -128,6 +128,6 @@ stdenv.mkDerivation rec {
     description = "Makes user-selected power profiles handling available over D-Bus";
     platforms = platforms.linux;
     license = licenses.gpl3Plus;
-    maintainers = with maintainers; [ jtojnar mvnetbiz ];
+    maintainers = with maintainers; [ mvnetbiz ];
   };
 }

--- a/pkgs/servers/neard/default.nix
+++ b/pkgs/servers/neard/default.nix
@@ -70,7 +70,7 @@ stdenv.mkDerivation rec {
     description = "Near Field Communication manager";
     homepage = "https://01.org/linux-nfc";
     license = licenses.gpl2Only;
-    maintainers = with maintainers; [ jtojnar ];
+    maintainers = with maintainers; [ ];
     platforms = platforms.unix;
   };
 }

--- a/pkgs/tools/misc/markdown-anki-decks/default.nix
+++ b/pkgs/tools/misc/markdown-anki-decks/default.nix
@@ -40,7 +40,7 @@ python3.pkgs.buildPythonApplication rec {
     description = "Tool to convert Markdown files into Anki Decks";
     homepage = "https://github.com/lukesmurray/markdown-anki-decks";
     license = licenses.mit;
-    maintainers = with maintainers; [ jtojnar ];
+    maintainers = with maintainers; [ ];
     platforms = platforms.unix;
   };
 }

--- a/pkgs/tools/networking/ofono/default.nix
+++ b/pkgs/tools/networking/ofono/default.nix
@@ -61,7 +61,7 @@ stdenv.mkDerivation rec {
     homepage = "https://git.kernel.org/pub/scm/network/ofono/ofono.git";
     changelog = "https://git.kernel.org/pub/scm/network/ofono/ofono.git/plain/ChangeLog?h=${version}";
     license = licenses.gpl2Only;
-    maintainers = with maintainers; [ jtojnar ];
+    maintainers = with maintainers; [ ];
     platforms = platforms.linux;
   };
 }

--- a/pkgs/tools/text/gtranslator/default.nix
+++ b/pkgs/tools/text/gtranslator/default.nix
@@ -69,7 +69,7 @@ stdenv.mkDerivation rec {
     description = "GNOME translation making program";
     homepage = "https://wiki.gnome.org/Apps/Gtranslator";
     license = licenses.gpl3Plus;
-    maintainers = with maintainers; [ jtojnar ];
+    maintainers = with maintainers; [ ];
     platforms = platforms.linux;
   };
 }


### PR DESCRIPTION
Notably fwupd, pipewire and flatpak.
I want to focus on GNOME and other packages I still actually use.
Pipewire is still important but I have not touched the packaging in a while.
