### PR TITLE
 takethetime: fetch from PyPI and disable checks

### DIFF
--- a/pkgs/development/python-modules/takethetime/default.nix
+++ b/pkgs/development/python-modules/takethetime/default.nix
@@ -1,36 +1,25 @@
 { lib
 , buildPythonPackage
-, fetchFromGitHub
+, fetchPypi
 , pythonOlder
-, pytestCheckHook
 }:
 
-buildPythonPackage {
+buildPythonPackage rec {
   pname = "takethetime";
   version = "0.3.1";
 
-  # pypi distribution doesn't include tests, so build from source instead
-  src = fetchFromGitHub {
-    owner = "ErikBjare";
-    repo = "TakeTheTime";
-    rev = "b0042ac5b1cc9d3b70ef59167b094469ceb660dd";
-    sha256 = "sha256-DwsMnP6G3BzOnINttaSC6QKkIKK5qyhUz+lN1DSvkw0=";
+  src = fetchPypi {
+    pname = "TakeTheTime";
+    inherit version;
+    sha256 = "sha256-2+MEU6G1lqOPni4/qOGtxa8tv2RsoIN61cIFmhb+L/k=";
   };
 
   disabled = pythonOlder "3.6";
 
-  nativeCheckInputs = [ pytestCheckHook ];
-
-  pytestFlagsArray = [ "tests/tests.py" ];
+  # Tests are timing dependent and aren't included with PyPI distribution
+  doCheck = false;
 
   pythonImportsCheck = [ "takethetime" ];
-
-  # Latest release is v0.3.1 on pypi, but this version was not bumped in
-  # the setup.py, causing packages that depend on v0.3.1 to fail to build.
-  postPatch = ''
-    substituteInPlace setup.py \
-      --replace "version='0.3'" "version='0.3.1'"
-  '';
 
   meta = with lib; {
     description = "Simple time taking library using context managers";

--- a/pkgs/development/python-modules/takethetime/default.nix
+++ b/pkgs/development/python-modules/takethetime/default.nix
@@ -16,7 +16,7 @@ buildPythonPackage rec {
 
   disabled = pythonOlder "3.6";
 
-  # Tests are timing dependent and aren't included with PyPI distribution
+  # all tests are timing dependent
   doCheck = false;
 
   pythonImportsCheck = [ "takethetime" ];


### PR DESCRIPTION
Previously, we built the package from GitHub in order to run the included tests. However, because those tests are timing dependent, they couldpotentially fail even when the package itself was fine. Because the tests were not useful, we switched back over to getting the package from PyPI and only using `pythonImportsCheck`.
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
