### PR TITLE
pgmanage: 11.0.1 -> unstable-2022-05-11

### DIFF
--- a/pkgs/applications/misc/pgmanage/default.nix
+++ b/pkgs/applications/misc/pgmanage/default.nix
@@ -1,18 +1,15 @@
 { lib, stdenv, fetchFromGitHub, postgresql, openssl, nixosTests } :
-let
+stdenv.mkDerivation rec {
+  pname = "pgmanage";
   # The last release 11.0.1 from 2018 fails the NixOS test
   # probably because of PostgreSQL-12 incompatibility.
   # Fortunately the latest master does succeed the test.
-  rev = "a028604416be382d6d310bc68b4e7c3cd16020fb";
-in
-stdenv.mkDerivation rec {
-  pname = "pgmanage";
-  version = "11.0.1-git-${builtins.substring 0 7 rev}";
+  version = "unstable-2022-05-11";
 
   src = fetchFromGitHub {
     owner  = "pgManage";
     repo   = "pgManage";
-    inherit rev;
+    rev    = "a028604416be382d6d310bc68b4e7c3cd16020fb";
     sha256 = "sha256-ibCzZrqfbio1wBVFKB6S/wdRxnCc7s3IQdtI9txxhaM=";
   };
 

--- a/pkgs/applications/misc/pgmanage/default.nix
+++ b/pkgs/applications/misc/pgmanage/default.nix
@@ -1,14 +1,19 @@
-{ lib, stdenv, fetchFromGitHub, postgresql, openssl } :
-
+{ lib, stdenv, fetchFromGitHub, postgresql, openssl, nixosTests } :
+let
+  # The last release 11.0.1 from 2018 fails the NixOS test
+  # probably because of PostgreSQL-12 incompatibility.
+  # Fortunately the latest master does succeed the test.
+  rev = "a028604416be382d6d310bc68b4e7c3cd16020fb";
+in
 stdenv.mkDerivation rec {
   pname = "pgmanage";
-  version = "11.0.1";
+  version = "11.0.1-git-${builtins.substring 0 7 rev}";
 
   src = fetchFromGitHub {
     owner  = "pgManage";
     repo   = "pgManage";
-    rev    = "v${version}";
-    sha256 = "1a1dbc32b3y0ph8ydf800h6pz7dg6g1gxgid4gffk7k58xj0c5yf";
+    inherit rev;
+    sha256 = "sha256-ibCzZrqfbio1wBVFKB6S/wdRxnCc7s3IQdtI9txxhaM=";
   };
 
   patchPhase = ''
@@ -20,6 +25,8 @@ stdenv.mkDerivation rec {
   '';
 
   buildInputs = [ postgresql openssl ];
+
+  passthru.tests.sign-in = nixosTests.pgmanage;
 
   meta = with lib; {
     description = "A fast replacement for PGAdmin";


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

The [last release 11.0.1 from 2018](https://github.com/pgManage/pgManage/releases) fails the NixOS test probably because of PostgreSQL-12 incompatibility. Fortunately the latest master does succeed the test.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
