### PR TITLE
antidote: init at 1.8.6

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -6364,6 +6364,12 @@
       fingerprint = "45A9 9917 578C D629 9F5F  B5B4 C22D 4DE4 D7B3 2D19";
     }];
   };
+  hitsmaxft = {
+    name = "Bhe Hongtyu";
+    email = "mfthits@gmail.com";
+    github = "hitsmaxft";
+    githubId = 352727;
+  };
   hjones2199 = {
     email = "hjones2199@gmail.com";
     github = "hjones2199";

--- a/pkgs/shells/zsh/antidote/default.nix
+++ b/pkgs/shells/zsh/antidote/default.nix
@@ -1,0 +1,33 @@
+{ lib, stdenv, fetchFromGitHub }:
+
+stdenv.mkDerivation (finalAttrs: {
+  version = "1.8.6";
+  pname = "antidote";
+
+  src = fetchFromGitHub {
+    owner = "mattmc3";
+    repo = "antidote";
+    rev = "v${finalAttrs.version}";
+    hash = "sha256-CcWEXvz1TB6LFu9qvkVB1LJsa68grK16VqjUTiuVG/c=";
+  };
+
+  dontPatch = true;
+  dontBuild = true;
+  dontConfigure = true;
+  dontFixup = true;
+
+  installPhase = ''
+    runHook preInstall
+    install -D antidote --target-directory=$out/share/antidote
+    install -D antidote.zsh --target-directory=$out/share/antidote
+    install -D functions/* --target-directory=$out/share/antidote/functions
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "A zsh plugin manager made from the ground up thinking about performance";
+    homepage = "https://getantidote.github.io/";
+    license = lib.licenses.mit;
+    maintainers = [ lib.maintainers.hitsmaxft ];
+  };
+})

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5973,6 +5973,8 @@ with pkgs;
 
   antibody = callPackage ../shells/zsh/antibody { };
 
+  antidote = callPackage ../shells/zsh/antidote { };
+
   antigen = callPackage ../shells/zsh/antigen { };
 
   apparix = callPackage ../tools/misc/apparix { };


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [x] aarch64-linux
  - [X] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).



antidote https://getantidote.github.io/ 

> Antidote is a Zsh plugin manager made from the ground up thinking about performance.
> It is fast because it can do things concurrently, and generates an ultra-fast static plugin file that you can easily load from your Zsh config.
> It is written natively in Zsh, is well tested, and picks up where [Antibody](https://github.com/getantibody/antibody) left off.
