### PR TITLE
argc: 1.1.0 -> 1.2.0

### DIFF
--- a/pkgs/development/tools/argc/default.nix
+++ b/pkgs/development/tools/argc/default.nix
@@ -2,28 +2,33 @@
 , rustPlatform
 , fetchFromGitHub
 , installShellFiles
-, rust
-, stdenv
+, fetchpatch
 }:
 
 rustPlatform.buildRustPackage rec {
   pname = "argc";
-  version = "1.1.0";
+  version = "1.2.0";
 
   src = fetchFromGitHub {
     owner = "sigoden";
     repo = pname;
     rev = "v${version}";
-    hash = "sha256-db75OoFmsR03lK99vGg8+fHJENOyoDFo+uqQJNYmI9M=";
+    hash = "sha256-sJINgB1cGtqLPl2RmwgChwnSrJL5TWu5AU6hfLhvmE4=";
   };
 
-  cargoHash = "sha256-6TC4RWDcg4el+jkq8Jal0k+2sdNsjMkMYqP/b9wP5mU=";
+  cargoHash = "sha256-HrmqARhEKlAjrW6QieVEEKkfda6R69oLcG/6fd3rvWM=";
+
+  patches = [
+    # tests make the assumption that the compiled binary is in target/debug,
+    # which fails since `cargoBuildHook` uses `--release` and `--target`
+    (fetchpatch {
+      name = "fix-tests-with-release-or-target";
+      url = "https://github.com/sigoden/argc/commit/a4f2db46e27cad14d3251ef0b25b6f2ea9e70f0e.patch";
+      hash = "sha256-bsHSo11/RVstyzdg0BKFhjuWUTLdKO4qsWIOjTTi+HQ=";
+    })
+  ];
 
   nativeBuildInputs = [ installShellFiles ];
-
-  preCheck = ''
-    export PATH=target/${rust.toRustTarget stdenv.hostPlatform}/release:$PATH
-  '';
 
   postInstall = ''
     installShellCompletion --cmd argc \


### PR DESCRIPTION
Diff: https://github.com/sigoden/argc/compare/v1.1.0...v1.2.0

Changelog: https://github.com/sigoden/argc/releases/tag/v1.2.0

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
