### PR TITLE
gnomeExtensions.easyeffects-preset-selector: patch EasyEffects schema source

### DIFF
--- a/pkgs/desktops/gnome/extensions/extensionOverrides.nix
+++ b/pkgs/desktops/gnome/extensions/extensionOverrides.nix
@@ -1,18 +1,20 @@
 { lib
 , ddcutil
+, easyeffects
 , gjs
+, glib
 , gnome
 , gobject-introspection
 , gsound
 , hddtemp
 , libgda
+, libgtop
 , liquidctl
 , lm_sensors
 , netcat-gnu
 , nvme-cli
 , procps
 , pulseaudio
-, libgtop
 , python3
 , smartmontools
 , substituteAll
@@ -59,6 +61,16 @@ super: lib.trivial.pipe super [
     postPatch = ''
       substituteInPlace "extension.js" --replace "/usr/bin/ddcutil" "${ddcutil}/bin/ddcutil"
     '';
+  }))
+
+  (patchExtension "eepresetselector@ulville.github.io" (old: {
+    patches = [
+      # Needed to find the currently set preset
+      (substituteAll {
+        src = ./extensionOverridesPatches/eepresetselector_at_ulville.github.io.patch;
+        easyeffects_gsettings_path = "${glib.getSchemaPath easyeffects}";
+      })
+    ];
   }))
 
   (patchExtension "freon@UshakovVasilii_Github.yahoo.com" (old: {

--- a/pkgs/desktops/gnome/extensions/extensionOverridesPatches/eepresetselector_at_ulville.github.io.patch
+++ b/pkgs/desktops/gnome/extensions/extensionOverridesPatches/eepresetselector_at_ulville.github.io.patch
@@ -1,0 +1,15 @@
+--- a/extension.js
++++ b/extension.js
+@@ -339,9 +339,9 @@ const EEPSIndicator = GObject.registerClass(
+                     _lastUsedInputPreset = _idata.trim().slice(1, -1);
+                 } else if (appType === 'native') {
+                     // Get last used presets
+-                    const settings = new Gio.Settings({
+-                        schema_id: 'com.github.wwmm.easyeffects',
+-                    });
++                    const _schema_source = Gio.SettingsSchemaSource.new_from_directory('@easyeffects_gsettings_path@', Gio.SettingsSchemaSource.get_default(), true);
++                    const _schema = _schema_source.lookup('com.github.wwmm.easyeffects', false);
++                    const settings = new Gio.Settings({settings_schema: _schema});
+                     _lastUsedOutputPreset = settings.get_string(
+                         'last-used-output-preset'
+                     );


### PR DESCRIPTION
###### Description of changes

Patches the extension such that it can find the settings of `easyeffects`.

Was not sure on if the inputs were following a specific order so I just added them at the end.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
