### PR TITLE
[23.05] prismlauncher: expose parameters of unwrapped package, prismlauncher: enable PIE, prismlauncher: allow empty msaClientID, prismlauncher: simplify postUnpack, prismlauncher: introduce unwrapped packages

### DIFF
--- a/pkgs/games/prismlauncher/default.nix
+++ b/pkgs/games/prismlauncher/default.nix
@@ -47,10 +47,7 @@ stdenv.mkDerivation rec {
 
   postUnpack = ''
     rm -rf source/libraries/libnbtplusplus
-    mkdir source/libraries/libnbtplusplus
-    ln -s ${libnbtplusplus}/* source/libraries/libnbtplusplus
-    chmod -R +r+w source/libraries/libnbtplusplus
-    chown -R $USER: source/libraries/libnbtplusplus
+    ln -s ${libnbtplusplus} source/libraries/libnbtplusplus
   '';
 
   dontWrapQtApps = true;

--- a/pkgs/games/prismlauncher/default.nix
+++ b/pkgs/games/prismlauncher/default.nix
@@ -3,29 +3,17 @@
 , fetchFromGitHub
 , cmake
 , ninja
-, jdk8
 , jdk17
 , zlib
-, file
-, wrapQtAppsHook
-, xorg
-, libpulseaudio
 , qtbase
-, qtsvg
-, qtwayland
-, libGL
 , quazip
-, glfw
-, openal
 , extra-cmake-modules
 , tomlplusplus
 , ghc_filesystem
-, msaClientID ? ""
-, jdks ? [ jdk17 jdk8 ]
-, gamemodeSupport ? true
 , gamemode
+, msaClientID ? ""
+, gamemodeSupport ? true
 }:
-
 let
   libnbtplusplus = fetchFromGitHub {
     owner = "PrismLauncher";
@@ -34,9 +22,8 @@ let
     sha256 = "sha256-TvVOjkUobYJD9itQYueELJX3wmecvEdCbJ0FinW2mL4=";
   };
 in
-
 stdenv.mkDerivation rec {
-  pname = "prismlauncher";
+  pname = "prismlauncher-unwrapped";
   version = "6.3";
 
   src = fetchFromGitHub {
@@ -46,17 +33,14 @@ stdenv.mkDerivation rec {
     sha256 = "sha256-7tptHKWkbdxTn6VIPxXE1K3opKRiUW2zv9r6J05dcS8=";
   };
 
-  nativeBuildInputs = [ extra-cmake-modules cmake file jdk17 ninja wrapQtAppsHook ];
+  nativeBuildInputs = [ extra-cmake-modules cmake jdk17 ninja ];
   buildInputs = [
     qtbase
-    qtsvg
     zlib
     quazip
     ghc_filesystem
     tomlplusplus
-  ]
-  ++ lib.optional (lib.versionAtLeast qtbase.version "6") qtwayland
-  ++ lib.optional gamemodeSupport gamemode.dev;
+  ] ++ lib.optional gamemodeSupport gamemode;
 
   cmakeFlags = lib.optionals (msaClientID != "") [ "-DLauncher_MSA_CLIENT_ID=${msaClientID}" ]
     ++ lib.optionals (lib.versionAtLeast qtbase.version "6") [ "-DLauncher_QT_VERSION_MAJOR=6" ];
@@ -69,28 +53,7 @@ stdenv.mkDerivation rec {
     chown -R $USER: source/libraries/libnbtplusplus
   '';
 
-  qtWrapperArgs =
-    let
-      libpath = with xorg;
-        lib.makeLibraryPath ([
-          libX11
-          libXext
-          libXcursor
-          libXrandr
-          libXxf86vm
-          libpulseaudio
-          libGL
-          glfw
-          openal
-          stdenv.cc.cc.lib
-        ] ++ lib.optional gamemodeSupport gamemode.lib);
-    in
-    [
-      "--set LD_LIBRARY_PATH /run/opengl-driver/lib:${libpath}"
-      "--prefix PRISMLAUNCHER_JAVA_PATHS : ${lib.makeSearchPath "bin/java" jdks}"
-      # xorg.xrandr needed for LWJGL [2.9.2, 3) https://github.com/LWJGL/lwjgl/issues/128
-      "--prefix PATH : ${lib.makeBinPath [xorg.xrandr]}"
-    ];
+  dontWrapQtApps = true;
 
   meta = with lib; {
     homepage = "https://prismlauncher.org/";

--- a/pkgs/games/prismlauncher/default.nix
+++ b/pkgs/games/prismlauncher/default.nix
@@ -42,6 +42,8 @@ stdenv.mkDerivation rec {
     tomlplusplus
   ] ++ lib.optional gamemodeSupport gamemode;
 
+  hardeningEnable = [ "pie" ];
+
   cmakeFlags = lib.optionals (msaClientID != null) [ "-DLauncher_MSA_CLIENT_ID=${msaClientID}" ]
     ++ lib.optionals (lib.versionAtLeast qtbase.version "6") [ "-DLauncher_QT_VERSION_MAJOR=6" ];
 

--- a/pkgs/games/prismlauncher/default.nix
+++ b/pkgs/games/prismlauncher/default.nix
@@ -11,7 +11,7 @@
 , tomlplusplus
 , ghc_filesystem
 , gamemode
-, msaClientID ? ""
+, msaClientID ? null
 , gamemodeSupport ? true
 }:
 let
@@ -42,7 +42,7 @@ stdenv.mkDerivation rec {
     tomlplusplus
   ] ++ lib.optional gamemodeSupport gamemode;
 
-  cmakeFlags = lib.optionals (msaClientID != "") [ "-DLauncher_MSA_CLIENT_ID=${msaClientID}" ]
+  cmakeFlags = lib.optionals (msaClientID != null) [ "-DLauncher_MSA_CLIENT_ID=${msaClientID}" ]
     ++ lib.optionals (lib.versionAtLeast qtbase.version "6") [ "-DLauncher_QT_VERSION_MAJOR=6" ];
 
   postUnpack = ''

--- a/pkgs/games/prismlauncher/wrapper.nix
+++ b/pkgs/games/prismlauncher/wrapper.nix
@@ -1,0 +1,74 @@
+{ lib
+, stdenv
+, symlinkJoin
+, prismlauncher-unwrapped
+, wrapQtAppsHook
+, qtbase  # needed for wrapQtAppsHook
+, qtsvg
+, qtwayland
+, xorg
+, libpulseaudio
+, libGL
+, glfw
+, openal
+, jdk8
+, jdk17
+, jdks ? [ jdk17 jdk8 ]
+, gamemode
+, gamemodeSupport ? true
+, additionalLibs ? [ ]
+}:
+let
+  prismlauncherFinal = prismlauncher-unwrapped.override {
+    inherit gamemodeSupport;
+    inherit gamemode;
+  };
+in
+symlinkJoin {
+  name = "prismlauncher-${prismlauncherFinal.version}";
+
+  paths = [ prismlauncherFinal ];
+
+  nativeBuildInputs = [
+    wrapQtAppsHook
+  ];
+
+  buildInputs = [
+    qtbase
+    qtsvg
+  ]
+  ++ lib.optional (lib.versionAtLeast qtbase.version "6") qtwayland;
+
+  postBuild = ''
+    wrapQtAppsHook
+  '';
+
+  qtWrapperArgs =
+    let
+      libs = (with xorg; [
+        libX11
+        libXext
+        libXcursor
+        libXrandr
+        libXxf86vm
+      ])
+      ++ [
+        libpulseaudio
+        libGL
+        glfw
+        openal
+        stdenv.cc.cc.lib
+      ]
+      ++ lib.optional gamemodeSupport gamemode.lib
+      ++ additionalLibs;
+
+    in
+    [
+      "--set LD_LIBRARY_PATH /run/opengl-driver/lib:${lib.makeLibraryPath libs}"
+      "--prefix PRISMLAUNCHER_JAVA_PATHS : ${lib.makeSearchPath "bin/java" jdks}"
+      # xorg.xrandr needed for LWJGL [2.9.2, 3) https://github.com/LWJGL/lwjgl/issues/128
+      "--prefix PATH : ${lib.makeBinPath [xorg.xrandr]}"
+    ];
+
+  inherit (prismlauncherFinal) meta;
+}

--- a/pkgs/games/prismlauncher/wrapper.nix
+++ b/pkgs/games/prismlauncher/wrapper.nix
@@ -13,15 +13,16 @@
 , openal
 , jdk8
 , jdk17
-, jdks ? [ jdk17 jdk8 ]
 , gamemode
+
+, msaClientID ? null
 , gamemodeSupport ? true
+, jdks ? [ jdk17 jdk8 ]
 , additionalLibs ? [ ]
 }:
 let
   prismlauncherFinal = prismlauncher-unwrapped.override {
-    inherit gamemodeSupport;
-    inherit gamemode;
+    inherit msaClientID gamemodeSupport;
   };
 in
 symlinkJoin {

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -36824,9 +36824,13 @@ with pkgs;
 
   principia = callPackage ../games/principia { };
 
-  prismlauncher-qt5 = libsForQt5.callPackage ../games/prismlauncher { };
+  prismlauncher-qt5-unwrapped = libsForQt5.callPackage ../games/prismlauncher { };
 
-  prismlauncher = qt6Packages.callPackage ../games/prismlauncher { };
+  prismlauncher-qt5 = libsForQt5.callPackage ../games/prismlauncher/wrapper.nix { prismlauncher-unwrapped = prismlauncher-qt5-unwrapped; };
+
+  prismlauncher-unwrapped = qt6Packages.callPackage ../games/prismlauncher { };
+
+  prismlauncher = qt6Packages.callPackage ../games/prismlauncher/wrapper.nix { };
 
   pong3d = callPackage ../games/pong3d { };
 


### PR DESCRIPTION
###### Description of changes

this is a backport of https://github.com/NixOS/nixpkgs/pull/229918, which (mainly) introduced unwrapped versions of the packages, PIE being enabled by default, and small improvements to the expression. i think it'd be a good idea to get this into 23.05 for the final release :)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
