### PR TITLE
srt-live-server: add missing ctime include

### DIFF
--- a/pkgs/applications/video/srt-live-server/add-ctime-include.patch
+++ b/pkgs/applications/video/srt-live-server/add-ctime-include.patch
@@ -1,0 +1,11 @@
+diff --git a/slscore/common.hpp b/slscore/common.hpp
+index 30aeeea..bed0e62 100644
+--- a/slscore/common.hpp
++++ b/slscore/common.hpp
+@@ -29,6 +29,7 @@
+ #include <stddef.h>
+ #include <stdint.h>
+ #include <string>
++#include <ctime>
+ #include <vector>
+ #include <unistd.h>

--- a/pkgs/applications/video/srt-live-server/default.nix
+++ b/pkgs/applications/video/srt-live-server/default.nix
@@ -19,6 +19,9 @@ stdenv.mkDerivation rec {
   patches = [
     # https://github.com/Edward-Wu/srt-live-server/pull/94
     ./fix-insecure-printfs.patch
+
+    # https://github.com/Edward-Wu/srt-live-server/pull/127  # adds `#include <ctime>`
+    ./add-ctime-include.patch
   ];
 
   buildInputs = [ srt zlib ];


### PR DESCRIPTION
###### Description of changes

Fixes srt-live-server.  It was missing the `#include <ctime>`.  There is already a PR open to adress this for musl, so this change just fetches that with fetchPatch.

For ZHF #230712 at the #ZurichZHF hackathon!

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
