### PR TITLE
gcc{6..11}: import a patch into nixpkgs

### DIFF
--- a/pkgs/development/compilers/gcc/10/default.nix
+++ b/pkgs/development/compilers/gcc/10/default.nix
@@ -53,11 +53,7 @@ let majorVersion = "10";
 
     patches = [
       # Fix https://gcc.gnu.org/bugzilla/show_bug.cgi?id=80431
-      (fetchurl {
-        name = "fix-bug-80431.patch";
-        url = "https://gcc.gnu.org/git/?p=gcc.git;a=patch;h=de31f5445b12fd9ab9969dc536d821fe6f0edad0";
-        sha256 = "0sd52c898msqg7m316zp0ryyj7l326cjcn2y19dcxqp15r74qj0g";
-      })
+      ../fix-bug-80431.patch
       ../11/fix-struct-redefinition-on-glibc-2.36.patch
       ../install-info-files-serially.patch
     ] ++ optional (targetPlatform != hostPlatform) ../libstdc++-target.patch

--- a/pkgs/development/compilers/gcc/11/default.nix
+++ b/pkgs/development/compilers/gcc/11/default.nix
@@ -57,11 +57,7 @@ let majorVersion = "11";
 
     patches = [
       # Fix https://gcc.gnu.org/bugzilla/show_bug.cgi?id=80431
-      (fetchurl {
-        name = "fix-bug-80431.patch";
-        url = "https://gcc.gnu.org/git/?p=gcc.git;a=patch;h=de31f5445b12fd9ab9969dc536d821fe6f0edad0";
-        sha256 = "0sd52c898msqg7m316zp0ryyj7l326cjcn2y19dcxqp15r74qj0g";
-      })
+      ../fix-bug-80431.patch
       ./fix-struct-redefinition-on-glibc-2.36.patch
       ../install-info-files-serially.patch
     ] ++ optional (targetPlatform != hostPlatform) ../libstdc++-target.patch

--- a/pkgs/development/compilers/gcc/6/default.nix
+++ b/pkgs/development/compilers/gcc/6/default.nix
@@ -67,11 +67,7 @@ let majorVersion = "6";
       ../use-source-date-epoch.patch ./0001-Fix-build-for-glibc-2.31.patch
 
       # Fix https://gcc.gnu.org/bugzilla/show_bug.cgi?id=80431
-      (fetchurl {
-        name = "fix-bug-80431.patch";
-        url = "https://gcc.gnu.org/git/?p=gcc.git;a=patch;h=de31f5445b12fd9ab9969dc536d821fe6f0edad0";
-        sha256 = "0sd52c898msqg7m316zp0ryyj7l326cjcn2y19dcxqp15r74qj0g";
-      })
+      ../fix-bug-80431.patch
       ../install-info-files-serially.patch
     ] ++ optional (targetPlatform != hostPlatform) ../libstdc++-target.patch
       ++ optional noSysDirs ../no-sys-dirs.patch

--- a/pkgs/development/compilers/gcc/7/default.nix
+++ b/pkgs/development/compilers/gcc/7/default.nix
@@ -58,11 +58,7 @@ let majorVersion = "7";
         ./0001-Fix-build-for-glibc-2.31.patch
 
         # Fix https://gcc.gnu.org/bugzilla/show_bug.cgi?id=80431
-        (fetchurl {
-          name = "fix-bug-80431.patch";
-          url = "https://gcc.gnu.org/git/?p=gcc.git;a=patch;h=de31f5445b12fd9ab9969dc536d821fe6f0edad0";
-          sha256 = "0sd52c898msqg7m316zp0ryyj7l326cjcn2y19dcxqp15r74qj0g";
-        })
+        ../fix-bug-80431.patch
 
         ../9/fix-struct-redefinition-on-glibc-2.36.patch
         ../install-info-files-serially.patch

--- a/pkgs/development/compilers/gcc/8/default.nix
+++ b/pkgs/development/compilers/gcc/8/default.nix
@@ -48,11 +48,7 @@ let majorVersion = "8";
 
     patches = [
       # Fix https://gcc.gnu.org/bugzilla/show_bug.cgi?id=80431
-      (fetchurl {
-        name = "fix-bug-80431.patch";
-        url = "https://gcc.gnu.org/git/?p=gcc.git;a=patch;h=de31f5445b12fd9ab9969dc536d821fe6f0edad0";
-        sha256 = "0sd52c898msqg7m316zp0ryyj7l326cjcn2y19dcxqp15r74qj0g";
-      })
+      ../fix-bug-80431.patch
       ../9/fix-struct-redefinition-on-glibc-2.36.patch
       ../install-info-files-serially.patch
     ] ++ optional (targetPlatform != hostPlatform) ../libstdc++-target.patch

--- a/pkgs/development/compilers/gcc/9/default.nix
+++ b/pkgs/development/compilers/gcc/9/default.nix
@@ -58,11 +58,7 @@ let majorVersion = "9";
     patches = [
       ./fix-struct-redefinition-on-glibc-2.36.patch
       # Fix https://gcc.gnu.org/bugzilla/show_bug.cgi?id=80431
-      (fetchurl {
-        name = "fix-bug-80431.patch";
-        url = "https://gcc.gnu.org/git/?p=gcc.git;a=patch;h=de31f5445b12fd9ab9969dc536d821fe6f0edad0";
-        sha256 = "0sd52c898msqg7m316zp0ryyj7l326cjcn2y19dcxqp15r74qj0g";
-      })
+      ../fix-bug-80431.patch
       ../install-info-files-serially.patch
     ] ++ optional (targetPlatform != hostPlatform) ../libstdc++-target.patch
       ++ optional targetPlatform.isNetBSD ../libstdc++-netbsd-ctypes.patch

--- a/pkgs/development/compilers/gcc/fix-bug-80431.patch
+++ b/pkgs/development/compilers/gcc/fix-bug-80431.patch
@@ -1,0 +1,92 @@
+From de31f5445b12fd9ab9969dc536d821fe6f0edad0 Mon Sep 17 00:00:00 2001
+From: Patrick Palka <ppalka@redhat.com>
+Date: Mon, 21 Jun 2021 07:54:26 -0400
+Subject: [PATCH] c++: conversion to base of vbase in NSDMI [PR80431]
+
+The delayed processing of conversions to a virtual base in an NSDMI
+assumes the target base type is a (possibly indirect) virtual base of
+the current class, but the target base type could also be a base of a
+virtual base, as in the testcase below.  Since such a base isn't a part
+of CLASSTYPE_VBASECLASSES, we end up miscompiling the testcase due to
+the call to build_base_path (with binfo=NULL_TREE) silently returning
+error_mark_node.  Fix this by using convert_to_base to build the
+conversion instead.
+
+	PR c++/80431
+
+gcc/cp/ChangeLog:
+
+	* tree.c (bot_replace): Use convert_to_base to build the
+	conversion to the (morally) virtual base.
+
+gcc/testsuite/ChangeLog:
+
+	* g++.dg/cpp0x/nsdmi-virtual1a.C: New test.
+---
+ gcc/cp/tree.c                                | 14 ++++------
+ gcc/testsuite/g++.dg/cpp0x/nsdmi-virtual1a.C | 28 ++++++++++++++++++++
+ 2 files changed, 33 insertions(+), 9 deletions(-)
+ create mode 100644 gcc/testsuite/g++.dg/cpp0x/nsdmi-virtual1a.C
+
+diff --git a/gcc/cp/tree.c b/gcc/cp/tree.c
+index fec5afaa2be..297da2b1550 100644
+--- a/gcc/cp/tree.c
++++ b/gcc/cp/tree.c
+@@ -3242,15 +3242,11 @@ bot_replace (tree* t, int* /*walk_subtrees*/, void* data_)
+   else if (TREE_CODE (*t) == CONVERT_EXPR
+ 	   && CONVERT_EXPR_VBASE_PATH (*t))
+     {
+-      /* In an NSDMI build_base_path defers building conversions to virtual
+-	 bases, and we handle it here.  */
+-      tree basetype = TYPE_MAIN_VARIANT (TREE_TYPE (TREE_TYPE (*t)));
+-      vec<tree, va_gc> *vbases = CLASSTYPE_VBASECLASSES (current_class_type);
+-      int i; tree binfo;
+-      FOR_EACH_VEC_SAFE_ELT (vbases, i, binfo)
+-	if (BINFO_TYPE (binfo) == basetype)
+-	  break;
+-      *t = build_base_path (PLUS_EXPR, TREE_OPERAND (*t, 0), binfo, true,
++      /* In an NSDMI build_base_path defers building conversions to morally
++	 virtual bases, and we handle it here.  */
++      tree basetype = TREE_TYPE (*t);
++      *t = convert_to_base (TREE_OPERAND (*t, 0), basetype,
++			    /*check_access=*/false, /*nonnull=*/true,
+ 			    tf_warning_or_error);
+     }
+ 
+diff --git a/gcc/testsuite/g++.dg/cpp0x/nsdmi-virtual1a.C b/gcc/testsuite/g++.dg/cpp0x/nsdmi-virtual1a.C
+new file mode 100644
+index 00000000000..dc847cc16e5
+--- /dev/null
++++ b/gcc/testsuite/g++.dg/cpp0x/nsdmi-virtual1a.C
+@@ -0,0 +1,28 @@
++// PR c++/80431
++// { dg-do run { target c++11 } }
++
++// A variant of nsdmi-virtual1.C where A is only a morally virtual base of B.
++
++struct A
++{
++  A(): i(42) { }
++  int i;
++  int f() { return i; }
++};
++
++struct D : A { int pad; };
++
++struct B : virtual D
++{
++  int j = i + f();
++  int k = A::i + A::f();
++};
++
++struct C: B { int pad; };
++
++int main()
++{
++  C c;
++  if (c.j != 84 || c.k != 84)
++    __builtin_abort();
++}
+-- 
+2.31.1
+


### PR DESCRIPTION
fetchurl can't be used on generated patches this way. The hash doesn't match anymore.  fetchpatch would be an alternative.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
