### PR TITLE
coqPackages.math-classes: 8.15.0 → 8.17.0

### DIFF
--- a/pkgs/development/coq-modules/corn/default.nix
+++ b/pkgs/development/coq-modules/corn/default.nix
@@ -5,7 +5,7 @@ mkCoqDerivation rec {
   inherit version;
   defaultVersion = with lib.versions; lib.switch coq.coq-version [
     { case = "8.6"; out = "8.8.1"; }
-    { case = (range "8.11" "8.16"); out = "8.16.0"; }
+    { case = (range "8.11" "8.17"); out = "8.16.0"; }
     { case = (range "8.7"  "8.15"); out = "8.13.0"; }
   ] null;
   release = {

--- a/pkgs/development/coq-modules/math-classes/default.nix
+++ b/pkgs/development/coq-modules/math-classes/default.nix
@@ -4,10 +4,14 @@ mkCoqDerivation {
 
   pname = "math-classes";
   inherit version;
-  defaultVersion = if lib.versions.range "8.6" "8.16" coq.coq-version then "8.15.0" else null;
+  defaultVersion = with lib.versions; lib.switch coq.coq-version [
+    { case = range "8.12" "8.17"; out = "8.17.0"; }
+    { case = range "8.6"  "8.16"; out = "8.15.0"; }
+  ] null;
   release."8.12.0".sha256 = "14nd6a08zncrl5yg2gzk0xf4iinwq4hxnsgm4fyv07ydbkxfb425";
   release."8.13.0".sha256 = "1ln7ziivfbxzbdvlhbvyg3v30jgblncmwcsam6gg3d1zz6r7cbby";
   release."8.15.0".sha256 = "10w1hm537k6jx8a8vghq1yx12rsa0sjk2ipv3scgir71ln30hllw";
+  release."8.17.0".sha256 = "sha256-WklL8pgYTd0l4TGt7h7tWj1qcFcXvoPn25+XKF1pIKA=";
 
   propagatedBuildInputs = [ bignums ];
 


### PR DESCRIPTION
###### Description of changes

https://github.com/coq-community/math-classes/releases/tag/8.17.0

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
