### PR TITLE
rnginline: 0.0.2 -> 1.0.0

### DIFF
--- a/pkgs/development/python-modules/rnginline/default.nix
+++ b/pkgs/development/python-modules/rnginline/default.nix
@@ -1,37 +1,42 @@
 { lib
 , fetchPypi
 , buildPythonPackage
+, poetry-core
 , lxml
-, docopt
-, six
+, docopt-ng
+, typing-extensions
+, importlib-metadata
+, importlib-resources
 , pytestCheckHook
 , mock
-, fetchpatch
 }:
 
 buildPythonPackage rec {
   pname = "rnginline";
-  version = "0.0.2";
+  version = "1.0.0";
 
   src = fetchPypi {
     inherit pname version;
-    hash = "sha256-j4W4zwHA4yA6iAFVa/LDKp00eeCX3PbmWkjd2LSUGfk=";
+    hash = "sha256-JWqzs+OqOynIAWYVgGrZiuiCqObAgGe6rBt0DcP3U6E=";
   };
 
-  patches = [
-    # Fix failing tests. Should be included in releases after 0.0.2
-    # https://github.com/h4l/rnginline/issues/3
-    (fetchpatch {
-      url = "https://github.com/h4l/rnginline/commit/b1d1c8cda2a17d46627309950f2442021749c07e.patch";
-      hash = "sha256-XbisEwun2wPOp7eqW2YDVdayJ4sjAMG/ezFwgoCKe9o=";
-      name = "fix_tests_failing_collect.patch";
-    })
+  format = "pyproject";
+
+  postPatch = ''
+    substituteInPlace pyproject.toml \
+      --replace 'importlib-metadata = "^6.6.0"' 'importlib-metadata = "^6.0.0"'
+  '';
+
+  nativeBuildInputs = [
+    poetry-core
   ];
 
   propagatedBuildInputs = [
-    docopt
+    docopt-ng
     lxml
-    six
+    typing-extensions
+    importlib-metadata
+    importlib-resources
   ];
 
   nativeCheckInputs = [


### PR DESCRIPTION
###### Description of changes

Changelog:
https://github.com/h4l/rnginline/blob/1.0.0/CHANGELOG.md
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
Result of `nixpkgs-review` run on x86_64-linux [1](https://github.com/Mic92/nixpkgs-review)
<details>
  <summary>4 packages built:</summary>
  <ul>
    <li>rnginline (python310Packages.rnginline)</li>
    <li>rnginline.dist (python310Packages.rnginline.dist)</li>
    <li>python311Packages.rnginline</li>
    <li>python311Packages.rnginline.dist</li>
  </ul>
</details>