### PR TITLE
advi: use ghostscriptX instead of gs discovered at build time

### DIFF
--- a/pkgs/tools/typesetting/tex/advi/default.nix
+++ b/pkgs/tools/typesetting/tex/advi/default.nix
@@ -45,6 +45,8 @@ ocamlPackages.buildDunePackage rec {
     substituteInPlace ./Makefile \
       --replace "\$(DUNE) install \$(DUNEROOT) --display=short" \
       "\$(DUNE) install \$(DUNEROOT) --prefix $out --docdir $out/share/doc --mandir $out/share/man"
+    substituteInPlace ./src/discover.sh \
+      --replace 'gs_path=$(which gs)' 'gs_path=${ghostscriptX}/bin/gs'
   '';
 
   duneVersion = "3";
@@ -52,10 +54,9 @@ ocamlPackages.buildDunePackage rec {
   nativeBuildInputs = [ fake-opam kpsexpand makeWrapper texlive.combined.scheme-medium which ];
   buildInputs = with ocamlPackages; [ camlimages ghostscriptX graphics ];
 
-  # TODO: ghostscript linked from texlive.combine will override ghostscriptX and break advi
+  # install additional files (such as man pages)
   preInstall = ''
     make install
-    wrapProgram "$out/bin/advi" --prefix PATH : "${lib.makeBinPath [ ghostscriptX ]}"
   '';
 
   # TODO: redirect /share/advi/tex/latex to tex output compatible with texlive.combine


### PR DESCRIPTION
###### Description of changes
advi hardcodes the path of `gs` found at build time, thus creating an unwanted dependency on `texlive.combined.scheme-medium`, moreover on a ghostscript version without X11 support.

This PR ensures that advi relies on `ghostscriptX` instead.

###### Things done
- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [X] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).