### PR TITLE
ocamlPackages.iter: 1.6 → 1.7

### DIFF
--- a/pkgs/development/ocaml-modules/iter/default.nix
+++ b/pkgs/development/ocaml-modules/iter/default.nix
@@ -1,25 +1,19 @@
-{ lib, fetchFromGitHub, buildDunePackage, ocaml, dune-configurator
-, result, seq
+{ lib, fetchurl, buildDunePackage
 , mdx, ounit2, qcheck-core
 }:
 
 buildDunePackage rec {
   pname = "iter";
-  version = "1.6";
+  version = "1.7";
 
-  duneVersion = "3";
+  minimalOCamlVersion = "4.08";
 
-  src = fetchFromGitHub {
-    owner = "c-cube";
-    repo = pname;
-    rev = "v${version}";
-    sha256 = "sha256-FbM/Vk/h4wkrBjyf9/QXTvTOA0nNqsdHP1mDnVkg1is=";
+  src = fetchurl {
+    url = "https://github.com/c-cube/iter/releases/download/v${version}/iter-${version}.tbz";
+    hash = "sha256-vtcSnPMxpBwDve1zsR6cEnUsyu3JELPt2Kwu4OEEtzA=";
   };
 
-  buildInputs = [ dune-configurator ];
-  propagatedBuildInputs = [ result seq ];
-
-  doCheck = lib.versionAtLeast ocaml.version "4.08";
+  doCheck = true;
   nativeCheckInputs = [ mdx.bin ];
   checkInputs = [ ounit2 qcheck-core ];
 

--- a/pkgs/development/ocaml-modules/lwt/default.nix
+++ b/pkgs/development/ocaml-modules/lwt/default.nix
@@ -16,6 +16,8 @@ buildDunePackage rec {
   };
 
   postPatch = lib.optionalString (lib.versionAtLeast ocaml.version "5.0") ''
+    substituteInPlace src/core/dune \
+      --replace "(libraries bytes)" ""
     substituteInPlace src/unix/dune \
       --replace "libraries bigarray lwt" "libraries lwt"
   '';

--- a/pkgs/development/ocaml-modules/ocplib-endian/default.nix
+++ b/pkgs/development/ocaml-modules/ocplib-endian/default.nix
@@ -13,7 +13,8 @@ buildDunePackage rec {
 
   postPatch = lib.optionalString (lib.versionAtLeast ocaml.version "5.0") ''
     substituteInPlace src/dune \
-      --replace "libraries ocplib_endian bigarray" "libraries ocplib_endian"
+      --replace "(libraries bytes)" "" \
+      --replace "libraries ocplib_endian bigarray bytes" "libraries ocplib_endian"
   '';
 
   minimalOCamlVersion = "4.03";


### PR DESCRIPTION
###### Description of changes

Support for OCaml 5: https://github.com/c-cube/iter/blob/v1.7/CHANGELOG.md

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
