### PR TITLE
accountsservice: 22.08.8 → 23.13.9

### DIFF
--- a/pkgs/development/libraries/accountsservice/Disable-methods-that-change-files-in-etc.patch
+++ b/pkgs/development/libraries/accountsservice/Disable-methods-that-change-files-in-etc.patch
@@ -10,10 +10,10 @@ Only if environment variable NIXOS_USERS_PURE is set.
  2 files changed, 45 insertions(+)
 
 diff --git a/src/daemon.c b/src/daemon.c
-index e62e124..87459b2 100644
+index 861430f..aefaf2d 100644
 --- a/src/daemon.c
 +++ b/src/daemon.c
-@@ -931,6 +931,11 @@ daemon_create_user (AccountsAccounts      *accounts,
+@@ -1378,6 +1378,11 @@ daemon_create_user (AccountsAccounts      *accounts,
                      const gchar           *real_name,
                      gint                   account_type)
  {
@@ -22,10 +22,10 @@ index e62e124..87459b2 100644
 +                return;
 +        }
 +
-         Daemon *daemon = (Daemon*)accounts;
+         Daemon *daemon = (Daemon *) accounts;
          CreateUserData *data;
  
-@@ -1138,6 +1143,11 @@ daemon_delete_user (AccountsAccounts      *accounts,
+@@ -1581,6 +1586,11 @@ daemon_delete_user (AccountsAccounts      *accounts,
                      gint64                 uid,
                      gboolean               remove_files)
  {
@@ -34,14 +34,14 @@ index e62e124..87459b2 100644
 +                return;
 +        }
 +
-         Daemon *daemon = (Daemon*)accounts;
+         Daemon *daemon = (Daemon *) accounts;
          DeleteUserData *data;
  
 diff --git a/src/user.c b/src/user.c
-index 0fb1a17..dbdebaf 100644
+index 28170db..df947a1 100644
 --- a/src/user.c
 +++ b/src/user.c
-@@ -904,6 +904,11 @@ user_set_real_name (AccountsUser          *auser,
+@@ -1216,6 +1216,11 @@ user_set_real_name (AccountsUser          *auser,
                      GDBusMethodInvocation *context,
                      const gchar           *real_name)
  {
@@ -50,10 +50,10 @@ index 0fb1a17..dbdebaf 100644
 +                return;
 +        }
 +
-         User *user = (User*)auser;
+         User *user = (User *) auser;
          int uid;
          const gchar *action_id;
-@@ -981,6 +986,11 @@ user_set_user_name (AccountsUser          *auser,
+@@ -1293,6 +1298,11 @@ user_set_user_name (AccountsUser          *auser,
                      GDBusMethodInvocation *context,
                      const gchar           *user_name)
  {
@@ -62,10 +62,10 @@ index 0fb1a17..dbdebaf 100644
 +                return;
 +        }
 +
-         User *user = (User*)auser;
+         User *user = (User *) auser;
+ 
          daemon_local_check_auth (user->daemon,
-                                  user,
-@@ -1263,6 +1273,11 @@ user_set_home_directory (AccountsUser          *auser,
+@@ -1945,6 +1955,11 @@ user_set_home_directory (AccountsUser          *auser,
                           GDBusMethodInvocation *context,
                           const gchar           *home_dir)
  {
@@ -74,10 +74,10 @@ index 0fb1a17..dbdebaf 100644
 +                return;
 +        }
 +
-         User *user = (User*)auser;
+         User *user = (User *) auser;
+ 
          daemon_local_check_auth (user->daemon,
-                                  user,
-@@ -1322,6 +1337,11 @@ user_set_shell (AccountsUser          *auser,
+@@ -2000,6 +2015,11 @@ user_set_shell (AccountsUser          *auser,
                  GDBusMethodInvocation *context,
                  const gchar           *shell)
  {
@@ -86,10 +86,10 @@ index 0fb1a17..dbdebaf 100644
 +                return;
 +        }
 +
-         User *user = (User*)auser;
+         User *user = (User *) auser;
+ 
          daemon_local_check_auth (user->daemon,
-                                  user,
-@@ -1602,6 +1622,11 @@ user_set_locked (AccountsUser          *auser,
+@@ -2249,6 +2269,11 @@ user_set_locked (AccountsUser          *auser,
                   GDBusMethodInvocation *context,
                   gboolean               locked)
  {
@@ -98,10 +98,10 @@ index 0fb1a17..dbdebaf 100644
 +                return;
 +        }
 +
-         User *user = (User*)auser;
+         User *user = (User *) auser;
+ 
          daemon_local_check_auth (user->daemon,
-                                  user,
-@@ -1814,6 +1839,11 @@ user_set_password_mode (AccountsUser          *auser,
+@@ -2457,6 +2482,11 @@ user_set_password_mode (AccountsUser          *auser,
                          GDBusMethodInvocation *context,
                          gint                   mode)
  {
@@ -110,10 +110,10 @@ index 0fb1a17..dbdebaf 100644
 +                return;
 +        }
 +
-         User *user = (User*)auser;
+         User *user = (User *) auser;
          const gchar *action_id;
- 
-@@ -1905,6 +1935,11 @@ user_set_password (AccountsUser          *auser,
+         gint uid;
+@@ -2550,6 +2580,11 @@ user_set_password (AccountsUser          *auser,
                     const gchar           *password,
                     const gchar           *hint)
  {
@@ -122,9 +122,6 @@ index 0fb1a17..dbdebaf 100644
 +                return;
 +        }
 +
-         User *user = (User*)auser;
+         User *user = (User *) auser;
          gchar **data;
- 
--- 
-2.9.3
-
+         const gchar *action_id;

--- a/pkgs/development/libraries/accountsservice/default.nix
+++ b/pkgs/development/libraries/accountsservice/default.nix
@@ -21,13 +21,13 @@
 
 stdenv.mkDerivation rec {
   pname = "accountsservice";
-  version = "22.08.8";
+  version = "23.13.9";
 
   outputs = [ "out" "dev" ];
 
   src = fetchurl {
     url = "https://www.freedesktop.org/software/accountsservice/accountsservice-${version}.tar.xz";
-    sha256 = "kJmXp2kZ/n3BOKmgHOpwvWItWpMtvJ+xMBARMCOno5E=";
+    sha256 = "rdpM3q4k+gmS598///nv+nCQvjrCM6Pt/fadWpybkk8=";
   };
 
   patches = [
@@ -46,6 +46,10 @@ stdenv.mkDerivation rec {
     # Do not ignore third-party (e.g Pantheon) extensions not matching FHS path scheme.
     # Fixes https://github.com/NixOS/nixpkgs/issues/72396
     ./drop-prefix-check-extensions.patch
+
+    # Detect DM type from config file.
+    # `readlink display-manager.service` won't return any of the candidates.
+    ./get-dm-type-from-config.patch
   ];
 
   nativeBuildInputs = [

--- a/pkgs/development/libraries/accountsservice/drop-prefix-check-extensions.patch
+++ b/pkgs/development/libraries/accountsservice/drop-prefix-check-extensions.patch
@@ -1,8 +1,8 @@
 diff --git a/src/extensions.c b/src/extensions.c
-index 038dcb2..830465d 100644
+index 354f476..8d020a6 100644
 --- a/src/extensions.c
 +++ b/src/extensions.c
-@@ -121,16 +121,7 @@ daemon_read_extension_directory (GHashTable  *ifaces,
+@@ -122,15 +122,7 @@ daemon_read_extension_directory (GHashTable  *ifaces,
                          continue;
                  }
  
@@ -10,8 +10,7 @@ index 038dcb2..830465d 100644
 -                const gchar * const prefix = "../../dbus-1/interfaces/";
 -                if (g_str_has_prefix (symlink, prefix) && g_str_equal (symlink + strlen (prefix), name)) {
 -                        daemon_read_extension_file (ifaces, filename);
--                }
--                else {
+-                } else {
 -                        g_warning ("Found accounts service vendor extension symlink %s, but it must be exactly "
 -                                   "equal to '../../dbus-1/interfaces/%s' for forwards-compatibility reasons.",
 -                                   filename, name);

--- a/pkgs/development/libraries/accountsservice/fix-paths.patch
+++ b/pkgs/development/libraries/accountsservice/fix-paths.patch
@@ -1,8 +1,8 @@
 diff --git a/src/daemon.c b/src/daemon.c
-index c8b6320..2b74949 100644
+index aa9d050..861430f 100644
 --- a/src/daemon.c
 +++ b/src/daemon.c
-@@ -1102,7 +1102,7 @@ daemon_create_user_authorized_cb (Daemon                *daemon,
+@@ -1319,7 +1319,7 @@ daemon_create_user_authorized_cb (Daemon                *daemon,
  
          sys_log (context, "create user '%s'", cd->user_name);
  
@@ -11,7 +11,7 @@ index c8b6320..2b74949 100644
          argv[1] = "-m";
          argv[2] = "-c";
          argv[3] = cd->real_name;
-@@ -1335,7 +1335,7 @@ daemon_delete_user_authorized_cb (Daemon                *daemon,
+@@ -1552,7 +1552,7 @@ daemon_delete_user_authorized_cb (Daemon                *daemon,
          }
          free (resolved_homedir);
  
@@ -21,10 +21,10 @@ index c8b6320..2b74949 100644
                  argv[1] = "-f";
                  argv[2] = "-r";
 diff --git a/src/user.c b/src/user.c
-index 189b2c5..5358c02 100644
+index 917d427..28170db 100644
 --- a/src/user.c
 +++ b/src/user.c
-@@ -1145,7 +1145,7 @@ user_change_real_name_authorized_cb (Daemon                *daemon,
+@@ -1193,7 +1193,7 @@ user_change_real_name_authorized_cb (Daemon                *daemon,
                          new_gecos = g_strdup (name);
                  }
  
@@ -33,7 +33,7 @@ index 189b2c5..5358c02 100644
                  argv[1] = "-c";
                  argv[2] = new_gecos;
                  argv[3] = "--";
-@@ -1218,7 +1218,7 @@ user_change_user_name_authorized_cb (Daemon                *daemon,
+@@ -1267,7 +1267,7 @@ user_change_user_name_authorized_cb (Daemon                *daemon,
                           accounts_user_get_uid (ACCOUNTS_USER (user)),
                           name);
  
@@ -42,7 +42,25 @@ index 189b2c5..5358c02 100644
                  argv[1] = "-l";
                  argv[2] = name;
                  argv[3] = "--";
-@@ -1627,7 +1627,7 @@ user_change_home_dir_authorized_cb (Daemon                *daemon,
+@@ -1718,7 +1718,7 @@ user_set_password_expiration_policy_authorized_cb (Daemon                *daemon
+                  accounts_user_get_uid (ACCOUNTS_USER (user)));
+ 
+         g_object_freeze_notify (G_OBJECT (user));
+-        argv[0] = "/usr/bin/chage";
++        argv[0] = "@shadow@/bin/chage";
+         argv[1] = "-m";
+         argv[2] = pwd_expiration->min_days_between_changes;
+         argv[3] = "-M";
+@@ -1806,7 +1806,7 @@ user_set_user_expiration_policy_authorized_cb (Daemon                *daemon,
+         } else {
+                 expiration_time = g_strdup ("-1");
+         }
+-        argv[0] = "/usr/bin/chage";
++        argv[0] = "@shadow@/bin/chage";
+         argv[1] = "-E";
+         argv[2] = expiration_time;
+         argv[3] = accounts_user_get_user_name (ACCOUNTS_USER (user));
+@@ -1919,7 +1919,7 @@ user_change_home_dir_authorized_cb (Daemon                *daemon,
                           accounts_user_get_uid (ACCOUNTS_USER (user)),
                           home_dir);
  
@@ -51,7 +69,7 @@ index 189b2c5..5358c02 100644
                  argv[1] = "-m";
                  argv[2] = "-d";
                  argv[3] = home_dir;
-@@ -1683,7 +1683,7 @@ user_change_shell_authorized_cb (Daemon                *daemon,
+@@ -1977,7 +1977,7 @@ user_change_shell_authorized_cb (Daemon                *daemon,
                           accounts_user_get_uid (ACCOUNTS_USER (user)),
                           shell);
  
@@ -60,7 +78,7 @@ index 189b2c5..5358c02 100644
                  argv[1] = "-s";
                  argv[2] = shell;
                  argv[3] = "--";
-@@ -1824,7 +1824,7 @@ user_change_icon_file_authorized_cb (Daemon                *daemon,
+@@ -2120,7 +2120,7 @@ user_change_icon_file_authorized_cb (Daemon                *daemon,
                          return;
                  }
  
@@ -69,7 +87,7 @@ index 189b2c5..5358c02 100644
                  argv[1] = filename;
                  argv[2] = NULL;
  
-@@ -1904,7 +1904,7 @@ user_change_locked_authorized_cb (Daemon                *daemon,
+@@ -2201,7 +2201,7 @@ user_change_locked_authorized_cb (Daemon                *daemon,
                           locked ? "locking" : "unlocking",
                           accounts_user_get_user_name (ACCOUNTS_USER (user)),
                           accounts_user_get_uid (ACCOUNTS_USER (user)));
@@ -78,7 +96,7 @@ index 189b2c5..5358c02 100644
                  argv[1] = locked ? "-L" : "-U";
                  argv[2] = "--";
                  argv[3] = accounts_user_get_user_name (ACCOUNTS_USER (user));
-@@ -2026,7 +2026,7 @@ user_change_account_type_authorized_cb (Daemon                *daemon,
+@@ -2328,7 +2328,7 @@ user_change_account_type_authorized_cb (Daemon                *daemon,
  
                  g_free (groups);
  
@@ -87,16 +105,16 @@ index 189b2c5..5358c02 100644
                  argv[1] = "-G";
                  argv[2] = str->str;
                  argv[3] = "--";
-@@ -2093,7 +2093,7 @@ user_change_password_mode_authorized_cb (Daemon                *daemon,
+@@ -2396,7 +2396,7 @@ user_change_password_mode_authorized_cb (Daemon                *daemon,
+ 
                  if (mode == PASSWORD_MODE_SET_AT_LOGIN ||
                      mode == PASSWORD_MODE_NONE) {
- 
 -                        argv[0] = "/usr/bin/passwd";
 +                        argv[0] = "/run/wrappers/bin/passwd";
                          argv[1] = "-d";
                          argv[2] = "--";
                          argv[3] = accounts_user_get_user_name (ACCOUNTS_USER (user));
-@@ -2105,7 +2105,7 @@ user_change_password_mode_authorized_cb (Daemon                *daemon,
+@@ -2408,7 +2408,7 @@ user_change_password_mode_authorized_cb (Daemon                *daemon,
                          }
  
                          if (mode == PASSWORD_MODE_SET_AT_LOGIN) {
@@ -105,21 +123,21 @@ index 189b2c5..5358c02 100644
                                  argv[1] = "-d";
                                  argv[2] = "0";
                                  argv[3] = "--";
-@@ -2126,7 +2126,7 @@ user_change_password_mode_authorized_cb (Daemon                *daemon,
+@@ -2428,7 +2428,7 @@ user_change_password_mode_authorized_cb (Daemon                *daemon,
+                          */
                          accounts_user_set_locked (ACCOUNTS_USER (user), FALSE);
-                 }
-                 else if (accounts_user_get_locked (ACCOUNTS_USER (user))) {
+                 } else if (accounts_user_get_locked (ACCOUNTS_USER (user))) {
 -                        argv[0] = "/usr/sbin/usermod";
 +                        argv[0] = "@shadow@/bin/usermod";
                          argv[1] = "-U";
                          argv[2] = "--";
                          argv[3] = accounts_user_get_user_name (ACCOUNTS_USER (user));
-@@ -2203,7 +2203,7 @@ user_change_password_authorized_cb (Daemon                *daemon,
+@@ -2505,7 +2505,7 @@ user_change_password_authorized_cb (Daemon                *daemon,
  
-         g_object_freeze_notify (G_OBJECT (user));
+         g_autoptr (GError) error = NULL;
+         g_autoptr (GSubprocess) process = NULL;
+-        const char *argv[] = { "/usr/sbin/chpasswd", "-e", NULL };
++        const char *argv[] = { "@shadow@/bin/chpasswd", "-e", NULL };
  
--        argv[0] = "/usr/sbin/usermod";
-+        argv[0] = "@shadow@/bin/usermod";
-         argv[1] = "-p";
-         argv[2] = strings[0];
-         argv[3] = "--";
+         sys_log (context,
+                  "set password and hint of user '%s' (%" G_GUINT64_FORMAT ")",

--- a/pkgs/development/libraries/accountsservice/get-dm-type-from-config.patch
+++ b/pkgs/development/libraries/accountsservice/get-dm-type-from-config.patch
@@ -1,0 +1,15 @@
+diff --git a/src/daemon.c b/src/daemon.c
+index aefaf2d..7c004d0 100644
+--- a/src/daemon.c
++++ b/src/daemon.c
+@@ -193,9 +193,9 @@ get_current_system_dm_type (void)
+                 basename = g_file_get_basename (file);
+                 g_object_unref (file);
+ 
+-                if (g_strcmp0 (basename, "lightdm.service") == 0)
++                if (g_file_test (PATH_LIGHTDM_CONF, G_FILE_TEST_EXISTS))
+                         return DISPLAY_MANAGER_TYPE_LIGHTDM;
+-                else if (g_strcmp0 (basename, "gdm.service") == 0)
++                else if (g_file_test (PATH_GDM_CUSTOM, G_FILE_TEST_EXISTS))
+                         return DISPLAY_MANAGER_TYPE_GDM;
+         }

--- a/pkgs/development/libraries/accountsservice/no-create-dirs.patch
+++ b/pkgs/development/libraries/accountsservice/no-create-dirs.patch
@@ -2,7 +2,7 @@ diff --git a/meson_post_install.py b/meson_post_install.py
 index d8c3dd1..620f714 100644
 --- a/meson_post_install.py
 +++ b/meson_post_install.py
-@@ -9,9 +9,9 @@ localstatedir = os.path.normpath(destdir + os.sep + sys.argv[1])
+@@ -9,9 +9,9 @@
  # FIXME: meson will not track the creation of these directories
  #        https://github.com/mesonbuild/meson/blob/master/mesonbuild/scripts/uninstall.py#L39
  dst_dirs = [


### PR DESCRIPTION
Okay I never touch this package before, hopefully I am not breaking stuff.

https://gitlab.freedesktop.org/accountsservice/accountsservice/-/compare/22.08.8...23.13.9

Or the patched accountsservice: https://github.com/bobby285271/accountsservice/compare/22.08.8-patched..23.13.9-patched-unreviewed

#### Commits prefixed with `tests`

I don't think we run tests right now.

<details>

- [ ] [<code>tests: fix the signature for the SetLocked call</code>](https://gitlab.freedesktop.org/accountsservice/accountsservice/-/commit/fea3ecdc8e4877eb1960f5ec3ae319a3fd1aea26)
- [ ] [<code>tests: fix invocation of AddUser</code>](https://gitlab.freedesktop.org/accountsservice/accountsservice/-/commit/c588aea01bcc20353f8d28a78125e211bdc25097)
- [ ] [<code>tests: Pass a correctly-formatted locale in tests</code>](https://gitlab.freedesktop.org/accountsservice/accountsservice/-/commit/d1f28a70ed46499fa7e33918b25a5e7695b7aa9b)
- [ ] [<code>tests: Add tests for new locale verification</code>](https://gitlab.freedesktop.org/accountsservice/accountsservice/-/commit/6ac57af143aa023231e4851af5cc16f83f96644d) <sub><code>meson.build</code></sub>
- [ ] [<code>tests: Add sufficient data to allow the daemon to run</code>](https://gitlab.freedesktop.org/accountsservice/accountsservice/-/commit/1777c0393914880800a01ce146a56f975ca06f25)
- [ ] [<code>tests: Add simple daemon test</code>](https://gitlab.freedesktop.org/accountsservice/accountsservice/-/commit/b7aade9391ab49ff551fd60e6f5c7e63f93ffd1b) <sub><code>meson.build</code></sub>
- [ ] [<code>tests: Add test for getting user data</code>](https://gitlab.freedesktop.org/accountsservice/accountsservice/-/commit/93d3aaa2741aa74df5c6de3e23b60def1168b292)
- [ ] [<code>tests: Add test for another invalid locale</code>](https://gitlab.freedesktop.org/accountsservice/accountsservice/-/commit/068038f7876af3106851a1eb2b696ec89824e9a0)
- [ ] [<code>tests: Add polkit support</code>](https://gitlab.freedesktop.org/accountsservice/accountsservice/-/commit/69a6101faa46b5f6825f346271b1776e2ca912f0)
- [ ] [<code>tests: Add test for setting invalid language</code>](https://gitlab.freedesktop.org/accountsservice/accountsservice/-/commit/9f102a9c28537e87ad997010ad7c00f7935c9bad)
- [ ] [<code>tests: Set locale from simple daemon test</code>](https://gitlab.freedesktop.org/accountsservice/accountsservice/-/commit/7ba53f819e01e018eefdedef1a5ba4cc9d263e21)
- [ ] [<code>tests: Add library tests for "Languages" property</code>](https://gitlab.freedesktop.org/accountsservice/accountsservice/-/commit/6bbe1d22377ce0ccdaf5574cec98f178b67111c4)
- [ ] [<code>tests: Add daemon tests for new Languages property</code>](https://gitlab.freedesktop.org/accountsservice/accountsservice/-/commit/283a736b1fc3210820074d48eeb3e113d1e99f3d)
- [ ] [<code>tests: Add test for GetUsersLanguages() method</code>](https://gitlab.freedesktop.org/accountsservice/accountsservice/-/commit/defe78a4f77608053fe9e3bfaf26c2ad751e01ee)
- [ ] [<code>tests: Support multiple users for user data</code>](https://gitlab.freedesktop.org/accountsservice/accountsservice/-/commit/ed0021b9939ed702f6449948615e14c18cb5f93f)
- [ ] [<code>tests: Add second user to test data</code>](https://gitlab.freedesktop.org/accountsservice/accountsservice/-/commit/eeaa2d041ae64c51164e03a9335d8dcc28bf7c50)
- [ ] [<code>tests: Fix tests for 2nd user</code>](https://gitlab.freedesktop.org/accountsservice/accountsservice/-/commit/d1bdde95aab7bab193f06a0a1b9d0ac418772566)
- [ ] [<code>tests: Fix dbusmock accountservice template user parameterization</code>](https://gitlab.freedesktop.org/accountsservice/accountsservice/-/commit/c7554931bbb673316a2c5541e0de4ddf25495a2f)
- [ ] [<code>tests: Add test for multiple in-flight get_user calls</code>](https://gitlab.freedesktop.org/accountsservice/accountsservice/-/commit/24645afea0da48496914614b4c0f0ab1d3d743d5)

</details>

#### Commits prefixed with `ci`

Some of them also touches tests.

<details>

- [ ] [<code>ci: Hide CI_JOB_JWT</code>](https://gitlab.freedesktop.org/accountsservice/accountsservice/-/commit/24a22484111a156e3796175c54596bc19df776fe)
- [ ] [<code>ci: Expose logs for the build too</code>](https://gitlab.freedesktop.org/accountsservice/accountsservice/-/commit/477a05f2d1838a94d918afb123bfd44bbd23dc37)
- [ ] [<code>ci: Install git so the version script actually works</code>](https://gitlab.freedesktop.org/accountsservice/accountsservice/-/commit/41747b8d6c6512b8564f5fd3c9ccc65e7fc2e2c0)
- [ ] [<code>ci: Run tests as a normal user</code>](https://gitlab.freedesktop.org/accountsservice/accountsservice/-/commit/30316f99ee5c4c90e23c597a5482beea8519dd9e)
- [ ] [<code>ci: Fail tests when some are skipped</code>](https://gitlab.freedesktop.org/accountsservice/accountsservice/-/commit/cecc08d8afde162558000cc62055c88a35605947)
- [ ] [<code>ci: Run test suite under valgrind</code>](https://gitlab.freedesktop.org/accountsservice/accountsservice/-/commit/ce75232458fb901286ae24d94f917ad8686b5b9a)
- [ ] [<code>ci: Make sure all locales are installed</code>](https://gitlab.freedesktop.org/accountsservice/accountsservice/-/commit/90d9601b29e8b013a0821b63333fb9e677feec43)
- [ ] [<code>ci: Fail run-tests if something fails</code>](https://gitlab.freedesktop.org/accountsservice/accountsservice/-/commit/f4bf6ffe4d31cf3eedfa03f9c0b798ed8d42fb87)
- [ ] [<code>ci: Only run ci stuff on merge requests</code>](https://gitlab.freedesktop.org/accountsservice/accountsservice/-/commit/ca5cbab77b934ea899fbd230f7444231efe101d6)
- [ ] [<code>ci: Do a coding style check</code>](https://gitlab.freedesktop.org/accountsservice/accountsservice/-/commit/d25f48f44487d1ef14e46629d66faf8790698b65) <sub><code>meson.build</code></sub>
- [ ] [<code>CI: Install systemd, for /usr/share/pkgconfig/systemd.pc</code>](https://gitlab.freedesktop.org/accountsservice/accountsservice/-/commit/d3124929e027f00576f38b6f6213508e53739753)
- [ ] [<code>CI: Fix build in a fork whose name is not accountsservice</code>](https://gitlab.freedesktop.org/accountsservice/accountsservice/-/commit/47242308957afa7fb1f631e13a9049e9864862a7)
- [ ] [<code>CI: Pass --gcov-ignore-parse-errors to gcovr</code>](https://gitlab.freedesktop.org/accountsservice/accountsservice/-/commit/a929c4c12375817954bfaedb8ea13568fcbb8b11)

</details>

#### Translations

<details>

- [ ] [<code>Update hr.po</code>](https://gitlab.freedesktop.org/accountsservice/accountsservice/-/commit/4e14a89d8a1bcf1fc6433b41e068e18e57c5a7bc)
- [ ] [<code>Update Catalan translation</code>](https://gitlab.freedesktop.org/accountsservice/accountsservice/-/commit/a763870139c1cc04f0f8042ce0859a33ef4d1212)
- [ ] [<code>Update Hungarian translation</code>](https://gitlab.freedesktop.org/accountsservice/accountsservice/-/commit/ca97a41fd56ba57f4f4479d31b80ed82b92406cd)
- [ ] [<code>Update Hindi (hi) translation</code>](https://gitlab.freedesktop.org/accountsservice/accountsservice/-/commit/a53bc047d9d641e8a414c976116cc40757da4455)
- [ ] [<code>po: Update Georgian translation</code>](https://gitlab.freedesktop.org/accountsservice/accountsservice/-/commit/1f1e67cafdde263b81033b535338bd85bd534808)
- [ ] [<code>Update friulian translation</code>](https://gitlab.freedesktop.org/accountsservice/accountsservice/-/commit/52df9d773bb285d2c66891722d31748da9ebf1f0)
- [ ] [<code>Update POTFILES.in</code>](https://gitlab.freedesktop.org/accountsservice/accountsservice/-/commit/c15cef7274866d2a750e9207305ea1ae1bf11365)

</details>

#### Non-trivial commits

- [x] [<code>daemon: Reload users less aggressively on wtmp changes</code>](https://gitlab.freedesktop.org/accountsservice/accountsservice/-/commit/836a9135fe2d8fdc7d6de3a6d11fb9a5fd05f926)
- [x] [<code>util: Drop spawn_with_login_uid function</code>](https://gitlab.freedesktop.org/accountsservice/accountsservice/-/commit/aef0cf1379a07e7d9819b15ff1045a181043ac8b)
- [x] [<code>user: Fix API docs to use neutral gender</code>](https://gitlab.freedesktop.org/accountsservice/accountsservice/-/commit/4505bd3d1d2338c90f28db067b72c7a6c8f8fdb2)
- [x] [<code>data: Fix possessives</code>](https://gitlab.freedesktop.org/accountsservice/accountsservice/-/commit/05b09e6e14025ad8d5f9ef4c1c7831c683d4c51c)
- [x] [<code>util: Add XPG locale verification function</code>](https://gitlab.freedesktop.org/accountsservice/accountsservice/-/commit/e4488b3ead25ea413a915085e911df5918233daa)
- [x] [<code>util: Add locale verification function</code>](https://gitlab.freedesktop.org/accountsservice/accountsservice/-/commit/dd34d89b668254aa8b05192d396ab9f3069a0c28)
- [x] [<code>user: Return an error when setting invalid language</code>](https://gitlab.freedesktop.org/accountsservice/accountsservice/-/commit/bed11bbec1a4cf17ef504c71ce4c48036eb17786)
- [x] [<code>user: Throw a warning for invalid locales</code>](https://gitlab.freedesktop.org/accountsservice/accountsservice/-/commit/9c3345bd425b1c1ff01bfcca378633d125593d29)
- [x] [<code>build: Fix warning about run_command() usage</code>](https://gitlab.freedesktop.org/accountsservice/accountsservice/-/commit/48ba464c68e111fb701d9ddc5c8859cfdef5999f) <sub><code>meson.build</code></sub>
- [x] [<code>all: Use pragma once</code>](https://gitlab.freedesktop.org/accountsservice/accountsservice/-/commit/67d05e1ba9018eb0927634a38909fc19eeec28ca)
- [x] [<code>user-classify: Remove unused password hash argument</code>](https://gitlab.freedesktop.org/accountsservice/accountsservice/-/commit/c8c648a8fe9917c83241ffc217218564b6a85a59)
- [x] [<code>README: Remove outdated INSTALL file</code>](https://gitlab.freedesktop.org/accountsservice/accountsservice/-/commit/6d2bad606f53b3878cbdfc20b0eeb69e75d947cc)
- [x] [<code>build: Fix cwd != srcdir in generate-version.sh</code>](https://gitlab.freedesktop.org/accountsservice/accountsservice/-/commit/f4634024097680ebb7dd3555e84f44c2bba09f84)
- [x] [<code>build: Add mocklibc subproject</code>](https://gitlab.freedesktop.org/accountsservice/accountsservice/-/commit/3f96fa3133396d2c821cf665e8ca7a58669d1bfb) <sub><code>meson.build</code></sub>
- [x] [<code>user: Add helper to allow overriding the root directory</code>](https://gitlab.freedesktop.org/accountsservice/accountsservice/-/commit/952105f3d9580ba1e7a28907769a9cf575ce0c48) <sub><code>meson.build</code></sub>
- [x] [<code>main: Use new overridable USERDIR</code>](https://gitlab.freedesktop.org/accountsservice/accountsservice/-/commit/6618e08bd6468c5197f5336fdfea7b87c6c570b4)
- [x] [<code>main: Use new overridable ICONDIR</code>](https://gitlab.freedesktop.org/accountsservice/accountsservice/-/commit/1adecd296f8ef0f2e79c7ed3c4c76b18677828ae)
- [x] [<code>main: Use new overridable sysconfdir</code>](https://gitlab.freedesktop.org/accountsservice/accountsservice/-/commit/a1a4ca85f8b3318b276de1387c077b2131dbe8cf)
- [x] [<code>user: Add "Languages" user property</code>](https://gitlab.freedesktop.org/accountsservice/accountsservice/-/commit/881e0ea74414d0b5442400e339bd23abf3313e4e)
  - <sub>Currently handle `user_set_languages` the same way as `user_set_language`</sub>
- [x] [<code>daemon: Move uid variable where it's used</code>](https://gitlab.freedesktop.org/accountsservice/accountsservice/-/commit/07dadfd22e2e3fa6419eb3e931f08aff5c5467e6)
- [x] [<code>daemon: Add GetUsersLanguages() function</code>](https://gitlab.freedesktop.org/accountsservice/accountsservice/-/commit/f49f6c46bbfcc3376cb498c9ab9bc91a1efde93a)
- [x] [<code>src: Run entire tree through uncrustify</code>](https://gitlab.freedesktop.org/accountsservice/accountsservice/-/commit/35a4410faf8a13755208ac8a6c1cdfcedac54875)
  - <sub>Treewide format</sub>
- [x] [<code>user: Replace usermod -p with chpasswd -e</code>](https://gitlab.freedesktop.org/accountsservice/accountsservice/-/commit/4fde420a7b25d1a54bdb4e4ade67770a5ac79d02)
  - <sub>Oh hardcoded absolute path</sub>
  - <sub>CVE-2012-6655</sub>
- [x] [<code>daemon: Clarify use of generator_state->users</code>](https://gitlab.freedesktop.org/accountsservice/accountsservice/-/commit/eba98a3b83dc2b00a31cf6f4eaee593ee4d216e1)
- [x] [<code>daemon: Define local users as being exactly those present in /etc/shadow</code>](https://gitlab.freedesktop.org/accountsservice/accountsservice/-/commit/c7c8945460324d0dc879fc452d8ee12dfc61d184)
- [x] [<code>user: Use correct format strings to print accounts_user_get_uid()</code>](https://gitlab.freedesktop.org/accountsservice/accountsservice/-/commit/a1a330b8720e4bc1c2154f120196372627dc7b2a)
- [x] [<code>Annotate varargs functions with G_GNUC_PRINTF</code>](https://gitlab.freedesktop.org/accountsservice/accountsservice/-/commit/c142812f7653cd1f6e52224da8410cd09f102a4f)
- [x] [<code>daemon: Don't crash if /etc/shadow doesn't exist</code>](https://gitlab.freedesktop.org/accountsservice/accountsservice/-/commit/322165ea2e1c1c4715d532910ccb31b3d1e0a04e)
- [ ] [<code>Add lightdm autologin support</code>](https://gitlab.freedesktop.org/accountsservice/accountsservice/-/commit/68e8a5d3d57344e893becdd80a4ead48438717e8) <sub><code>meson.build</code></sub>
  - <sub>Not sure if anything needs to be done here</sub>
- [x] [<code>meson.build: fix -Wimplicit-function-declaration in configure tests for printf</code>](https://gitlab.freedesktop.org/accountsservice/accountsservice/-/commit/453f893e3c38c209ae9dff47bca74ccb33a5bd34) <sub><code>meson.build</code></sub>
- [x] [<code>daemon: Track local users outside of fgetpwent generator</code>](https://gitlab.freedesktop.org/accountsservice/accountsservice/-/commit/78794fafaf1d3228a4b0b70c9eea53dba37c9497)
- [x] [<code>user: Support new LocalAccount property in cache file</code>](https://gitlab.freedesktop.org/accountsservice/accountsservice/-/commit/15e6a4c3a2982bdc6619258af34f13ba0f71046f) <sub><code>23.11.69</code></sub>
- [x] [<code>subprojects: Add mocklibc to package cache</code>](https://gitlab.freedesktop.org/accountsservice/accountsservice/-/commit/a5bec981764fa9b298bc4f7fdb8797404763b090)
- [x] [<code>daemon: Fix boot delay</code>](https://gitlab.freedesktop.org/accountsservice/accountsservice/-/commit/b9baa7113b7fc651feca317d691297abd9312e76)
- [x] [<code>user-manager: Don't prematurely free duplicate ActUser objects</code>](https://gitlab.freedesktop.org/accountsservice/accountsservice/-/commit/485b10740e46702952aeacafe0cf94bf8cc21f2e)
- [x] [<code>user-manager: Add cancellable to fetch user requests</code>](https://gitlab.freedesktop.org/accountsservice/accountsservice/-/commit/3ca35f267628cc80fa1299265e30bc6c9c742199)
- [x] [<code>user-manager: Cope with buggy callers better</code>](https://gitlab.freedesktop.org/accountsservice/accountsservice/-/commit/a6e627bf5797a812aebe90ad840b20a4950f064f)
- [x] [<code>user-manager: Deduplicate ActUser objects when possible</code>](https://gitlab.freedesktop.org/accountsservice/accountsservice/-/commit/ff58f16bd5c75bea47939fed41716845cd427208)
- [x] [<code>user-manager: Track non-existent users</code>](https://gitlab.freedesktop.org/accountsservice/accountsservice/-/commit/57e491f5e6f3da2d5a949f4f8747c8f4e8ed799d) <sub><code>23.13.9</code></sub>



----



###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
