### PR TITLE
libpq: init at 16.1

### DIFF
--- a/pkgs/servers/sql/postgresql/libpq.nix
+++ b/pkgs/servers/sql/postgresql/libpq.nix
@@ -1,0 +1,61 @@
+{ stdenv
+, lib
+, openssl
+, zlib
+, libkrb5
+, icu
+, postgresql
+, pkg-config
+, tzdata
+, gssSupport ? !stdenv.hostPlatform.isWindows
+}:
+
+stdenv.mkDerivation {
+  pname = "libpq";
+  inherit (postgresql) src version;
+
+  configureFlags = [
+    "--with-openssl"
+    "--with-icu"
+    "--without-readline"
+    "--with-system-tzdata=${tzdata}/share/zoneinfo"
+    "--enable-debug"
+  ]
+  ++ lib.optionals gssSupport [ "--with-gssapi" ];
+
+  nativeBuildInputs = [ pkg-config tzdata ];
+  buildInputs = [ openssl zlib icu ]
+    ++ lib.optional gssSupport libkrb5;
+
+  enableParallelBuilding = !stdenv.isDarwin;
+
+  separateDebugInfo = true;
+
+  buildFlags = [ "submake-libpq" "submake-libpgport" ];
+
+  installPhase = ''
+    runHook preInstall
+
+    make -C src/bin/pg_config install
+    make -C src/common install
+    make -C src/include install
+    make -C src/interfaces/libpq install
+    make -C src/port install
+
+    moveToOutput "bin" "$dev"
+    moveToOutput "lib/*.a" "$static"
+    rm -rfv $out/share
+
+    runHook postInstall
+  '';
+
+  outputs = [ "out" "dev" "static" ];
+
+  meta = with lib; {
+    homepage = "https://www.postgresql.org";
+    description = "Client API library for PostgreSQL";
+    license = licenses.postgresql;
+    maintainers = with maintainers; [ szlend ];
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -27123,6 +27123,8 @@ with pkgs;
 
   timescaledb-tune = callPackage ../development/tools/database/timescaledb-tune { };
 
+  libpq = callPackage ../servers/sql/postgresql/libpq.nix { postgresql = postgresql_16; };
+
   inherit (import ../servers/sql/postgresql pkgs)
     postgresql_12
     postgresql_13


### PR DESCRIPTION
###### Description of changes

Re: https://github.com/NixOS/nixpkgs/issues/61580

In my opinion `libpq` being a standalone derivation separate from `postgresql` makes the most sense. Here's why:
- `libpq` is one of the most popular libraries out there. It's a dependency of every single application that connects to a postgres database. As such I feel it deserves special considerations.
- `libpq` will likely be used in variety of different ways (static linking, cross-compilation, etc.). Being an output of the entire `postgresql` derivation causes additional friction as it has to build a ton of additional dependencies that may or may not work in those configurations. By minimizing the number of build-time dependencies we make the whole build process much smoother.
  - Having something like `pkgsCross.aarch64-multiplatform.libpq` just work is much nicer than playing whack-a-mole with `(pkgsCross.aarch64-multiplatform.postgresql.overrides { ... }).lib`, trying to figure out which magic set of overrides it will work with (or break in the next nixpkgs release).
- Changing `postgresql.lib` to only include `libpq` is a breaking change and has so far caused a ton of bike-shedding conversations on what it should be, while 4 years later we're the only major package repository that doesn't ship this.
- We don't need multiple packages of libpq.  `libpq` is guaranteed to be backwards compatible so it only needs to be based on `postgresql_<latest>.src`.
- Having one additional package that builds in under a minute in a package repository of 80k+ is not a serious concern
- `libpq` is really easy to package on its own.



###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
