### PR TITLE
dbcsr: init at 2.5.0

### DIFF
--- a/pkgs/development/libraries/science/math/dbcsr/default.nix
+++ b/pkgs/development/libraries/science/math/dbcsr/default.nix
@@ -1,0 +1,81 @@
+{ stdenv
+, lib
+, fetchFromGitHub
+, cmake
+, pkg-config
+, fypp
+, gfortran
+, blas
+, lapack
+, python3
+, libxsmm
+, mpi
+, openssh
+}:
+
+stdenv.mkDerivation rec {
+  pname = "dbcsr";
+  version = "2.5.0";
+
+  src = fetchFromGitHub {
+    owner = "cp2k";
+    repo = "dbcsr";
+    rev = "v${version}";
+    hash = "sha256-GGClK3heGE3zUM0R+u58vRdAK+xWzaqdCHaMIDerHSI=";
+  };
+
+  postPatch = ''
+    patchShebangs .
+
+    # Force build of shared library, otherwise just static.
+    substituteInPlace src/CMakeLists.txt \
+      --replace 'add_library(dbcsr ''${DBCSR_SRCS})' 'add_library(dbcsr SHARED ''${DBCSR_SRCS})' \
+      --replace 'add_library(dbcsr_c ''${DBCSR_C_SRCS})' 'add_library(dbcsr_c SHARED ''${DBCSR_C_SRCS})'
+
+    # Avoid calling the fypp wrapper script with python again. The nix wrapper took care of that.
+    substituteInPlace cmake/fypp-sources.cmake \
+      --replace 'COMMAND ''${Python_EXECUTABLE} ''${FYPP_EXECUTABLE}' 'COMMAND ''${FYPP_EXECUTABLE}'
+  '';
+
+  nativeBuildInputs = [
+    gfortran
+    python3
+    cmake
+    pkg-config
+    fypp
+  ];
+
+  buildInputs = [ blas lapack libxsmm ];
+
+  propagatedBuildInputs = [ mpi ];
+
+  preConfigure = ''
+    export PKG_CONFIG_PATH=${libxsmm}/lib
+  '';
+
+  cmakeFlags = [
+    "-DUSE_OPENMP=ON"
+    "-DUSE_SMM=libxsmm"
+    "-DWITH_C_API=ON"
+    "-DBUILD_TESTING=ON"
+    "-DTEST_OMP_THREADS=2"
+    "-DTEST_MPI_RANKS=2"
+    "-DENABLE_SHARED=ON"
+    "-DUSE_MPI=ON"
+  ];
+
+  checkInputs = [ openssh ];
+
+  doCheck = true;
+  preCheck = ''
+    export HYDRA_IFACE=lo  # Fix to make mpich run in a sandbox
+    export OMPI_MCA_rmaps_base_oversubscribe=1
+  '';
+
+  meta = with lib; {
+    description = "Distributed Block Compressed Sparse Row matrix library";
+    license = licenses.gpl2Only;
+    homepage = "https://github.com/cp2k/dbcsr";
+    maintainers = [ maintainers.sheepforce ];
+  };
+}

--- a/pkgs/development/python-modules/fypp/default.nix
+++ b/pkgs/development/python-modules/fypp/default.nix
@@ -1,0 +1,20 @@
+{ lib, stdenv, fetchFromGitHub, buildPythonApplication }:
+
+buildPythonApplication rec {
+  pname = "fypp";
+  version = "3.1";
+
+  src = fetchFromGitHub {
+    owner = "aradi";
+    repo = pname;
+    rev = version;
+    hash = "sha256-iog5Gdcd1F230Nl4JDrKoyYr8JualVgNZQzHLzd4xe8=";
+  };
+
+  meta = with lib; {
+    description = "Python powered Fortran preprocessor";
+    homepage = "https://github.com/aradi/fypp";
+    license = licenses.gpl3Only;
+    maintainers = [ maintainers.sheepforce ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -22952,6 +22952,8 @@ with pkgs;
 
   fypp = python3Packages.callPackage ../development/python-modules/fypp { };
 
+  dbcsr = callPackage ../development/libraries/science/math/dbcsr { };
+
   ## libGL/libGLU/Mesa stuff
 
   # Default libGL implementation, should provide headers and

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -22950,6 +22950,8 @@ with pkgs;
 
   toml-f = callPackage ../development/libraries/toml-f { };
 
+  fypp = python3Packages.callPackage ../development/python-modules/fypp { };
+
   ## libGL/libGLU/Mesa stuff
 
   # Default libGL implementation, should provide headers and


### PR DESCRIPTION
###### Description of changes

Adds the DBCSR library for MPI-parallel and memory-distributed, large scale block-sparse matrix multiplication.

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).