### PR TITLE
filebrowser: init at 2.23.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -11393,6 +11393,12 @@
       fingerprint = "E576 BFB2 CF6E B13D F571  33B9 E315 A758 4613 1564";
     }];
   };
+  nielsegberts = {
+    email = "nix@nielsegberts.nl";
+    github = "nielsegberts";
+    githubId = 368712;
+    name = "Niels Egberts";
+  };
   nigelgbanks = {
     name = "Nigel Banks";
     email = "nigel.g.banks@gmail.com";

--- a/pkgs/applications/networking/filebrowser/default.nix
+++ b/pkgs/applications/networking/filebrowser/default.nix
@@ -1,0 +1,60 @@
+{ buildGoModule, buildNpmPackage, fetchFromGitHub, lib }:
+
+let
+  frontend = buildNpmPackage rec {
+    pname = "filebrowser-frontend";
+    version = "2.23.0";
+
+    src = fetchFromGitHub {
+      owner = "filebrowser";
+      repo = "filebrowser";
+      rev = "v${version}";
+      hash = "sha256-xhBIJcEtxDdMXSgQtLAV0UWzPtrvKEil0WV76K5ycBc=";
+    };
+
+    sourceRoot = "source/frontend";
+
+    npmDepsHash = "sha256-acNIMKHc4q7eiFLPBtKZBNweEsrt+//0VR6dqwXHTvA=";
+
+    NODE_OPTIONS = "--openssl-legacy-provider";
+
+    installPhase = ''
+      runHook preInstall
+
+      mkdir $out
+      mv dist $out
+
+      runHook postInstall
+    '';
+  };
+in
+buildGoModule rec {
+  pname = "filebrowser";
+  version = "2.23.0";
+
+  src = fetchFromGitHub {
+    owner = "filebrowser";
+    repo = "filebrowser";
+    rev = "v${version}";
+    hash = "sha256-xhBIJcEtxDdMXSgQtLAV0UWzPtrvKEil0WV76K5ycBc=";
+  };
+
+  vendorHash = "sha256-MR0ju2Nomb3j78Z+1YcJY+jPd40MZpuOTuQJM94AM8A=";
+
+  excludedPackages = [ "tools" ];
+
+  preBuild = ''
+    cp -r ${frontend}/dist frontend/
+  '';
+
+  passthru = {
+    inherit frontend;
+  };
+
+  meta = with lib; {
+    description = "Filebrowser is a web application for managing files and directories";
+    homepage = "https://filebrowser.org";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ nielsegberts ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -31728,6 +31728,8 @@ with pkgs;
 
   irssi = callPackage ../applications/networking/irc/irssi { };
 
+  filebrowser = callPackage ../applications/networking/filebrowser { };
+
   fish-irssi = callPackage ../applications/networking/irc/irssi/fish { };
 
   kirc = callPackage ../applications/networking/irc/kirc { };


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Filebrowser is a web application for managing files and directories. See https://filebrowser.org/

Lightweight nextcloud/seafile/syncthing/ftp alternative to share files via HTTP.

A new service might be useful later, but this pull request just introduces the package.

Fixes https://github.com/NixOS/nixpkgs/issues/122339

This is my first package contribution to nixpkgs.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
