### PR TITLE
edac-utils: unstable-2015-01-07 -> unstable-2023-01-30

### DIFF
--- a/pkgs/os-specific/linux/edac-utils/default.nix
+++ b/pkgs/os-specific/linux/edac-utils/default.nix
@@ -13,7 +13,7 @@ stdenv.mkDerivation {
   };
 
   nativeBuildInputs = [ perl makeWrapper ];
-  buildInputs = [ sysfsutils ];
+  buildInputs = [ perl sysfsutils ];
 
   configureFlags = [
     "--sysconfdir=/etc"

--- a/pkgs/os-specific/linux/edac-utils/default.nix
+++ b/pkgs/os-specific/linux/edac-utils/default.nix
@@ -3,13 +3,13 @@
 
 stdenv.mkDerivation {
   pname = "edac-utils";
-  version = "unstable-2015-01-07";
+  version = "unstable-2023-01-30";
 
   src = fetchFromGitHub {
     owner = "grondo";
     repo = "edac-utils";
-    rev = "f9aa96205f610de39a79ff43c7478b7ef02e3138";
-    sha256 = "1dmfqb15ffldl5zirbmwiqzpxbcc2ny9rpfvxcfvpmh5b69knvdg";
+    rev = "8fdc1d40e30f65737fef6c3ddcd1d2cd769f6277";
+    hash = "sha256-jZGRrZ1sa4x0/TBJ5GsNVuWakmPNOU+oiOoXdhARunk=";
   };
 
   nativeBuildInputs = [ perl makeWrapper ];

--- a/pkgs/os-specific/linux/edac-utils/default.nix
+++ b/pkgs/os-specific/linux/edac-utils/default.nix
@@ -25,21 +25,20 @@ stdenv.mkDerivation {
       --replace-fail '"$sysconfdir/edac/mainboard"' '"/etc/edac/mainboard"'
   '';
 
+  # NB edac-utils needs Perl for configure script, but also edac-ctl program is
+  # a Perl script. Perl from buildInputs is used by patchShebangsAuto in
+  # fixupPhase to update the hash bang line.
+  strictDeps = true;
   nativeBuildInputs = [ perl ];
   buildInputs = [ perl sysfsutils ];
 
-  configureFlags = [
-    "--sysconfdir=/etc"
-    "--localstatedir=/var"
-  ];
-
   installFlags = [
-    "sysconfdir=\${out}/etc"
+    "sbindir=${placeholder "out"}/bin"
   ];
 
   # SysV init script is not relevant.
-  postFixup = ''
-    rm -r $out/etc/init.d
+  postInstall = ''
+    rm -r "$out"/etc/init.d
   '';
 
   meta = with lib; {

--- a/pkgs/os-specific/linux/edac-utils/default.nix
+++ b/pkgs/os-specific/linux/edac-utils/default.nix
@@ -37,6 +37,11 @@ stdenv.mkDerivation {
     "sysconfdir=\${out}/etc"
   ];
 
+  # SysV init script is not relevant.
+  postFixup = ''
+    rm -r $out/etc/init.d
+  '';
+
   meta = with lib; {
     homepage = "https://github.com/grondo/edac-utils";
     description = "Handles the reporting of hardware-related memory errors";


### PR DESCRIPTION
###### Description of changes

This change updates [edac-utils](https://github.com/grondo/edac-utils) package to the latest commit (see [changes](https://github.com/grondo/edac-utils/compare/f9aa96205f610de39a79ff43c7478b7ef02e3138...8fdc1d40e30f65737fef6c3ddcd1d2cd769f6277)).

It also
- adds `perl` to `buildInputs` so that shebang is fixed in `edac-ctl` command,
- adds a patch to avoid using wrapProgram for `PATH`,
- removes sysv init script from `$out/etc`.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux (pkgsCross.gnu64)
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
