### PR TITLE
makeInitrdNGTool: better errors

### DIFF
--- a/pkgs/build-support/kernel/make-initrd-ng/Cargo.lock
+++ b/pkgs/build-support/kernel/make-initrd-ng/Cargo.lock
@@ -9,6 +9,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
+name = "eyre"
+version = "0.6.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c2b6b5a29c02cdc822728b7d7b8ae1bab3e3b05d44522770ddd49722eeac7eb"
+dependencies = [
+ "indenter",
+ "once_cell",
+]
+
+[[package]]
 name = "goblin"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -18,6 +28,12 @@ dependencies = [
  "plain",
  "scroll",
 ]
+
+[[package]]
+name = "indenter"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce23b50ad8242c51a442f3ff322d56b02f08852c77e4c0b4d3fd684abc89c683"
 
 [[package]]
 name = "log"
@@ -32,8 +48,15 @@ dependencies = [
 name = "make-initrd-ng"
 version = "0.1.0"
 dependencies = [
+ "eyre",
  "goblin",
 ]
+
+[[package]]
+name = "once_cell"
+version = "1.17.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7e5500299e16ebb147ae15a00a942af264cf3688f47923b8fc2cd5858f23ad3"
 
 [[package]]
 name = "plain"

--- a/pkgs/build-support/kernel/make-initrd-ng/Cargo.toml
+++ b/pkgs/build-support/kernel/make-initrd-ng/Cargo.toml
@@ -7,4 +7,5 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+eyre = "0.6.8"
 goblin = "0.5.0"

--- a/pkgs/build-support/kernel/make-initrd-ng/src/main.rs
+++ b/pkgs/build-support/kernel/make-initrd-ng/src/main.rs
@@ -3,12 +3,13 @@ use std::env;
 use std::ffi::{OsStr, OsString};
 use std::fs;
 use std::hash::Hash;
+use std::io::{BufRead, BufReader};
 use std::iter::FromIterator;
-use std::io::{BufRead, BufReader, Error};
 use std::os::unix;
 use std::path::{Component, Path, PathBuf};
 use std::process::Command;
 
+use eyre::Context;
 use goblin::{elf::Elf, Object};
 
 struct NonRepeatingQueue<T> {
@@ -87,22 +88,30 @@ fn add_dependencies<P: AsRef<Path> + AsRef<OsStr>>(
     }
 }
 
-fn copy_file<P: AsRef<Path> + AsRef<OsStr>, S: AsRef<Path> + AsRef<OsStr>>(
+fn copy_file<
+    P: AsRef<Path> + AsRef<OsStr> + std::fmt::Debug,
+    S: AsRef<Path> + AsRef<OsStr> + std::fmt::Debug,
+>(
     source: P,
     target: S,
     queue: &mut NonRepeatingQueue<Box<Path>>,
-) -> Result<(), Error> {
-    fs::copy(&source, &target)?;
+) -> eyre::Result<()> {
+    fs::copy(&source, &target)
+        .wrap_err_with(|| format!("failed to copy {:?} to {:?}", source, target))?;
 
-    let contents = fs::read(&source)?;
+    let contents =
+        fs::read(&source).wrap_err_with(|| format!("failed to read from {:?}", source))?;
 
     if let Ok(Object::Elf(e)) = Object::parse(&contents) {
         add_dependencies(source, e, queue);
 
         // Make file writable to strip it
-        let mut permissions = fs::metadata(&target)?.permissions();
+        let mut permissions = fs::metadata(&target)
+            .wrap_err_with(|| format!("failed to get metadata for {:?}", target))?
+            .permissions();
         permissions.set_readonly(false);
-        fs::set_permissions(&target, permissions)?;
+        fs::set_permissions(&target, permissions)
+            .wrap_err_with(|| format!("failed to set readonly flag to false for {:?}", target))?;
 
         // Strip further than normal
         if let Ok(strip) = env::var("STRIP") {
@@ -121,11 +130,13 @@ fn copy_file<P: AsRef<Path> + AsRef<OsStr>, S: AsRef<Path> + AsRef<OsStr>>(
     Ok(())
 }
 
-fn queue_dir<P: AsRef<Path>>(
+fn queue_dir<P: AsRef<Path> + std::fmt::Debug>(
     source: P,
     queue: &mut NonRepeatingQueue<Box<Path>>,
-) -> Result<(), Error> {
-    for entry in fs::read_dir(source)? {
+) -> eyre::Result<()> {
+    for entry in
+        fs::read_dir(&source).wrap_err_with(|| format!("failed to read dir {:?}", source))?
+    {
         let entry = entry?;
         // No need to recurse. The queue will bring us back round here on its own.
         queue.push_back(Box::from(entry.path().as_path()));
@@ -138,7 +149,7 @@ fn handle_path(
     root: &Path,
     p: &Path,
     queue: &mut NonRepeatingQueue<Box<Path>>,
-) -> Result<(), Error> {
+) -> eyre::Result<()> {
     let mut source = PathBuf::new();
     let mut target = Path::new(root).to_path_buf();
     let mut iter = p.components().peekable();
@@ -161,15 +172,17 @@ fn handle_path(
             Component::Normal(name) => {
                 target.push(name);
                 source.push(name);
-                let typ = fs::symlink_metadata(&source)?.file_type();
+                let typ = fs::symlink_metadata(&source)
+                    .wrap_err_with(|| format!("failed to get symlink metadata for {:?}", source))?
+                    .file_type();
                 if typ.is_file() && !target.exists() {
                     copy_file(&source, &target, queue)?;
 
                     if let Some(filename) = source.file_name() {
                         source.set_file_name(OsString::from_iter([
-                                OsStr::new("."),
-                                filename,
-                                OsStr::new("-wrapped"),
+                            OsStr::new("."),
+                            filename,
+                            OsStr::new("-wrapped"),
                         ]));
 
                         let wrapped_path = source.as_path();
@@ -178,11 +191,14 @@ fn handle_path(
                         }
                     }
                 } else if typ.is_symlink() {
-                    let link_target = fs::read_link(&source)?;
+                    let link_target = fs::read_link(&source)
+                        .wrap_err_with(|| format!("failed to resolve symlink of {:?}", source))?;
 
                     // Create the link, then push its target to the queue
                     if !target.exists() {
-                        unix::fs::symlink(&link_target, &target)?;
+                        unix::fs::symlink(&link_target, &target).wrap_err_with(|| {
+                            format!("failed to symlink {:?} to {:?}", link_target, target)
+                        })?;
                     }
                     source.pop();
                     source.push(link_target);
@@ -196,12 +212,14 @@ fn handle_path(
                     break;
                 } else if typ.is_dir() {
                     if !target.exists() {
-                        fs::create_dir(&target)?;
+                        fs::create_dir(&target)
+                            .wrap_err_with(|| format!("failed to create dir {:?}", target))?;
                     }
 
                     // Only recursively copy if the directory is the target object
                     if iter.peek().is_none() {
-                        queue_dir(&source, queue)?;
+                        queue_dir(&source, queue)
+                            .wrap_err_with(|| format!("failed to queue dir {:?}", source))?;
                     }
                 }
             }
@@ -211,9 +229,10 @@ fn handle_path(
     Ok(())
 }
 
-fn main() -> Result<(), Error> {
+fn main() -> eyre::Result<()> {
     let args: Vec<String> = env::args().collect();
-    let input = fs::File::open(&args[1])?;
+    let input =
+        fs::File::open(&args[1]).wrap_err_with(|| format!("failed to open file {:?}", &args[1]))?;
     let output = &args[2];
     let out_path = Path::new(output);
 
@@ -235,8 +254,10 @@ fn main() -> Result<(), Error> {
             let link_path = Path::new(&link_string);
             let mut link_parent = link_path.to_path_buf();
             link_parent.pop();
-            fs::create_dir_all(link_parent)?;
-            unix::fs::symlink(obj_path, link_path)?;
+            fs::create_dir_all(&link_parent)
+                .wrap_err_with(|| format!("failed to create directories to {:?}", link_parent))?;
+            unix::fs::symlink(obj_path, link_path)
+                .wrap_err_with(|| format!("failed to symlink {:?} to {:?}", obj_path, link_path))?;
         }
     }
     while let Some(obj) = queue.pop_front() {


### PR DESCRIPTION
It's extremely frustrating seeing "Error: Os { code: 13, kind: PermissionDenied, message: "Permission denied" }" without any hint as to where exactly that occurred.

This commit fixes that by adding context to most errors.

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
