### PR TITLE
nixos/tests/headscale: test improvements

### DIFF
--- a/nixos/tests/headscale.nix
+++ b/nixos/tests/headscale.nix
@@ -1,17 +1,82 @@
-import ./make-test-python.nix ({ pkgs, lib, ... }: {
-  name = "headscale";
-  meta.maintainers = with lib.maintainers; [ misterio77 ];
+import ./make-test-python.nix ({ pkgs, lib, ... }:
+  let
+    tls-cert =
+      pkgs.runCommand "selfSignedCerts" { buildInputs = [ pkgs.openssl ]; } ''
+        openssl req \
+          -x509 -newkey rsa:4096 -sha256 -days 365 \
+          -nodes -out cert.pem -keyout key.pem \
+          -subj '/CN=headscale' -addext "subjectAltName=DNS:headscale"
 
-  nodes.machine = { ... }: {
-    services.headscale.enable = true;
-    environment.systemPackages = [ pkgs.headscale ];
-  };
+        mkdir -p $out
+        cp key.pem cert.pem $out
+      '';
+  in {
+    name = "headscale";
+    meta.maintainers = with lib.maintainers; [ misterio77 ];
 
-  testScript = ''
-    machine.wait_for_unit("headscale")
-    machine.wait_for_open_port(8080)
-    # Test basic functionality
-    machine.succeed("headscale namespaces create test")
-    machine.succeed("headscale preauthkeys -u test create")
-  '';
-})
+    nodes = let
+      headscalePort = 8080;
+      stunPort = 3478;
+      peer = {
+        services.tailscale.enable = true;
+        security.pki.certificateFiles = [ "${tls-cert}/cert.pem" ];
+      };
+    in {
+      peer1 = peer;
+      peer2 = peer;
+
+      headscale = {
+        services = {
+          headscale = {
+            enable = true;
+            port = headscalePort;
+            settings = {
+              server_url = "https://headscale";
+              ip_prefixes = [ "100.64.0.0/10" ];
+              derp.server = {
+                enabled = true;
+                region_id = 999;
+                stun_listen_addr = "0.0.0.0:${toString stunPort}";
+              };
+            };
+          };
+          nginx = {
+            enable = true;
+            virtualHosts.headscale = {
+              addSSL = true;
+              sslCertificate = "${tls-cert}/cert.pem";
+              sslCertificateKey = "${tls-cert}/key.pem";
+              locations."/" = {
+                proxyPass = "http://127.0.0.1:${toString headscalePort}";
+                proxyWebsockets = true;
+              };
+            };
+          };
+        };
+        networking.firewall = {
+          allowedTCPPorts = [ 80 443 ];
+          allowedUDPPorts = [ stunPort ];
+        };
+        environment.systemPackages = [ pkgs.headscale ];
+      };
+    };
+
+    testScript = ''
+      start_all()
+      headscale.wait_for_unit("headscale")
+      headscale.wait_for_open_port(443)
+
+      # Create headscale user and preauth-key
+      headscale.succeed("headscale users create test")
+      authkey = headscale.succeed("headscale preauthkeys -u test create --reusable")
+
+      # Connect peers
+      up_cmd = f"tailscale up --login-server 'https://headscale' --auth-key {authkey}"
+      peer1.execute(up_cmd)
+      peer2.execute(up_cmd)
+
+      # Check that they are reachable from the tailnet
+      peer1.wait_until_succeeds("tailscale ping peer2")
+      peer2.wait_until_succeeds("tailscale ping peer1")
+    '';
+  })

--- a/pkgs/servers/headscale/default.nix
+++ b/pkgs/servers/headscale/default.nix
@@ -3,6 +3,7 @@
   buildGoModule,
   fetchFromGitHub,
   installShellFiles,
+  nixosTests,
 }:
 buildGoModule rec {
   pname = "headscale";
@@ -30,6 +31,8 @@ buildGoModule rec {
       --fish <($out/bin/headscale completion fish) \
       --zsh <($out/bin/headscale completion zsh)
   '';
+
+  passthru.tests = { inherit (nixosTests) headscale; };
 
   meta = with lib; {
     homepage = "https://github.com/juanfont/headscale";


### PR DESCRIPTION
The test covers actual headscale+tailscale usage now.

###### Description of changes

We need a custom DERP for the tests to run without internet access; it's pretty easy to setup, but it requires the headscale server to be served through https. For that, we generate a self-signed tls cert, and set nginx in front of it.

I've also added the test to headscale package's passthru, so that it runs on future headscale PRs.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
