### PR TITLE
gnomeExtensions.gtk4-desktop-icons-ng-ding: add patches to make it work

### DIFF
--- a/pkgs/desktops/gnome/extensions/extensionOverrides.nix
+++ b/pkgs/desktops/gnome/extensions/extensionOverrides.nix
@@ -19,8 +19,10 @@
 , smartmontools
 , substituteAll
 , touchegg
+, util-linux
 , vte
 , wrapGAppsHook
+, xdg-utils
 , xprop
 }:
 let
@@ -92,6 +94,18 @@ super: lib.trivial.pipe super [
         substituteInPlace $file --replace "gjs" "${gjs}/bin/gjs"
       done
     '';
+  }))
+
+  (patchExtension "gtk4-ding@smedius.gitlab.com" (old: {
+    patches = [
+      (substituteAll {
+        inherit gjs util-linux xdg-utils;
+        util_linux = util-linux;
+        xdg_utils = xdg-utils;
+        src = ./extensionOverridesPatches/gtk4-ding_at_smedius.gitlab.com.patch;
+        nautilus_gsettings_path = "${glib.getSchemaPath gnome.nautilus}";
+      })
+    ];
   }))
 
   (patchExtension "pano@elhan.io" (old: {

--- a/pkgs/desktops/gnome/extensions/extensionOverridesPatches/gtk4-ding_at_smedius.gitlab.com.patch
+++ b/pkgs/desktops/gnome/extensions/extensionOverridesPatches/gtk4-ding_at_smedius.gitlab.com.patch
@@ -1,0 +1,109 @@
+diff --git a/app/createThumbnail.js b/app/createThumbnail.js
+index ebe5213..9f67873 100755
+--- a/app/createThumbnail.js
++++ b/app/createThumbnail.js
+@@ -1,4 +1,4 @@
+-#!/usr/bin/gjs
++#!@gjs@/bin/gjs
+ 
+ /* DING: Desktop Icons New Generation for GNOME Shell
+  *
+diff --git a/app/ding.js b/app/ding.js
+index b200be4..3ce05ef 100755
+--- a/app/ding.js
++++ b/app/ding.js
+@@ -1,4 +1,4 @@
+-#!/usr/bin/env gjs
++#!@gjs@/bin/gjs
+ 
+ /* DING: Desktop Icons New Generation for GNOME Shell
+  *
+diff --git a/app/fileItemMenu.js b/app/fileItemMenu.js
+index cadca48..9632ecc 100644
+--- a/app/fileItemMenu.js
++++ b/app/fileItemMenu.js
+@@ -683,7 +683,7 @@ var FileItemMenu = class {
+             return;
+         }
+         let xdgEmailCommand = [];
+-        xdgEmailCommand.push('xdg-email');
++        xdgEmailCommand.push('@xdg_utils@/bin/xdg-email');
+         for (let fileItem of this._desktopManager.getCurrentSelection(false)) {
+             fileItem.unsetSelected();
+             xdgEmailCommand.push('--attach');
+diff --git a/app/preferences.js b/app/preferences.js
+index c89271c..29f0db8 100644
+--- a/app/preferences.js
++++ b/app/preferences.js
+@@ -31,6 +31,7 @@ var Preferences = class {
+         this._extensionPath = Data.codePath;
+         this._Enums = Data.Enums;
+         let schemaSource = GioSSS.get_default();
++        const schemaSourceNautilus = Gio.SettingsSchemaSource.new_from_directory('@nautilus_gsettings_path@', Gio.SettingsSchemaSource.get_default(), true);
+         this._desktopManager = null;
+ 
+         // Gtk
+@@ -38,7 +39,7 @@ var Preferences = class {
+         this.gtkSettings = new Gio.Settings({ settings_schema: schemaGtk });
+ 
+         // Gnome Files
+-        let schemaObj = schemaSource.lookup(this._Enums.SCHEMA_NAUTILUS, true);
++        let schemaObj = schemaSourceNautilus.lookup(this._Enums.SCHEMA_NAUTILUS, true);
+         if (!schemaObj) {
+             this.nautilusSettings = null;
+             this.CLICK_POLICY_SINGLE = false;
+@@ -47,7 +48,7 @@ var Preferences = class {
+         }
+ 
+         // Compression
+-        const compressionSchema = schemaSource.lookup(this._Enums.SCHEMA_NAUTILUS_COMPRESSION, true);
++        const compressionSchema = schemaSourceNautilus.lookup(this._Enums.SCHEMA_NAUTILUS_COMPRESSION, true);
+         if (!compressionSchema)
+             this.nautilusCompression = null;
+         else
+diff --git a/app/thumbnailapp.js b/app/thumbnailapp.js
+index b22bbe0..c5c7711 100755
+--- a/app/thumbnailapp.js
++++ b/app/thumbnailapp.js
+@@ -1,4 +1,4 @@
+-#!/usr/bin/env gjs
++#!@gjs@/bin/gjs
+ 
+ /* DING: Desktop Icons New Generation for GNOME Shell
+  *
+diff --git a/extension.js b/extension.js
+index 2e5bcaa..4eaa108 100644
+--- a/extension.js
++++ b/extension.js
+@@ -373,7 +373,7 @@ function getDesktopGeometry() {
+ async function doKillAllOldDesktopProcesses() {
+     const procFolder = Gio.File.new_for_path('/proc');
+     const processes = await FileUtils.enumerateDir(procFolder);
+-    const thisPath = `gjs ${GLib.build_filenamev([
++    const thisPath = `@gjs@/bin/gjs ${GLib.build_filenamev([
+         ExtensionUtils.getCurrentExtension().path,
+         'app',
+         'ding.js',
+@@ -397,7 +397,7 @@ async function doKillAllOldDesktopProcesses() {
+             }
+ 
+             if (contents.startsWith(thisPath)) {
+-                let proc = new Gio.Subprocess({ argv: ['/bin/kill', filename] });
++                let proc = new Gio.Subprocess({ argv: ['@util_linux@/bin/kill', filename] });
+                 proc.init(null);
+                 print(`Killing old DING process ${filename}`);
+                 await proc.wait_async_promise(null);
+diff --git a/prefs.js b/prefs.js
+index 1ad0cad..d830f11 100644
+--- a/prefs.js
++++ b/prefs.js
+@@ -46,7 +46,8 @@ function fillPreferencesWindow(window) {
+     let schemaSource = GioSSS.get_default();
+     let schemaGtk = schemaSource.lookup(Enums.SCHEMA_GTK, true);
+     let gtkSettings = new Gio.Settings({ settings_schema: schemaGtk });
+-    let schemaNautilus = schemaSource.lookup(Enums.SCHEMA_NAUTILUS, true);
++    const schemaSourceNautilus = Gio.SettingsSchemaSource.new_from_directory('@nautilus_gsettings_path@', Gio.SettingsSchemaSource.get_default(), true);
++    let schemaNautilus = schemaSourceNautilus.lookup(Enums.SCHEMA_NAUTILUS, true);
+     let nautilusSettings;
+     if (!schemaNautilus)
+         nautilusSettings = null;


### PR DESCRIPTION
###### Description of changes

Patches the extension to make it work.

Potentially, along with similar PRs for patches to `gnomeExtensions.desktop-icons-ng-ding` and  `gnomeExtensions.desktop-icons-neo` (pretty dead, might not be worth to bother mantaining patches), closes/fixes https://github.com/NixOS/nixpkgs/issues/154944.

Wondering if patching all the executable paths is really necessary, you'd _probably_ want to actually have things like `nemo` and `nautilus` installed in your system when using the respective functionality. Works just as fine with just the `gjs` and `nautilus_schema_path` parts.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
