### PR TITLE
lib.sourceSubdirs: init

### DIFF
--- a/lib/default.nix
+++ b/lib/default.nix
@@ -119,7 +119,7 @@ let
       hiPrioSet getLicenseFromSpdxId getExe;
     inherit (self.filesystem) pathType pathIsDirectory pathIsRegularFile;
     inherit (self.sources) cleanSourceFilter
-      cleanSource sourceByRegex sourceFilesBySuffices
+      cleanSource sourceByRegex sourceFilesBySuffices sourceSubdirs
       commitIdFromGitRepo cleanSourceWith pathHasContext
       canCleanSource pathIsGitRepo;
     inherit (self.modules) evalModules setDefaultModuleLocation

--- a/lib/path/default.nix
+++ b/lib/path/default.nix
@@ -149,6 +149,24 @@ in /* No rec! Add dependencies on this file at the top. */ {
           ${subpathInvalidReason subpath}'';
     path + ("/" + subpath);
 
+  /*
+    Test whether one path is a child of another.
+    This is just based on the string values of the provided paths.
+    It does not access the filesystem.
+
+    Type: sourceLike -> Path|String -> Path|String -> bool
+
+    Examples:
+      path.hasPrefix "foo" "foo/bar" # => true
+      path.hasPrefix "foo" "foo" # => true
+      path.hasPrefix "food" "foo" => false
+      path.hasPrefix "foo/bar" "foo" # => false
+   */
+  hasPrefix = parent: child:
+    assert lib.isPath parent;
+    assert lib.isPath child;
+    lib.hasPrefix "${toString parent}/" "${toString child}/";
+
   /* Whether a value is a valid subpath string.
 
   - The value is a string

--- a/lib/sources.nix
+++ b/lib/sources.nix
@@ -156,6 +156,27 @@ let
       in type == "directory" || lib.any (ext: lib.hasSuffix ext base) exts;
     in cleanSourceWith { inherit filter src; };
 
+  /*
+    Filter a source directory down to only a specified list of
+    subdirectories.
+
+    Type: sourceLike -> [String] -> Source
+
+    Example:
+      sourceSubdirs src [ "host/rootfs" "scripts" ]
+  */
+  sourceSubdirs = src: subdirs: lib.cleanSourceWith {
+    filter = path: _type:
+      lib.any (subdir:
+        let
+          subdir' = lib.path.append (src.origSrc or src) subdir;
+          path' = /. + path;
+        in
+          lib.path.hasPrefix path' subdir' || lib.path.hasPrefix subdir' path'
+      ) subdirs;
+    inherit src;
+  };
+
   pathIsGitRepo = path: (_commitIdFromGitRepoOrError path)?value;
 
   /*
@@ -286,6 +307,7 @@ in {
 
     sourceByRegex
     sourceFilesBySuffices
+    sourceSubdirs
 
     trace
     ;


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

This is really useful for using Nix in monorepo layouts, where you
might have a component build that needs access to multiple
subdirectories of the repository.  Compared to settings "srcs", it's
more convenient, because it preserves the relative
structure (including parent directories), and it avoids unnecessary
rebuilds compared to not filtering for subdirectories.

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
