### PR TITLE
gnushogi: refactor, unbreak on darwin

### DIFF
--- a/pkgs/games/gnushogi/default.nix
+++ b/pkgs/games/gnushogi/default.nix
@@ -1,21 +1,31 @@
-{ lib, stdenv, fetchurl, zlib }:
+{ lib
+, stdenv
+, fetchurl
+, fetchpatch
+, zlib
+}:
 
 stdenv.mkDerivation rec {
   pname = "gnushogi";
   version = "1.4.2";
-  buildInputs = [ zlib ];
 
   src = fetchurl {
     url = "mirror://gnu/gnushogi/${pname}-${version}.tar.gz";
-    sha256 = "0a9bsl2nbnb138lq0h14jfc5xvz7hpb2bcsj4mjn6g1hcsl4ik0y";
+    hash = "sha256-HsxIqGYwPGNlJVKzJdaF5+9emJMkQIApGmHZZQXVKyk=";
   };
 
-  env.LDFLAGS = lib.optionalString (!stdenv.isDarwin) "-Wl,-z,muldefs";
+  patches = [
+    (fetchpatch {
+      url = "https://sources.debian.org/data/main/g/gnushogi/1.4.2-7/debian/patches/01-make-dont-ignore";
+      hash = "sha256-Aw0zfH+wkj+rQQzKIn6bSilP76YIO27FwJ8n1UzG6ow=";
+    })
+    (fetchpatch {
+      url = "https://sources.debian.org/data/main/g/gnushogi/1.4.2-7/debian/patches/globals";
+      hash = "sha256-wZJBPMYSz4n1kOyLmR9QOp70650R9xXQUWD5hvaMRok=";
+    })
+  ];
 
-  # Makefile ignores errors, so the build may silently succeed erroneously
-  postBuild = ''
-    test -e gnushogi/gnushogi || { echo "ERROR: no binary produced"; exit 1; }
-  '';
+  buildInputs = [ zlib ];
 
   meta = with lib; {
     description = "GNU implementation of Shogi, also known as Japanese Chess";
@@ -23,6 +33,5 @@ stdenv.mkDerivation rec {
     license = licenses.gpl3;
     maintainers = [ maintainers.ciil ];
     platforms = platforms.unix;
-    broken = stdenv.isDarwin; # darwin does not support -z muldefs
   };
 }


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
