### PR TITLE
ntfy: dynamic user + defaults

### DIFF
--- a/nixos/modules/services/misc/ntfy-sh.nix
+++ b/nixos/modules/services/misc/ntfy-sh.nix
@@ -19,18 +19,6 @@ in
       description = mdDoc "The ntfy.sh package to use.";
     };
 
-    user = mkOption {
-      default = "ntfy-sh";
-      type = types.str;
-      description = lib.mdDoc "User the ntfy-sh server runs under.";
-    };
-
-    group = mkOption {
-      default = "ntfy-sh";
-      type = types.str;
-      description = lib.mdDoc "Primary group of ntfy-sh user.";
-    };
-
     settings = mkOption {
       type = types.submodule { freeformType = settingsFormat.type; };
 
@@ -61,6 +49,9 @@ in
 
       services.ntfy-sh.settings = {
         auth-file = mkDefault "/var/lib/ntfy-sh/user.db";
+        listen-http = mkDefault "127.0.0.1:2586";
+        attachment-cache-dir = mkDefault "/var/lib/ntfy-sh/attachments";
+        cache-file = mkDefault "/var/lib/ntfy-sh/cache-file.db";
       };
 
       systemd.services.ntfy-sh = {
@@ -70,10 +61,15 @@ in
         after = [ "network.target" ];
 
         serviceConfig = {
+          ExecStartPre = [
+            "${pkgs.coreutils}/bin/touch ${cfg.settings.auth-file}"
+            "${pkgs.coreutils}/bin/mkdir -p ${cfg.settings.attachment-cache-dir}"
+            "${pkgs.coreutils}/bin/touch ${cfg.settings.cache-file}"
+          ];
           ExecStart = "${cfg.package}/bin/ntfy serve -c ${configuration}";
-          User = cfg.user;
           StateDirectory = "ntfy-sh";
 
+          DynamicUser = true;
           AmbientCapabilities = "CAP_NET_BIND_SERVICE";
           PrivateTmp = true;
           NoNewPrivileges = true;
@@ -88,17 +84,8 @@ in
           RestrictNamespaces = true;
           RestrictRealtime = true;
           MemoryDenyWriteExecute = true;
-        };
-      };
-
-      users.groups = optionalAttrs (cfg.group == "ntfy-sh") {
-        ntfy-sh = { };
-      };
-
-      users.users = optionalAttrs (cfg.user == "ntfy-sh") {
-        ntfy-sh = {
-          isSystemUser = true;
-          group = cfg.group;
+          # Upstream Requirements
+          LimitNOFILE = 20500;
         };
       };
     };

--- a/nixos/tests/ntfy-sh.nix
+++ b/nixos/tests/ntfy-sh.nix
@@ -19,5 +19,7 @@ import ./make-test-python.nix {
     notif = json.loads(machine.succeed("curl -s localhost:80/test/json?poll=1"))
 
     assert msg == notif["message"], "Wrong message"
+
+    machine.succeed("ntfy user list")
   '';
 }


### PR DESCRIPTION
###### Description of changes

I'm proposing to switch to dynamic user (mainly because I don't see a reason to have a specific user) and adding a few useful defaults.

@jfrankenau @kamilchm @arjan-s @JulienMalka could be interested / impacted

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
