### PR TITLE
ocamlPackages.gapi-ocaml: 0.4.3 -> 0.4.4

### DIFF
--- a/pkgs/development/ocaml-modules/gapi-ocaml/default.nix
+++ b/pkgs/development/ocaml-modules/gapi-ocaml/default.nix
@@ -5,7 +5,7 @@
 
 buildDunePackage rec {
   pname = "gapi-ocaml";
-  version = "0.4.3";
+  version = "0.4.4";
   duneVersion = "3";
 
   minimalOCamlVersion = "4.08";
@@ -14,7 +14,7 @@ buildDunePackage rec {
     owner = "astrada";
     repo = pname;
     rev = "v${version}";
-    sha256 = "sha256-V0GB9Bd06IdcI5PDFHGVZ0Y/qi7tTs/4ITqPXUOxCLs=";
+    hash = "sha256-+UNFW5tmIh5dVyTDEOfOmy1j+gV4P28jlnBTdpQNAjE=";
   };
 
   propagatedBuildInputs = [ cryptokit ocamlnet ocurl yojson ];
@@ -24,7 +24,7 @@ buildDunePackage rec {
 
   meta = {
     description = "OCaml client for google services";
-    inherit (src.meta) homepage;
+    homepage = "https://github.com/astrada/gapi-ocaml";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ bennofs ];
   };


### PR DESCRIPTION
Diff: https://github.com/astrada/gapi-ocaml/compare/v0.4.3...v0.4.4

Changelog: https://github.com/astrada/gapi-ocaml/releases/tag/v0.4.4

-------

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->