### PR TITLE
[22.11] ffmpeg: 4.4.2 -> 4.4.4, ffmpeg_5: 5.1.2 -> 5.1.3

### DIFF
--- a/pkgs/development/libraries/ffmpeg/4.nix
+++ b/pkgs/development/libraries/ffmpeg/4.nix
@@ -1,15 +1,8 @@
-{ callPackage, fetchpatch, ... }@args:
+{ callPackage, ... }@args:
 
 callPackage ./generic.nix (rec {
-  version = "4.4.2";
+  version = "4.4.3";
   branch = version;
-  sha256 = "sha256-+YpIJSDEdQdSGpB5FNqp77wThOBZG1r8PaGKqJfeKUg=";
+  sha256 = "sha256-M7jC281TD+HbVxBBU0Vgm0yiJ70NoeOpMy27DxH9Jzo=";
 
-  patches = [
-    # SDL2 recently changed their versioning
-    (fetchpatch {
-      url = "https://git.videolan.org/?p=ffmpeg.git;a=patch;h=e5163b1d34381a3319214a902ef1df923dd2eeba";
-      hash = "sha256-nLhP2+34cj5EgpnUrePZp60nYAxmbhZAEDfay4pBVk0=";
-    })
-  ];
 } // args)

--- a/pkgs/development/libraries/ffmpeg/4.nix
+++ b/pkgs/development/libraries/ffmpeg/4.nix
@@ -1,8 +1,8 @@
 { callPackage, ... }@args:
 
 callPackage ./generic.nix (rec {
-  version = "4.4.3";
+  version = "4.4.4";
   branch = version;
-  sha256 = "sha256-M7jC281TD+HbVxBBU0Vgm0yiJ70NoeOpMy27DxH9Jzo=";
+  sha256 = "sha256-R7H79wosCQ2cD65ZENoRxkBsqSQIu2nYyTXNRsYix84=";
 
 } // args)

--- a/pkgs/development/libraries/ffmpeg/5.nix
+++ b/pkgs/development/libraries/ffmpeg/5.nix
@@ -1,7 +1,8 @@
 { callPackage, ... }@args:
 
 callPackage ./generic.nix (rec {
-  version = "5.1.2";
+  version = "5.1.3";
   branch = version;
-  sha256 = "sha256-OaC8yNmFSfFsVwYkZ4JGpqxzbAZs69tAn5UC6RWyLys=";
+  sha256 = "sha256-XVvvahHwxQBYj5hw7JZaMKzA1U2LHlNdplVKMpAtI20=";
 } // args)
+


### PR DESCRIPTION
###### Description of changes

Addresses:

https://nvd.nist.gov/vuln/detail/CVE-2022-3964
https://nvd.nist.gov/vuln/detail/CVE-2022-3341
https://nvd.nist.gov/vuln/detail/CVE-2022-3109

in both branches.

Successfully built `ffmpeg`, `ffmpeg-full`, `ffmpeg_5`, `ffmpeg_5-full` on macos 10.15 & nixos x86_64.

Built `mlt`, `openjfx`, `audacity`, `mplayer`, `vlc` on nixos x86_64.

Built `mplayer`, `audacity` on macos 10.15

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
