### PR TITLE
syncplay: fix `TypeError` on Linux

### DIFF
--- a/pkgs/applications/networking/syncplay/default.nix
+++ b/pkgs/applications/networking/syncplay/default.nix
@@ -2,6 +2,7 @@
 , stdenv
 , fetchFromGitHub
 , buildPythonApplication
+, fetchpatch
 , pyside6
 , twisted
 , certifi
@@ -22,6 +23,14 @@ buildPythonApplication rec {
     rev = "v${version}";
     sha256 = "sha256-Te81yOv3D6M6aMfC5XrM6/I6BlMdlY1yRk1RRJa9Mxg=";
   };
+
+  patches = [
+    (fetchpatch {
+      name = "fix-typeerror.patch";
+      url = "https://github.com/Syncplay/syncplay/commit/b62b038cdf58c54205987dfc52ebf228505ad03b.patch";
+      hash = "sha256-pSP33Qn1I+nJBW8T1E1tSJKRh5OnZMRsbU+jr5z4u7c=";
+    })
+  ];
 
   buildInputs = lib.optionals enableGUI [ (if stdenv.isLinux then qt6.qtwayland else qt6.qtbase) ];
   propagatedBuildInputs = [ twisted certifi ]


### PR DESCRIPTION
###### Description of changes

After switching to Qt6 and PySide6, `syncplay` no longer runs on Linux with the following error:

```
Traceback (most recent call last):
  File "/nix/store/hq07g2r6lp8i7mdhvi2qy65196xlimhl-syncplay-1.7.0/bin/..syncplay-wrapped-wrapped", line 20, in <module>
    ep_client.main()
  File "/nix/store/hq07g2r6lp8i7mdhvi2qy65196xlimhl-syncplay-1.7.0/lib/syncplay/syncplay/ep_client.py", line 8, in main
    SyncplayClientManager().run()
  File "/nix/store/hq07g2r6lp8i7mdhvi2qy65196xlimhl-syncplay-1.7.0/lib/syncplay/syncplay/clientManager.py", line 12, in run
    interface = ui.getUi(graphical=not config["noGui"], passedBar=menuBar)
  File "/nix/store/hq07g2r6lp8i7mdhvi2qy65196xlimhl-syncplay-1.7.0/lib/syncplay/syncplay/ui/__init__.py", line 17, in getUi
    ui = GraphicalUI(passedBar=passedBar)
  File "/nix/store/hq07g2r6lp8i7mdhvi2qy65196xlimhl-syncplay-1.7.0/lib/syncplay/syncplay/ui/gui.py", line 2109, in __init__
    self.setWindowFlags(self.windowFlags() & Qt.AA_DontUseNativeMenuBar)
TypeError: unsupported operand type(s) for &: 'WindowType' and 'ApplicationAttribute'
```

This error has already been fixed on `syncplay` master but hasn't been included in a release yet

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).