### PR TITLE
clipboard-jh: fixed broken system clipboard integration

### DIFF
--- a/pkgs/tools/misc/clipboard-jh/default.nix
+++ b/pkgs/tools/misc/clipboard-jh/default.nix
@@ -4,6 +4,7 @@
 , cmake
 , libffi
 , pkg-config
+, patchelf
 , wayland-protocols
 , wayland
 , xorg
@@ -44,6 +45,10 @@ stdenv.mkDerivation rec {
     "-Wno-dev"
     "-DINSTALL_PREFIX=${placeholder "out"}"
   ];
+
+  postFixup = lib.optionalString stdenv.isLinux ''
+    patchelf $out/bin/cb --add-rpath $out/lib
+  '';
 
   meta = with lib; {
     description = "Cut, copy, and paste anything, anywhere, all from the terminal";


### PR DESCRIPTION
fixes https://github.com/NixOS/nixpkgs/issues/229659 as well as https://github.com/Slackadays/Clipboard/discussions/117

###### Description of changes

- fixed rpath of `$out/bin/cb` by adding `$out/lib` explicitly via patchelf
- added patchelf dependency, obviously

###### Things done

Tested on my machine (x11, kde), works as previously but now one can e.g. write `cb p | cat` with something in system clipboard and it will actually be pasted. Should work fine on wayland as well.

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).