### PR TITLE
elmPackages: nodejs_14 -> nodejs_18.

### DIFF
--- a/pkgs/development/compilers/elm/default.nix
+++ b/pkgs/development/compilers/elm/default.nix
@@ -1,10 +1,10 @@
-{ pkgs, lib, makeWrapper }:
+{ pkgs
+, lib
+, makeWrapper
+, nodejs ? pkgs.nodejs_18
+}:
 
 let
-
-  # To control nodejs version we pass down
-  nodejs = pkgs.nodejs_18;
-
   fetchElmDeps = pkgs.callPackage ./fetchElmDeps.nix { };
 
   # Haskell packages that require ghc 8.10
@@ -115,8 +115,7 @@ let
   };
 
   nodePkgs = pkgs.callPackage ./packages/node-composition.nix {
-    inherit pkgs;
-    nodejs = pkgs.nodejs_14;
+    inherit pkgs nodejs;
     inherit (pkgs.stdenv.hostPlatform) system;
   };
 
@@ -152,7 +151,8 @@ in lib.makeScope pkgs.newScope (self: with self; {
     };
   };
 } // (hs810Pkgs self).elmPkgs // (hs92Pkgs self).elmPkgs // (with elmLib; with (hs810Pkgs self).elmPkgs; {
-  elm-verify-examples = patchBinwrap [elmi-to-json] nodePkgs.elm-verify-examples // {
+  elm-verify-examples = let
+    patched = patchBinwrap [elmi-to-json] nodePkgs.elm-verify-examples // {
     meta = with lib; nodePkgs.elm-verify-examples.meta // {
       description = "Verify examples in your docs";
       homepage = "https://github.com/stoeffel/elm-verify-examples";
@@ -160,6 +160,14 @@ in lib.makeScope pkgs.newScope (self: with self; {
       maintainers = [ maintainers.turbomack ];
     };
   };
+  in patched.override (old: {
+    preRebuild = (old.preRebuild or "") + ''
+      # This should not be needed (thanks to binwrap* being nooped) but for some reason it still needs to be done
+      # in case of just this package
+      # TODO: investigate, same as for elm-coverage below
+      sed 's/\"install\".*/\"install\":\"echo no-op\",/g' --in-place node_modules/elmi-to-json/package.json
+    '';
+  });
 
   elm-coverage = let
       patched = patchNpmElm (patchBinwrap [elmi-to-json] nodePkgs.elm-coverage);


### PR DESCRIPTION
###### Description of changes

Follow-up to #230543, we were still using nodejs_14 for some packages (e.g. `elmPackages.elm-language-server`).

I also turned the node dependency into an input, so that it can be overriden, which is handy for local testing.

Ping @turboMaCk 

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
