### PR TITLE
rinetd: init at 0.73

### DIFF
--- a/pkgs/servers/rinetd/default.nix
+++ b/pkgs/servers/rinetd/default.nix
@@ -1,0 +1,40 @@
+{ lib
+, autoreconfHook
+, fetchFromGitHub
+, rinetd
+, stdenv
+, testers
+}:
+
+stdenv.mkDerivation rec {
+  pname = "rinetd";
+  version = "0.73";
+
+  src = fetchFromGitHub {
+    owner = "samhocevar";
+    repo = "rinetd";
+    rev = "v${version}";
+    hash = "sha256-W8PLGd3RwmBTh1kw3k8+ZfP6AzRhZORCkxZzQ9ZbPN4=";
+  };
+
+  nativeBuildInputs = [
+    autoreconfHook
+  ];
+
+  preConfigure = ''
+    ./bootstrap
+  '';
+
+  passthru.tests.version = testers.testVersion {
+    package = rinetd;
+    command = "rinetd --version";
+  };
+
+  meta = with lib; {
+    description = "TCP/UDP port redirector";
+    homepage = "https://github.com/samhocevar/rinetd";
+    changelog = "https://github.com/samhocevar/rinetd/blob/${src.rev}/CHANGES.md";
+    license = licenses.gpl2Plus;
+    maintainers = with maintainers; [ janik ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -38652,6 +38652,8 @@ with pkgs;
     stdenv = if stdenv.cc.isClang then llvmPackages_5.stdenv else stdenv;
   });
 
+  rinetd = callPackage ../servers/rinetd { };
+
   rink = callPackage ../applications/science/misc/rink {
     inherit (darwin.apple_sdk.frameworks) Security;
   };


### PR DESCRIPTION
###### Description of changes
Trying to package rinetd but build falis because it trys to install stuff at /usr/local/sbin which off course doesn't work. When grepping through the sources it's only mentioned in the man page and the index.html which both don't theme like they set that. I also build the configure script and ran autoconfig and make but they also don't create files with a mention of users and make install just fails.


<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
