### PR TITLE
org-stats: init at 1.11.2

### DIFF
--- a/pkgs/tools/misc/org-stats/default.nix
+++ b/pkgs/tools/misc/org-stats/default.nix
@@ -1,0 +1,62 @@
+{ lib
+, buildGoModule
+, fetchFromGitHub
+, substituteAll
+, installShellFiles
+, testers
+, org-stats
+}:
+
+buildGoModule rec {
+  pname = "org-stats";
+  version = "1.11.2";
+
+  src = fetchFromGitHub {
+    owner = "caarlos0";
+    repo = "org-stats";
+    rev = "v${version}";
+    hash = "sha256-b0Cfs4EqQOft/HNAoJvRriCMzNiOgYagBLiPYgsDgJM=";
+  };
+
+  vendorHash = "sha256-LKpnEXVfxBR3cebv46QontDVeA64MJe0vNiKSnTjLtQ=";
+
+  patches = [
+    # patch in version information
+    # since `debug.ReadBuildInfo` does not work with `go build
+    (substituteAll {
+      src = ./version.patch;
+      inherit version;
+    })
+  ];
+
+  nativeBuildInputs = [
+    installShellFiles
+  ];
+
+  ldflags = [ "-s" "-w" ];
+
+  postInstall = ''
+    $out/bin/org-stats man > org-stats.1
+    installManPage org-stats.1
+
+    installShellCompletion --cmd org-stats \
+      --bash <($out/bin/org-stats completion bash) \
+      --fish <($out/bin/org-stats completion fish) \
+      --zsh <($out/bin/org-stats completion zsh)
+  '';
+
+  passthru.tests = {
+    version = testers.testVersion {
+      package = org-stats;
+      command = "org-stats version";
+    };
+  };
+
+  meta = with lib; {
+    description = "Get the contributor stats summary from all repos of any given organization";
+    homepage = "https://github.com/caarlos0/org-stats";
+    changelog = "https://github.com/caarlos0/org-stats/releases/tag/${src.rev}";
+    license = licenses.mit;
+    maintainers = with maintainers; [ figsoda ];
+  };
+}

--- a/pkgs/tools/misc/org-stats/version.patch
+++ b/pkgs/tools/misc/org-stats/version.patch
@@ -1,0 +1,11 @@
+--- a/cmd/version.go
++++ b/cmd/version.go
+@@ -16,7 +16,7 @@ var versionCmd = &cobra.Command{
+ 			if sum == "" {
+ 				sum = "none"
+ 			}
+-			fmt.Printf("https://%s %s @ %s\n", info.Main.Path, info.Main.Version, sum)
++			fmt.Printf("https://%s %s @ %s\n", info.Main.Path, "@version@", sum)
+ 		} else {
+ 			fmt.Println("unknown")
+ 		}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10926,6 +10926,8 @@ with pkgs;
     autoreconfHook = buildPackages.autoreconfHook269;
   };
 
+  org-stats = callPackage ../tools/misc/org-stats { };
+
   orz = callPackage ../tools/compression/orz { };
 
   os-prober = callPackage ../tools/misc/os-prober { };


### PR DESCRIPTION
https://github.com/caarlos0/org-stats

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
