### PR TITLE
mle: 1.5.0 -> 1.7.2

### DIFF
--- a/pkgs/applications/editors/mle/default.nix
+++ b/pkgs/applications/editors/mle/default.nix
@@ -1,8 +1,7 @@
 { lib
 , stdenv
 , fetchFromGitHub
-, fetchpatch
-, pcre
+, pcre2
 , uthash
 , lua5_4
 , makeWrapper
@@ -11,28 +10,14 @@
 
 stdenv.mkDerivation rec {
   pname = "mle";
-  version = "1.5.0";
+  version = "1.7.2";
 
   src = fetchFromGitHub {
     owner = "adsr";
     repo = "mle";
     rev = "v${version}";
-    sha256 = "1nhd00lsx9v12zdmps92magz76c2d8zzln3lxvzl4ng73gbvq3n0";
+    sha256 = "0rkk7mh6w5y1lrbdv7wmxdgl5cqzpzw0p26adazkqlfdyb6wbj9k";
   };
-
-  # Bug fixes found after v1.5.0 release
-  patches = [
-    (fetchpatch {
-      name = "skip_locale_dep_test.patch";
-      url = "https://github.com/adsr/mle/commit/e4dc4314b02a324701d9ae9873461d34cce041e5.patch";
-      sha256 = "sha256-j3Z/n+2LqB9vEkWzvRVSOrF6yE+hk6f0dvEsTQ74erw=";
-    })
-    (fetchpatch {
-      name = "fix_input_trail.patch";
-      url = "https://github.com/adsr/mle/commit/bc05ec0eee4143d824010c6688fce526550ed508.patch";
-      sha256 = "sha256-dM63EBDQfHLAqGZk3C5NtNAv23nCTxXVW8XpLkAeEyQ=";
-    })
-  ];
 
   # Fix location of Lua 5.4 header and library
   postPatch = ''
@@ -41,13 +26,9 @@ stdenv.mkDerivation rec {
     patchShebangs tests/*
   '';
 
-  # Use select(2) instead of poll(2) (poll is returning POLLINVAL on macOS)
-  # Enable compiler optimization
-  CFLAGS = "-DTB_OPT_SELECT -O2";
-
   nativeBuildInputs = [ makeWrapper installShellFiles ];
 
-  buildInputs = [ pcre uthash lua5_4 ];
+  buildInputs = [ pcre2 uthash lua5_4 ];
 
   doCheck = true;
 


### PR DESCRIPTION
###### Description of changes

https://github.com/adsr/mle/compare/v1.5.0...v1.7.2

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
