### PR TITLE
python38Packages.eth-hash: fix the build by not depending on safe-pysha3

### DIFF
--- a/pkgs/development/python-modules/eth-hash/default.nix
+++ b/pkgs/development/python-modules/eth-hash/default.nix
@@ -1,6 +1,7 @@
 { lib
 , fetchFromGitHub
 , buildPythonPackage
+, pythonAtLeast
 , pythonOlder
 , pytest
 , safe-pysha3
@@ -22,10 +23,14 @@ buildPythonPackage rec {
   nativeCheckInputs = [
     pytest
   ] ++ passthru.optional-dependencies.pycryptodome
-  ++ passthru.optional-dependencies.pysha3;
+  # eth-hash can use either safe-pysha3 or pycryptodome;
+  # safe-pysha3 requires Python 3.9+ while pycryptodome does not.
+  # https://github.com/ethereum/eth-hash/issues/46#issuecomment-1314029211
+  ++ lib.optional (pythonAtLeast "3.9") passthru.optional-dependencies.pysha3;
 
   checkPhase = ''
     pytest tests/backends/pycryptodome/
+  '' + lib.optionalString (pythonAtLeast "3.9") ''
     pytest tests/backends/pysha3/
   '';
 

--- a/pkgs/development/python-modules/matplotlib/default.nix
+++ b/pkgs/development/python-modules/matplotlib/default.nix
@@ -80,7 +80,7 @@ buildPythonPackage rec {
   pname = "matplotlib";
   format = "pyproject";
 
-  disabled = pythonOlder "3.9";
+  disabled = pythonOlder "3.8";
 
   src = fetchPypi {
     inherit pname version;


### PR DESCRIPTION
eth-hash works with both pycryptodome and safe-pysha3 (https://github.com/ethereum/eth-hash/issues/46#issuecomment-1314029211); pycryptodome builds on Python 3.8, while safe-pysha3 requires Python 3.9+.

This fixes the build of grab-site, which is still stuck on Python 3.8, and depends on eth-hash through its autobahn dependency.

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

cc maintainer @SuperSandro2000
cc @nevivurn @wegank 
