### PR TITLE
libva: build minimal without a dependency on wayland

### DIFF
--- a/pkgs/development/libraries/libva/default.nix
+++ b/pkgs/development/libraries/libva/default.nix
@@ -1,6 +1,6 @@
 { stdenv, lib, fetchFromGitHub, meson, pkg-config, ninja, wayland-scanner
 , libdrm
-, minimal ? false, libva-minimal
+, minimal ? false
 , libX11, libXext, libXfixes, wayland, libffi, libGL
 , mesa
 # for passthru.tests
@@ -30,8 +30,7 @@ stdenv.mkDerivation rec {
     ++ lib.optional (!minimal) wayland-scanner;
 
   buildInputs = [ libdrm ]
-    ++ lib.optionals (!minimal) [ libva-minimal libX11 libXext libXfixes wayland libffi libGL ];
-  # TODO: share libs between minimal and !minimal - perhaps just symlink them
+    ++ lib.optionals (!minimal) [ libX11 libXext libXfixes wayland libffi libGL ];
 
   mesonFlags = [
     # Add FHS and Debian paths for non-NixOS applications

--- a/pkgs/development/libraries/libva/default.nix
+++ b/pkgs/development/libraries/libva/default.nix
@@ -26,7 +26,8 @@ stdenv.mkDerivation rec {
 
   depsBuildBuild = [ pkg-config ];
 
-  nativeBuildInputs = [ meson pkg-config ninja wayland-scanner ];
+  nativeBuildInputs = [ meson pkg-config ninja ]
+    ++ lib.optional (!minimal) wayland-scanner;
 
   buildInputs = [ libdrm ]
     ++ lib.optionals (!minimal) [ libva-minimal libX11 libXext libXfixes wayland libffi libGL ];


### PR DESCRIPTION
This fixes issues with environment.noXLibs

The error is the following and can be avoided by removing the wayland dependency.

```
unpacking sources
unpacking source archive /nix/store/iwg7f4kv2pfalirkp2aa74jzbhqg3fim-wayland-1.22.0.tar.xz
source root is wayland-1.22.0
setting SOURCE_DATE_EPOCH to timestamp 1680595111 of file wayland-1.22.0/wayland-scanner.mk
patching sources
applying patch /nix/store/3hzvdj9v9j4m82lx9l8wc5vbd7241b5w-darwin.patch
patching file meson.build
patching file src/event-loop.c
patching file src/wayland-os.c
patching script interpreter paths in doc/doxygen/gen-doxygen.py
doc/doxygen/gen-doxygen.py: interpreter directive changed from "#!/usr/bin/env python3" to "/nix/store/95cxzy2hpizr23343b8bskl4yacf4b3l-python3-3.10.11/bin/python3"
configuring
meson flags: --buildtype=plain         --libdir=/nix/store/xai9ipqdwnpswvlc6ppc658wwxdwzq2r-wayland-1.22.0/lib --libexecdir=/nix/store/xai9ipqdwnpswvlc6ppc658wwxdwzq2r-wayland-1.22.0/libexec         --bindir=/nix/store/fsfgiv3bgz9hd2d5jqk4ka6zslsxyywa-wayland-1.22.0-bin/bin --sbindir=/nix/store/fsfgiv3bgz9hd2d5jqk4ka6zslsxyywa-wayland-1.22.0-bin/sbin         --includedir=/nix/store/gvq6qcfg0fxpyj26ngri9xrfksg3wc1q-wayland-1.22.0-dev/include         --mandir=/nix/store/yjv8rmrmwmq8gyz2vgffk6h5g6gqmmdz-wayland-1.22.0-man/share/man --infodir=/nix/store/fsfgiv3bgz9hd2d5jqk4ka6zslsxyywa-wayland-1.22.0-bin/share/info         --localedir=/nix/store/xai9ipqdwnpswvlc6ppc658wwxdwzq2r-wayland-1.22.0/share/locale         -Dauto_features=enabled         -Dwrap_mode=nodownload         --prefix=/nix/store/xai9ipqdwnpswvlc6ppc658wwxdwzq2r-wayland-1.22.0 -Ddocumentation=true -Dlibraries=true -Dtests=true 
The Meson build system
Version: 1.1.0
Source dir: /build/wayland-1.22.0
Build dir: /build/wayland-1.22.0/build
Build type: native build
Project name: wayland
Project version: 1.22.0
C compiler for the host machine: gcc (gcc 12.2.0 "gcc (GCC) 12.2.0")
C linker for the host machine: gcc ld.bfd 2.40
Host machine cpu family: x86_64
Host machine cpu: x86_64
Compiler for C supports arguments -Wno-unused-parameter: YES 
Compiler for C supports arguments -Wstrict-prototypes: YES 
Compiler for C supports arguments -Wmissing-prototypes: YES 
Compiler for C supports arguments -fvisibility=hidden: YES 
Has header "sys/prctl.h" : YES 
Has header "sys/procctl.h" : NO 
Has header "sys/ucred.h" : NO 
Checking for function "accept4" : YES 
Checking for function "mkostemp" : YES 
Checking for function "posix_fallocate" : YES 
Checking for function "prctl" : YES 
Checking for function "memfd_create" : YES 
Checking for function "mremap" : YES 
Checking for function "strndup" : YES 
Checking whether type "struct xucred" has member "cr_pid" : NO 
Found pkg-config: /nix/store/09jbh8y3jbq0gs47793rzn6i7yaabxmp-pkg-config-wrapper-0.29.2/bin/pkg-config (0.29.2)
Run-time dependency libffi found: YES 3.4.4
Header "sys/signalfd.h" has symbol "SFD_CLOEXEC" : YES 
Header "sys/timerfd.h" has symbol "TFD_CLOEXEC" : YES 
Header "time.h" has symbol "CLOCK_MONOTONIC" : YES 
Checking for function "clock_gettime" : NO 
Library rt found: YES
Checking for function "clock_gettime" with dependency -lrt: YES 
Configuring config.h using configuration
Configuring wayland-version.h using configuration
Run-time dependency expat found: YES 2.5.0
Run-time dependency libxml-2.0 found: YES 2.10.4
Program embed.py found: YES (/nix/store/95cxzy2hpizr23343b8bskl4yacf4b3l-python3-3.10.11/bin/python3.10 /build/wayland-1.22.0/src/embed.py)
Library m found: YES
Run-time dependency threads found: YES
Program nm found: YES
Program wayland-egl-symbols-check found: YES (/build/wayland-1.22.0/egl/wayland-egl-symbols-check)
Library dl found: YES
Dependency threads found: YES unknown (cached)
Dependency threads found: YES unknown (cached)
Library dl found: YES
C++ compiler for the host machine: g++ (gcc 12.2.0 "g++ (GCC) 12.2.0")
C++ linker for the host machine: g++ ld.bfd 2.40
Program sed found: YES (/nix/store/gy82r5cf12hgkmhzifsyx3fp6cnf6j2l-gnused-4.9/bin/sed)
Program scanner-test.sh found: YES (/build/wayland-1.22.0/tests/scanner-test.sh)
Program dot found: YES (/nix/store/r3ki211x2syi7xi4arc3h0lc9s2zlgzl-graphviz-7.1.0/bin/dot)
Program doxygen found: YES (/nix/store/xmi6zqnfbwm76wmq9d5sxyjj2m96y3xi-doxygen-1.9.6/bin/doxygen)
Program xsltproc found: YES (/nix/store/8j99pdrnqq19ib1advps3g4l6ka4zdhs-libxslt-1.1.37-bin/bin/xsltproc)
Program xmlto found: YES (/nix/store/ya8zrzv9zdw5ayd5cb49a819ykq2rnk7-xmlto-0.0.28/bin/xmlto)
Message: doxygen: 1.9.6
Message: dot: dot - graphviz version 7.1.0 (0)
Configuring wayland.doxygen using configuration
Program gen-doxygen.py found: YES (/build/wayland-1.22.0/doc/doxygen/gen-doxygen.py)
Build targets in project: 60
NOTICE: Future-deprecated features used:
 * 0.62.0: {'pkgconfig.generate variable for builtin directories'}
 * 0.64.0: {'copy arg in configure_file'}

wayland 1.22.0

  User defined options
    auto_features: enabled
    bindir       : /nix/store/fsfgiv3bgz9hd2d5jqk4ka6zslsxyywa-wayland-1.22.0-bin/bin
    buildtype    : plain
    includedir   : /nix/store/gvq6qcfg0fxpyj26ngri9xrfksg3wc1q-wayland-1.22.0-dev/include
    infodir      : /nix/store/fsfgiv3bgz9hd2d5jqk4ka6zslsxyywa-wayland-1.22.0-bin/share/info
    libdir       : /nix/store/xai9ipqdwnpswvlc6ppc658wwxdwzq2r-wayland-1.22.0/lib
    libexecdir   : /nix/store/xai9ipqdwnpswvlc6ppc658wwxdwzq2r-wayland-1.22.0/libexec
    localedir    : /nix/store/xai9ipqdwnpswvlc6ppc658wwxdwzq2r-wayland-1.22.0/share/locale
    mandir       : /nix/store/yjv8rmrmwmq8gyz2vgffk6h5g6gqmmdz-wayland-1.22.0-man/share/man
    prefix       : /nix/store/xai9ipqdwnpswvlc6ppc658wwxdwzq2r-wayland-1.22.0
    sbindir      : /nix/store/fsfgiv3bgz9hd2d5jqk4ka6zslsxyywa-wayland-1.22.0-bin/sbin
    wrap_mode    : nodownload
    documentation: true
    libraries    : true
    tests        : true

Found ninja-1.11.1 at /nix/store/rcakkm09fivblba082qb6jch02926qhq-ninja-1.11.1/bin/ninja
meson: enabled parallel building
meson: enabled parallel installing
building
build flags: -j8
[1/107] Compiling C object egl/wayland-egl-abi-check.p/wayland-egl-abi-check.c.o
[2/107] Compiling C object tests/exec-fd-leak-checker.p/exec-fd-leak-checker.c.o
[3/107] Compiling C object tests/fixed-benchmark.p/fixed-benchmark.c.o
[4/107] Generating src/wayland.dtd.h with a custom command (wrapped by meson to capture output)
[5/107] Compiling C object src/libwayland-private.a.p/wayland-os.c.o
[6/107] Compiling C object tests/array-test.p/array-test.c.o
[7/107] Linking target egl/wayland-egl-abi-check
[8/107] Compiling C object tests/map-test.p/map-test.c.o
[9/107] Compiling C object tests/fixed-test.p/fixed-test.c.o
[10/107] Compiling C object tests/list-test.p/list-test.c.o
[11/107] Compiling C object src/libwayland-util.a.p/wayland-util.c.o
[12/107] Linking static target src/libwayland-util.a
[13/107] Generating doc/doxygen/xml/wayland-architecture.map with a custom command
FAILED: doc/doxygen/xml/wayland-architecture.map 
/nix/store/r3ki211x2syi7xi4arc3h0lc9s2zlgzl-graphviz-7.1.0/bin/dot -Tcmapx_np -odoc/doxygen/xml/wayland-architecture.map ../doc/doxygen/dot/wayland-architecture.gv
Error: Could not find/open font
Error: Could not find/open font
Error: Could not find/open font
Error: Could not find/open font
Error: Could not find/open font
Error: Could not find/open font
Error: Could not find/open font
Error: Could not find/open font
Error: Could not find/open font
Error: Could not find/open font
Warning: no value for width of non-ASCII character 226. Falling back to width of space character
Error: Could not find/open font
Error: Could not find/open font
Error: Could not find/open font
Error: Could not find/open font
[14/107] Generating doc/doxygen/xml/x-architecture.map with a custom command
FAILED: doc/doxygen/xml/x-architecture.map 
/nix/store/r3ki211x2syi7xi4arc3h0lc9s2zlgzl-graphviz-7.1.0/bin/dot -Tcmapx_np -odoc/doxygen/xml/x-architecture.map ../doc/doxygen/dot/x-architecture.gv
Error: Could not find/open font
Error: Could not find/open font
Error: Could not find/open font
Error: Could not find/open font
Error: Could not find/open font
Error: Could not find/open font
Error: Could not find/open font
Error: Could not find/open font
Error: Could not find/open font
Error: Could not find/open font
Error: Could not find/open font
Error: Could not find/open font
Error: Could not find/open font
Warning: no value for width of non-ASCII character 226. Falling back to width of space character
Error: Could not find/open font
Error: Could not find/open font
Error: Could not find/open font
Error: Could not find/open font
Error: Could not find/open font
Error: Could not find/open font
[15/107] Generating doc/doxygen/xml/wayland-architecture.png with a custom command
FAILED: doc/doxygen/xml/wayland-architecture.png 
/nix/store/r3ki211x2syi7xi4arc3h0lc9s2zlgzl-graphviz-7.1.0/bin/dot -Tpng -odoc/doxygen/xml/wayland-architecture.png ../doc/doxygen/dot/wayland-architecture.gv
Error: Could not find/open font
Error: Could not find/open font
Error: Could not find/open font
Error: Could not find/open font
Error: Could not find/open font
Error: Could not find/open font
Error: Could not find/open font
Error: Could not find/open font
Error: Could not find/open font
Error: Could not find/open font
Warning: no value for width of non-ASCII character 226. Falling back to width of space character
Error: Could not find/open font
Error: Could not find/open font
Error: Could not find/open font
Error: Could not find/open font
[16/107] Generating doc/doxygen/xml/x-architecture.png with a custom command
FAILED: doc/doxygen/xml/x-architecture.png 
/nix/store/r3ki211x2syi7xi4arc3h0lc9s2zlgzl-graphviz-7.1.0/bin/dot -Tpng -odoc/doxygen/xml/x-architecture.png ../doc/doxygen/dot/x-architecture.gv
Error: Could not find/open font
Error: Could not find/open font
Error: Could not find/open font
Error: Could not find/open font
Error: Could not find/open font
Error: Could not find/open font
Error: Could not find/open font
Error: Could not find/open font
Error: Could not find/open font
Error: Could not find/open font
Error: Could not find/open font
Error: Could not find/open font
Error: Could not find/open font
Warning: no value for width of non-ASCII character 226. Falling back to width of space character
Error: Could not find/open font
Error: Could not find/open font
Error: Could not find/open font
Error: Could not find/open font
Error: Could not find/open font
Error: Could not find/open font
[17/107] Compiling C object tests/os-wrappers-test.p/os-wrappers-test.c.o
[18/107] Compiling C object src/libwayland-private.a.p/connection.c.o
[19/107] Generating doc/doxygen/man-pages-3 with a custom command
/build/wayland-1.22.0/src/wayland-server-core.h:377: warning: explicit link request to 'wl_signal_add' could not be resolved
[20/107] Compiling C object src/wayland-scanner.p/scanner.c.o
ninja: build stopped: subcommand failed.
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
