### PR TITLE
asitop: init at 0.0.23

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -7881,6 +7881,12 @@
     githubId = 1792886;
     name = "Julien Malka";
   };
+  juliusrickert = {
+    email = "nixpkgs@juliusrickert.de";
+    github = "juliusrickert";
+    githubId = 5007494;
+    name = "Julius Rickert";
+  };
   julm = {
     email = "julm+nixpkgs@sourcephile.fr";
     github = "ju1m";

--- a/pkgs/development/python-modules/dashing/default.nix
+++ b/pkgs/development/python-modules/dashing/default.nix
@@ -1,0 +1,27 @@
+{ lib
+, python3
+}:
+
+python3.pkgs.buildPythonPackage rec {
+  pname = "dashing";
+  version = "0.1.0";
+  format = "setuptools";
+
+  disabled = python3.pythonOlder "3.7";
+
+  src = python3.pkgs.fetchPypi {
+    inherit pname version;
+    hash = "sha256-JRRgjg8pp3Xb0bERFWEhnOg9U8+kuqL+QQH6uE/Vbxs=";
+  };
+
+  propagatedBuildInputs = with python3.pkgs; [
+    blessed
+  ];
+
+  meta = with lib; {
+    homepage = "https://github.com/FedericoCeratto/dashing";
+    description = "Terminal dashboards for Python";
+    license = licenses.gpl3;
+    maintainers = with maintainers; [ juliusrickert ];
+  };
+}

--- a/pkgs/os-specific/darwin/asitop/default.nix
+++ b/pkgs/os-specific/darwin/asitop/default.nix
@@ -1,0 +1,32 @@
+{ lib
+, python3
+}:
+
+python3.pkgs.buildPythonApplication rec {
+  pname = "asitop";
+  version = "0.0.23";
+  format = "setuptools";
+
+  disabled = python3.pythonOlder "3.7";
+
+  src = python3.pkgs.fetchPypi {
+    inherit pname version;
+    hash = "sha256-BNncgQRNAd6Pgur5D1xVQi3LSsijSAYIYvhsuiVyi9Q=";
+  };
+
+  # has no tests
+  doCheck = false;
+
+  propagatedBuildInputs = with python3.pkgs; [
+    dashing
+    psutil
+  ];
+
+  meta = with lib; {
+    homepage = "https://github.com/tlkh/asitop";
+    description = "Perf monitoring CLI tool for Apple Silicon";
+    platforms = platforms.darwin;
+    license = licenses.mit;
+    maintainers = with maintainers; [ juliusrickert ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -260,6 +260,8 @@ with pkgs;
 
   alterx = callPackage ../tools/security/alterx { };
 
+  asitop = pkgs.python3Packages.callPackage ../os-specific/darwin/asitop { };
+
   asn = callPackage ../applications/networking/asn { };
 
   asnmap = callPackage ../tools/security/asnmap { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2254,6 +2254,8 @@ self: super: with self; {
 
   dash-table = callPackage ../development/python-modules/dash-table { };
 
+  dashing = callPackage ../development/python-modules/dashing { };
+
   dask = callPackage ../development/python-modules/dask { };
 
   dask-awkward = callPackage ../development/python-modules/dask-awkward { };


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

_asitop_ is a Terminal UI (TUI) which provides visualisations for macOS's [`powermetrics`](https://developer.apple.com/library/archive/documentation/Performance/Conceptual/power_efficiency_guidelines_osx/PrioritizeWorkAtTheTaskLevel.html#//apple_ref/doc/uid/TP40013929-CH35-SW10) tool.

https://github.com/tlkh/asitop

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

This PR adds _dashing_ too, a dependency of _asitop_.

I successfully ran _asitop_ using `nix run .#asitop`.
