### PR TITLE
sickgear: 0.25.60 -> 3.29.3

### DIFF
--- a/pkgs/servers/sickbeard/patches/override-python-version-check.patch
+++ b/pkgs/servers/sickbeard/patches/override-python-version-check.patch
@@ -1,21 +1,12 @@
-From e97f418803c1db9a753fa755a9ee0cf04eabaed3 Mon Sep 17 00:00:00 2001
-From: rembo10 <rembo10@users.noreply.github.com>
-Date: Sun, 11 Sep 2022 13:00:29 +0530
-Subject: [PATCH] Allow running on unsupported Python versions
-
----
- sickgear.py | 5 +----
- 1 file changed, 1 insertion(+), 4 deletions(-)
-
 diff --git a/sickgear.py b/sickgear.py
-index 9d0440bb..6d65e65d 100755
+index c37e2b01..d69704a3 100755
 --- a/sickgear.py
 +++ b/sickgear.py
-@@ -43,10 +43,7 @@ versions = [((2, 7, 9), (2, 7, 18)), ((3, 7, 1), (3, 8, 14)),
-             ((3, 9, 0), (3, 9, 2)), ((3, 9, 4), (3, 9, 14)),
-             ((3, 10, 0), (3, 10, 7))]  # inclusive version ranges
+@@ -41,10 +41,7 @@ versions = [((3, 8, 0), (3, 8, 16)),
+             ((3, 10, 0), (3, 11, 3))]  # inclusive version ranges
  if not any(list(map(lambda v: v[0] <= sys.version_info[:3] <= v[1], versions))) and not int(os.environ.get('PYT', 0)):
--    print('Python %s.%s.%s detected.' % sys.version_info[:3])
+     major, minor, micro = sys.version_info[:3]
+-    print('Python %s.%s.%s detected.' % (major, minor, micro))
 -    print('Sorry, SickGear requires a Python version %s' % ', '.join(map(
 -        lambda r: '%s - %s' % tuple(map(lambda v: str(v).replace(',', '.')[1:-1], r)), versions)))
 -    sys.exit(1)
@@ -23,6 +14,3 @@ index 9d0440bb..6d65e65d 100755
  
  sys.path.insert(1, os.path.abspath(os.path.join(os.path.dirname(__file__), 'lib')))
  is_win = 'win' == sys.platform[0:3]
--- 
-2.37.2
-

--- a/pkgs/servers/sickbeard/sickgear.nix
+++ b/pkgs/servers/sickbeard/sickgear.nix
@@ -4,13 +4,13 @@ let
   pythonEnv = python3.withPackages(ps: with ps; [ cheetah3 lxml ]);
 in stdenv.mkDerivation rec {
   pname = "sickgear";
-  version = "0.25.60";
+  version = "3.29.3";
 
   src = fetchFromGitHub {
     owner = "SickGear";
     repo = "SickGear";
     rev = "release_${version}";
-    sha256 = "sha256-5I6hJgUN2BdHc80RrcmWWxdq0iz6rcO4aX16CDtwu/g=";
+    hash = "sha256-aPpzWGVQS7waPJXHSdL/6cBhARgpE7/uIdvSadvsB0A=";
   };
 
   patches = [
@@ -23,15 +23,12 @@ in stdenv.mkDerivation rec {
   nativeBuildInputs = [ makeWrapper ];
   buildInputs = [ pythonEnv libarchive ];
 
-  postPatch = ''
-    substituteInPlace sickgear.py --replace "/usr/bin/env python2" "/usr/bin/env python"
-  '';
-
   installPhase = ''
     mkdir -p $out/bin $out/opt/sickgear
-    cp -R {autoProcessTV,gui,lib,sickbeard,sickgear.py} $out/opt/sickgear/
+    cp -R {autoProcessTV,gui,lib,sickgear,sickgear.py} $out/opt/sickgear/
 
-    makeWrapper $out/opt/sickgear/sickgear.py $out/bin/sickgear
+    makeWrapper $out/opt/sickgear/sickgear.py $out/bin/sickgear \
+      --suffix PATH : ${lib.makeBinPath [ libarchive ]}
   '';
 
   meta = with lib; {


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
Version bump to 3.29.3 (major version number bump is just to show that sickgear is now python 3 only). There were also some other changes to the project structure, so I modified the package accordingly. I also put libarchive in the path

Built and tested working on nixos-unstable

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
