### PR TITLE
lightspark: 0.8.6.1 -> 0.8.7

### DIFF
--- a/pkgs/misc/lightspark/default.nix
+++ b/pkgs/misc/lightspark/default.nix
@@ -1,17 +1,16 @@
 { lib, stdenv, fetchFromGitHub, pkg-config, cmake, curl, zlib, ffmpeg, glew, pcre
-, rtmpdump, cairo, boost, SDL2, SDL2_mixer, libjpeg, pango, xz, nasm
-, llvm, glibmm
+, rtmpdump, cairo, boost, SDL2, libjpeg, pango, xz, nasm, llvm, glibmm
 }:
 
 stdenv.mkDerivation rec {
   pname = "lightspark";
-  version = "0.8.6.1";
+  version = "0.8.7";
 
   src = fetchFromGitHub {
     owner = "lightspark";
     repo = "lightspark";
     rev = version;
-    sha256 = "sha256-/w0cqPIeQC1Oz1teSjMpeiQEI6bIpnyOOu0GoGyi6Kg=";
+    hash = "sha256-qX/ft9slWTbvuSyi2jB6YC7D7QTtCybL/dTo1dJp3pQ=";
   };
 
   postPatch = ''
@@ -21,8 +20,8 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ pkg-config cmake ];
 
   buildInputs = [
-    curl zlib ffmpeg glew pcre rtmpdump cairo boost SDL2 SDL2_mixer libjpeg
-    pango xz nasm llvm glibmm
+    curl zlib ffmpeg glew pcre rtmpdump cairo boost SDL2 libjpeg pango xz nasm
+    llvm glibmm
   ];
 
   meta = with lib; {


### PR DESCRIPTION
###### Description of changes
This release contains a bunch of compatibility improvements and other fixes. SDL_mixer is no longer used, so we can remove that.

[Upstream release notes:](https://github.com/lightspark/lightspark/releases/tag/0.8.7)
```
* implement DefineScalingGrid tag
* switch to 32bit float audio sampling for standalone player and remove SDL2_mixer dependency
* improved support for AVM1 swf files
* implement "erase" blendmode
* use nanoVG for bitmaps in fillstyles
* improved support for morphshapes
* improved support for adpcm encoded sounds
* add garbage collection mechanism for less memory usage
* better overall compatibility for many swf files
* several performance improvements
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
