### PR TITLE
python3Packages.stopit: added setuptools dependency

### DIFF
--- a/pkgs/development/python-modules/stopit/default.nix
+++ b/pkgs/development/python-modules/stopit/default.nix
@@ -1,6 +1,8 @@
 { lib
 , buildPythonPackage
 , fetchFromGitHub
+, setuptools
+
 }:
 
 buildPythonPackage rec {
@@ -14,6 +16,10 @@ buildPythonPackage rec {
     rev = version;
     hash = "sha256-uXJUA70JOGWT2NmS6S7fPrTWAJZ0mZ/hICahIUzjfbw=";
   };
+
+  propagatedBuildInputs = [
+    setuptools # for pkg_resources
+  ];
 
   pythonImportsCheck = [ "stopit" ];
 


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done
Added setuptools, otherwise it wouldn't work.

```
eyjhb@jhbws01 ~> nix-shell -p python3Packages.stopit                                               
this path will be fetched (0.01 MiB download, 0.05 MiB unpacked):
  /nix/store/d3sr2vsy7lkajj4dxqhx1nps78kpwl9p-python3.10-stopit-1.1.2
copying path '/nix/store/d3sr2vsy7lkajj4dxqhx1nps78kpwl9p-python3.10-stopit-1.1.2' from 'https://cache.nixos.org'...
eyjhb@jhbws01 ~> python3                                                                           
Python 3.10.11 (main, Apr  4 2023, 22:10:32) [GCC 12.2.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> def infinite():
...     while True:
...             pass
...     return "eee"
... 
>>> from stopit import ThreadingTimeout
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/nix/store/d3sr2vsy7lkajj4dxqhx1nps78kpwl9p-python3.10-stopit-1.1.2/lib/python3.10/site-pac
    import pkg_resources
```
<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
