### PR TITLE
python3Packages.xformers: init at 0.0.20

### DIFF
--- a/pkgs/development/python-modules/pyre-extensions/default.nix
+++ b/pkgs/development/python-modules/pyre-extensions/default.nix
@@ -1,0 +1,34 @@
+{
+  buildPythonPackage,
+  fetchPypi,
+  lib,
+  # propagateBuildInputs
+  typing-extensions,
+  typing-inspect,
+}: let
+  attrs = {
+    # NOTE: Kept in sync with xformers
+    pname = "pyre-extensions";
+    version = "0.0.29";
+
+    src = fetchPypi {
+      inherit (attrs) pname version;
+      hash = "sha256-QRNgBwbEcwahVtzJxAX01FjFBb5DJplXHjV+8g4tXXc=";
+    };
+
+    propagatedBuildInputs = [
+      typing-extensions
+      typing-inspect
+    ];
+
+    pythonImportsCheck = [(lib.strings.replaceStrings ["-"] ["_"] attrs.pname)];
+
+    meta = with lib; {
+      description = "Type system extensions for use with the pyre type checker";
+      homepage = "https://pyre-check.org";
+      license = licenses.mit;
+      maintainers = with maintainers; [connorbaker];
+    };
+  };
+in
+  buildPythonPackage attrs

--- a/pkgs/development/python-modules/xformers/default.nix
+++ b/pkgs/development/python-modules/xformers/default.nix
@@ -1,0 +1,94 @@
+{
+  buildPythonPackage,
+  config,
+  cudaPackages,
+  fetchFromGitHub,
+  lib,
+  symlinkJoin,
+  # nativeBuildInputs
+  git,
+  ninja,
+  which,
+  # propagatedBuildInputs
+  numpy,
+  pyre-extensions,
+  torch,
+}: let
+  cudaSupport = config.cudaSupport or false;
+
+  # Build-time dependencies
+  cuda-native-redist = symlinkJoin {
+    name = "cuda-native-redist-${cudaPackages.cudaVersion}";
+    paths = with cudaPackages; [
+      cuda_cccl #include <thrust/*>
+      cuda_cudart #include <cuda_runtime.h>
+      cuda_nvcc
+      libcublas #include <cublas_v2.h>
+      libcurand #include <curand_kernel.h>
+      libcusolver #include <cusolverDn.h>
+      libcusparse #include <cusparse.h>
+    ];
+  };
+
+  attrs = {
+    pname = "xformers";
+    version = "0.0.20";
+
+    src = fetchFromGitHub {
+      owner = "facebookresearch";
+      repo = attrs.pname;
+      rev = "v${attrs.version}";
+      fetchSubmodules = true;
+      leaveDotGit = true;
+      hash = "sha256-vNZ69KMID6NRtlUSFXxXcoTbY5qFZSD9pnsLnQ0Q6MQ=";
+    };
+
+    nativeBuildInputs = [
+      cuda-native-redist
+      git
+      ninja
+      which
+    ];
+
+    propagatedBuildInputs = [
+      numpy
+      pyre-extensions
+      torch
+    ];
+
+    postPatch = ''
+      substituteInPlace xformers/__init__.py \
+        --replace "_is_functorch_available: bool = False" "_is_functorch_available: bool = True"
+    '';
+
+    preBuild =
+      ''
+        export XFORMERS_BUILD_TYPE=Release
+      ''
+      + lib.strings.optionalString cudaSupport ''
+        export TORCH_CUDA_ARCH_LIST="${lib.strings.concatStringsSep ";" torch.cudaCapabilities}"
+        export CC="${cudaPackages.backendStdenv.cc}/bin/cc"
+        export CXX="${cudaPackages.backendStdenv.cc}/bin/c++"
+      '';
+
+    # Note: Tests require ragged_inference, which is in the experimental module and is not built
+    # by default.
+    doCheck = false;
+    pythonImportsCheck = [attrs.pname];
+
+    passthru = {
+      inherit cudaSupport cudaPackages;
+      cudaCapabilities = lib.lists.optionals cudaSupport torch.cudaCapabilities;
+    };
+
+    meta = with lib; {
+      description = "Hackable and optimized Transformers building blocks, supporting a composable construction";
+      homepage = "https://github.com/facebookresearch/xformers";
+      license = licenses.bsd3;
+      platforms = platforms.linux;
+      broken = cudaSupport != torch.cudaSupport;
+      maintainers = with maintainers; [connorbaker];
+    };
+  };
+in
+  buildPythonPackage attrs

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -7681,6 +7681,8 @@ self: super: with self; {
 
   pyrevolve = callPackage ../development/python-modules/pyrevolve { };
 
+  pyre-extensions = callPackage ../development/python-modules/pyre-extensions { };
+
   pyrfxtrx = callPackage ../development/python-modules/pyrfxtrx { };
 
   pyrogram = callPackage ../development/python-modules/pyrogram { };
@@ -13080,6 +13082,8 @@ self: super: with self; {
   xdot = callPackage ../development/python-modules/xdot {
     inherit (pkgs) graphviz;
   };
+
+  xformers = callPackage ../development/python-modules/xformers { };
 
   xgboost = callPackage ../development/python-modules/xgboost {
     inherit (pkgs) xgboost;


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Add xformers. Able to run benchmarks in their repo.

```console
$ python3 -m xformers.info
xFormers 0.0.20+1dc3d7a.d20230528
memory_efficient_attention.cutlassF:               available
memory_efficient_attention.cutlassB:               available
memory_efficient_attention.flshattF:               available
memory_efficient_attention.flshattB:               available
memory_efficient_attention.smallkF:                available
memory_efficient_attention.smallkB:                available
memory_efficient_attention.tritonflashattF:        available
memory_efficient_attention.tritonflashattB:        available
indexing.scaled_index_addF:                        available
indexing.scaled_index_addB:                        available
indexing.index_select:                             available
swiglu.dual_gemm_silu:                             available
swiglu.gemm_fused_operand_sum:                     available
swiglu.fused.p.cpp:                                available
is_triton_available:                               True
is_functorch_available:                            True
pytorch.version:                                   2.0.1
pytorch.cuda:                                      available
gpu.compute_capability:                            8.9
gpu.name:                                          NVIDIA GeForce RTX 4090
build.info:                                        available
build.cuda_version:                                1108
build.python_version:                              3.10.11
build.torch_version:                               2.0.1
build.env.TORCH_CUDA_ARCH_LIST:                    8.9
build.env.XFORMERS_BUILD_TYPE:                     Release
build.env.XFORMERS_ENABLE_DEBUG_ASSERTIONS:        None
build.env.NVCC_FLAGS:                              None
build.env.XFORMERS_PACKAGE_FROM:                   None
build.nvcc_version:                                11.8.89
source.privacy:                                    open source
```

<details>

<summary>Flake reproducer</summary>

```nix
{
  inputs = {
    nixpkgs.url = "github:ConnorBaker/nixpkgs/feat/xformers_0_0_20";
    nixGL = {
      url = "github:guibou/nixGL";
      inputs.nixpkgs.follows = "nixpkgs";
    };
  };

  nixConfig = {
    # Add the CUDA maintainer's cache to the binary cache list and my own cache.
    extra-substituters = [
      "https://cantcache.me?trusted=1"
      "https://cuda-maintainers.cachix.org"
    ];
    extra-trusted-public-keys = [
      "cuda-maintainers.cachix.org-1:0dq3bujKpuEPMCX6U4WylrUDZ9JyUG0VpVZa7CNfq5E="
    ];
  };

  outputs = {
    self,
    nixpkgs,
    nixGL,
  }: let
    system = "x86_64-linux";

    pkgs = import nixpkgs {
      inherit system;
      config = {
        allowUnfree = true;
        cudaSupport = true;
        cudaCapabilities = ["8.9"];
        cudaForwardCompat = false;
      };
      overlays = [
        (final: prev: {
          python3 = prev.python310;
          python3Packages = prev.python310Packages;
          cudaPackages = prev.cudaPackages_11_8;
        })
        (final: prev: {
          nixgl = import nixGL.outPath {
            pkgs = prev;
            enableIntelX86Extensions = true;
            enable32bits = false;
            nvidiaVersion = "530.41.03";
            nvidiaHash = "sha256-riehapaMhVA/XRYd2jQ8FgJhKwJfSu4V+S4uoKy3hLE=";
          };
        })
      ];
    };
  in {
    devShells.${system}.default = pkgs.mkShell {
      packages = [
        pkgs.nixgl.nixGLNvidia
        # TODO: Must set torch._inductor.config.compile_threads = 1 or else Segmentation fault
        #   when running torch.compile.
        (pkgs.python3.withPackages (ps:
          with ps; [
            torch
            openai-triton
            xformers
          ]))
      ];

      # Make an alias for python so it's wrapped with nixGLNvidia.
      shellHook = ''
        alias python3="${pkgs.nixgl.nixGLNvidia.name} python3"
        alias python="${pkgs.nixgl.nixGLNvidia.name} python3"
      '';
    };

    formatter.${system} = pkgs.alejandra;
  };
}
```

</details>

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
