### PR TITLE
avrdude: always build documentation on Linux

### DIFF
--- a/pkgs/development/embedded/avrdude/default.nix
+++ b/pkgs/development/embedded/avrdude/default.nix
@@ -1,9 +1,7 @@
-{ lib, stdenv, fetchFromGitHub, cmake, bison, flex, libusb-compat-0_1, libelf, libftdi1, readline
-# docSupport is a big dependency, disabled by default
-, docSupport ? false, texLive ? null, texinfo ? null, texi2html ? null
-}:
-
-assert docSupport -> texLive != null && texinfo != null && texi2html != null;
+{ lib, stdenv, fetchFromGitHub, cmake, bison, flex, libusb-compat-0_1, libelf
+, libftdi1, readline
+# documentation building is broken on darwin
+, docSupport ? (!stdenv.isDarwin), texlive, texinfo, texi2html, unixtools }:
 
 stdenv.mkDerivation rec {
   pname = "avrdude";
@@ -16,10 +14,14 @@ stdenv.mkDerivation rec {
     sha256 = "sha256-pGjOefWnf11kG/zFGwYGet1OjAhKsULNGgh6vqvIQ7c=";
   };
 
-  nativeBuildInputs = [ cmake bison flex ];
+  nativeBuildInputs = [ cmake bison flex ] ++ lib.optionals docSupport [
+    unixtools.more
+    texlive.combined.scheme-medium
+    texinfo
+    texi2html
+  ];
 
-  buildInputs = [ libusb-compat-0_1 libelf libftdi1 readline ]
-    ++ lib.optionals docSupport [ texLive texinfo texi2html ];
+  buildInputs = [ libusb-compat-0_1 libelf libftdi1 readline ];
 
   cmakeFlags = lib.optionals docSupport [
     "-DBUILD_DOC=ON"


### PR DESCRIPTION
###### Description of changes

Make texlive a build-time dependency to always build the docs.

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).