### PR TITLE
breitbandmessung: 3.1.0 -> 3.3.0; use electron_24

### DIFF
--- a/pkgs/applications/networking/breitbandmessung/default.nix
+++ b/pkgs/applications/networking/breitbandmessung/default.nix
@@ -2,7 +2,7 @@
 , stdenv
 , fetchurl
 , dpkg
-, electron_16
+, electron_24
 , makeWrapper
 , nixosTests
 , nodePackages
@@ -12,13 +12,13 @@
 let
   inherit (stdenv.hostPlatform) system;
 
-  version = "3.1.0";
+  version = "3.3.0";
 
   systemArgs = rec {
     x86_64-linux = rec {
       src = fetchurl {
         url = "https://download.breitbandmessung.de/bbm/Breitbandmessung-${version}-linux.deb";
-        sha256 = "sha256-jSP+H9ej9Wd+swBZSy9uMi2ExSTZ191FGZhqaocTl7w=";
+        sha256 = "sha256-12mbdxklje9msnRtNk1RAtIg3OCybev/vUersDZj2i4=";
       };
 
       nativeBuildInputs = [
@@ -49,7 +49,7 @@ let
         }
         EOF
 
-        makeWrapper ${electron_16}/bin/electron $out/bin/breitbandmessung \
+        makeWrapper ${electron_24}/bin/electron $out/bin/breitbandmessung \
           --add-flags $out/share/breitbandmessung/resources/build/electron.js
 
         # Fix the desktop link
@@ -61,7 +61,7 @@ let
     x86_64-darwin = {
       src = fetchurl {
         url = "https://download.breitbandmessung.de/bbm/Breitbandmessung-${version}-mac.dmg";
-        sha256 = "sha256-2c8mDKJuHDSw7p52EKnJO5vr2kNTLU6r9pmGPANjE20=";
+        sha256 = "sha256-a27R/N13i4qU2znTKz+LGxSdgSzJ0MzIHeiPHyRd65k=";
       };
 
       nativeBuildInputs = [ undmg ];


### PR DESCRIPTION

###### Description of changes
Using Electron 24 works perfectly fine for me. Also updated to the latest version available. Changelogs are only available in German[1], but it contains mostly bugfixes and some small changes on the UI.

[1] https://breitbandmessung.de/desktop-app

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
