### PR TITLE
furnace: 0.6pre4-hotfix -> 0.6pre5

### DIFF
--- a/pkgs/applications/audio/furnace/default.nix
+++ b/pkgs/applications/audio/furnace/default.nix
@@ -10,6 +10,7 @@
 , fftw
 , fmt_8
 , libsndfile
+, libX11
 , rtmidi
 , SDL2
 , zlib
@@ -21,15 +22,22 @@
 
 stdenv.mkDerivation rec {
   pname = "furnace";
-  version = "0.6pre4-hotfix";
+  version = "0.6pre5";
 
   src = fetchFromGitHub {
     owner = "tildearrow";
     repo = "furnace";
     rev = "v${version}";
     fetchSubmodules = true;
-    sha256 = "sha256-lJtV/0GnWN5mSjv2LaPEMnkuThaNeijBMjLGFPOJX4k=";
+    sha256 = "sha256-6KiG7nfQUdPW+EkBW3PPM141kOmolAgrrqhEGH/Azg4=";
   };
+
+  postPatch = lib.optionalString stdenv.hostPlatform.isLinux ''
+    # To offer scaling detection on X11, furnace checks if libX11.so is available via dlopen and uses some of its functions
+    # But it's being linked against a versioned libX11.so.VERSION via SDL, so the unversioned one is not on the rpath
+    substituteInPlace src/gui/scaling.cpp \
+      --replace 'libX11.so' '${lib.getLib libX11}/lib/libX11.so'
+  '';
 
   nativeBuildInputs = [
     cmake
@@ -97,6 +105,7 @@ stdenv.mkDerivation rec {
   meta = with lib; {
     description = "Multi-system chiptune tracker compatible with DefleMask modules";
     homepage = "https://github.com/tildearrow/furnace";
+    changelog = "https://github.com/tildearrow/furnace/releases/tag/v${version}";
     license = with licenses; [ gpl2Plus ];
     maintainers = with maintainers; [ OPNA2608 ];
     platforms = platforms.all;


### PR DESCRIPTION
###### Description of changes

https://github.com/tildearrow/furnace/releases/tag/v0.6pre5

> this version fixes a critical issue in where Furnace would suddenly reset its configuration in some setups
> additionally, it massively improves the backup system. now we save several backup files per song rather than a single, global backup.fur.

I think this would be good to have in 23.05.

Also fixing the scaling detection under X11, and adds changelog link.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
