### PR TITLE
frink: 2023-01-31 -> 2023-05-22

### DIFF
--- a/pkgs/development/tools/frink/default.nix
+++ b/pkgs/development/tools/frink/default.nix
@@ -8,12 +8,12 @@
 }:
 stdenv.mkDerivation rec {
   pname = "frink";
-  version = "2023-01-31";
+  version = "2023-05-22";
 
   src = fetchurl {
     # Upstream does not provide versioned download links
-    url = "https://web.archive.org/web/20230202134810/https://frinklang.org/frinkjar/frink.jar";
-    sha256 = "sha256-xs1FQvFPgeAxscAiwBBP8N8aYe0OlsYbH/vbzzCbYZc=";
+    url = "https://web.archive.org/web/20230526123219/https://frinklang.org/frinkjar/frink.jar";
+    sha256 = "sha256-IgINJvt9G5f1HELKhV5BHIu9NoA8STDqNg/dVTFzK0Y=";
   };
 
   dontUnpack = true;

--- a/pkgs/development/tools/frink/default.nix
+++ b/pkgs/development/tools/frink/default.nix
@@ -18,6 +18,8 @@ stdenv.mkDerivation rec {
 
   dontUnpack = true;
 
+  nativeBuildInputs = [ jdk ];
+
   buildInputs = [ jdk rlwrap ];
 
   installPhase = ''
@@ -27,9 +29,18 @@ stdenv.mkDerivation rec {
 
     cp ${src} $out/lib/frink.jar
 
+    # Generate rlwrap helper files.
+    # See https://frinklang.org/fsp/colorize.fsp?f=listUnits.frink
+    # and https://frinklang.org/fsp/colorize.fsp?f=listFunctions.frink
+    java -classpath "$out/lib/frink.jar" frink.gui.FrinkStarter -e 'joinln[lexicalSort[units[]]]' > $out/lib/unitnames.txt
+    java -classpath "$out/lib/frink.jar" frink.gui.FrinkStarter -e 'joinln[map[{|f|
+        f =~ %s/\s+//g
+        return "$f$"
+      }, lexicalSort[functions[]]]]' > $out/lib/functionnames.txt
+
     cat > "$out/bin/frink" << EOF
     #!${stdenv.shell}
-    exec ${rlwrap}/bin/rlwrap ${jdk}/bin/java -classpath "$out/lib/frink.jar" frink.gui.FrinkStarter "\$@"
+    exec ${rlwrap}/bin/rlwrap -f $out/lib/unitnames.txt -b '$' -f $out/lib/functionnames.txt ${jdk}/bin/java -classpath "$out/lib/frink.jar" frink.gui.FrinkStarter "\$@"
     EOF
 
     chmod a+x "$out/bin/frink"


### PR DESCRIPTION
###### Description of changes

Upstream version changes: https://frinklang.org/whatsnew.html

This includes the changes for rlwrap helper files, see #230318.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
