### PR TITLE
gitlab-container-registry: init at 3.74.0

### DIFF
--- a/pkgs/applications/version-management/gitlab/gitlab-container-registry/default.nix
+++ b/pkgs/applications/version-management/gitlab/gitlab-container-registry/default.nix
@@ -1,0 +1,30 @@
+{ lib, buildGoModule, fetchFromGitLab }:
+
+buildGoModule rec {
+  pname = "gitlab-container-registry";
+  version = "3.74.0";
+  rev = "v${version}-gitlab";
+
+  src = fetchFromGitLab {
+    owner = "gitlab-org";
+    repo = "container-registry";
+    inherit rev;
+    sha256 = "sha256-fwMu45OFfNgFgMyQFWfvmM3Qv+co1ofsZLL44OoW9Wo=";
+  };
+
+  vendorHash = "sha256-9rO2GmoFZrNA3Udaktn8Ek9uM8EEoc0I3uv4UEq1c1k=";
+
+  postPatch = ''
+    substituteInPlace health/checks/checks_test.go \
+      --replace \
+        'func TestHTTPChecker(t *testing.T) {' \
+        'func TestHTTPChecker(t *testing.T) { t.Skip("Test requires network connection")'
+  '';
+
+  meta = with lib; {
+    description = "The GitLab Docker toolset to pack, ship, store, and deliver content";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ yayayayaka xanderio ];
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/applications/version-management/gitlab/update.py
+++ b/pkgs/applications/version-management/gitlab/update.py
@@ -14,15 +14,17 @@ from typing import Iterable
 
 import requests
 
-NIXPKGS_PATH = pathlib.Path(__file__).parent / '../../../../'
+NIXPKGS_PATH = pathlib.Path(__file__).parent / "../../../../"
 GITLAB_DIR = pathlib.Path(__file__).parent
 
 logger = logging.getLogger(__name__)
 click_log.basic_config(logger)
 
+
 class GitLabRepo:
     version_regex = re.compile(r"^v\d+\.\d+\.\d+(\-rc\d+)?(\-ee)?(\-gitlab)?")
-    def __init__(self, owner: str = 'gitlab-org', repo: str = 'gitlab'):
+
+    def __init__(self, owner: str = "gitlab-org", repo: str = "gitlab"):
         self.owner = owner
         self.repo = repo
 
@@ -40,17 +42,41 @@ class GitLabRepo:
         versions = list(filter(self.version_regex.match, tags))
 
         # sort, but ignore v, -ee and -gitlab for sorting comparisons
-        versions.sort(key=lambda x: Version(x.replace("v", "").replace("-ee", "").replace("-gitlab", "")), reverse=True)
+        versions.sort(
+            key=lambda x: Version(
+                x.replace("v", "").replace("-ee", "").replace("-gitlab", "")
+            ),
+            reverse=True,
+        )
         return versions
 
     def get_git_hash(self, rev: str):
-        return subprocess.check_output(['nix-universal-prefetch', 'fetchFromGitLab', '--owner', self.owner, '--repo', self.repo, '--rev', rev]).decode('utf-8').strip()
+        return (
+            subprocess.check_output(
+                [
+                    "nix-universal-prefetch",
+                    "fetchFromGitLab",
+                    "--owner",
+                    self.owner,
+                    "--repo",
+                    self.repo,
+                    "--rev",
+                    rev,
+                ]
+            )
+            .decode("utf-8")
+            .strip()
+        )
 
     def get_yarn_hash(self, rev: str):
         with tempfile.TemporaryDirectory() as tmp_dir:
-            with open(tmp_dir + '/yarn.lock', 'w') as f:
-                f.write(self.get_file('yarn.lock', rev))
-            return subprocess.check_output(['prefetch-yarn-deps', tmp_dir + '/yarn.lock']).decode('utf-8').strip()
+            with open(tmp_dir + "/yarn.lock", "w") as f:
+                f.write(self.get_file("yarn.lock", rev))
+            return (
+                subprocess.check_output(["prefetch-yarn-deps", tmp_dir + "/yarn.lock"])
+                .decode("utf-8")
+                .strip()
+            )
 
     @staticmethod
     def rev2version(tag: str) -> str:
@@ -61,9 +87,9 @@ class GitLabRepo:
         :return: a normalized version number
         """
         # strip v prefix
-        version = re.sub(r"^v", '', tag)
+        version = re.sub(r"^v", "", tag)
         # strip -ee and -gitlab suffixes
-        return re.sub(r"-(ee|gitlab)$", '', version)
+        return re.sub(r"-(ee|gitlab)$", "", version)
 
     def get_file(self, filepath, rev):
         """
@@ -77,29 +103,39 @@ class GitLabRepo:
     def get_data(self, rev):
         version = self.rev2version(rev)
 
-        passthru = {v: self.get_file(v, rev).strip() for v in ['GITALY_SERVER_VERSION', 'GITLAB_PAGES_VERSION',
-                                                               'GITLAB_SHELL_VERSION']}
+        passthru = {
+            v: self.get_file(v, rev).strip()
+            for v in [
+                "GITALY_SERVER_VERSION",
+                "GITLAB_PAGES_VERSION",
+                "GITLAB_SHELL_VERSION",
+            ]
+        }
 
         passthru["GITLAB_WORKHORSE_VERSION"] = version
 
-        return dict(version=self.rev2version(rev),
-                    repo_hash=self.get_git_hash(rev),
-                    yarn_hash=self.get_yarn_hash(rev),
-                    owner=self.owner,
-                    repo=self.repo,
-                    rev=rev,
-                    passthru=passthru)
+        return dict(
+            version=self.rev2version(rev),
+            repo_hash=self.get_git_hash(rev),
+            yarn_hash=self.get_yarn_hash(rev),
+            owner=self.owner,
+            repo=self.repo,
+            rev=rev,
+            passthru=passthru,
+        )
 
 
 def _get_data_json():
-    data_file_path = pathlib.Path(__file__).parent / 'data.json'
-    with open(data_file_path, 'r') as f:
+    data_file_path = pathlib.Path(__file__).parent / "data.json"
+    with open(data_file_path, "r") as f:
         return json.load(f)
 
 
 def _call_nix_update(pkg, version):
     """calls nix-update from nixpkgs root dir"""
-    return subprocess.check_output(['nix-update', pkg, '--version', version], cwd=NIXPKGS_PATH)
+    return subprocess.check_output(
+        ["nix-update", pkg, "--version", version], cwd=NIXPKGS_PATH
+    )
 
 
 @click_log.simple_verbosity_option(logger)
@@ -108,8 +144,8 @@ def cli():
     pass
 
 
-@cli.command('update-data')
-@click.option('--rev', default='latest', help='The rev to use (vX.Y.Z-ee), or \'latest\'')
+@cli.command("update-data")
+@click.option("--rev", default="latest", help="The rev to use (vX.Y.Z-ee), or 'latest'")
 def update_data(rev: str):
     """Update data.json"""
     logger.info("Updating data.json")
@@ -117,18 +153,18 @@ def update_data(rev: str):
     repo = GitLabRepo()
     if rev == "latest":
         # filter out pre and rc releases
-        rev = next(filter(lambda x: not ('rc' in x or x.endswith('pre')), repo.tags))
+        rev = next(filter(lambda x: not ("rc" in x or x.endswith("pre")), repo.tags))
 
-    data_file_path = pathlib.Path(__file__).parent / 'data.json'
+    data_file_path = pathlib.Path(__file__).parent / "data.json"
 
     data = repo.get_data(rev)
 
-    with open(data_file_path.as_posix(), 'w') as f:
+    with open(data_file_path.as_posix(), "w") as f:
         json.dump(data, f, indent=2)
         f.write("\n")
 
 
-@cli.command('update-rubyenv')
+@cli.command("update-rubyenv")
 def update_rubyenv():
     """Update rubyEnv"""
     logger.info("Updating gitlab")
@@ -137,110 +173,137 @@ def update_rubyenv():
 
     # load rev from data.json
     data = _get_data_json()
-    rev = data['rev']
-    version = data['version']
+    rev = data["rev"]
+    version = data["version"]
 
-    for fn in ['Gemfile.lock', 'Gemfile']:
-        with open(rubyenv_dir / fn, 'w') as f:
+    for fn in ["Gemfile.lock", "Gemfile"]:
+        with open(rubyenv_dir / fn, "w") as f:
             f.write(repo.get_file(fn, rev))
 
     # patch for openssl 3.x support
-    subprocess.check_output(['sed', '-i', "s:'openssl', '2.*':'openssl', '3.0.2':g", 'Gemfile'], cwd=rubyenv_dir)
+    subprocess.check_output(
+        ["sed", "-i", "s:'openssl', '2.*':'openssl', '3.0.2':g", "Gemfile"],
+        cwd=rubyenv_dir,
+    )
 
     # Fetch vendored dependencies temporarily in order to build the gemset.nix
-    subprocess.check_output(['mkdir', '-p', 'vendor/gems'], cwd=rubyenv_dir)
-    subprocess.check_output(['sh', '-c', f'curl -L https://gitlab.com/gitlab-org/gitlab/-/archive/v{version}-ee/gitlab-v{version}-ee.tar.bz2?path=vendor/gems | tar -xj --strip-components=3'], cwd=f'{rubyenv_dir}/vendor/gems')
+    subprocess.check_output(["mkdir", "-p", "vendor/gems"], cwd=rubyenv_dir)
+    subprocess.check_output(
+        [
+            "sh",
+            "-c",
+            f"curl -L https://gitlab.com/gitlab-org/gitlab/-/archive/v{version}-ee/gitlab-v{version}-ee.tar.bz2?path=vendor/gems | tar -xj --strip-components=3",
+        ],
+        cwd=f"{rubyenv_dir}/vendor/gems",
+    )
 
     # Undo our gemset.nix patches so that bundix runs through
-    subprocess.check_output(['sed', '-i', '-e', '1d', '-e', 's:\\${src}/::g', 'gemset.nix'], cwd=rubyenv_dir)
+    subprocess.check_output(
+        ["sed", "-i", "-e", "1d", "-e", "s:\\${src}/::g", "gemset.nix"], cwd=rubyenv_dir
+    )
 
-    subprocess.check_output(['bundle', 'lock'], cwd=rubyenv_dir)
-    subprocess.check_output(['bundix'], cwd=rubyenv_dir)
+    subprocess.check_output(["bundle", "lock"], cwd=rubyenv_dir)
+    subprocess.check_output(["bundix"], cwd=rubyenv_dir)
 
-    subprocess.check_output(['sed', '-i', '-e', '1i\\src:', '-e', 's:path = \\(vendor/[^;]*\\);:path = "${src}/\\1";:g', 'gemset.nix'], cwd=rubyenv_dir)
-    subprocess.check_output(['rm', '-rf', 'vendor'], cwd=rubyenv_dir)
+    subprocess.check_output(
+        [
+            "sed",
+            "-i",
+            "-e",
+            "1i\\src:",
+            "-e",
+            's:path = \\(vendor/[^;]*\\);:path = "${src}/\\1";:g',
+            "gemset.nix",
+        ],
+        cwd=rubyenv_dir,
+    )
+    subprocess.check_output(["rm", "-rf", "vendor"], cwd=rubyenv_dir)
 
 
-
-@cli.command('update-gitaly')
+@cli.command("update-gitaly")
 def update_gitaly():
     """Update gitaly"""
     logger.info("Updating gitaly")
     data = _get_data_json()
-    gitaly_server_version = data['passthru']['GITALY_SERVER_VERSION']
-    repo = GitLabRepo(repo='gitaly')
-    gitaly_dir = pathlib.Path(__file__).parent / 'gitaly'
+    gitaly_server_version = data["passthru"]["GITALY_SERVER_VERSION"]
+    repo = GitLabRepo(repo="gitaly")
+    gitaly_dir = pathlib.Path(__file__).parent / "gitaly"
 
-    for fn in ['Gemfile.lock', 'Gemfile']:
-        with open(gitaly_dir / fn, 'w') as f:
+    for fn in ["Gemfile.lock", "Gemfile"]:
+        with open(gitaly_dir / fn, "w") as f:
             f.write(repo.get_file(f"ruby/{fn}", f"v{gitaly_server_version}"))
 
-    subprocess.check_output(['bundle', 'lock'], cwd=gitaly_dir)
-    subprocess.check_output(['bundix'], cwd=gitaly_dir)
+    subprocess.check_output(["bundle", "lock"], cwd=gitaly_dir)
+    subprocess.check_output(["bundix"], cwd=gitaly_dir)
 
-    _call_nix_update('gitaly', gitaly_server_version)
+    _call_nix_update("gitaly", gitaly_server_version)
 
 
-@cli.command('update-gitlab-pages')
+@cli.command("update-gitlab-pages")
 def update_gitlab_pages():
     """Update gitlab-pages"""
     logger.info("Updating gitlab-pages")
     data = _get_data_json()
-    gitlab_pages_version = data['passthru']['GITLAB_PAGES_VERSION']
-    _call_nix_update('gitlab-pages', gitlab_pages_version)
+    gitlab_pages_version = data["passthru"]["GITLAB_PAGES_VERSION"]
+    _call_nix_update("gitlab-pages", gitlab_pages_version)
+
 
 def get_container_registry_version() -> str:
     """Returns the version attribute of gitlab-container-registry"""
-    return str(subprocess.check_output(
-        [
-            'nix',
-            '--experimental-features',
-            'nix-command',
-            'eval',
-            '-f',
-            '.',
-            '--raw',
-            'gitlab-container-registry.version'
-        ],
-        cwd=NIXPKGS_PATH
-    ))
+    return str(
+        subprocess.check_output(
+            [
+                "nix",
+                "--experimental-features",
+                "nix-command",
+                "eval",
+                "-f",
+                ".",
+                "--raw",
+                "gitlab-container-registry.version",
+            ],
+            cwd=NIXPKGS_PATH,
+        )
+    )
 
 
-@cli.command('update-gitlab-shell')
+@cli.command("update-gitlab-shell")
 def update_gitlab_shell():
     """Update gitlab-shell"""
     logger.info("Updating gitlab-shell")
     data = _get_data_json()
-    gitlab_shell_version = data['passthru']['GITLAB_SHELL_VERSION']
-    _call_nix_update('gitlab-shell', gitlab_shell_version)
+    gitlab_shell_version = data["passthru"]["GITLAB_SHELL_VERSION"]
+    _call_nix_update("gitlab-shell", gitlab_shell_version)
 
 
-@cli.command('update-gitlab-workhorse')
+@cli.command("update-gitlab-workhorse")
 def update_gitlab_workhorse():
     """Update gitlab-workhorse"""
     logger.info("Updating gitlab-workhorse")
     data = _get_data_json()
-    gitlab_workhorse_version = data['passthru']['GITLAB_WORKHORSE_VERSION']
-    _call_nix_update('gitlab-workhorse', gitlab_workhorse_version)
+    gitlab_workhorse_version = data["passthru"]["GITLAB_WORKHORSE_VERSION"]
+    _call_nix_update("gitlab-workhorse", gitlab_workhorse_version)
 
 
-@cli.command('update-gitlab-container-registry')
-@click.option('--rev', default='latest', help='The rev to use (vX.Y.Z-ee), or \'latest\'')
+@cli.command("update-gitlab-container-registry")
+@click.option("--rev", default="latest", help="The rev to use (vX.Y.Z-ee), or 'latest'")
 def update_gitlab_container_registry(rev: str):
     """Update gitlab-container-registry"""
     logger.info("Updading gitlab-container-registry")
     repo = GitLabRepo(repo="container-registry")
 
     if rev == "latest":
-        rev = next(filter(lambda x: not ('rc' in x or x.endswith('pre')), repo.tags))
+        rev = next(filter(lambda x: not ("rc" in x or x.endswith("pre")), repo.tags))
 
     version = repo.rev2version(rev)
-    _call_nix_update('gitlab-container-registry', version)
+    _call_nix_update("gitlab-container-registry", version)
 
 
-@cli.command('update-all')
-@click.option('--rev', default='latest', help='The rev to use (vX.Y.Z-ee), or \'latest\'')
-@click.option('--commit', is_flag=True, default=False, help='Commit the changes for you')
+@cli.command("update-all")
+@click.option("--rev", default="latest", help="The rev to use (vX.Y.Z-ee), or 'latest'")
+@click.option(
+    "--commit", is_flag=True, default=False, help="Commit the changes for you"
+)
 @click.pass_context
 def update_all(ctx, rev: str, commit: bool):
     """Update all gitlab components to the latest stable release"""
@@ -257,44 +320,57 @@ def update_all(ctx, rev: str, commit: bool):
     ctx.invoke(update_gitlab_shell)
     ctx.invoke(update_gitlab_workhorse)
     if commit:
-        commit_gitlab(old_data_json['version'], new_data_json['version'], new_data_json['rev'])
+        commit_gitlab(
+            old_data_json["version"], new_data_json["version"], new_data_json["rev"]
+        )
 
     ctx.invoke(update_gitlab_container_registry)
     if commit:
         new_container_registry_version = get_container_registry_version()
-        commit_container_registry(old_container_registry_version, new_container_registry_version)
+        commit_container_registry(
+            old_container_registry_version, new_container_registry_version
+        )
+
 
 def commit_gitlab(old_version: str, new_version: str, new_rev: str) -> None:
     """Commits the gitlab changes for you"""
     subprocess.run(
-        ['git', 'add', 'data.json', 'rubyEnv', 'gitaly', 'gitlab-pages', 'gitlab-shell', 'gitlab-workhorse'],
-        cwd=GITLAB_DIR
+        [
+            "git",
+            "add",
+            "data.json",
+            "rubyEnv",
+            "gitaly",
+            "gitlab-pages",
+            "gitlab-shell",
+            "gitlab-workhorse",
+        ],
+        cwd=GITLAB_DIR,
     )
     subprocess.run(
         [
-            'git',
-            'commit',
-            '--message',
-            f'''gitlab: {old_version} -> {new_version}\n\nhttps://gitlab.com/gitlab-org/gitlab/-/blob/{new_rev}/CHANGELOG.md'''
+            "git",
+            "commit",
+            "--message",
+            f"""gitlab: {old_version} -> {new_version}\n\nhttps://gitlab.com/gitlab-org/gitlab/-/blob/{new_rev}/CHANGELOG.md""",
         ],
-        cwd=GITLAB_DIR
+        cwd=GITLAB_DIR,
     )
+
 
 def commit_container_registry(old_version: str, new_version: str) -> None:
     """Commits the gitlab-container-registry changes for you"""
-    subprocess.run(
-        ['git', 'add', 'gitlab-container-registry'],
-        cwd=GITLAB_DIR
-    )
+    subprocess.run(["git", "add", "gitlab-container-registry"], cwd=GITLAB_DIR)
     subprocess.run(
         [
-            'git',
-            'commit',
-            '--message',
-            f"gitlab-container-registry: {old_version} -> {new_version}"
+            "git",
+            "commit",
+            "--message",
+            f"gitlab-container-registry: {old_version} -> {new_version}",
         ],
-        cwd=GITLAB_DIR
+        cwd=GITLAB_DIR,
     )
 
-if __name__ == '__main__':
+
+if __name__ == "__main__":
     cli()

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7921,6 +7921,8 @@ with pkgs;
 
   gitlab-clippy = callPackage ../development/tools/rust/gitlab-clippy { };
 
+  gitlab-container-registry = callPackage ../applications/version-management/gitlab/gitlab-container-registry { };
+
   gitlab-pages = callPackage ../applications/version-management/gitlab/gitlab-pages { };
 
   gitlab-runner = callPackage ../development/tools/continuous-integration/gitlab-runner { };


### PR DESCRIPTION
With version 15.8 GitLab deprecates the use of an "external" container registry (in our case `pkgs.docker-distribution`). With version GitLab 16 the usage of an external registry is not possible anymore. The external registry will be replaced with this fork that contains extra functionality that GitLab uses internally. See https://gitlab.com/gitlab-org/container-registry/-/blob/master/docs-gitlab/README.md

This PR only adds the package. Integrating this new registry into our gitlab module will be done when we upgrade GitLab to 16.0.x.

Thanks @xanderio for the initial effort in #213552 :heart: 

###### Description of changes
- Add `pkgs.gitlab-container-registry`
- Make it possible to update `gitlab-container-registry`through our `update.py`
- Add an optional `--commit` flag to `update.py` to let the script commit the changes for you
- Reformat `update.py` script with `black`
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
