### PR TITLE
abracadabra: init at 2.1.1

### DIFF
--- a/pkgs/applications/radio/abracadabra/default.nix
+++ b/pkgs/applications/radio/abracadabra/default.nix
@@ -1,0 +1,50 @@
+{ lib, stdenv, fetchFromGitHub, cmake, wrapQtAppsHook
+, qtbase, qtmultimedia, qttools
+, faad2, mpg123, portaudio
+, libusb1, rtl-sdr, airspy, soapysdr-with-plugins
+} :
+
+stdenv.mkDerivation rec {
+  pname = "abracadabra";
+  version = "2.1.1";
+
+  src = fetchFromGitHub {
+    owner = "KejPi";
+    repo = "AbracaDABra";
+    rev = "v${version}";
+    sha256 = "sha256-pjcao8KTEmgE54dUBxLLnStszR32LryfciMKScBOGdc=";
+  };
+
+  nativeBuildInputs = [
+    cmake
+    wrapQtAppsHook
+    qttools
+  ];
+
+  buildInputs = [
+    qtbase
+    qtmultimedia
+    faad2
+    mpg123
+    portaudio
+    libusb1
+    rtl-sdr
+    airspy
+    soapysdr-with-plugins
+  ];
+
+  cmakeFlags = [
+    "-DAIRSPY=ON"
+    "-DSOAPYSDR=ON"
+  ];
+
+  meta = with lib; {
+    description = "DAB/DAB+ radio application";
+    homepage = "https://github.com/KejPi/AbracaDABra";
+    platforms = platforms.linux;
+    license = licenses.mit;
+    maintainers = [ maintainers.markuskowa ];
+    mainProgram = "AbracaDABra";
+  };
+}
+

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2767,6 +2767,8 @@ with pkgs;
 
   twine = with python3Packages; toPythonApplication twine;
 
+  abracadabra = qt6Packages.callPackage ../applications/radio/abracadabra { };
+
   accelergy = callPackage ../applications/science/computer-architecture/accelergy { };
 
   aldo = callPackage ../applications/radio/aldo { };


### PR DESCRIPTION
###### Description of changes
DAB/DAB+ radio application for RTL-SDR, Airspy, and SoapySDR supported radios with Qt6 GUI.


###### Things done
Tested with RTL-SDR and Airspy mini.
<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
