### PR TITLE
vrc-get: init at 1.1.1

### DIFF
--- a/pkgs/tools/misc/vrc-get/default.nix
+++ b/pkgs/tools/misc/vrc-get/default.nix
@@ -2,12 +2,12 @@
 
 rustPlatform.buildRustPackage rec {
   pname = "vrc-get";
-  version = "v1.1.1";
+  version = "1.1.1";
 
   src = fetchFromGitHub {
     owner = "anatawa12";
     repo = pname;
-    rev = version;
+    rev = "v${version}";
     sha256 = "16r3b2w4xfw1lwxp8ib23f76i4zgl8hk7q2g82yw6hxjimq69sy2";
   };
 
@@ -18,10 +18,10 @@ rustPlatform.buildRustPackage rec {
   # Make openssl-sys use pkg-config.
   OPENSSL_NO_VENDOR = 1;
 
-  cargoSha256 = "0szwr8r1y7w82xfx24ffxwqa9gv8m35k30nycfn8vng54vba1rcy";
+  cargoSha256 = "1f76y7hzh4pk7gj0w5gqb65w8qvkfx1bxx9z3w9vdqdkz39439rf";
 
   meta = with lib; {
-    description = "Open Source command line client of VRChat Package Manager, the main feature of VRChat Creator Companion (VCC), that supports Windows, Linux, and macOS.";
+    description = "Command line client of VRChat Package Manager, the main feature of VRChat Creator Companion (VCC)";
     homepage = "https://github.com/anatawa12/vrc-get";
     license = licenses.mit;
     maintainers = with maintainers; [ bddvlpr ];

--- a/pkgs/tools/misc/vrc-get/default.nix
+++ b/pkgs/tools/misc/vrc-get/default.nix
@@ -1,0 +1,29 @@
+{ fetchFromGitHub, lib, rustPlatform, pkg-config, openssl, stdenv, Security }:
+
+rustPlatform.buildRustPackage rec {
+  pname = "vrc-get";
+  version = "v1.1.1";
+
+  src = fetchFromGitHub {
+    owner = "anatawa12";
+    repo = pname;
+    rev = version;
+    sha256 = "16r3b2w4xfw1lwxp8ib23f76i4zgl8hk7q2g82yw6hxjimq69sy2";
+  };
+
+  nativeBuildInputs = [ pkg-config ];
+
+  buildInputs = [ openssl ] ++ lib.optionals stdenv.isDarwin [ Security ];
+
+  # Make openssl-sys use pkg-config.
+  OPENSSL_NO_VENDOR = 1;
+
+  cargoSha256 = "0szwr8r1y7w82xfx24ffxwqa9gv8m35k30nycfn8vng54vba1rcy";
+
+  meta = with lib; {
+    description = "Open Source command line client of VRChat Package Manager, the main feature of VRChat Creator Companion (VCC), that supports Windows, Linux, and macOS.";
+    homepage = "https://github.com/anatawa12/vrc-get";
+    license = licenses.mit;
+    maintainers = with maintainers; [ bddvlpr ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1765,6 +1765,10 @@ with pkgs;
 
   vopono = callPackage ../tools/networking/vopono { };
 
+  vrc-get = callPackage ../tools/misc/vrc-get {
+    inherit (darwin.apple_sdk.frameworks) Security;
+  };
+
   winbox = callPackage ../tools/admin/winbox {
     wine = wineWowPackages.staging;
   };


### PR DESCRIPTION
###### Description of changes

Initialized package at v1.0.1. Package was updated on 6th of June to v1.0.2. Package was updated on 19th of June to v1.1.0. Package was updated on 25th of June to v1.1.1.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
