### PR TITLE
libcpr: use version variable as Git rev

### DIFF
--- a/pkgs/development/libraries/libcpr/default.nix
+++ b/pkgs/development/libraries/libcpr/default.nix
@@ -10,7 +10,7 @@ stdenv.mkDerivation {
   src = fetchFromGitHub {
     owner = "libcpr";
     repo = "cpr";
-    rev = "1.10.3";
+    rev = version;
     hash = "sha256-NueZPBiICrh8GXXdCqNtVaB7PfqwtQ0WolvRij8SYbE=";
   };
 


### PR DESCRIPTION
###### Description of changes

Just fixes a mistake.