### PR TITLE
libbson: 1.9.5 -> 1.13.0

### DIFF
--- a/pkgs/development/libraries/libbson/default.nix
+++ b/pkgs/development/libraries/libbson/default.nix
@@ -2,14 +2,19 @@
 
 stdenv.mkDerivation rec {
   pname = "libbson";
-  version = "1.9.5";
+  version = "1.13.0";
 
   src = fetchFromGitHub {
     owner = "mongodb";
-    repo = "libbson";
+    repo = "mongo-c-driver";
     rev = version;
-    sha256 = "16rmzxhhmbvhp4q6qac5j9c74z2pcg5raag5w16mynzikdd2l05b";
+    sha256 = "sha256-15YKd5zfvEpsPpJX5DtXhDl3kErMGfCCGNAhQul01nk=";
   };
+
+  cmakeFlags = [
+    "-DENABLE_MONGOC=OFF"
+    "-DENABLE_BSON=ON"
+  ];
 
   nativeBuildInputs = [ cmake ];
   buildInputs = [ perl ];


### PR DESCRIPTION
###### Description of changes

Original repo https://github.com/mongodb/libbson archived, moved to subdirectory at https://github.com/mongodb/mongo-c-driver/tree/master/src/libbson.  
https://github.com/mongodb/mongo-c-driver provides `libmongoc` & `libbson`, it is possible to build and install only `libbson`.

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
