### PR TITLE
nixos/public-inbox: use DynamicUser for readers

### DIFF
--- a/nixos/modules/services/mail/public-inbox.nix
+++ b/nixos/modules/services/mail/public-inbox.nix
@@ -53,7 +53,9 @@ let
       # if running simultaneous services.
       NonBlocking = true;
       #LimitNOFILE = 30000;
-      User = config.users.users."public-inbox".name;
+      User =
+        lib.mkIf config.systemd.services."public-inbox-${srv}".confinement.enable
+          config.users.users."public-inbox".name;
       Group = config.users.groups."public-inbox".name;
       RuntimeDirectory = [
           "public-inbox-${srv}/perl-inline"
@@ -61,9 +63,7 @@ let
       RuntimeDirectoryMode = "700";
       # This is for BindPaths= and BindReadOnlyPaths=
       # to allow traversal of directories they create inside RootDirectory=
-      UMask = "0066";
-      StateDirectory = ["public-inbox"];
-      StateDirectoryMode = "0750";
+      UMask = "0026";
       WorkingDirectory = stateDir;
       BindReadOnlyPaths = [
           "/etc"
@@ -433,8 +433,10 @@ in
       (mkIf cfg.imap.enable
         { public-inbox-imapd = mkMerge [(serviceConfig "imapd") {
           after = [ "public-inbox-init.service" "public-inbox-watch.service" ];
+          environment.PI_DIR = "/var/lib/public-inbox/.public-inbox";
           requires = [ "public-inbox-init.service" ];
           serviceConfig = {
+            DynamicUser = !config.systemd.services."public-inbox-imapd".confinement.enable;
             ExecStart = escapeShellArgs (
               [ "${cfg.package}/bin/public-inbox-imapd" ] ++
               cfg.imap.args ++
@@ -447,8 +449,10 @@ in
       (mkIf cfg.http.enable
         { public-inbox-httpd = mkMerge [(serviceConfig "httpd") {
           after = [ "public-inbox-init.service" "public-inbox-watch.service" ];
+          environment.PI_DIR = "/var/lib/public-inbox/.public-inbox";
           requires = [ "public-inbox-init.service" ];
           serviceConfig = {
+            DynamicUser = !config.systemd.services."public-inbox-httpd".confinement.enable;
             ExecStart = escapeShellArgs (
               [ "${cfg.package}/bin/public-inbox-httpd" ] ++
               cfg.http.args ++
@@ -486,8 +490,10 @@ in
       (mkIf cfg.nntp.enable
         { public-inbox-nntpd = mkMerge [(serviceConfig "nntpd") {
           after = [ "public-inbox-init.service" "public-inbox-watch.service" ];
+          environment.PI_DIR = "/var/lib/public-inbox/.public-inbox";
           requires = [ "public-inbox-init.service" ];
           serviceConfig = {
+            DynamicUser = !config.systemd.services."public-inbox-nntpd".confinement.enable;
             ExecStart = escapeShellArgs (
               [ "${cfg.package}/bin/public-inbox-nntpd" ] ++
               cfg.nntp.args ++
@@ -508,6 +514,10 @@ in
           serviceConfig = {
             ExecStart = "${cfg.package}/bin/public-inbox-watch";
             ExecReload = "${pkgs.coreutils}/bin/kill -HUP $MAINPID";
+            StateDirectory = ["public-inbox"];
+            StateDirectoryMode = "0750";
+            User = config.users.users."public-inbox".name;
+            Group = config.users.groups."public-inbox".name;
           };
         }];
       })
@@ -561,15 +571,22 @@ in
               ls -1 "$inbox" | grep -q '^xap' ||
               ${cfg.package}/bin/public-inbox-index "$inbox"
             done
+
+            # Older versions of the module did not make inboxes group-readable.
+            # chmod -R g+r ${stateDir}/inboxes
           '';
           serviceConfig = {
             Type = "oneshot";
             RemainAfterExit = true;
             StateDirectory = [
+              "public-inbox"
               "public-inbox/.public-inbox"
               "public-inbox/.public-inbox/emergency"
               "public-inbox/inboxes"
             ];
+            StateDirectoryMode = "0750";
+            User = config.users.users."public-inbox".name;
+            Group = config.users.groups."public-inbox".name;
           };
         }];
       })

--- a/nixos/modules/services/mail/public-inbox.nix
+++ b/nixos/modules/services/mail/public-inbox.nix
@@ -109,7 +109,6 @@ let
       SystemCallArchitectures = "native";
 
       # The following options are redundant when confinement is enabled
-      RootDirectory = "/var/empty";
       TemporaryFileSystem = "/";
       PrivateMounts = true;
       MountAPIVFS = true;


### PR DESCRIPTION
###### Description of changes

public-inbox-{http,nntp,imap}d only need to be able to read the repositories, so they don't need to run as the public-inbox user, which has write permission for /var/lib/public-inbox.

Annoyingly, confinement is currently not compatible with DynamicUser, so we can't enable both at the same time.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
