### PR TITLE
meson: fix build with case-sensitive store on Darwin

### DIFF
--- a/pkgs/development/tools/build-managers/meson/darwin-case-sensitive-fs.patch
+++ b/pkgs/development/tools/build-managers/meson/darwin-case-sensitive-fs.patch
@@ -1,0 +1,51 @@
+From 1643ed0d8a9201732905bee51b096605d26aaaac Mon Sep 17 00:00:00 2001
+From: Randy Eckenrode <randy@largeandhighquality.com>
+Date: Fri, 26 May 2023 00:10:45 -0400
+Subject: [PATCH] Fix test failures on Darwin on a case-sensitive fs
+
+This issue was encounetered while working on a contribution to nixpkgs.
+Nix allows the store to be installed on a separate, case-sensitive APFS
+volume. When the store is on a case-sensitive volume, these tests fail
+because they try to use `foundation` instead of `Foundation`.
+---
+ .../failing/78 framework dependency with version/meson.build    | 2 +-
+ test cases/objc/2 nsstring/meson.build                          | 2 +-
+ test cases/osx/6 multiframework/meson.build                     | 2 +-
+ 3 files changed, 3 insertions(+), 3 deletions(-)
+
+diff --git a/test cases/failing/78 framework dependency with version/meson.build b/test cases/failing/78 framework dependency with version/meson.build
+index b7e04bab446..ee315ebcbd7 100644
+--- a/test cases/failing/78 framework dependency with version/meson.build	
++++ b/test cases/failing/78 framework dependency with version/meson.build	
+@@ -5,4 +5,4 @@ if host_machine.system() != 'darwin'
+ endif
+ 
+ # do individual frameworks have a meaningful version to test?  And multiple frameworks might be listed...
+-dep = dependency('appleframeworks', modules: 'foundation', version: '>0')
++dep = dependency('appleframeworks', modules: 'Foundation', version: '>0')
+diff --git a/test cases/objc/2 nsstring/meson.build b/test cases/objc/2 nsstring/meson.build
+index 94d2cf18ab4..2c483d50d68 100644
+--- a/test cases/objc/2 nsstring/meson.build	
++++ b/test cases/objc/2 nsstring/meson.build	
+@@ -1,7 +1,7 @@
+ project('nsstring', 'objc')
+ 
+ if host_machine.system() == 'darwin'
+-  dep = dependency('appleframeworks', modules : 'foundation')
++  dep = dependency('appleframeworks', modules : 'Foundation')
+ elif host_machine.system() == 'cygwin'
+   error('MESON_SKIP_TEST GNUstep is not packaged for Cygwin.')
+ else
+diff --git a/test cases/osx/6 multiframework/meson.build b/test cases/osx/6 multiframework/meson.build
+index 28846243b21..57e5d61560b 100644
+--- a/test cases/osx/6 multiframework/meson.build	
++++ b/test cases/osx/6 multiframework/meson.build	
+@@ -4,7 +4,7 @@ project('multiframework', 'objc')
+ # that causes a build failure when defining two modules. The
+ # arguments for the latter module overwrote the arguments for
+ # the first one rather than adding to them.
+-cocoa_dep = dependency('appleframeworks', modules : ['AppKit', 'foundation'])
++cocoa_dep = dependency('appleframeworks', modules : ['AppKit', 'Foundation'])
+ 
+ executable('deptester',
+   'main.m',

--- a/pkgs/development/tools/build-managers/meson/default.nix
+++ b/pkgs/development/tools/build-managers/meson/default.nix
@@ -27,10 +27,8 @@ python3.pkgs.buildPythonApplication rec {
 
   patches = [
     # Fix Meson tests that fail when the Nix store is case-sensitive APFS.
-    (fetchpatch {
-      url = "https://github.com/mesonbuild/meson/pull/11820.patch";
-      sha256 = "sha256-mzSEvAQl13OpFFzSvMI4kkdnW6CXXnKz2xNlXaXduhY=";
-    })
+    # https://github.com/mesonbuild/meson/pull/11820
+    ./darwin-case-sensitive-fs.patch
 
     # Meson is currently inspecting fewer variables than autoconf does, which
     # makes it harder for us to use setup hooks, etc.  Taken from

--- a/pkgs/development/tools/build-managers/meson/default.nix
+++ b/pkgs/development/tools/build-managers/meson/default.nix
@@ -26,6 +26,12 @@ python3.pkgs.buildPythonApplication rec {
   };
 
   patches = [
+    # Fix Meson tests that fail when the Nix store is case-sensitive APFS.
+    (fetchpatch {
+      url = "https://github.com/mesonbuild/meson/pull/11820.patch";
+      sha256 = "sha256-mzSEvAQl13OpFFzSvMI4kkdnW6CXXnKz2xNlXaXduhY=";
+    })
+
     # Meson is currently inspecting fewer variables than autoconf does, which
     # makes it harder for us to use setup hooks, etc.  Taken from
     # https://github.com/mesonbuild/meson/pull/6827


### PR DESCRIPTION
###### Description of changes

I run Darwin with a case-sensitive store because it’s offered as an option. Meson is the first thing that actually broke because of it. This patch corrects the casing of “foundation” references in some of the tests that expect to find it.

I did not run `nixpkgs-review` because this change causes a lot of rebuilds, but I did rebuild a number of packages as part of my work on #229786.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
