### PR TITLE
swayfx: 0.2 -> 0.3

### DIFF
--- a/pkgs/applications/window-managers/sway/fx.nix
+++ b/pkgs/applications/window-managers/sway/fx.nix
@@ -2,17 +2,30 @@
 
 sway-unwrapped.overrideAttrs (oldAttrs: rec {
   pname = "swayfx";
-  version = "0.2";
+  version = "0.3";
 
   src = fetchFromGitHub {
     owner = "WillPower3309";
     repo = "swayfx";
     rev = version;
-    sha256 = "sha256-nVy7GdAnheWhjevcCPE407xWSLN8F4Le0uq2RDwv/Zc=";
+    sha256 = "sha256-3Odyeb10AGbNf6TI1W79sLiwB4PrszC5VzjCr7FuPz4=";
   };
 
+  # This patch was backported into SwayFX
+  # remove when next release is rebased on Sway 1.9
+  patches =
+    let
+      removePatches = [
+        "LIBINPUT_CONFIG_ACCEL_PROFILE_CUSTOM.patch"
+      ];
+    in
+    builtins.filter
+      (patch: !builtins.elem (patch.name or null) removePatches)
+      (oldAttrs.patches or [ ]);
+
+
   meta = with lib; {
-    description = "A Beautiful Sway Fork";
+    description = "Sway, but with eye candy!";
     homepage = "https://github.com/WillPower3309/swayfx";
     maintainers = with maintainers; [ ricarch97 ];
     license = licenses.mit;


### PR DESCRIPTION
###### Description of changes

Adds blur to SwayFX, and fixes several issues.

Patch for libinput was backported to SwayFX, so it is removed here, until the rebase onto Sway 1.9 where it should not be required anymore.

Diff: https://github.com/WillPower3309/swayfx/compare/0.2...0.3

Fixes: https://github.com/NixOS/nixpkgs/issues/233178

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
