### PR TITLE
lowdown: 1.0.1 -> 1.0.2

### DIFF
--- a/pkgs/tools/typesetting/lowdown/default.nix
+++ b/pkgs/tools/typesetting/lowdown/default.nix
@@ -49,11 +49,12 @@ stdenv.mkDerivation rec {
   postInstall =
     let
       inherit (stdenv.hostPlatform.extensions) sharedLibrary;
+      soVersion = "2";
     in
 
     lib.optionalString (enableShared && stdenv.isDarwin) ''
-      darwinDylib="$lib/lib/liblowdown.2.dylib"
-      mv "$lib/lib/liblowdown.so.2" "$darwinDylib"
+      darwinDylib="$lib/lib/liblowdown.${soVersion}.dylib"
+      mv "$lib/lib/liblowdown.so.${soVersion}" "$darwinDylib"
 
       # Make sure we are re-creating a symbolic link here
       test -L "$lib/lib/liblowdown.so"

--- a/pkgs/tools/typesetting/lowdown/default.nix
+++ b/pkgs/tools/typesetting/lowdown/default.nix
@@ -58,6 +58,7 @@ stdenv.mkDerivation rec {
       # Make sure we are re-creating a symbolic link here
       test -L "$lib/lib/liblowdown.so"
       ln -s "$darwinDylib" "$lib/lib/liblowdown.dylib"
+      rm "$lib/lib/liblowdown.so"
     '';
 
   doInstallCheck = true;

--- a/pkgs/tools/typesetting/lowdown/default.nix
+++ b/pkgs/tools/typesetting/lowdown/default.nix
@@ -7,13 +7,13 @@
 
 stdenv.mkDerivation rec {
   pname = "lowdown";
-  version = "1.0.1";
+  version = "1.0.2";
 
   outputs = [ "out" "lib" "dev" "man" ];
 
   src = fetchurl {
     url = "https://kristaps.bsd.lv/lowdown/snapshots/lowdown-${version}.tar.gz";
-    sha512 = "2jsskdrx035vy5kyb371swcn23vj7ww1fmrsalmyp1jc3459vgh2lk4nlvrw74r93z9yyzsq9vra2sspx173cpjlr8lyyqdw5h91lms";
+    sha512 = "1cizrzmldi7lrgdkpn4b6skp1b5hz2jskkbcbv9k6lmz08clm02gyifh7fgd8j2rklqsim34n5ifyg83xhsjzd57xqjys1ccjdn3a5m";
   };
 
   nativeBuildInputs = [ which ]
@@ -47,7 +47,7 @@ stdenv.mkDerivation rec {
   postInstall =
     let
       inherit (stdenv.hostPlatform.extensions) sharedLibrary;
-      soVersion = "2";
+      soVersion = "3";
     in
 
     # Check that soVersion is up to date even if we are not on darwin

--- a/pkgs/tools/typesetting/lowdown/default.nix
+++ b/pkgs/tools/typesetting/lowdown/default.nix
@@ -44,15 +44,21 @@ stdenv.mkDerivation rec {
     "install_static"
   ];
 
-  # Fix lib extension so that fixDarwinDylibNames detects it, see
-  # <https://github.com/kristapsdz/lowdown/issues/87#issuecomment-1532243650>.
   postInstall =
     let
       inherit (stdenv.hostPlatform.extensions) sharedLibrary;
       soVersion = "2";
     in
 
-    lib.optionalString (enableShared && stdenv.isDarwin) ''
+    # Check that soVersion is up to date even if we are not on darwin
+    lib.optionalString (enableShared && !stdenv.isDarwin) ''
+      set -x
+      test -f $lib/lib/liblowdown.so.${soVersion}
+      set +x
+    ''
+    # Fix lib extension so that fixDarwinDylibNames detects it, see
+    # <https://github.com/kristapsdz/lowdown/issues/87#issuecomment-1532243650>.
+    + lib.optionalString (enableShared && stdenv.isDarwin) ''
       darwinDylib="$lib/lib/liblowdown.${soVersion}.dylib"
       mv "$lib/lib/liblowdown.so.${soVersion}" "$darwinDylib"
 


### PR DESCRIPTION
https://github.com/kristapsdz/lowdown/releases/tag/VERSION_1_0_2

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
