### PR TITLE
fwupd: 1.8.15 -> 1.9.2

### DIFF
--- a/nixos/modules/services/hardware/fwupd.nix
+++ b/nixos/modules/services/hardware/fwupd.nix
@@ -13,16 +13,13 @@ let
   };
 
   customEtc = {
-    "fwupd/daemon.conf" = {
-      source = format.generate "daemon.conf" {
+    "fwupd/fwupd.conf" = {
+      source = format.generate "fwupd.conf" {
         fwupd = cfg.daemonSettings;
-      };
-    };
-
-    "fwupd/uefi_capsule.conf" = {
-      source = format.generate "uefi_capsule.conf" {
         uefi_capsule = cfg.uefiCapsuleSettings;
       };
+      # fwupd tries to chmod the file if it doesn't have the right permissions
+      mode = "0640";
     };
   };
 

--- a/pkgs/os-specific/linux/firmware/fwupd/add-option-for-installation-sysconfdir.patch
+++ b/pkgs/os-specific/linux/firmware/fwupd/add-option-for-installation-sysconfdir.patch
@@ -1,5 +1,5 @@
 diff --git a/data/bios-settings.d/meson.build b/data/bios-settings.d/meson.build
-index b0ff5b106..13ac380d0 100644
+index b0ff5b10..13ac380d 100644
 --- a/data/bios-settings.d/meson.build
 +++ b/data/bios-settings.d/meson.build
 @@ -1,5 +1,5 @@
@@ -10,20 +10,20 @@ index b0ff5b106..13ac380d0 100644
  )
  endif
 diff --git a/data/meson.build b/data/meson.build
-index 865b20e26..ff1c2657b 100644
+index 8999ee57..b57174dc 100644
 --- a/data/meson.build
 +++ b/data/meson.build
 @@ -26,7 +26,7 @@ endif
- 
+
  if build_standalone
-   install_data(['daemon.conf'],
--    install_dir: join_paths(sysconfdir, 'fwupd')
-+    install_dir: join_paths(sysconfdir_install, 'fwupd')
+   install_data(['fwupd.conf'],
+-    install_dir: join_paths(sysconfdir, 'fwupd'),
++    install_dir: join_paths(sysconfdir_install, 'fwupd'),
+     install_mode: 'rw-r-----',
    )
    plugin_quirks += files([
-     'power.quirk',
 diff --git a/data/pki/meson.build b/data/pki/meson.build
-index 3649fecea..c3462744b 100644
+index 3649fece..c3462744 100644
 --- a/data/pki/meson.build
 +++ b/data/pki/meson.build
 @@ -12,13 +12,13 @@ install_data([
@@ -41,7 +41,7 @@ index 3649fecea..c3462744b 100644
 +  install_dir: join_paths(sysconfdir_install, 'pki', 'fwupd-metadata')
  )
  endif
- 
+
 @@ -26,11 +26,11 @@ if supported_pkcs7
  install_data([
      'LVFS-CA.pem',
@@ -57,7 +57,7 @@ index 3649fecea..c3462744b 100644
  )
  endif
 diff --git a/data/remotes.d/meson.build b/data/remotes.d/meson.build
-index c20a1a05e..87b1fa930 100644
+index c20a1a05..5354bac7 100644
 --- a/data/remotes.d/meson.build
 +++ b/data/remotes.d/meson.build
 @@ -15,14 +15,14 @@ if build_standalone and get_option('lvfs') != 'false'
@@ -77,7 +77,7 @@ index c20a1a05e..87b1fa930 100644
    )
    i18n.merge_file(
      input: 'lvfs.metainfo.xml',
-@@ -54,12 +54,12 @@ configure_file(
+@@ -56,12 +56,12 @@ configure_file(
    output: 'vendor.conf',
    configuration: con2,
    install: true,
@@ -93,13 +93,13 @@ index c20a1a05e..87b1fa930 100644
 +  install_dir: join_paths(sysconfdir_install, 'fwupd', 'remotes.d'),
  )
 diff --git a/meson.build b/meson.build
-index d3e08af43..30011f548 100644
+index fa7a5599..5b53a407 100644
 --- a/meson.build
 +++ b/meson.build
-@@ -193,6 +193,12 @@ endif
+@@ -191,6 +191,12 @@ endif
  mandir = join_paths(prefix, get_option('mandir'))
  localedir = join_paths(prefix, get_option('localedir'))
- 
+
 +if get_option('sysconfdir_install') != ''
 +  sysconfdir_install = join_paths(prefix, get_option('sysconfdir_install'))
 +else
@@ -109,8 +109,9 @@ index d3e08af43..30011f548 100644
  diffcmd = find_program('diff')
  gio = dependency('gio-2.0', version: '>= 2.45.8')
  giounix = dependency('gio-unix-2.0', version: '>= 2.45.8', required: false)
+
 diff --git a/meson_options.txt b/meson_options.txt
-index 204690640..6fc7e8437 100644
+index 81d373f8..d214cf64 100644
 --- a/meson_options.txt
 +++ b/meson_options.txt
 @@ -1,3 +1,4 @@
@@ -119,7 +120,7 @@ index 204690640..6fc7e8437 100644
  option('consolekit', type : 'feature', description : 'ConsoleKit support', deprecated: {'true': 'enabled', 'false': 'disabled'})
  option('static_analysis', type : 'boolean', value : false, description : 'enable GCC static analysis support')
 diff --git a/plugins/dell-esrt/meson.build b/plugins/dell-esrt/meson.build
-index 88c039f85..62a7691f3 100644
+index 88c039f8..62a7691f 100644
 --- a/plugins/dell-esrt/meson.build
 +++ b/plugins/dell-esrt/meson.build
 @@ -27,6 +27,6 @@ configure_file(
@@ -130,47 +131,8 @@ index 88c039f85..62a7691f3 100644
 +  install_dir: join_paths(sysconfdir_install, 'fwupd', 'remotes.d'),
  )
  endif
-diff --git a/plugins/msr/meson.build b/plugins/msr/meson.build
-index 23ec5ec82..b03826fc0 100644
---- a/plugins/msr/meson.build
-+++ b/plugins/msr/meson.build
-@@ -10,7 +10,7 @@ install_data(['fwupd-msr.conf'],
- endif
- 
- install_data(['msr.conf'],
--  install_dir: join_paths(sysconfdir, 'fwupd')
-+  install_dir: join_paths(sysconfdir_install, 'fwupd')
- )
- plugin_builtins += static_library('fu_plugin_msr',
-   sources: [
-diff --git a/plugins/redfish/meson.build b/plugins/redfish/meson.build
-index 1e35b6ce9..33ca1447f 100644
---- a/plugins/redfish/meson.build
-+++ b/plugins/redfish/meson.build
-@@ -35,7 +35,7 @@ plugin_builtin_redfish = static_library('fu_plugin_redfish',
- plugin_builtins += plugin_builtin_redfish
- 
- install_data(['redfish.conf'],
--  install_dir: join_paths(sysconfdir, 'fwupd'),
-+  install_dir: join_paths(sysconfdir_install, 'fwupd'),
-   install_mode: 'rw-r-----',
- )
- 
-diff --git a/plugins/thunderbolt/meson.build b/plugins/thunderbolt/meson.build
-index 71d930e62..399fb5781 100644
---- a/plugins/thunderbolt/meson.build
-+++ b/plugins/thunderbolt/meson.build
-@@ -19,7 +19,7 @@ plugin_builtin_thunderbolt = static_library('fu_plugin_thunderbolt',
- plugin_builtins += plugin_builtin_thunderbolt
- 
- install_data(['thunderbolt.conf'],
--  install_dir: join_paths(sysconfdir, 'fwupd')
-+  install_dir: join_paths(sysconfdir_install, 'fwupd')
- )
- # we use functions from 2.52 in the tests
- if get_option('tests') and run_sanitize_unsafe_tests and umockdev.found() and gio.version().version_compare('>= 2.52')
 diff --git a/plugins/uefi-capsule/meson.build b/plugins/uefi-capsule/meson.build
-index b4b038313..9c5407c3f 100644
+index f4657a6a..28ca0653 100644
 --- a/plugins/uefi-capsule/meson.build
 +++ b/plugins/uefi-capsule/meson.build
 @@ -20,7 +20,7 @@ if host_machine.system() == 'linux'
@@ -182,12 +144,5 @@ index b4b038313..9c5407c3f 100644
    )
  elif host_machine.system() == 'freebsd'
    backend_srcs += 'fu-uefi-backend-freebsd.c'
-@@ -87,7 +87,7 @@ if get_option('compat_cli') and get_option('man')
- endif
- 
- install_data(['uefi_capsule.conf'],
--  install_dir: join_paths(sysconfdir, 'fwupd')
-+  install_dir: join_paths(sysconfdir_install, 'fwupd')
- )
- 
- # add all the .po files as inputs to watch
+--
+2.40.1

--- a/pkgs/os-specific/linux/firmware/fwupd/default.nix
+++ b/pkgs/os-specific/linux/firmware/fwupd/default.nix
@@ -58,6 +58,7 @@
 
 let
   python = python3.withPackages (p: with p; [
+    jinja2
     pygobject3
     setuptools
   ]);
@@ -122,7 +123,7 @@ let
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "fwupd";
-  version = "1.8.15";
+  version = "1.9.1";
 
   # libfwupd goes to lib
   # daemon, plug-ins and libfwupdplugin go to out
@@ -133,7 +134,7 @@ stdenv.mkDerivation (finalAttrs: {
     owner = "fwupd";
     repo = "fwupd";
     rev = finalAttrs.version;
-    hash = "sha256-M7uCT8xJ6ym0X6iAgT3rM2ki0T6QgLJWlFU39aC64o4=";
+    hash = "sha256-9eUWt7zk6Vv2c+VDiKnWQ8Tn6uk70pyz6qDNcof1dyQ=";
   };
 
   patches = [
@@ -261,6 +262,7 @@ stdenv.mkDerivation (finalAttrs: {
   postPatch = ''
     patchShebangs \
       contrib/generate-version-script.py \
+      contrib/generate-man.py \
       po/test-deps
 
     substituteInPlace data/installed-tests/fwupdmgr-p2p.sh \
@@ -337,12 +339,11 @@ stdenv.mkDerivation (finalAttrs: {
   passthru = {
     filesInstalledToEtc = [
       "fwupd/bios-settings.d/README.md"
-      "fwupd/daemon.conf"
+      "fwupd/fwupd.conf"
       "fwupd/remotes.d/lvfs-testing.conf"
       "fwupd/remotes.d/lvfs.conf"
       "fwupd/remotes.d/vendor.conf"
       "fwupd/remotes.d/vendor-directory.conf"
-      "fwupd/uefi_capsule.conf"
       "pki/fwupd/GPG-KEY-Linux-Foundation-Firmware"
       "pki/fwupd/GPG-KEY-Linux-Vendor-Firmware-Service"
       "pki/fwupd/LVFS-CA.pem"
@@ -352,12 +353,6 @@ stdenv.mkDerivation (finalAttrs: {
       "grub.d/35_fwupd"
     ] ++ lib.optionals haveDell [
       "fwupd/remotes.d/dell-esrt.conf"
-    ] ++ lib.optionals haveRedfish [
-      "fwupd/redfish.conf"
-    ] ++ lib.optionals haveMSR [
-      "fwupd/msr.conf"
-    ] ++ lib.optionals isx86 [
-      "fwupd/thunderbolt.conf"
     ];
 
     # DisabledPlugins key in fwupd/daemon.conf
@@ -392,7 +387,7 @@ stdenv.mkDerivation (finalAttrs: {
           assert len(passthru_etc - package_etc) == 0, f'fwupd package lists the following paths in passthru.filesInstalledToEtc that are not contained in /etc: {passthru_etc - package_etc}'
 
           config = configparser.RawConfigParser()
-          config.read('${finalAttrs.finalPackage}/etc/fwupd/daemon.conf')
+          config.read('${finalAttrs.finalPackage}/etc/fwupd/fwupd.conf')
           package_disabled_plugins = config.get('fwupd', 'DisabledPlugins').rstrip(';').split(';')
           passthru_disabled_plugins = ${listToPy finalAttrs.passthru.defaultDisabledPlugins}
           assert package_disabled_plugins == passthru_disabled_plugins, f'Default disabled plug-ins in the package {package_disabled_plugins} do not match those listed in passthru.defaultDisabledPlugins {passthru_disabled_plugins}'

--- a/pkgs/os-specific/linux/firmware/fwupd/default.nix
+++ b/pkgs/os-specific/linux/firmware/fwupd/default.nix
@@ -123,7 +123,7 @@ let
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "fwupd";
-  version = "1.9.1";
+  version = "1.9.2";
 
   # libfwupd goes to lib
   # daemon, plug-ins and libfwupdplugin go to out
@@ -134,7 +134,7 @@ stdenv.mkDerivation (finalAttrs: {
     owner = "fwupd";
     repo = "fwupd";
     rev = finalAttrs.version;
-    hash = "sha256-9eUWt7zk6Vv2c+VDiKnWQ8Tn6uk70pyz6qDNcof1dyQ=";
+    hash = "sha256-ESBTT7KO4WZKS5ArXZI0pxQpfFK4h4HbClaITm5bxfU=";
   };
 
   patches = [


### PR DESCRIPTION
###### Description of changes

Release notes:
* https://github.com/fwupd/fwupd/releases/tag/1.9.1
* https://github.com/fwupd/fwupd/releases/tag/1.9.2

Ping @jtojnar @zhaofengli 

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
