### PR TITLE
libxisf: 0.2.3 -> 0.2.8

### DIFF
--- a/pkgs/development/libraries/science/astronomy/libxisf/0001-Fix-pkg-config-paths.patch
+++ b/pkgs/development/libraries/science/astronomy/libxisf/0001-Fix-pkg-config-paths.patch
@@ -1,0 +1,23 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Nicolas Benes <nbenes.gh@xandea.de>
+Date: Mon, 22 May 2023 09:25:27 +0200
+Subject: [PATCH] Fix pkg-config paths
+
+
+diff --git a/libxisf.pc.in b/libxisf.pc.in
+index b0b8b53..944b068 100644
+--- a/libxisf.pc.in
++++ b/libxisf.pc.in
+@@ -1,7 +1,7 @@
+ prefix="@CMAKE_INSTALL_PREFIX@"
+ exec_prefix="${prefix}"
+-libdir="${exec_prefix}/@CMAKE_INSTALL_LIBDIR@"
+-includedir="${prefix}/@CMAKE_INSTALL_INCLUDEDIR@"
++libdir="@CMAKE_INSTALL_FULL_LIBDIR@"
++includedir="@CMAKE_INSTALL_FULL_INCLUDEDIR@"
+ 
+ Name: @PROJECT_NAME@
+ Description: @CMAKE_PROJECT_DESCRIPTION@
+-- 
+2.38.5
+

--- a/pkgs/development/libraries/science/astronomy/libxisf/default.nix
+++ b/pkgs/development/libraries/science/astronomy/libxisf/default.nix
@@ -10,15 +10,19 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "libxisf";
-  version = "0.2.3";
+  version = "0.2.8";
 
   src = fetchFromGitea {
     domain = "gitea.nouspiro.space";
     owner = "nou";
     repo = "libXISF";
     rev = "v${finalAttrs.version}";
-    hash = "sha256-u5EYnRO2rUV8ofLL9qfACeVvVbWXEXpkqh2Q4OOxpaQ=";
+    hash = "sha256-YB97vMz2+cFRYq8x2Su3Eh952U6kGIVLYV7kDEd5S8g=";
   };
+
+  patches = [
+    ./0001-Fix-pkg-config-paths.patch
+  ];
 
   nativeBuildInputs = [
     cmake


### PR DESCRIPTION
###### Description of changes

Update: https://gitea.nouspiro.space/nou/libXISF/compare/v0.2.3...v0.2.8

Upstream added a pkg-config file.

###### Things done

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [X] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes (or backporting 23.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2311-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
