### PR TITLE
shell-mommy: init at unstable-2023-03-08

### DIFF
--- a/pkgs/tools/misc/shell-mommy/default.nix
+++ b/pkgs/tools/misc/shell-mommy/default.nix
@@ -1,0 +1,27 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+}:
+
+stdenv.mkDerivation rec {
+  pname = "shell-mommy";
+  version = "unstable-2023-03-08";
+
+  src = fetchFromGitHub {
+    owner = "sudofox";
+    repo = pname;
+    rev = "0c4d87ede2da93b65c990c18b9ab2d0b357f15f0";
+    hash = "sha256-9bW0n7qOETMY8GrOdaCgpZtPWaE6O040U91Ts42cut4=";
+  };
+
+  installPhase = ''
+    install -Dt $out/bin shell-mommy.sh
+  '';
+
+  meta = with lib; {
+    homepage = "https://github.com/sudofox/shell-mommy";
+    description = "Mommy is here for you on the command line ~ heart";
+    license = "";
+    maintainers = with maintainers; [ ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5801,6 +5801,8 @@ with pkgs;
 
   shell-hist = callPackage ../tools/misc/shell-hist { };
 
+  shell-mommy = callPackage ../tools/misc/shell-mommy { };
+
   shellhub-agent = callPackage ../applications/networking/shellhub-agent { };
 
   shellclear = callPackage ../tools/security/shellclear { };


### PR DESCRIPTION
###### Description of changes

Mommy is here for you on the command line ~ :heart:
https://github.com/sudofox/shell-mommy

I don't want to maintain this. Closes https://github.com/NixOS/nixpkgs/issues/233259. 
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
