### PR TITLE
buzztrax: init at unstable-2022-01-26

### DIFF
--- a/pkgs/applications/audio/buzztrax/default.nix
+++ b/pkgs/applications/audio/buzztrax/default.nix
@@ -1,0 +1,57 @@
+{ stdenv, lib, fetchFromGitHub, wrapGAppsHook, makeFontsConf
+, autoreconfHook, gtk-doc, intltool, libtool, pkg-config, yelp-tools, itstool
+, gst_all_1
+, glib, libgsf, libxml2
+, clutter-gtk, gtk2
+, orc, fluidsynth
+}:
+
+stdenv.mkDerivation {
+
+  pname = "buzztrax";
+  version = "unstable-2022-01-26";
+
+  src = fetchFromGitHub {
+    owner = "Buzztrax";
+    repo = "buzztrax";
+    rev = "833287c6a06bddc922cd346d6f0fcec7a882aee5";
+    hash = "sha256-iI6m+zBWDDBjmeuU9Nm4aIbEKfaPe36APPktdjznQpU=";
+  };
+
+  postPatch = ''
+    touch AUTHORS
+  '';
+
+  # 'g_memdup' is deprecated: Use 'g_memdup2' instead
+  env.NIX_CFLAGS_COMPILE = "-Wno-error=deprecated-declarations";
+
+
+  nativeBuildInputs = [
+    autoreconfHook gtk-doc intltool libtool pkg-config
+    wrapGAppsHook yelp-tools itstool
+  ];
+
+  buildInputs = [
+
+    gst_all_1.gstreamer
+    gst_all_1.gst-plugins-base
+    gst_all_1.gst-plugins-good
+    glib libgsf libxml2
+    clutter-gtk gtk2
+
+    ## Optional
+    gst_all_1.gst-plugins-bad
+    gst_all_1.gst-plugins-ugly
+    orc
+    fluidsynth
+  ];
+
+  meta = with lib; {
+    description = "Buzztrax is a modular music composer for Linux.";
+    homepage = "https://www.buzztrax.org/";
+    license = licenses.lgpl21Plus;
+    maintainers = [ maintainers.bendlas ];
+    platforms = platforms.unix;
+  };
+
+}

--- a/pkgs/applications/audio/buzztrax/default.nix
+++ b/pkgs/applications/audio/buzztrax/default.nix
@@ -1,13 +1,25 @@
-{ stdenv, lib, fetchFromGitHub, wrapGAppsHook, makeFontsConf
-, autoreconfHook, gtk-doc, intltool, libtool, pkg-config, yelp-tools, itstool
+{ lib
+, stdenv
+, fetchFromGitHub
+, autoreconfHook
+, gtk-doc
+, intltool
+, itstool
+, libtool
+, pkg-config
+, wrapGAppsHook
+, yelp-tools
+, clutter-gtk
 , gst_all_1
-, glib, libgsf, libxml2
-, clutter-gtk, gtk2
-, orc, fluidsynth
+, glib
+, gtk2
+, libgsf
+, libxml2
+, fluidsynth
+, orc
 }:
 
 stdenv.mkDerivation {
-
   pname = "buzztrax";
   version = "unstable-2022-01-26";
 
@@ -22,29 +34,35 @@ stdenv.mkDerivation {
     touch AUTHORS
   '';
 
-  # 'g_memdup' is deprecated: Use 'g_memdup2' instead
-  env.NIX_CFLAGS_COMPILE = "-Wno-error=deprecated-declarations";
-
-
   nativeBuildInputs = [
-    autoreconfHook gtk-doc intltool libtool pkg-config
-    wrapGAppsHook yelp-tools itstool
+    autoreconfHook
+    gtk-doc
+    intltool
+    itstool
+    libtool
+    pkg-config
+    wrapGAppsHook
+    yelp-tools
   ];
 
   buildInputs = [
-
+    clutter-gtk
     gst_all_1.gstreamer
     gst_all_1.gst-plugins-base
     gst_all_1.gst-plugins-good
-    glib libgsf libxml2
-    clutter-gtk gtk2
-
-    ## Optional
+    glib
+    gtk2
+    libgsf
+    libxml2
+    # optional packages
+    fluidsynth
     gst_all_1.gst-plugins-bad
     gst_all_1.gst-plugins-ugly
     orc
-    fluidsynth
   ];
+
+  # 'g_memdup' is deprecated: Use 'g_memdup2' instead
+  env.NIX_CFLAGS_COMPILE = "-Wno-error=deprecated-declarations";
 
   meta = with lib; {
     description = "Buzztrax is a modular music composer for Linux.";
@@ -53,5 +71,4 @@ stdenv.mkDerivation {
     maintainers = [ maintainers.bendlas ];
     platforms = platforms.unix;
   };
-
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -29506,6 +29506,8 @@ with pkgs;
 
   bottles-unwrapped = callPackage ../applications/misc/bottles { };
 
+  buzztrax = callPackage ../applications/audio/buzztrax { };
+
   brave = callPackage ../applications/networking/browsers/brave { };
 
   break-time = callPackage ../applications/misc/break-time { };


### PR DESCRIPTION
###### Description of changes

Added package for https://www.buzztrax.org/

###### Things done


- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
