### PR TITLE
oauth2c: init at 1.7.0

### DIFF
--- a/pkgs/tools/security/oauth2c/default.nix
+++ b/pkgs/tools/security/oauth2c/default.nix
@@ -1,0 +1,34 @@
+{ buildGoModule
+, fetchFromGitHub
+, lib
+}:
+
+buildGoModule rec {
+  pname = "oauth2c";
+  version = "1.7.0";
+
+  src = fetchFromGitHub {
+    owner = "cloudentity";
+    repo = pname;
+    rev = "v${version}";
+    hash = "sha256-IOfY0lKOeuArO3bI1JjTOXHhCqr3GTfsOHCOI0Qh4xk=";
+  };
+
+  vendorHash = "sha256-euEmslrSbXPVDNZkIguq+ukt74Um4H0+lIXEyCBorjE=";
+
+  doCheck = false; # tests want to talk to oauth2c.us.authz.cloudentity.io
+
+  meta = with lib; {
+    homepage = "https://github.com/cloudentity/oauth2c";
+    description = "User-friendly OAuth2 CLI";
+    longDescription = ''
+      oauth2c is a command-line tool for interacting with OAuth 2.0
+      authorization servers. Its goal is to make it easy to fetch access tokens
+      using any grant type or client authentication method. It is compliant with
+      almost all basic and advanced OAuth 2.0, OIDC, OIDF FAPI and JWT profiles.
+    '';
+    license = licenses.asl20;
+    maintainers = [ maintainers.flokli ];
+    platforms = platforms.darwin ++ platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -667,6 +667,8 @@ with pkgs;
 
   erosmb = callPackage ../tools/security/erosmb { };
 
+  oauth2c = callPackage ../tools/security/oauth2c { };
+
   octosuite = callPackage ../tools/security/octosuite { };
 
   octosql = callPackage ../tools/misc/octosql { };


### PR DESCRIPTION
oauth2c is a command-line tool for interacting with OAuth 2.0 authorization servers. Its goal is to make it easy to fetch access tokens using any grant type or client authentication method. It is compliant with almost all basic and advanced OAuth 2.0, OIDC, OIDF FAPI and JWT profiles.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

Fixes https://github.com/cloudentity/oauth2c/issues/53.
