### PR TITLE
emacsPackages.color-theme-solarized: use packageRequires

### DIFF
--- a/pkgs/applications/editors/emacs/elisp-packages/manual-packages/color-theme-solarized/default.nix
+++ b/pkgs/applications/editors/emacs/elisp-packages/manual-packages/color-theme-solarized/default.nix
@@ -1,7 +1,6 @@
 { lib
 , trivialBuild
 , fetchFromGitHub
-, emacs
 , color-theme
 }:
 
@@ -16,23 +15,12 @@ trivialBuild {
     hash = "sha256-oxX0lo6sxotEiR3nPrKPE9H01HKB3ohB/p8eEHFTp5k=";
   };
 
-  buildInputs = [ emacs ];
-  propagatedUserEnvPkgs = [ color-theme ];
-
-  buildPhase = ''
-    runHook preBuild
-
-    emacs -L . -L ${color-theme}/share/emacs/site-lisp/elpa/color-theme-* \
-      --batch -f batch-byte-compile *.el
-
-    runHook postBuild
-  '';
+  packageRequires = [ color-theme ];
 
   meta = with lib; {
     homepage = "http://ethanschoonover.com/solarized";
     description = "Precision colors for machines and people; Emacs implementation";
     license = licenses.mit;
     maintainers = with maintainers; [ samuelrivas AndersonTorres ];
-    inherit (emacs.meta) platforms;
   };
 }


### PR DESCRIPTION
###### Description of changes



###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).