### PR TITLE
zf: install shell files, run tests

### DIFF
--- a/pkgs/tools/misc/zf/default.nix
+++ b/pkgs/tools/misc/zf/default.nix
@@ -4,6 +4,7 @@
   fetchFromGitHub,
   zig,
   testers,
+  installShellFiles,
   zf,
 }:
 stdenv.mkDerivation rec {
@@ -18,17 +19,33 @@ stdenv.mkDerivation rec {
     hash = "sha256-MzlSU5x2lb6PJZ/iNAi2aebfuClBprlfHMIG/4OPmuc=";
   };
 
-  nativeBuildInputs = [ zig ];
-
-  dontConfigure = true;
+  nativeBuildInputs = [ zig installShellFiles ];
 
   preBuild = ''
     export HOME=$TMPDIR
   '';
 
+  buildPhase = ''
+    runHook preBuild
+    zig build -Drelease-safe -Dcpu=baseline
+    runHook postBuild
+  '';
+
+  doCheck = true;
+  checkPhase = ''
+    runHook preCheck
+    zig build test
+    runHook postCheck
+  '';
+
   installPhase = ''
     runHook preInstall
     zig build -Drelease-safe -Dcpu=baseline --prefix $out install
+    installManPage doc/zf.1
+    installShellCompletion \
+      --bash complete/zf \
+      --fish complete/zf.fish \
+      --zsh complete/_zf
     runHook postInstall
   '';
 


### PR DESCRIPTION
###### Description of changes

Also separate buildPhase to make nix-shell workable.

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).