### PR TITLE
nc4nix: add patch to fix unstable package updates

### DIFF
--- a/pkgs/development/tools/nc4nix/default.nix
+++ b/pkgs/development/tools/nc4nix/default.nix
@@ -8,27 +8,36 @@
 
 buildGoModule rec {
   pname = "nc4nix";
-  version = "unstable-2022-12-07";
+  version = "unstable-2023-05-25";
 
   src = fetchFromGitHub {
     owner = "helsinki-systems";
     repo = "nc4nix";
-    rev = "c556a596b1d40ff69b71adab257ec5ae51ba4df1";
-    sha256 = "sha256-EIPCMiVTf0ryXRMRGhepORaOlimt3/funvUdORRbVa8=";
+    rev = "14cab9b2f8628ae6668c1d01519f558069f7f675";
+    sha256 = "sha256-iy9jJMRu0SkfrDufO6WAObqdiusvwhyv+GGHVrD3CV4=";
   };
 
   patches = [
     # Switch hash calculation method
+    # https://github.com/helsinki-systems/nc4nix/pull/3
     (fetchpatch {
       url = "https://github.com/helsinki-systems/nc4nix/commit/88c182fbdddef148e086fa86438dcd72208efd75.patch";
       sha256 = "sha256-zAF0+t9wHrKhhyD0+/d58BiaavLHfxO8X5J6vNlEWx0=";
       name = "switch_hash_calculation_method.patch";
     })
      # Add package selection command line argument
+     # https://github.com/helsinki-systems/nc4nix/pull/2
     (fetchpatch {
       url = "https://github.com/helsinki-systems/nc4nix/pull/2/commits/449eec89538df4e92106d06046831202eb84a1db.patch";
       sha256 = "sha256-qAAbR1G748+2vwwfAhpe8luVEIKNGifqXqTV9QqaUFc=";
       name = "add_package_selection_command_line_arg.patch";
+    })
+    # Only consider (new) stable releases of NC apps
+    # https://github.com/helsinki-systems/nc4nix/issues/4
+    (fetchpatch {
+      url = "https://github.com/helsinki-systems/nc4nix/pull/5/commits/076a188bf30203ddea0217d83f2e3b16f3b9392b.patch";
+      sha256 = "sha256-N7X9j0tWD8ZAWjXXCXGITl/EBbrIbKbHJHyskT1rVTs=";
+      name = "only_consider_stable_releases.patch";
     })
   ];
 


### PR DESCRIPTION
###### Description of changes

[nc4nix](https://github.com/helsinki-systems/nc4nix) is used to update our nextcloudPackages set to new app updates. Currently it also fetches beta releases which is not the correct behaviour. [This patch](https://github.com/helsinki-systems/nc4nix/pull/5) fixes nc4nix to only consider stable releases.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
