### PR TITLE
python3Packages.pymanopt: marked as broken

### DIFF
--- a/pkgs/development/python-modules/pymanopt/default.nix
+++ b/pkgs/development/python-modules/pymanopt/default.nix
@@ -5,14 +5,14 @@
 , scipy
 , torch
 , autograd
-, nose2
 , matplotlib
-, tensorflow
+, pytestCheckHook
 }:
 
 buildPythonPackage rec {
   pname = "pymanopt";
   version = "2.1.1";
+  format = "setuptools";
 
   src = fetchFromGitHub {
     owner = pname;
@@ -22,24 +22,20 @@ buildPythonPackage rec {
   };
 
   propagatedBuildInputs = [ numpy scipy torch ];
-  nativeCheckInputs = [ nose2 autograd matplotlib tensorflow ];
+  nativeCheckInputs = [ autograd matplotlib pytestCheckHook ];
 
-  checkPhase = ''
-    runHook preCheck
-
-    # upstream themselves seem unsure about the robustness of these
-    # tests - see https://github.com/pymanopt/pymanopt/issues/219
-    grep -lr 'test_second_order_function_approximation' tests/ | while read -r fn ; do
-      substituteInPlace "$fn" \
-        --replace \
-          'test_second_order_function_approximation' \
-          'dont_test_second_order_function_approximation'
-    done
-
-    nose2 tests -v
-
-    runHook postCheck
+  preCheck = ''
+    substituteInPlace "tests/conftest.py" \
+      --replace "import tensorflow as tf" ""
+    substituteInPlace "tests/conftest.py" \
+      --replace "tf.random.set_seed(seed)" ""
   '';
+
+  disabledTestPaths = [
+    "tests/test_examples.py"
+    "tests/backends/test_tensorflow.py"
+    "tests/test_problem.py"
+  ];
 
   pythonImportsCheck = [ "pymanopt" ];
 
@@ -48,5 +44,6 @@ buildPythonPackage rec {
     homepage = "https://www.pymanopt.org/";
     license = lib.licenses.bsd3;
     maintainers = with lib.maintainers; [ yl3dy ];
+    broken = lib.versionAtLeast scipy.version "1.10.0";
   };
 }


### PR DESCRIPTION
###### Description of changes

pymanopt is incompatible with scipy 1.10, waiting for upstream to catch up. Alternative to #233607

ZHF: https://github.com/NixOS/nixpkgs/issues/230712

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).