### PR TITLE
gmic-qt: fix updateScript

### DIFF
--- a/pkgs/tools/graphics/gmic-qt/default.nix
+++ b/pkgs/tools/graphics/gmic-qt/default.nix
@@ -3,23 +3,27 @@
 , fetchzip
 , cimg
 , cmake
+, coreutils
 , curl
 , fftw
 , gimp
 , gimpPlugins
 , gmic
+, gnugrep
+, gnused
 , graphicsmagick
 , libjpeg
 , libpng
 , libtiff
 , ninja
-, nix-update-script
+, nix-update
 , opencv3
 , openexr
 , pkg-config
 , qtbase
 , qttools
 , wrapQtAppsHook
+, writeShellScript
 , zlib
 , variant ? "standalone"
 }:
@@ -108,7 +112,23 @@ stdenv.mkDerivation (finalAttrs: {
       inherit cimg gmic;
     };
 
-    updateScript = nix-update-script { };
+    updateScript = writeShellScript "gmic-qt-update-script" ''
+      set -euo pipefail
+
+      export PATH="${lib.makeBinPath [ coreutils curl gnugrep gnused nix-update ]}:$PATH"
+
+      latestVersion=$(curl 'https://gmic.eu/files/source/' \
+                       | grep -E 'gmic_[^"]+\.tar\.gz' \
+                       | sed -E 's/.+<a href="gmic_([^"]+)\.tar\.gz".+/\1/g' \
+                       | sort --numeric-sort --reverse | head -n1)
+
+      if [[ '${finalAttrs.version}' = "$latestVersion" ]]; then
+          echo "The new version same as the old version."
+          exit 0
+      fi
+
+      nix-update --version "$latestVersion"
+    '';
   };
 
   meta = {


### PR DESCRIPTION
###### Description of changes

The current `nix-update` script no longer runs since switching back from `fetchFromGitHub` to fetching the tarball via `fetchzip`

This updates it with the version detection logic from `gmic.updateScript` and just calls `nix-update` with that version

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).