### PR TITLE
pufferpanel: build frontend from source

### DIFF
--- a/pkgs/servers/pufferpanel/default.nix
+++ b/pkgs/servers/pufferpanel/default.nix
@@ -11,34 +11,16 @@
 
 buildGoModule rec {
   pname = "pufferpanel";
-  version = "2.6.6";
+  version = "2.6.7";
 
   src = applyPatches {
     src = fetchFromGitHub {
       owner = "PufferPanel";
       repo = "PufferPanel";
       rev = "v${version}";
-      hash = "sha256-0Vyi47Rkpe3oODHfsl/7tCerENpiEa3EWBHhfTO/uu4=";
+      hash = "sha256-ay9NNcK+6QFobe/rwtZF8USl0vMbDZBg5z57fjA5VLw=";
     };
     patches = [
-      # Bump go-sqlite3 version to avoid a GNU C compiler error.
-      (fetchpatch {
-        url = "https://github.com/PufferPanel/PufferPanel/commit/dd7fc80c33c7618c98311af09c78c25b77658aef.patch";
-        hash = "sha256-ygMrhJoba8swoRBBii7BEiLihqOebLUtSH7os7W3s+k=";
-      })
-
-      # Fix errors in tests.
-      (fetchpatch {
-        url = "https://github.com/PufferPanel/PufferPanel/commit/ad6ab4b4368e1111292fadfb3d9f058fa399fa21.patch";
-        hash = "sha256-BzGfcWhzRrCHKkAhWf0uvXiiiutWqthn/ed7bN2hR8U=";
-      })
-
-      # AutoFill for OTP codes in Safari.
-      (fetchpatch {
-        url = "https://github.com/PufferPanel/PufferPanel/commit/0c59ef0fe935ef8b5c69e0b91b32ecc2c1458f5c.patch";
-        hash = "sha256-QpsEskw/xBhvesBGQQopiqXL0BRciF0j8KGcmKmJzeE=";
-      })
-
       # Bump sha1cd package, otherwise i686-linux fails to build.
       ./bump-sha1cd.patch
 
@@ -67,7 +49,7 @@ buildGoModule rec {
 
     src = "${src}/client";
 
-    npmDepsHash = "sha256-geQHIbYYCOWsPQYAPiwMhtC+kbgQs7LMHqNYomTPrxA=";
+    npmDepsHash = "sha256-oWFXtV/dxzHv3sfIi01l1lHE5tcJgpVq87XgS6Iy62g=";
 
     NODE_OPTIONS = "--openssl-legacy-provider";
     npmBuildFlags = [ "--" "--dest=${placeholder "out"}" ];

--- a/pkgs/servers/pufferpanel/default.nix
+++ b/pkgs/servers/pufferpanel/default.nix
@@ -7,7 +7,6 @@
 , makeWrapper
 , go-swag
 , nixosTests
-, pathDeps ? [ ]
 }:
 
 buildGoModule rec {
@@ -103,8 +102,7 @@ buildGoModule rec {
     makeWrapper $out/share/pufferpanel/pufferpanel $out/bin/pufferpanel \
       --set-default GIN_MODE release \
       --set-default PUFFER_PANEL_EMAIL_TEMPLATES $out/share/pufferpanel/email/emails.json \
-      --set-default PUFFER_PANEL_WEB_FILES $out/share/pufferpanel/www \
-      --prefix PATH : ${lib.escapeShellArg (lib.makeBinPath pathDeps)}
+      --set-default PUFFER_PANEL_WEB_FILES $out/share/pufferpanel/www
 
     runHook postInstall
   '';

--- a/pkgs/servers/pufferpanel/default.nix
+++ b/pkgs/servers/pufferpanel/default.nix
@@ -1,43 +1,59 @@
 { lib
-, buildGoModule
 , fetchFromGitHub
-, makeWrapper
-, fetchzip
 , fetchpatch
-, pathDeps ? [ ]
+, applyPatches
+, buildGoModule
+, buildNpmPackage
+, makeWrapper
+, go-swag
 , nixosTests
+, pathDeps ? [ ]
 }:
 
 buildGoModule rec {
   pname = "pufferpanel";
   version = "2.6.6";
 
-  patches = [
-    # Bump go-sqlite3 version to avoid a GNU C compiler error.
-    (fetchpatch {
-      url = "https://github.com/PufferPanel/PufferPanel/commit/dd7fc80c33c7618c98311af09c78c25b77658aef.patch";
-      hash = "sha256-ygMrhJoba8swoRBBii7BEiLihqOebLUtSH7os7W3s+k=";
-    })
+  src = applyPatches {
+    src = fetchFromGitHub {
+      owner = "PufferPanel";
+      repo = "PufferPanel";
+      rev = "v${version}";
+      hash = "sha256-0Vyi47Rkpe3oODHfsl/7tCerENpiEa3EWBHhfTO/uu4=";
+    };
+    patches = [
+      # Bump go-sqlite3 version to avoid a GNU C compiler error.
+      (fetchpatch {
+        url = "https://github.com/PufferPanel/PufferPanel/commit/dd7fc80c33c7618c98311af09c78c25b77658aef.patch";
+        hash = "sha256-ygMrhJoba8swoRBBii7BEiLihqOebLUtSH7os7W3s+k=";
+      })
 
-    # Fix errors in tests.
-    (fetchpatch {
-      url = "https://github.com/PufferPanel/PufferPanel/commit/ad6ab4b4368e1111292fadfb3d9f058fa399fa21.patch";
-      hash = "sha256-BzGfcWhzRrCHKkAhWf0uvXiiiutWqthn/ed7bN2hR8U=";
-    })
+      # Fix errors in tests.
+      (fetchpatch {
+        url = "https://github.com/PufferPanel/PufferPanel/commit/ad6ab4b4368e1111292fadfb3d9f058fa399fa21.patch";
+        hash = "sha256-BzGfcWhzRrCHKkAhWf0uvXiiiutWqthn/ed7bN2hR8U=";
+      })
 
-    # Bump sha1cd package, otherwise i686-linux fails to build.
-    ./bump-sha1cd.patch
+      # AutoFill for OTP codes in Safari.
+      (fetchpatch {
+        url = "https://github.com/PufferPanel/PufferPanel/commit/0c59ef0fe935ef8b5c69e0b91b32ecc2c1458f5c.patch";
+        hash = "sha256-QpsEskw/xBhvesBGQQopiqXL0BRciF0j8KGcmKmJzeE=";
+      })
 
-    # Seems to be an anti-feature. Startup is the only place where user/group is
-    # hardcoded and checked.
-    #
-    # There is no technical reason PufferPanel cannot run as a different user,
-    # especially for simple commands like `pufferpanel version`.
-    ./disable-group-checks.patch
+      # Bump sha1cd package, otherwise i686-linux fails to build.
+      ./bump-sha1cd.patch
 
-    # Some tests do not have network requests stubbed :(
-    ./skip-network-tests.patch
-  ];
+      # Seems to be an anti-feature. Startup is the only place where user/group is
+      # hardcoded and checked.
+      #
+      # There is no technical reason PufferPanel cannot run as a different user,
+      # especially for simple commands like `pufferpanel version`.
+      ./disable-group-checks.patch
+
+      # Some tests do not have network requests stubbed :(
+      ./skip-network-tests.patch
+    ];
+  };
 
   ldflags = [
     "-s"
@@ -46,50 +62,51 @@ buildGoModule rec {
     "-X=github.com/pufferpanel/pufferpanel/v2.Version=${version}-nixpkgs"
   ];
 
-  src = fetchFromGitHub {
-    owner = "pufferpanel";
-    repo = pname;
-    rev = "v${version}";
-    hash = "sha256-0Vyi47Rkpe3oODHfsl/7tCerENpiEa3EWBHhfTO/uu4=";
+  frontend = buildNpmPackage {
+    pname = "pufferpanel-frontend";
+    inherit version;
+
+    src = "${src}/client";
+
+    npmDepsHash = "sha256-geQHIbYYCOWsPQYAPiwMhtC+kbgQs7LMHqNYomTPrxA=";
+
+    NODE_OPTIONS = "--openssl-legacy-provider";
+    npmBuildFlags = [ "--" "--dest=${placeholder "out"}" ];
+    dontNpmInstall = true;
   };
 
-  # PufferPanel is split into two parts: the backend daemon and the
-  # frontend.
-  # Getting the frontend to build in the Nix environment fails even
-  # with all the proper node_modules populated. To work around this,
-  # we just download the built frontend and package that.
-  frontend = fetchzip {
-    url = "https://github.com/PufferPanel/PufferPanel/releases/download/v${version}/pufferpanel_${version}_linux_arm64.zip";
-    hash = "sha256-z7HWhiEBma37OMGEkTGaEbnF++Nat8wAZE2UeOoaO/U=";
-    stripRoot = false;
-    postFetch = ''
-      mv $out $TMPDIR/subdir
-      mv $TMPDIR/subdir/www $out
-    '';
-  };
-
-  nativeBuildInputs = [ makeWrapper ];
+  nativeBuildInputs = [ makeWrapper go-swag ];
 
   vendorHash = "sha256-Esfk7SvqiWeiobXSI+4wYVEH9yVkB+rO7bxUQ5TzvG4=";
   proxyVendor = true;
 
-  postFixup = ''
-    mkdir -p $out/share/pufferpanel
-    cp -r ${src}/assets/email $out/share/pufferpanel/templates
-    cp -r ${frontend} $out/share/pufferpanel/www
+  # Generate code for Swagger documentation endpoints (see web/swagger/docs.go).
+  # Note that GOROOT embedded in go-swag is empty by default since it is built
+  # with -trimpath (see https://go.dev/cl/399214). It looks like go-swag skips
+  # file paths that start with $GOROOT, thus all files when it is empty.
+  preBuild = ''
+    GOROOT=''${GOROOT-$(go env GOROOT)} swag init --output web/swagger --generalInfo web/loader.go
+  '';
 
-    # Rename cmd to pufferpanel and remove other binaries.
-    mv $out/bin $TMPDIR/bin
-    mkdir $out/bin
-    mv $TMPDIR/bin/cmd $out/bin/pufferpanel
+  installPhase = ''
+    runHook preInstall
+
+    # Set up directory structure similar to the official PufferPanel releases.
+    mkdir -p $out/share/pufferpanel
+    cp "$GOPATH"/bin/cmd $out/share/pufferpanel/pufferpanel
+    cp -r $frontend $out/share/pufferpanel/www
+    cp -r $src/assets/email $out/share/pufferpanel/email
+    cp web/swagger/swagger.{json,yaml} $out/share/pufferpanel
 
     # Wrap the binary with the path to the external files, but allow setting
     # custom paths if needed.
-    wrapProgram $out/bin/pufferpanel \
+    makeWrapper $out/share/pufferpanel/pufferpanel $out/bin/pufferpanel \
       --set-default GIN_MODE release \
-      --set-default PUFFER_PANEL_EMAIL_TEMPLATES $out/share/pufferpanel/templates/emails.json \
+      --set-default PUFFER_PANEL_EMAIL_TEMPLATES $out/share/pufferpanel/email/emails.json \
       --set-default PUFFER_PANEL_WEB_FILES $out/share/pufferpanel/www \
       --prefix PATH : ${lib.escapeShellArg (lib.makeBinPath pathDeps)}
+
+    runHook postInstall
   '';
 
   passthru.tests = {


### PR DESCRIPTION
###### Description of changes

This change updates the PufferPanel package to build frontend from source. ~~Note that cross-compilation with `buildNpmPackage` seems to be broken (at least from `aarch64-linux` to `x86_64-linux`), but the frontend is platform-independent so we use `pkgsBuildBuild.buildNpmPackage`.~~

It is bundled with 2.6.7 version bump since it allows us to drop upstreamed patches.

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
