### PR TITLE
python3Packages.{ziafont, ziamath, schemdraw}: update origin, ziafont: 0.5 -> 0.6

### DIFF
--- a/pkgs/development/python-modules/schemdraw/default.nix
+++ b/pkgs/development/python-modules/schemdraw/default.nix
@@ -1,7 +1,7 @@
 { lib
 , buildPythonPackage
 , pythonOlder
-, fetchFromBitbucket
+, fetchFromGitHub
 , pyparsing
 , matplotlib
 , latex2mathml
@@ -18,7 +18,7 @@ buildPythonPackage rec {
 
   disabled = pythonOlder "3.8";
 
-  src = fetchFromBitbucket {
+  src = fetchFromGitHub {
     owner = "cdelker";
     repo = pname;
     rev = version;

--- a/pkgs/development/python-modules/ziafont/default.nix
+++ b/pkgs/development/python-modules/ziafont/default.nix
@@ -8,7 +8,9 @@
 
 buildPythonPackage rec {
   pname = "ziafont";
-  version = "0.5";
+  version = "0.6";
+
+  format = "pyproject";
 
   disabled = pythonOlder "3.8";
 
@@ -16,7 +18,7 @@ buildPythonPackage rec {
     owner = "cdelker";
     repo = pname;
     rev = version;
-    hash = "sha256-mTQ2yRG+E2nZ2g9eSg+XTzK8A1EgKsRfbvNO3CdYeLg=";
+    hash = "sha256-3ZVj1ZxbFkFDDYbsIPzo7GMWGx7f5qWZQlcGCVXv73M=";
   };
 
   nativeCheckInputs = [

--- a/pkgs/development/python-modules/ziafont/default.nix
+++ b/pkgs/development/python-modules/ziafont/default.nix
@@ -1,7 +1,7 @@
 { lib
 , buildPythonPackage
 , pythonOlder
-, fetchFromBitbucket
+, fetchFromGitHub
 , pytestCheckHook
 , nbval
 }:
@@ -12,7 +12,7 @@ buildPythonPackage rec {
 
   disabled = pythonOlder "3.8";
 
-  src = fetchFromBitbucket {
+  src = fetchFromGitHub {
     owner = "cdelker";
     repo = pname;
     rev = version;

--- a/pkgs/development/python-modules/ziamath/default.nix
+++ b/pkgs/development/python-modules/ziamath/default.nix
@@ -1,7 +1,7 @@
 { lib
 , buildPythonPackage
 , pythonOlder
-, fetchFromBitbucket
+, fetchFromGitHub
 , ziafont
 , pytestCheckHook
 , nbval
@@ -14,7 +14,7 @@ buildPythonPackage rec {
 
   disabled = pythonOlder "3.8";
 
-  src = fetchFromBitbucket {
+  src = fetchFromGitHub {
     owner = "cdelker";
     repo = pname;
     rev = version;


### PR DESCRIPTION
###### Description of changes

These are all packages by the same author that depend on each other.
Ziafont 0.6 is not available on Bitbucket and PyPi points to GitHub now.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
