### PR TITLE
ocamlPackages: small fixes

### DIFF
--- a/pkgs/development/ocaml-modules/ocaml-lsp/lsp.nix
+++ b/pkgs/development/ocaml-modules/ocaml-lsp/lsp.nix
@@ -16,6 +16,7 @@
 , chrome-trace
 , dune_3
 , csexp
+, result
 , pp
 , cmdliner
 , ordering
@@ -101,6 +102,7 @@ buildDunePackage rec {
       jsonrpc
       pp
       ppx_yojson_conv_lib
+      result
       uutf
     ] else [
       csexp

--- a/pkgs/development/ocaml-modules/polynomial/default.nix
+++ b/pkgs/development/ocaml-modules/polynomial/default.nix
@@ -9,6 +9,7 @@ buildDunePackage rec {
   pname = "polynomial";
   version = "0.4.0";
   duneVersion = "3";
+  minimalOCamlVersion = "4.08";
   src = fetchFromGitLab {
     owner = "nomadic-labs";
     repo = "cryptography/ocaml-polynomial";

--- a/pkgs/development/tools/ocaml/merlin/dot-merlin-reader.nix
+++ b/pkgs/development/tools/ocaml/merlin/dot-merlin-reader.nix
@@ -1,4 +1,4 @@
-{ lib, fetchurl, yojson, csexp, findlib, buildDunePackage, merlin-lib, merlin }:
+{ lib, fetchurl, yojson, csexp, findlib, buildDunePackage, merlin-lib, merlin, result }:
 
 buildDunePackage rec {
   pname = "dot-merlin-reader";
@@ -12,7 +12,7 @@ buildDunePackage rec {
   buildInputs = [ findlib ]
   ++ (if lib.versionAtLeast version "4.7-414"
   then [ merlin-lib ]
-  else [ yojson csexp ]);
+  else [ yojson csexp result ]);
 
   meta = with lib; {
     description = "Reads config files for merlin";


### PR DESCRIPTION
###### Description of changes

Various minor fixes

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
