### PR TITLE
pyload-ng: init at 0.5.0b3.dev72

### DIFF
--- a/pkgs/applications/networking/pyload-ng/default.nix
+++ b/pkgs/applications/networking/pyload-ng/default.nix
@@ -1,0 +1,54 @@
+{ lib, fetchPypi, python3 }:
+
+python3.pkgs.buildPythonApplication rec {
+  version = "0.5.0b3.dev72";
+  pname = "pyload-ng";
+  format = "pyproject";
+
+  src = fetchPypi {
+    inherit pname version;
+    hash = "sha256-pcbJc23Fylh/JoWRmbZmC8xUzUqh2ej6gT+B2w8DHFQ=";
+  };
+
+  postPatch = ''
+    # relax version bounds
+    sed -i 's/\([A-z0-9]*\)~=.*$/\1/' setup.cfg
+    # not sure what Flask-Session2 is but flask-session works just fine
+    sed -i '/Flask-Session2/d' setup.cfg
+  '';
+
+  propagatedBuildInputs = with python3.pkgs; [
+    setuptools
+    cheroot
+    pycurl
+    filetype
+    flask
+    semver
+    bitmath
+    cryptography
+    certifi
+    js2py
+    flask-themes2
+    flask-session
+    flask-compress
+    flask-babel
+    flask-caching
+  ];
+
+  passthru.optional-dependencies = {
+    plugins = with python3.pkgs; [
+      beautifulsoup4 # for some plugins
+      slixmpp # XMPP plugin
+      send2trash # send some files to trash instead of deleting them
+      pillow # for some CAPTCHA plugin
+      colorlog # colorful console logging
+    ];
+  };
+
+  meta = with lib; {
+    description = "Free and open-source download manager with support for 1-click-hosting sites";
+    homepage = "https://github.com/pyload/pyload";
+    license = licenses.agpl3Plus;
+    maintainers = with maintainers; [ ruby0b ];
+  };
+}

--- a/pkgs/development/python-modules/flask-themes2/default.nix
+++ b/pkgs/development/python-modules/flask-themes2/default.nix
@@ -1,0 +1,25 @@
+{ lib, fetchPypi, buildPythonPackage, flask, pythonOlder, pytestCheckHook }:
+
+buildPythonPackage rec {
+  pname = "flask-themes2";
+  version = "1.0.0";
+  format = "setuptools";
+
+  disabled = pythonOlder "3.8";
+
+  src = fetchPypi {
+    pname = "Flask-Themes2";
+    inherit version;
+    hash = "sha256-0U0cSdBddb9+IG3CU6zUPlxaJhQlxOV6OLgxnNDChy8=";
+  };
+
+  nativeCheckInputs = [ pytestCheckHook ];
+  propagatedBuildInputs = [ flask ];
+
+  meta = with lib; {
+    description = "Easily theme your Flask app";
+    homepage = "https://github.com/sysr-q/flask-themes2";
+    license = licenses.mit;
+    maintainers = with maintainers; [ ruby0b ];
+  };
+}

--- a/pkgs/top-level/aliases.nix
+++ b/pkgs/top-level/aliases.nix
@@ -1419,7 +1419,7 @@ mapAliases ({
   pybitmessage = throw "pybitmessage was removed from nixpkgs as it is stuck on python2"; # Added 2022-01-01
   pyext = throw "pyext was removed because it does not support python 3.11, is upstream unmaintained and was unused"; # Added 2022-11-21
   pygmentex = texlive.bin.pygmentex; # Added 2019-12-15
-  pyload = throw "pyload has been removed from nixpkgs, as it was unmaintained"; # Added 2021-03-21
+  pyload = throw "pyload has been removed from nixpkgs. Use pyload-ng instead."; # Added 2021-03-21
   pynagsystemd = throw "pynagsystemd was removed as it was unmaintained and incompatible with recent systemd versions. Instead use its fork check_systemd"; # Added 2020-10-24
   pyo3-pack = maturin;
   pypi2nix = throw "pypi2nix has been removed due to being unmaintained";

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -34226,6 +34226,8 @@ with pkgs;
 
   pwdsafety = callPackage ../tools/security/pwdsafety { };
 
+  pyload-ng = callPackage ../applications/networking/pyload-ng {};
+
   pyrosimple = callPackage ../applications/networking/p2p/pyrosimple { };
 
   qbittorrent = libsForQt5.callPackage ../applications/networking/p2p/qbittorrent { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -3794,6 +3794,8 @@ self: super: with self; {
 
   flask-testing = callPackage ../development/python-modules/flask-testing { };
 
+  flask-themes2 = callPackage ../development/python-modules/flask-themes2 { };
+
   flask-versioned = callPackage ../development/python-modules/flask-versioned { };
 
   flask-wtf = callPackage ../development/python-modules/flask-wtf { };


### PR DESCRIPTION
###### Description of changes
This packages the newer pyload-ng version of [pyload](https://pyload.net/), a download manager with support for 1-click-hosting sites.

The old pyload got dropped from nixpkgs in 2021 due to being unmaintained: https://github.com/NixOS/nixpkgs/commit/c0914a76c40230fb06eb6df8f54995796edef3ef

Potential future work: writing a NixOS service for autostarting

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
