### PR TITLE
woof: 2020-12-17 -> 2022-01-13

### DIFF
--- a/pkgs/tools/misc/woof/default.nix
+++ b/pkgs/tools/misc/woof/default.nix
@@ -1,24 +1,22 @@
 { lib, stdenv, fetchFromGitHub, python3 }:
 
-stdenv.mkDerivation rec {
-  version = "2020-12-17";
+stdenv.mkDerivation {
   pname = "woof";
+  version = "2022-01-13";
 
   src = fetchFromGitHub {
     owner = "simon-budig";
     repo = "woof";
-    rev = "4aab9bca5b80379522ab0bdc5a07e4d652c375c5";
-    sha256 = "0ypd2fs8isv6bqmlrdl2djgs5lnk91y1c3rn4ar6sfkpsqp9krjn";
+    rev = "f51e9db264118d4cbcd839348c4a6223fda49813";
+    sha256 = "sha256-tk55q2Ew2mZkQtkxjWCuNgt9t+UbjH4llIJ42IruqGY=";
   };
 
   propagatedBuildInputs = [ python3 ];
 
-  dontUnpack = true;
-
   installPhase = ''
-    mkdir -p $out/bin
-    cp $src/woof $out/bin/woof
-    chmod +x $out/bin/woof
+    runHook preInstall
+    install -Dm555 -t $out/bin woof
+    runHook postInstall
   '';
 
   meta = with lib; {
@@ -29,4 +27,3 @@ stdenv.mkDerivation rec {
     maintainers = with maintainers; [ matthiasbeyer ];
   };
 }
-


### PR DESCRIPTION
###### Description of changes

Diff: https://github.com/simon-budig/woof/compare/4aab9bca5b80379522ab0bdc5a07e4d652c375c5..f51e9db264118d4cbcd839348c4a6223fda49813


###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).