### PR TITLE
`haskellPackages.basement`: fix build on `i686-linux`

### DIFF
--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -209,6 +209,22 @@ self: super: {
   ### END HASKELL-LANGUAGE-SERVER SECTION ###
   ###########################################
 
+  # basement is broken on some 32-bit systems due to missing imports
+  # See: https://github.com/haskell-foundation/foundation/issues/565
+  # This patch is taken from a PR to fix the above issue. See:
+  # https://github.com/haskell-foundation/foundation/issues/573
+  # However, that PR doesn't work completely, because it doesn't apply to
+  # all the GHC versions we want to fix. So the actual patch file is modified
+  # to also affect those other versions.
+  #
+  # The patch applies, but does not compile, on non-32-bit systems.
+  #
+  # This patch can be removed once the above issue is closed and the fix is
+  # available on Hackage (and Nixpkgs.)
+  basement = if pkgs.stdenv.isi686
+    then appendPatch ./patches/basement-fix-32-bit.patch super.basement
+    else super.basement;
+
   vector = overrideCabal (old: {
     # Too strict bounds on doctest which isn't used, but is part of the configuration
     jailbreak = true;

--- a/pkgs/development/haskell-modules/patches/basement-fix-32-bit.patch
+++ b/pkgs/development/haskell-modules/patches/basement-fix-32-bit.patch
@@ -1,0 +1,216 @@
+--- a/Basement/Bits.hs
++++ b/Basement/Bits.hs
+@@ -54,8 +54,12 @@
+ import Basement.Compat.Primitive
+ 
+ #if WORD_SIZE_IN_BITS < 64
++#if __GLASGOW_HASKELL__ >= 902
++import GHC.Exts
++#else
+ import GHC.IntWord64
+ #endif
++#endif
+ 
+ -- | operation over finite bits
+ class FiniteBitsOps bits where
+--- a/Basement/From.hs
++++ b/Basement/From.hs
+@@ -272,23 +272,11 @@
+     tryFrom = BlockN.toBlockN . UArray.toBlock . BoxArray.mapToUnboxed id
+ 
+ instance (KnownNat n, NatWithinBound Word8 n) => From (Zn64 n) Word8 where
+-#if __GLASGOW_HASKELL__ >= 904
+-    from = narrow . unZn64 where narrow (W64# w) = W8# (wordToWord8# (word64ToWord# (GHC.Prim.word64ToWord# w)))
+-#else
+     from = narrow . unZn64 where narrow (W64# w) = W8# (wordToWord8# (word64ToWord# w))
+-#endif
+ instance (KnownNat n, NatWithinBound Word16 n) => From (Zn64 n) Word16 where
+-#if __GLASGOW_HASKELL__ >= 904
+-    from = narrow . unZn64 where narrow (W64# w) = W16# (wordToWord16# (word64ToWord# (GHC.Prim.word64ToWord# w)))
+-#else
+     from = narrow . unZn64 where narrow (W64# w) = W16# (wordToWord16# (word64ToWord# w))
+-#endif
+ instance (KnownNat n, NatWithinBound Word32 n) => From (Zn64 n) Word32 where
+-#if __GLASGOW_HASKELL__ >= 904
+-    from = narrow . unZn64 where narrow (W64# w) = W32# (wordToWord32# (word64ToWord# (GHC.Prim.word64ToWord# w)))
+-#else
+     from = narrow . unZn64 where narrow (W64# w) = W32# (wordToWord32# (word64ToWord# w))
+-#endif
+ instance From (Zn64 n) Word64 where
+     from = unZn64
+ instance From (Zn64 n) Word128 where
+@@ -297,23 +285,11 @@
+     from = from . unZn64
+ 
+ instance (KnownNat n, NatWithinBound Word8 n) => From (Zn n) Word8 where
+-#if __GLASGOW_HASKELL__ >= 904
+-    from = narrow . naturalToWord64 . unZn where narrow (W64# w) = W8# (wordToWord8# (word64ToWord# (GHC.Prim.word64ToWord# w)))
+-#else
+     from = narrow . naturalToWord64 . unZn where narrow (W64# w) = W8# (wordToWord8# (word64ToWord# w))
+-#endif
+ instance (KnownNat n, NatWithinBound Word16 n) => From (Zn n) Word16 where
+-#if __GLASGOW_HASKELL__ >= 904
+-    from = narrow . naturalToWord64 . unZn where narrow (W64# w) = W16# (wordToWord16# (word64ToWord# (GHC.Prim.word64ToWord# w)))
+-#else
+     from = narrow . naturalToWord64 . unZn where narrow (W64# w) = W16# (wordToWord16# (word64ToWord# w))
+-#endif
+ instance (KnownNat n, NatWithinBound Word32 n) => From (Zn n) Word32 where
+-#if __GLASGOW_HASKELL__ >= 904
+-    from = narrow . naturalToWord64 . unZn where narrow (W64# w) = W32# (wordToWord32# (word64ToWord# (GHC.Prim.word64ToWord# w)))
+-#else
+     from = narrow . naturalToWord64 . unZn where narrow (W64# w) = W32# (wordToWord32# (word64ToWord# w))
+-#endif
+ instance (KnownNat n, NatWithinBound Word64 n) => From (Zn n) Word64 where
+     from = naturalToWord64 . unZn
+ instance (KnownNat n, NatWithinBound Word128 n) => From (Zn n) Word128 where
+--- a/Basement/Numerical/Additive.hs
++++ b/Basement/Numerical/Additive.hs
+@@ -30,8 +30,12 @@
+ import qualified Basement.Types.Word256 as Word256
+ 
+ #if WORD_SIZE_IN_BITS < 64
++#if __GLASGOW_HASKELL__ >= 902
++import           GHC.Exts
++#else
+ import           GHC.IntWord64
+ #endif
++#endif
+ 
+ -- | Represent class of things that can be added together,
+ -- contains a neutral element and is commutative.
+--- a/Basement/Numerical/Conversion.hs
++++ b/Basement/Numerical/Conversion.hs
+@@ -26,8 +26,12 @@
+ import Basement.Compat.Primitive
+ 
+ #if WORD_SIZE_IN_BITS < 64
++#if __GLASGOW_HASKELL__ >= 902
++import GHC.Exts
++#else
+ import GHC.IntWord64
+ #endif
++#endif
+ 
+ intToInt64 :: Int -> Int64
+ #if WORD_SIZE_IN_BITS == 64
+@@ -96,11 +100,22 @@
+ #endif
+ 
+ #if WORD_SIZE_IN_BITS == 64
++#if __GLASGOW_HASKELL__ >= 902
++word64ToWord# :: Word64# -> Word#
++word64ToWord# i = word64ToWord# i
++#else
+ word64ToWord# :: Word# -> Word#
+ word64ToWord# i = i
++#endif
+ {-# INLINE word64ToWord# #-}
+ #endif
+ 
++#if WORD_SIZE_IN_BITS < 64
++word64ToWord32# :: Word64# -> Word32#
++word64ToWord32# i = wordToWord32# (word64ToWord# i)
++{-# INLINE word64ToWord32# #-}
++#endif
++
+ -- | 2 Word32s
+ data Word32x2 = Word32x2 {-# UNPACK #-} !Word32
+                          {-# UNPACK #-} !Word32
+@@ -113,9 +128,14 @@
+ word64ToWord32s (W64# w64) = Word32x2 (W32# (wordToWord32# (uncheckedShiftRL# w64 32#))) (W32# (wordToWord32# w64))
+ #endif
+ #else
++#if __GLASGOW_HASKELL__ >= 902
++word64ToWord32s :: Word64 -> Word32x2
++word64ToWord32s (W64# w64) = Word32x2 (W32# (word64ToWord32# (uncheckedShiftRL64# w64 32#))) (W32# (word64ToWord32# w64))
++#else
+ word64ToWord32s :: Word64 -> Word32x2
+ word64ToWord32s (W64# w64) = Word32x2 (W32# (word64ToWord# (uncheckedShiftRL64# w64 32#))) (W32# (word64ToWord# w64))
+ #endif
++#endif
+ 
+ wordToChar :: Word -> Char
+ wordToChar (W# word) = C# (chr# (word2Int# word))
+--- a/Basement/PrimType.hs
++++ b/Basement/PrimType.hs
+@@ -54,7 +54,11 @@
+ import qualified Prelude (quot)
+ 
+ #if WORD_SIZE_IN_BITS < 64
+-import           GHC.IntWord64
++#if __GLASGOW_HASKELL__ >= 902
++import GHC.Exts
++#else
++import GHC.IntWord64
++#endif
+ #endif
+ 
+ #ifdef FOUNDATION_BOUNDS_CHECK
+--- a/Basement/Types/OffsetSize.hs
++++ b/Basement/Types/OffsetSize.hs
+@@ -70,8 +70,12 @@
+ import qualified Prelude
+ 
+ #if WORD_SIZE_IN_BITS < 64
++#if __GLASGOW_HASKELL__ >= 902
++import GHC.Exts
++#else
+ import GHC.IntWord64
+ #endif
++#endif
+ 
+ -- | File size in bytes
+ newtype FileSize = FileSize Word64
+@@ -225,20 +229,26 @@
+ 
+ csizeOfSize :: CountOf Word8 -> CSize
+ #if WORD_SIZE_IN_BITS < 64
++#if __GLASGOW_HASKELL__ >= 902
++csizeOfSize (CountOf (I# sz)) = CSize (W32# (wordToWord32# (int2Word# sz)))
++#else
+ csizeOfSize (CountOf (I# sz)) = CSize (W32# (int2Word# sz))
++#endif
+ #else
+ #if __GLASGOW_HASKELL__ >= 904
+ csizeOfSize (CountOf (I# sz)) = CSize (W64# (wordToWord64# (int2Word# sz)))
+-
+ #else
+ csizeOfSize (CountOf (I# sz)) = CSize (W64# (int2Word# sz))
+-
+ #endif
+ #endif
+ 
+ csizeOfOffset :: Offset8 -> CSize
+ #if WORD_SIZE_IN_BITS < 64
++#if __GLASGOW_HASKELL__ >= 902
++csizeOfOffset (Offset (I# sz)) = CSize (W32# (wordToWord32# (int2Word# sz)))
++#else
+ csizeOfOffset (Offset (I# sz)) = CSize (W32# (int2Word# sz))
++#endif
+ #else
+ #if __GLASGOW_HASKELL__ >= 904
+ csizeOfOffset (Offset (I# sz)) = CSize (W64# (wordToWord64# (int2Word# sz)))
+@@ -250,7 +260,11 @@
+ sizeOfCSSize :: CSsize -> CountOf Word8
+ sizeOfCSSize (CSsize (-1))      = error "invalid size: CSSize is -1"
+ #if WORD_SIZE_IN_BITS < 64
++#if __GLASGOW_HASKELL__ >= 902
++sizeOfCSSize (CSsize (I32# sz)) = CountOf (I# (int32ToInt# sz))
++#else
+ sizeOfCSSize (CSsize (I32# sz)) = CountOf (I# sz)
++#endif
+ #else
+ #if __GLASGOW_HASKELL__ >= 904
+ sizeOfCSSize (CSsize (I64# sz)) = CountOf (I# (int64ToInt# sz))
+@@ -261,7 +275,11 @@
+ 
+ sizeOfCSize :: CSize -> CountOf Word8
+ #if WORD_SIZE_IN_BITS < 64
++#if __GLASGOW_HASKELL__ >= 902
++sizeOfCSize (CSize (W32# sz)) = CountOf (I# (word2Int# (word32ToWord# sz)))
++#else
+ sizeOfCSize (CSize (W32# sz)) = CountOf (I# (word2Int# sz))
++#endif
+ #else
+ #if __GLASGOW_HASKELL__ >= 904
+ sizeOfCSize (CSize (W64# sz)) = CountOf (I# (word2Int# (word64ToWord# sz)))


### PR DESCRIPTION


###### Description of changes

This package was broken on GHC 9.2+ on 32-bit Linux, because of a known issue with modules no longer exposed by GHC. The patch is taken from [here](https://github.com/haskell-foundation/foundation/pull/573) but adapted according to the comments to also support GHC 9.2 (the original PR only supports GHC 9.4)

For ZHF #230712 at the #ZurichZHF hackathon.

###### Things done

 * Added a patch to the `basement` Haskell package which fixes a build error on 32-bit Linux systems - see [this Hydra failure](https://hydra.nixos.org/build/220721222)

- Built on platform(s)
  - [x] x86_64-linux
  - [x] i686-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
