### PR TITLE
cantor: fix linking libR.so and add patch which fixes issue with nix-installed julia

### DIFF
--- a/pkgs/applications/kde/cantor.nix
+++ b/pkgs/applications/kde/cantor.nix
@@ -3,6 +3,7 @@
 
 , cmake
 , extra-cmake-modules
+, fetchpatch
 , makeWrapper
 , shared-mime-info
 
@@ -45,6 +46,15 @@
 
 mkDerivation {
   pname = "cantor";
+
+  patches = [
+    # remove the dependency on Julia's executable
+    (fetchpatch {
+      url = "https://invent.kde.org/education/cantor/-/commit/5c038e422c8fe2fcc14ddca2f8ec8d8c6fbca592.patch";
+      includes = ["src/*"]; # The patch fails on the changelog.md. But we only really need src for building
+      sha256 = "sha256-iYfL8NwDuO0SRotWvx6wipA5l58deuR2g2nJSN20uEQ=";
+    })
+  ];
 
   nativeBuildInputs = [
     cmake

--- a/pkgs/applications/kde/cantor.nix
+++ b/pkgs/applications/kde/cantor.nix
@@ -87,7 +87,7 @@ mkDerivation {
   ++ lib.optional withQalculate libqalculate
   ++ lib.optional withLua luajit
   ++ lib.optional withPython python3
-  ++ lib.optional withR R
+  ++ lib.optional withR "${R}/lib/R" # Required for build system to automatically link ${R}/lib/R/lib/libR.so
   ++ lib.optional withSage sage-with-env
   ;
 


### PR DESCRIPTION
###### Description of changes

The libR.so is stored in ${R}/lib/R/lib instead of the usual ${R}/lib. I suspect that this causes issues with the build system and prevents it from linking libR.so correctly.

Fixes #234421

This PR also applies the patch https://invent.kde.org/education/cantor/-/commit/5c038e422c8fe2fcc14ddca2f8ec8d8c6fbca592. This patch removes the backend's reliance on the julia executable on the path. Prior to this patch the julia backend would not allow julia which was installed using for example `nix profile install` since it was installed via a symlink

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
