### PR TITLE
nemo-emblems: init at 5.6.0, nemo: add missing xapp icons

### DIFF
--- a/pkgs/desktops/cinnamon/default.nix
+++ b/pkgs/desktops/cinnamon/default.nix
@@ -13,8 +13,11 @@ lib.makeScope pkgs.newScope (self: with self; {
   });
 
   # Extensions added here will be shipped by default
+  # We keep this in sync with a default Mint installation
+  # Right now (only) nemo-share is missing
   nemoExtensions = [
     folder-color-switcher
+    nemo-emblems
     nemo-fileroller
     nemo-python
   ];
@@ -33,6 +36,7 @@ lib.makeScope pkgs.newScope (self: with self; {
   cjs = callPackage ./cjs { };
   folder-color-switcher = callPackage ./folder-color-switcher { };
   nemo = callPackage ./nemo { };
+  nemo-emblems = callPackage ./nemo-extensions/nemo-emblems { };
   nemo-fileroller = callPackage ./nemo-extensions/nemo-fileroller { };
   nemo-python = callPackage ./nemo-extensions/nemo-python { };
   nemo-with-extensions = callPackage ./nemo/wrapper.nix { };

--- a/pkgs/desktops/cinnamon/nemo-extensions/nemo-emblems/default.nix
+++ b/pkgs/desktops/cinnamon/nemo-extensions/nemo-emblems/default.nix
@@ -1,0 +1,37 @@
+{ python3
+, lib
+, fetchFromGitHub
+}:
+
+python3.pkgs.buildPythonApplication rec {
+  pname = "nemo-emblems";
+  version = "5.6.0";
+
+  format = "setuptools";
+
+  src = fetchFromGitHub {
+    owner = "linuxmint";
+    repo = "nemo-extensions";
+    rev = version;
+    sha256 = "sha256-cxutiz5bc/dZ9D7XzvMWodWNYvNJPj+5IhJDPJwnb5I=";
+  };
+
+  sourceRoot = "${src.name}/nemo-emblems";
+
+  postPatch = ''
+    substituteInPlace setup.py \
+      --replace "/usr/share" "share"
+  '';
+
+  meta = with lib; {
+    homepage = "https://github.com/linuxmint/nemo-extensions/tree/master/nemo-emblems";
+    description = "Change a folder or file emblem in Nemo";
+    longDescription = ''
+      Nemo extension that allows you to change folder or file emblems.
+      When adding this to nemo-with-extensions you also need to add nemo-python.
+    '';
+    license = licenses.gpl3Only;
+    platforms = platforms.linux;
+    maintainers = teams.cinnamon.members;
+  };
+}

--- a/pkgs/desktops/cinnamon/nemo/default.nix
+++ b/pkgs/desktops/cinnamon/nemo/default.nix
@@ -67,6 +67,13 @@ stdenv.mkDerivation rec {
     "--localedir=${cinnamon-translations}/share/locale"
   ];
 
+  preFixup = ''
+    # Used for some non-fd.o icons (e.g. xapp-text-case-symbolic)
+    gappsWrapperArgs+=(
+      --prefix XDG_DATA_DIRS : "${xapp}/share"
+    )
+  '';
+
   # Taken from libnemo-extension.pc.
   passthru.extensiondir = "lib/nemo/extensions-3.0";
 


### PR DESCRIPTION
###### Description of changes

Similar to folder-color-switcher, it sounds like we don't need to patch nemo-emblems.py in any way thanks to how nemo-python works.

<img src="https://github.com/NixOS/nixpkgs/assets/20080233/8d163418-6e28-4ef4-8a5d-5826592827fc" width=40%>

Also since nemo uses xapp-specific icons itself, sneak in a change to fix missing icon outside cinnamon

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
