### PR TITLE
python310Packages.trio-websocket: 0.9.2 -> 0.10.2

### DIFF
--- a/pkgs/development/python-modules/trio-websocket/default.nix
+++ b/pkgs/development/python-modules/trio-websocket/default.nix
@@ -1,4 +1,5 @@
 { lib
+, stdenv
 , buildPythonPackage
 , fetchFromGitHub
 , exceptiongroup
@@ -32,6 +33,19 @@ buildPythonPackage rec {
     pytestCheckHook
     trustme
   ];
+
+  disabledTests = lib.optionals stdenv.isDarwin [
+    # Failed: DID NOT RAISE <class 'ValueError'>
+    "test_finalization_dropped_exception"
+    # Timing related
+    "test_client_close_timeout"
+    "test_cm_exit_with_pending_messages"
+    "test_server_close_timeout"
+    "test_server_handler_exit"
+    "test_server_open_timeout"
+  ];
+
+  __darwinAllowLocalNetworking = true;
 
   pythonImportsCheck = [ "trio_websocket" ];
 

--- a/pkgs/development/python-modules/trio-websocket/default.nix
+++ b/pkgs/development/python-modules/trio-websocket/default.nix
@@ -1,7 +1,7 @@
 { lib
 , buildPythonPackage
 , fetchFromGitHub
-, async_generator
+, exceptiongroup
 , pytest-trio
 , pytestCheckHook
 , trio
@@ -11,17 +11,18 @@
 
 buildPythonPackage rec {
   pname = "trio-websocket";
-  version = "0.9.2";
+  version = "0.10.2";
+  format = "setuptools";
 
   src = fetchFromGitHub {
     owner = "HyperionGray";
     repo = "trio-websocket";
     rev = version;
-    hash = "sha256-8VrpI/pk5IhEvqzo036cnIbJ1Hu3UfQ6GHTNkNJUYvo=";
+    hash = "sha256-djoTxkIKY52l+WnxL1FwlqrU/zvsLVkPUAHn9BxJ45k=";
   };
 
   propagatedBuildInputs = [
-    async_generator
+    exceptiongroup
     trio
     wsproto
   ];
@@ -35,7 +36,9 @@ buildPythonPackage rec {
   pythonImportsCheck = [ "trio_websocket" ];
 
   meta = with lib; {
+    changelog = "https://github.com/HyperionGray/trio-websocket/blob/${version}/CHANGELOG.md";
     description = "WebSocket client and server implementation for Python Trio";
+    homepage = "https://github.com/HyperionGray/trio-websocket";
     license = licenses.mit;
     maintainers = with maintainers; [ SuperSandro2000 ];
   };


### PR DESCRIPTION
Fixes the build on Python 3.11. https://hydra.nixos.org/build/221652975

https://github.com/HyperionGray/trio-websocket/blob/0.10.2/CHANGELOG.md
https://github.com/HyperionGray/trio-websocket/compare/0.9.2...0.10.2


ZHF: #230712 

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
