### PR TITLE
python311Packages.dsnap: init at 1.0.0

### DIFF
--- a/pkgs/development/python-modules/dsnap/default.nix
+++ b/pkgs/development/python-modules/dsnap/default.nix
@@ -1,0 +1,69 @@
+{ lib
+, aws-sam-cli
+, boto3
+, buildPythonPackage
+, cfn-lint
+, fetchFromGitHub
+, mock
+, moto
+, mypy-boto3-ebs
+, poetry-core
+, pytestCheckHook
+, pythonOlder
+, typer
+, urllib3
+}:
+
+buildPythonPackage rec {
+  pname = "dsnap";
+  version = "1.0.0";
+  format = "pyproject";
+
+  disabled = pythonOlder "3.7";
+
+  src = fetchFromGitHub {
+    owner = "RhinoSecurityLabs";
+    repo = "dsnap";
+    rev = "refs/tags/v${version}";
+    hash = "sha256-yKch+tKjFhvZfzloazMH378dkERF8gnZEX1Som+d670=";
+  };
+
+  nativeBuildInputs = [
+    poetry-core
+  ];
+
+  propagatedBuildInputs = [
+    boto3
+    urllib3
+  ];
+
+  passthru.optional-dependencies = {
+    cli = [
+      typer
+    ];
+    scannerd = [
+      aws-sam-cli
+      cfn-lint
+    ];
+  };
+
+  nativeCheckInputs = [
+    mock
+    moto
+    mypy-boto3-ebs
+    pytestCheckHook
+  ] ++ lib.flatten (builtins.attrValues passthru.optional-dependencies);
+
+  pythonImportsCheck = [
+    "dsnap"
+  ];
+
+  meta = with lib; {
+    description = "Utility for downloading and mounting EBS snapshots using the EBS Direct API's";
+    homepage = "https://github.com/RhinoSecurityLabs/dsnap";
+    changelog = "https://github.com/RhinoSecurityLabs/dsnap/releases/tag/v${version}";
+    license = licenses.bsd3;
+    maintainers = with maintainers; [ fab ];
+  };
+}
+

--- a/pkgs/development/python-modules/mypy-boto3-ebs/default.nix
+++ b/pkgs/development/python-modules/mypy-boto3-ebs/default.nix
@@ -1,0 +1,39 @@
+{ lib
+, boto3
+, buildPythonPackage
+, fetchPypi
+, pythonOlder
+, typing-extensions
+}:
+
+buildPythonPackage rec {
+  pname = "mypy-boto3-ebs";
+  version = "1.26.0";
+  format = "setuptools";
+
+  disabled = pythonOlder "3.7";
+
+  src = fetchPypi {
+    inherit pname version;
+    hash = "sha256-w15SM5F1IFtX4qDrMv5B7PItaTnXOOABg0aUU24onBk=";
+  };
+
+  propagatedBuildInputs = [
+    boto3
+    typing-extensions
+  ];
+
+  # Project has no tests
+  doCheck = false;
+
+  pythonImportsCheck = [
+    "mypy_boto3_ebs"
+  ];
+
+  meta = with lib; {
+    description = "Type annotations for boto3.s3";
+    homepage = "https://github.com/youtype/mypy_boto3_builder";
+    license = with licenses; [ mit ];
+    maintainers = with maintainers; [ fab ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -6483,6 +6483,8 @@ self: super: with self; {
 
   mypy-boto3-builder = callPackage ../development/python-modules/mypy-boto3-builder { };
 
+  mypy-boto3-ebs = callPackage ../development/python-modules/mypy-boto3-ebs { };
+
   mypy-boto3-s3 = callPackage ../development/python-modules/mypy-boto3-s3 { };
 
   mypy-extensions = callPackage ../development/python-modules/mypy/extensions.nix { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -3000,6 +3000,8 @@ self: super: with self; {
 
   dsmr-parser = callPackage ../development/python-modules/dsmr-parser { };
 
+  dsnap = callPackage ../development/python-modules/dsnap { };
+
   dtlssocket = callPackage ../development/python-modules/dtlssocket { };
 
   dtschema = callPackage ../development/python-modules/dtschema { };


### PR DESCRIPTION
###### Description of changes
Utility for downloading and mounting EBS snapshots using the EBS Direct API's"

https://github.com/RhinoSecurityLabs/dsnap
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
