### PR TITLE
cudaPackages: show informative error when targeting unsupported capability

### DIFF
--- a/pkgs/development/compilers/cudatoolkit/common.nix
+++ b/pkgs/development/compilers/cudatoolkit/common.nix
@@ -1,345 +1,383 @@
-args@
-{ version
-, sha256
-, url ? ""
-, name ? ""
-, developerProgram ? false
-, runPatches ? []
-, autoPatchelfHook
-, autoAddOpenGLRunpathHook
-, addOpenGLRunpath
-, alsa-lib
-, expat
-, fetchurl
-, fontconfig
-, freetype
-, gdk-pixbuf
-, glib
-, glibc
-, gtk2
-, lib
-, libxkbcommon
-, libkrb5
-, krb5
-, makeWrapper
-, ncurses5
-, numactl
-, nss
-, perl
-, python3 # FIXME: CUDAToolkit 10 may still need python27
-, pulseaudio
-, requireFile
-, stdenv
-, backendStdenv # E.g. gcc11Stdenv, set in extension.nix
-, unixODBC
-, wayland
-, xorg
-, zlib
-, freeglut
-, libGLU
-, libsForQt5
-, libtiff
-, qt6Packages
-, rdma-core
-, ucx
-, rsync
-}:
+{
+  addOpenGLRunpath,
+  alsa-lib,
+  autoAddOpenGLRunpathHook,
+  autoPatchelfHook,
+  backendStdenv, # E.g. gcc11Stdenv, set in extension.nix
+  cudaFlags,
+  developerProgram ? false,
+  expat,
+  fetchurl,
+  fontconfig,
+  freeglut,
+  freetype,
+  gdk-pixbuf,
+  glib,
+  glibc,
+  gtk2,
+  krb5,
+  lib,
+  libGLU,
+  libkrb5,
+  libsForQt5,
+  libtiff,
+  libxkbcommon,
+  makeWrapper,
+  name ? "",
+  ncurses5,
+  nss,
+  numactl,
+  perl,
+  pulseaudio,
+  python3, # FIXME: CUDAToolkit 10 may still need python27
+  qt6Packages,
+  rdma-core,
+  requireFile,
+  rsync,
+  runPatches ? [],
+  sha256,
+  stdenv,
+  ucx,
+  unixODBC,
+  url ? "",
+  version,
+  wayland,
+  xorg,
+  zlib,
+}: let
+  inherit (lib.lists) elem filter optionals;
+  inherit (lib.strings) concatStringsSep optionalString versionAtLeast versionOlder;
+  inherit (lib.trivial) warnIf;
+  inherit (lib.versions) major majorMinor;
 
-backendStdenv.mkDerivation rec {
-  pname = "cudatoolkit";
-  inherit version runPatches;
+  # unsupportedCapabilities :: List Capability
+  unsupportedCapabilities =
+    filter
+    (computeCapability: !elem computeCapability cudaFlags.cudaSupportedCapabilities)
+    cudaFlags.cudaCapabilities;
 
-  dontPatchELF = true;
-  dontStrip = true;
+  # broken :: Bool
+  broken = let
+    isBroken = unsupportedCapabilities != [];
+  in
+    warnIf
+    isBroken
+    ''
+      CUDA ${version} supports the following capabilities:
+        ${concatStringsSep ", " cudaFlags.cudaSupportedCapabilities}
+      However, the following unsupported capabilities were requested:
+        ${concatStringsSep ", " unsupportedCapabilities}
+      This means that packages relying on this version of CUDA are not available.
+      If possible, consider upgrading to a newer version of CUDA.
+    ''
+    isBroken;
+in
+  backendStdenv.mkDerivation {
+    pname = "cudatoolkit";
+    inherit version runPatches;
 
-  src =
-    if developerProgram then
-      requireFile {
-        message = ''
-          This nix expression requires that ${args.name} is already part of the store.
-          Register yourself to NVIDIA Accelerated Computing Developer Program, retrieve the CUDA toolkit
-          at https://developer.nvidia.com/cuda-toolkit, and run the following command in the download directory:
-          nix-prefetch-url file://\$PWD/${args.name}
-        '';
-        inherit (args) name sha256;
-      }
-    else
-      fetchurl {
-        inherit (args) url sha256;
-      };
+    dontPatchELF = true;
+    dontStrip = true;
 
-  outputs = [ "out" "lib" "doc" ];
+    src =
+      if developerProgram
+      then
+        requireFile {
+          inherit name sha256;
+          message = ''
+            This nix expression requires that ${name} is already part of the store.
+            Register yourself to NVIDIA Accelerated Computing Developer Program, retrieve the CUDA toolkit
+            at https://developer.nvidia.com/cuda-toolkit, and run the following command in the download directory:
+            nix-prefetch-url file://\$PWD/${name}
+          '';
+        }
+      else
+        fetchurl {
+          inherit url sha256;
+        };
 
-  nativeBuildInputs = [
-    perl
-    makeWrapper
-    rsync
-    addOpenGLRunpath
-    autoPatchelfHook
-    autoAddOpenGLRunpathHook
-  ] ++ lib.optionals (lib.versionOlder version "11") [
-    libsForQt5.wrapQtAppsHook
-  ] ++ lib.optionals (lib.versionAtLeast version "11.8") [
-    qt6Packages.wrapQtAppsHook
-  ];
-  buildInputs = lib.optionals (lib.versionOlder version "11") [
-    libsForQt5.qt5.qtwebengine
-    freeglut
-    libGLU
-  ] ++ [
-    # To get $GDK_PIXBUF_MODULE_FILE via setup-hook
-    gdk-pixbuf
+    outputs = ["out" "lib" "doc"];
 
-    # For autoPatchelf
-    ncurses5
-    expat
-    python3
-    zlib
-    glibc
-    xorg.libX11
-    xorg.libXext
-    xorg.libXrender
-    xorg.libXt
-    xorg.libXtst
-    xorg.libXi
-    xorg.libXext
-    xorg.libXdamage
-    xorg.libxcb
-    xorg.xcbutilimage
-    xorg.xcbutilrenderutil
-    xorg.xcbutilwm
-    xorg.xcbutilkeysyms
-    pulseaudio
-    libxkbcommon
-    libkrb5
-    krb5
-    gtk2
-    glib
-    fontconfig
-    freetype
-    numactl
-    nss
-    unixODBC
-    alsa-lib
-    wayland
-  ] ++ lib.optionals (lib.versionAtLeast version "11.8") [
-    (lib.getLib libtiff)
-    qt6Packages.qtwayland
-    rdma-core
-    ucx
-    xorg.libxshmfence
-    xorg.libxkbfile
-  ];
+    nativeBuildInputs =
+      [
+        addOpenGLRunpath
+        autoAddOpenGLRunpathHook
+        autoPatchelfHook
+        makeWrapper
+        perl
+        rsync
+      ]
+      ++ optionals (versionOlder version "11") [
+        libsForQt5.wrapQtAppsHook
+      ]
+      ++ optionals (versionAtLeast version "11.8") [
+        qt6Packages.wrapQtAppsHook
+      ];
+    buildInputs =
+      optionals (versionOlder version "11") [
+        freeglut
+        libGLU
+        libsForQt5.qt5.qtwebengine
+      ]
+      ++ [
+        # To get $GDK_PIXBUF_MODULE_FILE via setup-hook
+        gdk-pixbuf
 
-  # Prepended to runpaths by autoPatchelf.
-  # The order inherited from older rpath preFixup code
-  runtimeDependencies = [
-    (placeholder "lib")
-    (placeholder "out")
-    "${placeholder "out"}/nvvm"
-    # NOTE: use the same libstdc++ as the rest of nixpkgs, not from backendStdenv
-    "${lib.getLib stdenv.cc.cc}/lib64"
-    "${placeholder "out"}/jre/lib/amd64/jli"
-    "${placeholder "out"}/lib64"
-    "${placeholder "out"}/nvvm/lib64"
-  ];
+        # For autoPatchelf
+        alsa-lib
+        expat
+        fontconfig
+        freetype
+        glib
+        glibc
+        gtk2
+        krb5
+        libkrb5
+        libxkbcommon
+        ncurses5
+        nss
+        numactl
+        pulseaudio
+        python3
+        unixODBC
+        wayland
+        xorg.libX11
+        xorg.libxcb
+        xorg.libXdamage
+        xorg.libXext
+        xorg.libXext
+        xorg.libXi
+        xorg.libXrender
+        xorg.libXt
+        xorg.libXtst
+        xorg.xcbutilimage
+        xorg.xcbutilkeysyms
+        xorg.xcbutilrenderutil
+        xorg.xcbutilwm
+        zlib
+      ]
+      ++ optionals (versionAtLeast version "11.8") [
+        (lib.getLib libtiff)
+        qt6Packages.qtwayland
+        rdma-core
+        ucx
+        xorg.libxshmfence
+        xorg.libxkbfile
+      ];
 
-  autoPatchelfIgnoreMissingDeps = [
-    # This is the hardware-dependent userspace driver that comes from
-    # nvidia_x11 package. It must be deployed at runtime in
-    # /run/opengl-driver/lib or pointed at by LD_LIBRARY_PATH variable, rather
-    # than pinned in runpath
-    "libcuda.so.1"
+    # Prepended to runpaths by autoPatchelf.
+    # The order inherited from older rpath preFixup code
+    runtimeDependencies = [
+      (placeholder "lib")
+      (placeholder "out")
+      "${placeholder "out"}/nvvm"
+      # NOTE: use the same libstdc++ as the rest of nixpkgs, not from backendStdenv
+      "${lib.getLib stdenv.cc.cc}/lib64"
+      "${placeholder "out"}/jre/lib/amd64/jli"
+      "${placeholder "out"}/lib64"
+      "${placeholder "out"}/nvvm/lib64"
+    ];
 
-    # The krb5 expression ships libcom_err.so.3 but cudatoolkit asks for the
-    # older
-    # This dependency is asked for by target-linux-x64/CollectX/RedHat/x86_64/libssl.so.10
-    # - do we even want to use nvidia-shipped libssl?
-    "libcom_err.so.2"
-  ];
+    autoPatchelfIgnoreMissingDeps = [
+      # This is the hardware-dependent userspace driver that comes from
+      # nvidia_x11 package. It must be deployed at runtime in
+      # /run/opengl-driver/lib or pointed at by LD_LIBRARY_PATH variable, rather
+      # than pinned in runpath
+      "libcuda.so.1"
 
-  unpackPhase = ''
-    sh $src --keep --noexec
+      # The krb5 expression ships libcom_err.so.3 but cudatoolkit asks for the
+      # older
+      # This dependency is asked for by target-linux-x64/CollectX/RedHat/x86_64/libssl.so.10
+      # - do we even want to use nvidia-shipped libssl?
+      "libcom_err.so.2"
+    ];
 
-    ${lib.optionalString (lib.versionOlder version "10.1") ''
-      cd pkg/run_files
-      sh cuda-linux*.run --keep --noexec
-      sh cuda-samples*.run --keep --noexec
-      mv pkg ../../$(basename $src)
-      cd ../..
-      rm -rf pkg
+    unpackPhase =
+      ''
+        sh $src --keep --noexec
+      ''
+      + optionalString (versionOlder version "10.1") ''
+        cd pkg/run_files
+        sh cuda-linux*.run --keep --noexec
+        sh cuda-samples*.run --keep --noexec
+        mv pkg ../../$(basename $src)
+        cd ../..
+        rm -rf pkg
 
-      for patch in $runPatches; do
-        sh $patch --keep --noexec
-        mv pkg $(basename $patch)
-      done
-    ''}
-  '';
+        for patch in $runPatches; do
+          sh $patch --keep --noexec
+          mv pkg $(basename $patch)
+        done
+      '';
 
-  installPhase = ''
-    runHook preInstall
-    mkdir $out
-    ${lib.optionalString (lib.versionOlder version "10.1") ''
-    cd $(basename $src)
-    export PERL5LIB=.
-    perl ./install-linux.pl --prefix="$out"
-    cd ..
-    for patch in $runPatches; do
-      cd $(basename $patch)
-      perl ./install_patch.pl --silent --accept-eula --installdir="$out"
-      cd ..
-    done
-    ''}
-    ${lib.optionalString (lib.versionAtLeast version "10.1" && lib.versionOlder version "11") ''
-      cd pkg/builds/cuda-toolkit
-      mv * $out/
-    ''}
-    ${lib.optionalString (lib.versionAtLeast version "11") ''
-      mkdir -p $out/bin $out/lib64 $out/include $doc
-      for dir in pkg/builds/* pkg/builds/cuda_nvcc/nvvm pkg/builds/cuda_cupti/extras/CUPTI; do
-        if [ -d $dir/bin ]; then
-          mv $dir/bin/* $out/bin
-        fi
-        if [ -d $dir/doc ]; then
-          (cd $dir/doc && find . -type d -exec mkdir -p $doc/\{} \;)
-          (cd $dir/doc && find . \( -type f -o -type l \) -exec mv \{} $doc/\{} \;)
-        fi
-        if [ -L $dir/include ] || [ -d $dir/include ]; then
-          (cd $dir/include && find . -type d -exec mkdir -p $out/include/\{} \;)
-          (cd $dir/include && find . \( -type f -o -type l \) -exec mv \{} $out/include/\{} \;)
-        fi
-        if [ -L $dir/lib64 ] || [ -d $dir/lib64 ]; then
-          (cd $dir/lib64 && find . -type d -exec mkdir -p $out/lib64/\{} \;)
-          (cd $dir/lib64 && find . \( -type f -o -type l \) -exec mv \{} $out/lib64/\{} \;)
-        fi
-      done
-      mv pkg/builds/cuda_nvcc/nvvm $out/nvvm
+    installPhase =
+      ''
+        runHook preInstall
+        mkdir $out
+      ''
+      + optionalString (versionOlder version "10.1") ''
+        cd $(basename $src)
+        export PERL5LIB=.
+        perl ./install-linux.pl --prefix="$out"
+        cd ..
+        for patch in $runPatches; do
+          cd $(basename $patch)
+          perl ./install_patch.pl --silent --accept-eula --installdir="$out"
+          cd ..
+        done
+      ''
+      + optionalString (versionAtLeast version "10.1" && versionOlder version "11") ''
+        cd pkg/builds/cuda-toolkit
+        mv * $out/
+      ''
+      + optionalString (versionAtLeast version "11") ''
+        mkdir -p $out/bin $out/lib64 $out/include $doc
+        for dir in pkg/builds/* pkg/builds/cuda_nvcc/nvvm pkg/builds/cuda_cupti/extras/CUPTI; do
+          if [ -d $dir/bin ]; then
+            mv $dir/bin/* $out/bin
+          fi
+          if [ -d $dir/doc ]; then
+            (cd $dir/doc && find . -type d -exec mkdir -p $doc/\{} \;)
+            (cd $dir/doc && find . \( -type f -o -type l \) -exec mv \{} $doc/\{} \;)
+          fi
+          if [ -L $dir/include ] || [ -d $dir/include ]; then
+            (cd $dir/include && find . -type d -exec mkdir -p $out/include/\{} \;)
+            (cd $dir/include && find . \( -type f -o -type l \) -exec mv \{} $out/include/\{} \;)
+          fi
+          if [ -L $dir/lib64 ] || [ -d $dir/lib64 ]; then
+            (cd $dir/lib64 && find . -type d -exec mkdir -p $out/lib64/\{} \;)
+            (cd $dir/lib64 && find . \( -type f -o -type l \) -exec mv \{} $out/lib64/\{} \;)
+          fi
+        done
+        mv pkg/builds/cuda_nvcc/nvvm $out/nvvm
 
-      mv pkg/builds/cuda_sanitizer_api $out/cuda_sanitizer_api
-      ln -s $out/cuda_sanitizer_api/compute-sanitizer/compute-sanitizer $out/bin/compute-sanitizer
+        mv pkg/builds/cuda_sanitizer_api $out/cuda_sanitizer_api
+        ln -s $out/cuda_sanitizer_api/compute-sanitizer/compute-sanitizer $out/bin/compute-sanitizer
 
-      mv pkg/builds/nsight_systems/target-linux-x64 $out/target-linux-x64
-      mv pkg/builds/nsight_systems/host-linux-x64 $out/host-linux-x64
-      rm $out/host-linux-x64/libstdc++.so*
-    ''}
-      ${lib.optionalString (lib.versionAtLeast version "11.8")
+        mv pkg/builds/nsight_systems/target-linux-x64 $out/target-linux-x64
+        mv pkg/builds/nsight_systems/host-linux-x64 $out/host-linux-x64
+        rm $out/host-linux-x64/libstdc++.so*
+      ''
       # error: auto-patchelf could not satisfy dependency libtiff.so.5 wanted by /nix/store/.......-cudatoolkit-12.0.1/host-linux-x64/Plugins/imageformats/libqtiff.so
       # we only ship libtiff.so.6, so let's use qt plugins built by Nix.
       # TODO: don't copy, come up with a symlink-based "merge"
-    ''
-      rsync ${lib.getLib qt6Packages.qtimageformats}/lib/qt-6/plugins/ $out/host-linux-x64/Plugins/ -aP
-    ''}
+      + optionalString (versionAtLeast version "11.8") ''
+        rsync ${lib.getLib qt6Packages.qtimageformats}/lib/qt-6/plugins/ $out/host-linux-x64/Plugins/ -aP
+      ''
+      + ''
+        rm -f $out/tools/CUDA_Occupancy_Calculator.xls # FIXME: why?
+      ''
+      + optionalString (versionOlder version "10.1") ''
+        # let's remove the 32-bit libraries, they confuse the lib64->lib mover
+        rm -rf $out/lib
+      ''
+      # Remove some cruft.
+      + optionalString ((versionAtLeast version "7.0") && (versionOlder version "10.1")) ''
+        rm $out/bin/uninstall*
+      ''
+      # Fixup path to samples (needed for cuda 6.5 or else nsight will not find them)
+      + ''
+        if [ -d "$out"/cuda-samples ]; then
+          mv "$out"/cuda-samples "$out"/samples
+        fi
 
-    rm -f $out/tools/CUDA_Occupancy_Calculator.xls # FIXME: why?
+        # Change the #error on GCC > 4.9 to a #warning.
+        sed -i $out/include/host_config.h -e 's/#error\(.*unsupported GNU version\)/#warning\1/'
 
-    ${lib.optionalString (lib.versionOlder version "10.1") ''
-    # let's remove the 32-bit libraries, they confuse the lib64->lib mover
-    rm -rf $out/lib
-    ''}
+        # Fix builds with newer glibc version
+        sed -i "1 i#define _BITS_FLOATN_H" "$out/include/host_defines.h"
+      ''
+      # Point NVCC at a compatible compiler
+      # FIXME: redist cuda_nvcc copy-pastes this code
+      # Refer to comments in the overrides for cuda_nvcc for explanation
+      # CUDA_TOOLKIT_ROOT_DIR is legacy,
+      # Cf. https://cmake.org/cmake/help/latest/module/FindCUDA.html#input-variables
+      # NOTE: We unconditionally set -Xfatbin=-compress-all, which reduces the size of the compiled
+      #   binaries. If binaries grow over 2GB, they will fail to link. This is a problem for us, as
+      #   the default set of CUDA capabilities we build can regularly cause this to occur (for
+      #   example, with Magma).
+      + ''
+        mkdir -p $out/nix-support
+        cat <<EOF >> $out/nix-support/setup-hook
+        cmakeFlags+=' -DCUDA_TOOLKIT_ROOT_DIR=$out'
+        cmakeFlags+=' -DCUDA_HOST_COMPILER=${backendStdenv.cc}/bin'
+        cmakeFlags+=' -DCMAKE_CUDA_HOST_COMPILER=${backendStdenv.cc}/bin'
+        if [ -z "\''${CUDAHOSTCXX-}" ]; then
+          export CUDAHOSTCXX=${backendStdenv.cc}/bin;
+        fi
+        export NVCC_PREPEND_FLAGS+=' --compiler-bindir=${backendStdenv.cc}/bin -Xfatbin=-compress-all'
+        EOF
 
-    # Remove some cruft.
-    ${lib.optionalString ((lib.versionAtLeast version "7.0") && (lib.versionOlder version "10.1"))
-      "rm $out/bin/uninstall*"}
+        # Move some libraries to the lib output so that programs that
+        # depend on them don't pull in this entire monstrosity.
+        mkdir -p $lib/lib
+        mv -v $out/lib64/libcudart* $lib/lib/
 
-    # Fixup path to samples (needed for cuda 6.5 or else nsight will not find them)
-    if [ -d "$out"/cuda-samples ]; then
-        mv "$out"/cuda-samples "$out"/samples
-    fi
+        # Remove OpenCL libraries as they are provided by ocl-icd and driver.
+        rm -f $out/lib64/libOpenCL*
+      ''
+      + optionalString (versionAtLeast version "10.1" && (versionOlder version "11")) ''
+        mv $out/lib64 $out/lib
+        mv $out/extras/CUPTI/lib64/libcupti* $out/lib
+      ''
+      # nvprof do not find any program to profile if LD_LIBRARY_PATH is not set
+      + ''
+        wrapProgram $out/bin/nvprof --prefix LD_LIBRARY_PATH : $out/lib
+      ''
+      + optionalString (versionOlder version "8.0") ''
+        # Hack to fix building against recent Glibc/GCC.
+        echo "NIX_CFLAGS_COMPILE+=' -D_FORCE_INLINES'" >> $out/nix-support/setup-hook
+      ''
+      # 11.8 includes a broken symlink, include/include, pointing to targets/x86_64-linux/include
+      + lib.optionalString (lib.versions.majorMinor version == "11.8") ''
+        rm $out/include/include
+      ''
+      + ''
+        runHook postInstall
+      '';
 
-    # Change the #error on GCC > 4.9 to a #warning.
-    sed -i $out/include/host_config.h -e 's/#error\(.*unsupported GNU version\)/#warning\1/'
+    postInstall = let
+      exes =
+        ["nvvp"]
+        ++ optionals (versionOlder version "11") ["nsight"];
+    in ''
+      for b in ${concatStringsSep " " exes}; do
+        wrapProgram "$out/bin/$b" --set GDK_PIXBUF_MODULE_FILE "$GDK_PIXBUF_MODULE_FILE"
+      done
+    '';
 
-    # Fix builds with newer glibc version
-    sed -i "1 i#define _BITS_FLOATN_H" "$out/include/host_defines.h"
-  '' +
-  # Point NVCC at a compatible compiler
-  # FIXME: redist cuda_nvcc copy-pastes this code
-  # Refer to comments in the overrides for cuda_nvcc for explanation
-  # CUDA_TOOLKIT_ROOT_DIR is legacy,
-  # Cf. https://cmake.org/cmake/help/latest/module/FindCUDA.html#input-variables
-  # NOTE: We unconditionally set -Xfatbin=-compress-all, which reduces the size of the compiled
-  #   binaries. If binaries grow over 2GB, they will fail to link. This is a problem for us, as
-  #   the default set of CUDA capabilities we build can regularly cause this to occur (for
-  #   example, with Magma).
-  ''
-    mkdir -p $out/nix-support
-    cat <<EOF >> $out/nix-support/setup-hook
-    cmakeFlags+=' -DCUDA_TOOLKIT_ROOT_DIR=$out'
-    cmakeFlags+=' -DCUDA_HOST_COMPILER=${backendStdenv.cc}/bin'
-    cmakeFlags+=' -DCMAKE_CUDA_HOST_COMPILER=${backendStdenv.cc}/bin'
-    if [ -z "\''${CUDAHOSTCXX-}" ]; then
-      export CUDAHOSTCXX=${backendStdenv.cc}/bin;
-    fi
-    export NVCC_PREPEND_FLAGS+=' --compiler-bindir=${backendStdenv.cc}/bin -Xfatbin=-compress-all'
-    EOF
+    # cuda-gdb doesn't run correctly when not using sandboxing, so
+    # temporarily disabling the install check.  This should be set to true
+    # when we figure out how to get `cuda-gdb --version` to run correctly
+    # when not using sandboxing.
+    doInstallCheck = false;
+    postInstallCheck = ''
+      # Smoke test binaries
+      pushd $out/bin
+      for f in *; do
+        case $f in
+          crt)                           continue;;
+          nvcc.profile)                  continue;;
+          nsight_ee_plugins_manage.sh)   continue;;
+          uninstall_cuda_toolkit_6.5.pl) continue;;
+          computeprof|nvvp|nsight)       continue;; # GUIs don't feature "--version"
+          *)                             echo "Executing '$f --version':"; ./$f --version;;
+        esac
+      done
+      popd
+    '';
+    passthru = {
+      inherit (backendStdenv) cc;
+      majorMinorVersion = majorMinor version;
+      majorVersion = major version;
+    };
 
-    # Move some libraries to the lib output so that programs that
-    # depend on them don't pull in this entire monstrosity.
-    mkdir -p $lib/lib
-    mv -v $out/lib64/libcudart* $lib/lib/
-
-    # Remove OpenCL libraries as they are provided by ocl-icd and driver.
-    rm -f $out/lib64/libOpenCL*
-    ${lib.optionalString (lib.versionAtLeast version "10.1" && (lib.versionOlder version "11")) ''
-      mv $out/lib64 $out/lib
-      mv $out/extras/CUPTI/lib64/libcupti* $out/lib
-    ''}
-
-    # nvprof do not find any program to profile if LD_LIBRARY_PATH is not set
-    wrapProgram $out/bin/nvprof \
-      --prefix LD_LIBRARY_PATH : $out/lib
-  '' + lib.optionalString (lib.versionOlder version "8.0") ''
-    # Hack to fix building against recent Glibc/GCC.
-    echo "NIX_CFLAGS_COMPILE+=' -D_FORCE_INLINES'" >> $out/nix-support/setup-hook
-  ''
-  # 11.8 includes a broken symlink, include/include, pointing to targets/x86_64-linux/include
-  + lib.optionalString (lib.versions.majorMinor version == "11.8") ''
-    rm $out/include/include
-  '' + ''
-    runHook postInstall
-  '';
-
-  postInstall = ''
-    for b in nvvp ${lib.optionalString (lib.versionOlder version "11") "nsight"}; do
-      wrapProgram "$out/bin/$b" \
-        --set GDK_PIXBUF_MODULE_FILE "$GDK_PIXBUF_MODULE_FILE"
-    done
-  '';
-
-
-  # cuda-gdb doesn't run correctly when not using sandboxing, so
-  # temporarily disabling the install check.  This should be set to true
-  # when we figure out how to get `cuda-gdb --version` to run correctly
-  # when not using sandboxing.
-  doInstallCheck = false;
-  postInstallCheck = let
-  in ''
-    # Smoke test binaries
-    pushd $out/bin
-    for f in *; do
-      case $f in
-        crt)                           continue;;
-        nvcc.profile)                  continue;;
-        nsight_ee_plugins_manage.sh)   continue;;
-        uninstall_cuda_toolkit_6.5.pl) continue;;
-        computeprof|nvvp|nsight)       continue;; # GUIs don't feature "--version"
-        *)                             echo "Executing '$f --version':"; ./$f --version;;
-      esac
-    done
-    popd
-  '';
-  passthru = {
-    inherit (backendStdenv) cc;
-    majorMinorVersion = lib.versions.majorMinor version;
-    majorVersion = lib.versions.majorMinor version;
-  };
-
-  meta = with lib; {
-    description = "A compiler for NVIDIA GPUs, math libraries, and tools";
-    homepage = "https://developer.nvidia.com/cuda-toolkit";
-    platforms = [ "x86_64-linux" ];
-    license = licenses.unfree;
-    maintainers = teams.cuda.members;
-  };
-}
-
+    meta = with lib; {
+      inherit broken;
+      description = "A compiler for NVIDIA GPUs, math libraries, and tools";
+      homepage = "https://developer.nvidia.com/cuda-toolkit";
+      platforms = ["x86_64-linux"];
+      license = licenses.unfree;
+      maintainers = teams.cuda.members;
+    };
+  }

--- a/pkgs/development/compilers/cudatoolkit/flags.nix
+++ b/pkgs/development/compilers/cudatoolkit/flags.nix
@@ -8,7 +8,7 @@
 #   - See the documentation in ./gpus.nix.
 
 let
-  inherit (lib) attrsets lists strings trivial versions;
+  inherit (lib) lists strings;
 
   # Flags are determined based on your CUDA toolkit by default.  You may benefit
   # from improved performance, reduced file size, or greater hardware support by
@@ -136,7 +136,7 @@ let
         base = gencodeMapper "sm" cudaCapabilities;
         forward = gencodeMapper "compute" [ (lists.last cudaCapabilities) ];
       in
-      base ++ lib.optionals enableForwardCompat forward;
+      base ++ lists.optionals enableForwardCompat forward;
   };
 
 in
@@ -161,6 +161,11 @@ assert (formatCapabilities { cudaCapabilities = [ "7.5" "8.6" ]; }) == {
 
   # cudaComputeCapabilityToName :: String => String
   inherit cudaComputeCapabilityToName;
+
+  # Note: Rather than enforce cudaSupportedCapabilities be non-empty here with an assert, we mark
+  #   the packages in cudaPackages as broken.
+  # cudaSupportedCapabilities :: List Capability
+  cudaSupportedCapabilities = supportedCapabilities;
 
   # dropDot :: String -> String
   inherit dropDot;

--- a/pkgs/development/compilers/cudatoolkit/redist/build-cuda-redist-package.nix
+++ b/pkgs/development/compilers/cudatoolkit/redist/build-cuda-redist-package.nix
@@ -1,66 +1,88 @@
-{ lib
-, stdenv
-, backendStdenv
-, fetchurl
-, autoPatchelfHook
-, autoAddOpenGLRunpathHook
-}:
-
-pname:
-attrs:
-
-let
+{
+  autoAddOpenGLRunpathHook,
+  autoPatchelfHook,
+  backendStdenv,
+  cudaFlags,
+  cudaVersion,
+  fetchurl,
+  lib,
+  stdenv,
+}: pname: attrs: let
+  inherit (lib) attrsets lists strings trivial;
   arch = "linux-x86_64";
+
+  # unsupportedCapabilities :: List Capability
+  unsupportedCapabilities =
+    lists.filter
+    (computeCapability: !lists.elem computeCapability cudaFlags.cudaSupportedCapabilities)
+    cudaFlags.cudaCapabilities;
+
+  # broken :: Bool
+  broken = let
+    isBroken = unsupportedCapabilities != [];
+  in
+    trivial.warnIf
+    isBroken
+    ''
+      CUDA ${cudaVersion} supports the following capabilities:
+        ${strings.concatStringsSep ", " cudaFlags.cudaSupportedCapabilities}
+      However, the following unsupported capabilities were requested:
+        ${strings.concatStringsSep ", " unsupportedCapabilities}
+      This means that packages relying on this version of CUDA are not available.
+      If possible, consider upgrading to a newer version of CUDA.
+    ''
+    isBroken;
 in
-backendStdenv.mkDerivation {
-  inherit pname;
-  inherit (attrs) version;
+  backendStdenv.mkDerivation {
+    inherit pname;
+    inherit (attrs) version;
 
-  src = assert (lib.hasAttr arch attrs); fetchurl {
-    url = "https://developer.download.nvidia.com/compute/cuda/redist/${attrs.${arch}.relative_path}";
-    inherit (attrs.${arch}) sha256;
-  };
+    src = fetchurl {
+      url = "https://developer.download.nvidia.com/compute/cuda/redist/${attrs.${arch}.relative_path}";
+      inherit (attrs.${arch}) sha256;
+    };
 
-  nativeBuildInputs = [
-    autoPatchelfHook
-    # This hook will make sure libcuda can be found
-    # in typically /lib/opengl-driver by adding that
-    # directory to the rpath of all ELF binaries.
-    # Check e.g. with `patchelf --print-rpath path/to/my/binary
-    autoAddOpenGLRunpathHook
-  ];
+    nativeBuildInputs = [
+      autoPatchelfHook
+      # This hook will make sure libcuda can be found
+      # in typically /lib/opengl-driver by adding that
+      # directory to the rpath of all ELF binaries.
+      # Check e.g. with `patchelf --print-rpath path/to/my/binary
+      autoAddOpenGLRunpathHook
+    ];
 
-  buildInputs = [
-    # autoPatchelfHook will search for a libstdc++ and we're giving it
-    # one that is compatible with the rest of nixpkgs, even when
-    # nvcc forces us to use an older gcc
-    # NB: We don't actually know if this is the right thing to do
-    stdenv.cc.cc.lib
-  ];
+    buildInputs = [
+      # autoPatchelfHook will search for a libstdc++ and we're giving it
+      # one that is compatible with the rest of nixpkgs, even when
+      # nvcc forces us to use an older gcc
+      # NB: We don't actually know if this is the right thing to do
+      stdenv.cc.cc.lib
+    ];
 
-  # Picked up by autoPatchelf
-  # Needed e.g. for libnvrtc to locate (dlopen) libnvrtc-builtins
-  appendRunpaths = [
-    "$ORIGIN"
-  ];
+    # Picked up by autoPatchelf
+    # Needed e.g. for libnvrtc to locate (dlopen) libnvrtc-builtins
+    appendRunpaths = [
+      "$ORIGIN"
+    ];
 
-  dontBuild = true;
+    dontBuild = true;
 
-  # TODO: choose whether to install static/dynamic libs
-  installPhase = ''
-    runHook preInstall
-    rm LICENSE
-    mkdir -p $out
-    mv * $out
-    runHook postInstall
-  '';
+    # TODO: choose whether to install static/dynamic libs
+    installPhase = ''
+      runHook preInstall
+      rm LICENSE
+      mkdir -p $out
+      mv * $out
+      runHook postInstall
+    '';
 
-  passthru.stdenv = backendStdenv;
+    passthru.stdenv = backendStdenv;
 
-  meta = {
-    description = attrs.name;
-    license = lib.licenses.unfree;
-    maintainers = lib.teams.cuda.members;
-    platforms = lib.optionals (lib.hasAttr arch attrs) [ "x86_64-linux" ];
-  };
-}
+    meta = {
+      inherit broken;
+      description = attrs.name;
+      license = lib.licenses.unfree;
+      maintainers = lib.teams.cuda.members;
+      platforms = lists.optionals (attrsets.hasAttr arch attrs) ["x86_64-linux"];
+    };
+  }


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

> **Note**
> Converted to a draft while I finish up and simplify.

- Marks packages in `cudaPackages` as broken if the requested compute capabilities (either from `config` or from `defaultCapabilities`) are not provided by the requested version.
- Adds `cudaSupportedCapabilities` as an attribute to `cudaFlags`, providing visibility into the versions supported by a particular CUDA release.
- Refactors `common.nix` used to build `cudaPackages.cudatoolkit` to avoid using `rec` and explicitly imports commonly used functions.

There is duplication which I'm not entirely happy with, but in my opinion it's better than what we have currently.

Previously, with the following `config.nix`,

```nix
{
  allowUnfree = true;
  cudaSupport = true;
  cudaCapabilities = [ "8.9" ];
  cudaForwardCompat = false;
}
```

such errors would be discovered by NVCC failing to build a binary for the unsupported capability. Here's an attempt to build `magma`:

```console
$ nix build --impure -L .#magma
magma> unpacking sources
magma> unpacking source archive /nix/store/vmjzj2qmqsrn4s8davbd3p9plf777ihf-magma-2.7.1.tar.gz
magma> source root is magma-2.7.1
magma> setting SOURCE_DATE_EPOCH to timestamp 1677097364 of file magma-2.7.1/Makefile
magma> patching sources
magma> configuring
magma> fixing cmake files...
magma> cmake flags: -GNinja -DCMAKE_FIND_USE_SYSTEM_PACKAGE_REGISTRY=OFF -DCMAKE_FIND_USE_PACKAGE_REGISTRY=OFF -DCMAKE_EXPORT_NO_PACKAGE_REGISTRY=ON -DCMAKE_BUILD_TYPE=Release -DBUILD_TESTING=OFF -DCMAKE_INSTALL_LOCALEDIR=/nix/store/ys9k6xrksjx5abn7qqkl34czxhqxldjp-magma-2.7.1/share/locale -DCMAKE_INSTALL_LIBEXECDIR=/nix/store/ys9k6xrksjx5abn7qqkl34czxhqxldjp-magma-2.7.1/libexec -DCMAKE_INSTALL_LIBDIR=/nix/store/ys9k6xrksjx5abn7qqkl34czxhqxldjp-magma-2.7.1/lib -DCMAKE_INSTALL_DOCDIR=/nix/store/ys9k6xrksjx5abn7qqkl34czxhqxldjp-magma-2.7.1/share/doc/MAGMA -DCMAKE_INSTALL_INFODIR=/nix/store/ys9k6xrksjx5abn7qqkl34czxhqxldjp-magma-2.7.1/share/info -DCMAKE_INSTALL_MANDIR=/nix/store/ys9k6xrksjx5abn7qqkl34czxhqxldjp-magma-2.7.1/share/man -DCMAKE_INSTALL_OLDINCLUDEDIR=/nix/store/ys9k6xrksjx5abn7qqkl34czxhqxldjp-magma-2.7.1/include -DCMAKE_INSTALL_INCLUDEDIR=/nix/store/ys9k6xrksjx5abn7qqkl34czxhqxldjp-magma-2.7.1/include -DCMAKE_INSTALL_SBINDIR=/nix/store/ys9k6xrksjx5abn7qqkl34czxhqxldjp-magma-2.7.1/sbin -DCMAKE_INSTALL_BINDIR=/nix/store/ys9k6xrksjx5abn7qqkl34czxhqxldjp-magma-2.7.1/bin -DCMAKE_INSTALL_NAME_DIR=/nix/store/ys9k6xrksjx5abn7qqkl34czxhqxldjp-magma-2.7.1/lib -DCMAKE_POLICY_DEFAULT_CMP0025=NEW -DCMAKE_OSX_SYSROOT= -DCMAKE_FIND_FRAMEWORK=LAST -DCMAKE_STRIP=/nix/store/jd2jamjrg7mwp19591r90m1wh5if3nay-gfortran-wrapper-12.2.0/bin/strip -DCMAKE_RANLIB=/nix/store/jd2jamjrg7mwp19591r90m1wh5if3nay-gfortran-wrapper-12.2.0/bin/ranlib -DCMAKE_AR=/nix/store/jd2jamjrg7mwp19591r90m1wh5if3nay-gfortran-wrapper-12.2.0/bin/ar -DCMAKE_C_COMPILER=gcc -DCMAKE_CXX_COMPILER=g++ -DCMAKE_INSTALL_PREFIX=/nix/store/ys9k6xrksjx5abn7qqkl34czxhqxldjp-magma-2.7.1 -DGPU_TARGET= -DCMAKE_CUDA_ARCHITECTURES=89 -DMIN_ARCH=890 -DCMAKE_C_COMPILER=/nix/store/rai3zb3njw7n2riba6c8h66rgy6k1rzc-gcc-wrapper-11.3.0/bin/cc -DCMAKE_CXX_COMPILER=/nix/store/rai3zb3njw7n2riba6c8h66rgy6k1rzc-gcc-wrapper-11.3.0/bin/c++ -DMAGMA_ENABLE_CUDA=ON -DCUDA_HOST_COMPILER=/nix/store/rai3zb3njw7n2riba6c8h66rgy6k1rzc-gcc-wrapper-11.3.0/bin -DCMAKE_CUDA_HOST_COMPILER=/nix/store/rai3zb3njw7n2riba6c8h66rgy6k1rzc-gcc-wrapper-11.3.0/bin
magma> -- The C compiler identification is GNU 11.3.0
magma> -- The CXX compiler identification is GNU 11.3.0
magma> -- The Fortran compiler identification is GNU 12.2.0
magma> -- Detecting C compiler ABI info
magma> -- Detecting C compiler ABI info - done
magma> -- Check for working C compiler: /nix/store/rai3zb3njw7n2riba6c8h66rgy6k1rzc-gcc-wrapper-11.3.0/bin/cc - skipped
magma> -- Detecting C compile features
magma> -- Detecting C compile features - done
magma> -- Detecting CXX compiler ABI info
magma> -- Detecting CXX compiler ABI info - done
magma> -- Check for working CXX compiler: /nix/store/rai3zb3njw7n2riba6c8h66rgy6k1rzc-gcc-wrapper-11.3.0/bin/c++ - skipped
magma> -- Detecting CXX compile features
magma> -- Detecting CXX compile features - done
magma> -- Detecting Fortran compiler ABI info
magma> -- Detecting Fortran compiler ABI info - done
magma> -- Check for working Fortran compiler: /nix/store/jd2jamjrg7mwp19591r90m1wh5if3nay-gfortran-wrapper-12.2.0/bin/gfortran - skipped
magma> -- Performing Test COMPILER_SUPPORTS_CXX11
magma> -- Performing Test COMPILER_SUPPORTS_CXX11 - Success
magma> -- Performing Test COMPILER_SUPPORTS_CXX0X
magma> -- Performing Test COMPILER_SUPPORTS_CXX0X - Success
magma> -- Performing Test COMPILER_SUPPORTS_FPIC
magma> -- Performing Test COMPILER_SUPPORTS_FPIC - Success
magma> -- Performing Test COMPILER_SUPPORTS_C99
magma> -- Performing Test COMPILER_SUPPORTS_C99 - Success
magma> -- Detecting Fortran/C Interface
magma> -- Detecting Fortran/C Interface - Found GLOBAL and MODULE mangling
magma> -- Found OpenMP_C: -fopenmp (found version "4.5")
magma> -- Found OpenMP_CXX: -fopenmp (found version "4.5")
magma> -- Found OpenMP_Fortran: -fopenmp (found version "4.5")
magma> -- Found OpenMP: TRUE (found version "4.5")
magma> -- Found OpenMP
magma> --     OpenMP_C_FLAGS   -fopenmp
magma> --     OpenMP_CXX_FLAGS -fopenmp
magma> -- The CUDA compiler identification is NVIDIA 11.7.64
magma> -- Detecting CUDA compiler ABI info
magma> -- Detecting CUDA compiler ABI info - failed
magma> -- Check for working CUDA compiler: /nix/store/9vnwi402zlcd47n5hffkxz3hhr31z5hb-cuda-native-redist-11.7/bin/nvcc
magma> -- Check for working CUDA compiler: /nix/store/9vnwi402zlcd47n5hffkxz3hhr31z5hb-cuda-native-redist-11.7/bin/nvcc - broken
magma> CMake Error at /nix/store/fic9avx8yabwb3ib8m49ld3kq9fkwwwd-cmake-3.25.3/share/cmake-3.25/Modules/CMakeTestCUDACompiler.cmake:103 (message):
magma>   The CUDA compiler
magma>     "/nix/store/9vnwi402zlcd47n5hffkxz3hhr31z5hb-cuda-native-redist-11.7/bin/nvcc"
magma>   is not able to compile a simple test program.
magma>   It fails with the following output:
magma>     Change Dir: /build/magma-2.7.1/build/CMakeFiles/CMakeScratch/TryCompile-BemqXw
magma>     Run Build Command(s):/nix/store/rcakkm09fivblba082qb6jch02926qhq-ninja-1.11.1/bin/ninja cmTC_b80b7 && [1/2] Building CUDA object CMakeFiles/cmTC_b80b7.dir/main.cu.o
magma>     FAILED: CMakeFiles/cmTC_b80b7.dir/main.cu.o
magma>     /nix/store/9vnwi402zlcd47n5hffkxz3hhr31z5hb-cuda-native-redist-11.7/bin/nvcc -forward-unknown-to-host-compiler -ccbin=/nix/store/rai3zb3njw7n2riba6c8h66rgy6k1rzc-gcc-wrapper-11.3.0/bin   -O3 -DNDEBUG --generate-code=arch=compute_89,code=[compute_89,sm_89] -MD -MT CMakeFiles/cmTC_b80b7.dir/main.cu.o -MF CMakeFiles/cmTC_b80b7.dir/main.cu.o.d -x cu -c /build/magma-2.7.1/build/CMakeFiles/CMakeScratch/TryCompile-BemqXw/main.cu -o CMakeFiles/cmTC_b80b7.dir/main.cu.o
magma>     nvcc fatal   : Unsupported gpu architecture 'compute_89'
magma>     ninja: build stopped: subcommand failed.
magma>   CMake will not be able to correctly generate this project.
magma> Call Stack (most recent call first):
magma>   CMakeLists.txt:116 (enable_language)
magma> 
magma> -- Configuring incomplete, errors occurred!
magma> See also "/build/magma-2.7.1/build/CMakeFiles/CMakeOutput.log".
magma> See also "/build/magma-2.7.1/build/CMakeFiles/CMakeError.log".
error: builder for '/nix/store/pbhrw4cv5h5f85nvgam0l5l3kdlrly2s-magma-2.7.1.drv' failed with exit code 1
```

With this change, we now receive an error when attempting to build Magma with the default version of CUDA:

```console
$ nix build --impure -L .#magma
warning: Git tree '/home/connorbaker/Documents/nixpkgs' is dirty
trace: warning: CUDA 11.7 supports the following capabilities:
  3.5, 3.7, 5.0, 5.2, 5.3, 6.0, 6.1, 6.2, 7.0, 7.2, 7.5, 8.0, 8.6, 8.7
However, the following unsupported capabilities were requested:
  8.9
This means that packages relying on this version of CUDA are not available.
If possible, consider upgrading to a newer version of CUDA.

error:
       … while calling the 'derivationStrict' builtin

         at /builtin/derivation.nix:9:12: (source not available)

       … while evaluating derivation 'magma-2.7.1'
         whose name attribute is located at /nix/store/2hzmcyn14sdak3pkmzpdx455z5y53ia8-source/pkgs/stdenv/generic/make-derivation.nix:303:7

       … while evaluating attribute 'buildInputs' of derivation 'magma-2.7.1'

         at /nix/store/2hzmcyn14sdak3pkmzpdx455z5y53ia8-source/pkgs/stdenv/generic/make-derivation.nix:350:7:

          349|       depsHostHost                = lib.elemAt (lib.elemAt dependencies 1) 0;
          350|       buildInputs                 = lib.elemAt (lib.elemAt dependencies 1) 1;
             |       ^
          351|       depsTargetTarget            = lib.elemAt (lib.elemAt dependencies 2) 0;

       (stack trace truncated; use '--show-trace' to show the full trace)

       error: Package ‘libcublas-11.10.1.25’ in /nix/store/2hzmcyn14sdak3pkmzpdx455z5y53ia8-source/pkgs/development/compilers/cudatoolkit/redist/build-cuda-redist-package.nix:83 is marked as broken, refusing to evaluate.

       a) To temporarily allow broken packages, you can use an environment variable
          for a single invocation of the nix tools.

            $ export NIXPKGS_ALLOW_BROKEN=1

        Note: For `nix shell`, `nix build`, `nix develop` or any other Nix 2.4+
        (Flake) command, `--impure` must be passed in order to read this
        environment variable.

       b) For `nixos-rebuild` you can set
         { nixpkgs.config.allowBroken = true; }
       in configuration.nix to override this.

       c) For `nix-env`, `nix-build`, `nix-shell` or any other Nix command you can add
         { allowBroken = true; }
       to ~/.config/nixpkgs/config.nix.
```

If we were in doubt, we can evaluate `cudaFlags.cudaSupportedCapabilities` with the default version of CUDA to confirm that it does not support 8.9:

```console
$ nix eval --impure .#cudaPackages.cudaFlags.cudaSupportedCapabilities
[ "3.5" "3.7" "5.0" "5.2" "5.3" "6.0" "6.1" "6.2" "7.0" "7.2" "7.5" "8.0" "8.6" "8.7" ]
```

Compare this with the error we would receive trying to build `magma` without this change:

```console
$ nix build --impure -L .#magma
magma> unpacking sources
magma> unpacking source archive /nix/store/vmjzj2qmqsrn4s8davbd3p9plf777ihf-magma-2.7.1.tar.gz
magma> source root is magma-2.7.1
magma> setting SOURCE_DATE_EPOCH to timestamp 1677097364 of file magma-2.7.1/Makefile
magma> patching sources
magma> configuring
magma> fixing cmake files...
magma> cmake flags: -GNinja -DCMAKE_FIND_USE_SYSTEM_PACKAGE_REGISTRY=OFF -DCMAKE_FIND_USE_PACKAGE_REGISTRY=OFF -DCMAKE_EXPORT_NO_PACKAGE_REGISTRY=ON -DCMAKE_BUILD_TYPE=Release -DBUILD_TESTING=OFF -DCMAKE_INSTALL_LOCALEDIR=/nix/store/ys9k6xrksjx5abn7qqkl34czxhqxldjp-magma-2.7.1/share/locale -DCMAKE_INSTALL_LIBEXECDIR=/nix/store/ys9k6xrksjx5abn7qqkl34czxhqxldjp-magma-2.7.1/libexec -DCMAKE_INSTALL_LIBDIR=/nix/store/ys9k6xrksjx5abn7qqkl34czxhqxldjp-magma-2.7.1/lib -DCMAKE_INSTALL_DOCDIR=/nix/store/ys9k6xrksjx5abn7qqkl34czxhqxldjp-magma-2.7.1/share/doc/MAGMA -DCMAKE_INSTALL_INFODIR=/nix/store/ys9k6xrksjx5abn7qqkl34czxhqxldjp-magma-2.7.1/share/info -DCMAKE_INSTALL_MANDIR=/nix/store/ys9k6xrksjx5abn7qqkl34czxhqxldjp-magma-2.7.1/share/man -DCMAKE_INSTALL_OLDINCLUDEDIR=/nix/store/ys9k6xrksjx5abn7qqkl34czxhqxldjp-magma-2.7.1/include -DCMAKE_INSTALL_INCLUDEDIR=/nix/store/ys9k6xrksjx5abn7qqkl34czxhqxldjp-magma-2.7.1/include -DCMAKE_INSTALL_SBINDIR=/nix/store/ys9k6xrksjx5abn7qqkl34czxhqxldjp-magma-2.7.1/sbin -DCMAKE_INSTALL_BINDIR=/nix/store/ys9k6xrksjx5abn7qqkl34czxhqxldjp-magma-2.7.1/bin -DCMAKE_INSTALL_NAME_DIR=/nix/store/ys9k6xrksjx5abn7qqkl34czxhqxldjp-magma-2.7.1/lib -DCMAKE_POLICY_DEFAULT_CMP0025=NEW -DCMAKE_OSX_SYSROOT= -DCMAKE_FIND_FRAMEWORK=LAST -DCMAKE_STRIP=/nix/store/jd2jamjrg7mwp19591r90m1wh5if3nay-gfortran-wrapper-12.2.0/bin/strip -DCMAKE_RANLIB=/nix/store/jd2jamjrg7mwp19591r90m1wh5if3nay-gfortran-wrapper-12.2.0/bin/ranlib -DCMAKE_AR=/nix/store/jd2jamjrg7mwp19591r90m1wh5if3nay-gfortran-wrapper-12.2.0/bin/ar -DCMAKE_C_COMPILER=gcc -DCMAKE_CXX_COMPILER=g++ -DCMAKE_INSTALL_PREFIX=/nix/store/ys9k6xrksjx5abn7qqkl34czxhqxldjp-magma-2.7.1 -DGPU_TARGET= -DCMAKE_CUDA_ARCHITECTURES=89 -DMIN_ARCH=890 -DCMAKE_C_COMPILER=/nix/store/rai3zb3njw7n2riba6c8h66rgy6k1rzc-gcc-wrapper-11.3.0/bin/cc -DCMAKE_CXX_COMPILER=/nix/store/rai3zb3njw7n2riba6c8h66rgy6k1rzc-gcc-wrapper-11.3.0/bin/c++ -DMAGMA_ENABLE_CUDA=ON -DCUDA_HOST_COMPILER=/nix/store/rai3zb3njw7n2riba6c8h66rgy6k1rzc-gcc-wrapper-11.3.0/bin -DCMAKE_CUDA_HOST_COMPILER=/nix/store/rai3zb3njw7n2riba6c8h66rgy6k1rzc-gcc-wrapper-11.3.0/bin
magma> -- The C compiler identification is GNU 11.3.0
magma> -- The CXX compiler identification is GNU 11.3.0
magma> -- The Fortran compiler identification is GNU 12.2.0
magma> -- Detecting C compiler ABI info
magma> -- Detecting C compiler ABI info - done
magma> -- Check for working C compiler: /nix/store/rai3zb3njw7n2riba6c8h66rgy6k1rzc-gcc-wrapper-11.3.0/bin/cc - skipped
magma> -- Detecting C compile features
magma> -- Detecting C compile features - done
magma> -- Detecting CXX compiler ABI info
magma> -- Detecting CXX compiler ABI info - done
magma> -- Check for working CXX compiler: /nix/store/rai3zb3njw7n2riba6c8h66rgy6k1rzc-gcc-wrapper-11.3.0/bin/c++ - skipped
magma> -- Detecting CXX compile features
magma> -- Detecting CXX compile features - done
magma> -- Detecting Fortran compiler ABI info
magma> -- Detecting Fortran compiler ABI info - done
magma> -- Check for working Fortran compiler: /nix/store/jd2jamjrg7mwp19591r90m1wh5if3nay-gfortran-wrapper-12.2.0/bin/gfortran - skipped
magma> -- Performing Test COMPILER_SUPPORTS_CXX11
magma> -- Performing Test COMPILER_SUPPORTS_CXX11 - Success
magma> -- Performing Test COMPILER_SUPPORTS_CXX0X
magma> -- Performing Test COMPILER_SUPPORTS_CXX0X - Success
magma> -- Performing Test COMPILER_SUPPORTS_FPIC
magma> -- Performing Test COMPILER_SUPPORTS_FPIC - Success
magma> -- Performing Test COMPILER_SUPPORTS_C99
magma> -- Performing Test COMPILER_SUPPORTS_C99 - Success
magma> -- Detecting Fortran/C Interface
magma> -- Detecting Fortran/C Interface - Found GLOBAL and MODULE mangling
magma> -- Found OpenMP_C: -fopenmp (found version "4.5")
magma> -- Found OpenMP_CXX: -fopenmp (found version "4.5")
magma> -- Found OpenMP_Fortran: -fopenmp (found version "4.5")
magma> -- Found OpenMP: TRUE (found version "4.5")
magma> -- Found OpenMP
magma> --     OpenMP_C_FLAGS   -fopenmp
magma> --     OpenMP_CXX_FLAGS -fopenmp
magma> -- The CUDA compiler identification is NVIDIA 11.7.64
magma> -- Detecting CUDA compiler ABI info
magma> -- Detecting CUDA compiler ABI info - failed
magma> -- Check for working CUDA compiler: /nix/store/9vnwi402zlcd47n5hffkxz3hhr31z5hb-cuda-native-redist-11.7/bin/nvcc
magma> -- Check for working CUDA compiler: /nix/store/9vnwi402zlcd47n5hffkxz3hhr31z5hb-cuda-native-redist-11.7/bin/nvcc - broken
magma> CMake Error at /nix/store/fic9avx8yabwb3ib8m49ld3kq9fkwwwd-cmake-3.25.3/share/cmake-3.25/Modules/CMakeTestCUDACompiler.cmake:103 (message):
magma>   The CUDA compiler
magma>     "/nix/store/9vnwi402zlcd47n5hffkxz3hhr31z5hb-cuda-native-redist-11.7/bin/nvcc"
magma>   is not able to compile a simple test program.
magma>   It fails with the following output:
magma>     Change Dir: /build/magma-2.7.1/build/CMakeFiles/CMakeScratch/TryCompile-BemqXw
magma>     Run Build Command(s):/nix/store/rcakkm09fivblba082qb6jch02926qhq-ninja-1.11.1/bin/ninja cmTC_b80b7 && [1/2] Building CUDA object CMakeFiles/cmTC_b80b7.dir/main.cu.o
magma>     FAILED: CMakeFiles/cmTC_b80b7.dir/main.cu.o
magma>     /nix/store/9vnwi402zlcd47n5hffkxz3hhr31z5hb-cuda-native-redist-11.7/bin/nvcc -forward-unknown-to-host-compiler -ccbin=/nix/store/rai3zb3njw7n2riba6c8h66rgy6k1rzc-gcc-wrapper-11.3.0/bin   -O3 -DNDEBUG --generate-code=arch=compute_89,code=[compute_89,sm_89] -MD -MT CMakeFiles/cmTC_b80b7.dir/main.cu.o -MF CMakeFiles/cmTC_b80b7.dir/main.cu.o.d -x cu -c /build/magma-2.7.1/build/CMakeFiles/CMakeScratch/TryCompile-BemqXw/main.cu -o CMakeFiles/cmTC_b80b7.dir/main.cu.o
magma>     nvcc fatal   : Unsupported gpu architecture 'compute_89'
magma>     ninja: build stopped: subcommand failed.
magma>   CMake will not be able to correctly generate this project.
magma> Call Stack (most recent call first):
magma>   CMakeLists.txt:116 (enable_language)
magma> 
magma> -- Configuring incomplete, errors occurred!
magma> See also "/build/magma-2.7.1/build/CMakeFiles/CMakeOutput.log".
magma> See also "/build/magma-2.7.1/build/CMakeFiles/CMakeError.log".
error: builder for '/nix/store/pbhrw4cv5h5f85nvgam0l5l3kdlrly2s-magma-2.7.1.drv' failed with exit code 1
````

Another example, this time attempting to build `python3Packages.torch`, which relies on `cudaPackages.cudaToolkit`:

```console
$ nix build --impure -L .#python3Packages.torch
warning: Git tree '/home/connorbaker/Documents/nixpkgs' is dirty
trace: warning: CUDA 11.7.0 supports the following capabilities:
  3.5, 3.7, 5.0, 5.2, 5.3, 6.0, 6.1, 6.2, 7.0, 7.2, 7.5, 8.0, 8.6, 8.7
However, the following unsupported capabilities were requested:
  8.9
This means that packages relying on this version of CUDA are not available.
If possible, consider upgrading to a newer version of CUDA.

error:
       … while evaluating a branch condition

         at /nix/store/2hzmcyn14sdak3pkmzpdx455z5y53ia8-source/pkgs/development/interpreters/python/default.nix:41:13:

           40|           func = name: value:
           41|             if lib.isDerivation value then
             |             ^
           42|               lib.extendDerivation (valid value || throw "${name} should use `buildPythonPackage` or `toPythonModule` if it is to be part of the Python packages set.") {} value

       … while evaluating a branch condition

         at /nix/store/2hzmcyn14sdak3pkmzpdx455z5y53ia8-source/lib/customisation.nix:92:7:

           91|     in
           92|       if builtins.isAttrs result then
             |       ^
           93|         result // {

       (stack trace truncated; use '--show-trace' to show the full trace)

       error: Package ‘cudatoolkit-11.7.0’ in /nix/store/2hzmcyn14sdak3pkmzpdx455z5y53ia8-source/pkgs/development/compilers/cudatoolkit/common.nix:371 is marked as broken, refusing to evaluate.

       a) To temporarily allow broken packages, you can use an environment variable
          for a single invocation of the nix tools.

            $ export NIXPKGS_ALLOW_BROKEN=1

        Note: For `nix shell`, `nix build`, `nix develop` or any other Nix 2.4+
        (Flake) command, `--impure` must be passed in order to read this
        environment variable.

       b) For `nixos-rebuild` you can set
         { nixpkgs.config.allowBroken = true; }
       in configuration.nix to override this.

       c) For `nix-env`, `nix-build`, `nix-shell` or any other Nix command you can add
         { allowBroken = true; }
       to ~/.config/nixpkgs/config.nix.
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
