### PR TITLE
mkshell: amend MANPATH and INFOPATH according to inputs

### DIFF
--- a/pkgs/build-support/mkshell/default.nix
+++ b/pkgs/build-support/mkshell/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, buildEnv }:
+{ lib, stdenv, buildEnv, buildPackages }:
 
 # A special kind of derivation that is only meant to be consumed by the
 # nix-shell.
@@ -28,18 +28,63 @@ let
     "propagatedNativeBuildInputs"
     "shellHook"
   ];
+
+  merged = {
+    buildInputs = mergeInputs "buildInputs";
+    nativeBuildInputs = packages ++ (mergeInputs "nativeBuildInputs");
+    propagatedBuildInputs = mergeInputs "propagatedBuildInputs";
+    propagatedNativeBuildInputs = mergeInputs "propagatedNativeBuildInputs";
+  };
+
+  docPathShellHook = let
+    unwrapCC = pkg: if pkg ? cc then unwrapCC pkg.cc else pkg;
+    docInputs = builtins.concatLists (builtins.attrValues merged)
+                # grab the unwrapped cc, as wrappers may or may not
+                # retain doc outputs
+                ++ (lib.optional (stdenv ? cc) (unwrapCC stdenv.cc))
+                ++ stdenv.defaultBuildInputs ++ stdenv.defaultNativeBuildInputs
+                ++ stdenv.initialPath;
+    docDrvs = lib.unique (builtins.filter lib.isDerivation docInputs);
+    docPaths = type: lib.pipe docDrvs [
+      (map (lib.getOutput type))
+      (map (out: builtins.toPath "${out}/share/${type}"))
+      (builtins.filter builtins.pathExists)
+    ];
+    infoPaths = docPaths "info";
+    manPaths = docPaths "man";
+
+    # some packages neglect to build an info dir file
+    infoDirAddenda = stdenv.mkDerivation {
+      inherit (stdenv) system;
+      name = "${name}-info-dir-addenda";
+      passAsFile = ["buildCommand"];
+      buildCommand = ''
+        shopt -s nullglob
+        mkdir -p $out/share/info
+        for path in ${builtins.concatStringsSep " " infoPaths}; do
+          [[ -s $path/dir ]] && continue || :
+          for file in $path/*.info{,.gz}; do
+            ${buildPackages.texinfo}/bin/install-info $file $out/share/info/dir
+          done
+        done
+      '';
+    };
+  in ''
+    export INFOPATH=${builtins.concatStringsSep ":" (infoPaths ++ [(builtins.toPath "${infoDirAddenda}/share/info")])}:$INFOPATH
+    export MANPATH=${builtins.concatStringsSep ":" manPaths}:$MANPATH
+  '';
 in
 
 stdenv.mkDerivation ({
   inherit name;
 
-  buildInputs = mergeInputs "buildInputs";
-  nativeBuildInputs = packages ++ (mergeInputs "nativeBuildInputs");
-  propagatedBuildInputs = mergeInputs "propagatedBuildInputs";
-  propagatedNativeBuildInputs = mergeInputs "propagatedNativeBuildInputs";
+  inherit (merged)
+    buildInputs nativeBuildInputs
+    propagatedBuildInputs propagatedNativeBuildInputs;
 
-  shellHook = lib.concatStringsSep "\n" (lib.catAttrs "shellHook"
-    (lib.reverseList inputsFrom ++ [ attrs ]));
+  shellHook = lib.concatStringsSep "\n" ((lib.catAttrs "shellHook"
+    (lib.reverseList inputsFrom ++ [ attrs ]))
+  ++ [docPathShellHook]);
 
   phases = [ "buildPhase" ];
 


### PR DESCRIPTION
###### Description of changes

The fact that stdenv devshells don't set up proper MANPATH and INFOPATH has annoyed me for quite a while (and not just me: https://github.com/NixOS/nix/issues/3383), and it does not actually seem hard to fix

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [v] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
