### PR TITLE
kitti3: init at unstable-2021-09-11

### DIFF
--- a/pkgs/applications/window-managers/i3/kitti3-fix-build-system.patch
+++ b/pkgs/applications/window-managers/i3/kitti3-fix-build-system.patch
@@ -1,0 +1,21 @@
+commit 410e98569c87469672086d4144f7ca0f2ee08fb7
+Author: Michael Hoang <enzime@users.noreply.github.com>
+Date:   Sun May 21 00:13:37 2023 +1000
+
+    Allow project to be built with just `pip`
+---
+ pyproject.toml | 4 ++++
+ 1 file changed, 4 insertions(+)
+
+diff --git a/pyproject.toml b/pyproject.toml
+index 10ed786..574e42a 100644
+--- a/pyproject.toml
++++ b/pyproject.toml
+@@ -1,3 +1,7 @@
++[build-system]
++requires = ["poetry-core"]
++build-backend = "poetry.core.masonry.api"
++
+ [tool.poetry]
+ name = "kitti3"
+ version = "0.5.1"

--- a/pkgs/applications/window-managers/i3/kitti3.nix
+++ b/pkgs/applications/window-managers/i3/kitti3.nix
@@ -1,0 +1,40 @@
+{ buildPythonApplication
+, fetchFromGitHub
+, poetry-core
+, i3ipc
+, lib
+}:
+
+buildPythonApplication rec {
+  pname = "kitti3";
+  version = "unstable-2021-09-11";
+  format = "pyproject";
+
+  src = fetchFromGitHub {
+    owner = "LandingEllipse";
+    repo = pname;
+    rev = "f9f94c8b9f8b61a9d085206ada470cfe755a2a92";
+    hash = "sha256-bcIzbDpIe2GKS9EcVqpjwz0IG2ixNMn06OIQpZ7PeH0=";
+  };
+
+  patches = [
+    # Fixes `build-system` not being specified in `pyproject.toml`
+    # https://github.com/LandingEllipse/kitti3/pull/25
+    ./kitti3-fix-build-system.patch
+  ];
+
+  nativeBuildInputs = [
+    poetry-core
+  ];
+
+  propagatedBuildInputs = [
+    i3ipc
+  ];
+
+  meta = with lib; {
+    homepage = "https://github.com/LandingEllipse/kitti3";
+    description = "Kitty drop-down service for sway & i3wm";
+    license = licenses.bsd3;
+    maintainers = with maintainers; [ Enzime ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -31424,6 +31424,8 @@ with pkgs;
 
   i3-wk-switch = callPackage ../applications/window-managers/i3/wk-switch.nix { };
 
+  kitti3 = python3.pkgs.callPackage ../applications/window-managers/i3/kitti3.nix { };
+
   waybox = callPackage ../applications/window-managers/waybox { };
 
   workstyle = callPackage ../applications/window-managers/i3/workstyle.nix { };


### PR DESCRIPTION
###### Description of changes

> Kitti3 turns Kitty into a drop-down, Quake-style floating terminal for the i3 and Sway window managers.

https://github.com/LandingEllipse/kitti3

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).