### PR TITLE
linuxPackages.ena: 2.8.3 -> 2.8.6 and fix build against Linux 6.3

### DIFF
--- a/pkgs/os-specific/linux/ena/default.nix
+++ b/pkgs/os-specific/linux/ena/default.nix
@@ -1,15 +1,32 @@
-{ lib, stdenv, fetchFromGitHub, kernel }:
+{ lib, stdenv, fetchFromGitHub, fetchpatch, kernel }:
 
 stdenv.mkDerivation rec {
-  version = "2.8.3";
+  version = "2.8.6";
   name = "ena-${version}-${kernel.version}";
 
   src = fetchFromGitHub {
     owner = "amzn";
     repo = "amzn-drivers";
     rev = "ena_linux_${version}";
-    sha256 = "sha256-Z5BCqqC4FNKHqpocJ6CsHwhh5sszj5QfxiN6+Dkaqek=";
+    hash = "sha256-clRu+ecK/Je0kvlAAm6qCJqMyvZv0C88YIGDImhRhKA=";
   };
+
+  patches =
+    [ # https://github.com/amzn/amzn-drivers/issues/269#issuecomment-1552483792
+      (fetchpatch {
+        url = "https://github.com/amzn/amzn-drivers/files/11504862/phc_kernel_6_2_fix.patch";
+        hash = "sha256-/EBkISwXMd7t4WZjsG9KVP6vncFwcZq1QBsxQLXyWsY=";
+      })
+      # https://github.com/amzn/amzn-drivers/issues/270#issuecomment-1561924754
+      (fetchpatch {
+        url = "https://github.com/amzn/amzn-drivers/files/11559312/devlink_6_2_fix.patch";
+        hash = "sha256-Nc71u91G0dL+ld6ovqjHaE6X2TxduWeQYr5K0KdoA3Q=";
+      })
+      (fetchpatch {
+        url = "https://github.com/amzn/amzn-drivers/files/11559314/devlink_6_3_fix.patch";
+        hash = "sha256-aEQTbwHC1DcDrtj188eoGzi3GU9MXnwIxuJW4L7qb/I=";
+      })
+    ];
 
   hardeningDisable = [ "pic" ];
 


### PR DESCRIPTION
###### Description of changes

This applies some patches that will be in the next version of ena, one fixing the removal of the adjfreq field in ptp_clock_info, and the others dealing with devlink changes.

https://hydra.nixos.org/build/221431596

Closes #224286 and #224287.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
