### PR TITLE
gnome-flashback: fix screenshot key and screen not locking when idle

### DIFF
--- a/pkgs/desktops/gnome/misc/gnome-flashback/default.nix
+++ b/pkgs/desktops/gnome/misc/gnome-flashback/default.nix
@@ -82,7 +82,7 @@ let
 
       rm -r $out/share/gnome-session
       rm -r $out/share/xsessions
-      rm -r $out/libexec
+      rm $out/libexec/gnome-flashback-metacity
     '';
 
     nativeBuildInputs = [


### PR DESCRIPTION
These auto-started services are failing to start in the gnome-flashback desktop manager service, leaving warnings in the log:

`gnome-flashback-clipboard`
`gnome-flashback-idle-monitor`
`gnome-flashback-media-keys`

Fix the failures by removing the line from `postInstall` in the gnome-flashback package which is deleting the executables for those services, which the build creates in `$out/libexec`.

`gnome-flashback-idle-monitor` is responsible for sending a dbus message when the system is idle, so without it the screen never dims or locks.  When `gnome-flashback-media-keys` is not running, using the PrtScr key to grab screenshots does not work.

`gnome-flashback-clipboard` from my cursory inspection of its source deals with streaming large clipboard transfers and translating clipboard formats.  I have had copy and paste fail to work on my system before this fix, and haven't seen the problem since, but I don't have a reproducible case.

There's one more warning in the log about `gnome-flashback-nm-applet` failing to start, but the executable for that one is not present in `$out/libexec` so it seems to be a separate issue.

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
