### PR TITLE
python310Packages.typeguard: 2.13.3 -> 3.0.2

### DIFF
--- a/pkgs/development/python-modules/typeguard/default.nix
+++ b/pkgs/development/python-modules/typeguard/default.nix
@@ -1,57 +1,55 @@
-{ buildPythonPackage
-, fetchPypi
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
 , pythonOlder
-, lib
 , setuptools-scm
-, pytestCheckHook
-, typing-extensions
-, sphinxHook
 , sphinx-autodoc-typehints
 , sphinx-rtd-theme
-, glibcLocales
+, sphinxHook
+, importlib-metadata
+, typing-extensions
+, mypy
+, pytestCheckHook
 }:
 
 buildPythonPackage rec {
   pname = "typeguard";
-  version = "2.13.3";
-  disabled = pythonOlder "3.5";
+  version = "3.0.2";
+  format = "pyproject";
+  disabled = pythonOlder "3.7";
   outputs = [ "out" "doc" ];
 
-  src = fetchPypi {
-    inherit pname version;
-    sha256 = "00edaa8da3a133674796cf5ea87d9f4b4c367d77476e185e80251cc13dfbb8c4";
+  src = fetchFromGitHub {
+    owner = "agronholm";
+    repo = "typeguard";
+    rev = "refs/tags/${version}";
+    hash = "sha256-1Cl34HDbAEiTFMMVgYlCv9e6RtwHu7h7PgpCttuCu3c=";
   };
 
+  SETUPTOOLS_SCM_PRETEND_VERSION = version;
+
   nativeBuildInputs = [
-    glibcLocales
     setuptools-scm
-    sphinxHook
     sphinx-autodoc-typehints
     sphinx-rtd-theme
+    sphinxHook
   ];
 
-  LC_ALL = "en_US.utf-8";
-
-  postPatch = ''
-    substituteInPlace setup.cfg --replace " --cov" ""
-  '';
-
-  nativeCheckInputs = [ pytestCheckHook typing-extensions ];
-
-  disabledTestPaths = [
-    # mypy tests aren't passing with latest mypy
-    "tests/mypy"
+  propagatedBuildInputs = [
+    importlib-metadata
+    typing-extensions
   ];
 
-  disabledTests = [
-    # not compatible with python3.10
-    "test_typed_dict"
+  nativeCheckInputs = [
+    mypy
+    pytestCheckHook
   ];
 
   meta = with lib; {
-    description = "This library provides run-time type checking for functions defined with argument type annotations";
+    description = "Run-time type checker for Python";
     homepage = "https://github.com/agronholm/typeguard";
+    changelog = "https://github.com/agronholm/typeguard/releases/tag/${version}";
     license = licenses.mit;
-    maintainers = with maintainers; [ ];
+    maintainers = with maintainers; [ kira-bruneau ];
   };
 }


### PR DESCRIPTION
###### Description of changes

Update to the next major version: https://github.com/agronholm/typeguard/releases/tag/3.0.2

4.0.0 was released 2 weeks ago, but I don't think any packages require it yet: https://github.com/agronholm/typeguard/releases/tag/4.0.0.

I'm hoping we can completely upgrade to 3.0.2 without needing a back-fill for 2.13.3, but I'll add one if we find any packages still need it.

This update is needed for pygls 1.0.2: #233862

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
