### PR TITLE
bonsai: init at 1.0.2

### DIFF
--- a/pkgs/tools/misc/bonsai/default.nix
+++ b/pkgs/tools/misc/bonsai/default.nix
@@ -1,0 +1,66 @@
+{ stdenv
+, lib
+, fetchFromSourcehut
+, gitUpdater
+, hare
+, hareThirdParty
+}:
+
+stdenv.mkDerivation rec {
+  pname = "bonsai";
+  version = "1.0.2";
+
+  src = fetchFromSourcehut {
+    owner = "~stacyharper";
+    repo = "bonsai";
+    rev = "v${version}";
+    hash = "sha256-Yosf07KUOQv4O5111tLGgI270g0KVGwzdTPtPOsTcP8=";
+  };
+
+  postPatch = ''
+    substituteInPlace Makefile \
+      --replace 'hare build' 'hare build $(HARE_TARGET_FLAGS)'
+  '';
+
+  nativeBuildInputs = [
+    hare
+  ];
+
+  buildInputs = with hareThirdParty; [
+    hare-ev
+    hare-json
+  ];
+
+  env.HARE_TARGET_FLAGS =
+    if stdenv.hostPlatform.isAarch64 then
+      "-a aarch64"
+    else if stdenv.hostPlatform.isRiscV64 then
+      "-a riscv64"
+    else if stdenv.hostPlatform.isx86_64 then
+      "-a x86_64"
+    else
+      "";
+  # TODO: hare setup-hook is supposed to do this for us.
+  # It does it correctly for native compilation, but not cross compilation: wrong offset?
+  env.HAREPATH = with hareThirdParty; "${hare-json}/src/hare/third-party:${hare-ev}/src/hare/third-party";
+
+  preConfigure = ''
+    export HARECACHE=$(mktemp -d)
+  '';
+
+  installFlags = [ "PREFIX=$(out)" ];
+
+  doCheck = true;
+
+  passthru.updateScript = gitUpdater {
+    rev-prefix = "v";
+  };
+
+  meta = with lib; {
+    description = "Finite State Machine structured as a tree";
+    homepage = "https://git.sr.ht/~stacyharper/bonsai";
+    license = licenses.agpl3;
+    maintainers = with maintainers; [ colinsane ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1770,6 +1770,8 @@ with pkgs;
 
   bikeshed = python3Packages.callPackage ../applications/misc/bikeshed { };
 
+  bonsai = callPackage ../tools/misc/bonsai { };
+
   cie-middleware-linux = callPackage ../tools/security/cie-middleware-linux { };
 
   cidrgrep = callPackage ../tools/text/cidrgrep { };


### PR DESCRIPTION
###### Description of changes

[bonsai](https://sr.ht/~stacyharper/bonsai/)'s an event-triggered state machine implemented as a daemon. it's used by [sxmo](https://sxmo.org/) to make button-mapping highly configurable by the user.

upstreamed from [here](https://git.uninsane.org/colin/nix-files/src/commit/f50feb6c96383e7dcaa8a2ff61e1dfc2a6fff84b/pkgs/additional/bonsai/default.nix), where i've been using it within sxmo deployed to a NixOS Pinephone for a few days without issue.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux  (via binfmt emulation)
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
