### PR TITLE
nixos: Support fileSystems.<name>.depends with fstab-generator

### DIFF
--- a/nixos/modules/tasks/filesystems.nix
+++ b/nixos/modules/tasks/filesystems.nix
@@ -1,4 +1,4 @@
-{ config, lib, pkgs, utils, ... }:
+{ config, lib, pkgs, utils, ... }@moduleArgs:
 
 with lib;
 with utils;
@@ -136,10 +136,21 @@ let
 
     };
 
-    config.options = mkMerge [
+    config.options = let
+      inInitrd = utils.fsNeededForBoot config;
+    in mkMerge [
       (mkIf config.autoResize [ "x-systemd.growfs" ])
       (mkIf config.autoFormat [ "x-systemd.makefs" ])
       (mkIf (utils.fsNeededForBoot config) [ "x-initrd.mount" ])
+      (mkIf
+        # With scripted stage 1, depends is implemented by sorting 'config.system.build.fileSystems'
+        (lib.length config.depends > 0 && (inInitrd -> moduleArgs.config.boot.initrd.systemd.enable))
+        (
+          map (
+            x: "x-systemd.requires-mounts-for=${optionalString inInitrd "/sysroot"}${x}"
+          ) config.depends
+        )
+      )
     ];
 
   };

--- a/nixos/modules/tasks/filesystems/overlayfs.nix
+++ b/nixos/modules/tasks/filesystems/overlayfs.nix
@@ -82,6 +82,10 @@ let
     config = lib.mkIf (config.overlay.lowerdir != null) {
       fsType = "overlay";
       device = lib.mkDefault "overlay";
+      depends = map (x: "${x}") (config.overlay.lowerdir ++ lib.optionals (config.overlay.upperdir != null) [
+        config.overlay.upperdir
+        config.overlay.workdir
+      ]);
 
       options =
         let
@@ -96,7 +100,7 @@ let
         ] ++ lib.optionals (config.overlay.upperdir != null) [
           "upperdir=${upperdir}"
           "workdir=${workdir}"
-        ] ++ (map (s: "x-systemd.requires-mounts-for=${s}") lowerdir);
+        ];
     };
 
   };

--- a/nixos/tests/filesystems-overlayfs.nix
+++ b/nixos/tests/filesystems-overlayfs.nix
@@ -26,7 +26,6 @@ in
 
   nodes.machine = { config, pkgs, ... }: {
     boot.initrd.systemd.enable = true;
-    boot.initrd.availableKernelModules = [ "overlay" ];
 
     virtualisation.fileSystems = {
       "/initrd-overlay" = {


### PR DESCRIPTION
###### Description of changes

I have barely tested this, so I'm not entirely sure it's correct. Closes #217179

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
