### PR TITLE
nixosTests: fix tests that relies on an empty rootfs using a bootloader

### DIFF
--- a/nixos/tests/initrd-luks-empty-passphrase.nix
+++ b/nixos/tests/initrd-luks-empty-passphrase.nix
@@ -18,6 +18,11 @@ in {
       emptyDiskImages = [ 512 ];
       useBootLoader = true;
       useEFIBoot = true;
+      # This requires to have access
+      # to a host Nix store as
+      # the new root device is /dev/vdb
+      # an empty 512MiB drive, containing no Nix store.
+      mountHostNixStore = true;
     };
 
     boot.loader.systemd-boot.enable = true;

--- a/nixos/tests/luks.nix
+++ b/nixos/tests/luks.nix
@@ -7,6 +7,8 @@ import ./make-test-python.nix ({ lib, pkgs, ... }: {
       emptyDiskImages = [ 512 512 ];
       useBootLoader = true;
       useEFIBoot = true;
+      # To boot off the encrypted disk, we need to have a init script which comes from the Nix store
+      mountHostNixStore = true;
     };
     boot.loader.systemd-boot.enable = true;
 

--- a/nixos/tests/lvm2/systemd-stage-1.nix
+++ b/nixos/tests/lvm2/systemd-stage-1.nix
@@ -65,6 +65,8 @@ in import ../make-test-python.nix ({ pkgs, ... }: {
       emptyDiskImages = [ 8192 8192 ];
       useBootLoader = true;
       useEFIBoot = true;
+      # To boot off the LVM disk, we need to have a init script which comes from the Nix store.
+      mountHostNixStore = true;
     };
     boot.loader.systemd-boot.enable = true;
     boot.loader.efi.canTouchEfiVariables = true;

--- a/nixos/tests/systemd-initrd-btrfs-raid.nix
+++ b/nixos/tests/systemd-initrd-btrfs-raid.nix
@@ -6,6 +6,8 @@ import ./make-test-python.nix ({ lib, pkgs, ... }: {
     virtualisation = {
       emptyDiskImages = [ 512 512 ];
       useBootLoader = true;
+      # Booting off the BTRFS RAID requires an available init script from the Nix store
+      mountHostNixStore = true;
       useEFIBoot = true;
     };
     boot.loader.systemd-boot.enable = true;

--- a/nixos/tests/systemd-initrd-luks-fido2.nix
+++ b/nixos/tests/systemd-initrd-luks-fido2.nix
@@ -6,6 +6,8 @@ import ./make-test-python.nix ({ lib, pkgs, ... }: {
     virtualisation = {
       emptyDiskImages = [ 512 ];
       useBootLoader = true;
+      # Booting off the encrypted disk requires having a Nix store available for the init script
+      mountHostNixStore = true;
       useEFIBoot = true;
       qemu.package = lib.mkForce (pkgs.qemu_test.override { canokeySupport = true; });
       qemu.options = [ "-device canokey,file=/tmp/canokey-file" ];

--- a/nixos/tests/systemd-initrd-luks-keyfile.nix
+++ b/nixos/tests/systemd-initrd-luks-keyfile.nix
@@ -14,6 +14,8 @@ in {
     virtualisation = {
       emptyDiskImages = [ 512 ];
       useBootLoader = true;
+      # Necessary to boot off the encrypted disk because it requires a init script coming from the Nix store
+      mountHostNixStore = true;
       useEFIBoot = true;
     };
     boot.loader.systemd-boot.enable = true;

--- a/nixos/tests/systemd-initrd-luks-password.nix
+++ b/nixos/tests/systemd-initrd-luks-password.nix
@@ -6,6 +6,8 @@ import ./make-test-python.nix ({ lib, pkgs, ... }: {
     virtualisation = {
       emptyDiskImages = [ 512 512 ];
       useBootLoader = true;
+      # Booting off the encrypted disk requires an available init script
+      mountHostNixStore = true;
       useEFIBoot = true;
     };
     boot.loader.systemd-boot.enable = true;

--- a/nixos/tests/systemd-initrd-luks-tpm2.nix
+++ b/nixos/tests/systemd-initrd-luks-tpm2.nix
@@ -6,6 +6,8 @@ import ./make-test-python.nix ({ lib, pkgs, ... }: {
     virtualisation = {
       emptyDiskImages = [ 512 ];
       useBootLoader = true;
+      # Booting off the TPM2-encrypted device requires an available init script
+      mountHostNixStore = true;
       useEFIBoot = true;
       qemu.options = ["-chardev socket,id=chrtpm,path=/tmp/mytpm1/swtpm-sock -tpmdev emulator,id=tpm0,chardev=chrtpm -device tpm-tis,tpmdev=tpm0"];
     };

--- a/nixos/tests/systemd-initrd-networkd-ssh.nix
+++ b/nixos/tests/systemd-initrd-networkd-ssh.nix
@@ -10,6 +10,8 @@ import ./make-test-python.nix ({ lib, ... }: {
       virtualisation = {
         emptyDiskImages = [ 4096 ];
         useBootLoader = true;
+        # Booting off the encrypted disk requires an available init script from the Nix store
+        mountHostNixStore = true;
         useEFIBoot = true;
       };
 

--- a/nixos/tests/systemd-initrd-networkd-ssh.nix
+++ b/nixos/tests/systemd-initrd-networkd-ssh.nix
@@ -16,9 +16,9 @@ import ./make-test-python.nix ({ lib, ... }: {
       };
 
       specialisation.encrypted-root.configuration = {
-        virtualisation.bootDevice = "/dev/mapper/root";
+        virtualisation.rootDevice = "/dev/mapper/root";
         boot.initrd.luks.devices = lib.mkVMOverride {
-          root.device = "/dev/vdc";
+          root.device = "/dev/vdb";
         };
         boot.initrd.systemd.enable = true;
         boot.initrd.network = {
@@ -63,7 +63,7 @@ import ./make-test-python.nix ({ lib, ... }: {
 
     server.wait_for_unit("multi-user.target")
     server.succeed(
-        "echo somepass | cryptsetup luksFormat --type=luks2 /dev/vdc",
+        "echo somepass | cryptsetup luksFormat --type=luks2 /dev/vdb",
         "bootctl set-default nixos-generation-1-specialisation-encrypted-root.conf",
         "sync",
     )

--- a/nixos/tests/systemd-initrd-swraid.nix
+++ b/nixos/tests/systemd-initrd-swraid.nix
@@ -6,6 +6,8 @@ import ./make-test-python.nix ({ lib, pkgs, ... }: {
     virtualisation = {
       emptyDiskImages = [ 512 512 ];
       useBootLoader = true;
+      # Booting off the RAID requires an available init script
+      mountHostNixStore = true;
       useEFIBoot = true;
     };
     boot.loader.systemd-boot.enable = true;


### PR DESCRIPTION
###### Description of changes

Some tests relies on booting on an empty rootfs to do their verification, this is not supported under `useBootLoader = true;` by default which expect you want a "full system image" with a proper Nix store.

Therefore, to make this work, we re-enable the host nix store.

A cleanup for overlay is included in this change, I will drop it.

Fixes the fallout for #227881.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
