### PR TITLE
searxng: unstable-2023-03-13 -> unstable-2023-05-19

### DIFF
--- a/pkgs/servers/web-apps/searxng/default.nix
+++ b/pkgs/servers/web-apps/searxng/default.nix
@@ -5,13 +5,13 @@
 
 python3.pkgs.buildPythonApplication rec {
   pname = "searxng";
-  version = "unstable-2023-03-13";
+  version = "unstable-2023-05-19";
 
   src = fetchFromGitHub {
     owner = pname;
     repo = pname;
-    rev = "295c87a926c3deb1e438234550a9d8fbbaad17fa";
-    sha256 = "sha256-ItPFUyyuctx/yyMVUn5Ez9f+taNiV6FR0q9wz1jwk8M=";
+    rev = "d867bf17e6d2f9a7c83c9a1ffafda5184a24c0e3";
+    sha256 = "sha256-W7/8/3FzwErPkRlfuyqajova6LRKarANPtc6L/z20CI=";
   };
 
   postPatch = ''


### PR DESCRIPTION
###### Description of changes

Diff: https://github.com/searxng/searxng/compare/295c87a926c3deb1e438234550a9d8fbbaad17fa..d867bf17e6d2f9a7c83c9a1ffafda5184a24c0e3


###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).