### PR TITLE
minimal-bootstrap: init `gnutar`, `gzip`, `bzip2`

### DIFF
--- a/pkgs/os-specific/linux/minimal-bootstrap/bzip2/default.nix
+++ b/pkgs/os-specific/linux/minimal-bootstrap/bzip2/default.nix
@@ -1,0 +1,70 @@
+{ lib
+, fetchurl
+, bash
+, tinycc
+, gnumake
+, gnupatch
+, gzip
+}:
+let
+  pname = "bzip2";
+  version = "1.0.8";
+
+  src = fetchurl {
+    url = "https://sourceware.org/pub/bzip2/bzip2-${version}.tar.gz";
+    sha256 = "0s92986cv0p692icqlw1j42y9nld8zd83qwhzbqd61p1dqbh6nmb";
+  };
+
+  patches = [
+    # mes libc has no time support, so we remove that.
+    # It also does not have fch{own,mod}, which we don't care about in the bootstrap
+    # anyway, so we can null-op those calls.
+    (fetchurl {
+      url = "https://github.com/fosslinux/live-bootstrap/raw/87e9d7db9d22b400d1c05247254ac39ee2577e80/sysa/bzip2-1.0.8/patches/mes-libc.patch";
+      sha256 = "14dciwib28h413skzfkh7samzh8x87dmwhldyxxphff04pvl1j3c";
+    })
+  ];
+in
+bash.runCommand "${pname}-${version}" {
+  inherit pname version;
+
+  nativeBuildInputs = [
+    tinycc.compiler
+    gnumake
+    gnupatch
+    gzip
+  ];
+
+  passthru.tests.get-version = result:
+    bash.runCommand "${pname}-get-version-${version}" {} ''
+      ${result}/bin/bzip2 --version --help
+      mkdir $out
+    '';
+
+  meta = with lib; {
+    description = "High-quality data compression program";
+    homepage = "https://www.sourceware.org/bzip2";
+    license = licenses.bsdOriginal;
+    maintainers = teams.minimal-bootstrap.members;
+    platforms = platforms.unix;
+  };
+} ''
+  # Unpack
+  cp ${src} bzip2.tar.gz
+  gunzip bzip2.tar.gz
+  untar --file bzip2.tar
+  rm bzip2.tar
+  cd bzip2-${version}
+
+  # Patch
+  ${lib.concatMapStringsSep "\n" (f: "patch -Np0 -i ${f}") patches}
+
+  # Build
+  make \
+    CC="tcc -static -B ${tinycc.libs}/lib -I ." \
+    AR="tcc -ar" \
+    bzip2 bzip2recover
+
+  # Install
+  make install PREFIX=$out
+''

--- a/pkgs/os-specific/linux/minimal-bootstrap/default.nix
+++ b/pkgs/os-specific/linux/minimal-bootstrap/default.nix
@@ -13,6 +13,11 @@ lib.makeScope
 
     bash_2_05 = callPackage ./bash/2.nix { tinycc = tinycc-mes; };
 
+    bzip2 = callPackage ./bzip2 {
+      bash = bash_2_05;
+      tinycc = tinycc-mes;
+    };
+
     coreutils = callPackage ./coreutils { tinycc = tinycc-mes; };
 
     gawk = callPackage ./gawk {
@@ -60,6 +65,7 @@ lib.makeScope
 
     test = kaem.runCommand "minimal-bootstrap-test" {} ''
       echo ${bash_2_05.tests.get-version}
+      echo ${bzip2.tests.get-version}
       echo ${gawk.tests.get-version}
       echo ${gnugrep.tests.get-version}
       echo ${gnused.tests.get-version}

--- a/pkgs/os-specific/linux/minimal-bootstrap/default.nix
+++ b/pkgs/os-specific/linux/minimal-bootstrap/default.nix
@@ -39,6 +39,11 @@ lib.makeScope
       tinycc = tinycc-mes;
     };
 
+    gzip = callPackage ./gzip {
+      bash = bash_2_05;
+      tinycc = tinycc-mes;
+    };
+
     ln-boot = callPackage ./ln-boot { };
 
     mes = callPackage ./mes { };
@@ -59,6 +64,7 @@ lib.makeScope
       echo ${gnugrep.tests.get-version}
       echo ${gnused.tests.get-version}
       echo ${gnutar.tests.get-version}
+      echo ${gzip.tests.get-version}
       echo ${mes.compiler.tests.get-version}
       echo ${tinycc-mes.compiler.tests.chain}
       mkdir ''${out}

--- a/pkgs/os-specific/linux/minimal-bootstrap/default.nix
+++ b/pkgs/os-specific/linux/minimal-bootstrap/default.nix
@@ -34,6 +34,11 @@ lib.makeScope
       tinycc = tinycc-mes;
     };
 
+    gnutar = callPackage ./gnutar {
+      bash = bash_2_05;
+      tinycc = tinycc-mes;
+    };
+
     ln-boot = callPackage ./ln-boot { };
 
     mes = callPackage ./mes { };
@@ -53,6 +58,7 @@ lib.makeScope
       echo ${gawk.tests.get-version}
       echo ${gnugrep.tests.get-version}
       echo ${gnused.tests.get-version}
+      echo ${gnutar.tests.get-version}
       echo ${mes.compiler.tests.get-version}
       echo ${tinycc-mes.compiler.tests.chain}
       mkdir ''${out}

--- a/pkgs/os-specific/linux/minimal-bootstrap/gnutar/default.nix
+++ b/pkgs/os-specific/linux/minimal-bootstrap/gnutar/default.nix
@@ -1,0 +1,65 @@
+{ lib
+, buildPlatform
+, hostPlatform
+, fetchurl
+, bash
+, tinycc
+, gnumake
+, gnused
+, gnugrep
+}:
+let
+  pname = "gnutar";
+  # >= 1.13 is incompatible with mes-libc
+  version = "1.12";
+
+  src = fetchurl {
+    url = "mirror://gnu/tar/tar-${version}.tar.gz";
+    sha256 = "02m6gajm647n8l9a5bnld6fnbgdpyi4i3i83p7xcwv0kif47xhy6";
+  };
+in
+bash.runCommand "${pname}-${version}" {
+  inherit pname version;
+
+  nativeBuildInputs = [
+    tinycc.compiler
+    gnumake
+    gnused
+    gnugrep
+  ];
+
+  passthru.tests.get-version = result:
+    bash.runCommand "${pname}-get-version-${version}" {} ''
+      ${result}/bin/tar --version
+      mkdir $out
+    '';
+
+  meta = with lib; {
+    description = "GNU implementation of the `tar' archiver";
+    homepage = "https://www.gnu.org/software/tar";
+    license = licenses.gpl3Plus;
+    maintainers = teams.minimal-bootstrap.members;
+    mainProgram = "tar";
+    platforms = platforms.unix;
+  };
+} ''
+  # Unpack
+  ungz --file ${src} --output tar.tar
+  untar --file tar.tar
+  rm tar.tar
+  cd tar-${version}
+
+  # Configure
+  export CC="tcc -static -B ${tinycc.libs}/lib"
+  bash ./configure \
+    --build=${buildPlatform.config} \
+    --host=${hostPlatform.config} \
+    --disable-nls \
+    --prefix=$out
+
+  # Build
+  make AR="tcc -ar"
+
+  # Install
+  make install
+''

--- a/pkgs/os-specific/linux/minimal-bootstrap/gzip/default.nix
+++ b/pkgs/os-specific/linux/minimal-bootstrap/gzip/default.nix
@@ -1,0 +1,58 @@
+{ lib
+, fetchurl
+, bash
+, tinycc
+, gnumake
+, gnused
+, gnugrep
+}:
+let
+  pname = "gzip";
+  version = "1.2.4";
+
+  src = fetchurl {
+    url = "mirror://gnu/gzip/gzip-${version}.tar.gz";
+    sha256 = "0ryr5b00qz3xcdcv03qwjdfji8pasp0007ay3ppmk71wl8c1i90w";
+  };
+in
+bash.runCommand "${pname}-${version}" {
+  inherit pname version;
+
+  nativeBuildInputs = [
+    tinycc.compiler
+    gnumake
+    gnused
+    gnugrep
+  ];
+
+  passthru.tests.get-version = result:
+    bash.runCommand "${pname}-get-version-${version}" {} ''
+      ${result}/bin/gzip --version
+      mkdir $out
+    '';
+
+  meta = with lib; {
+    description = "GNU zip compression program";
+    homepage = "https://www.gnu.org/software/gzip";
+    license = licenses.gpl3Plus;
+    maintainers = teams.minimal-bootstrap.members;
+    platforms = platforms.unix;
+  };
+} ''
+  # Unpack
+  ungz --file ${src} --output gzip.tar
+  untar --file gzip.tar
+  rm gzip.tar
+  cd gzip-${version}
+
+  # Configure
+  export CC="tcc -static -B ${tinycc.libs}/lib -Dstrlwr=unused"
+  bash ./configure --prefix=$out
+
+  # Build
+  make
+
+  # Install
+  mkdir $out
+  make install
+''


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Adds the essential archive tools. After this we will have a complete set of replacements for `mescc-tools-extra`.

Related #227914

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
