### PR TITLE
androidenv: rename android sdk package name

### DIFF
--- a/pkgs/development/mobile/androidenv/deploy-androidpackages.nix
+++ b/pkgs/development/mobile/androidenv/deploy-androidpackages.nix
@@ -60,7 +60,7 @@ let
 in
 stdenv.mkDerivation ({
   inherit buildInputs;
-  pname = lib.concatMapStringsSep "-" (package: package.name) sortedPackages;
+  pname = "android-sdk-${lib.concatMapStringsSep "-" (package: package.name) sortedPackages}";
   version = lib.concatMapStringsSep "-" (package: package.revision) sortedPackages;
   src = map (package:
     if os != null && builtins.hasAttr os package.archives then package.archives.${os} else package.archives.all


### PR DESCRIPTION
###### Description of changes
The problem is explained in https://github.com/NixOS/nixpkgs/issues/233278. 

###### Things done

In this PR we just changed the name of the deployed derivation to avoid general names like `tools` for derivation in the androidenv.

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [X] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [X] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

