### PR TITLE
python3Packages.umap-learn: patch for numpy>=1.24

### DIFF
--- a/pkgs/development/python-modules/umap-learn/default.nix
+++ b/pkgs/development/python-modules/umap-learn/default.nix
@@ -42,6 +42,21 @@ buildPythonPackage rec {
       url = "https://github.com/lmcinnes/umap/commit/949abd082524fce8c45dfb147bcd8e8ef49eade3.patch";
       hash = "sha256-8/1k8iYeF77FIaUApNtY07auPJkrt3vNRR/HTYRvq+0=";
     })
+    # Fix tests with numpy>=1.24
+    # https://github.com/lmcinnes/umap/pull/952
+    (fetchpatch {
+      url = "https://github.com/lmcinnes/umap/commit/588e1f724c9f5de528eb1500b0c85a1a609fe947.patch";
+      hash = "sha256-B50eyMs3CRuzOAq+jxz56XMJPdiUofUxCL0Vqolaafo=";
+    })
+    # https://github.com/lmcinnes/umap/pull/1010
+    (fetchpatch {
+      url = "https://github.com/lmcinnes/umap/commit/848396c762c894e666aaf3d0bcfe1e041b529ea6.patch";
+      hash = "sha256-ir0Pxfr2c0oSuFGXQqHjkj7nzvlpTXCYbaI9qAiLun0=";
+    })
+    (fetchpatch {
+      url = "https://github.com/lmcinnes/umap/commit/30e39938f4627f327223245dfe2c908af6b7e304.patch";
+      hash = "sha256-7Divrym05wIPa7evgrNYXGm44/EOWG8sIYV8fmtuzJ4=";
+    })
   ];
 
   propagatedBuildInputs = [


### PR DESCRIPTION
###### Description of changes

ZHF: #230712
https://hydra.nixos.org/build/221534472

The dependency `scikit-tda` still fails to build because it does not support numpy>=1.24.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
