### PR TITLE
nixos/tests/nar-serve: Fix

### DIFF
--- a/nixos/tests/nar-serve.nix
+++ b/nixos/tests/nar-serve.nix
@@ -27,6 +27,8 @@ import ./make-test-python.nix (
         };
       };
     testScript = ''
+      import os
+
       start_all()
 
       # Create a fake cache with Nginx service the static files


### PR DESCRIPTION
###### Description of changes

Fix one of the two problems with this test: It's [currently failing](https://hydra.nixos.org/job/nixos/trunk-combined/nixos.tests.allDrivers.nar-serve.x86_64-linux) due to a [missing python import](https://hydra.nixos.org/build/221523926/nixlog/1).

[The other problem](https://github.com/NixOS/nixpkgs/pull/178851#issuecomment-1563702699) is an [upstream regression](https://github.com/numtide/nar-serve/issues/23), and needs to be [fixed upstream](https://github.com/numtide/nar-serve/pull/24)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).