### PR TITLE
nixos/below: Add service module

### DIFF
--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -723,6 +723,7 @@
   ./services/monitoring/alerta.nix
   ./services/monitoring/apcupsd.nix
   ./services/monitoring/arbtt.nix
+  ./services/monitoring/below.nix
   ./services/monitoring/bosun.nix
   ./services/monitoring/cadvisor.nix
   ./services/monitoring/cockpit.nix

--- a/nixos/modules/services/monitoring/below.nix
+++ b/nixos/modules/services/monitoring/below.nix
@@ -13,12 +13,13 @@ let
   mkDisableOption = n: mkOption {
     type = types.bool;
     default = true;
-    description = "Whether to enable ${n}.";
+    description = mdDoc "Whether to enable ${n}.";
   };
-  optionalType = ty: x: mkOption ({
+  optionalType = ty: x: mkOption (x // {
+    description = mdDoc x.description;
     type = (types.nullOr ty);
     default = null;
-  } // x);
+  });
   optionalPath = optionalType types.path;
   optionalStr = optionalType types.str;
   optionalInt = optionalType types.int;
@@ -33,13 +34,13 @@ in {
       };
       collect = {
         diskStats = mkDisableOption "dist_stat collection";
-        ioStats   = mkEnableOption "io.stat collection for cgroups";
+        ioStats   = mkEnableOption (mdDoc "io.stat collection for cgroups");
         exitStats = mkDisableOption "eBPF-based exitstats";
       };
-      compression.enable = mkEnableOption "data compression";
+      compression.enable = mkEnableOption (mdDoc "data compression");
       retention = {
         size = optionalInt {
-          description = mdDoc ''
+          description = ''
             Size limit for below's data, in bytes. Data is deleted oldest-first, in 24h 'shards'.
 
             ::: {.note}
@@ -50,7 +51,7 @@ in {
           '';
         };
         time = optionalInt {
-          description = mdDoc ''
+          description = ''
             Retention time, in seconds.
 
             ::: {.note}

--- a/nixos/modules/services/monitoring/below.nix
+++ b/nixos/modules/services/monitoring/below.nix
@@ -1,0 +1,105 @@
+{ config, lib, pkgs, ... }:
+with lib;
+let
+  cfg = config.services.below;
+  cfgContents = concatStringsSep "\n" (
+    mapAttrsToList (n: v: ''${n} = "${v}"'') (filterAttrs (_k: v: v != null) {
+      log_dir = cfg.dirs.log;
+      store_dir = cfg.dirs.store;
+      cgroup_filter_out = cfg.cgroupFilterOut;
+    })
+  );
+
+  mkDisableOption = n: mkOption {
+    type = types.bool;
+    default = true;
+    description = "Whether to enable ${n}.";
+  };
+  optionalType = ty: x: mkOption ({
+    type = (types.nullOr ty);
+    default = null;
+  } // x);
+  optionalPath = optionalType types.path;
+  optionalStr = optionalType types.str;
+  optionalInt = optionalType types.int;
+in {
+  options = {
+    services.below = {
+      enable = mkEnableOption (mdDoc "'below' resource monitor");
+
+      cgroupFilterOut = optionalStr {
+        description = "A regexp matching the full paths of cgroups whose data shouldn't be collected";
+        example = "user.slice.*";
+      };
+      collect = {
+        diskStats = mkDisableOption "dist_stat collection";
+        ioStats   = mkEnableOption "io.stat collection for cgroups";
+        exitStats = mkDisableOption "eBPF-based exitstats";
+      };
+      compression.enable = mkEnableOption "data compression";
+      retention = {
+        size = optionalInt {
+          description = mdDoc ''
+            Size limit for below's data, in bytes. Data is deleted oldest-first, in 24h 'shards'.
+
+            ::: {.note}
+            The size limit may be exceeded by at most the size of the active shard, as:
+            - the active shard cannot be deleted;
+            - the size limit is only enforced when a new shard is created.
+            :::
+          '';
+        };
+        time = optionalInt {
+          description = mdDoc ''
+            Retention time, in seconds.
+
+            ::: {.note}
+            As data is stored in 24 hour shards which are discarded as a whole,
+            only data expired by 24h (or more) is guaranteed to be discarded.
+            :::
+
+            ::: {.note}
+            If `retention.size` is set, data may be discarded earlier than the specified time.
+            :::
+          '';
+        };
+      };
+      dirs = {
+        log = optionalPath { description = "Where to store below's logs"; };
+        store = optionalPath {
+          description = "Where to store below's data";
+          example = "/var/lib/below";
+        };
+      };
+    };
+  };
+
+  config = mkIf cfg.enable {
+    environment.systemPackages = [ pkgs.below ];
+    # /etc/below.conf is also refered to by the `below` CLI tool,
+    #  so this can't be a store-only file whose path is passed to the service
+    environment.etc."below/below.conf".text = cfgContents;
+
+    systemd = {
+      packages = [ pkgs.below ];
+      services.below = {
+        # Workaround for https://github.com/NixOS/nixpkgs/issues/81138
+        wantedBy = [ "multi-user.target" ];
+        restartTriggers = [ cfgContents ];
+
+        serviceConfig.ExecStart = [
+          ""
+          ("${lib.getExe pkgs.below} record " + (concatStringsSep " " (
+            optional (!cfg.collect.diskStats) "--disable-disk-stat" ++
+            optional   cfg.collect.ioStats    "--collect-io-stat"   ++
+            optional (!cfg.collect.exitStats) "--disable-exitstats" ++
+            optional   cfg.compression.enable "--compress"          ++
+
+            optional (cfg.retention.size != null) "--store-size-limit ${toString cfg.retention.size}" ++
+            optional (cfg.retention.time != null) "--retain-for-s ${toString cfg.retention.time}"
+          )))
+        ];
+      };
+    };
+  };
+}

--- a/pkgs/os-specific/linux/below/default.nix
+++ b/pkgs/os-specific/linux/below/default.nix
@@ -22,6 +22,12 @@ rustPlatform.buildRustPackage rec {
 
   cargoSha256 = "sha256-EoRCmEe9SAySZCm+QhaR4ngik4Arnm4SZjgDM5fSRmk=";
 
+  prePatch = ''sed -i "s,ExecStart=.*/bin,ExecStart=$out/bin," etc/below.service'';
+  postInstall = ''
+    install -d $out/lib/systemd/system
+    install -t $out/lib/systemd/system etc/below.service
+  '';
+
   # bpf code compilation
   hardeningDisable = [ "stackprotector" ];
 


### PR DESCRIPTION
###### Description of changes

- Ship systemd service unit in derivation `below`.
- Add a new NixOS module to enable & configure said service.

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
