### PR TITLE
dbus: rename "enableSystemd" to "withSystemd"

### DIFF
--- a/pkgs/development/libraries/dbus/default.nix
+++ b/pkgs/development/libraries/dbus/default.nix
@@ -3,7 +3,7 @@
 , fetchurl
 , pkg-config
 , expat
-, enableSystemd ? lib.meta.availableOn stdenv.hostPlatform systemdMinimal
+, withSystemd ? lib.meta.availableOn stdenv.hostPlatform systemdMinimal
 , systemdMinimal
 , audit
 , libapparmor
@@ -63,7 +63,7 @@ stdenv.mkDerivation rec {
       libX11
       libICE
       libSM
-    ]) ++ lib.optional enableSystemd systemdMinimal
+    ]) ++ lib.optional withSystemd systemdMinimal
     ++ lib.optionals stdenv.isLinux [ audit libapparmor ];
   # ToDo: optional selinux?
 
@@ -82,7 +82,7 @@ stdenv.mkDerivation rec {
     "--with-systemduserunitdir=${placeholder "out"}/etc/systemd/user"
   ] ++ lib.optional (!x11Support) "--without-x"
   ++ lib.optionals stdenv.isLinux [ "--enable-apparmor" "--enable-libaudit" ]
-  ++ lib.optionals enableSystemd [ "SYSTEMCTL=${systemdMinimal}/bin/systemctl" ];
+  ++ lib.optionals withSystemd [ "SYSTEMCTL=${systemdMinimal}/bin/systemctl" ];
 
   NIX_CFLAGS_LINK = lib.optionalString (!stdenv.isDarwin) "-Wl,--as-needed";
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -20892,7 +20892,7 @@ with pkgs;
     # these things are only used for tests, they don't get into the closure
     shared-mime-info = shared-mime-info.override { glib = glib-untested; };
     desktop-file-utils = desktop-file-utils.override { glib = glib-untested; };
-    dbus = dbus.override { enableSystemd = false; };
+    dbus = dbus.override { withSystemd = false; };
   });
 
   glibmm = callPackage ../development/libraries/glibmm { };


### PR DESCRIPTION
Naming convention <foo>Support seems to be more popular than enable<Foo> in
general, in case of systemd -- 59 to 34 as far as "git grep" concerned, so it
makes sense to unify flags under already dominant convention.

Merging such changes treewide is hard (ref: #177832), so here I follow
suggestion of @doronbehar and make one pull request per package affected.

Naturally, this is no-rebuild change.
