### PR TITLE
swayfx: Add swayfx-wrapped 

### DIFF
--- a/pkgs/applications/window-managers/sway/fx.nix
+++ b/pkgs/applications/window-managers/sway/fx.nix
@@ -1,9 +1,21 @@
-{ fetchFromGitHub, lib, sway-unwrapped }:
-
+{ lib
+, stdenv
+, fetchFromGitHub
+, sway-unwrapped
+, # Used by the NixOS module:
+  isNixOS ? false
+, enableXWayland ? true
+, systemdSupport ? lib.meta.availableOn stdenv.hostPlatform systemd
+, systemd
+, dbusSupport ? true
+, trayEnabled ? systemdSupport && dbusSupport
+,
+}:
 sway-unwrapped.overrideAttrs (oldAttrs: rec {
   pname = "swayfx";
   version = "0.3";
 
+  inherit isNixOS enableXWayland systemdSupport dbusSupport trayEnabled;
   src = fetchFromGitHub {
     owner = "WillPower3309";
     repo = "swayfx";

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -31456,7 +31456,8 @@ with pkgs;
 
   swaycons = callPackage ../applications/window-managers/sway/swaycons.nix { };
 
-  swayfx = callPackage ../applications/window-managers/sway/fx.nix { };
+  swayfx-unwrapped = callPackage ../applications/window-managers/sway/fx.nix { };
+  swayfx = callPackage ../applications/window-managers/sway/wrapper.nix { sway-unwrapped=swayfx-unwrapped; };
 
   swaylock-fancy = callPackage ../applications/window-managers/sway/lock-fancy.nix { };
 


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
Current swayfx package is equivalent to the sway-unwrapped package. This PR moves the current swayfx implementation to `swayfx-unwrapped` and `swayfx` is now sway's wrapper, using swayfx-unwrapped instead. This makes `sway-unwrapped` and `sway` packages  interchangeable with their `fx` versions.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [X] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
