### PR TITLE
zsh: remove pcre as a native build input

### DIFF
--- a/pkgs/shells/zsh/default.nix
+++ b/pkgs/shells/zsh/default.nix
@@ -10,6 +10,7 @@
 , texinfo
 , ncurses
 , pcre
+, pkg-config
 , buildPackages }:
 
 let
@@ -32,7 +33,7 @@ stdenv.mkDerivation {
   ];
 
   strictDeps = true;
-  nativeBuildInputs = [ autoreconfHook perl groff texinfo pcre]
+  nativeBuildInputs = [ autoreconfHook perl groff texinfo pkg-config ]
                       ++ lib.optionals stdenv.isLinux [ util-linux yodl ];
 
   buildInputs = [ ncurses pcre ];
@@ -55,6 +56,11 @@ stdenv.mkDerivation {
     "zsh_cv_sys_dynamic_strip_exe=yes"
     "zsh_cv_sys_dynamic_strip_lib=yes"
   ];
+
+  preConfigure = ''
+    # use pkg-config instead of pcre-config
+    configureFlagsArray+=("PCRECONF=''${PKG_CONFIG} libpcre")
+  '';
 
   # the zsh/zpty module is not available on hydra
   # so skip groups Y Z


### PR DESCRIPTION
###### Description of changes

The configure script calls pcre-config to find pcre however using nativeBuildInputs for this meant that zsh found the native libraries.

pcre does not appear to be needed as a nativeBuildInput any where within zsh.

if pcre is needed as a nativeBuildInput then the location of pcre-config can be overrided through the ac_cv_prog_PCRECONF variable

fixes https://github.com/NixOS/nixpkgs/issues/233805
fixes https://github.com/NixOS/nixpkgs/issues/174566

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
