### PR TITLE
fetchFromSourcehut: expose `gitRepoUrl` to consumers

### DIFF
--- a/pkgs/build-support/fetchsourcehut/default.nix
+++ b/pkgs/build-support/fetchsourcehut/default.nix
@@ -15,7 +15,8 @@ with lib;
 assert (lib.assertOneOf "vc" vc [ "hg" "git" ]);
 
 let
-  baseUrl = "https://${vc}.${domain}/${owner}/${repo}";
+  urlFor = resource: "https://${resource}.${domain}/${owner}/${repo}";
+  baseUrl = urlFor vc;
   baseArgs = {
     inherit name;
   } // removeAttrs args [
@@ -42,6 +43,9 @@ let
         postFetch = optionalString (vc == "hg") ''
           rm -f "$out/.hg_archival.txt"
         ''; # impure file; see #12002
+        passthru = {
+          gitRepoUrl = urlFor "git";
+        };
       };
     };
   };


### PR DESCRIPTION
notable consumers include `unstableGitUpdater`.
other git-like fetchers ([`fetchFromGitHub`](https://github.com/NixOS/nixpkgs/blob/master/pkgs/build-support/fetchgithub/default.nix#L57)) already do this.

example workflow that this enables:
- add `passthru.updateScript = unstableGitUpdater { }` to pkgs/applications/emulators/uxn/default.nix
- invoke the update script: `nix-shell maintainers/scripts/update.nix --argstr package uxn`

without this patch step 2 fails: `error: attribute 'gitRepoUrl' missing`. with this patch, it succeeds. 


###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

since this only touches `passthru` it largely shouldn't trigger any rebuilds, but i re-evaluated some sourcehut packages like `wofi` and `greetd.gtkgreet` as a sanity check.