### PR TITLE
nixos/azure-new: Fix small issues with scripts

### DIFF
--- a/nixos/maintainers/scripts/azure-new/boot-vm.sh
+++ b/nixos/maintainers/scripts/azure-new/boot-vm.sh
@@ -8,7 +8,7 @@ group="nixos-test-vm"
 vm_size="Standard_D2s_v3";  os_size=42;
 
 # ensure group
-az group create --location "westus2" --name "${group}"
+az group create --location "${location}" --name "${group}"
 group_id="$(az group show --name "${group}" -o tsv --query "[id]")"
 
 # (optional) identity
@@ -30,7 +30,6 @@ az vm create \
   --os-disk-size-gb "${os_size}" \
   --image "${image}" \
   --admin-username "${USER}" \
-  --location "westus2" \
+  --location "${location}" \
   --storage-sku "Premium_LRS" \
-  --ssh-key-values "$(ssh-add -L)"
-
+  --ssh-key-values "$(ssh-add -L | grep ssh-rsa)"

--- a/nixos/maintainers/scripts/azure-new/examples/basic/system.nix
+++ b/nixos/maintainers/scripts/azure-new/examples/basic/system.nix
@@ -15,6 +15,7 @@ in
     isNormalUser = true;
     home = "/home/${username}";
     description = "Azure NixOS Test User";
+    extraGroups = [ "wheel" ];
     openssh.authorizedKeys.keys = [ (builtins.readFile ~/.ssh/id_ed25519.pub) ];
   };
   nix.settings.trusted-users = [ username ];
@@ -24,7 +25,7 @@ in
   boot.kernelPackages = pkgs.linuxPackages_latest;
 
   # test user doesn't have a password
-  services.openssh.passwordAuthentication = false;
+  services.openssh.settings.PasswordAuthentication = false;
   security.sudo.wheelNeedsPassword = false;
 
   environment.systemPackages = with pkgs; [


### PR DESCRIPTION
###### Description of changes

I had some problems creating azure vm images using the azure-new scripts. Here are some fixes.

- Fixed #39523
- Used variable instead of hardcoding in more places
- Azure wants ssh-rsa format SSH public keys
- Fixed deprecation
- Updated system.stateVersion

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
- [x] Tested on azure
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
