### PR TITLE
girsh: init at 0.41

### DIFF
--- a/pkgs/tools/networking/girsh/default.nix
+++ b/pkgs/tools/networking/girsh/default.nix
@@ -1,0 +1,35 @@
+{ lib
+, buildGoModule
+, fetchFromGitHub
+}:
+
+buildGoModule rec {
+  pname = "girsh";
+  version = "0.41";
+
+  src = fetchFromGitHub {
+    owner = "nodauf";
+    repo = "Girsh";
+    rev = "refs/tags/v${version}";
+    hash = "sha256-MgzIBag0Exoh0TXW/AD0lbSOj7PVkMeVYQ8v5jdCgAs=";
+  };
+
+  vendorHash = "sha256-8NPFohguMX/X1khEPF+noLBNe/MUoPpXS2PN6SiotL8=";
+
+  ldflags = [
+    "-s"
+    "-w"
+  ];
+
+  postInstall = ''
+    mv $out/bin/src $out/bin/$pname
+  '';
+
+  meta = with lib; {
+    description = "Automatically spawn a reverse shell fully interactive for Linux or Windows victim";
+    homepage = "https://github.com/nodauf/Girsh";
+    changelog = "https://github.com/nodauf/Girsh/releases/tag/v${version}";
+    license = licenses.gpl2Only;
+    maintainers = with maintainers; [ fab ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5015,6 +5015,8 @@ with pkgs;
 
   gir-rs = callPackage ../development/tools/gir { };
 
+  girsh = callPackage ../tools/networking/girsh { };
+
   gist = callPackage ../tools/text/gist { };
 
   gitjacker = callPackage ../tools/security/gitjacker { };


### PR DESCRIPTION
###### Description of changes
Automatically spawn a reverse shell fully interactive for Linux or Windows victim

https://github.com/nodauf/Girsh

Related to https://github.com/NixOS/nixpkgs/issues/81418
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
