### PR TITLE
gnushogi: fix build

### DIFF
--- a/pkgs/games/gnushogi/default.nix
+++ b/pkgs/games/gnushogi/default.nix
@@ -10,11 +10,19 @@ stdenv.mkDerivation rec {
     sha256 = "0a9bsl2nbnb138lq0h14jfc5xvz7hpb2bcsj4mjn6g1hcsl4ik0y";
   };
 
+  env.LDFLAGS = lib.optionalString (!stdenv.isDarwin) "-Wl,-z,muldefs";
+
+  # Makefile ignores errors, so the build may silently succeed erroneously
+  postBuild = ''
+    test -e gnushogi/gnushogi || { echo "ERROR: no binary produced"; exit 1; }
+  '';
+
   meta = with lib; {
     description = "GNU implementation of Shogi, also known as Japanese Chess";
     homepage = "https://www.gnu.org/software/gnushogi/";
     license = licenses.gpl3;
     maintainers = [ maintainers.ciil ];
     platforms = platforms.unix;
+    broken = stdenv.isDarwin; # darwin does not support -z muldefs
   };
 }


### PR DESCRIPTION
###### Description of changes

- Fix gnushogi build silently succeeding with empty output
- Example build: https://hydra.nixos.org/build/219348389/nixlog/1

Fixes #211433

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
