### PR TITLE
minimal-bootstrap.tinycc-*: static link by default

### DIFF
--- a/pkgs/os-specific/linux/minimal-bootstrap/bzip2/default.nix
+++ b/pkgs/os-specific/linux/minimal-bootstrap/bzip2/default.nix
@@ -61,7 +61,7 @@ bash.runCommand "${pname}-${version}" {
 
   # Build
   make \
-    CC="tcc -static -B ${tinycc.libs}/lib -I ." \
+    CC="tcc -B ${tinycc.libs}/lib -I ." \
     AR="tcc -ar" \
     bzip2 bzip2recover
 

--- a/pkgs/os-specific/linux/minimal-bootstrap/gawk/default.nix
+++ b/pkgs/os-specific/linux/minimal-bootstrap/gawk/default.nix
@@ -59,7 +59,7 @@ bash.runCommand "${pname}-${version}" {
   ${lib.concatMapStringsSep "\n" (f: "patch -Np0 -i ${f}") patches}
 
   # Configure
-  export CC="tcc -static -B ${tinycc.libs}/lib"
+  export CC="tcc -B ${tinycc.libs}/lib"
   export ac_cv_func_getpgrp_void=yes
   export ac_cv_func_tzset=yes
   bash ./configure \

--- a/pkgs/os-specific/linux/minimal-bootstrap/gnugrep/default.nix
+++ b/pkgs/os-specific/linux/minimal-bootstrap/gnugrep/default.nix
@@ -53,7 +53,7 @@ bash.runCommand "${pname}-${version}" {
   cp ${makefile} Makefile
 
   # Build
-  make CC="tcc -static -B ${tinycc.libs}/lib"
+  make CC="tcc -B ${tinycc.libs}/lib"
 
   # Install
   make install PREFIX=$out

--- a/pkgs/os-specific/linux/minimal-bootstrap/gnumake/default.nix
+++ b/pkgs/os-specific/linux/minimal-bootstrap/gnumake/default.nix
@@ -45,7 +45,7 @@ let
         ./configure \
           --build i686-pc-linux-gnu \
           --host i686-pc-linux-gnu \
-          CC="${tinycc.compiler}/bin/tcc -B ${tinycc.libs}/lib -static" \
+          CC="${tinycc.compiler}/bin/tcc -B ${tinycc.libs}/lib" \
           ac_cv_func_dup=no
     - `ac_cv_func_dup` disabled as mes-libc doesn't implement tmpfile()
 
@@ -178,7 +178,7 @@ kaem.runCommand "${pname}-${version}" {
   ${lib.concatMapStringsSep "\n" (f: "CC -c ${f}") sources}
 
   # Link
-  CC -static -o make ${lib.concatStringsSep " " objects}
+  CC -o make ${lib.concatStringsSep " " objects}
 
   # Check
   ./make --version

--- a/pkgs/os-specific/linux/minimal-bootstrap/gnupatch/default.nix
+++ b/pkgs/os-specific/linux/minimal-bootstrap/gnupatch/default.nix
@@ -95,7 +95,7 @@ kaem.runCommand "${pname}-${version}" {
   ${lib.concatMapStringsSep "\n" (f: "CC -c ${f}") sources}
 
   # Link
-  CC -static -o patch ${lib.concatStringsSep " " objects}
+  CC -o patch ${lib.concatStringsSep " " objects}
 
   # Check
   ./patch --version

--- a/pkgs/os-specific/linux/minimal-bootstrap/gnutar/default.nix
+++ b/pkgs/os-specific/linux/minimal-bootstrap/gnutar/default.nix
@@ -50,7 +50,7 @@ bash.runCommand "${pname}-${version}" {
   cd tar-${version}
 
   # Configure
-  export CC="tcc -static -B ${tinycc.libs}/lib"
+  export CC="tcc -B ${tinycc.libs}/lib"
   bash ./configure \
     --build=${buildPlatform.config} \
     --host=${hostPlatform.config} \

--- a/pkgs/os-specific/linux/minimal-bootstrap/gzip/default.nix
+++ b/pkgs/os-specific/linux/minimal-bootstrap/gzip/default.nix
@@ -46,7 +46,7 @@ bash.runCommand "${pname}-${version}" {
   cd gzip-${version}
 
   # Configure
-  export CC="tcc -static -B ${tinycc.libs}/lib -Dstrlwr=unused"
+  export CC="tcc -B ${tinycc.libs}/lib -Dstrlwr=unused"
   bash ./configure --prefix=$out
 
   # Build

--- a/pkgs/os-specific/linux/minimal-bootstrap/tinycc/bootstrappable.nix
+++ b/pkgs/os-specific/linux/minimal-bootstrap/tinycc/bootstrappable.nix
@@ -29,6 +29,11 @@ let
     mkdir -p ''${out}
     cd ''${out}
     untar --file ''${NIX_BUILD_TOP}/tinycc.tar
+
+    # Patch
+    cd tinycc-${rev}
+    # Static link by default
+    replace --file libtcc.c --output libtcc.c --match-on "s->ms_extensions = 1;" --replace-with "s->ms_extensions = 1; s->static_link = 1;"
   '') + "/tinycc-${rev}";
 
   meta = with lib; {

--- a/pkgs/os-specific/linux/minimal-bootstrap/tinycc/common.nix
+++ b/pkgs/os-specific/linux/minimal-bootstrap/tinycc/common.nix
@@ -74,7 +74,6 @@ rec {
           -B ${prev.libs}/lib \
           -g \
           -v \
-          -static \
           -o ''${out}/bin/tcc \
           -D BOOTSTRAP=1 \
           ${options} \

--- a/pkgs/os-specific/linux/minimal-bootstrap/tinycc/mes.nix
+++ b/pkgs/os-specific/linux/minimal-bootstrap/tinycc/mes.nix
@@ -25,6 +25,11 @@ let
     mkdir -p ''${out}
     cd ''${out}
     untar --file ''${NIX_BUILD_TOP}/tinycc.tar
+
+    # Patch
+    cd tinycc-${builtins.substring 0 7 rev}
+    # Static link by default
+    replace --file libtcc.c --output libtcc.c --match-on "s->ms_extensions = 1;" --replace-with "s->ms_extensions = 1; s->static_link = 1;"
   '') + "/tinycc-${builtins.substring 0 7 rev}";
 
   meta = with lib; {
@@ -39,7 +44,6 @@ let
     mkdir ''${out}
     ${tinycc-bootstrappable.compiler}/bin/tcc \
       -B ${tinycc-bootstrappable.libs}/lib \
-      -static \
       -DC2STR \
       -o c2str \
       ${src}/conftest.c


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Make tinycc enable static linking by default as mes-libc doesn't support dynamic linking. this aligns us with how it behaves in guix and live-bootstrap.

Related #227914

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
