### PR TITLE
etcd: use etcd_3_5, etcd_3_3: mark vulnerable to CVE-2023-32082

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2311.section.md
+++ b/nixos/doc/manual/release-notes/rl-2311.section.md
@@ -14,6 +14,8 @@
 
 - The latest version of `clonehero` now stores custom content in `~/.clonehero`. See the [migration instructions](https://clonehero.net/2022/11/29/v23-to-v1-migration-instructions.html). Typically, these content files would exist along side the binary, but the previous build used a wrapper script that would store them in `~/.config/unity3d/srylain Inc_/Clone Hero`.
 
+- `etcd` has been updated to 3.5, you will want to read the [3.3 to 3.4](https://etcd.io/docs/v3.5/upgrades/upgrade_3_4/) and [3.4 to 3.5](https://etcd.io/docs/v3.5/upgrades/upgrade_3_5/) upgrade guides
+
 ## Other Notable Changes {#sec-release-23.11-notable-changes}
 
 - A new option was added to the virtualisation module that enables specifying explicitly named network interfaces in QEMU VMs. The existing `virtualisation.vlans` is still supported for cases where the name of the network interface is irrelevant.

--- a/nixos/modules/services/misc/etcd.nix
+++ b/nixos/modules/services/misc/etcd.nix
@@ -15,6 +15,8 @@ in {
       type = types.bool;
     };
 
+    package = mkPackageOptionMD pkgs "etcd" { };
+
     name = mkOption {
       description = lib.mdDoc "Etcd unique node name.";
       default = config.networking.hostName;
@@ -187,13 +189,13 @@ in {
 
       serviceConfig = {
         Type = "notify";
-        ExecStart = "${pkgs.etcd}/bin/etcd";
+        ExecStart = "${cfg.package}/bin/etcd";
         User = "etcd";
         LimitNOFILE = 40000;
       };
     };
 
-    environment.systemPackages = [ pkgs.etcd ];
+    environment.systemPackages = [ cfg.package ];
 
     users.users.etcd = {
       isSystemUser = true;

--- a/nixos/tests/etcd-cluster.nix
+++ b/nixos/tests/etcd-cluster.nix
@@ -53,7 +53,7 @@ import ./make-test-python.nix ({ pkgs, ... } : let
     [ v3_req ]
     basicConstraints = CA:FALSE
     keyUsage = digitalSignature, keyEncipherment
-    extendedKeyUsage = serverAuth
+    extendedKeyUsage = serverAuth, clientAuth
     subjectAltName = @alt_names
     [alt_names]
     DNS.1 = node1
@@ -86,10 +86,13 @@ import ./make-test-python.nix ({ pkgs, ... } : let
     };
 
     environment.variables = {
-      ETCDCTL_CERT_FILE = "${etcd_client_cert}";
-      ETCDCTL_KEY_FILE = "${etcd_client_key}";
-      ETCDCTL_CA_FILE = "${ca_pem}";
-      ETCDCTL_PEERS = "https://127.0.0.1:2379";
+      ETCD_CERT_FILE = "${etcd_client_cert}";
+      ETCD_KEY_FILE = "${etcd_client_key}";
+      ETCD_CA_FILE = "${ca_pem}";
+      ETCDCTL_ENDPOINTS = "https://127.0.0.1:2379";
+      ETCDCTL_CACERT = "${ca_pem}";
+      ETCDCTL_CERT = "${etcd_cert}";
+      ETCDCTL_KEY = "${etcd_key}";
     };
 
     networking.firewall.allowedTCPPorts = [ 2380 ];
@@ -134,21 +137,21 @@ in {
         node2.start()
         node1.wait_for_unit("etcd.service")
         node2.wait_for_unit("etcd.service")
-        node2.wait_until_succeeds("etcdctl cluster-health")
-        node1.succeed("etcdctl set /foo/bar 'Hello world'")
+        node2.wait_until_succeeds("etcdctl endpoint status")
+        node1.succeed("etcdctl put /foo/bar 'Hello world'")
         node2.succeed("etcdctl get /foo/bar | grep 'Hello world'")
 
     with subtest("should add another member"):
-        node1.wait_until_succeeds("etcdctl member add node3 https://node3:2380")
+        node1.wait_until_succeeds("etcdctl member add node3 --peer-urls=https://node3:2380")
         node3.start()
         node3.wait_for_unit("etcd.service")
         node3.wait_until_succeeds("etcdctl member list | grep 'node3'")
-        node3.succeed("etcdctl cluster-health")
+        node3.succeed("etcdctl endpoint status")
 
     with subtest("should survive member crash"):
         node3.crash()
-        node1.succeed("etcdctl cluster-health")
-        node1.succeed("etcdctl set /foo/bar 'Hello degraded world'")
+        node1.succeed("etcdctl endpoint status")
+        node1.succeed("etcdctl put /foo/bar 'Hello degraded world'")
         node1.succeed("etcdctl get /foo/bar | grep 'Hello degraded world'")
   '';
 })

--- a/nixos/tests/etcd.nix
+++ b/nixos/tests/etcd.nix
@@ -19,7 +19,7 @@ import ./make-test-python.nix ({ pkgs, ... } : {
         node.wait_for_unit("etcd.service")
 
     with subtest("should write and read some values to etcd"):
-        node.succeed("etcdctl set /foo/bar 'Hello world'")
+        node.succeed("etcdctl put /foo/bar 'Hello world'")
         node.succeed("etcdctl get /foo/bar | grep 'Hello world'")
   '';
 })

--- a/pkgs/servers/etcd/3.3.nix
+++ b/pkgs/servers/etcd/3.3.nix
@@ -30,5 +30,6 @@ buildGoPackage rec {
     homepage = "https://etcd.io/";
     maintainers = with maintainers; [ offline zowoq ];
     broken = stdenv.isDarwin; # outdated golang.org/x/sys
+    knownVulnerabilities = [ "CVE-2023-32082" ];
   };
 }

--- a/pkgs/servers/etcd/3.3.nix
+++ b/pkgs/servers/etcd/3.3.nix
@@ -1,4 +1,4 @@
-{ lib, buildGoPackage, fetchFromGitHub, nixosTests, stdenv }:
+{ lib, buildGoPackage, fetchFromGitHub, stdenv }:
 
 buildGoPackage rec {
   pname = "etcd";
@@ -23,8 +23,6 @@ buildGoPackage rec {
   installPhase = ''
     install -Dm755 bin/* bin/functional/cmd/* -t $out/bin
   '';
-
-  passthru.tests = { inherit (nixosTests) etcd etcd-cluster; };
 
   meta = with lib; {
     description = "Distributed reliable key-value store for the most critical data of a distributed system";

--- a/pkgs/servers/etcd/3.5.nix
+++ b/pkgs/servers/etcd/3.5.nix
@@ -1,4 +1,4 @@
-{ lib, buildGoModule, fetchFromGitHub, symlinkJoin }:
+{ lib, buildGoModule, fetchFromGitHub, symlinkJoin, nixosTests }:
 
 let
   version = "3.5.9";
@@ -65,7 +65,10 @@ symlinkJoin {
 
   inherit meta version;
 
-  passthru = { inherit etcdserver etcdutl etcdctl; };
+  passthru = {
+    inherit etcdserver etcdutl etcdctl;
+    tests = { inherit (nixosTests) etcd etcd-cluster; };
+  };
 
   paths = [
     etcdserver

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -25308,7 +25308,7 @@ with pkgs;
 
   ergochat = callPackage ../servers/irc/ergochat { };
 
-  etcd = etcd_3_3;
+  etcd = etcd_3_5;
   etcd_3_3 = callPackage ../servers/etcd/3.3.nix { };
   etcd_3_4 = callPackage ../servers/etcd/3.4.nix { };
   etcd_3_5 = callPackage ../servers/etcd/3.5.nix { };


### PR DESCRIPTION
###### Description of changes

etcd 3.3 is end of life for a while and is vulnerable to CVE-2023-32082.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [x] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
