### PR TITLE
fontfinder: init at 2.1.0

### DIFF
--- a/pkgs/applications/misc/fontfinder/default.nix
+++ b/pkgs/applications/misc/fontfinder/default.nix
@@ -1,0 +1,59 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, cargo
+, pkg-config
+, rustPlatform
+, rustc
+, wrapGAppsHook
+, gdk-pixbuf
+, gtk3
+, libsoup_3
+, webkitgtk_4_1
+}:
+
+stdenv.mkDerivation rec {
+  pname = "fontfinder";
+  version = "2.1.0";
+
+  src = fetchFromGitHub {
+    owner = "mmstick";
+    repo = "fontfinder";
+    rev = version;
+    hash = "sha256-C4KqEdqToVnPXFPWvNkl/md9L2W4NxRd5jvZ4E7CtfA=";
+  };
+
+  cargoDeps = rustPlatform.fetchCargoTarball {
+    inherit src;
+    name = "${pname}-${version}";
+    hash = "sha256-PXO8E41KHPNOR527gs2vM3J9JMG0PWi8Eg/13UCkr3U=";
+  };
+
+  nativeBuildInputs = [
+    cargo
+    pkg-config
+    rustPlatform.cargoSetupHook
+    rustc
+    wrapGAppsHook
+  ];
+
+  buildInputs = [
+    gdk-pixbuf
+    gtk3
+    libsoup_3
+    webkitgtk_4_1
+  ];
+
+  makeFlags = [
+    "prefix=$(out)"
+  ];
+
+  meta = with lib; {
+    description = "GTK application for browsing and installing fonts from Google's font archive";
+    homepage = "https://github.com/mmstick/fontfinder";
+    changelog = "https://github.com/mmstick/fontfinder/releases/tag/${src.rev}";
+    license = licenses.mit;
+    maintainers = with maintainers; [ figsoda ];
+    mainProgram = "fontfinder-gtk";
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -30339,6 +30339,8 @@ with pkgs;
 
   font-manager = callPackage ../applications/misc/font-manager { };
 
+  fontfinder = callPackage ../applications/misc/fontfinder { };
+
   fontpreview = callPackage ../applications/misc/fontpreview { };
 
   fossil = callPackage ../applications/version-management/fossil {


### PR DESCRIPTION
https://github.com/mmstick/fontfinder

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
