### PR TITLE
vscode: fix decrypting credentials after update

### DIFF
--- a/pkgs/applications/editors/vscode/generic.nix
+++ b/pkgs/applications/editors/vscode/generic.nix
@@ -101,6 +101,11 @@ let
       # Override the previously determined VSCODE_PATH with the one we know to be correct
       sed -i "/ELECTRON=/iVSCODE_PATH='$out/lib/vscode'" "$out/bin/${executableName}"
       grep -q "VSCODE_PATH='$out/lib/vscode'" "$out/bin/${executableName}" # check if sed succeeded
+
+      # Remove native encryption code, as it derives the key from the executable path which does not work for us.
+      # The credentials should be stored in a secure keychain already, so the benefit of this is questionable
+      # in the first place.
+      rm -rf $out/lib/vscode/resources/app/node_modules/vscode-encrypt
     '') + ''
       runHook postInstall
     '';


### PR DESCRIPTION
###### Description of changes

VSCode proprietary uses a security-by-obscurity module which derives encryption keys for credentials as follows (see `/lib/vscode/resources/app/node_modules/vscode-encrypt/rs-pure/src/lib.rs`, which is not on github for some reason?):

(also, before anyone says I'm exposing Microsoft proprietary code, it's in the tarball and there's a LICENSE file that says MIT)

```rust
fn create_key(key: &[u8]) -> Result<Vec<u8>, Error> {
    use openssl::hash::{Hasher, MessageDigest};

    let exe = std::env::current_exe().map_err(|_| Error::generic())?;
    let exe = exe.to_string_lossy();
    let mut exe = exe.as_ref();

    // SNAP is set to the directory where the snap is mounted when running in a snap package. This snap path has a version number in it
    // which can't be used to reliably encrypt/decrypt after a version update. to get around this, we check for the SNAP environment
    // variable and remove that from the process path. What’s left over is /usr/bin/code (or similar) which is perfect to be used in the encryption.
    // More info: https://snapcraft.io/docs/environment-variables
    if cfg!(target_os = "linux") {
        if let Ok(snap) = std::env::var("SNAP") {
            if exe.contains(&snap) {
                exe = &exe[snap.len()..];
            }
        }
    }

    let mut h = Hasher::new(MessageDigest::sha256()).unwrap();
    h.update(key).unwrap();
    h.update(exe.as_bytes()).unwrap();
    Ok(h.finish().unwrap().to_vec())
}
```

Which invalidates the stored credentials if the store path ever changes.

Work around this by removing the encryption module entirely, which forces a fallback to plaintext storage: https://github.com/microsoft/vscode/blob/4700994c75c9c44c762e48d626042e3f2633c98d/src/vs/platform/encryption/node/encryptionMainService.ts#L24

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
