### PR TITLE
kicad: 7.0.2 -> 7.0.4

### DIFF
--- a/pkgs/applications/science/electronics/kicad/versions.nix
+++ b/pkgs/applications/science/electronics/kicad/versions.nix
@@ -3,23 +3,23 @@
 {
   "kicad" = {
     kicadVersion = {
-      version =			"7.0.2";
+      version =			"7.0.4";
       src = {
-        rev =			"6a45011f421d65a241e1df4a2dc720819922f343";
-        sha256 =		"0san7pjgvd8niwrki722qb6y46r71rlyspqp43pmkiz55dmz52zx";
+        rev =			"4faf1bf99feaa338516c3abe0726232557f2098d";
+        sha256 =		"0kxn4aaaw0n47avw4fvx2v6wp4vh2r7w9vw69f87aqas15w2x1gs";
       };
     };
     libVersion = {
-      version =			"7.0.2";
+      version =			"7.0.4";
       libSources = {
-        symbols.rev =		"22ed11504c140fded542eeb104cdb02e0a65672e";
-        symbols.sha256 =	"0aah92rb8yx00z0xwx9z7xn5rrw4cc3z35gr7c0bnb49hiak01jc";
-        templates.rev =		"331068741c80fee8195646d3dee40f3b840495e7";
+        symbols.rev =		"833e50e9cefa929c4e50259a7754040c6c89a262";
+        symbols.sha256 =	"15100z8g4x28sxz8097ay1vxfxz2c4a1nvvzyx5vjfmhydwqwk49";
+        templates.rev =		"b9de2281e38524068703e6d4876999e323f8c735";
         templates.sha256 =	"1qi20mrsfn4fxmr1fyphmil2i9p2nzmwk5rlfchc5aq2194nj3lq";
-        footprints.rev =	"e187e2dfa9bd04d91cad0d875049ab56780b6e32";
-        footprints.sha256 =	"1qrdznfd4a6kzwd4aaijkpyjy0xnrmi66isq9z52652a8s6ja48v";
-        packages3d.rev =	"6374ae3db8b43a4d779185b7017fcfe0e1f32590";
-        packages3d.sha256 =	"1nkk4325jh89vh52ykfnf9pz1k3jk5017gz6r2cia2v4b3jadi31";
+        footprints.rev =	"651238cdd56ea8ba601665eb754005d7eec4c89f";
+        footprints.sha256 =	"18w9l9fszbsq8gmfi0118f1m91q88cwijz4nyivyw824qk4vwx3f";
+        packages3d.rev =	"0cf4dc05de6369d653051c4c2800820bb5dabfaa";
+        packages3d.sha256 =	"1bzb6b7llzwabjkdd0xsyan0x8kihccap4gwvipzydfg7gm5fjxm";
       };
     };
   };


### PR DESCRIPTION
###### Description of changes

release blog post / notes expected [here](https://www.kicad.org/blog/2023/05/KiCad-7.0.4-Release/) soon

(7.0.3 skipped because a critical issue was found after tagging)

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [x] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
