### PR TITLE
makeself: use installManPage

### DIFF
--- a/pkgs/applications/misc/makeself/default.nix
+++ b/pkgs/applications/misc/makeself/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchFromGitHub, which, zstd, pbzip2 }:
+{ lib, stdenv, fetchFromGitHub, which, zstd, pbzip2, installShellFiles }:
 
 stdenv.mkDerivation rec {
   version = "2.4.5";
@@ -12,6 +12,8 @@ stdenv.mkDerivation rec {
     sha256 = "sha256-15lUtErGsbXF2Gn0f0rvA18mMuVMmkKrGO2poeYZU9g=";
   };
 
+  nativeBuildInputs = [ installShellFiles ];
+
   postPatch = "patchShebangs test";
 
   # Issue #110149: our default /bin/sh apparently has 32-bit math only
@@ -22,11 +24,11 @@ stdenv.mkDerivation rec {
   nativeCheckInputs = [ which zstd pbzip2 ];
 
   installPhase = ''
-    mkdir -p $out/{bin,share/{${pname}-${version},man/man1}}
-    cp makeself.lsm README.md $out/share/${pname}-${version}
-    cp makeself.sh $out/bin/makeself
-    cp makeself.1  $out/share/man/man1/
-    cp makeself-header.sh $out/share/${pname}-${version}
+    runHook preInstall
+    installManPage makeself.1
+    install -Dm555 makeself.sh $out/bin/makeself
+    install -Dm444 -t $out/share/${pname}/ makeself.lsm README.md makeself-header.sh
+    runHook postInstall
   '';
 
   fixupPhase = ''


### PR DESCRIPTION
###### Description of changes



###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).