### PR TITLE
libxfce4ui, xfce4-panel: 4.18.3 -> 4.18.4

### DIFF
--- a/pkgs/desktops/xfce/core/libxfce4ui/default.nix
+++ b/pkgs/desktops/xfce/core/libxfce4ui/default.nix
@@ -4,9 +4,9 @@
 mkXfceDerivation {
   category = "xfce";
   pname = "libxfce4ui";
-  version = "4.18.3";
+  version = "4.18.4";
 
-  sha256 = "sha256-Wb1nq744HDO4erJ2nJdFD0OMHVh14810TngN3FLFWIA=";
+  sha256 = "sha256-HnLmZftvFvQAvmQ7jZCaYAQ5GB0YMjzhqZkILzvifoE=";
 
   nativeBuildInputs = [ gobject-introspection vala ];
   buildInputs =  [ gtk3 libstartup_notification libgtop libepoxy xfconf ];

--- a/pkgs/desktops/xfce/core/xfce4-panel/default.nix
+++ b/pkgs/desktops/xfce/core/xfce4-panel/default.nix
@@ -16,9 +16,9 @@
 mkXfceDerivation {
   category = "xfce";
   pname = "xfce4-panel";
-  version = "4.18.3";
+  version = "4.18.4";
 
-  sha256 = "sha256-NSy0MTphzGth0w+Kn93hWvsjLw6qR8SqjYYc1Z2SWIs=";
+  sha256 = "sha256-OEU9NzvgWn6zJGdK9Te2qBbARlwvRrLHuaUocNyGd/g=";
 
   nativeBuildInputs = [
     gobject-introspection


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

Result of `nixpkgs-review pr 233536 --extra-nixpkgs-config '{ allowBroken = false; }'` run on x86_64-linux [1](https://github.com/Mic92/nixpkgs-review)
<details>
  <summary>4 packages marked as broken and skipped:</summary>
  <ul>
    <li>xfce.thunar-bare</li>
    <li>xfce.xfce4-embed-plugin</li>
    <li>xfce.xfce4-namebar-plugin</li>
    <li>xmonad_log_applet_xfce</li>
  </ul>
</details>
<details>
  <summary>88 packages built:</summary>
  <ul>
    <li>xfce.exo</li>
    <li>xfce.exo.dev</li>
    <li>xfce.garcon</li>
    <li>xfce.garcon.dev</li>
    <li>xfce.libxfce4ui</li>
    <li>xfce.libxfce4ui.dev</li>
    <li>xfce.orage</li>
    <li>xfce.orage.dev</li>
    <li>xfce.parole</li>
    <li>xfce.parole.dev</li>
    <li>xfce.ristretto</li>
    <li>xfce.ristretto.dev</li>
    <li>xfce.thunar</li>
    <li>xfce.thunar-archive-plugin</li>
    <li>xfce.thunar-archive-plugin.dev</li>
    <li>xfce.thunar-dropbox-plugin</li>
    <li>xfce.thunar-media-tags-plugin</li>
    <li>xfce.thunar-media-tags-plugin.dev</li>
    <li>xfce.thunar-volman</li>
    <li>xfce.thunar-volman.dev</li>
    <li>xfce.thunar.dev</li>
    <li>xfce.xfburn</li>
    <li>xfce.xfburn.dev</li>
    <li>xfce.xfce4-appfinder</li>
    <li>xfce.xfce4-appfinder.dev</li>
    <li>xfce.xfce4-battery-plugin</li>
    <li>xfce.xfce4-battery-plugin.dev</li>
    <li>xfce.xfce4-clipman-plugin</li>
    <li>xfce.xfce4-clipman-plugin.dev</li>
    <li>xfce.xfce4-cpufreq-plugin</li>
    <li>xfce.xfce4-cpufreq-plugin.dev</li>
    <li>xfce.xfce4-cpugraph-plugin</li>
    <li>xfce.xfce4-cpugraph-plugin.dev</li>
    <li>xfce.xfce4-datetime-plugin</li>
    <li>xfce.xfce4-datetime-plugin.dev</li>
    <li>xfce.xfce4-dict</li>
    <li>xfce.xfce4-dict.dev</li>
    <li>xfce.xfce4-dockbarx-plugin</li>
    <li>xfce.xfce4-eyes-plugin</li>
    <li>xfce.xfce4-fsguard-plugin</li>
    <li>xfce.xfce4-genmon-plugin</li>
    <li>xfce.xfce4-i3-workspaces-plugin</li>
    <li>xfce.xfce4-mailwatch-plugin</li>
    <li>xfce.xfce4-mpc-plugin</li>
    <li>xfce.xfce4-netload-plugin</li>
    <li>xfce.xfce4-netload-plugin.dev</li>
    <li>xfce.xfce4-notes-plugin</li>
    <li>xfce.xfce4-notifyd</li>
    <li>xfce.xfce4-notifyd.dev</li>
    <li>xfce.xfce4-panel</li>
    <li>xfce.xfce4-panel-profiles</li>
    <li>xfce.xfce4-panel-profiles.dev</li>
    <li>xfce.xfce4-panel.dev</li>
    <li>xfce.xfce4-power-manager</li>
    <li>xfce.xfce4-power-manager.dev</li>
    <li>xfce.xfce4-pulseaudio-plugin</li>
    <li>xfce.xfce4-pulseaudio-plugin.dev</li>
    <li>xfce.xfce4-screensaver</li>
    <li>xfce.xfce4-screensaver.dev</li>
    <li>xfce.xfce4-screenshooter</li>
    <li>xfce.xfce4-screenshooter.dev</li>
    <li>xfce.xfce4-sensors-plugin</li>
    <li>xfce.xfce4-session</li>
    <li>xfce.xfce4-session.dev</li>
    <li>xfce.xfce4-settings</li>
    <li>xfce.xfce4-settings.dev</li>
    <li>xfce.xfce4-systemload-plugin</li>
    <li>xfce.xfce4-taskmanager</li>
    <li>xfce.xfce4-taskmanager.dev</li>
    <li>xfce.xfce4-terminal</li>
    <li>xfce.xfce4-terminal.dev</li>
    <li>xfce.xfce4-time-out-plugin</li>
    <li>xfce.xfce4-time-out-plugin.dev</li>
    <li>xfce.xfce4-timer-plugin</li>
    <li>xfce.xfce4-verve-plugin</li>
    <li>xfce.xfce4-verve-plugin.dev</li>
    <li>xfce.xfce4-weather-plugin</li>
    <li>xfce.xfce4-whiskermenu-plugin</li>
    <li>xfce.xfce4-whiskermenu-plugin.dev</li>
    <li>xfce.xfce4-windowck-plugin</li>
    <li>xfce.xfce4-xkb-plugin</li>
    <li>xfce.xfce4-xkb-plugin.dev</li>
    <li>xfce.xfdashboard</li>
    <li>xfce.xfdashboard.dev</li>
    <li>xfce.xfdesktop</li>
    <li>xfce.xfdesktop.dev</li>
    <li>xfce.xfwm4</li>
    <li>xfce.xfwm4.dev</li>
  </ul>
</details>
