### PR TITLE
inkcut: prepare for python 3.11

### DIFF
--- a/pkgs/applications/misc/inkcut/default.nix
+++ b/pkgs/applications/misc/inkcut/default.nix
@@ -1,14 +1,12 @@
 { lib
 , fetchpatch
-, python3Packages
+, python3
 , fetchFromGitHub
 , wrapQtAppsHook
 , cups
 }:
 
-with python3Packages;
-
-buildPythonApplication rec {
+python3.pkgs.buildPythonApplication rec {
   pname = "inkcut";
   version = "2.1.5";
 
@@ -48,7 +46,7 @@ buildPythonApplication rec {
 
   nativeBuildInputs = [ wrapQtAppsHook ];
 
-  propagatedBuildInputs = [
+  propagatedBuildInputs = with python3.pkgs; [
     enamlx
     twisted
     lxml

--- a/pkgs/development/python-modules/enaml/default.nix
+++ b/pkgs/development/python-modules/enaml/default.nix
@@ -11,7 +11,7 @@
 , setuptools
 , setuptools-scm
 , pythonOlder
-, sip_4
+, sip
 }:
 
 buildPythonPackage rec {
@@ -43,7 +43,7 @@ buildPythonPackage rec {
     pegen
     ply
     qtpy
-    sip_4
+    sip
   ];
 
   # qt bindings cannot be found during tests


### PR DESCRIPTION
As 'python3' is [scheduled](https://github.com/NixOS/nixpkgs/blob/master/doc/languages-frameworks/python.section.md#cpython-update-schedule-python-cpython-update-schedule) to start pointing to that somewhere in June.

###### Description of changes

The dependency on 'sip' was changed to 08a26e45796e456278d75201fadb2498fe08dd7d out of caution, but it seems to work fine with the new default sip, so I changed that (`sip_4` does not build on python 3.11, and we probably shouldn't care)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
