### PR TITLE
petsc: 3.17.4 -> 3.19.1, fixed build and quicktests

### DIFF
--- a/pkgs/development/libraries/science/math/petsc/default.nix
+++ b/pkgs/development/libraries/science/math/petsc/default.nix
@@ -18,11 +18,11 @@ assert petsc-withp4est -> p4est.mpiSupport;
 
 stdenv.mkDerivation rec {
   pname = "petsc";
-  version = "3.17.4";
+  version = "3.19.1";
 
   src = fetchurl {
     url = "http://ftp.mcs.anl.gov/pub/petsc/release-snapshots/petsc-${version}.tar.gz";
-    sha256 = "sha256-mcEnSGcio//ZWiaLTOsJdsvyF5JsaBqWMb1yRuq4yyo=";
+    sha256 = "sha256-dNtgxTyAtI1cOeB7w5qIPsztiLnySl3hfPb0hakD4SA=";
   };
 
   mpiSupport = !withp4est || p4est.mpiSupport;
@@ -41,6 +41,12 @@ stdenv.mkDerivation rec {
     substituteInPlace config/install.py \
       --replace /usr/bin/install_name_tool ${darwin.cctools}/bin/install_name_tool
   '';
+
+  # Both OpenMPI and MPICH get confused by the sandbox environment and spew errors like this (both to stdout and stderr):
+  #     [hwloc/linux] failed to find sysfs cpu topology directory, aborting linux discovery.
+  #     [1684747490.391106] [localhost:14258:0]       tcp_iface.c:837  UCX  ERROR opendir(/sys/class/net) failed: No such file or directory
+  # These messages contaminate test output, which makes the quicktest suite to fail. The patch adds filtering for these messages.
+  patches = [ ./filter_mpi_warnings.patch ];
 
   preConfigure = ''
     export FC="${gfortran}/bin/gfortran" F77="${gfortran}/bin/gfortran"

--- a/pkgs/development/libraries/science/math/petsc/filter_mpi_warnings.patch
+++ b/pkgs/development/libraries/science/math/petsc/filter_mpi_warnings.patch
@@ -1,0 +1,100 @@
+diff --git a/src/snes/tutorials/makefile b/src/snes/tutorials/makefile
+index 168febb34b6..71068469066 100644
+--- a/src/snes/tutorials/makefile
++++ b/src/snes/tutorials/makefile
+@@ -13,6 +13,7 @@ include ${PETSC_DIR}/lib/petsc/conf/rules
+ #  these tests are used by the makefile in PETSC_DIR for basic tests of the install and should not be removed
+ testex5f: ex5f.PETSc
+ 	-@${MPIEXEC} -n 1 ${MPIEXEC_TAIL} ./ex5f -snes_rtol 1e-4 > ex5f_1.tmp 2>&1; \
++        sed -i '/\[hwloc\/linux\]/d ; /ERROR opendir(\/sys\/class\/net) failed/d' ex5f_1.tmp; \
+         if (${DIFF} output/ex5f_1.testout ex5f_1.tmp > /dev/null 2>&1) then \
+           echo "Fortran example src/snes/tutorials/ex5f run successfully with 1 MPI process"; \
+         else \
+@@ -25,6 +26,7 @@ testex5f: ex5f.PETSc
+         ${MAKE} PETSC_ARCH=${PETSC_ARCH} PETSC_DIR=${PETSC_DIR} ex5f.rm;
+ testex19: ex19.PETSc
+ 	-@${MPIEXEC} -n 1 ${MPIEXEC_TAIL} ./ex19 -da_refine 3 -pc_type mg -ksp_type fgmres  > ex19_1.tmp 2>&1; \
++        sed -i '/\[hwloc\/linux\]/d ; /ERROR opendir(\/sys\/class\/net) failed/d' ex19_1.tmp; \
+         if (${DIFF} output/ex19_1.testout ex19_1.tmp > /dev/null 2>&1) then \
+           echo "C/C++ example src/snes/tutorials/ex19 run successfully with 1 MPI process"; \
+         else \
+@@ -36,6 +38,7 @@ testex19: ex19.PETSc
+         ${RM} -f ex19_1.tmp;
+ testex19_mpi:
+ 	-@${MPIEXEC} -n 2 ${MPIEXEC_TAIL} ./ex19 -da_refine 3 -pc_type mg -ksp_type fgmres  > ex19_1.tmp 2>&1; \
++        sed -i '/\[hwloc\/linux\]/d ; /ERROR opendir(\/sys\/class\/net) failed/d' ex19_1.tmp; \
+         if (${DIFF} output/ex19_1.testout ex19_1.tmp > /dev/null 2>&1) then \
+           echo "C/C++ example src/snes/tutorials/ex19 run successfully with 2 MPI processes"; \
+         else \
+@@ -48,6 +51,7 @@ testex19_mpi:
+ #use unpreconditioned norm because HYPRE device installations use different AMG parameters
+ runex19_hypre:
+ 	-@${MPIEXEC} -n 2 ${MPIEXEC_TAIL} ./ex19 -da_refine 3 -snes_monitor_short -ksp_norm_type unpreconditioned -pc_type hypre > ex19_1.tmp 2>&1; \
++        sed -i '/\[hwloc\/linux\]/d ; /ERROR opendir(\/sys\/class\/net) failed/d' ex19_1.tmp; \
+           if (${DIFF} output/ex19_hypre.out ex19_1.tmp) then \
+             echo "C/C++ example src/snes/tutorials/ex19 run successfully with hypre"; \
+           else  \
+@@ -57,6 +61,7 @@ runex19_hypre:
+           ${RM} -f ex19_1.tmp
+ runex19_hypre_cuda:
+ 	-@${MPIEXEC} -n 2 ${MPIEXEC_TAIL} ./ex19 -dm_vec_type cuda -dm_mat_type aijcusparse -da_refine 3 -snes_monitor_short -ksp_norm_type unpreconditioned -pc_type hypre > ex19_1.tmp 2>&1; \
++        sed -i '/\[hwloc\/linux\]/d ; /ERROR opendir(\/sys\/class\/net) failed/d' ex19_1.tmp; \
+ 	   if (${DIFF} output/ex19_hypre.out ex19_1.tmp) then \
+            echo "C/C++ example src/snes/tutorials/ex19 run successfully with hypre/cuda"; \
+            else  \
+@@ -66,6 +71,7 @@ runex19_hypre_cuda:
+ 	   ${RM} -f ex19_1.tmp
+ runex19_hypre_hip:
+ 	-@${MPIEXEC} -n 2 ${MPIEXEC_TAIL} ./ex19 -dm_vec_type hip -da_refine 3 -snes_monitor_short -ksp_norm_type unpreconditioned -pc_type hypre > ex19_1.tmp 2>&1; \
++        sed -i '/\[hwloc\/linux\]/d ; /ERROR opendir(\/sys\/class\/net) failed/d' ex19_1.tmp; \
+ 	   if (${DIFF} output/ex19_hypre.out ex19_1.tmp) then \
+            echo "C/C++ example src/snes/tutorials/ex19 run successfully with hypre/hip"; \
+            else \
+@@ -75,6 +81,7 @@ runex19_hypre_hip:
+ 	   ${RM} -f ex19_1.tmp
+ runex19_cuda:
+ 	-@${MPIEXEC} -n 1 ${MPIEXEC_TAIL} ./ex19 -snes_monitor -dm_mat_type seqaijcusparse -dm_vec_type seqcuda -pc_type gamg -pc_gamg_esteig_ksp_max_it 10 -ksp_monitor -mg_levels_ksp_max_it 3  > ex19_1.tmp 2>&1; \
++        sed -i '/\[hwloc\/linux\]/d ; /ERROR opendir(\/sys\/class\/net) failed/d' ex19_1.tmp; \
+ 	   if (${DIFF} output/ex19_cuda_1.out ex19_1.tmp) then \
+            echo "C/C++ example src/snes/tutorials/ex19 run successfully with cuda"; \
+            else  \
+@@ -84,6 +91,7 @@ runex19_cuda:
+ 	   ${RM} -f ex19_1.tmp
+ runex19_ml:
+ 	-@${MPIEXEC} -n 2 ${MPIEXEC_TAIL} ./ex19 -da_refine 3 -snes_monitor_short -pc_type ml > ex19_1.tmp 2>&1; \
++        sed -i '/\[hwloc\/linux\]/d ; /ERROR opendir(\/sys\/class\/net) failed/d' ex19_1.tmp; \
+ 	   if (${DIFF} output/ex19_ml.out ex19_1.tmp) then  \
+            echo "C/C++ example src/snes/tutorials/ex19 run successfully with ml"; \
+            else \
+@@ -93,6 +101,7 @@ runex19_ml:
+            ${RM} -f ex19_1.tmp
+ runex19_fieldsplit_mumps:
+ 	-@${MPIEXEC} -n 2 ${MPIEXEC_TAIL} ./ex19 -pc_type fieldsplit -pc_fieldsplit_block_size 4 -pc_fieldsplit_type SCHUR -pc_fieldsplit_0_fields 0,1,2 -pc_fieldsplit_1_fields 3 -fieldsplit_0_pc_type lu -fieldsplit_1_pc_type lu -snes_monitor_short -ksp_monitor_short  -fieldsplit_0_pc_factor_mat_solver_type mumps -fieldsplit_1_pc_factor_mat_solver_type mumps > ex19_6.tmp 2>&1; \
++        sed -i '/\[hwloc\/linux\]/d ; /ERROR opendir(\/sys\/class\/net) failed/d' ex19_6.tmp; \
+ 	   if (${DIFF} output/ex19_fieldsplit_5.out ex19_6.tmp) then  \
+            echo "C/C++ example src/snes/tutorials/ex19 run successfully with mumps"; \
+            else  \
+@@ -102,6 +111,7 @@ runex19_fieldsplit_mumps:
+            ${RM} -f ex19_6.tmp
+ runex19_superlu_dist:
+ 	-@${MPIEXEC} -n 1 ${MPIEXEC_TAIL} ./ex19 -da_grid_x 20 -da_grid_y 20 -pc_type lu -pc_factor_mat_solver_type superlu_dist > ex19.tmp 2>&1; \
++        sed -i '/\[hwloc\/linux\]/d ; /ERROR opendir(\/sys\/class\/net) failed/d' ex19.tmp; \
+ 	   if (${DIFF} output/ex19_superlu.out ex19.tmp) then \
+            echo "C/C++ example src/snes/tutorials/ex19 run successfully with superlu_dist"; \
+            else  \
+@@ -111,6 +121,7 @@ runex19_superlu_dist:
+ 	   ${RM} -f ex19.tmp
+ runex19_suitesparse:
+ 	-@${MPIEXEC} -n 1 ${MPIEXEC_TAIL} ./ex19 -da_refine 3 -snes_monitor_short -pc_type lu -pc_factor_mat_solver_type umfpack > ex19_1.tmp 2>&1; \
++        sed -i '/\[hwloc\/linux\]/d ; /ERROR opendir(\/sys\/class\/net) failed/d' ex19_1.tmp; \
+ 	   if (${DIFF} output/ex19_suitesparse.out ex19_1.tmp) then \
+            echo "C/C++ example src/snes/tutorials/ex19 run successfully with suitesparse"; \
+            else \
+@@ -120,6 +131,7 @@ runex19_suitesparse:
+ 	   ${RM} -f ex19_1.tmp
+ runex3k_kokkos: ex3k.PETSc
+ 	-@OMP_PROC_BIND=false ${MPIEXEC} -n 2 ${MPIEXEC_TAIL} ./ex3k -view_initial -dm_vec_type kokkos -dm_mat_type aijkokkos -use_gpu_aware_mpi 0 -snes_monitor > ex3k_1.tmp 2>&1 ;\
++        sed -i '/\[hwloc\/linux\]/d ; /ERROR opendir(\/sys\/class\/net) failed/d' ex3k_1.tmp; \
+ 	if (${DIFF} output/ex3k_1.out ex3k_1.tmp) then \
+           echo "C/C++ example src/snes/tutorials/ex3k run successfully with kokkos-kernels"; \
+         else \


### PR DESCRIPTION
###### Description of changes

Fixed PETSc build. Versions earlier than 3.18.6 fail because of incorrect make option generation, newer ones required a patch for quicktests to ignore MPI messages about missing network. Updated to the most recent version and added a patch.

See the relevant bug report: https://github.com/NixOS/nixpkgs/issues/229328

ZHF: https://github.com/NixOS/nixpkgs/issues/230712

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).