### PR TITLE
python310Packages.macfsevents: 0.8.1 -> 0.8.4

### DIFF
--- a/pkgs/development/python-modules/macfsevents/default.nix
+++ b/pkgs/development/python-modules/macfsevents/default.nix
@@ -2,11 +2,11 @@
 
 buildPythonPackage rec {
   pname = "MacFSEvents";
-  version = "0.8.1";
+  version = "0.8.4";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "1324b66b356051de662ba87d84f73ada062acd42b047ed1246e60a449f833e10";
+    sha256 = "sha256-v3KD8dUXdkzNyBlbIWMdu6wcUGuSC/mo6ilWsxJ2Ucs=";
   };
 
   buildInputs = [ CoreFoundation CoreServices ];

--- a/pkgs/development/python-modules/macfsevents/default.nix
+++ b/pkgs/development/python-modules/macfsevents/default.nix
@@ -1,4 +1,9 @@
-{ lib, buildPythonPackage, fetchPypi, CoreFoundation, CoreServices }:
+{ lib
+, buildPythonPackage
+, fetchPypi
+, CoreFoundation
+, CoreServices
+}:
 
 buildPythonPackage rec {
   pname = "MacFSEvents";
@@ -14,9 +19,12 @@ buildPythonPackage rec {
   # Some tests fail under nix build directory
   doCheck = false;
 
+  pythonImportsCheck = [ "fsevents" ];
+
   meta = with lib; {
-    homepage = "https://github.com/malthe/macfsevents";
     description = "Thread-based interface to file system observation primitives";
+    homepage = "https://github.com/malthe/macfsevents";
+    changelog = "https://github.com/malthe/macfsevents/blob/${version}/CHANGES.rst";
     license = licenses.bsd2;
     maintainers = [ maintainers.marsam ];
     platforms = platforms.darwin;


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done
Changelog: https://github.com/malthe/macfsevents/blob/0.8.4/CHANGES.rst
<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->