### PR TITLE
doc/lisp: Add clarification about arguments to buildASDFSystem

### DIFF
--- a/doc/languages-frameworks/lisp.section.md
+++ b/doc/languages-frameworks/lisp.section.md
@@ -142,17 +142,25 @@ In that file, use the `build-asdf-system` function, which is a wrapper around
 as `build-with-compile-into-pwd` for systems which create files during
 compilation.
 
-The `build-asdf-system` function is documented with comments in
-`nix-cl.nix`. Also, `packages.nix` is full of examples of how to use it.
+`build-asdf-system` takes the following arguments:
+
+- `pname`: The package name
+- `version`: The package version
+- `src`: The package source
+- `patches`: The patches to apply
+- `nativeLibs`: Native libraries, will be appended to the library path
+- `javaLibs`: Java libraries for ABCL, will be appended to the class path
+- `lispLibs`: Lisp dependencies (built with `build-asdf-system`)
+- `systems`: List of ASDF system to compile
+
+Also, `packages.nix` is full of examples of how to use it.
 
 ## Defining packages manually outside Nixpkgs {#lisp-defining-packages-outside}
 
 Lisp derivations (`abcl`, `sbcl` etc.) also export the `buildASDFSystem`
-function, which is the same as `build-asdf-system`, except for the `lisp`
-argument which is set to the given CL implementation.
-
-It can be used to define packages outside Nixpkgs, and, for example, add them
-into the package scope with `withOverrides` which will be discussed later on.
+function. It takes the same arguments as `build-asdf-system`. It can be used to
+define packages outside Nixpkgs, and, for example, add them into the package
+scope with `withOverrides` which will be discussed later on.
 
 ### Including an external package in scope {#lisp-including-external-pkg-in-scope}
 

--- a/pkgs/development/lisp-modules/nix-cl.nix
+++ b/pkgs/development/lisp-modules/nix-cl.nix
@@ -109,6 +109,8 @@ let
       # TODO(kasper): use propagatedBuildInputs
       lispLibs ? [],
 
+      ## PRIVATE, don't use
+
       # Derivation containing the CL implementation package
       pkg,
 
@@ -124,6 +126,8 @@ let
       # ASDF amalgamation file to use
       # Created in build/asdf.lisp by `make` in ASDF source tree
       asdf,
+
+      ## end of PRIVATE
 
       # Some libraries have multiple systems under one project, for
       # example, cffi has cffi-grovel, cffi-toolchain etc.  By


### PR DESCRIPTION
###### Description of changes

Add clarification about arguments to buildASDFSystem.

Fixes #233465

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
