### PR TITLE
openbugs: init at 3.2.3

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -911,6 +911,12 @@
     githubId = 293191;
     name = "Andres Loeh";
   };
+  andresnav = {
+    email = "nix@andresnav.com";
+    github = "andres-nav";
+    githubId = 118762770;
+    name = "Andres Navarro";
+  };
   andresilva = {
     email = "andre.beat@gmail.com";
     github = "andresilva";

--- a/pkgs/applications/science/machine-learning/openbugs/default.nix
+++ b/pkgs/applications/science/machine-learning/openbugs/default.nix
@@ -1,0 +1,48 @@
+{ lib
+, stdenv
+, fetchurl
+, glibc_multi
+, gcc_multi
+, libgccjit
+}:
+
+stdenv.mkDerivation rec {
+  pname = "openbugs";
+  version = "3.2.3";
+
+  src = fetchurl {
+    url = "https://www.mrc-bsu.cam.ac.uk/wp-content/uploads/2018/04/OpenBUGS-${version}.tar.gz";
+    sha256 = "sha256-oonE2gxKw3H4ATImyF69Cp4d7F3puFiVDkhUy4FLTtg=";
+  };
+
+  nativeBuildInputs = [ glibc_multi gcc_multi libgccjit ];
+
+  configurePhase = ''
+    ./configure
+  '';
+
+  buildPhase = ''
+    cd src
+    make
+    cd ..
+  '';
+
+  installPhase = ''
+    mkdir -p $out/bin
+
+    cd src
+    cp OpenBUGSCli $out/bin/openbugs
+    cd ..
+
+    cp -r lib $out
+    cp -r doc $out
+  '';
+
+
+  meta = with lib; {
+    description = "Open source program for Bayesian modelling based on MCMC";
+    homepage = "https://www.mrc-bsu.cam.ac.uk/software/bugs/openbugs/";
+    maintainers = with maintainers; [ andresnav ];
+    license = licenses.gpl3;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1600,6 +1600,8 @@ with pkgs;
 
   ocs-url = libsForQt5.callPackage ../tools/misc/ocs-url { };
 
+  openbugs = callPackage ../applications/science/machine-learning/openbugs { };
+
   paperview = callPackage ../tools/X11/paperview { };
 
   pferd = callPackage ../tools/misc/pferd { };


### PR DESCRIPTION
###### Description of changes

Uploaded a new package calles OpenBUGS and added myself as a maintainer.

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

