### PR TITLE
acme-dns: init at 1.0; nixos/acme-dns: init; nixos/acme-dns: init

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2311.section.md
+++ b/nixos/doc/manual/release-notes/rl-2311.section.md
@@ -8,6 +8,8 @@
 
 - Create the first release note entry in this section!
 
+- [acme-dns](https://github.com/joohoi/acme-dns), a limited DNS server to handle ACME DNS challenges easily and securely. Available as [services.acme-dns](#opt-services.acme-dns.enable).
+
 <!-- To avoid merge conflicts, consider adding your item at an arbitrary place in the list instead. -->
 
 - [river](https://github.com/riverwm/river), A dynamic tiling wayland compositor. Available as [programs.river](#opt-programs.river.enable).

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -807,6 +807,7 @@
   ./services/network-filesystems/xtreemfs.nix
   ./services/network-filesystems/yandex-disk.nix
   ./services/networking/3proxy.nix
+  ./services/networking/acme-dns.nix
   ./services/networking/adguardhome.nix
   ./services/networking/alice-lg.nix
   ./services/networking/amuled.nix

--- a/nixos/modules/services/networking/acme-dns.nix
+++ b/nixos/modules/services/networking/acme-dns.nix
@@ -1,0 +1,154 @@
+{ lib
+, config
+, pkgs
+, ...
+}:
+
+let
+  cfg = config.services.acme-dns;
+  format = pkgs.formats.toml { };
+  inherit (lib)
+    literalExpression
+    mdDoc
+    mkEnableOption
+    mkOption
+    mkPackageOptionMD
+    types
+    ;
+  domain = "acme-dns.example.com";
+in
+{
+  options.services.acme-dns = {
+    enable = mkEnableOption (mdDoc "acme-dns");
+
+    package = mkPackageOptionMD pkgs "acme-dns" { };
+
+    settings = mkOption {
+      description = mdDoc ''
+        Free-form settings written directly to the `acme-dns.cfg` file.
+        Refer to <https://github.com/joohoi/acme-dns/blob/master/README.md#configuration> for supported values.
+      '';
+
+      default = { };
+
+      type = types.submodule {
+        freeformType = format.type;
+        options = {
+          general = {
+            listen = mkOption {
+              type = types.str;
+              description = mdDoc "IP+port combination to bind and serve the DNS server on.";
+              default = "[::]:53";
+              example = "127.0.0.1:53";
+            };
+
+            protocol = mkOption {
+              type = types.enum [ "both" "both4" "both6" "udp" "udp4" "udp6" "tcp" "tcp4" "tcp6" ];
+              description = mdDoc "Protocols to serve DNS responses on.";
+              default = "both";
+            };
+
+            domain = mkOption {
+              type = types.str;
+              description = mdDoc "Domain name to serve the requests off of.";
+              example = domain;
+            };
+
+            nsname = mkOption {
+              type = types.str;
+              description = mdDoc "Zone name server.";
+              example = domain;
+            };
+
+            nsadmin = mkOption {
+              type = types.str;
+              description = mdDoc "Zone admin email address for `SOA`.";
+              example = "admin.example.com";
+            };
+
+            records = mkOption {
+              type = types.listOf types.str;
+              description = mdDoc "Predefined DNS records served in addition to the `_acme-challenge` TXT records.";
+              example = literalExpression ''
+                [
+                  # replace with your acme-dns server's public IPv4
+                  "${domain}. A 198.51.100.1"
+                  # replace with your acme-dns server's public IPv6
+                  "${domain}. AAAA 2001:db8::1"
+                  # ${domain} should resolve any *.${domain} records
+                  "${domain}. NS ${domain}."
+                ]
+              '';
+            };
+          };
+
+          database = {
+            engine = mkOption {
+              type = types.enum [ "sqlite3" "postgres" ];
+              description = mdDoc "Database engine to use.";
+              default = "sqlite3";
+            };
+            connection = mkOption {
+              type = types.str;
+              description = mdDoc "Database connection string.";
+              example = "postgres://user:password@localhost/acmedns";
+              default = "/var/lib/acme-dns/acme-dns.db";
+            };
+          };
+
+          api = {
+            ip = mkOption {
+              type = types.str;
+              description = mdDoc "IP to bind the HTTP API on.";
+              default = "[::]";
+              example = "127.0.0.1";
+            };
+
+            port = mkOption {
+              type = types.port;
+              description = mdDoc "Listen port for the HTTP API.";
+              default = 8080;
+              # acme-dns expects this value to be a string
+              apply = toString;
+            };
+
+            disable_registration = mkOption {
+              type = types.bool;
+              description = mdDoc "Whether to disable the HTTP registration endpoint.";
+              default = false;
+              example = true;
+            };
+
+            tls = mkOption {
+              type = types.enum [ "letsencrypt" "letsencryptstaging" "cert" "none" ];
+              description = mdDoc "TLS backend to use.";
+              default = "none";
+            };
+          };
+
+
+          logconfig = {
+            loglevel = mkOption {
+              type = types.enum [ "error" "warning" "info" "debug" ];
+              description = mdDoc "Level to log on.";
+              default = "info";
+            };
+          };
+        };
+      };
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    systemd.packages = [ cfg.package ];
+    systemd.services.acme-dns = {
+      wantedBy = [ "multi-user.target" ];
+      serviceConfig = {
+        ExecStart = [ "" "${lib.getExe cfg.package} -c ${format.generate "acme-dns.toml" cfg.settings}" ];
+        StateDirectory = "acme-dns";
+        WorkingDirectory = "%S/acme-dns";
+        DynamicUser = true;
+      };
+    };
+  };
+}

--- a/nixos/tests/acme-dns.nix
+++ b/nixos/tests/acme-dns.nix
@@ -1,0 +1,50 @@
+import ./make-test-python.nix ({ ... }: {
+  name = "acme-dns";
+
+  nodes.machine = { pkgs, ... }: {
+    services.acme-dns = {
+      enable = true;
+      settings = {
+        general = rec {
+          domain = "acme-dns.home.arpa";
+          nsname = domain;
+          nsadmin = "admin.home.arpa";
+          records = [
+            "${domain}. A 127.0.0.1"
+            "${domain}. AAAA ::1"
+            "${domain}. NS ${domain}."
+          ];
+        };
+        logconfig.loglevel = "debug";
+      };
+    };
+    environment.systemPackages = with pkgs; [ curl bind ];
+  };
+
+  testScript = ''
+    import json
+
+    machine.wait_for_unit("acme-dns.service")
+    machine.wait_for_open_port(53) # dns
+    machine.wait_for_open_port(8080) # http api
+
+    result = machine.succeed("curl --fail -X POST http://localhost:8080/register")
+    print(result)
+
+    registration = json.loads(result)
+
+    machine.succeed(f'dig -t TXT @localhost {registration["fulldomain"]} | grep "SOA" | grep "admin.home.arpa"')
+
+    # acme-dns exspects a TXT value string length of exactly 43 chars
+    txt = "___dummy_validation_token_for_txt_record___"
+
+    machine.succeed(
+      "curl --fail -X POST http://localhost:8080/update "
+      + f' -H "X-Api-User: {registration["username"]}"'
+      + f' -H "X-Api-Key: {registration["password"]}"'
+      + f' -d \'{{"subdomain":"{registration["subdomain"]}", "txt":"{txt}"}}\'''
+    )
+
+    assert txt in machine.succeed(f'dig -t TXT +short @localhost {registration["fulldomain"]}')
+  '';
+})

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -95,6 +95,7 @@ in {
   _3proxy = runTest ./3proxy.nix;
   aaaaxy = runTest ./aaaaxy.nix;
   acme = runTest ./acme.nix;
+  acme-dns = handleTest ./acme-dns.nix {};
   adguardhome = runTest ./adguardhome.nix;
   aesmd = runTestOn ["x86_64-linux"] ./aesmd.nix;
   agate = runTest ./web-servers/agate.nix;

--- a/pkgs/servers/dns/acme-dns/default.nix
+++ b/pkgs/servers/dns/acme-dns/default.nix
@@ -1,6 +1,7 @@
 { lib
 , buildGoModule
 , fetchFromGitHub
+, nixosTests
 }:
 
 buildGoModule rec {
@@ -20,6 +21,8 @@ buildGoModule rec {
     install -D -m0444 -t $out/lib/systemd/system ./acme-dns.service
     substituteInPlace $out/lib/systemd/system/acme-dns.service --replace "/usr/local/bin/acme-dns" "$out/bin/acme-dns"
   '';
+
+  passthru.tests = { inherit (nixosTests) acme-dns; };
 
   meta = {
     description = "Limited DNS server to handle ACME DNS challenges easily and securely";

--- a/pkgs/servers/dns/acme-dns/default.nix
+++ b/pkgs/servers/dns/acme-dns/default.nix
@@ -1,0 +1,31 @@
+{ lib
+, buildGoModule
+, fetchFromGitHub
+}:
+
+buildGoModule rec {
+  pname = "acme-dns";
+  version = "1.0";
+
+  src = fetchFromGitHub {
+    owner = "joohoi";
+    repo = pname;
+    rev = "v${version}";
+    hash = "sha256-qQwvhouqzkChWeu65epgoeMNqZyAD18T+xqEMgdMbhA=";
+  };
+
+  vendorHash = "sha256-q/P+cH2OihvPxPj2XWeLsTBHzQQABp0zjnof+Ys/qKo=";
+
+  postInstall = ''
+    install -D -m0444 -t $out/lib/systemd/system ./acme-dns.service
+    substituteInPlace $out/lib/systemd/system/acme-dns.service --replace "/usr/local/bin/acme-dns" "$out/bin/acme-dns"
+  '';
+
+  meta = {
+    description = "Limited DNS server to handle ACME DNS challenges easily and securely";
+    homepage = "https://github.com/joohoi/acme-dns";
+    changelog = "https://github.com/joohoi/acme-dns/releases/tag/${src.rev}";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ emilylange ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1303,6 +1303,8 @@ with pkgs;
 
   accuraterip-checksum = callPackage ../tools/audio/accuraterip-checksum { };
 
+  acme-dns = callPackage ../servers/dns/acme-dns/default.nix { };
+
   acme-sh = callPackage ../tools/admin/acme-sh { };
 
   acousticbrainz-client = callPackage ../tools/audio/acousticbrainz-client { };


### PR DESCRIPTION
###### Description of changes

Previously (2020): #83474

https://github.com/joohoi/acme-dns
> A simplified DNS server with a RESTful HTTP API to provide a simple way to automate ACME DNS challenges.

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
