### PR TITLE
spamassassin: 3.4.6 → 4.0.0

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2311.section.md
+++ b/nixos/doc/manual/release-notes/rl-2311.section.md
@@ -50,6 +50,8 @@
 
 - `services.lemmy.settings.federation` was removed in 0.17.0 and no longer has any effect. To enable federation, the hostname must be set in the configuration file and then federation must be enabled in the admin web UI. See the [release notes](https://github.com/LemmyNet/lemmy/blob/c32585b03429f0f76d1e4ff738786321a0a9df98/RELEASES.md#upgrade-instructions) for more details.
 
+- `spamassassin` no longer supports the `Hashcash` module. The module needs to be removed from the `loadplugin` list if it was copied over from the default `initPreConf` option.
+
 ## Other Notable Changes {#sec-release-23.11-notable-changes}
 
 - The Cinnamon module now enables XDG desktop integration by default. If you are experiencing collisions related to xdg-desktop-portal-gtk you can safely remove `xdg.portal.extraPortals = [ pkgs.xdg-desktop-portal-gtk ];` from your NixOS configuration.

--- a/nixos/modules/services/mail/spamassassin.nix
+++ b/nixos/modules/services/mail/spamassassin.nix
@@ -77,6 +77,7 @@ in
           loadplugin Mail::SpamAssassin::Plugin::Check
           #loadplugin Mail::SpamAssassin::Plugin::DCC
           loadplugin Mail::SpamAssassin::Plugin::DKIM
+          loadplugin Mail::SpamAssassin::Plugin::DMARC
           loadplugin Mail::SpamAssassin::Plugin::DNSEval
           loadplugin Mail::SpamAssassin::Plugin::FreeMail
           loadplugin Mail::SpamAssassin::Plugin::HeaderEval

--- a/nixos/modules/services/mail/spamassassin.nix
+++ b/nixos/modules/services/mail/spamassassin.nix
@@ -79,7 +79,6 @@ in
           loadplugin Mail::SpamAssassin::Plugin::DKIM
           loadplugin Mail::SpamAssassin::Plugin::DNSEval
           loadplugin Mail::SpamAssassin::Plugin::FreeMail
-          loadplugin Mail::SpamAssassin::Plugin::Hashcash
           loadplugin Mail::SpamAssassin::Plugin::HeaderEval
           loadplugin Mail::SpamAssassin::Plugin::HTMLEval
           loadplugin Mail::SpamAssassin::Plugin::HTTPSMismatch

--- a/pkgs/servers/mail/spamassassin/default.nix
+++ b/pkgs/servers/mail/spamassassin/default.nix
@@ -1,4 +1,4 @@
-{ lib, fetchurl, perlPackages, makeWrapper, gnupg, re2c, gcc, gnumake, libxcrypt, coreutils, poppler_utils, tesseract, iana-etc }:
+{ lib, fetchurl, perlPackages, makeWrapper, gnupg, re2c, gcc, gnumake, libxcrypt, openssl, coreutils, poppler_utils, tesseract, iana-etc }:
 
 perlPackages.buildPerlPackage rec {
   pname = "SpamAssassin";
@@ -21,11 +21,13 @@ perlPackages.buildPerlPackage rec {
     Razor2ClientAgent MailSPF NetDNSResolverProgrammable Socket6
     ArchiveZip EmailAddressXS NetLibIDN2 MaxMindDBReader GeoIP MailDMARC
     MaxMindDBReaderXS
-  ]);
+  ]) ++ [
+    openssl
+  ];
 
   # Enabling 'taint' mode is desirable, but that flag disables support
   # for the PERL5LIB environment variable. Needs further investigation.
-  makeFlags = [ "PERL_BIN=${perlPackages.perl}/bin/perl" "PERL_TAINT=no" ];
+  makeFlags = [ "PERL_BIN=${perlPackages.perl}/bin/perl" "PERL_TAINT=no" "ENABLE_SSL=yes" ];
 
   makeMakerFlags = [ "SYSCONFDIR=/etc LOCALSTATEDIR=/var/lib/spamassassin" ];
 

--- a/pkgs/servers/mail/spamassassin/default.nix
+++ b/pkgs/servers/mail/spamassassin/default.nix
@@ -9,14 +9,7 @@ perlPackages.buildPerlPackage rec {
     hash = "sha256-5aoXBQowvHK6qGr9xgSMrepNHsLsxh14dxegWbgxnog=";
   };
 
-  # ExtUtil::MakeMaker is bundled with Perl, but the bundled version
-  # causes build errors for aarch64-darwin, so we override it with the
-  # latest version.  We can drop the dependency to go back to the
-  # bundled version when the version that comes with Perl is ≥7.57_02.
-  #
-  # Check the version bundled with Perl like this:
-  #   perl -e 'use ExtUtils::MakeMaker qw($VERSION); print "$VERSION\n"'
-  nativeBuildInputs = [ makeWrapper perlPackages.ExtUtilsMakeMaker ];
+  nativeBuildInputs = [ makeWrapper ];
   buildInputs = (with perlPackages; [
     HTMLParser NetCIDRLite NetDNS NetAddrIP DBFile HTTPDate MailDKIM LWP
     LWPProtocolHttps IOSocketSSL DBI EncodeDetect IPCountry NetIdent

--- a/pkgs/servers/mail/spamassassin/default.nix
+++ b/pkgs/servers/mail/spamassassin/default.nix
@@ -1,12 +1,12 @@
-{ lib, fetchurl, perlPackages, makeWrapper, gnupg, re2c, gcc, gnumake }:
+{ lib, fetchurl, perlPackages, makeWrapper, gnupg, re2c, gcc, gnumake, libxcrypt }:
 
 perlPackages.buildPerlPackage rec {
   pname = "SpamAssassin";
-  version = "3.4.6";
+  version = "4.0.0";
 
   src = fetchurl {
     url = "mirror://apache/spamassassin/source/Mail-${pname}-${version}.tar.bz2";
-    sha256 = "044ng2aazqy8g0m17q0a4939ck1ca4x230q2q7q7jndvwkrpaj5w";
+    hash = "sha256-5aoXBQowvHK6qGr9xgSMrepNHsLsxh14dxegWbgxnog=";
   };
 
   # ExtUtil::MakeMaker is bundled with Perl, but the bundled version
@@ -36,7 +36,7 @@ perlPackages.buildPerlPackage rec {
     mv "rules/"* $out/share/spamassassin/
 
     for n in "$out/bin/"*; do
-      wrapProgram "$n" --prefix PERL5LIB : "$PERL5LIB" --prefix PATH : ${lib.makeBinPath [ gnupg re2c gcc gnumake ]}
+      wrapProgram "$n" --prefix PERL5LIB : "$PERL5LIB" --prefix PATH : ${lib.makeBinPath [ gnupg re2c gcc gnumake ]} --prefix C_INCLUDE_PATH : ${lib.makeSearchPathOutput "include" "include" [ libxcrypt ]}
     done
   '';
 

--- a/pkgs/servers/mail/spamassassin/default.nix
+++ b/pkgs/servers/mail/spamassassin/default.nix
@@ -14,6 +14,8 @@ perlPackages.buildPerlPackage rec {
     HTMLParser NetCIDRLite NetDNS NetAddrIP DBFile HTTPDate MailDKIM LWP
     LWPProtocolHttps IOSocketSSL DBI EncodeDetect IPCountry NetIdent
     Razor2ClientAgent MailSPF NetDNSResolverProgrammable Socket6
+    ArchiveZip EmailAddressXS NetLibIDN2 MaxMindDBReader GeoIP MailDMARC
+    MaxMindDBReaderXS
   ]);
 
   # Enabling 'taint' mode is desirable, but that flag disables support

--- a/pkgs/servers/mail/spamassassin/sa_compile-use-perl5lib.patch
+++ b/pkgs/servers/mail/spamassassin/sa_compile-use-perl5lib.patch
@@ -1,0 +1,23 @@
+diff -ru orig/t/sa_compile.t new/t/sa_compile.t
+--- orig/t/sa_compile.t	2022-12-14 06:03:26.000000000 +0000
++++ new/t/sa_compile.t	2023-06-25 12:30:39.735577152 +0000
+@@ -40,7 +40,7 @@
+ 
+ # we now have an "installed" version we can run sa-compile with.  Ensure
+ # sarun() will use it appropriately
+-$scr = "$instdir/$temp_binpath/spamassassin";
++$scr = "$perl_cmd -T $instdir/$temp_binpath/spamassassin";
+ $scr_localrules_args = $scr_cf_args = "";      # use the default rules dir, from our "install"
+ 
+ &set_rules('
+@@ -86,8 +86,8 @@
+ # -------------------------------------------------------------------
+ 
+ rmtree( glob "~/.spamassassin/sa-compile.cache". { safe => 1 }); # reset test
+-system_or_die "TMP=$instdir TMPDIR=$instdir $instdir/$temp_binpath/sa-compile --quiet -p $cwd/$workdir/user.cf --keep-tmps -D 2>$instdir/sa-compile.debug";  # --debug
+-$scr = "$instdir/$temp_binpath/spamassassin";
++system_or_die "TMP=$instdir TMPDIR=$instdir $perl_cmd -T $instdir/$temp_binpath/sa-compile --quiet -p $cwd/$workdir/user.cf --keep-tmps -D 2>$instdir/sa-compile.debug";  # --debug
++$scr = "$perl_cmd -T $instdir/$temp_binpath/spamassassin";
+ $scr_localrules_args = $scr_cf_args = "";      # use the default rules dir, from our "install"
+ 
+ %patterns = (

--- a/pkgs/servers/mail/spamassassin/satest-no-clean-path.patch
+++ b/pkgs/servers/mail/spamassassin/satest-no-clean-path.patch
@@ -1,0 +1,18 @@
+diff -ru orig/t/SATest.pm new/t/SATest.pm
+--- orig/t/SATest.pm	2023-06-25 11:26:27.663204415 +0000
++++ new/t/SATest.pm	2023-06-25 11:34:08.902174669 +0000
+@@ -65,9 +65,12 @@
+ 
+   # Clean PATH so taint doesn't complain
+   if (!$RUNNING_ON_WINDOWS) {
+-    $ENV{'PATH'} = '/bin:/usr/bin:/usr/local/bin';
++    # untaint PATH
++    $ENV{'PATH'} =~ /^(.+)$/;
++    $ENV{'PATH'} = $1;
++    # $ENV{'PATH'} = '/bin:/usr/bin:/usr/local/bin';
+     # Remove tainted envs, at least ENV used in FreeBSD
+-    delete @ENV{qw(IFS CDPATH ENV BASH_ENV)};
++    # delete @ENV{qw(IFS CDPATH ENV BASH_ENV)};
+   } else {
+     # Windows might need non-system directories in PATH to run a Perl installation
+     # The best we can do is clean out obviously bad stuff such as relative paths or \..\

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -18001,6 +18001,21 @@ with self; {
     };
   };
 
+  NetLibIDN2 = buildPerlModule {
+    pname = "Net-LibIDN2";
+    version = "1.02";
+    src = fetchurl {
+      url = "mirror://cpan/authors/id/T/TH/THOR/Net-LibIDN2-1.02.tar.gz";
+      hash = "sha256-0fMK/GrPplQbAMCafkx059jkuknjJ3wLvEGuNcE5DQc=";
+    };
+    propagatedBuildInputs = [ pkgs.libidn2 ];
+    meta = {
+      description = "Perl bindings for GNU Libidn2";
+      homepage = "https://github.com/gnuthor/Net--LibIDN2";
+      license = with lib.licenses; [ artistic1 gpl1Plus ];
+    };
+  };
+
   NetNetmask = buildPerlPackage {
     pname = "Net-Netmask";
     version = "2.0001";

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -14256,6 +14256,28 @@ with self; {
     };
   };
 
+  MailDMARC = buildPerlPackage {
+    pname = "Mail-DMARC";
+    version = "1.20230215";
+    src = fetchurl {
+      url = "mirror://cpan/authors/id/M/MB/MBRADSHAW/Mail-DMARC-1.20230215.tar.gz";
+      hash = "sha256-V9z1R1nLkkSOVukUE0D2E0QnTFjZ3WWqkKqczw5+uQM=";
+    };
+    buildInputs = [ ExtUtilsMakeMaker FileShareDirInstall ];
+    doCheck = false;  # uses actual DNS at runtime
+    checkInputs = [ XMLSAX XMLValidatorSchema TestException TestFileShareDir TestMore TestOutput ];
+    propagatedBuildInputs = [
+      ConfigTiny DBDSQLite DBIxSimple EmailMIME EmailSender Encode FileShareDir GetoptLong
+      IOCompress IO IOSocketSSL NetDNS NetIDNEncode NetIP NetSSLeay RegexpCommon Socket6
+      SysSyslog URI XMLLibXML
+    ];
+    meta = {
+      description = "Perl implementation of DMARC";
+      homepage = "https://github.com/msimerson/mail-dmarc";
+      license = with lib.licenses; [ artistic1 gpl1Plus ];
+    };
+  };
+
   MailMaildir = buildPerlPackage {
     version = "1.0.0";
     pname = "Mail-Maildir";


### PR DESCRIPTION
###### Description of changes

Update spamassassin from 3.4.6 to 4.0.0

The HashCash module has been removed, so this change also drops it from the default config for spamassassin.

Also add a dependency on libxcrypt to fix compilation of spam rules.

Fixes #215463

###### Things done

Technically there is a test in #215464 that would be fixed by this, but I have not tried to run it yet. There are currently no tests in the tree.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [x] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).