### PR TITLE
ubi_reader: 0.8.5 -> 0.8.9

### DIFF
--- a/pkgs/development/python-modules/lzallright/default.nix
+++ b/pkgs/development/python-modules/lzallright/default.nix
@@ -1,8 +1,10 @@
 { lib
+, stdenv
 , buildPythonPackage
 , callPackage
 , fetchFromGitHub
 , rustPlatform
+, libiconv
 }:
 
 buildPythonPackage rec {
@@ -25,6 +27,8 @@ buildPythonPackage rec {
   format = "pyproject";
 
   nativeBuildInputs = with rustPlatform; [ cargoSetupHook maturinBuildHook ];
+
+  buildInputs = lib.optionals stdenv.isDarwin [ libiconv ];
 
   pythonImportsCheck = [ "lzallright" ];
 

--- a/pkgs/development/python-modules/lzallright/default.nix
+++ b/pkgs/development/python-modules/lzallright/default.nix
@@ -1,0 +1,46 @@
+{ lib
+, buildPythonPackage
+, callPackage
+, fetchFromGitHub
+, rustPlatform
+}:
+
+buildPythonPackage rec {
+  pname = "lzallright";
+  version = "0.2.3";
+
+  src = fetchFromGitHub {
+    owner = "vlaci";
+    repo = pname;
+    rev = "v${version}";
+    hash = "sha256-Zzif6WtecgAkNmml0kt0Z+Ewx0L30ahr+kwzYR5aUAM=";
+  };
+
+  cargoDeps = rustPlatform.fetchCargoTarball {
+    inherit src;
+    name = "${pname}-${version}";
+    hash = "sha256-+pV9q2QM6qFA1a5E10OAsE7KJEUsTiEiU1KqO4/2rFw=";
+  };
+
+  format = "pyproject";
+
+  nativeBuildInputs = with rustPlatform; [ cargoSetupHook maturinBuildHook ];
+
+  pythonImportsCheck = [ "lzallright" ];
+
+  doCheck = false;
+
+  passthru.tests = {
+    pytest = callPackage ./tests.nix { };
+  };
+
+  meta = with lib; {
+    description = ''
+      A Python 3.8+ binding for lzokay library which is an MIT licensed
+      a minimal, C++14 implementation of the LZO compression format.
+    '';
+    homepage = "https://github.com/vlaci/lzallright";
+    license = licenses.mit;
+    maintainers = with maintainers; [ vlaci ];
+  };
+}

--- a/pkgs/development/python-modules/lzallright/tests.nix
+++ b/pkgs/development/python-modules/lzallright/tests.nix
@@ -1,0 +1,15 @@
+{ lzallright, buildPythonPackage, pytestCheckHook }:
+
+buildPythonPackage {
+  inherit (lzallright) version src;
+  pname = "lzallright-tests";
+  format = "other";
+
+  dontBuild = true;
+  dontInstall = true;
+
+  nativeCheckInputs = [
+    lzallright
+    pytestCheckHook
+  ];
+}

--- a/pkgs/tools/filesystems/ubi_reader/default.nix
+++ b/pkgs/tools/filesystems/ubi_reader/default.nix
@@ -5,24 +5,25 @@
 
 python3.pkgs.buildPythonApplication rec {
   pname = "ubi_reader";
-  version = "0.8.5";
-  format = "setuptools";
+  version = "0.8.9";
+  format = "pyproject";
 
   src = fetchFromGitHub {
-    owner = "jrspruitt";
+    owner = "onekey-sec";
     repo = pname;
-    rev = "v${version}-master";
-    hash = "sha256-tjQs1F9kcFrC9FDkfdnax0C8O8Bg7blkpL7GU56eeWU=";
+    rev = "v${version}";
+    hash = "sha256-04HwzkonPzzWfX8VE//fMoVv5ggAS+61zx2W8VEUIy4=";
   };
 
-  propagatedBuildInputs = with python3.pkgs; [ python-lzo ];
+  nativeBuildInputs = with python3.pkgs; [ poetry-core ];
+  propagatedBuildInputs = with python3.pkgs; [ lzallright ];
 
   # There are no tests in the source
   doCheck = false;
 
   meta = with lib; {
     description = "Collection of Python scripts for reading information about and extracting data from UBI and UBIFS images";
-    homepage = "https://github.com/jrspruitt/ubi_reader";
+    homepage = "https://github.com/onekey-sec/ubi_reader";
     license = licenses.gpl3Only;
     maintainers = with maintainers; [ vlaci ];
   };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5969,6 +5969,8 @@ self: super: with self; {
 
   lz4 = callPackage ../development/python-modules/lz4 { };
 
+  lzallright = callPackage ../development/python-modules/lzallright { };
+
   lzstring = callPackage ../development/python-modules/lzstring { };
 
   m2crypto = callPackage ../development/python-modules/m2crypto { };


### PR DESCRIPTION
###### Description of changes

- Repository ownership was transferred to `onekey-sec`[^1].
- Packaging now uses `Poetry`
- `python-lzo` is switched to `lzallright`, which is the same commit as in https://github.com/NixOS/nixpkgs/pull/233487
    
[^1]: https://github.com/onekey-sec/ubi_reader/discussions/74

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
