### PR TITLE
mailctl: init at 0.8.8

### DIFF
--- a/pkgs/tools/networking/mailctl/default.nix
+++ b/pkgs/tools/networking/mailctl/default.nix
@@ -1,0 +1,85 @@
+{ mkDerivation
+, fetchFromSourcehut
+, aeson
+, base
+, bytestring
+, containers
+, directory
+, hsyslog
+, http-conduit
+, lib
+, network-uri
+, optparse-applicative
+, pretty-simple
+, process
+, template-haskell
+, text
+, time
+, twain
+, utf8-string
+, warp
+, yaml
+}:
+mkDerivation rec {
+  pname = "mailctl";
+  version = "0.8.8";
+
+  src = fetchFromSourcehut {
+    owner = "~petrus";
+    repo = "mailctl";
+    rev = version;
+    hash = "sha256-aFt6y2DzreROLcOLU8ynnSSVQW840T5wFqSRdSODQX4=";
+  };
+
+  isLibrary = true;
+  isExecutable = true;
+
+  libraryHaskellDepends = [
+    aeson
+    base
+    bytestring
+    containers
+    directory
+    hsyslog
+    http-conduit
+    network-uri
+    optparse-applicative
+    pretty-simple
+    process
+    template-haskell
+    text
+    time
+    twain
+    utf8-string
+    warp
+    yaml
+  ];
+
+  executableHaskellDepends = [
+    aeson
+    base
+    bytestring
+    containers
+    directory
+    hsyslog
+    http-conduit
+    network-uri
+    optparse-applicative
+    pretty-simple
+    process
+    template-haskell
+    text
+    time
+    twain
+    utf8-string
+    warp
+    yaml
+  ];
+
+  description = "OAuth2 tool for mail clients";
+  homepage = "https://sr.ht/~petrus/mailctl/";
+  changelog = "https://git.sr.ht/~petrus/mailctl/refs/${version}";
+  license = lib.licenses.bsd3;
+  maintainers = with lib.maintainers; [ aidalgol ];
+  mainProgram = "mailctl";
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2292,6 +2292,9 @@ with pkgs;
 
   mainsail = callPackage ../applications/misc/mainsail { };
 
+  # Does not build with default Haskell version because upstream uses a newer Cabal version.
+  mailctl = haskell.packages.ghc94.callPackage ../tools/networking/mailctl { };
+
   mame = libsForQt5.callPackage ../applications/emulators/mame { };
 
   mame-tools = lib.addMetaAttrs {


### PR DESCRIPTION
###### Description of changes
Add package [mailctl](https://github.com/pdobsan/mailctl).

###### Things done
- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).