### PR TITLE
canon-cups-ufr2: 5.40 -> 5.70, aarch64 build

### DIFF
--- a/pkgs/misc/cups/drivers/canon/default.nix
+++ b/pkgs/misc/cups/drivers/canon/default.nix
@@ -35,13 +35,13 @@ let
   ld64 = "${stdenv.cc}/nix-support/dynamic-linker";
   libs = pkgs: lib.makeLibraryPath buildInputs;
 
-  version = "5.40";
-  dl = "6/0100009236/10";
+  version = "5.70";
+  dl = "8/0100007658/33";
 
   versionNoDots = builtins.replaceStrings [ "." ] [ "" ] version;
   src_canon = fetchurl {
-    url = "http://gdlp01.c-wss.com/gds/${dl}/linux-UFRII-drv-v${versionNoDots}-usen-20.tar.gz";
-    sha256 = "sha256:069z6ijmql62mcdyxnzc9mf0dxa6z1107cd0ab4i1adk8kr3d75k";
+    url = "http://gdlp01.c-wss.com/gds/${dl}/linux-UFRII-drv-v${versionNoDots}-m17n-11.tar.gz";
+    hash = "sha256-d5VHlPpUPAr3RWVdQRdn42YLuVekOw1IaMFLVt1Iu7o=";
   };
 
   buildInputs = [ cups zlib jbigkit glib gtk3 gnome2.libglade libxml2 gdk-pixbuf pango cairo atk ];
@@ -54,10 +54,11 @@ stdenv.mkDerivation rec {
   postUnpack = ''
     (
       cd $sourceRoot
-      tar -xzf Sources/cnrdrvcups-lb-${version}-1.tar.gz
+      tar -xf Sources/cnrdrvcups-lb-${version}-1.11.tar.xz
       sed -ie "s@_prefix=/usr@_prefix=$out@" cnrdrvcups-common-${version}/allgen.sh
       sed -ie "s@_libdir=/usr/lib@_libdir=$out/lib@" cnrdrvcups-common-${version}/allgen.sh
       sed -ie "s@_bindir=/usr/bin@_bindir=$out/bin@" cnrdrvcups-common-${version}/allgen.sh
+      sed -ie "s@/usr@$out@" cnrdrvcups-common-${version}/{backend,rasterfilter}/Makefile.am
       sed -ie "s@etc/cngplp@$out/etc/cngplp@" cnrdrvcups-common-${version}/cngplp/Makefile.am
       sed -ie "s@usr/share/cngplp@$out/usr/share/cngplp@" cnrdrvcups-common-${version}/cngplp/src/Makefile.am
       patchShebangs cnrdrvcups-common-${version}
@@ -67,6 +68,7 @@ stdenv.mkDerivation rec {
       sed -ie "s@_bindir=/usr/bin@_bindir=$out/bin@" cnrdrvcups-lb-${version}/allgen.sh
       sed -ie '/^cd \.\.\/cngplp/,/^cd files/{/^cd files/!{d}}' cnrdrvcups-lb-${version}/allgen.sh
       sed -ie "s@cd \.\./pdftocpca@cd pdftocpca@" cnrdrvcups-lb-${version}/allgen.sh
+      sed -ie "s@/usr@$out@" cnrdrvcups-lb-${version}/pdftocpca/Makefile.am
       sed -i "/CNGPLPDIR/d" cnrdrvcups-lb-${version}/Makefile
       patchShebangs cnrdrvcups-lb-${version}
     )

--- a/pkgs/misc/cups/drivers/canon/default.nix
+++ b/pkgs/misc/cups/drivers/canon/default.nix
@@ -21,7 +21,6 @@
 , libredirect
 , ghostscript
 , pkgs
-, pkgsi686Linux
 , zlib
 }:
 
@@ -30,7 +29,6 @@ let
     if stdenv.targetPlatform.system == "x86_64-linux" then "intel"
     else if stdenv.targetPlatform.system == "aarch64-linux" then "arm"
     else throw "Unsupported platform for Canon UFR2 Drivers: ${stdenv.targetPlatform.system}";
-  i686_NIX_GCC = pkgsi686Linux.callPackage ({ gcc }: gcc) { };
   ld64 = "${stdenv.cc}/nix-support/dynamic-linker";
   libs = pkgs: lib.makeLibraryPath buildInputs;
 
@@ -98,23 +96,7 @@ stdenv.mkDerivation rec {
       mkdir -p $out/share/cups/model
       install -m 644 ppd/*.ppd $out/share/cups/model/
     )
-    '' + lib.optionalString (system == "intel") ''
-    (
-      cd lib
-      mkdir -p $out/lib32
-      install -m 755 libs32/intel/libColorGearCufr2.so.2.0.0 $out/lib32
-      install -m 755 libs32/intel/libcaepcmufr2.so.1.0 $out/lib32
-      install -m 755 libs32/intel/libcaiocnpkbidir.so.1.0.0 $out/lib32
-      install -m 755 libs32/intel/libcaiousb.so.1.0.0 $out/lib32
-      install -m 755 libs32/intel/libcaiowrapufr2.so.1.0.0 $out/lib32
-      install -m 755 libs32/intel/libcanon_slimufr2.so.1.0.0 $out/lib32
-      install -m 755 libs32/intel/libcanonufr2r.so.1.0.0 $out/lib32
-      install -m 755 libs32/intel/libcnaccm.so.1.0 $out/lib32
-      install -m 755 libs32/intel/libcnlbcmr.so.1.0 $out/lib32
-      install -m 755 libs32/intel/libcnncapcmr.so.1.0 $out/lib32
-      install -m 755 libs32/intel/libufr2filterr.so.1.0.0 $out/lib32
-    )
-    '' + ''
+
     (
       cd lib
       mkdir -p $out/lib
@@ -142,24 +124,6 @@ stdenv.mkDerivation rec {
       mkdir -p $out/share/ufr2filter
       install -m 644 libs64/${system}/ThLB* $out/share/ufr2filter
     )
-
-    '' + lib.optionalString (system == "intel") ''
-    (
-      cd $out/lib32
-      ln -sf libcaepcmufr2.so.1.0 libcaepcmufr2.so
-      ln -sf libcaepcmufr2.so.1.0 libcaepcmufr2.so.1
-      ln -sf libcaiowrapufr2.so.1.0.0 libcaiowrapufr2.so
-      ln -sf libcaiowrapufr2.so.1.0.0 libcaiowrapufr2.so.1
-      ln -sf libcanon_slimufr2.so.1.0.0 libcanon_slimufr2.so
-      ln -sf libcanon_slimufr2.so.1.0.0 libcanon_slimufr2.so.1
-      ln -sf libufr2filterr.so.1.0.0 libufr2filterr.so
-      ln -sf libufr2filterr.so.1.0.0 libufr2filterr.so.1
-
-      patchelf --set-rpath "$(cat ${i686_NIX_GCC}/nix-support/orig-cc)/lib:${libs pkgsi686Linux}:${pkgsi686Linux.stdenv.cc.libc}/lib:${pkgsi686Linux.libxml2.out}/lib:$out/lib32" libcanonufr2r.so.1.0.0
-      patchelf --set-rpath "$(cat ${i686_NIX_GCC}/nix-support/orig-cc)/lib:${libs pkgsi686Linux}:${pkgsi686Linux.stdenv.cc.libc}/lib" libcaepcmufr2.so.1.0
-      patchelf --set-rpath "$(cat ${i686_NIX_GCC}/nix-support/orig-cc)/lib:${libs pkgsi686Linux}:${pkgsi686Linux.stdenv.cc.libc}/lib" libColorGearCufr2.so.2.0.0
-    )
-    '' + ''
 
     (
       cd $out/lib

--- a/pkgs/misc/cups/drivers/canon/default.nix
+++ b/pkgs/misc/cups/drivers/canon/default.nix
@@ -57,7 +57,7 @@ stdenv.mkDerivation rec {
       sed -ie "s@_prefix=/usr@_prefix=$out@" cnrdrvcups-common-${version}/allgen.sh
       sed -ie "s@_libdir=/usr/lib@_libdir=$out/lib@" cnrdrvcups-common-${version}/allgen.sh
       sed -ie "s@_bindir=/usr/bin@_bindir=$out/bin@" cnrdrvcups-common-${version}/allgen.sh
-      sed -ie "s@/usr@$out@" cnrdrvcups-common-${version}/{backend,rasterfilter}/Makefile.am
+      sed -ie "s@/usr@$out@" cnrdrvcups-common-${version}/{{backend,rasterfilter}/Makefile.am,rasterfilter/cnrasterproc.h}
       sed -ie "s@etc/cngplp@$out/etc/cngplp@" cnrdrvcups-common-${version}/cngplp/Makefile.am
       sed -ie "s@usr/share/cngplp@$out/usr/share/cngplp@" cnrdrvcups-common-${version}/cngplp/src/Makefile.am
       patchShebangs cnrdrvcups-common-${version}
@@ -87,8 +87,8 @@ stdenv.mkDerivation rec {
     )
     (
       cd cnrdrvcups-common-${version}/Rule
-      mkdir -p $out/share/usb
-      install -m 644 *.usb-quirks $out/share/usb
+      mkdir -p $out/share/cups/usb
+      install -m 644 *.usb-quirks $out/share/cups/usb
     )
     (
       cd cnrdrvcups-lb-${version}
@@ -163,14 +163,25 @@ stdenv.mkDerivation rec {
 
     (
       cd $out/lib
+
+      ln -sf libColorGearCufr2.so.2.0.0 libColorGearCufr2.so
+      ln -sf libColorGearCufr2.so.2.0.0 libColorGearCufr2.so.2
       ln -sf libcaepcmufr2.so.1.0 libcaepcmufr2.so
       ln -sf libcaepcmufr2.so.1.0 libcaepcmufr2.so.1
+      ln -sf libcaiocnpkbidir.so.1.0.0 libcaiocnpkbidir.so
+      ln -sf libcaiocnpkbidir.so.1.0.0 libcaiocnpkbidir.so.1
       ln -sf libcaiowrapufr2.so.1.0.0 libcaiowrapufr2.so
       ln -sf libcaiowrapufr2.so.1.0.0 libcaiowrapufr2.so.1
       ln -sf libcanon_slimufr2.so.1.0.0 libcanon_slimufr2.so
       ln -sf libcanon_slimufr2.so.1.0.0 libcanon_slimufr2.so.1
+      ln -sf libcanonufr2r.so.1.0.0 libcanonufr2r.so
+      ln -sf libcanonufr2r.so.1.0.0 libcanonufr2r.so.1
+      ln -sf libcnlbcmr.so.1.0 libcnlbcmr.so
+      ln -sf libcnlbcmr.so.1.0 libcnlbcmr.so.1
       ln -sf libufr2filterr.so.1.0.0 libufr2filterr.so
       ln -sf libufr2filterr.so.1.0.0 libufr2filterr.so.1
+      ln -sf libuictlufr2r.so.1.0.0 libuictlufr2r.so
+      ln -sf libuictlufr2r.so.1.0.0 libuictlufr2r.so.1
 
       patchelf --set-rpath "$(cat $NIX_CC/nix-support/orig-cc)/lib:${libs pkgs}:${stdenv.cc.cc.lib}/lib64:${stdenv.cc.libc}/lib64:$out/lib" libcanonufr2r.so.1.0.0
       patchelf --set-rpath "$(cat $NIX_CC/nix-support/orig-cc)/lib:${libs pkgs}:${stdenv.cc.cc.lib}/lib64:${stdenv.cc.libc}/lib64" libcaepcmufr2.so.1.0
@@ -179,10 +190,13 @@ stdenv.mkDerivation rec {
 
     (
       cd $out/bin
-      patchelf --set-interpreter "$(cat ${ld64})" --set-rpath "${lib.makeLibraryPath buildInputs}:${stdenv.cc.cc.lib}/lib64:${stdenv.cc.libc}/lib64" cnsetuputil2
-      patchelf --set-interpreter "$(cat ${ld64})" --set-rpath "${lib.makeLibraryPath buildInputs}:${stdenv.cc.cc.lib}/lib64:${stdenv.cc.libc}/lib64" cnpdfdrv
-      patchelf --set-interpreter "$(cat ${ld64})" --set-rpath "${lib.makeLibraryPath buildInputs}:${stdenv.cc.cc.lib}/lib64:${stdenv.cc.libc}/lib64:$out/lib" cnpkbidir
-      patchelf --set-interpreter "$(cat ${ld64})" --set-rpath "${lib.makeLibraryPath buildInputs}:${stdenv.cc.cc.lib}/lib64:${stdenv.cc.libc}/lib64:$out/lib" cnrsdrvufr2
+      patchelf --set-interpreter "$(cat ${ld64})" --set-rpath "${lib.makeLibraryPath buildInputs}:${stdenv.cc.cc.lib}/lib64:${stdenv.cc.libc}/lib64" cnsetuputil2 cnpdfdrv
+      patchelf --set-interpreter "$(cat ${ld64})" --set-rpath "${lib.makeLibraryPath buildInputs}:${stdenv.cc.cc.lib}/lib64:${stdenv.cc.libc}/lib64:$out/lib" cnpkbidir cnrsdrvufr2 cnpkmoduleufr2r cnjbigufr2
+
+      wrapProgram $out/bin/cnrsdrvufr2 \
+        --prefix LD_LIBRARY_PATH ":" "$out/lib" \
+        --set LD_PRELOAD "${libredirect}/lib/libredirect.so" \
+        --set NIX_REDIRECTS /usr/bin/cnpkmoduleufr2r=$out/bin/cnpkmoduleufr2r:/usr/bin/cnjbigufr2=$out/bin/cnjbigufr2
 
       wrapProgram $out/bin/cnsetuputil2 \
         --set LD_PRELOAD "${libredirect}/lib/libredirect.so" \

--- a/pkgs/misc/cups/drivers/canon/default.nix
+++ b/pkgs/misc/cups/drivers/canon/default.nix
@@ -16,7 +16,6 @@
 , coreutils
 , atk
 , pkg-config
-, gnome2
 , libxml2
 , runtimeShell
 , libredirect
@@ -44,7 +43,7 @@ let
     hash = "sha256-d5VHlPpUPAr3RWVdQRdn42YLuVekOw1IaMFLVt1Iu7o=";
   };
 
-  buildInputs = [ cups zlib jbigkit glib gtk3 gnome2.libglade libxml2 gdk-pixbuf pango cairo atk ];
+  buildInputs = [ cups zlib jbigkit glib gtk3 libxml2 gdk-pixbuf pango cairo atk ];
 in
 stdenv.mkDerivation rec {
   pname = "canon-cups-ufr2";

--- a/pkgs/misc/cups/drivers/canon/default.nix
+++ b/pkgs/misc/cups/drivers/canon/default.nix
@@ -194,8 +194,6 @@ stdenv.mkDerivation rec {
     homepage = "http://www.canon.com/";
     sourceProvenance = with sourceTypes; [ binaryNativeCode ];
     license = licenses.unfree;
-    maintainers = with maintainers; [
-      # please consider maintaining if you are updating this package
-    ];
+    maintainers = with maintainers; [ lluchs ];
   };
 }


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Update to the latest version of the driver, and enable building on aarch64. As part of that, I replaced proot with libredirect as proposed in #156090 since I couldn't get proot to build on aarch64.

~~Unfortunately, neither the old 5.40 nor the new 5.70 package actually manages to print something on my iR 1022, so something isn't built or packaged correctly. Still, the update might be useful as-is for people with other printers.~~

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

cc @dmayle