### PR TITLE
treewide: replace manual unpacking code with dpkg (WIP)

### DIFF
--- a/nixos/modules/hardware/raid/hpsa.nix
+++ b/nixos/modules/hardware/raid/hpsa.nix
@@ -17,8 +17,6 @@ let
 
     nativeBuildInputs = [ pkgs.dpkg ];
 
-    unpackPhase = "dpkg -x $src ./";
-
     installPhase = ''
       mkdir -p $out/bin $out/share/doc $out/share/man
       mv opt/hp/hpssacli/bld/{hpssascripting,hprmstr,hpssacli} $out/bin/

--- a/pkgs/applications/audio/bitwig-studio/bitwig-studio1.nix
+++ b/pkgs/applications/audio/bitwig-studio/bitwig-studio1.nix
@@ -16,8 +16,6 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ dpkg makeWrapper autoPatchelfHook wrapGAppsHook ];
 
-  unpackCmd = "mkdir root ; dpkg-deb -x $curSrc root";
-
   dontBuild    = true;
   dontWrapGApps = true; # we only want $gappsWrapperArgs here
 

--- a/pkgs/applications/audio/bitwig-studio/bitwig-studio3.nix
+++ b/pkgs/applications/audio/bitwig-studio/bitwig-studio3.nix
@@ -15,11 +15,6 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ dpkg makeWrapper wrapGAppsHook ];
 
-  unpackCmd = ''
-    mkdir -p root
-    dpkg-deb -x $curSrc root
-  '';
-
   dontBuild = true;
   dontWrapGApps = true; # we only want $gappsWrapperArgs here
 

--- a/pkgs/applications/audio/bitwig-studio/bitwig-studio4.nix
+++ b/pkgs/applications/audio/bitwig-studio/bitwig-studio4.nix
@@ -33,11 +33,6 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ dpkg makeWrapper wrapGAppsHook ];
 
-  unpackCmd = ''
-    mkdir -p root
-    dpkg-deb -x $curSrc root
-  '';
-
   dontBuild = true;
   dontWrapGApps = true; # we only want $gappsWrapperArgs here
 

--- a/pkgs/applications/audio/headset/default.nix
+++ b/pkgs/applications/audio/headset/default.nix
@@ -20,8 +20,6 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ makeWrapper dpkg ];
 
-  unpackPhase = "dpkg-deb --fsys-tarfile $src | tar -x --no-same-permissions --no-same-owner";
-
   installPhase = ''
     runHook preInstall
 

--- a/pkgs/applications/audio/tidal-hifi/default.nix
+++ b/pkgs/applications/audio/tidal-hifi/default.nix
@@ -89,8 +89,6 @@ stdenv.mkDerivation rec {
   runtimeDependencies =
     [ (lib.getLib systemd) libnotify libdbusmenu xdg-utils ];
 
-  unpackPhase = "dpkg-deb -x $src .";
-
   installPhase = ''
     runHook preInstall
 

--- a/pkgs/applications/audio/tonelib-gfx/default.nix
+++ b/pkgs/applications/audio/tonelib-gfx/default.nix
@@ -41,8 +41,6 @@ stdenv.mkDerivation rec {
     libjack2
   ];
 
-  unpackCmd = "dpkg -x $curSrc source";
-
   installPhase = ''
     mv usr $out
     substituteInPlace $out/share/applications/ToneLib-GFX.desktop --replace /usr/ $out/

--- a/pkgs/applications/audio/tonelib-jam/default.nix
+++ b/pkgs/applications/audio/tonelib-jam/default.nix
@@ -44,8 +44,6 @@ stdenv.mkDerivation rec {
     libjack2
   ];
 
-  unpackCmd = "dpkg -x $curSrc source";
-
   installPhase = ''
     mv usr $out
     substituteInPlace $out/share/applications/ToneLib-Jam.desktop --replace /usr/ $out/

--- a/pkgs/applications/audio/tonelib-metal/default.nix
+++ b/pkgs/applications/audio/tonelib-metal/default.nix
@@ -43,8 +43,6 @@ stdenv.mkDerivation rec {
     libjack2
   ];
 
-  unpackCmd = "dpkg -x $curSrc source";
-
   installPhase = ''
     mv usr $out
     substituteInPlace $out/share/applications/ToneLib-Metal.desktop --replace /usr/ $out/

--- a/pkgs/applications/audio/tonelib-noisereducer/default.nix
+++ b/pkgs/applications/audio/tonelib-noisereducer/default.nix
@@ -43,8 +43,6 @@ stdenv.mkDerivation rec {
     libjack2
   ];
 
-  unpackCmd = "dpkg -x $curSrc source";
-
   installPhase = ''
     mv usr $out
  '';

--- a/pkgs/applications/audio/tonelib-zoom/default.nix
+++ b/pkgs/applications/audio/tonelib-zoom/default.nix
@@ -46,8 +46,6 @@ stdenv.mkDerivation rec {
     libjack2
   ];
 
-  unpackCmd = "dpkg -x $curSrc source";
-
   installPhase = ''
     mv usr $out
     substituteInPlace $out/share/applications/ToneLib-Zoom.desktop --replace /usr/ $out/

--- a/pkgs/applications/audio/yesplaymusic/default.nix
+++ b/pkgs/applications/audio/yesplaymusic/default.nix
@@ -91,6 +91,7 @@ else stdenv.mkDerivation {
     autoPatchelfHook
     wrapGAppsHook
     makeWrapper
+    dpkg
   ];
 
   buildInputs = libraries;
@@ -98,10 +99,6 @@ else stdenv.mkDerivation {
   runtimeDependencies = [
     (lib.getLib systemd)
   ];
-
-  unpackPhase = ''
-    ${dpkg}/bin/dpkg-deb -x $src .
-  '';
 
   installPhase = ''
     runHook preInstall

--- a/pkgs/applications/blockchains/bisq-desktop/default.nix
+++ b/pkgs/applications/blockchains/bisq-desktop/default.nix
@@ -54,10 +54,6 @@ stdenv.mkDerivation rec {
     })
   ];
 
-  unpackPhase = ''
-    dpkg -x $src .
-  '';
-
   buildPhase = ''
     # Replace the embedded Tor binary (which is in a Tar archive)
     # with one from Nixpkgs.

--- a/pkgs/applications/blockchains/terra-station/default.nix
+++ b/pkgs/applications/blockchains/terra-station/default.nix
@@ -32,14 +32,10 @@ stdenv.mkDerivation rec {
     inherit sha256;
   };
 
-  nativeBuildInputs = [ makeWrapper ];
+  nativeBuildInputs = [ makeWrapper dpkg ];
 
   dontConfigure = true;
   dontBuild = true;
-
-  unpackPhase = ''
-    ${dpkg}/bin/dpkg-deb -x $src .
-  '';
 
   installPhase = ''
     runHook preInstall

--- a/pkgs/applications/editors/atom/default.nix
+++ b/pkgs/applications/editors/atom/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, pkgs, fetchurl, wrapGAppsHook, glib, gtk3, atomEnv }:
+{ lib, stdenv, pkgs, fetchurl, wrapGAppsHook, dpkg, glib, gtk3, atomEnv }:
 
 let
   versions = {
@@ -30,6 +30,7 @@ let
 
     nativeBuildInputs = [
       wrapGAppsHook  # Fix error: GLib-GIO-ERROR **: No GSettings schemas are installed on the system
+      dpkg
     ];
 
     buildInputs = [
@@ -38,10 +39,6 @@ let
 
     dontBuild = true;
     dontConfigure = true;
-
-    unpackPhase = ''
-      ar p $src data.tar.xz | tar xJ ./usr/
-    '';
 
     installPhase = ''
       runHook preInstall

--- a/pkgs/applications/editors/bluej/default.nix
+++ b/pkgs/applications/editors/bluej/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchurl, openjdk, glib, wrapGAppsHook }:
+{ lib, stdenv, fetchurl, openjdk, glib, wrapGAppsHook, dpkg }:
 
 stdenv.mkDerivation rec {
   pname = "bluej";
@@ -12,22 +12,8 @@ stdenv.mkDerivation rec {
     sha256 = "sha256-tOb15wU9OjUt0D8l/JkaGYj84L7HV4FUnQQB5cRAxG0=";
   };
 
-  nativeBuildInputs = [ wrapGAppsHook ];
+  nativeBuildInputs = [ wrapGAppsHook dpkg ];
   buildInputs = [ glib ];
-
-  sourceRoot = ".";
-
-  preUnpack = ''
-    unpackCmdHooks+=(_tryDebData)
-    _tryDebData() {
-      if ! [[ "$1" =~ \.deb$ ]]; then return 1; fi
-      ar xf "$1"
-      if ! [[ -e data.tar.xz ]]; then return 1; fi
-      unpackFile data.tar.xz
-    }
-  '';
-
-  dontWrapGApps = true;
 
   installPhase = ''
     runHook preInstall

--- a/pkgs/applications/editors/greenfoot/default.nix
+++ b/pkgs/applications/editors/greenfoot/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchurl, makeWrapper, jdk }:
+{ lib, stdenv, fetchurl, makeWrapper, dpkg, jdk }:
 
 stdenv.mkDerivation rec {
   pname = "greenfoot";
@@ -11,12 +11,7 @@ stdenv.mkDerivation rec {
     sha256 = "sha256-wGgKDsA/2luw+Nzs9dWb/HRHMx/0S0CFfoI53OCzxug=";
   };
 
-  nativeBuildInputs = [ makeWrapper ];
-
-  unpackPhase = ''
-    ar xf $src
-    tar xf data.tar.xz
-  '';
+  nativeBuildInputs = [ makeWrapper dpkg ];
 
   installPhase = ''
     mkdir -p $out

--- a/pkgs/applications/graphics/figma-linux/default.nix
+++ b/pkgs/applications/graphics/figma-linux/default.nix
@@ -47,10 +47,6 @@ stdenv.mkDerivation rec {
 
   runtimeDependencies = with pkgs; [ eudev ];
 
-  unpackCmd = "dpkg -x $src .";
-
-  sourceRoot = ".";
-
   installPhase = ''
     runHook preInstall
 

--- a/pkgs/applications/graphics/odafileconverter/default.nix
+++ b/pkgs/applications/graphics/odafileconverter/default.nix
@@ -18,11 +18,6 @@ in mkDerivation {
     sha256 = "10027a3ab18efd04ca75aa699ff550eca3bdfe6f7084460d3c00001bffb50070";
   };
 
-  unpackPhase = ''
-    dpkg -x $src oda_unpacked
-    sourceRoot=$PWD/oda_unpacked
-  '';
-
   installPhase = ''
     mkdir -p $out/bin $out/lib
     cp -vr $sourceRoot/usr/bin/ODAFileConverter_${version} $out/libexec

--- a/pkgs/applications/graphics/pencil/default.nix
+++ b/pkgs/applications/graphics/pencil/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, lib, makeWrapper, wrapGAppsHook,
+{ stdenv, fetchurl, lib, makeWrapper, wrapGAppsHook, dpkg,
   # build dependencies
   alsa-lib, atk, at-spi2-atk, at-spi2-core, cairo, cups, dbus, expat, fontconfig,
   freetype, gdk-pixbuf, glib, glibc, gtk3, libuuid, nspr, nss, pango,
@@ -50,15 +50,9 @@ in stdenv.mkDerivation rec {
     sha256 = "01ae54b1a1351b909eb2366c6ec00816e1deba370e58f35601cf7368f10aaba3";
   };
 
-  sourceRoot = ".";
-
-  unpackCmd = ''
-    ar p "$src" data.tar.gz | tar xz
-  '';
-
   dontBuild = true;
 
-  nativeBuildInputs = [ makeWrapper wrapGAppsHook ];
+  nativeBuildInputs = [ makeWrapper wrapGAppsHook dpkg ];
 
   buildInputs = deps;
 

--- a/pkgs/applications/graphics/pixeluvo/default.nix
+++ b/pkgs/applications/graphics/pixeluvo/default.nix
@@ -26,10 +26,6 @@ stdenv.mkDerivation rec {
   dontBuild = true;
   dontConfigure = true;
 
-  unpackPhase = ''
-    dpkg-deb -x ${src} ./
-  '';
-
   installPhase = ''
     runHook preInstall
 

--- a/pkgs/applications/graphics/sane/backends/brscan4/default.nix
+++ b/pkgs/applications/graphics/sane/backends/brscan4/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, lib, fetchurl, callPackage, patchelf, makeWrapper, libusb-compat-0_1 }:
+{ stdenv, lib, fetchurl, callPackage, patchelf, makeWrapper, dpkg, libusb-compat-0_1 }:
 let
   myPatchElf = file: with lib; ''
     patchelf --set-interpreter \
@@ -23,12 +23,7 @@ stdenv.mkDerivation rec {
     };
   }."${stdenv.hostPlatform.system}";
 
-  unpackPhase = ''
-    ar x $src
-    tar xfvz data.tar.gz
-  '';
-
-  nativeBuildInputs = [ makeWrapper patchelf udevRules ];
+  nativeBuildInputs = [ makeWrapper patchelf dpkg.deb udevRules ];
   buildInputs = [ libusb-compat-0_1 ];
   dontBuild = true;
 

--- a/pkgs/applications/graphics/sane/backends/brscan4/udev_rules_type1.nix
+++ b/pkgs/applications/graphics/sane/backends/brscan4/udev_rules_type1.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchurl, libsaneUDevRuleNumber ? "49" }:
+{ lib, stdenv, fetchurl, dpkg, libsaneUDevRuleNumber ? "49" }:
 
 stdenv.mkDerivation rec {
   pname = "brother-udev-rule-type1";
@@ -11,10 +11,7 @@ stdenv.mkDerivation rec {
 
   dontBuild = true;
 
-  unpackPhase = ''
-    ar x $src
-    tar xfvz data.tar.gz
-  '';
+  nativeBuildInputs = [ dpkg ];
 
   /*
     Fix the following error:

--- a/pkgs/applications/graphics/sane/backends/brscan5/default.nix
+++ b/pkgs/applications/graphics/sane/backends/brscan5/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, lib, fetchurl, callPackage, patchelf, makeWrapper, libusb1, avahi-compat, glib, libredirect, nixosTests }:
+{ stdenv, lib, fetchurl, callPackage, patchelf, makeWrapper, dpkg, libusb1, avahi-compat, glib, libredirect, nixosTests }:
 let
   myPatchElf = file: with lib; ''
     patchelf --set-interpreter \
@@ -22,12 +22,7 @@ stdenv.mkDerivation rec {
     };
   }."${system}" or (throw "Unsupported system: ${system}");
 
-  unpackPhase = ''
-    ar x $src
-    tar xfv data.tar.xz
-  '';
-
-  nativeBuildInputs = [ makeWrapper patchelf ];
+  nativeBuildInputs = [ makeWrapper patchelf dpkg ];
   buildInputs = [ libusb1 avahi-compat stdenv.cc.cc glib ];
   dontBuild = true;
 

--- a/pkgs/applications/misc/binance/default.nix
+++ b/pkgs/applications/misc/binance/default.nix
@@ -23,10 +23,6 @@ stdenv.mkDerivation rec {
   dontBuild = true;
   dontConfigure = true;
 
-  unpackPhase = ''
-    dpkg-deb -x ${src} ./
-  '';
-
   installPhase = ''
     runHook preInstall
 

--- a/pkgs/applications/misc/googleearth-pro/default.nix
+++ b/pkgs/applications/misc/googleearth-pro/default.nix
@@ -69,12 +69,6 @@ mkDerivation rec {
 
   dontBuild = true;
 
-  unpackPhase = ''
-    # deb file contains a setuid binary, so 'dpkg -x' doesn't work here
-    mkdir deb
-    dpkg --fsys-tarfile ${src} | tar --extract -C deb
-  '';
-
   installPhase =''
     runHook preInstall
 

--- a/pkgs/applications/misc/holochain-launcher/default.nix
+++ b/pkgs/applications/misc/holochain-launcher/default.nix
@@ -31,8 +31,6 @@ stdenv.mkDerivation rec {
     libappindicator
   ];
 
-  unpackCmd = "dpkg-deb -x $curSrc source";
-
   installPhase = ''
     mv usr $out
   '';

--- a/pkgs/applications/misc/ideamaker/default.nix
+++ b/pkgs/applications/misc/ideamaker/default.nix
@@ -39,12 +39,6 @@ stdenv.mkDerivation rec {
     zlib
   ];
 
-  unpackPhase = ''
-    runHook preUnpack
-    dpkg-deb -x $src .
-    runHook postUnpack
-  '';
-
   installPhase = ''
     runHook preInstall
 

--- a/pkgs/applications/misc/join-desktop/default.nix
+++ b/pkgs/applications/misc/join-desktop/default.nix
@@ -36,8 +36,6 @@ stdenv.mkDerivation rec {
     xorg.libXtst
   ];
 
-  unpackPhase = "dpkg-deb -x $src .";
-
   runtimeDependencies = [
     (lib.getLib systemd)
     # TODO: check if they are required

--- a/pkgs/applications/misc/keeweb/default.nix
+++ b/pkgs/applications/misc/keeweb/default.nix
@@ -90,16 +90,13 @@ else stdenv.mkDerivation {
   inherit pname version src meta;
 
   nativeBuildInputs = [
+    dpkg
     autoPatchelfHook
     wrapGAppsHook
     makeWrapper
   ];
 
   buildInputs = libraries;
-
-  unpackPhase = ''
-    ${dpkg}/bin/dpkg-deb --fsys-tarfile $src | tar --extract
-  '';
 
   installPhase = ''
     runHook preInstall

--- a/pkgs/applications/misc/koreader/default.nix
+++ b/pkgs/applications/misc/koreader/default.nix
@@ -43,7 +43,6 @@ stdenv.mkDerivation rec {
     sdcv
     SDL2
   ];
-  unpackCmd = "dpkg-deb -x ${src} .";
 
   dontConfigure = true;
   dontBuild = true;

--- a/pkgs/applications/misc/parsec/bin.nix
+++ b/pkgs/applications/misc/parsec/bin.nix
@@ -19,14 +19,6 @@ stdenvNoCC.mkDerivation {
     sha256 = "sha256-wwBy86TdrHaH9ia40yh24yd5G84WTXREihR+9I6o6uU=";
   };
 
-  unpackPhase = ''
-    runHook preUnpack
-
-    dpkg-deb -x $src .
-
-    runHook postUnpack
-  '';
-
   nativeBuildInputs = [ dpkg autoPatchelfHook makeWrapper ];
 
   buildInputs = [

--- a/pkgs/applications/misc/pdfsam-basic/default.nix
+++ b/pkgs/applications/misc/pdfsam-basic/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, makeDesktopItem, fetchurl, jdk19, wrapGAppsHook, glib }:
+{ lib, stdenv, makeDesktopItem, fetchurl, jdk19, dpkg, wrapGAppsHook, glib }:
 
 stdenv.mkDerivation rec {
   pname = "pdfsam-basic";
@@ -9,12 +9,7 @@ stdenv.mkDerivation rec {
     hash = "sha256-NST5d5dzO26ifKStbgD7qNbumUMQhfUFNE472LR1z5k=";
   };
 
-  unpackPhase = ''
-    ar vx ${src}
-    tar xvf data.tar.gz
-  '';
-
-  nativeBuildInputs = [ wrapGAppsHook ];
+  nativeBuildInputs = [ dpkg wrapGAppsHook ];
   buildInputs = [ glib ];
 
   preFixup = ''

--- a/pkgs/applications/misc/pdfstudio/common.nix
+++ b/pkgs/applications/misc/pdfstudio/common.nix
@@ -45,7 +45,6 @@ let
       })
     ];
 
-    unpackCmd = "dpkg-deb -x $src ./${program}-${version}";
     dontBuild = true;
 
     postPatch = ''

--- a/pkgs/applications/misc/polar-bookshelf/default.nix
+++ b/pkgs/applications/misc/polar-bookshelf/default.nix
@@ -93,8 +93,6 @@ stdenv.mkDerivation rec {
 
   runtimeLibs = lib.makeLibraryPath [ libudev0-shim glibc curl openssl libnghttp2 ];
 
-  unpackPhase = "dpkg-deb -x $src .";
-
   installPhase = ''
     runHook preInstall
 

--- a/pkgs/applications/misc/polar-bookshelf1/default.nix
+++ b/pkgs/applications/misc/polar-bookshelf1/default.nix
@@ -87,10 +87,6 @@ stdenv.mkDerivation rec {
 
   runtimeLibs = lib.makeLibraryPath [ libudev0-shim glibc curl openssl libnghttp2 ];
 
-  unpackPhase = ''
-    dpkg-deb -x $src .
-  '';
-
   installPhase = ''
     mkdir -p $out/share/polar-bookshelf $out/bin $out/lib
     mv opt/Polar\ Bookshelf/* $out/share/polar-bookshelf

--- a/pkgs/applications/misc/rescuetime/default.nix
+++ b/pkgs/applications/misc/rescuetime/default.nix
@@ -20,11 +20,6 @@ in mkDerivation rec {
   nativeBuildInputs = [ dpkg ];
   # avoid https://github.com/NixOS/patchelf/issues/99
   dontStrip = true;
-  unpackPhase = ''
-    mkdir pkg
-    dpkg-deb -x $src pkg
-    sourceRoot=pkg
-  '';
   installPhase = ''
     mkdir -p $out/bin
     cp usr/bin/rescuetime $out/bin

--- a/pkgs/applications/misc/signumone-ks/default.nix
+++ b/pkgs/applications/misc/signumone-ks/default.nix
@@ -26,10 +26,6 @@ stdenv.mkDerivation rec {
 
   libPath = lib.makeLibraryPath buildInputs;
 
-  unpackPhase = ''
-    dpkg-deb -x ${src} ./
-  '';
-
   installPhase = ''
     DESKTOP_PATH=$out/share/applications/signumone-ks.desktop
 

--- a/pkgs/applications/misc/simplenote/default.nix
+++ b/pkgs/applications/misc/simplenote/default.nix
@@ -70,8 +70,6 @@ let
 
     buildInputs = atomEnv.packages;
 
-    unpackPhase = "dpkg-deb -x $src .";
-
     installPhase = ''
       mkdir -p "$out/bin"
       cp -R "opt" "$out"

--- a/pkgs/applications/misc/thedesk/default.nix
+++ b/pkgs/applications/misc/thedesk/default.nix
@@ -21,10 +21,6 @@ stdenv.mkDerivation rec {
   dontBuild = true;
   dontConfigure = true;
 
-  unpackPhase = ''
-    dpkg-deb -x ${src} ./
-  '';
-
   installPhase = ''
     runHook preInstall
 

--- a/pkgs/applications/misc/upwork/default.nix
+++ b/pkgs/applications/misc/upwork/default.nix
@@ -34,10 +34,6 @@ stdenv.mkDerivation rec {
   dontBuild = true;
   dontConfigure = true;
 
-  unpackPhase = ''
-    dpkg-deb -x ${src} ./
-  '';
-
   installPhase = ''
     runHook preInstall
 

--- a/pkgs/applications/networking/appgate-sdp/default.nix
+++ b/pkgs/applications/networking/appgate-sdp/default.nix
@@ -109,12 +109,9 @@ stdenv.mkDerivation rec {
     dpkg
   ];
 
-  unpackPhase = ''
-    dpkg-deb -x $src $out
-  '';
-
   installPhase = ''
-    cp -r $out/usr/share $out/share
+    mkdir -p $out
+    cp -r opt/ usr/share/ $out
 
     substituteInPlace $out/lib/systemd/system/appgate-dumb-resolver.service \
         --replace "/opt/" "$out/opt/"

--- a/pkgs/applications/networking/breitbandmessung/default.nix
+++ b/pkgs/applications/networking/breitbandmessung/default.nix
@@ -27,8 +27,6 @@ let
         nodePackages.asar
       ];
 
-      unpackPhase = "dpkg-deb -x $src .";
-
       installPhase = ''
         mkdir -p $out/bin
         mv usr/share $out/share

--- a/pkgs/applications/networking/browsers/brave/default.nix
+++ b/pkgs/applications/networking/browsers/brave/default.nix
@@ -115,8 +115,6 @@ stdenv.mkDerivation rec {
     gnome.adwaita-icon-theme
   ];
 
-  unpackPhase = "dpkg-deb --fsys-tarfile $src | tar -x --no-same-permissions --no-same-owner";
-
   installPhase = ''
       runHook preInstall
 

--- a/pkgs/applications/networking/browsers/opera/default.nix
+++ b/pkgs/applications/networking/browsers/opera/default.nix
@@ -58,8 +58,6 @@ stdenv.mkDerivation rec {
     hash = "sha256-3HVgEOscds+VBn9ajmkRnPdqNi9lLItJrb3uRH6L96Q=";
   };
 
-  unpackPhase = "dpkg-deb -x $src .";
-
   nativeBuildInputs = [
     dpkg
     autoPatchelfHook

--- a/pkgs/applications/networking/browsers/vivaldi/default.nix
+++ b/pkgs/applications/networking/browsers/vivaldi/default.nix
@@ -9,7 +9,7 @@
 , libdrm, mesa
 , vulkan-loader
 , nss, nspr
-, patchelf, makeWrapper
+, dpkg, patchelf, makeWrapper
 , wayland, pipewire
 , isSnapshot ? false
 , proprietaryCodecs ? false, vivaldi-ffmpeg-codecs ? null
@@ -38,12 +38,7 @@ in stdenv.mkDerivation rec {
     }.${stdenv.hostPlatform.system} or (throw "Unsupported system: ${stdenv.hostPlatform.system}");
   };
 
-  unpackPhase = ''
-    ar vx $src
-    tar -xvf data.tar.xz
-  '';
-
-  nativeBuildInputs = [ patchelf makeWrapper ];
+  nativeBuildInputs = [ dpkg patchelf makeWrapper ];
 
   dontWrapQtApps = true;
 

--- a/pkgs/applications/networking/browsers/vivaldi/ffmpeg-codecs.nix
+++ b/pkgs/applications/networking/browsers/vivaldi/ffmpeg-codecs.nix
@@ -9,11 +9,7 @@ stdenv.mkDerivation rec {
     sha256 = "sha256-V+zqLhI8L/8ssxSR6S2v4gUAtoK3fB8Fi9bajBFEauU=";
   };
 
-  buildInputs = [ dpkg ];
-
-  unpackPhase = ''
-    dpkg-deb -x $src .
-  '';
+  nativeBuildInputs = [ dpkg ];
 
   installPhase = ''
     install -vD usr/lib/chromium-browser/libffmpeg.so $out/lib/libffmpeg.so

--- a/pkgs/applications/networking/browsers/yandex-browser/default.nix
+++ b/pkgs/applications/networking/browsers/yandex-browser/default.nix
@@ -1,6 +1,7 @@
 { stdenv
 , lib
 , fetchurl
+, dpkg
 , autoPatchelfHook
 , wrapGAppsHook
 , flac
@@ -59,6 +60,7 @@ stdenv.mkDerivation rec {
   };
 
   nativeBuildInputs = [
+    dpkg
     autoPatchelfHook
     wrapGAppsHook
   ];
@@ -110,14 +112,10 @@ stdenv.mkDerivation rec {
     libqt5pas
   ];
 
-  unpackPhase = ''
-    mkdir $TMP/ya/ $out/bin/ -p
-    ar vx $src
-    tar --no-overwrite-dir -xvf data.tar.xz -C $TMP/ya/
-  '';
-
   installPhase = ''
-    cp $TMP/ya/{usr/share,opt} $out/ -R
+    mkdir -p $out
+    cp usr/share/ opt/ $out/ -R
+
     substituteInPlace $out/share/applications/yandex-browser-beta.desktop --replace /usr/ $out/
     ln -sf $out/opt/yandex/browser-beta/yandex_browser $out/bin/yandex-browser
     ln -sf $out/opt/yandex/browser-beta/yandex_browser $out/bin/yandex-browser-beta
@@ -139,8 +137,8 @@ stdenv.mkDerivation rec {
 
     knownVulnerabilities = [
       ''
-      Trusts a Russian government issued CA certificate for some websites.
-      See https://habr.com/en/company/yandex/blog/655185/ (Russian) for details.
+        Trusts a Russian government issued CA certificate for some websites.
+        See https://habr.com/en/company/yandex/blog/655185/ (Russian) for details.
       ''
     ];
   };


### PR DESCRIPTION
###### Description of changes
Follow up to #225504. Opening as draft as I won't be able to finish this for a while, as I'll be away for ~a week.
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### TODO
- [ ] Convert existing packages that manually set `unpackCmd` or `unpackPhase` to use the built-in hook.
- [ ] Add documentation on this, specifically for packaging binary packages in a `.deb` format.
- [ ] Consider using `ar` to extract the data archive from `.deb`? Saves us from having to pull in the entirety of `dpkg`.
  - Some packages already do this, for example [atom](https://github.com/NixOS/nixpkgs/blob/0ec28ceedf4d522de160adbedbcb80ca42edc9fe/pkgs/applications/editors/atom/default.nix#L42-L44). 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
