### PR TITLE
retroshare: fix build failure

### DIFF
--- a/pkgs/applications/networking/p2p/retroshare/cpp-filesystem.patch
+++ b/pkgs/applications/networking/p2p/retroshare/cpp-filesystem.patch
@@ -1,0 +1,12 @@
+diff --git a/libretroshare/src/util/rsdir.cc b/libretroshare/src/util/rsdir.cc
+index 8556b8198..d63699216 100644
+--- a/libretroshare/src/util/rsdir.cc
++++ b/libretroshare/src/util/rsdir.cc
+@@ -47,6 +47,7 @@
+ 
+ #include <fstream>
+ #include <stdexcept>
++#include <filesystem>
+ 
+ #if defined(WIN32) || defined(__CYGWIN__)
+ #include "util/rsstring.h"

--- a/pkgs/applications/networking/p2p/retroshare/default.nix
+++ b/pkgs/applications/networking/p2p/retroshare/default.nix
@@ -19,6 +19,7 @@ mkDerivation rec {
     # The build normally tries to get git sub-modules during build
     # but we already have them checked out
     ./no-submodules.patch
+    ./cpp-filesystem.patch
   ];
 
   nativeBuildInputs = [ pkg-config qmake cmake ];


### PR DESCRIPTION
###### Description of changes

Retroshare at some point seemed to have stopped building due to a compiler error, as reported in #224146.
Adding the `<filesystem>` header to the appropriate source file seems to fix it.
This is done as a new patch file.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
