### PR TITLE
rustPlatform.bindgenHook: use the correct Libsystem on the 11.0 SDK

### DIFF
--- a/pkgs/os-specific/darwin/apple-sdk-11.0/default.nix
+++ b/pkgs/os-specific/darwin/apple-sdk-11.0/default.nix
@@ -50,16 +50,18 @@ let
     '';
   };
 
-  mkStdenv = stdenv:
-    let
-      cc = stdenv.cc.override {
+  mkCc = cc:
+    if stdenv.isAarch64 then cc
+    else
+      cc.override {
         bintools = stdenv.cc.bintools.override { libc = packages.Libsystem; };
         libc = packages.Libsystem;
       };
-    in
+
+  mkStdenv = stdenv:
     if stdenv.isAarch64 then stdenv
     else
-      (overrideCC stdenv cc).override {
+      (overrideCC stdenv (mkCc stdenv.cc)).override {
         targetPlatform = stdenv.targetPlatform // {
           darwinMinVersion = "10.12";
           darwinSdkVersion = "11.0";
@@ -108,10 +110,7 @@ let
       inherit (pkgs.callPackage ../../../build-support/rust/hooks {
         inherit (pkgs.darwin.apple_sdk_11_0) stdenv;
         inherit (pkgs) cargo rustc;
-        clang = pkgs.clang.override {
-          bintools = pkgs.clang.bintools.override { libc = packages.Libsystem; };
-          libc = packages.Libsystem;
-        };
+        clang = mkCc pkgs.clang;
       }) bindgenHook;
     };
 

--- a/pkgs/os-specific/darwin/apple-sdk-11.0/default.nix
+++ b/pkgs/os-specific/darwin/apple-sdk-11.0/default.nix
@@ -104,6 +104,15 @@ let
     rustPlatform = pkgs.makeRustPlatform {
       inherit (pkgs.darwin.apple_sdk_11_0) stdenv;
       inherit (pkgs) rustc cargo;
+    } // {
+      inherit (pkgs.callPackage ../../../build-support/rust/hooks {
+        inherit (pkgs.darwin.apple_sdk_11_0) stdenv;
+        inherit (pkgs) cargo rustc;
+        clang = pkgs.clang.override {
+          bintools = pkgs.clang.bintools.override { libc = packages.Libsystem; };
+          libc = packages.Libsystem;
+        };
+      }) bindgenHook;
     };
 
     callPackage = newScope (lib.optionalAttrs stdenv.isDarwin (stdenvs // rec {


### PR DESCRIPTION
###### Description of changes

While troubleshooting https://github.com/ipetkov/crane/discussions/329, I found that the 11.0 SDK `rustPlatform.bindgenHook` was propagating Libsystem from the 10.12 SDK (because the hook exports Clang’s `nix-support/libc-c(xx)flags`). Providing it with a wrapped Clang using the 11.0 SDK Libsystem resolves the issue.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
