### PR TITLE
minecraft: 2.2.1441 -> 1.2.4

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -7439,6 +7439,11 @@
     githubId = 1061229;
     name = "Jiehong Ma";
   };
+  JimSpoonbaker = {
+    name = "Jim Spoonbaker";
+    github = "JimSpoonbaker";
+    githubId = 47164123;
+  };
   jirkamarsik = {
     email = "jiri.marsik89@gmail.com";
     github = "jirkamarsik";

--- a/pkgs/games/minecraft/update.sh
+++ b/pkgs/games/minecraft/update.sh
@@ -1,7 +1,27 @@
 #!/usr/bin/env nix-shell
-#!nix-shell -i bash -p curl jq common-updater-scripts
+#!nix-shell -i bash -p curl jq coreutils gawk
 
-set -eu -o pipefail
+#common-updater-scripts
 
-version=$(curl -s 'https://launchermeta.mojang.com/v1/products/launcher/6f083b80d5e6fabbc4236f81d0d8f8a350c665a9/linux.json' | jq -r '."launcher-core"[0].version.name')
-update-source-version minecraft "${version}"
+set -Eeuo pipefail # TODO: -E needed?
+
+json=$(curl -s 'https://redstone-launcher.mojang.com/release/v2/products/launcher/75c4b4bddedcc2b1b10af1a720b8dc7a9a18c8d4/linux.json' | jq -r '.bootstrap')
+version=$(jq -r '.version.name' <<< $json)
+
+manifest=$(curl -s $(jq -r '.manifest.url' <<< $json))
+sha1=$(jq -r '.files."minecraft-launcher".downloads.raw.sha1' <<< $manifest)
+url=$(jq -r '.files."minecraft-launcher".downloads.raw.url' <<< $manifest)
+
+
+# Get Nar hash, because flat hash mode doesn't work for executables
+t=$(mktemp -d)
+trap "rm -r $t" EXIT # TODO: is this safe? is there some edge case where this will delete something important?
+
+curl -s $url -o $t/minecraft-launcher
+chmod +x $t/minecraft-launcher
+[ x$(sha1sum $t/minecraft-launcher | awk '{ print $1 }') = x$sha1 ] || (echo >&2 "SHA1 sum incorrect! This is bad!"; exit 1)
+
+hash=$(nix --extra-experimental-features nix-command hash path $t/minecraft-launcher)
+
+
+echo "{\"version\": \"$version\",\"url\": \"$url\",\"hash\": \"$hash\"}" > version.json

--- a/pkgs/games/minecraft/version.json
+++ b/pkgs/games/minecraft/version.json
@@ -1,0 +1,1 @@
+{"version": "1.2.4","url": "https://redstone-launcher.mojang.com/release/v2/objects/e535cca8252955f224cb97b522ca8389c4c37baf/minecraft-launcher","hash": "sha256-CnQHpT2T8Jywg2V49dg+IQwo3QkueP15+7k4+nckY3I="}


### PR DESCRIPTION
There doesn't seem to be any easy way to get the updated launcher, so this commit instead builds an FHSEnv for the launcher bootstrap. This does mean slightly less reproducibility, but provided new versions don't add any new dependencies, it should be fine.

###### Description of changes

Ship launcher bootstrap version 1.2.4 instead of launcher version 2.2.1441. Use FHSEnv instead of executable patching, because the bootstrap downloads other files.

###### TODO:

- Consider using wrapper that sets `LD_LIBRARY_PATH` instead of building an FHSEnv
- Only depend on the necessary libraries
- Test login & launch on GNOME

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).