### PR TITLE
libei: 1.0.0rc1 -> 1.0.0rc2

### DIFF
--- a/pkgs/development/libraries/libei/default.nix
+++ b/pkgs/development/libraries/libei/default.nix
@@ -24,14 +24,14 @@ let
 in
 stdenv.mkDerivation rec {
   pname = "libei";
-  version = "0.99.1";
+  version = "0.99.2";
 
   src = fetchFromGitLab {
     domain = "gitlab.freedesktop.org";
     owner = "libinput";
     repo = "libei";
     rev = version;
-    hash = "sha256-r/rkN2d8P30P/IL1YaLWWRbA5s3uVq5Fc/K1vhS31tw=";
+    hash = "sha256-hxWWOvqenHHnzrvRwSwNT1GFVx9NR+Mm1XK9nisF8fA=";
   };
 
   buildInputs = [


### PR DESCRIPTION
###### Description of changes

Release: https://gitlab.freedesktop.org/libinput/libei/-/releases/0.99.2
Diff: https://gitlab.freedesktop.org/libinput/libei/-/compare/0.99.1...0.99.2?from_project_id=6869&straight=false

###### Things done

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

