### PR TITLE
scala-cli: 1.0.0-RC2 -> 1.0.0

### DIFF
--- a/pkgs/development/tools/build-managers/scala-cli/sources.json
+++ b/pkgs/development/tools/build-managers/scala-cli/sources.json
@@ -1,21 +1,21 @@
 {
-  "version": "1.0.0-RC2",
+  "version": "1.0.0",
   "assets": {
     "aarch64-darwin": {
       "asset": "scala-cli-aarch64-apple-darwin.gz",
-      "sha256": "1wrr1s3dhymvcz5j0vbd038p3yd2d5q3bgb0590wing04hc4hl6s"
+      "sha256": "0lkgfcbwmrrxvdyi76zgj2mbz6nyzc0raq4sd1lcyiyavnr3mxgq"
     },
     "aarch64-linux": {
       "asset": "scala-cli-aarch64-pc-linux.gz",
-      "sha256": "008g95srb34286akk2cbnz1qf5pw9qaws1cppynxzbzpcj3jx5mk"
+      "sha256": "1z7i2jq8lrrnw4wj78xb5c49nrbilr3yi1mda9vanssdy8x27ybh"
     },
     "x86_64-darwin": {
       "asset": "scala-cli-x86_64-apple-darwin.gz",
-      "sha256": "00ifbdp6lxpbwk3yjqy6scywarl44rn1f54jds4xfvh6i22bga1g"
+      "sha256": "1qgqp0cybijbz4nryrsb1x48kf0sja35rvmv1skg8m6ld7hwkn9s"
     },
     "x86_64-linux": {
       "asset": "scala-cli-x86_64-pc-linux.gz",
-      "sha256": "14kk1z7fx8j3kwlhnadhvclnccbnwr97xiw8w2g6nd19b95hnfnf"
+      "sha256": "0z94spyx8x9p0jzaq90vm6yrycyvfi11w1lpv9fzlwldpzk50lq8"
     }
   }
 }


### PR DESCRIPTION
###### Description of changes

Update scala-cli from 1.0.0-RC2 to [1.0.0](https://github.com/VirtusLab/scala-cli/releases/tag/v1.0.0).

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).