### PR TITLE
kotatogram-desktop.tg_owt: unpin openssl_1_1

### DIFF
--- a/pkgs/applications/networking/instant-messengers/telegram/kotatogram-desktop/tg_owt.nix
+++ b/pkgs/applications/networking/instant-messengers/telegram/kotatogram-desktop/tg_owt.nix
@@ -6,7 +6,7 @@
 , ninja
 , yasm
 , libjpeg
-, openssl_1_1
+, openssl
 , libopus
 , ffmpeg_4
 , protobuf
@@ -74,7 +74,7 @@ stdenv.mkDerivation {
 
   propagatedBuildInputs = [
     libjpeg
-    openssl_1_1
+    openssl
     libopus
     ffmpeg_4
     protobuf

--- a/pkgs/applications/networking/instant-messengers/telegram/kotatogram-desktop/tg_owt.nix
+++ b/pkgs/applications/networking/instant-messengers/telegram/kotatogram-desktop/tg_owt.nix
@@ -1,6 +1,7 @@
 { lib
 , stdenv
 , fetchFromGitHub
+, fetchpatch
 , pkg-config
 , cmake
 , ninja
@@ -44,6 +45,17 @@
 , ApplicationServices
 }:
 
+let
+  libsrtp = fetchFromGitHub {
+    owner = "cisco";
+    repo = "libsrtp";
+
+    # https://github.com/desktop-app/tg_owt/commit/6894e86eef8809d42b66eb85e376006f2a816a56
+    rev = "a566a9cfcd619e8327784aa7cff4a1276dc1e895";
+    sha256 = "sha256-OvCw7oF1OuamP3qO2BsimeBSHq1rcXFLfK8KnbbgkMU=";
+  };
+in
+
 stdenv.mkDerivation {
   pname = "tg_owt";
   version = "unstable-2022-04-13";
@@ -58,6 +70,16 @@ stdenv.mkDerivation {
 
   patches = [
     ./tg_owt.patch
+
+    (fetchpatch {
+      url = "https://github.com/desktop-app/tg_owt/commit/0614aac699b1a53242ffe2664e3724533bf64f97.patch";
+      hash = "sha256-iCdX518CB/RboDFhl3opnwcAgtqpNWZzYtV75Q+WB6Y=";
+    })
+
+    (fetchpatch {
+      url = "https://github.com/desktop-app/tg_owt/commit/9d120195334db4f232c925529aa7601656dc59d7.patch";
+      hash = "sha256-k99OBCdE2eQVyXEyvreEqVtzC8Xfdolbgd1Z7lV2ceE=";
+    })
   ];
 
   postPatch = lib.optionalString stdenv.isLinux ''
@@ -66,6 +88,9 @@ stdenv.mkDerivation {
       --replace '"libGL.so.1"' '"${libGL}/lib/libGL.so.1"' \
       --replace '"libgbm.so.1"' '"${mesa}/lib/libgbm.so.1"' \
       --replace '"libdrm.so.2"' '"${libdrm}/lib/libdrm.so.2"'
+
+    rm -r src/third_party/libsrtp
+    cp -r --no-preserve=mode ${libsrtp} src/third_party/libsrtp
   '';
 
   outputs = [ "out" "dev" ];


### PR DESCRIPTION
This reverts commit f83a8af.

###### Description of changes

https://github.com/NixOS/nixpkgs/pull/229392#issuecomment-1564547894

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
