### PR TITLE
shattered-pixel-dungeon: 1.1.2 -> 2.0.2

### DIFF
--- a/pkgs/games/shattered-pixel-dungeon/default.nix
+++ b/pkgs/games/shattered-pixel-dungeon/default.nix
@@ -2,7 +2,7 @@
 , makeWrapper
 , fetchFromGitHub
 , nixosTests
-, gradle_6
+, gradle
 , perl
 , jre
 , libpulseaudio
@@ -10,16 +10,18 @@
 
 let
   pname = "shattered-pixel-dungeon";
-  version = "1.1.2";
+  version = "2.0.2";
 
   src = fetchFromGitHub {
     owner = "00-Evan";
     repo = "shattered-pixel-dungeon";
-    # NOTE: always use the commit sha, not the tag. Tags _will_ disappear!
-    # https://github.com/00-Evan/shattered-pixel-dungeon/issues/596
-    rev = "5d1a2dce6b554b40f6737ead45d411fd98f4c67d";
-    sha256 = "sha256-Vu7K0NnqFY298BIQV9AwNEahV0eJl14tAeq+rw6KrtM=";
+    rev = "v${version}";
+    sha256 = "sha256-gg8FHLkw964mYejXvK5GClTvTLGK3FyXR8Kkxjl/pRs=";
   };
+
+  patches = [
+    ./disable-beryx.patch
+  ];
 
   postPatch = ''
     # disable gradle plugins with native code and their targets
@@ -32,8 +34,8 @@ let
   # fake build to pre-download deps into fixed-output derivation
   deps = stdenv.mkDerivation {
     pname = "${pname}-deps";
-    inherit version src postPatch;
-    nativeBuildInputs = [ gradle_6 perl ];
+    inherit version src patches postPatch;
+    nativeBuildInputs = [ gradle perl ];
     buildPhase = ''
       export GRADLE_USER_HOME=$(mktemp -d)
       # https://github.com/gradle/gradle/issues/4426
@@ -47,13 +49,13 @@ let
         | sh
     '';
     outputHashMode = "recursive";
-    outputHash = "sha256-UI5/ZJbUtEz1Fr+qn6a8kzi9rrP+lVrpBbuDv8TG5y0=";
+    outputHash = "sha256-ojwvs6j3R31723lfRlKdeyR5+txnetyK3foJTLqy28Q=";
   };
 
 in stdenv.mkDerivation rec {
-  inherit pname version src postPatch;
+  inherit pname version src patches postPatch;
 
-  nativeBuildInputs = [ gradle_6 perl makeWrapper ];
+  nativeBuildInputs = [ gradle perl makeWrapper ];
 
   buildPhase = ''
     export GRADLE_USER_HOME=$(mktemp -d)

--- a/pkgs/games/shattered-pixel-dungeon/disable-beryx.patch
+++ b/pkgs/games/shattered-pixel-dungeon/disable-beryx.patch
@@ -1,0 +1,47 @@
+diff --git a/desktop/build.gradle b/desktop/build.gradle
+index 97f35f7..afd5116 100644
+--- a/desktop/build.gradle
++++ b/desktop/build.gradle
+@@ -1,6 +1,7 @@
+-plugins {
+-    id 'org.beryx.runtime' version '1.12.7'
+-}
++//plugins {
++//    id 'org.beryx.runtime' version '1.12.7'
++//}
++apply plugin: "java"
+ 
+ [compileJava, compileTestJava]*.options*.encoding = 'UTF-8'
+ sourceCompatibility = targetCompatibility = appJavaCompatibility
+@@ -43,11 +44,11 @@ task release(type: Jar) {
+         attributes 'Implementation-Version': appVersionCode
+     }
+ }
+-installDist.dependsOn release
+-startScripts.dependsOn release
+-jpackageImage.dependsOn release
++//installDist.dependsOn release
++//startScripts.dependsOn release
++//jpackageImage.dependsOn release
+ 
+-runtime {
++/*runtime {
+     modules = ['java.base',
+                'java.desktop',
+                'jdk.unsupported',
+@@ -102,7 +103,7 @@ runtime {
+         }
+     }
+ 
+-}
++}*/
+ 
+ dependencies {
+     implementation project(':core')
+@@ -123,4 +124,4 @@ dependencies {
+ 
+     implementation project(':services:updates:githubUpdates')
+     implementation project(':services:news:shatteredNews')
+-}
+\ No newline at end of file
++}


### PR DESCRIPTION
###### Description of changes

I finally managed to update this package. The trick was to replace the `org.beryx.runtime` with the `java` plugin.

Since the package was _very_ out of date and 23.05 isn't out yet, I'd like to backport this even though it's a major release.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
