### PR TITLE
noson: init at 5.4.1

### DIFF
--- a/pkgs/applications/audio/noson/default.nix
+++ b/pkgs/applications/audio/noson/default.nix
@@ -1,0 +1,51 @@
+{ stdenv
+, lib
+, fetchFromGitHub
+, cmake
+, flac
+, libpulseaudio
+, qtbase
+, qtgraphicaleffects
+, qtquickcontrols2
+, wrapQtAppsHook
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "noson";
+  version = "5.4.1";
+
+  src = fetchFromGitHub {
+    owner = "janbar";
+    repo = "noson-app";
+    rev = finalAttrs.version;
+    hash = "sha256-7RrBfkUCRVzUGl+OT3OuoMlu4D3Sa7RpBefFgmfX1Fs=";
+  };
+
+  nativeBuildInputs = [
+    cmake
+    wrapQtAppsHook
+  ];
+
+  buildInputs = [
+    flac
+    libpulseaudio
+    qtbase
+    qtgraphicaleffects
+    qtquickcontrols2
+  ];
+
+  # wrapQtAppsHook doesn't automatically find noson-gui
+  dontWrapQtApps = true;
+  preFixup = ''
+    wrapQtApp "$out/lib/noson/noson-gui"
+  '';
+
+  meta = with lib; {
+    description = "SONOS controller for Linux (and macOS)";
+    homepage = "https://janbar.github.io/noson-app/";
+    mainProgram = "noson-app";
+    platforms = platforms.linux ++ platforms.darwin;
+    license = [ licenses.gpl3Only ];
+    maintainers = with maintainers; [ callahad ];
+  };
+})

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -31341,6 +31341,8 @@ with pkgs;
 
   mt32emu-smf2wav = callPackage ../applications/audio/munt/mt32emu-smf2wav.nix { };
 
+  noson = libsForQt5.callPackage ../applications/audio/noson { };
+
   offpunk = callPackage ../applications/networking/browsers/offpunk { };
 
   owl-compositor = callPackage ../applications/window-managers/owl { };


### PR DESCRIPTION
###### Description of changes

Add Noson, a Sonos speaker controller, to Nixpkgs

- https://janbar.github.io/noson-app/
- https://github.com/janbar/noson-app/

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).