### PR TITLE
quickbms: fix build

### DIFF
--- a/pkgs/tools/archivers/quickbms/0002-disable-openssl.patch
+++ b/pkgs/tools/archivers/quickbms/0002-disable-openssl.patch
@@ -1,0 +1,10 @@
+--- src/Makefile	2023-05-25 18:16:56.000296653 +0900
++++ src/Makefile	2023-05-25 18:17:00.772272861 +0900
+@@ -23,7 +23,6 @@
+ EXTRA_TARGETS  = libs/amiga/amiga.s libs/powzix/*.cpp
+ CFLAGS += -msse2
+ endif
+-USE_OPENSSL	= 1
+ endif
+ 
+ # -liconv and -fPIC are necessary on Android

--- a/pkgs/tools/archivers/quickbms/default.nix
+++ b/pkgs/tools/archivers/quickbms/default.nix
@@ -1,4 +1,13 @@
-{ stdenv, lib, fetchzip, bzip2, lzo, openssl, zlib }:
+{ stdenv
+, lib
+, fetchzip
+, fetchpatch
+, bzip2
+, lzo
+, openssl_1_1
+, opensslSupport ? false
+, zlib
+}:
 
 stdenv.mkDerivation rec {
   version = "0.11.0";
@@ -9,7 +18,18 @@ stdenv.mkDerivation rec {
     hash = "sha256-uQKTE36pLO8uhrX794utqaDGUeyqRz6zLCQFA7DYkNc=";
   };
 
-  buildInputs = [ bzip2 lzo openssl zlib ];
+  patches = [
+    # Fix errors on x86_64 and _rotl definition
+    (fetchpatch {
+      name = "0001-fix-compile.patch";
+      url = "https://aur.archlinux.org/cgit/aur.git/plain/fix-compile.patch?h=quickbms&id=a2e3e4638295d7cfe39513bfef9447fb23154a6b";
+      hash = "sha256-49fT/L4BNzMYnq1SXhFMgSDLybLkz6KSbgKmUpZZu08=";
+      stripLen = 1;
+    })
+  ] ++ lib.optional (!opensslSupport) ./0002-disable-openssl.patch;
+
+  buildInputs = [ bzip2 lzo zlib ]
+    ++ lib.optional (opensslSupport) openssl_1_1;
 
   makeFlags = [ "PREFIX=$(out)" ];
 


### PR DESCRIPTION
###### Description of changes

- [Failing build](https://hydra.nixos.org/build/219716416)
- Fixes #221875
- Depends on openssl features removed on openssl 3 (`RSA_SSLV23_PADDING`).
- Builds successfully & some basic functionality (unpacking zips) tested working with openssl disabled.
- Patch also fixes an error due to duplicate `_rotl` declaration.
- Also, the latest quickbms 0.12.0 released 2022-08-24 does not build on Linux as it depends on MSVC-specific definitions.

ZHF: #230712

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
