### PR TITLE
aflplusplus: 2.64c -> 4.06c

### DIFF
--- a/pkgs/tools/security/aflplusplus/default.nix
+++ b/pkgs/tools/security/aflplusplus/default.nix
@@ -19,13 +19,13 @@ let
   libtokencap = callPackage ./libtokencap.nix { inherit aflplusplus; };
   aflplusplus = stdenvNoCC.mkDerivation rec {
     pname = "aflplusplus";
-    version = "4.05c";
+    version = "4.06c";
 
     src = fetchFromGitHub {
       owner = "AFLplusplus";
       repo = "AFLplusplus";
       rev = version;
-      sha256 = "sha256-c4GFOuCwIOFkwIxXtwE3VTVlWW7lS8h+GMN70fZbgDI=";
+      sha256 = "sha256-Gb1nYDBnwLS+m8e1UD0WLIrnp8KRgliGQVvQD22JXrQ=";
     };
     enableParallelBuilding = true;
 

--- a/pkgs/tools/security/aflplusplus/default.nix
+++ b/pkgs/tools/security/aflplusplus/default.nix
@@ -1,6 +1,8 @@
 { lib, stdenv, stdenvNoCC, fetchFromGitHub, callPackage, makeWrapper
-, clang, llvm, gcc, which, libcgroup, python, perl, gmp
+, clang, llvm, gcc, which, libcgroup, python3, perl, gmp
 , file, wine ? null, fetchpatch
+, cmocka
+, llvmPackages
 }:
 
 # wine fuzzing is only known to work for win32 binaries, and using a mixture of
@@ -17,38 +19,51 @@ let
   libtokencap = callPackage ./libtokencap.nix { inherit aflplusplus; };
   aflplusplus = stdenvNoCC.mkDerivation rec {
     pname = "aflplusplus";
-    version = "2.65c";
+    version = "4.05c";
 
     src = fetchFromGitHub {
       owner = "AFLplusplus";
       repo = "AFLplusplus";
       rev = version;
-      sha256 = "1np2a3kypb2m8nyv6qnij18yzn41pl8619jzydci40br4vxial9l";
+      sha256 = "sha256-c4GFOuCwIOFkwIxXtwE3VTVlWW7lS8h+GMN70fZbgDI=";
     };
     enableParallelBuilding = true;
 
     # Note: libcgroup isn't needed for building, just for the afl-cgroup
     # script.
     nativeBuildInputs = [ makeWrapper which clang gcc ];
-    buildInputs = [ llvm python gmp ]
-      ++ lib.optional (wine != null) python.pkgs.wrapPython;
+    buildInputs = [ llvm python3 gmp llvmPackages.bintools ]
+      ++ lib.optional (wine != null) python3.pkgs.wrapPython;
 
+    # Flag is already set by package and causes some compiler warnings.
+    # warning: "_FORTIFY_SOURCE" redefined
+    hardeningDisable = [ "fortify" ];
 
     postPatch = ''
-      # Replace the CLANG_BIN variables with the correct path
-      substituteInPlace llvm_mode/afl-clang-fast.c \
+      # Don't care about this.
+      rm Android.bp
+
+      # Replace the CLANG_BIN variables with the correct path.
+      # Replace "gcc" and friends with full paths in afl-gcc.
+      # Prevents afl-gcc picking up any (possibly incorrect) gcc from the path.
+      # Replace LLVM_BINDIR with a non-existing path to give a hard error when it's used.
+      substituteInPlace src/afl-cc.c \
         --replace "CLANGPP_BIN" '"${clang}/bin/clang++"' \
         --replace "CLANG_BIN" '"${clang}/bin/clang"' \
-        --replace 'getenv("AFL_PATH")' "(getenv(\"AFL_PATH\") ? getenv(\"AFL_PATH\") : \"$out/lib/afl\")"
-
-      # Replace "gcc" and friends with full paths in afl-gcc
-      # Prevents afl-gcc picking up any (possibly incorrect) gcc from the path
-      substituteInPlace src/afl-gcc.c \
         --replace '"gcc"' '"${gcc}/bin/gcc"' \
         --replace '"g++"' '"${gcc}/bin/g++"' \
-        --replace '"gcj"' '"gcj-UNSUPPORTED"' \
-        --replace '"clang"' '"clang-UNSUPPORTED"' \
-        --replace '"clang++"' '"clang++-UNSUPPORTED"'
+        --replace 'getenv("AFL_PATH")' "(getenv(\"AFL_PATH\") ? getenv(\"AFL_PATH\") : \"$out/lib/afl\")"
+
+      substituteInPlace src/afl-ld-lto.c \
+        --replace 'LLVM_BINDIR' '"/nixpkgs-patched-does-not-exist"'
+
+      # Remove the rest of the line
+      sed -i 's|LLVM_BINDIR = .*|LLVM_BINDIR = |' utils/aflpp_driver/GNUmakefile
+      substituteInPlace utils/aflpp_driver/GNUmakefile \
+        --replace 'LLVM_BINDIR = ' 'LLVM_BINDIR = ${clang}/bin/'
+
+      substituteInPlace GNUmakefile.llvm \
+        --replace "\$(LLVM_BINDIR)/clang" "${clang}/bin/clang"
     '';
 
     env.NIX_CFLAGS_COMPILE = toString [
@@ -56,15 +71,19 @@ let
       "-Wno-error=use-after-free"
     ];
 
-    makeFlags = [ "PREFIX=$(out)" ];
+    makeFlags = [
+      "PREFIX=$(out)"
+      "USE_BINDIR=0"
+    ];
     buildPhase = ''
+      runHook preBuild
+
       common="$makeFlags -j$NIX_BUILD_CORES"
-      make all $common
-      make radamsa $common
-      make -C gcc_plugin CC=${gcc}/bin/gcc CXX=${gcc}/bin/g++ $common
-      make -C llvm_mode $common
+      make distrib $common
       make -C qemu_mode/libcompcov $common
       make -C qemu_mode/unsigaction $common
+
+      runHook postBuild
     '';
 
     postInstall = ''
@@ -75,7 +94,7 @@ let
       cp qemu_mode/unsigaction/unsigaction*.so $out/lib/afl/
 
       # Install the custom QEMU emulator for binary blob fuzzing.
-      cp ${aflplusplus-qemu}/bin/${qemu-exe-name} $out/bin/afl-qemu-trace
+      ln -s ${aflplusplus-qemu}/bin/${qemu-exe-name} $out/bin/afl-qemu-trace
 
       # give user a convenient way of accessing libcompconv.so, libdislocator.so, libtokencap.so
       cat > $out/bin/get-afl-qemu-libcompcov-so <<END
@@ -83,11 +102,11 @@ let
       echo $out/lib/afl/libcompcov.so
       END
       chmod +x $out/bin/get-afl-qemu-libcompcov-so
-      cp ${libdislocator}/bin/get-libdislocator-so $out/bin/
-      cp ${libtokencap}/bin/get-libtokencap-so $out/bin/
+      ln -s ${libdislocator}/bin/get-libdislocator-so $out/bin/
+      ln -s ${libtokencap}/bin/get-libtokencap-so $out/bin/
 
       # Install the cgroups wrapper for asan-based fuzzing.
-      cp examples/asan_cgroups/limit_memory.sh $out/bin/afl-cgroup
+      cp utils/asan_cgroups/limit_memory.sh $out/bin/afl-cgroup
       chmod +x $out/bin/afl-cgroup
       substituteInPlace $out/bin/afl-cgroup \
         --replace "cgcreate" "${libcgroup}/bin/cgcreate" \
@@ -107,19 +126,32 @@ let
         if [ -x $winePath ]; then break; fi
       done
       makeWrapperArgs="--set-default 'AFL_WINE_PATH' '$winePath'" \
-        wrapPythonProgramsIn $out/bin ${python.pkgs.pefile}
+        wrapPythonProgramsIn $out/bin ${python3.pkgs.pefile}
     '';
 
-    nativeInstallCheckInputs = [ perl file ];
+    nativeInstallCheckInputs = [ perl file cmocka ];
     doInstallCheck = true;
     installCheckPhase = ''
+      runHook preInstallCheck
+
       # replace references to tools in build directory with references to installed locations
-      substituteInPlace test/test.sh \
+      substituteInPlace test/test-qemu-mode.sh \
         --replace '../libcompcov.so' '`$out/bin/get-afl-qemu-libcompcov-so`' \
+        --replace '../afl-qemu-trace' '$out/bin/afl-qemu-trace' \
+        --replace '../afl-fuzz' '$out/bin/afl-fuzz' \
+        --replace '../qemu_mode/unsigaction/unsigaction32.so' '$out/lib/afl/unsigaction32.so' \
+        --replace '../qemu_mode/unsigaction/unsigaction64.so' '$out/lib/afl/unsigaction64.so'
+
+      substituteInPlace test/test-libextensions.sh \
         --replace '../libdislocator.so' '`$out/bin/get-libdislocator-so`' \
         --replace '../libtokencap.so' '`$out/bin/get-libtokencap-so`'
-      perl -pi -e 's|(?<!\.)(?<!-I)(\.\./)([^\s\/]+?)(?<!\.c)(?<!\.s?o)(?=\s)|\$out/bin/\2|g' test/test.sh
-      cd test && ./test.sh
+      substituteInPlace test/test-llvm.sh \
+        --replace '../afl-cmin.bash' '`$out/bin/afl-cmin.bash`'
+      # perl -pi -e 's|(?<!\.)(?<!-I)(\.\./)([^\s\/]+?)(?<!\.c)(?<!\.s?o)(?=\s)|\$out/bin/\2|g' test/test.sh
+      patchShebangs .
+      cd test && ./test-all.sh
+
+      runHook postInstallCheck
     '';
 
     passthru = {

--- a/pkgs/tools/security/aflplusplus/libdislocator.nix
+++ b/pkgs/tools/security/aflplusplus/libdislocator.nix
@@ -6,15 +6,14 @@ stdenv.mkDerivation {
 
   src = aflplusplus.src;
   postUnpack = "chmod -R +w ${aflplusplus.src.name}";
-  sourceRoot = "${aflplusplus.src.name}/libdislocator";
+  sourceRoot = "${aflplusplus.src.name}/utils/libdislocator";
 
   makeFlags = [ "PREFIX=$(out)" ];
 
   preInstall = ''
     mkdir -p $out/lib/afl
-    # issue is fixed upstream: https://github.com/AFLplusplus/AFLplusplus/commit/2a60ceb6944a7ca273057ddf64dcf837bf7f9521
-    sed -i 's/README\.dislocator\.md/README\.md/g' Makefile
   '';
+
   postInstall = ''
     mkdir $out/bin
     cat > $out/bin/get-libdislocator-so <<END

--- a/pkgs/tools/security/aflplusplus/libtokencap.nix
+++ b/pkgs/tools/security/aflplusplus/libtokencap.nix
@@ -6,7 +6,7 @@ stdenv.mkDerivation {
 
   src = aflplusplus.src;
   postUnpack = "chmod -R +w ${aflplusplus.src.name}";
-  sourceRoot = "${aflplusplus.src.name}/libtokencap";
+  sourceRoot = "${aflplusplus.src.name}/utils/libtokencap";
 
   makeFlags = [ "PREFIX=$(out)" ];
 
@@ -24,7 +24,7 @@ stdenv.mkDerivation {
   '';
 
   meta = with lib; {
-    homepage = "https://github.com/vanhauser-thc/AFLplusplus";
+    homepage = "https://github.com/AFLplusplus/AFLplusplus";
     description = "strcmp & memcmp token capture library";
     license = lib.licenses.asl20;
     maintainers = with maintainers; [ ris ];

--- a/pkgs/tools/security/aflplusplus/qemu.nix
+++ b/pkgs/tools/security/aflplusplus/qemu.nix
@@ -1,78 +1,147 @@
-{ lib, stdenv, fetchurl, aflplusplus, python3, zlib, pkg-config, glib, perl
-, texinfo, libuuid, flex, bison, pixman, autoconf
+{ lib
+, stdenv
+, fetchurl
+, aflplusplus
+, python3
+, zlib
+, pkg-config
+, glib
+, perl
+, texinfo
+, libuuid
+, flex
+, bison
+, pixman
+, meson
+, fetchFromGitHub
+, ninja
 }:
 
 let
-  qemuName = "qemu-3.1.0";
-  cpuTarget = if stdenv.targetPlatform.system == "x86_64-linux" then "x86_64-linux-user"
+  qemuName = "qemu-5.2.50";
+  cpuTarget =
+    if stdenv.targetPlatform.system == "x86_64-linux" then "x86_64-linux-user"
     else if stdenv.targetPlatform.system == "i686-linux" then "i386-linux-user"
     else throw "aflplusplus: no support for ${stdenv.targetPlatform.system}!";
 in
 stdenv.mkDerivation {
   name = "aflplusplus-${qemuName}";
 
-  srcs = [
-    (fetchurl {
-      url = "http://wiki.qemu.org/download/${qemuName}.tar.bz2";
-      sha256 = "08frr1fdjx8qcfh3fafn10kibdwbvkqqvfl7hpqbm7i9dg4f1zlq";
-    })
-    aflplusplus.src
-  ];
-
-  sourceRoot = qemuName;
-
-  postUnpack = ''
-    chmod -R +w ${aflplusplus.src.name}
-    for f in ${aflplusplus.src.name}/qemu_mode/patches/* ; do
-      sed -E -i 's|(\.\./)+patches/([a-z-]+\.h)|\2|g' $f
-      sed -E -i 's|\.\./\.\./config\.h|afl-config.h|g' $f
-      sed -E -i 's|\.\./\.\./include/cmplog\.h|afl-cmplog.h|g' $f
-    done
-    cp ${aflplusplus.src.name}/qemu_mode/patches/*.h $sourceRoot/
-    cp ${aflplusplus.src.name}/types.h $sourceRoot/afl-types.h
-    substitute ${aflplusplus.src.name}/config.h $sourceRoot/afl-config.h \
-      --replace "types.h" "afl-types.h"
-    substitute ${aflplusplus.src.name}/include/cmplog.h $sourceRoot/afl-cmplog.h \
-      --replace "config.h" "afl-config.h" \
-      --replace "forkserver.h" "afl-forkserver.h"
-    substitute ${aflplusplus.src.name}/include/forkserver.h $sourceRoot/afl-forkserver.h \
-      --replace "types.h" "afl-types.h"
-
-    cat ${aflplusplus.src.name}/qemu_mode/patches/*.diff > all.patch
-  '';
+  src = fetchFromGitHub {
+    owner = "AFLplusplus";
+    repo = "qemuafl";
+    rev = "a8af9cbde71e333ce72a46f15e655d0b82ed0939";
+    sha256 = "sha256-veT9Vne9arB1kbQDAKGZ/skse5C5KNAiMBj2JWkS4tQ=";
+    fetchSubmodules = true;
+  };
 
   nativeBuildInputs = [
-    python3 perl pkg-config flex bison autoconf texinfo
+    python3
+    perl
+    pkg-config
+    flex
+    bison
+    meson
+    texinfo
+    ninja
   ];
 
   buildInputs = [
-    zlib glib pixman libuuid
+    zlib
+    glib
+    pixman
+    libuuid
   ];
 
   enableParallelBuilding = true;
 
-  patches = [
-    # patches extracted from aflplusplus source
-    "../all.patch"
-    # nix-specific patches to make installation more well-behaved
-    ./qemu-no-etc-install.patch
-  ];
+  dontUseMesonConfigure = true; # meson's configurePhase isn't compatible with qemu build
+  preBuild = "cd build";
+  preConfigure = ''
+    # this script isn't marked as executable b/c it's indirectly used by meson. Needed to patch its shebang
+    chmod +x ./scripts/shaderinclude.pl
+    patchShebangs .
+  '';
 
   configureFlags =
-    [ "--disable-system"
-      "--enable-linux-user"
-      "--disable-gtk"
-      "--disable-sdl"
-      "--disable-vnc"
-      "--disable-kvm"
-      "--target-list=${cpuTarget}"
-      "--enable-pie"
+    [
+      "--target-list=${stdenv.hostPlatform.uname.processor}-linux-user"
       "--sysconfdir=/etc"
       "--localstatedir=/var"
+      "--meson=meson"
+      "--disable-system"
+      "--enable-linux-user"
+      "--enable-pie"
+      "--audio-drv-list="
+      "--disable-blobs"
+      "--disable-bochs"
+      "--disable-brlapi"
+      "--disable-bsd-user"
+      "--disable-bzip2"
+      "--disable-cap-ng"
+      "--disable-cloop"
+      "--disable-curl"
+      "--disable-curses"
+      "--disable-dmg"
+      "--disable-fdt"
+      "--disable-gcrypt"
+      "--disable-glusterfs"
+      "--disable-gnutls"
+      "--disable-gtk"
+      "--disable-guest-agent"
+      "--disable-iconv"
+      "--disable-libiscsi"
+      "--disable-libnfs"
+      "--disable-libssh"
+      "--disable-libusb"
+      "--disable-linux-aio"
+      "--disable-live-block-migration"
+      "--disable-lzo"
+      "--disable-nettle"
+      "--disable-numa"
+      "--disable-opengl"
+      "--disable-parallels"
+      "--disable-plugins"
+      "--disable-qcow1"
+      "--disable-qed"
+      "--disable-rbd"
+      "--disable-rdma"
+      "--disable-replication"
+      "--disable-sdl"
+      "--disable-seccomp"
+      "--disable-sheepdog"
+      "--disable-smartcard"
+      "--disable-snappy"
+      "--disable-spice"
+      "--disable-system"
+      "--disable-tools"
+      "--disable-tpm"
+      "--disable-usb-redir"
+      "--disable-vde"
+      "--disable-vdi"
+      "--disable-vhost-crypto"
+      "--disable-vhost-kernel"
+      "--disable-vhost-net"
+      "--disable-vhost-scsi"
+      "--disable-vhost-user"
+      "--disable-vhost-vdpa"
+      "--disable-vhost-vsock"
+      "--disable-virglrenderer"
+      "--disable-virtfs"
+      "--disable-vnc"
+      "--disable-vnc-jpeg"
+      "--disable-vnc-png"
+      "--disable-vnc-sasl"
+      "--disable-vte"
+      "--disable-vvfat"
+      "--disable-xen"
+      "--disable-xen-pci-passthrough"
+      "--disable-xfsctl"
+      "--without-default-devices"
     ];
 
   meta = with lib; {
-    homepage = "https://www.qemu.org/";
+    homepage = "https://github.com/AFLplusplus/qemuafl";
     description = "Fork of QEMU with AFL++ instrumentation support";
     license = licenses.gpl2Plus;
     maintainers = with maintainers; [ ris ];

--- a/pkgs/tools/security/aflplusplus/qemu.nix
+++ b/pkgs/tools/security/aflplusplus/qemu.nix
@@ -30,8 +30,8 @@ stdenv.mkDerivation {
   src = fetchFromGitHub {
     owner = "AFLplusplus";
     repo = "qemuafl";
-    rev = "a8af9cbde71e333ce72a46f15e655d0b82ed0939";
-    sha256 = "sha256-veT9Vne9arB1kbQDAKGZ/skse5C5KNAiMBj2JWkS4tQ=";
+    rev = "0569eff8a12dec73642b96757f6b5b51a618a03a";
+    sha256 = "sha256-nYWHyRfOH2p9znRxjxsiyw11uZuMBiuJfEc7FHM5X7M=";
     fetchSubmodules = true;
   };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1394,9 +1394,9 @@ with pkgs;
   };
 
   aflplusplus = callPackage ../tools/security/aflplusplus {
-    clang = clang_9;
-    llvm = llvm_9;
-    python = python3;
+    clang = clang_14;
+    llvm = llvm_14;
+    llvmPackages = llvmPackages_14;
     wine = null;
   };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1394,9 +1394,9 @@ with pkgs;
   };
 
   aflplusplus = callPackage ../tools/security/aflplusplus {
-    clang = clang_14;
-    llvm = llvm_14;
-    llvmPackages = llvmPackages_14;
+    clang = clang_15;
+    llvm = llvm_15;
+    llvmPackages = llvmPackages_15;
     wine = null;
   };
 


### PR DESCRIPTION
###### Description of changes

https://github.com/AFLplusplus/AFLplusplus/releases/tag/4.06c

Lots of changes between the versions.

Based on work started here: https://github.com/NixOS/nixpkgs/pull/211189

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

