### PR TITLE
haskellPackages.glualint: init at 1.24.3

### DIFF
--- a/pkgs/development/haskell-modules/configuration-ghc-9.0.x.nix
+++ b/pkgs/development/haskell-modules/configuration-ghc-9.0.x.nix
@@ -181,4 +181,7 @@ self: super: {
 
   # Needs OneTuple for ghc < 9.2
   binary-orphans = addBuildDepends [ self.OneTuple ] super.binary-orphans;
+
+  # 2023-05-212: doesn't support Cabal >= 3.8 but GHC 9 works since it ships cabal 3.6
+  uuagc-cabal = doDistribute (unmarkBroken super.uuagc-cabal);
 }

--- a/pkgs/development/haskell-modules/non-hackage-packages.nix
+++ b/pkgs/development/haskell-modules/non-hackage-packages.nix
@@ -38,4 +38,6 @@ self: super: {
   # Unofficial fork until PRs are merged https://github.com/pcapriotti/optparse-applicative/pulls/roberth
   # cabal2nix --maintainer roberth https://github.com/hercules-ci/optparse-applicative.git > pkgs/development/misc/haskell/hercules-ci-optparse-applicative.nix
   hercules-ci-optparse-applicative = self.callPackage ../misc/haskell/hercules-ci-optparse-applicative.nix {};
+
+  glualint = self.callPackage ../tools/glualint {};
 }

--- a/pkgs/development/tools/glualint/default.nix
+++ b/pkgs/development/tools/glualint/default.nix
@@ -1,0 +1,75 @@
+{ mkDerivation
+, aeson
+, base
+, bytestring
+, containers
+, deepseq
+, directory
+, effectful
+, fetchFromGitHub
+, filemanip
+, filepath
+, lib
+, MissingH
+, optparse-applicative
+, parsec
+, pretty
+, signal
+, uu-parsinglib
+, uuagc
+, uuagc-cabal
+}:
+mkDerivation rec {
+  pname = "glualint";
+  version = "1.24.3";
+
+  src = fetchFromGitHub {
+    owner = "FPtje";
+    repo = "GLuaFixer";
+    rev = version;
+    hash = "sha256-FmgQYONm1UciYa4Grmn+y1uVh9RSL90hO2rWusya0C0=";
+  };
+
+  isLibrary = true;
+  isExecutable = true;
+  libraryToolDepends = [ uuagc uuagc-cabal ];
+  libraryHaskellDepends = [
+    aeson
+    base
+    bytestring
+    containers
+    MissingH
+    parsec
+    pretty
+    uu-parsinglib
+    uuagc
+    uuagc-cabal
+  ];
+  executableHaskellDepends = [
+    aeson
+    base
+    bytestring
+    containers
+    deepseq
+    directory
+    effectful
+    filemanip
+    filepath
+    optparse-applicative
+    signal
+  ];
+
+  preBuild = ''
+    echo "Generating attribute grammar haskell files"
+    uuagc --haskellsyntax --data src/GLua/AG/AST.ag
+    uuagc --haskellsyntax --data --strictdata src/GLua/AG/Token.ag
+    uuagc --catas --haskellsyntax --semfuns --wrappers --signatures src/GLua/AG/PrettyPrint.ag
+    uuagc --catas --haskellsyntax --semfuns --wrappers --signatures --optimize src/GLuaFixer/AG/LexLint.ag
+    uuagc --catas --haskellsyntax --semfuns --wrappers --signatures --optimize src/GLuaFixer/AG/ASTLint.ag
+  '';
+
+  homepage = "https://github.com/FPtje/GLuaFixer";
+  description = "Linter for Garry's mod Lua";
+  license = lib.licenses.lgpl21;
+  maintainers = with lib.maintainers; [ ruby0b ];
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -18391,6 +18391,8 @@ with pkgs;
 
   global = callPackage ../development/tools/misc/global { };
 
+  glualint = haskell.lib.compose.justStaticExecutables haskell.packages.ghc90.glualint;
+
   gnatcoll-db2ada = callPackage ../development/libraries/ada/gnatcoll/db.nix {
     component = "gnatcoll_db2ada";
   };


### PR DESCRIPTION
###### Description of changes
(corrected and updated version of #222356)

[glualint](https://github.com/FPtje/GLuaFixer) is a linter and pretty printer for Garry's Mod's variant of Lua.
The derivation pretty much just uses the project's own [default.nix](https://github.com/FPtje/GLuaFixer/blob/1.24.1/default.nix).

The package is not available on hackage and the version stated in its cabal file is a constant 0.1.0.0 (even though the github release is at version 1.24.3). The derivation uses the github release version.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->