### PR TITLE
mesa: fix cross compilation to x86_64

### DIFF
--- a/lib/systems/default.nix
+++ b/lib/systems/default.nix
@@ -43,6 +43,10 @@ rec {
   elaborate = args': let
     args = if lib.isString args' then { system = args'; }
            else args';
+
+    # TODO: deprecate args.rustc in favour of args.rust after 23.05 is EOL.
+    rust = assert !(args ? rust && args ? rustc); args.rust or args.rustc or {};
+
     final = {
       # Prefer to parse `config` as it is strictly more informative.
       parsed = parse.mkSystemFromString (if args ? config then args.config else args.system);
@@ -159,9 +163,101 @@ rec {
         ({
           linux-kernel = args.linux-kernel or {};
           gcc = args.gcc or {};
-          rustc = args.rustc or {};
         } // platforms.select final)
-        linux-kernel gcc rustc;
+        linux-kernel gcc;
+
+      # TODO: remove after 23.05 is EOL, with an error pointing to the rust.* attrs.
+      rustc = args.rustc or {};
+
+      rust = rust // {
+        # Once args.rustc.platform.target-family is deprecated and
+        # removed, there will no longer be any need to modify any
+        # values from args.rust.platform, so we can drop all the
+        # "args ? rust" etc. checks, and merge args.rust.platform in
+        # /after/.
+        platform = rust.platform or {} // {
+          # https://doc.rust-lang.org/reference/conditional-compilation.html#target_arch
+          arch =
+            /**/ if rust ? platform then rust.platform.arch
+            else if final.isAarch32 then "arm"
+            else if final.isMips64  then "mips64"     # never add "el" suffix
+            else if final.isPower64 then "powerpc64"  # never add "le" suffix
+            else final.parsed.cpu.name;
+
+          # https://doc.rust-lang.org/reference/conditional-compilation.html#target_os
+          os =
+            /**/ if rust ? platform then rust.platform.os or "none"
+            else if final.isDarwin then "macos"
+            else final.parsed.kernel.name;
+
+          # https://doc.rust-lang.org/reference/conditional-compilation.html#target_family
+          target-family =
+            /**/ if args ? rust.platform.target-family then args.rust.platform.target-family
+            else if args ? rustc.platform.target-family
+            then
+              (
+                # Since https://github.com/rust-lang/rust/pull/84072
+                # `target-family` is a list instead of single value.
+                let
+                  f = args.rustc.platform.target-family;
+                in
+                  if builtins.isList f then f else [ f ]
+              )
+            else lib.optional final.isUnix "unix"
+                 ++ lib.optional final.isWindows "windows";
+
+          # https://doc.rust-lang.org/reference/conditional-compilation.html#target_vendor
+          vendor = let
+            inherit (final.parsed) vendor;
+          in rust.platform.vendor or {
+            "w64" = "pc";
+          }.${vendor.name} or vendor.name;
+        };
+
+        # The name of the rust target, even if it is custom. Adjustments are
+        # because rust has slightly different naming conventions than we do.
+        rustcTarget = let
+          inherit (final.parsed) cpu kernel abi;
+          cpu_ = rust.platform.arch or {
+            "armv7a" = "armv7";
+            "armv7l" = "armv7";
+            "armv6l" = "arm";
+            "armv5tel" = "armv5te";
+            "riscv64" = "riscv64gc";
+          }.${cpu.name} or cpu.name;
+          vendor_ = final.rust.platform.vendor;
+        in rust.config
+          or "${cpu_}-${vendor_}-${kernel.name}${lib.optionalString (abi.name != "unknown") "-${abi.name}"}";
+
+        # The name of the rust target if it is standard, or the json file
+        # containing the custom target spec.
+        rustcTargetSpec =
+          /**/ if rust ? platform
+          then builtins.toFile (final.rust.rustcTarget + ".json") (builtins.toJSON rust.platform)
+          else final.rust.rustcTarget;
+
+        # The name of the rust target if it is standard, or the
+        # basename of the file containing the custom target spec,
+        # without the .json extension.
+        #
+        # This is the name used by Cargo for target subdirectories.
+        cargoShortTarget =
+          lib.removeSuffix ".json" (baseNameOf "${final.rust.rustcTargetSpec}");
+
+        # When used as part of an environment variable name, triples are
+        # uppercased and have all hyphens replaced by underscores:
+        #
+        # https://github.com/rust-lang/cargo/pull/9169
+        # https://github.com/rust-lang/cargo/issues/8285#issuecomment-634202431
+        cargoEnvVarTarget =
+          lib.strings.replaceStrings ["-"] ["_"]
+            (lib.strings.toUpper final.rust.cargoShortTarget);
+
+        # True if the target is no_std
+        # https://github.com/rust-lang/rust/blob/2e44c17c12cec45b6a682b1e53a04ac5b5fcc9d2/src/bootstrap/config.rs#L415-L421
+        isNoStdTarget =
+          builtins.any (t: lib.hasInfix t final.rust.rustcTarget) ["-none" "nvptx" "switch" "-uefi"];
+      };
 
       linuxArch =
         if final.isAarch32 then "arm"

--- a/pkgs/applications/blockchains/zcash/default.nix
+++ b/pkgs/applications/blockchains/zcash/default.nix
@@ -1,5 +1,5 @@
 { autoreconfHook, boost180, cargo, coreutils, curl, cxx-rs, db62, fetchFromGitHub
-, git, hexdump, lib, libevent, libsodium, makeWrapper, rust, rustPlatform
+, git, hexdump, lib, libevent, libsodium, makeWrapper, rustPlatform
 , pkg-config, Security, stdenv, testers, tl-expected, utf8cpp, util-linux, zcash, zeromq
 }:
 
@@ -57,7 +57,7 @@ rustPlatform.buildRustPackage.override { inherit stdenv; } rec {
   configureFlags = [
     "--disable-tests"
     "--with-boost-libdir=${lib.getLib boost180}/lib"
-    "RUST_TARGET=${rust.toRustTargetSpec stdenv.hostPlatform}"
+    "RUST_TARGET=${stdenv.hostPlatform.rust.rustcTargetSpec}"
   ];
 
   enableParallelBuilding = true;

--- a/pkgs/applications/misc/effitask/default.nix
+++ b/pkgs/applications/misc/effitask/default.nix
@@ -5,7 +5,6 @@
 , openssl
 , gtk3
 , stdenv
-, rust
 }:
 
 rustPlatform.buildRustPackage rec {
@@ -28,7 +27,7 @@ rustPlatform.buildRustPackage rec {
   # default installPhase don't install assets
   installPhase = ''
     runHook preInstall
-    make install PREFIX="$out" TARGET="target/${rust.toRustTarget stdenv.hostPlatform}/release/effitask"
+    make install PREFIX="$out" TARGET="target/${stdenv.hostPlatform.rust.rustcTarget}/release/effitask"
     runHook postInstall
   '';
 

--- a/pkgs/applications/window-managers/cosmic/applets/default.nix
+++ b/pkgs/applications/window-managers/cosmic/applets/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchFromGitHub, rust, rustPlatform
+{ lib, stdenv, fetchFromGitHub, rustPlatform
 , cargo, just, pkg-config, util-linuxMinimal
 , dbus, glib, libxkbcommon, pulseaudio, wayland
 }:
@@ -41,11 +41,11 @@ rustPlatform.buildRustPackage {
 
   justFlags = [
     "--set" "prefix" (placeholder "out")
-    "--set" "target" "${rust.lib.toRustTargetSpecShort stdenv.hostPlatform}/release"
+    "--set" "target" "${stdenv.hostPlatform.rust.cargoShortTarget}/release"
   ];
 
   # Force linking to libwayland-client, which is always dlopen()ed.
-  "CARGO_TARGET_${rust.toRustTargetForUseInEnvVars stdenv.hostPlatform}_RUSTFLAGS" =
+  "CARGO_TARGET_${stdenv.hostPlatform.rust.cargoEnvVarTarget}_RUSTFLAGS" =
     map (a: "-C link-arg=${a}") [
       "-Wl,--push-state,--no-as-needed"
       "-lwayland-client"

--- a/pkgs/applications/window-managers/cosmic/panel/default.nix
+++ b/pkgs/applications/window-managers/cosmic/panel/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchFromGitHub, cargo, just, pkg-config, rust, rustPlatform
+{ lib, stdenv, fetchFromGitHub, cargo, just, pkg-config, rustPlatform
 , libglvnd, libxkbcommon, wayland
 }:
 
@@ -33,11 +33,11 @@ rustPlatform.buildRustPackage {
 
   justFlags = [
     "--set" "prefix" (placeholder "out")
-    "--set" "bin-src" "target/${rust.lib.toRustTargetSpecShort stdenv.hostPlatform}/release/cosmic-panel"
+    "--set" "bin-src" "target/${stdenv.hostPlatform.rust.cargoShortTarget}/release/cosmic-panel"
   ];
 
   # Force linking to libEGL, which is always dlopen()ed.
-  "CARGO_TARGET_${rust.toRustTargetForUseInEnvVars stdenv.hostPlatform}_RUSTFLAGS" =
+  "CARGO_TARGET_${stdenv.hostPlatform.rust.cargoEnvVarTarget}_RUSTFLAGS" =
     map (a: "-C link-arg=${a}") [
       "-Wl,--push-state,--no-as-needed"
       "-lEGL"

--- a/pkgs/applications/window-managers/cosmic/settings/default.nix
+++ b/pkgs/applications/window-managers/cosmic/settings/default.nix
@@ -61,7 +61,7 @@ rustPlatform.buildRustPackage {
     (placeholder "out")
     "--set"
     "bin-src"
-    "target/${rust.lib.toRustTargetSpecShort stdenv.hostPlatform}/release/cosmic-settings"
+    "target/${stdenv.hostPlatform.rust.cargoShortTarget}/release/cosmic-settings"
   ];
 
   meta = with lib; {

--- a/pkgs/build-support/rust/build-rust-crate/build-crate.nix
+++ b/pkgs/build-support/rust/build-rust-crate/build-crate.nix
@@ -1,6 +1,5 @@
 { lib, stdenv
 , mkRustcDepArgs, mkRustcFeatureArgs, needUnstableCLI
-, rust
 }:
 
 { crateName,
@@ -21,7 +20,7 @@
         (mkRustcDepArgs dependencies crateRenames)
         (mkRustcFeatureArgs crateFeatures)
       ] ++ lib.optionals (stdenv.hostPlatform != stdenv.buildPlatform) [
-        "--target" (rust.toRustTargetSpec stdenv.hostPlatform)
+        "--target" stdenv.hostPlatform.rust.rustcTargetSpec
       ] ++ lib.optionals (needUnstableCLI dependencies) [
         "-Z" "unstable-options"
       ] ++ extraRustcOpts

--- a/pkgs/build-support/rust/build-rust-crate/configure-crate.nix
+++ b/pkgs/build-support/rust/build-rust-crate/configure-crate.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, rust, echo_colored, noisily, mkRustcDepArgs, mkRustcFeatureArgs }:
+{ lib, stdenv, echo_colored, noisily, mkRustcDepArgs, mkRustcFeatureArgs }:
 {
   build
 , buildDependencies
@@ -124,8 +124,8 @@ in ''
   export CARGO_PKG_AUTHORS="${authors}"
   export CARGO_PKG_DESCRIPTION="${crateDescription}"
 
-  export CARGO_CFG_TARGET_ARCH=${rust.toTargetArch stdenv.hostPlatform}
-  export CARGO_CFG_TARGET_OS=${rust.toTargetOs stdenv.hostPlatform}
+  export CARGO_CFG_TARGET_ARCH=${stdenv.hostPlatform.rust.platform.arch}
+  export CARGO_CFG_TARGET_OS=${stdenv.hostPlatform.rust.platform.os}
   export CARGO_CFG_TARGET_FAMILY="unix"
   export CARGO_CFG_UNIX=1
   export CARGO_CFG_TARGET_ENV="gnu"
@@ -136,8 +136,8 @@ in ''
   export CARGO_MANIFEST_DIR=$(pwd)
   export DEBUG="${toString (!release)}"
   export OPT_LEVEL="${toString optLevel}"
-  export TARGET="${rust.toRustTargetSpec stdenv.hostPlatform}"
-  export HOST="${rust.toRustTargetSpec stdenv.buildPlatform}"
+  export TARGET="${stdenv.hostPlatform.rust.rustcTargetSpec}"
+  export HOST="${stdenv.buildPlatform.rust.rustcTargetSpec}"
   export PROFILE=${if release then "release" else "debug"}
   export OUT_DIR=$(pwd)/target/build/${crateName}.out
   export CARGO_PKG_VERSION_MAJOR=${lib.elemAt version 0}

--- a/pkgs/build-support/rust/build-rust-crate/default.nix
+++ b/pkgs/build-support/rust/build-rust-crate/default.nix
@@ -10,7 +10,6 @@
 , fetchCrate
 , pkgsBuildBuild
 , rustc
-, rust
 , cargo
 , jq
 , libiconv
@@ -71,18 +70,14 @@ let
   inherit (import ./log.nix { inherit lib; }) noisily echo_colored;
 
   configureCrate = import ./configure-crate.nix {
-    inherit lib stdenv rust echo_colored noisily mkRustcDepArgs mkRustcFeatureArgs;
+    inherit lib stdenv echo_colored noisily mkRustcDepArgs mkRustcFeatureArgs;
   };
 
   buildCrate = import ./build-crate.nix {
-    inherit lib stdenv mkRustcDepArgs mkRustcFeatureArgs needUnstableCLI rust;
+    inherit lib stdenv mkRustcDepArgs mkRustcFeatureArgs needUnstableCLI;
   };
 
   installCrate = import ./install-crate.nix { inherit stdenv; };
-
-  # Allow access to the rust attribute set from inside buildRustCrate, which
-  # has a parameter that shadows the name.
-  rustAttrs = rust;
 in
 
   /* The overridable pkgs.buildRustCrate function.
@@ -310,7 +305,7 @@ crate_: lib.makeOverridable
           depsMetadata = lib.foldl' (str: dep: str + dep.metadata) "" (dependencies ++ buildDependencies);
           hashedMetadata = builtins.hashString "sha256"
             (crateName + "-" + crateVersion + "___" + toString (mkRustcFeatureArgs crateFeatures) +
-              "___" + depsMetadata + "___" + rustAttrs.toRustTarget stdenv.hostPlatform);
+              "___" + depsMetadata + "___" + stdenv.hostPlatform.rust.rustcTarget);
         in
         lib.substring 0 10 hashedMetadata;
 

--- a/pkgs/build-support/rust/build-rust-package/default.nix
+++ b/pkgs/build-support/rust/build-rust-package/default.nix
@@ -1,7 +1,6 @@
 { lib
 , importCargoLock
 , fetchCargoTarball
-, rust
 , stdenv
 , callPackage
 , cargoBuildHook
@@ -78,13 +77,13 @@ let
       sha256 = args.cargoSha256;
     } // depsExtraArgs);
 
-  target = rust.toRustTargetSpec stdenv.hostPlatform;
+  target = stdenv.hostPlatform.rust.rustcTargetSpec;
   targetIsJSON = lib.hasSuffix ".json" target;
   useSysroot = targetIsJSON && !__internal_dontAddSysroot;
 
   sysroot = callPackage ./sysroot { } {
     inherit target;
-    shortTarget = rust.lib.toRustTargetSpecShort stdenv.hostPlatform;
+    shortTarget = stdenv.hostPlatform.rust.cargoShortTarget;
     RUSTFLAGS = args.RUSTFLAGS or "";
     originalCargoToml = src + /Cargo.toml; # profile info is later extracted
   };

--- a/pkgs/build-support/rust/build-rust-package/sysroot/default.nix
+++ b/pkgs/build-support/rust/build-rust-package/sysroot/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, rust, rustPlatform, buildPackages }:
+{ lib, stdenv, rustPlatform, buildPackages }:
 
 { shortTarget, originalCargoToml, target, RUSTFLAGS }:
 
@@ -26,7 +26,7 @@ in rustPlatform.buildRustPackage {
     done
 
     export RUST_SYSROOT=$(rustc --print=sysroot)
-    host=${rust.toRustTarget stdenv.buildPlatform}
+    host=${stdenv.buildPlatform.rust.rustcTarget}
     cp -r $RUST_SYSROOT/lib/rustlib/$host $out
   '';
 

--- a/pkgs/build-support/rust/hooks/default.nix
+++ b/pkgs/build-support/rust/hooks/default.nix
@@ -13,7 +13,7 @@
 # This confusingly-named parameter indicates the *subdirectory of
 # `target/` from which to copy the build artifacts.  It is derived
 # from a stdenv platform (or a JSON file).
-, target ? rust.lib.toRustTargetSpecShort stdenv.hostPlatform
+, target ? stdenv.hostPlatform.rust.cargoShortTarget
 }:
 
 {
@@ -65,10 +65,10 @@
         diff = "${lib.getBin buildPackages.diffutils}/bin/diff";
 
         cargoConfig = ''
-          [target."${rust.toRustTarget stdenv.buildPlatform}"]
+          [target."${stdenv.buildPlatform.rust.rustcTarget}"]
           "linker" = "${rust.envVars.ccForBuild}"
           ${lib.optionalString (stdenv.buildPlatform.config != stdenv.hostPlatform.config) ''
-            [target."${rust.toRustTarget stdenv.hostPlatform}"]
+            [target."${stdenv.hostPlatform.rust.rustcTarget}"]
             "linker" = "${rust.envVars.ccForHost}"
           ''}
           "rustflags" = [ "-C", "target-feature=${if stdenv.hostPlatform.isStatic then "+" else "-"}crt-static" ]

--- a/pkgs/build-support/rust/lib/default.nix
+++ b/pkgs/build-support/rust/lib/default.nix
@@ -5,89 +5,6 @@
 }:
 
 rec {
-  # https://doc.rust-lang.org/reference/conditional-compilation.html#target_arch
-  toTargetArch = platform:
-    /**/ if platform ? rustc.platform then platform.rustc.platform.arch
-    else if platform.isAarch32 then "arm"
-    else if platform.isMips64  then "mips64"     # never add "el" suffix
-    else if platform.isPower64 then "powerpc64"  # never add "le" suffix
-    else platform.parsed.cpu.name;
-
-  # https://doc.rust-lang.org/reference/conditional-compilation.html#target_os
-  toTargetOs = platform:
-    /**/ if platform ? rustc.platform then platform.rustc.platform.os or "none"
-    else if platform.isDarwin then "macos"
-    else platform.parsed.kernel.name;
-
-  # https://doc.rust-lang.org/reference/conditional-compilation.html#target_family
-  toTargetFamily = platform:
-    if platform ? rustc.platform.target-family
-    then
-      (
-        # Since https://github.com/rust-lang/rust/pull/84072
-        # `target-family` is a list instead of single value.
-        let
-          f = platform.rustc.platform.target-family;
-        in
-        if builtins.isList f then f else [ f ]
-      )
-    else lib.optional platform.isUnix "unix"
-      ++ lib.optional platform.isWindows "windows";
-
-  # https://doc.rust-lang.org/reference/conditional-compilation.html#target_vendor
-  toTargetVendor = platform: let
-    inherit (platform.parsed) vendor;
-  in platform.rustc.platform.vendor or {
-    "w64" = "pc";
-  }.${vendor.name} or vendor.name;
-
-  # Returns the name of the rust target, even if it is custom. Adjustments are
-  # because rust has slightly different naming conventions than we do.
-  toRustTarget = platform: let
-    inherit (platform.parsed) cpu kernel abi;
-    cpu_ = platform.rustc.platform.arch or {
-      "armv7a" = "armv7";
-      "armv7l" = "armv7";
-      "armv6l" = "arm";
-      "armv5tel" = "armv5te";
-      "riscv64" = "riscv64gc";
-    }.${cpu.name} or cpu.name;
-    vendor_ = toTargetVendor platform;
-  in platform.rustc.config
-    or "${cpu_}-${vendor_}-${kernel.name}${lib.optionalString (abi.name != "unknown") "-${abi.name}"}";
-
-  # Returns the name of the rust target if it is standard, or the json file
-  # containing the custom target spec.
-  toRustTargetSpec = platform:
-    if platform ? rustc.platform
-    then builtins.toFile (toRustTarget platform + ".json") (builtins.toJSON platform.rustc.platform)
-    else toRustTarget platform;
-
-  # Returns the name of the rust target if it is standard, or the
-  # basename of the file containing the custom target spec, without
-  # the .json extension.
-  #
-  # This is the name used by Cargo for target subdirectories.
-  toRustTargetSpecShort = platform:
-    lib.removeSuffix ".json"
-      (baseNameOf "${toRustTargetSpec platform}");
-
-  # When used as part of an environment variable name, triples are
-  # uppercased and have all hyphens replaced by underscores:
-  #
-  # https://github.com/rust-lang/cargo/pull/9169
-  # https://github.com/rust-lang/cargo/issues/8285#issuecomment-634202431
-  #
-  toRustTargetForUseInEnvVars = platform:
-    lib.strings.replaceStrings ["-"] ["_"]
-      (lib.strings.toUpper
-        (toRustTargetSpecShort platform));
-
-  # Returns true if the target is no_std
-  # https://github.com/rust-lang/rust/blob/2e44c17c12cec45b6a682b1e53a04ac5b5fcc9d2/src/bootstrap/config.rs#L415-L421
-  IsNoStdTarget = platform: let rustTarget = toRustTarget platform; in
-    builtins.any (t: lib.hasInfix t rustTarget) ["-none" "nvptx" "switch" "-uefi"];
-
   # These environment variables must be set when using `cargo-c` and
   # several other tools which do not deal well with cross
   # compilation.  The symptom of the problem they fix is errors due
@@ -107,12 +24,12 @@ rec {
     ccForTarget = "${targetPackages.stdenv.cc}/bin/${targetPackages.stdenv.cc.targetPrefix}cc";
     cxxForTarget = "${targetPackages.stdenv.cc}/bin/${targetPackages.stdenv.cc.targetPrefix}c++";
 
-    rustBuildPlatform = toRustTarget stdenv.buildPlatform;
-    rustBuildPlatformSpec = toRustTargetSpec stdenv.buildPlatform;
-    rustHostPlatform = toRustTarget stdenv.hostPlatform;
-    rustHostPlatformSpec = toRustTargetSpec stdenv.hostPlatform;
-    rustTargetPlatform = toRustTarget stdenv.targetPlatform;
-    rustTargetPlatformSpec = toRustTargetSpec stdenv.targetPlatform;
+    rustBuildPlatform = stdenv.buildPlatform.rust.rustcTarget;
+    rustBuildPlatformSpec = stdenv.buildPlatform.rust.rustcTargetSpec;
+    rustHostPlatform = stdenv.hostPlatform.rust.rustcTarget;
+    rustHostPlatformSpec = stdenv.hostPlatform.rust.rustcTargetSpec;
+    rustTargetPlatform = stdenv.targetPlatform.rust.rustcTarget;
+    rustTargetPlatformSpec = stdenv.targetPlatform.rust.rustcTargetSpec;
   in {
     inherit
       ccForBuild  cxxForBuild  rustBuildPlatform   rustBuildPlatformSpec
@@ -131,20 +48,34 @@ rec {
     # the following lines when rustTargetPlatform collides with
     # rustHostPlatform.
     + lib.optionalString (rustTargetPlatform != rustHostPlatform) ''
-      "CC_${toRustTargetForUseInEnvVars stdenv.targetPlatform}=${ccForTarget}" \
-      "CXX_${toRustTargetForUseInEnvVars stdenv.targetPlatform}=${cxxForTarget}" \
-      "CARGO_TARGET_${toRustTargetForUseInEnvVars stdenv.targetPlatform}_LINKER=${ccForTarget}" \
+      "CC_${stdenv.targetPlatform.rust.cargoEnvVarTarget}=${ccForTarget}" \
+      "CXX_${stdenv.targetPlatform.rust.cargoEnvVarTarget}=${cxxForTarget}" \
+      "CARGO_TARGET_${stdenv.targetPlatform.rust.cargoEnvVarTarget}_LINKER=${ccForTarget}" \
     '' + ''
-      "CC_${toRustTargetForUseInEnvVars stdenv.hostPlatform}=${ccForHost}" \
-      "CXX_${toRustTargetForUseInEnvVars stdenv.hostPlatform}=${cxxForHost}" \
-      "CARGO_TARGET_${toRustTargetForUseInEnvVars stdenv.hostPlatform}_LINKER=${ccForHost}" \
+      "CC_${stdenv.hostPlatform.rust.cargoEnvVarTarget}=${ccForHost}" \
+      "CXX_${stdenv.hostPlatform.rust.cargoEnvVarTarget}=${cxxForHost}" \
+      "CARGO_TARGET_${stdenv.hostPlatform.rust.cargoEnvVarTarget}_LINKER=${ccForHost}" \
     '' + ''
-      "CC_${toRustTargetForUseInEnvVars stdenv.buildPlatform}=${ccForBuild}" \
-      "CXX_${toRustTargetForUseInEnvVars stdenv.buildPlatform}=${cxxForBuild}" \
-      "CARGO_TARGET_${toRustTargetForUseInEnvVars stdenv.buildPlatform}_LINKER=${ccForBuild}" \
+      "CC_${stdenv.buildPlatform.rust.cargoEnvVarTarget}=${ccForBuild}" \
+      "CXX_${stdenv.buildPlatform.rust.cargoEnvVarTarget}=${cxxForBuild}" \
+      "CARGO_TARGET_${stdenv.buildPlatform.rust.cargoEnvVarTarget}_LINKER=${ccForBuild}" \
       "CARGO_BUILD_TARGET=${rustBuildPlatform}" \
       "HOST_CC=${buildPackages.stdenv.cc}/bin/cc" \
       "HOST_CXX=${buildPackages.stdenv.cc}/bin/c++" \
     '';
   };
+} // lib.mapAttrs (old: new: platform:
+  # TODO: enable warning after 23.05 is EOL.
+  # lib.warn "`rust.${old} platform` is deprecated. Use `platform.rust.${new}` instead."
+    lib.getAttrFromPath new platform.rust)
+{
+  toTargetArch = [ "platform" "arch" ];
+  toTargetOs = [ "platform" "os" ];
+  toTargetFamily = [ "platform" "target-family" ];
+  toTargetVendor = [ "platform" "vendor" ];
+  toRustTarget = [ "rustcTarget" ];
+  toRustTargetSpec = [ "rustcTargetSpec" ];
+  toRustTargetSpecShort = [ "cargoShortTarget" ];
+  toRustTargetForUseInEnvVars = [ "cargoEnvVarTarget" ];
+  IsNoStdTarget = [ "isNoStdTarget" ];
 }

--- a/pkgs/desktops/gnome/core/gnome-tour/default.nix
+++ b/pkgs/desktops/gnome/core/gnome-tour/default.nix
@@ -17,7 +17,6 @@
 , libadwaita
 , librsvg
 , rustc
-, rust
 , writeText
 , cargo
 }:
@@ -65,7 +64,7 @@ stdenv.mkDerivation rec {
       # ERROR: 'rust' compiler binary not defined in cross or native file
       crossFile = writeText "cross-file.conf" ''
         [binaries]
-        rust = [ 'rustc', '--target', '${rust.toRustTargetSpec stdenv.hostPlatform}' ]
+        rust = [ 'rustc', '--target', '${stdenv.hostPlatform.rust.rustcTargetSpec}' ]
       '';
     in
     lib.optionals (stdenv.hostPlatform != stdenv.buildPlatform) [ "--cross-file=${crossFile}" ];

--- a/pkgs/desktops/gnome/core/gnome-tour/default.nix
+++ b/pkgs/desktops/gnome/core/gnome-tour/default.nix
@@ -17,7 +17,6 @@
 , libadwaita
 , librsvg
 , rustc
-, writeText
 , cargo
 }:
 
@@ -58,16 +57,6 @@ stdenv.mkDerivation rec {
     libadwaita
     librsvg
   ];
-
-  mesonFlags =
-    let
-      # ERROR: 'rust' compiler binary not defined in cross or native file
-      crossFile = writeText "cross-file.conf" ''
-        [binaries]
-        rust = [ 'rustc', '--target', '${stdenv.hostPlatform.rust.rustcTargetSpec}' ]
-      '';
-    in
-    lib.optionals (stdenv.hostPlatform != stdenv.buildPlatform) [ "--cross-file=${crossFile}" ];
 
   passthru = {
     updateScript = gnome.updateScript {

--- a/pkgs/development/compilers/mrustc/bootstrap.nix
+++ b/pkgs/development/compilers/mrustc/bootstrap.nix
@@ -2,7 +2,6 @@
 , fetchurl
 , mrustc
 , mrustc-minicargo
-, rust
 , llvm_12
 , llvmPackages_12
 , libffi
@@ -74,7 +73,7 @@ stdenv.mkDerivation rec {
     "MRUSTC=${mrustc}/bin/mrustc"
     #"MINICARGO=${mrustc-minicargo}/bin/minicargo"  # FIXME: we need to rebuild minicargo locally so --manifest-overrides is applied
     "LLVM_CONFIG=${llvm_12.dev}/bin/llvm-config"
-    "RUSTC_TARGET=${rust.toRustTarget stdenv.targetPlatform}"
+    "RUSTC_TARGET=${stdenv.targetPlatform.rust.rustcTarget}"
   ];
 
   buildPhase = ''
@@ -129,7 +128,7 @@ stdenv.mkDerivation rec {
     cp run_rustc/${outputDir}/prefix/bin/rustc_binary $out/bin/rustc
 
     cp -r run_rustc/${outputDir}/prefix/lib/* $out/lib/
-    cp $out/lib/rustlib/${rust.toRustTarget stdenv.targetPlatform}/lib/*.so $out/lib/
+    cp $out/lib/rustlib/${stdenv.targetPlatform.rust.rustcTarget}/lib/*.so $out/lib/
     runHook postInstall
   '';
 
@@ -146,4 +145,3 @@ stdenv.mkDerivation rec {
     platforms = [ "x86_64-linux" ];
   };
 }
-

--- a/pkgs/development/compilers/rust/bootstrap.nix
+++ b/pkgs/development/compilers/rust/bootstrap.nix
@@ -1,7 +1,7 @@
-{ stdenv, fetchurl, rust, callPackage, version, hashes }:
+{ stdenv, fetchurl, callPackage, version, hashes }:
 
 let
-  platform = rust.toRustTarget stdenv.hostPlatform;
+  platform = stdenv.hostPlatform.rust.rustcTarget;
 
   src = fetchurl {
      url = "https://static.rust-lang.org/dist/rust-${version}-${platform}.tar.gz";

--- a/pkgs/development/compilers/rust/cargo.nix
+++ b/pkgs/development/compilers/rust/cargo.nix
@@ -1,6 +1,6 @@
 { lib, stdenv, pkgsBuildHost, pkgsHostHost
 , file, curl, pkg-config, python3, openssl, cmake, zlib
-, installShellFiles, makeWrapper, rustPlatform, rust, rustc
+, installShellFiles, makeWrapper, rustPlatform, rustc
 , CoreFoundation, Security
 , auditable ? !cargo-auditable.meta.broken
 , cargo-auditable
@@ -116,6 +116,6 @@ rustPlatform.buildRustPackage.override {
     broken = stdenv.hostPlatform.isx86 && stdenv.buildPlatform != stdenv.hostPlatform;
   };
 }
-// lib.optionalAttrs (rust.toRustTarget stdenv.buildPlatform != rust.toRustTarget stdenv.hostPlatform) {
+// lib.optionalAttrs (stdenv.buildPlatform.rust.rustcTarget != stdenv.hostPlatform.rust.rustcTarget) {
   HOST_PKG_CONFIG_PATH="${pkgsBuildBuild.pkg-config}/bin/pkg-config";
 })

--- a/pkgs/development/compilers/rust/rustc.nix
+++ b/pkgs/development/compilers/rust/rustc.nix
@@ -1,7 +1,7 @@
 { lib, stdenv, removeReferencesTo, pkgsBuildBuild, pkgsBuildHost, pkgsBuildTarget, targetPackages
 , llvmShared, llvmSharedForBuild, llvmSharedForHost, llvmSharedForTarget, llvmPackages
 , fetchurl, file, python3
-, darwin, cargo, cmake, rust, rustc
+, darwin, cargo, cmake, rustc
 , pkg-config, openssl, xz
 , libiconv
 , which, libffi
@@ -51,7 +51,7 @@ in stdenv.mkDerivation rec {
   # but it does support checking these idiosyncratic PKG_CONFIG_${TRIPLE}
   # environment variables.
   # [1]: https://github.com/rust-lang/pkg-config-rs/issues/53
-  "PKG_CONFIG_${builtins.replaceStrings ["-"] ["_"] (rust.toRustTarget stdenv.buildPlatform)}" =
+  "PKG_CONFIG_${builtins.replaceStrings ["-"] ["_"] stdenv.buildPlatform.rust.rustcTarget}" =
     "${pkgsBuildHost.stdenv.cc.targetPrefix}pkg-config";
 
   NIX_LDFLAGS = toString (
@@ -69,9 +69,9 @@ in stdenv.mkDerivation rec {
     prefixForStdenv = stdenv: "${stdenv.cc}/bin/${stdenv.cc.targetPrefix}";
     ccPrefixForStdenv = stdenv: "${prefixForStdenv stdenv}${if (stdenv.cc.isClang or false) then "clang" else "cc"}";
     cxxPrefixForStdenv = stdenv: "${prefixForStdenv stdenv}${if (stdenv.cc.isClang or false) then "clang++" else "c++"}";
-    setBuild  = "--set=target.${rust.toRustTarget stdenv.buildPlatform}";
-    setHost   = "--set=target.${rust.toRustTarget stdenv.hostPlatform}";
-    setTarget = "--set=target.${rust.toRustTarget stdenv.targetPlatform}";
+    setBuild  = "--set=target.${stdenv.buildPlatform.rust.rustcTarget}";
+    setHost   = "--set=target.${stdenv.hostPlatform.rust.rustcTarget}";
+    setTarget = "--set=target.${stdenv.targetPlatform.rust.rustcTarget}";
     ccForBuild  = ccPrefixForStdenv pkgsBuildBuild.targetPackages.stdenv;
     cxxForBuild  = cxxPrefixForStdenv pkgsBuildBuild.targetPackages.stdenv;
     ccForHost  = ccPrefixForStdenv pkgsBuildHost.targetPackages.stdenv;
@@ -85,23 +85,23 @@ in stdenv.mkDerivation rec {
     "--tools=rustc,rust-analyzer-proc-macro-srv"
     "--enable-rpath"
     "--enable-vendor"
-    "--build=${rust.toRustTargetSpec stdenv.buildPlatform}"
-    "--host=${rust.toRustTargetSpec stdenv.hostPlatform}"
+    "--build=${stdenv.buildPlatform.rust.rustcTargetSpec}"
+    "--host=${stdenv.hostPlatform.rust.rustcTargetSpec}"
     # std is built for all platforms in --target.
     "--target=${concatStringsSep "," ([
-      (rust.toRustTargetSpec stdenv.targetPlatform)
+      stdenv.targetPlatform.rust.rustcTargetSpec
 
     # (build!=target): When cross-building a compiler we need to add
     # the build platform as well so rustc can compile build.rs
     # scripts.
     ] ++ optionals (stdenv.buildPlatform != stdenv.targetPlatform && !fastCross) [
-      (rust.toRustTargetSpec stdenv.buildPlatform)
+      stdenv.buildPlatform.rust.rustcTargetSpec
 
     # (host!=target): When building a cross-targeting compiler we
     # need to add the host platform as well so rustc can compile
     # build.rs scripts.
     ] ++ optionals (stdenv.hostPlatform != stdenv.targetPlatform && !fastCross) [
-      (rust.toRustTargetSpec stdenv.hostPlatform)
+      stdenv.hostPlatform.rust.rustcTargetSpec
     ])}"
 
     "${setBuild}.cc=${ccForBuild}"
@@ -132,7 +132,7 @@ in stdenv.mkDerivation rec {
     "${setHost}.musl-root=${pkgsBuildHost.targetPackages.stdenv.cc.libc}"
   ] ++ optionals stdenv.targetPlatform.isMusl [
     "${setTarget}.musl-root=${pkgsBuildTarget.targetPackages.stdenv.cc.libc}"
-  ] ++ optionals (rust.IsNoStdTarget stdenv.targetPlatform) [
+  ] ++ optionals stdenv.targetPlatform.rust.isNoStdTarget [
     "--disable-docs"
   ] ++ optionals (stdenv.isDarwin && stdenv.isx86_64) [
     # https://github.com/rust-lang/rust/issues/92173
@@ -144,12 +144,12 @@ in stdenv.mkDerivation rec {
   buildPhase = if fastCross then "
     runHook preBuild
 
-    mkdir -p build/${rust.toRustTargetSpec stdenv.hostPlatform}/stage0-{std,rustc}/${rust.toRustTargetSpec stdenv.hostPlatform}/release/
-    ln -s ${rustc}/lib/rustlib/${rust.toRustTargetSpec stdenv.hostPlatform}/libstd-*.so build/${rust.toRustTargetSpec stdenv.hostPlatform}/stage0-std/${rust.toRustTargetSpec stdenv.hostPlatform}/release/libstd.so
-    ln -s ${rustc}/lib/rustlib/${rust.toRustTargetSpec stdenv.hostPlatform}/librustc_driver-*.so build/${rust.toRustTargetSpec stdenv.hostPlatform}/stage0-rustc/${rust.toRustTargetSpec stdenv.hostPlatform}/release/librustc.so
-    ln -s ${rustc}/bin/rustc build/${rust.toRustTargetSpec stdenv.hostPlatform}/stage0-rustc/${rust.toRustTargetSpec stdenv.hostPlatform}/release/rustc-main
-    touch build/${rust.toRustTargetSpec stdenv.hostPlatform}/stage0-std/${rust.toRustTargetSpec stdenv.hostPlatform}/release/.libstd.stamp
-    touch build/${rust.toRustTargetSpec stdenv.hostPlatform}/stage0-rustc/${rust.toRustTargetSpec stdenv.hostPlatform}/release/.librustc.stamp
+    mkdir -p build/${stdenv.hostPlatform.rust.rustcTargetSpec}/stage0-{std,rustc}/${stdenv.hostPlatform.rust.rustcTargetSpec}/release/
+    ln -s ${rustc}/lib/rustlib/${stdenv.hostPlatform.rust.rustcTargetSpec}/libstd-*.so build/${stdenv.hostPlatform.rust.rustcTargetSpec}/stage0-std/${stdenv.hostPlatform.rust.rustcTargetSpec}/release/libstd.so
+    ln -s ${rustc}/lib/rustlib/${stdenv.hostPlatform.rust.rustcTargetSpec}/librustc_driver-*.so build/${stdenv.hostPlatform.rust.rustcTargetSpec}/stage0-rustc/${stdenv.hostPlatform.rust.rustcTargetSpec}/release/librustc.so
+    ln -s ${rustc}/bin/rustc build/${stdenv.hostPlatform.rust.rustcTargetSpec}/stage0-rustc/${stdenv.hostPlatform.rust.rustcTargetSpec}/release/rustc-main
+    touch build/${stdenv.hostPlatform.rust.rustcTargetSpec}/stage0-std/${stdenv.hostPlatform.rust.rustcTargetSpec}/release/.libstd.stamp
+    touch build/${stdenv.hostPlatform.rust.rustcTargetSpec}/stage0-rustc/${stdenv.hostPlatform.rust.rustcTargetSpec}/release/.librustc.stamp
     python ./x.py --keep-stage=0 --stage=1 build library/std
 
     runHook postBuild
@@ -162,8 +162,8 @@ in stdenv.mkDerivation rec {
     mkdir -v $out/bin $doc $man
     makeWrapper ${rustc}/bin/rustc $out/bin/rustc --add-flags "--sysroot $out"
     makeWrapper ${rustc}/bin/rustdoc $out/bin/rustdoc --add-flags "--sysroot $out"
-    ln -s ${rustc}/lib/rustlib/{manifest-rust-std-,}${rust.toRustTargetSpec stdenv.hostPlatform} $out/lib/rustlib/
-    echo rust-std-${rust.toRustTargetSpec stdenv.hostPlatform} >> $out/lib/rustlib/components
+    ln -s ${rustc}/lib/rustlib/{manifest-rust-std-,}${stdenv.hostPlatform.rust.rustcTargetSpec} $out/lib/rustlib/
+    echo rust-std-${stdenv.hostPlatform.rust.rustcTargetSpec} >> $out/lib/rustlib/components
     lndir ${rustc.doc} $doc
     lndir ${rustc.man} $man
 

--- a/pkgs/development/interpreters/python/hooks/default.nix
+++ b/pkgs/development/interpreters/python/hooks/default.nix
@@ -183,16 +183,14 @@ in {
       };
     } ./setuptools-check-hook.sh) {};
 
-    setuptoolsRustBuildHook = callPackage ({ makePythonHook, setuptools-rust, rust }:
+    setuptoolsRustBuildHook = callPackage ({ makePythonHook, setuptools-rust }:
       makePythonHook {
         name = "setuptools-rust-setup-hook";
         propagatedBuildInputs = [ setuptools-rust ];
         substitutions = {
           pyLibDir = "${python}/lib/${python.libPrefix}";
-          cargoBuildTarget = rust.toRustTargetSpec stdenv.hostPlatform;
-          cargoLinkerVar = lib.toUpper (
-              builtins.replaceStrings ["-"] ["_"] (
-                rust.toRustTarget stdenv.hostPlatform));
+          cargoBuildTarget = stdenv.hostPlatform.rust.rustcTargetSpec;
+          cargoLinkerVar = stdenv.hostPlatform.rust.cargoEnvVarTarget;
           targetLinker = "${stdenv.cc}/bin/${stdenv.cc.targetPrefix}cc";
         };
       } ./setuptools-rust-hook.sh) {};

--- a/pkgs/development/libraries/gstreamer/rs/default.nix
+++ b/pkgs/development/libraries/gstreamer/rs/default.nix
@@ -2,7 +2,6 @@
 , stdenv
 , fetchFromGitLab
 , fetchpatch
-, writeText
 , rustPlatform
 , meson
 , ninja
@@ -204,14 +203,7 @@ stdenv.mkDerivation rec {
   ) ++ [
     (lib.mesonOption "sodium-source" "system")
     (lib.mesonEnable "doc" enableDocumentation)
-  ] ++ (let
-    crossFile = writeText "cross-file.conf" ''
-      [binaries]
-      rust = [ 'rustc', '--target', '${stdenv.hostPlatform.rust.rustcTargetSpec}' ]
-    '';
-  in lib.optionals (stdenv.buildPlatform != stdenv.hostPlatform) [
-    "--cross-file=${crossFile}"
-  ]);
+  ];
 
   # turn off all auto plugins since we use a list of plugins we generate
   mesonAutoFeatures = "disabled";

--- a/pkgs/development/libraries/gstreamer/rs/default.nix
+++ b/pkgs/development/libraries/gstreamer/rs/default.nix
@@ -8,7 +8,6 @@
 , ninja
 , python3
 , pkg-config
-, rust
 , rustc
 , cargo
 , cargo-c
@@ -208,7 +207,7 @@ stdenv.mkDerivation rec {
   ] ++ (let
     crossFile = writeText "cross-file.conf" ''
       [binaries]
-      rust = [ 'rustc', '--target', '${rust.toRustTargetSpec stdenv.hostPlatform}' ]
+      rust = [ 'rustc', '--target', '${stdenv.hostPlatform.rust.rustcTargetSpec}' ]
     '';
   in lib.optionals (stdenv.buildPlatform != stdenv.hostPlatform) [
     "--cross-file=${crossFile}"

--- a/pkgs/development/libraries/libdovi/default.nix
+++ b/pkgs/development/libraries/libdovi/default.nix
@@ -5,9 +5,7 @@
 , rust
 , stdenv
 }:
-let
-  rustTargetPlatformSpec = rust.toRustTargetSpec stdenv.hostPlatform;
-in
+
 rustPlatform.buildRustPackage rec {
   pname = "libdovi";
   version = "3.1.2";
@@ -28,19 +26,19 @@ rustPlatform.buildRustPackage rec {
 
   buildPhase = ''
     runHook preBuild
-    ${rust.envVars.setEnv} cargo cbuild -j $NIX_BUILD_CORES --release --frozen --prefix=${placeholder "out"} --target ${rustTargetPlatformSpec}
+    ${rust.envVars.setEnv} cargo cbuild -j $NIX_BUILD_CORES --release --frozen --prefix=${placeholder "out"} --target ${stdenv.hostPlatform.rust.rustcTarget}
     runHook postBuild
   '';
 
   installPhase = ''
     runHook preInstall
-    ${rust.envVars.setEnv} cargo cinstall -j $NIX_BUILD_CORES --release --frozen --prefix=${placeholder "out"} --target ${rustTargetPlatformSpec}
+    ${rust.envVars.setEnv} cargo cinstall -j $NIX_BUILD_CORES --release --frozen --prefix=${placeholder "out"} --target ${stdenv.hostPlatform.rust.rustcTarget}
     runHook postInstall
   '';
 
   checkPhase = ''
     runHook preCheck
-    ${rust.envVars.setEnv} cargo ctest -j $NIX_BUILD_CORES --release --frozen --prefix=${placeholder "out"} --target ${rustTargetPlatformSpec}
+    ${rust.envVars.setEnv} cargo ctest -j $NIX_BUILD_CORES --release --frozen --prefix=${placeholder "out"} --target ${stdenv.hostPlatform.rust.rustcTarget}
     runHook postCheck
   '';
 

--- a/pkgs/development/libraries/libimagequant/default.nix
+++ b/pkgs/development/libraries/libimagequant/default.nix
@@ -1,8 +1,5 @@
 { lib, stdenv, fetchFromGitHub, fetchurl, rust, rustPlatform, cargo-c, python3 }:
 
-let
-  rustTargetPlatformSpec = rust.toRustTargetSpec stdenv.hostPlatform;
-in
 rustPlatform.buildRustPackage rec {
   pname = "libimagequant";
   version = "4.2.2";
@@ -26,13 +23,13 @@ rustPlatform.buildRustPackage rec {
 
   postBuild = ''
     pushd imagequant-sys
-    ${rust.envVars.setEnv} cargo cbuild --release --frozen --prefix=${placeholder "out"} --target ${rustTargetPlatformSpec}
+    ${rust.envVars.setEnv} cargo cbuild --release --frozen --prefix=${placeholder "out"} --target ${stdenv.hostPlatform.rust.rustcTarget}
     popd
   '';
 
   postInstall = ''
     pushd imagequant-sys
-    ${rust.envVars.setEnv} cargo cinstall --release --frozen --prefix=${placeholder "out"} --target ${rustTargetPlatformSpec}
+    ${rust.envVars.setEnv} cargo cinstall --release --frozen --prefix=${placeholder "out"} --target ${stdenv.hostPlatform.rust.rustcTarget}
     popd
   '';
 

--- a/pkgs/development/libraries/librsvg/default.nix
+++ b/pkgs/development/libraries/librsvg/default.nix
@@ -15,7 +15,6 @@
 , libobjc
 , rustPlatform
 , rustc
-, rust
 , cargo-auditable-cargo-wrapper
 , gi-docgen
 , python3Packages
@@ -106,7 +105,7 @@ stdenv.mkDerivation (finalAttrs: {
 
     "--enable-always-build-tests"
   ] ++ lib.optional stdenv.isDarwin "--disable-Bsymbolic"
-    ++ lib.optional (stdenv.buildPlatform != stdenv.hostPlatform) "RUST_TARGET=${rust.toRustTarget stdenv.hostPlatform}";
+    ++ lib.optional (stdenv.buildPlatform != stdenv.hostPlatform) "RUST_TARGET=${stdenv.hostPlatform.rust.rustcTarget}";
 
   doCheck = false; # all tests fail on libtool-generated rsvg-convert not being able to find coreutils
 

--- a/pkgs/development/libraries/relibc/default.nix
+++ b/pkgs/development/libraries/relibc/default.nix
@@ -64,7 +64,7 @@ redoxRustPlatform.buildRustPackage rec {
   '';
 
   # TODO: should be hostPlatform
-  TARGET = buildPackages.rust.toRustTargetSpec stdenvNoCC.targetPlatform;
+  TARGET = stdenvNoCC.targetPlatform.rust.rustcTargetSpec;
 
   cargoLock = {
     lockFile = ./Cargo.lock;

--- a/pkgs/development/libraries/rustc-demangle/default.nix
+++ b/pkgs/development/libraries/rustc-demangle/default.nix
@@ -1,4 +1,4 @@
-{ rustPlatform, fetchFromGitHub, rust, lib, stdenv }:
+{ rustPlatform, fetchFromGitHub, lib, stdenv }:
 
 rustPlatform.buildRustPackage rec {
   pname = "rustc-demangle";
@@ -24,7 +24,7 @@ rustPlatform.buildRustPackage rec {
 
   postInstall = ''
     mkdir -p $out/lib
-    cp target/${rust.toRustTargetSpec stdenv.hostPlatform}/release/librustc_demangle.so $out/lib
+    cp target/${stdenv.hostPlatform.rust.rustcTargetSpec}/release/librustc_demangle.so $out/lib
     cp -R crates/capi/include $out
   '';
 

--- a/pkgs/development/tools/lalrpop/default.nix
+++ b/pkgs/development/tools/lalrpop/default.nix
@@ -1,6 +1,5 @@
 { lib
 , rustPlatform
-, rust
 , fetchFromGitHub
 , substituteAll
 , stdenv
@@ -24,7 +23,7 @@ rustPlatform.buildRustPackage rec {
   patches = [
     (substituteAll {
       src = ./use-correct-binary-path-in-tests.patch;
-      target_triple = rust.toRustTarget stdenv.hostPlatform;
+      target_triple = stdenv.hostPlatform.rust.rustcTarget;
     })
   ];
 

--- a/pkgs/development/tools/rust/cargo-benchcmp/default.nix
+++ b/pkgs/development/tools/rust/cargo-benchcmp/default.nix
@@ -2,7 +2,6 @@
 , rustPlatform
 , fetchFromGitHub
 , substituteAll
-, rust
 , stdenv
 }:
 
@@ -23,7 +22,7 @@ rustPlatform.buildRustPackage rec {
     # patch the binary path so tests can find the binary when `--target` is present
     (substituteAll {
       src = ./fix-test-binary-path.patch;
-      shortTarget = rust.toRustTarget stdenv.hostPlatform;
+      shortTarget = stdenv.hostPlatform.rust.rustcTarget;
     })
   ];
 

--- a/pkgs/development/tools/rust/cargo-watch/default.nix
+++ b/pkgs/development/tools/rust/cargo-watch/default.nix
@@ -5,7 +5,6 @@
 , Cocoa
 , CoreServices
 , Foundation
-, rust
 , libiconv
 }:
 
@@ -27,7 +26,7 @@ rustPlatform.buildRustPackage rec {
   # `test with_cargo` tries to call cargo-watch as a cargo subcommand
   # (calling cargo-watch with command `cargo watch`)
   preCheck = ''
-    export PATH="$(pwd)/target/${rust.toRustTarget stdenv.hostPlatform}/release:$PATH"
+    export PATH="$(pwd)/target/${stdenv.hostPlatform.rust.rustcTarget}/release:$PATH"
   '';
 
   meta = with lib; {

--- a/pkgs/development/web/deno/librusty_v8.nix
+++ b/pkgs/development/web/deno/librusty_v8.nix
@@ -1,11 +1,10 @@
 # auto-generated file -- DO NOT EDIT!
-{ rust, stdenv, fetchurl }:
+{ stdenv, fetchurl }:
 
 let
-  arch = rust.toRustTarget stdenv.hostPlatform;
   fetch_librusty_v8 = args: fetchurl {
     name = "librusty_v8-${args.version}";
-    url = "https://github.com/denoland/rusty_v8/releases/download/v${args.version}/librusty_v8_release_${arch}.a";
+    url = "https://github.com/denoland/rusty_v8/releases/download/v${args.version}/librusty_v8_release_${stdenv.hostPlatform.rust.rustcTarget}.a";
     sha256 = args.shas.${stdenv.hostPlatform.system};
     meta = { inherit (args) version; };
   };

--- a/pkgs/development/web/deno/update/librusty_v8.ts
+++ b/pkgs/development/web/deno/update/librusty_v8.ts
@@ -40,13 +40,12 @@ fetchurl {
 
 const templateDeps = (version: string, deps: PrefetchResult[]) =>
   `# auto-generated file -- DO NOT EDIT!
-{ rust, stdenv, fetchurl }:
+{ stdenv, fetchurl }:
 
 let
-  arch = rust.toRustTarget stdenv.hostPlatform;
   fetch_librusty_v8 = args: fetchurl {
     name = "librusty_v8-\${args.version}";
-    url = "https://github.com/denoland/rusty_v8/releases/download/v\${args.version}/librusty_v8_release_\${arch}.a";
+    url = "https://github.com/denoland/rusty_v8/releases/download/v\${args.version}/librusty_v8_release_\${stdenv.hostPlatform.rust.rustcTarget}.a";
     sha256 = args.shas.\${stdenv.hostPlatform.system};
     meta = { inherit (args) version; };
   };

--- a/pkgs/development/web/edge-runtime/librusty_v8.nix
+++ b/pkgs/development/web/edge-runtime/librusty_v8.nix
@@ -1,11 +1,10 @@
 # auto-generated file -- DO NOT EDIT!
-{ rust, stdenv, fetchurl }:
+{ stdenv, fetchurl }:
 
 let
-  arch = rust.toRustTarget stdenv.hostPlatform;
   fetch_librusty_v8 = args: fetchurl {
     name = "librusty_v8-${args.version}";
-    url = "https://github.com/denoland/rusty_v8/releases/download/v${args.version}/librusty_v8_release_${arch}.a";
+    url = "https://github.com/denoland/rusty_v8/releases/download/v${args.version}/librusty_v8_release_${stdenv.hostPlatform.rust.rustcTarget}.a";
     sha256 = args.shas.${stdenv.hostPlatform.system};
     meta = { inherit (args) version; };
   };

--- a/pkgs/servers/http/router/librusty_v8.nix
+++ b/pkgs/servers/http/router/librusty_v8.nix
@@ -1,10 +1,9 @@
-{ rust, stdenv, fetchurl }:
+{ stdenv, fetchurl }:
 
 let
-  arch = rust.toRustTarget stdenv.hostPlatform;
   fetch_librusty_v8 = args: fetchurl {
     name = "librusty_v8-${args.version}";
-    url = "https://github.com/denoland/rusty_v8/releases/download/v${args.version}/librusty_v8_release_${arch}.a";
+    url = "https://github.com/denoland/rusty_v8/releases/download/v${args.version}/librusty_v8_release_${stdenv.hostPlatform.rust.rustcTarget}.a";
     sha256 = args.shas.${stdenv.hostPlatform.system};
     meta = { inherit (args) version; };
   };

--- a/pkgs/servers/matrix-synapse/matrix-hookshot/default.nix
+++ b/pkgs/servers/matrix-synapse/matrix-hookshot/default.nix
@@ -5,7 +5,6 @@
 , makeWrapper
 , matrix-sdk-crypto-nodejs
 , mkYarnPackage
-, rust
 , cargo
 , rustPlatform
 , rustc
@@ -60,7 +59,7 @@ mkYarnPackage rec {
   buildPhase = ''
     runHook preBuild
     cd deps/${pname}
-    napi build --target ${rust.toRustTargetSpec stdenv.targetPlatform} --dts ../src/libRs.d.ts --release ./lib
+    napi build --target ${stdenv.targetPlatform.rust.rustcTargetSpec} --dts ../src/libRs.d.ts --release ./lib
     yarn run build:app:fix-defs
     yarn run build:app
     yarn run build:web

--- a/pkgs/servers/windmill/default.nix
+++ b/pkgs/servers/windmill/default.nix
@@ -16,7 +16,6 @@
 , pixman
 , pkg-config
 , python3
-, rust
 , rustfmt
 , stdenv
 , swagger-cli
@@ -70,11 +69,10 @@ rustPlatform.buildRustPackage {
     SQLX_OFFLINE = "true";
     RUSTY_V8_ARCHIVE =
       let
-        arch = rust.toRustTarget stdenv.hostPlatform;
         fetch_librusty_v8 = args:
           fetchurl {
             name = "librusty_v8-${args.version}";
-            url = "https://github.com/denoland/rusty_v8/releases/download/v${args.version}/librusty_v8_release_${arch}.a";
+            url = "https://github.com/denoland/rusty_v8/releases/download/v${args.version}/librusty_v8_release_${stdenv.hostPlatform.rust.rustcTarget}.a";
             sha256 = args.shas.${stdenv.hostPlatform.system} or (throw "Unsupported platform ${stdenv.hostPlatform.system}");
             meta = { inherit (args) version; };
           };

--- a/pkgs/stdenv/generic/make-derivation.nix
+++ b/pkgs/stdenv/generic/make-derivation.nix
@@ -402,6 +402,7 @@ else let
 
           crossFile = builtins.toFile "cross-file.conf" ''
             [properties]
+            bindgen_clang_arguments = ['-target', '${stdenv.targetPlatform.config}']
             needs_exe_wrapper = ${lib.boolToString (!stdenv.buildPlatform.canExecute stdenv.hostPlatform)}
 
             [host_machine]
@@ -412,6 +413,7 @@ else let
 
             [binaries]
             llvm-config = 'llvm-config-native'
+            rust = ['rustc', '--target', '${stdenv.targetPlatform.rust.rustcTargetSpec}']
           '';
           crossFlags = lib.optionals (stdenv.hostPlatform != stdenv.buildPlatform) [ "--cross-file=${crossFile}" ];
         in crossFlags ++ mesonFlags;

--- a/pkgs/tools/misc/halp/default.nix
+++ b/pkgs/tools/misc/halp/default.nix
@@ -5,7 +5,6 @@
 , stdenv
 , darwin
 , unixtools
-, rust
 }:
 
 rustPlatform.buildRustPackage rec {
@@ -48,7 +47,7 @@ rustPlatform.buildRustPackage rec {
 
   postPatch = ''
     substituteInPlace src/helper/args/mod.rs \
-      --subst-var-by releaseDir target/${rust.toRustTargetSpec stdenv.hostPlatform}/$cargoCheckType
+      --subst-var-by releaseDir target/${stdenv.hostPlatform.rust.rustcTargetSpec}/$cargoCheckType
   '';
 
   preCheck = ''

--- a/pkgs/tools/system/zram-generator/default.nix
+++ b/pkgs/tools/system/zram-generator/default.nix
@@ -1,7 +1,6 @@
 { lib
 , stdenv
 , fetchFromGitHub
-, rust
 , rustPlatform
 , pkg-config
 , ronn
@@ -28,7 +27,7 @@ rustPlatform.buildRustPackage rec {
   postPatch = ''
     cp ${./Cargo.lock} Cargo.lock
     substituteInPlace Makefile \
-      --replace 'target/$(BUILDTYPE)' 'target/${rust.toRustTargetSpec stdenv.hostPlatform}/$(BUILDTYPE)'
+      --replace 'target/$(BUILDTYPE)' 'target/${stdenv.hostPlatform.rust.rustcTargetSpec}/$(BUILDTYPE)'
     substituteInPlace src/generator.rs \
       --replace 'Command::new("systemd-detect-virt")' 'Command::new("${systemd}/bin/systemd-detect-virt")' \
       --replace 'Command::new("modprobe")' 'Command::new("${kmod}/bin/modprobe")'

--- a/pkgs/tools/video/rav1e/default.nix
+++ b/pkgs/tools/video/rav1e/default.nix
@@ -13,10 +13,7 @@
 , buildPackages
 }:
 
-let
-  rustTargetPlatformSpec = rust.toRustTargetSpec stdenv.hostPlatform;
-
-in rustPlatform.buildRustPackage rec {
+rustPlatform.buildRustPackage rec {
   pname = "rav1e";
   version = "0.6.6";
 
@@ -47,11 +44,11 @@ in rustPlatform.buildRustPackage rec {
   checkType = "debug";
 
   postBuild =  ''
-    ${rust.envVars.setEnv} cargo cbuild --release --frozen --prefix=${placeholder "out"} --target ${rustTargetPlatformSpec}
+    ${rust.envVars.setEnv} cargo cbuild --release --frozen --prefix=${placeholder "out"} --target ${stdenv.hostPlatform.rust.rustcTarget}
   '';
 
   postInstall = ''
-    ${rust.envVars.setEnv} cargo cinstall --release --frozen --prefix=${placeholder "out"} --target ${rustTargetPlatformSpec}
+    ${rust.envVars.setEnv} cargo cinstall --release --frozen --prefix=${placeholder "out"} --target ${stdenv.hostPlatform.rust.rustcTarget}
   '';
 
   meta = with lib; {


### PR DESCRIPTION
###### Description of changes

In particular, fix cross compilation of rusticl.  Previously, Nixpkgs has not been equipped to handle non-Cargo Rust cross compilation.  That's getting increasingly important, now that we're building Mesa with Rust, and soon the kernel, and [potentially](https://github.com/systemd/systemd/issues/26640) systemd in not too long.

This is a bigger PR than I usually like to make, but it's difficult to explain each of these changes out of context, so I've bundled them into a single PR.  I'd definitely recommend reviewing commit by commit though.  The commit messages contain the details of each change.

Spiritual successor to #159064.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
