### PR TITLE
Revert "nixos/syncthing: use rfc42 style settings"

### DIFF
--- a/nixos/modules/services/networking/syncthing.nix
+++ b/nixos/modules/services/networking/syncthing.nix
@@ -7,26 +7,25 @@ let
   opt = options.services.syncthing;
   defaultUser = "syncthing";
   defaultGroup = defaultUser;
-  settingsFormat = pkgs.formats.json { };
 
-  devices = mapAttrsToList (_: device: device // {
+  devices = mapAttrsToList (name: device: {
     deviceID = device.id;
-  }) cfg.settings.devices;
+    inherit (device) name addresses introducer autoAcceptFolders;
+  }) cfg.devices;
 
-  folders = mapAttrsToList (_: folder: folder //
-    throwIf (folder?rescanInterval || folder?watch || folder?watchDelay) ''
-      The options services.syncthing.settings.folders.<name>.{rescanInterval,watch,watchDelay}
-      were removed. Please use, respectively, {rescanIntervalS,fsWatcherEnabled,fsWatcherDelayS} instead.
-    '' {
-    devices = map (device:
-      if builtins.isString device then
-        { deviceId = cfg.settings.devices.${device}.id; }
-      else
-        device
-    ) folder.devices;
-  }) (filterAttrs (_: folder:
+  folders = mapAttrsToList ( _: folder: {
+    inherit (folder) path id label type;
+    devices = map (device: { deviceId = cfg.devices.${device}.id; }) folder.devices;
+    rescanIntervalS = folder.rescanInterval;
+    fsWatcherEnabled = folder.watch;
+    fsWatcherDelayS = folder.watchDelay;
+    ignorePerms = folder.ignorePerms;
+    ignoreDelete = folder.ignoreDelete;
+    versioning = folder.versioning;
+  }) (filterAttrs (
+    _: folder:
     folder.enable
-  ) cfg.settings.folders);
+  ) cfg.folders);
 
   updateConfig = pkgs.writers.writeDash "merge-syncthing-config" ''
     set -efu
@@ -55,10 +54,10 @@ let
     old_cfg=$(curl ${cfg.guiAddress}/rest/config)
 
     # generate the new config by merging with the NixOS config options
-    new_cfg=$(printf '%s\n' "$old_cfg" | ${pkgs.jq}/bin/jq -c ${escapeShellArg ''. * ${builtins.toJSON cfg.settings} * {
-        "devices": (${builtins.toJSON devices}${optionalString (cfg.settings.devices == {} || ! cfg.overrideDevices) " + .devices"}),
-        "folders": (${builtins.toJSON folders}${optionalString (cfg.settings.folders == {} || ! cfg.overrideFolders) " + .folders"})
-    }''})
+    new_cfg=$(printf '%s\n' "$old_cfg" | ${pkgs.jq}/bin/jq -c '. * {
+        "devices": (${builtins.toJSON devices}${optionalString (cfg.devices == {} || ! cfg.overrideDevices) " + .devices"}),
+        "folders": (${builtins.toJSON folders}${optionalString (cfg.folders == {} || ! cfg.overrideFolders) " + .folders"})
+    } * ${builtins.toJSON cfg.extraOptions}')
 
     # send the new config
     curl -X PUT -d "$new_cfg" ${cfg.guiAddress}/rest/config
@@ -100,10 +99,75 @@ in {
         default = true;
         description = mdDoc ''
           Whether to delete the devices which are not configured via the
-          [devices](#opt-services.syncthing.settings.devices) option.
+          [devices](#opt-services.syncthing.devices) option.
           If set to `false`, devices added via the web
           interface will persist and will have to be deleted manually.
         '';
+      };
+
+      devices = mkOption {
+        default = {};
+        description = mdDoc ''
+          Peers/devices which Syncthing should communicate with.
+
+          Note that you can still add devices manually, but those changes
+          will be reverted on restart if [overrideDevices](#opt-services.syncthing.overrideDevices)
+          is enabled.
+        '';
+        example = {
+          bigbox = {
+            id = "7CFNTQM-IMTJBHJ-3UWRDIU-ZGQJFR6-VCXZ3NB-XUH3KZO-N52ITXR-LAIYUAU";
+            addresses = [ "tcp://192.168.0.10:51820" ];
+          };
+        };
+        type = types.attrsOf (types.submodule ({ name, ... }: {
+          options = {
+
+            name = mkOption {
+              type = types.str;
+              default = name;
+              description = lib.mdDoc ''
+                The name of the device.
+              '';
+            };
+
+            addresses = mkOption {
+              type = types.listOf types.str;
+              default = [];
+              description = lib.mdDoc ''
+                The addresses used to connect to the device.
+                If this is left empty, dynamic configuration is attempted.
+              '';
+            };
+
+            id = mkOption {
+              type = types.str;
+              description = mdDoc ''
+                The device ID. See <https://docs.syncthing.net/dev/device-ids.html>.
+              '';
+            };
+
+            introducer = mkOption {
+              type = types.bool;
+              default = false;
+              description = mdDoc ''
+                Whether the device should act as an introducer and be allowed
+                to add folders on this computer.
+                See <https://docs.syncthing.net/users/introducer.html>.
+              '';
+            };
+
+            autoAcceptFolders = mkOption {
+              type = types.bool;
+              default = false;
+              description = mdDoc ''
+                Automatically create or share folders that this device advertises at the default path.
+                See <https://docs.syncthing.net/users/config.html?highlight=autoaccept#config-file-format>.
+              '';
+            };
+
+          };
+        }));
       };
 
       overrideFolders = mkOption {
@@ -111,271 +175,211 @@ in {
         default = true;
         description = mdDoc ''
           Whether to delete the folders which are not configured via the
-          [folders](#opt-services.syncthing.settings.folders) option.
+          [folders](#opt-services.syncthing.folders) option.
           If set to `false`, folders added via the web
           interface will persist and will have to be deleted manually.
         '';
       };
 
-      settings = mkOption {
-        type = types.submodule {
-          freeformType = settingsFormat.type;
+      folders = mkOption {
+        default = {};
+        description = mdDoc ''
+          Folders which should be shared by Syncthing.
+
+          Note that you can still add folders manually, but those changes
+          will be reverted on restart if [overrideFolders](#opt-services.syncthing.overrideFolders)
+          is enabled.
+        '';
+        example = literalExpression ''
+          {
+            "/home/user/sync" = {
+              id = "syncme";
+              devices = [ "bigbox" ];
+            };
+          }
+        '';
+        type = types.attrsOf (types.submodule ({ name, ... }: {
           options = {
-            # global options
-            options = mkOption {
-              default = {};
-              description = mdDoc ''
-                The options element contains all other global configuration options
+
+            enable = mkOption {
+              type = types.bool;
+              default = true;
+              description = lib.mdDoc ''
+                Whether to share this folder.
+                This option is useful when you want to define all folders
+                in one place, but not every machine should share all folders.
               '';
-              type = types.submodule ({ name, ... }: {
-                freeformType = settingsFormat.type;
+            };
+
+            path = mkOption {
+              # TODO for release 23.05: allow relative paths again and set
+              # working directory to cfg.dataDir
+              type = types.str // {
+                check = x: types.str.check x && (substring 0 1 x == "/" || substring 0 2 x == "~/");
+                description = types.str.description + " starting with / or ~/";
+              };
+              default = name;
+              description = lib.mdDoc ''
+                The path to the folder which should be shared.
+                Only absolute paths (starting with `/`) and paths relative to
+                the [user](#opt-services.syncthing.user)'s home directory
+                (starting with `~/`) are allowed.
+              '';
+            };
+
+            id = mkOption {
+              type = types.str;
+              default = name;
+              description = lib.mdDoc ''
+                The ID of the folder. Must be the same on all devices.
+              '';
+            };
+
+            label = mkOption {
+              type = types.str;
+              default = name;
+              description = lib.mdDoc ''
+                The label of the folder.
+              '';
+            };
+
+            devices = mkOption {
+              type = types.listOf types.str;
+              default = [];
+              description = mdDoc ''
+                The devices this folder should be shared with. Each device must
+                be defined in the [devices](#opt-services.syncthing.devices) option.
+              '';
+            };
+
+            versioning = mkOption {
+              default = null;
+              description = mdDoc ''
+                How to keep changed/deleted files with Syncthing.
+                There are 4 different types of versioning with different parameters.
+                See <https://docs.syncthing.net/users/versioning.html>.
+              '';
+              example = literalExpression ''
+                [
+                  {
+                    versioning = {
+                      type = "simple";
+                      params.keep = "10";
+                    };
+                  }
+                  {
+                    versioning = {
+                      type = "trashcan";
+                      params.cleanoutDays = "1000";
+                    };
+                  }
+                  {
+                    versioning = {
+                      type = "staggered";
+                      fsPath = "/syncthing/backup";
+                      params = {
+                        cleanInterval = "3600";
+                        maxAge = "31536000";
+                      };
+                    };
+                  }
+                  {
+                    versioning = {
+                      type = "external";
+                      params.versionsPath = pkgs.writers.writeBash "backup" '''
+                        folderpath="$1"
+                        filepath="$2"
+                        rm -rf "$folderpath/$filepath"
+                      ''';
+                    };
+                  }
+                ]
+              '';
+              type = with types; nullOr (submodule {
                 options = {
-                  localAnnounceEnabled = mkOption {
-                    type = types.bool;
-                    default = true;
-                    description = lib.mdDoc ''
-                      Whether to send announcements to the local LAN, also use such announcements to find other devices.
+                  type = mkOption {
+                    type = enum [ "external" "simple" "staggered" "trashcan" ];
+                    description = mdDoc ''
+                      The type of versioning.
+                      See <https://docs.syncthing.net/users/versioning.html>.
                     '';
                   };
-
-                  localAnnouncePort = mkOption {
-                    type = types.int;
-                    default = 21027;
-                    description = lib.mdDoc ''
-                      The port on which to listen and send IPv4 broadcast announcements to.
+                  fsPath = mkOption {
+                    default = "";
+                    type = either str path;
+                    description = mdDoc ''
+                      Path to the versioning folder.
+                      See <https://docs.syncthing.net/users/versioning.html>.
                     '';
                   };
-
-                  relaysEnabled = mkOption {
-                    type = types.bool;
-                    default = true;
-                    description = lib.mdDoc ''
-                      When true, relays will be connected to and potentially used for device to device connections.
-                    '';
-                  };
-
-                  urAccepted = mkOption {
-                    type = types.int;
-                    default = 0;
-                    description = lib.mdDoc ''
-                      Whether the user has accepted to submit anonymous usage data.
-                      The default, 0, mean the user has not made a choice, and Syncthing will ask at some point in the future.
-                      "-1" means no, a number above zero means that that version of usage reporting has been accepted.
-                    '';
-                  };
-
-                  limitBandwidthInLan = mkOption {
-                    type = types.bool;
-                    default = false;
-                    description = lib.mdDoc ''
-                      Whether to apply bandwidth limits to devices in the same broadcast domain as the local device.
-                    '';
-                  };
-
-                  maxFolderConcurrency = mkOption {
-                    type = types.int;
-                    default = 0;
-                    description = lib.mdDoc ''
-                      This option controls how many folders may concurrently be in I/O-intensive operations such as syncing or scanning.
-                      The mechanism is described in detail in a [separate chapter](https://docs.syncthing.net/advanced/option-max-concurrency.html).
+                  params = mkOption {
+                    type = attrsOf (either str path);
+                    description = mdDoc ''
+                      The parameters for versioning. Structure depends on
+                      [versioning.type](#opt-services.syncthing.folders._name_.versioning.type).
+                      See <https://docs.syncthing.net/users/versioning.html>.
                     '';
                   };
                 };
               });
             };
 
-            # device settings
-            devices = mkOption {
-              default = {};
-              description = mdDoc ''
-                Peers/devices which Syncthing should communicate with.
-
-                Note that you can still add devices manually, but those changes
-                will be reverted on restart if [overrideDevices](#opt-services.syncthing.overrideDevices)
-                is enabled.
+            rescanInterval = mkOption {
+              type = types.int;
+              default = 3600;
+              description = lib.mdDoc ''
+                How often the folder should be rescanned for changes.
               '';
-              example = {
-                bigbox = {
-                  id = "7CFNTQM-IMTJBHJ-3UWRDIU-ZGQJFR6-VCXZ3NB-XUH3KZO-N52ITXR-LAIYUAU";
-                  addresses = [ "tcp://192.168.0.10:51820" ];
-                };
-              };
-              type = types.attrsOf (types.submodule ({ name, ... }: {
-                freeformType = settingsFormat.type;
-                options = {
-
-                  name = mkOption {
-                    type = types.str;
-                    default = name;
-                    description = lib.mdDoc ''
-                      The name of the device.
-                    '';
-                  };
-
-                  id = mkOption {
-                    type = types.str;
-                    description = mdDoc ''
-                      The device ID. See <https://docs.syncthing.net/dev/device-ids.html>.
-                    '';
-                  };
-
-                  autoAcceptFolders = mkOption {
-                    type = types.bool;
-                    default = false;
-                    description = mdDoc ''
-                      Automatically create or share folders that this device advertises at the default path.
-                      See <https://docs.syncthing.net/users/config.html?highlight=autoaccept#config-file-format>.
-                    '';
-                  };
-
-                };
-              }));
             };
 
-            # folder settings
-            folders = mkOption {
-              default = {};
-              description = mdDoc ''
-                Folders which should be shared by Syncthing.
-
-                Note that you can still add folders manually, but those changes
-                will be reverted on restart if [overrideFolders](#opt-services.syncthing.overrideFolders)
-                is enabled.
+            type = mkOption {
+              type = types.enum [ "sendreceive" "sendonly" "receiveonly" "receiveencrypted" ];
+              default = "sendreceive";
+              description = lib.mdDoc ''
+                Whether to only send changes for this folder, only receive them
+                or both. `receiveencrypted` can be used for untrusted devices. See
+                <https://docs.syncthing.net/users/untrusted.html> for reference.
               '';
-              example = literalExpression ''
-                {
-                  "/home/user/sync" = {
-                    id = "syncme";
-                    devices = [ "bigbox" ];
-                  };
-                }
-              '';
-              type = types.attrsOf (types.submodule ({ name, ... }: {
-                freeformType = settingsFormat.type;
-                options = {
-
-                  enable = mkOption {
-                    type = types.bool;
-                    default = true;
-                    description = lib.mdDoc ''
-                      Whether to share this folder.
-                      This option is useful when you want to define all folders
-                      in one place, but not every machine should share all folders.
-                    '';
-                  };
-
-                  path = mkOption {
-                    # TODO for release 23.05: allow relative paths again and set
-                    # working directory to cfg.dataDir
-                    type = types.str // {
-                      check = x: types.str.check x && (substring 0 1 x == "/" || substring 0 2 x == "~/");
-                      description = types.str.description + " starting with / or ~/";
-                    };
-                    default = name;
-                    description = lib.mdDoc ''
-                      The path to the folder which should be shared.
-                      Only absolute paths (starting with `/`) and paths relative to
-                      the [user](#opt-services.syncthing.user)'s home directory
-                      (starting with `~/`) are allowed.
-                    '';
-                  };
-
-                  id = mkOption {
-                    type = types.str;
-                    default = name;
-                    description = lib.mdDoc ''
-                      The ID of the folder. Must be the same on all devices.
-                    '';
-                  };
-
-                  label = mkOption {
-                    type = types.str;
-                    default = name;
-                    description = lib.mdDoc ''
-                      The label of the folder.
-                    '';
-                  };
-
-                  devices = mkOption {
-                    type = types.listOf types.str;
-                    default = [];
-                    description = mdDoc ''
-                      The devices this folder should be shared with. Each device must
-                      be defined in the [devices](#opt-services.syncthing.settings.devices) option.
-                    '';
-                  };
-
-                  versioning = mkOption {
-                    default = null;
-                    description = mdDoc ''
-                      How to keep changed/deleted files with Syncthing.
-                      There are 4 different types of versioning with different parameters.
-                      See <https://docs.syncthing.net/users/versioning.html>.
-                    '';
-                    example = literalExpression ''
-                      [
-                        {
-                          versioning = {
-                            type = "simple";
-                            params.keep = "10";
-                          };
-                        }
-                        {
-                          versioning = {
-                            type = "trashcan";
-                            params.cleanoutDays = "1000";
-                          };
-                        }
-                        {
-                          versioning = {
-                            type = "staggered";
-                            fsPath = "/syncthing/backup";
-                            params = {
-                              cleanInterval = "3600";
-                              maxAge = "31536000";
-                            };
-                          };
-                        }
-                        {
-                          versioning = {
-                            type = "external";
-                            params.versionsPath = pkgs.writers.writeBash "backup" '''
-                              folderpath="$1"
-                              filepath="$2"
-                              rm -rf "$folderpath/$filepath"
-                            ''';
-                          };
-                        }
-                      ]
-                    '';
-                    type = with types; nullOr (submodule {
-                      freeformType = settingsFormat.type;
-                      options = {
-                        type = mkOption {
-                          type = enum [ "external" "simple" "staggered" "trashcan" ];
-                          description = mdDoc ''
-                            The type of versioning.
-                            See <https://docs.syncthing.net/users/versioning.html>.
-                          '';
-                        };
-                      };
-                    });
-                  };
-
-                  copyOwnershipFromParent = mkOption {
-                    type = types.bool;
-                    default = false;
-                    description = mdDoc ''
-                      On Unix systems, tries to copy file/folder ownership from the parent directory (the directory it’s located in).
-                      Requires running Syncthing as a privileged user, or granting it additional capabilities (e.g. CAP_CHOWN on Linux).
-                    '';
-                  };
-                };
-              }));
             };
 
+            watch = mkOption {
+              type = types.bool;
+              default = true;
+              description = lib.mdDoc ''
+                Whether the folder should be watched for changes by inotify.
+              '';
+            };
+
+            watchDelay = mkOption {
+              type = types.int;
+              default = 10;
+              description = lib.mdDoc ''
+                The delay after an inotify event is triggered.
+              '';
+            };
+
+            ignorePerms = mkOption {
+              type = types.bool;
+              default = true;
+              description = lib.mdDoc ''
+                Whether to ignore permission changes.
+              '';
+            };
+
+            ignoreDelete = mkOption {
+              type = types.bool;
+              default = false;
+              description = mdDoc ''
+                Whether to skip deleting files that are deleted by peers.
+                See <https://docs.syncthing.net/advanced/folder-ignoredelete.html>.
+              '';
+            };
           };
-        };
+        }));
+      };
+
+      extraOptions = mkOption {
+        type = types.addCheck (pkgs.formats.json {}).type isAttrs;
         default = {};
         description = mdDoc ''
           Extra configuration options for Syncthing.
@@ -526,10 +530,6 @@ in {
       This option was removed because Syncthing now has the inotify functionality included under the name "fswatcher".
       It can be enabled on a per-folder basis through the web interface.
     '')
-    (mkRenamedOptionModule [ "services" "syncthing" "extraOptions" ] [ "services" "syncthing" "settings" ])
-    (mkRenamedOptionModule [ "services" "syncthing" "folders" ] [ "services" "syncthing" "settings" "folders" ])
-    (mkRenamedOptionModule [ "services" "syncthing" "devices" ] [ "services" "syncthing" "settings" "devices" ])
-    (mkRenamedOptionModule [ "services" "syncthing" "options" ] [ "services" "syncthing" "settings" "options" ])
   ] ++ map (o:
     mkRenamedOptionModule [ "services" "syncthing" "declarative" o ] [ "services" "syncthing" o ]
   ) [ "cert" "key" "devices" "folders" "overrideDevices" "overrideFolders" "extraOptions"];
@@ -615,7 +615,9 @@ in {
           ];
         };
       };
-      syncthing-init = mkIf (cfg.settings != {}) {
+      syncthing-init = mkIf (
+        cfg.devices != {} || cfg.folders != {} || cfg.extraOptions != {}
+      ) {
         description = "Syncthing configuration updater";
         requisite = [ "syncthing.service" ];
         after = [ "syncthing.service" ];

--- a/nixos/tests/syncthing-init.nix
+++ b/nixos/tests/syncthing-init.nix
@@ -9,21 +9,14 @@ in {
   nodes.machine = {
     services.syncthing = {
       enable = true;
-      settings = {
-        options.crashReportingEnabled = false;
-        devices.testDevice = {
-          id = testId;
-        };
-        folders.testFolder = {
-          path = "/tmp/test";
-          devices = [ "testDevice" ];
-          versioning = {
-            type = "simple";
-            params.keep = "10";
-          };
-        };
-        gui.user = "guiUser";
+      devices.testDevice = {
+        id = testId;
       };
+      folders.testFolder = {
+        path = "/tmp/test";
+        devices = [ "testDevice" ];
+      };
+      extraOptions.gui.user = "guiUser";
     };
   };
 


### PR DESCRIPTION
Reverts https://github.com/NixOS/nixpkgs/pull/226088 and the [two](https://github.com/NixOS/nixpkgs/pull/232439) [fixups](https://github.com/NixOS/nixpkgs/pull/232582). Branch-off is now and we can't figure out how to unfuck this. See https://github.com/NixOS/nixpkgs/issues/232679

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [X] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
