### PR TITLE
python310Packages.fastnumbers: disable timing sensitive test, remove …

### DIFF
--- a/pkgs/development/python-modules/fastnumbers/default.nix
+++ b/pkgs/development/python-modules/fastnumbers/default.nix
@@ -1,7 +1,6 @@
 { lib
 , stdenv
 , buildPythonPackage
-, fastnumbers
 , fetchFromGitHub
 , hypothesis
 , numpy
@@ -41,6 +40,10 @@ buildPythonPackage rec {
     hypothesis
     numpy
     pytestCheckHook
+  ];
+
+  pytestFlagsArray = [
+    "--hypothesis-profile=standard"
   ];
 
   pythonImportsCheck = [


### PR DESCRIPTION
…unused input

log lines I have:

last 10 log lines:
> tests/test_fastnumbers.py:1330: in test_given_unicode_digit_returns_true
>     @parametrize("func", get_funcs(funcs), ids=funcs)
> E   hypothesis.errors.FailedHealthCheck: Data generation is extremely slow: Only produced 9 valid examples in 1.26 seconds (0 invalid ones and 0 exceeded maximum size). Try decreasing size of the data you're generating (with e.g. max_size or max_leaves parameters).
> E   See https://hypothesis.readthedocs.io/en/latest/healthchecks.html for more information about this. If you want to disable just this health check, add HealthCheck.too_slow to the suppress_health_check settings for this test.
> ---------------------------------- Hypothesis ----------------------------------
> You can add @seed(21402865096374572269346745328342401108) to this test or run pytest with --hypothesis-seed=21402865096374572269346745328342401108 to reproduce this failure.
> =========================== short test summary info ============================
> FAILED tests/test_fastnumbers.py::TestCheckingFunctions::test_given_unicode_digit_returns_true[check_int] - hypothesis.errors.FailedHealthCheck: Data generation is extremely slow: Onl...
> ============ 1 failed, 1838 passed, 1 skipped in 383.89s (0:06:23) =============
> /nix/store/37p8gq9zijbw6pj3lpi1ckqiv18j2g62-stdenv-linux/setup: line 1594: pop_var_context: head of shell_variables not a function context
For full logs, run 'nix log /nix/store/avsxawhbbrfmp0128i5qfsqkzxka343z-python3.10-fastnumbers-5.0.1.drv'.

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
