### PR TITLE
vorta: don't replace Exec line in desktop file

### DIFF
--- a/pkgs/applications/backup/vorta/default.nix
+++ b/pkgs/applications/backup/vorta/default.nix
@@ -39,7 +39,6 @@ python3Packages.buildPythonApplication rec {
     --replace pytest-runner ""
 
     substituteInPlace src/vorta/assets/metadata/com.borgbase.Vorta.desktop \
-    --replace Exec=vorta "Exec=$out/bin/vorta" \
     --replace com.borgbase.Vorta "com.borgbase.Vorta-symbolic"
   '';
 


### PR DESCRIPTION
###### Description of changes

This replacement breaks autostart feature. Let's say I have NixOS 22.11 installed with Vorta v0.8.9. I run it and enable autostart for the application in its settings. Then I decide to upgrade to NixOS unstable and Vorta is upgraded to v0.8.12. I will end up with situation like that:

```
nix on  master ➜  cat ~/.config/autostart/vorta.desktop 
[Desktop Entry]
Name=Vorta
GenericName=Backup Software
Exec=/nix/store/40f2r64929dlp6i2vcbx18za0qyan3zd-vorta-0.8.9/bin/vorta
Type=Application
Icon=com.borgbase.Vorta-symbolic
Categories=Utility;Archiving;Qt;
Keywords=borg;
StartupWMClass=vorta
StartupNotify=false
X-GNOME-Autostart-enabled=true
X-GNOME-Autostart-Delay=20

nix on  master ➜  vorta --version
Vorta 0.8.12

nix on  master ➜  cat ~/.nix-profile/share/applications/com.borgbase.Vorta.desktop 
[Desktop Entry]
Name=Vorta
GenericName=Backup Software
Exec=/nix/store/csq8wsdp93yniqznjfzm3j1ih0ll2w9l-vorta-0.8.12/bin/vorta
Type=Application
Icon=com.borgbase.Vorta-symbolic
Categories=Utility;Archiving;Qt;
Keywords=borg;
StartupWMClass=vorta

```

Hence, I propose we leave the Exec line as is provided by upstream. For example we don't replace the Exec line in keepassxc and the autostart feature works like a charm there between version upgrades.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
