### PR TITLE
cartridges: init at 2.0.4

### DIFF
--- a/pkgs/applications/misc/cartridges/default.nix
+++ b/pkgs/applications/misc/cartridges/default.nix
@@ -1,0 +1,56 @@
+{ blueprint-compiler
+, desktop-file-utils
+, fetchFromGitHub
+, gobject-introspection
+, lib
+, libadwaita
+, meson
+, ninja
+, python3
+, stdenv
+, wrapGAppsHook4
+}:
+stdenv.mkDerivation (finalAttrs: {
+  pname = "cartridges";
+  version = "2.0.4";
+
+  src = fetchFromGitHub {
+    owner = "kra-mo";
+    repo = "cartridges";
+    rev = "v${finalAttrs.version}";
+    sha256 = "sha256-DaeAdxgp6/a3H2ppgVxRjYUbHGZcyIeREVPX6FxE7bc=";
+  };
+
+  buildInputs = [
+    libadwaita
+    (python3.withPackages (p: with p; [
+      pillow
+      pygobject3
+      pyyaml
+      requests
+    ]))
+  ];
+
+  nativeBuildInputs = [
+    blueprint-compiler
+    desktop-file-utils
+    gobject-introspection
+    meson
+    ninja
+    wrapGAppsHook4
+  ];
+
+  meta = with lib; {
+    description = "A GTK4 + Libadwaita game launcher";
+    longDescription = ''
+      A simple game launcher for all of your games.
+      It has support for importing games from Steam, Lutris, Heroic
+      and more with no login necessary.
+      You can sort and hide games or download cover art from SteamGridDB.
+    '';
+    homepage = "https://apps.gnome.org/app/hu.kramo.Cartridges/";
+    license = licenses.gpl3Plus;
+    maintainers = [ maintainers.getchoo ];
+    platforms = platforms.linux;
+  };
+})

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -395,6 +395,8 @@ with pkgs;
 
   caroline = callPackage ../development/libraries/caroline { };
 
+  cartridges = callPackage ../applications/misc/cartridges { };
+
   castget = callPackage ../applications/networking/feedreaders/castget { };
 
   castxml = callPackage ../development/tools/castxml { };


### PR DESCRIPTION
###### Description of changes

[cartridges](https://github.com/kra-mo/cartridges) is a simple game launcher written in python using libadwaita. it supports managing games from platforms/programs such as steam, lutris, heroic, bottles, and itch.io

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
