### PR TITLE
flashmq: init at 1.4.5

### DIFF
--- a/pkgs/servers/mqtt/flashmq/default.nix
+++ b/pkgs/servers/mqtt/flashmq/default.nix
@@ -1,0 +1,34 @@
+{ lib, stdenv, fetchFromGitHub, cmake, installShellFiles, openssl }:
+
+stdenv.mkDerivation rec {
+  pname = "flashmq";
+  version = "1.4.5";
+
+  src = fetchFromGitHub {
+    owner = "halfgaar";
+    repo = "FlashMQ";
+    rev = "v${version}";
+    hash = "sha256-DcxwwUNpnMeK8A3LuyfrWAMCng0yIcX9bKxNGY0uDSo=";
+  };
+
+  nativeBuildInputs = [ cmake installShellFiles ];
+
+  buildInputs = [ openssl ];
+
+  installPhase = ''
+    runHook preInstall
+
+    install -Dm755 flashmq -t $out/bin
+    installManPage $src/man/*.{1,5}
+
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    description = "Fast light-weight MQTT broker/server";
+    homepage = "https://www.flashmq.org/";
+    license = licenses.agpl3Only;
+    maintainers = with maintainers; [ sikmir ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -25363,6 +25363,8 @@ with pkgs;
 
   inherit (callPackages ../servers/firebird { }) firebird_4 firebird_3 firebird_2_5 firebird;
 
+  flashmq = callPackage ../servers/mqtt/flashmq { };
+
   freeradius = callPackage ../servers/freeradius { };
 
   freshrss = callPackage ../servers/web-apps/freshrss { };


### PR DESCRIPTION
###### Description of changes
[FlashMQ](https://www.flashmq.org/) is a fast light-weight MQTT broker/server.

Test instructions:
```sh
$ cat <<EOF > flashmq.conf
allow_anonymous yes
listen {
  protocol mqtt
  inet_protocol ip4
  port 1883
}
EOF
$ result/bin/flashmq -c flashmq.conf
[2023-05-28 12:35:02] [INFO] Setting rlimit nofile to 1000000.
[2023-05-28 12:35:02] [NOTICE] 8 CPUs are detected, making as many threads. Use 'thread_count' setting to override.
[2023-05-28 12:35:02] [NOTICE] Starting FlashMQ version 1.4.5, release build with SSE4.2 support.
[2023-05-28 12:35:02] [NOTICE] Creating IPv4 non-SSL TCP listener on [0.0.0.0]:1883
[2023-05-28 12:35:02] [NOTICE] Thread 2 doing auth init.
[2023-05-28 12:35:02] [NOTICE] Thread 1 doing auth init.
[2023-05-28 12:35:02] [NOTICE] Thread 3 doing auth init.
[2023-05-28 12:35:02] [NOTICE] Thread 0 doing auth init.
[2023-05-28 12:35:02] [NOTICE] Thread 5 doing auth init.
[2023-05-28 12:35:02] [NOTICE] Thread 6 doing auth init.
[2023-05-28 12:35:02] [NOTICE] Thread 4 doing auth init.
[2023-05-28 12:35:02] [NOTICE] Thread 7 doing auth init.
[2023-05-28 12:35:12] [NOTICE] Rebuilding subscription tree
[2023-05-28 12:36:09] [NOTICE] Accepting connection from: address='127.0.0.1', transport='TCP/Non-SSL', fd=24
...
```
```sh
$ nix shell nixpkgs#mosquitto
$ mosquitto_pub -t /foo/bar -m test -r
$ mosquitto_sub -t /foo/bar -C 1
test
```

###### Things done
- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux (cross)
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
