### PR TITLE
python3Packages.fiona: 1.9.1 -> 1.9.4

### DIFF
--- a/pkgs/development/python-modules/fiona/default.nix
+++ b/pkgs/development/python-modules/fiona/default.nix
@@ -19,17 +19,16 @@
 
 buildPythonPackage rec {
   pname = "fiona";
-  version = "1.9.1";
+  version = "1.9.4";
+  format = "pyproject";
 
   disabled = pythonOlder "3.7";
-
-  format = "pyproject";
 
   src = fetchFromGitHub {
     owner = "Toblerity";
     repo = "Fiona";
     rev = "refs/tags/${version}";
-    hash = "sha256-2CGLkgnpCAh9G+ILol5tmRj9S6/XeKk8eLzGEODiyP8=";
+    hash = "sha256-v4kTjoGu4AiEepBrGyY1e1OFC1eCk/U6f8XA/vtfY0E=";
   };
 
   nativeBuildInputs = [
@@ -49,7 +48,6 @@ buildPythonPackage rec {
     cligj
     click-plugins
     munch
-    setuptools
   ];
 
   passthru.optional-dependencies = {
@@ -66,12 +64,27 @@ buildPythonPackage rec {
     rm -r fiona # prevent importing local fiona
   '';
 
-  disabledTests = [
-    # Some tests access network, others test packaging
-    "http" "https" "wheel"
+  pytestFlagsArray = [
+    # Tests with gdal marker do not test the functionality of Fiona,
+    # but they are used to check GDAL driver capabilities.
+    "-m 'not gdal'"
   ];
 
-  pythonImportsCheck = [ "fiona" ];
+  disabledTests = [
+    # Some tests access network, others test packaging
+    "http"
+    "https"
+    "wheel"
+
+    # see: https://github.com/Toblerity/Fiona/issues/1273
+    "test_append_memoryfile_drivers"
+  ];
+
+  pythonImportsCheck = [
+    "fiona"
+  ];
+
+  doInstallCheck = true;
 
   meta = with lib; {
     changelog = "https://github.com/Toblerity/Fiona/blob/${src.rev}/CHANGES.txt";


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Update package to latest bug fix release.

List of changes:
* https://github.com/Toblerity/Fiona/releases/tag/1.9.2
* https://github.com/Toblerity/Fiona/releases/tag/1.9.3
* https://github.com/Toblerity/Fiona/releases/tag/1.9.4

Important note:

setuptools is removed from propagatedBuildInputs due to Fiona 1.9.2
dropping runtime dependency on setuptools.
See: https://github.com/Toblerity/Fiona/releases/tag/1.9.2

This PR is also disabling broken "test_append_memoryfile_drivers" test.
See: https://github.com/Toblerity/Fiona/issues/1273

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
