### PR TITLE
emacsPackages.mind-wave 2d94f553a394ce73bcb91490b81e0fc042baa8d3 -> 5…

### DIFF
--- a/pkgs/applications/editors/emacs/elisp-packages/manual-packages/mind-wave/default.nix
+++ b/pkgs/applications/editors/emacs/elisp-packages/manual-packages/mind-wave/default.nix
@@ -47,14 +47,14 @@
 # ];
 melpaBuild rec {
   pname = "mind-wave";
-  version = "20230322.1348"; # 13:48 UTC
+  version = "20230523.0332"; # 03:32 UTC
   src = pkgs.fetchFromGitHub {
     owner = "manateelazycat";
     repo = "mind-wave";
-    rev = "2d94f553a394ce73bcb91490b81e0fc042baa8d3";
-    sha256 = "sha256-6tmcPYAEch5bX5hEHMiQGDNYEMUOvnxF1Vq0VVpBsYo=";
+    rev = "5109162b74872091c5090a28389bef8f7020274c";
+    sha256 = "sha256-ZyXrpb0GLWSGnMsVIGL9qALSBCeIWNF0UwkCFgCKnu8=";
   };
-  commit = "2d94f553a394ce73bcb91490b81e0fc042baa8d3";
+  commit = "5109162b74872091c5090a28389bef8f7020274c";
   # elisp dependencies
   packageRequires = [
     pkgs.emacsPackages.markdown-mode


### PR DESCRIPTION
…109162b74872091c5090a28389bef8f7020274c

###### Description of changes

emacsPackages.mind-wave 2d94f553a394ce73bcb91490b81e0fc042baa8d3 -> 5109162b74872091c5090a28389bef8f7020274c

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
