### PR TITLE
kicad: make KICAD7_TEMPLATE_DIR a single path

### DIFF
--- a/pkgs/applications/science/electronics/kicad/default.nix
+++ b/pkgs/applications/science/electronics/kicad/default.nix
@@ -24,6 +24,7 @@
 , with3d ? true
 , withI18n ? true
 , srcs ? { }
+, symlinkJoin
 }:
 
 # The `srcs` parameter can be used to override the kicad source code
@@ -136,6 +137,17 @@ stdenv.mkDerivation rec {
     ++ optionals (withScripting)
     [ python.pkgs.wrapPython ];
 
+  # KICAD7_TEMPLATE_DIR only works with a single path (it does not handle : separated paths)
+  # but it's used to find both the templates and the symbol/footprint library tables
+  # https://gitlab.com/kicad/code/kicad/-/issues/14792
+  template_dir = symlinkJoin {
+    name = "KiCad_template_dir";
+    paths = with passthru.libraries; [
+      "${templates}/share/kicad/template"
+      "${footprints}/share/kicad/template"
+      "${symbols}/share/kicad/template"
+    ];
+  };
   # We are emulating wrapGAppsHook, along with other variables to the wrapper
   makeWrapperArgs = with passthru.libraries; [
     "--prefix XDG_DATA_DIRS : ${base}/share"
@@ -150,9 +162,7 @@ stdenv.mkDerivation rec {
     "--set-default MOZ_DBUS_REMOTE 1"
     "--set-default KICAD7_FOOTPRINT_DIR ${footprints}/share/kicad/footprints"
     "--set-default KICAD7_SYMBOL_DIR ${symbols}/share/kicad/symbols"
-    "--set-default KICAD7_TEMPLATE_DIR ${templates}/share/kicad/template"
-    "--prefix KICAD7_TEMPLATE_DIR : ${symbols}/share/kicad/template"
-    "--prefix KICAD7_TEMPLATE_DIR : ${footprints}/share/kicad/template"
+    "--set-default KICAD7_TEMPLATE_DIR ${template_dir}"
   ]
   ++ optionals (with3d)
   [


### PR DESCRIPTION
workaround for the upstream issue of not searching a `:` separated path

###### Description of changes

build a path that contains everything looked for in the env var and use that instead

this fixes the issue of KiCad not finding the templates
without it failing to find the symbol and footprint library tables

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [x] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
