### PR TITLE
linux: default stdenv.hostPlatform.linux-kernel

### DIFF
--- a/pkgs/os-specific/linux/kernel/generic.nix
+++ b/pkgs/os-specific/linux/kernel/generic.nix
@@ -47,7 +47,7 @@
   # symbolic name and `patch' is the actual patch.  The patch may
   # optionally be compressed with gzip or bzip2.
   kernelPatches ? []
-, ignoreConfigErrors ? stdenv.hostPlatform.linux-kernel.name != "pc"
+, ignoreConfigErrors ? stdenv.hostPlatform.linux-kernel.name or "" != "pc"
 , extraMeta ? {}
 
 , isZen      ? false
@@ -55,7 +55,7 @@
 , isHardened ? false
 
 # easy overrides to stdenv.hostPlatform.linux-kernel members
-, autoModules ? stdenv.hostPlatform.linux-kernel.autoModules
+, autoModules ? stdenv.hostPlatform.linux-kernel.autoModules or true
 , preferBuiltin ? stdenv.hostPlatform.linux-kernel.preferBuiltin or false
 , kernelArch ? stdenv.hostPlatform.linuxArch
 , kernelTests ? []
@@ -128,11 +128,10 @@ let
       ++ lib.optionals (lib.versionAtLeast version "4.16") [ bison flex ]
       ++ lib.optional (lib.versionAtLeast version "5.2") pahole;
 
-    platformName = stdenv.hostPlatform.linux-kernel.name;
     # e.g. "defconfig"
-    kernelBaseConfig = if defconfig != null then defconfig else stdenv.hostPlatform.linux-kernel.baseConfig;
+    kernelBaseConfig = if defconfig != null then defconfig else stdenv.hostPlatform.linux-kernel.baseConfig or "defconfig";
     # e.g. "bzImage"
-    kernelTarget = stdenv.hostPlatform.linux-kernel.target;
+    kernelTarget = stdenv.hostPlatform.linux-kernel.target or "vmlinux";
 
     makeFlags = lib.optionals (stdenv.hostPlatform.linux-kernel ? makeFlags) stdenv.hostPlatform.linux-kernel.makeFlags
       ++ extraMakeFlags;

--- a/pkgs/os-specific/linux/kernel/manual-config.nix
+++ b/pkgs/os-specific/linux/kernel/manual-config.nix
@@ -87,7 +87,8 @@ let
 
   isModular = config.isYes "MODULES";
 
-  kernelConf =  stdenv.hostPlatform.linux-kernel;
+  kernelConf = stdenv.hostPlatform.linux-kernel;
+  target = kernelConf.target or "vmlinux";
 
   buildDTBs = kernelConf.DTB or false;
 in
@@ -101,7 +102,7 @@ stdenv.mkDerivation ({
 
   depsBuildBuild = [ buildPackages.stdenv.cc ];
   nativeBuildInputs = [ perl bc nettools openssl rsync gmp libmpc mpfr zstd python3Minimal ]
-      ++ optional  (kernelConf.target == "uImage") buildPackages.ubootTools
+      ++ optional  (target == "uImage") buildPackages.ubootTools
       ++ optional  (lib.versionOlder version "5.8") libelf
       ++ optionals (lib.versionAtLeast version "4.16") [ bison flex ]
       ++ optionals (lib.versionAtLeast version "5.2")  [ cpio pahole zlib ]
@@ -297,8 +298,8 @@ stdenv.mkDerivation ({
   # Some image types need special install targets (e.g. uImage is installed with make uinstall)
   installTargets = [
     (kernelConf.installTarget or (
-      /**/ if kernelConf.target == "uImage" then "uinstall"
-      else if kernelConf.target == "zImage" || kernelConf.target == "Image.gz" then "zinstall"
+      /**/ if target == "uImage" then "uinstall"
+      else if target == "zImage" || target == "Image.gz" then "zinstall"
       else "install"))
   ];
 


### PR DESCRIPTION
###### Description of changes

With this change, we can do a reasonable default build of Linux for configurations that do not have a corresponding platforms.nix entry, and where the user has not explicitly specified the linux-kernel values.  This allows us to do best effort builds for obscure architectures (I tested a build for s390x).

The platformName binding has not been used since 70cb7050f5c ("Trying to make the linux kernels also cross-build."), so I removed it.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
