### PR TITLE
Use binary wrapper instead of shell wrapper for PHP

### DIFF
--- a/pkgs/development/interpreters/php/generic.nix
+++ b/pkgs/development/interpreters/php/generic.nix
@@ -9,7 +9,7 @@ let
     , nixosTests
     , tests
     , fetchurl
-    , makeWrapper
+    , makeBinaryWrapper
     , symlinkJoin
     , writeText
     , autoconf
@@ -141,7 +141,7 @@ let
           phpWithExtensions = symlinkJoin {
             name = "php-with-extensions-${version}";
             inherit (php) version;
-            nativeBuildInputs = [ makeWrapper ];
+            nativeBuildInputs = [ makeBinaryWrapper ];
             passthru = php.passthru // {
               buildEnv = mkBuildEnv allArgs allExtensionFunctions;
               withExtensions = mkWithExtensions allArgs allExtensionFunctions;


### PR DESCRIPTION
###### Description of changes

Uses `makeBinaryWrapper` instead of `makeWrapper` to produce a binary wrapper. This change was consciously removed from https://github.com/NixOS/nixpkgs/pull/221845, so this is the separate change.

###### Things done


- Built on platform(s)
  - [x] aarch64-darwin

- Tried the following tools/cases
  - Ran composer
  - Ran phpunit
  - Ran psalm
  - Ran phpstan
  - Started fpm