### PR TITLE
rust-bindgen-0_56-kernel: init at 0.56.0

### DIFF
--- a/pkgs/development/tools/rust/bindgen/unwrapped-0_56-kernel.nix
+++ b/pkgs/development/tools/rust/bindgen/unwrapped-0_56-kernel.nix
@@ -1,0 +1,21 @@
+{ fetchFromGitHub, rust-bindgen-unwrapped }:
+
+rust-bindgen-unwrapped.overrideAttrs (old: rec {
+  version = "0.56.0";
+
+  # The version we need can't be fetched via fetchCrate yet, because
+  # only version from 0.61.0 upwards exist on crates.io.
+  src = fetchFromGitHub {
+    owner = "rust-lang";
+    repo = "rust-bindgen";
+    rev = "v${version}";
+    sha256 = "bqAQrECDz8WMM5wAsAcmZlbeGZ8ngpakvpC1W/AKfCU=";
+  };
+
+  cargoDeps = old.cargoDeps.overrideAttrs (_: {
+    inherit src;
+
+    name = "${old.pname}-${version}-vendor.tar.gz";
+    outputHash = "17hxpakwpxp2nva0bk621h7bn9zjlr5jx3d3m82ncgai44hg77cp";
+  });
+})

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -16545,6 +16545,13 @@ with pkgs;
   rust-cbindgen = callPackage ../development/tools/rust/cbindgen {
     inherit (darwin.apple_sdk.frameworks) Security;
   };
+
+  # These bindgen versions are for the Linux kernel build.
+  rust-bindgen-0_56-kernel-unwrapped = callPackage ../development/tools/rust/bindgen/unwrapped-0_56-kernel.nix {};
+  rust-bindgen-0_56-kernel = callPackage ../development/tools/rust/bindgen {
+    rust-bindgen-unwrapped = rust-bindgen-0_56-kernel-unwrapped;
+  };
+
   rust-script = callPackage ../development/tools/rust/rust-script { };
   rustup = callPackage ../development/tools/rust/rustup {
     inherit (darwin.apple_sdk.frameworks) CoreServices Security;


### PR DESCRIPTION

###### Description of changes

This PR resurrects https://github.com/NixOS/nixpkgs/pull/179581. Also see https://github.com/NixOS/nixpkgs/pull/232861 for some context.

This PR works towards Rust support in the Linux kernel by packaging the rust-bindgen version that the Linux kernel uses. Linux is currently picky and wants a specific one. As Linux will likely change which version they require, we package it with an explicit version.

In #179581, it was suggested to add bindgen to `linuxPackages`. I didn't do this, because it creates an awkward circular dependency between the kernel derivation and `linuxPackages`.

To see how this could be used to build a Linux kernel with Rust support, checkout the last commits here: 
https://github.com/blitz/nixpkgs/commits/rust-kernel

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
