### PR TITLE
Update http3 libraries

### DIFF
--- a/nixos/tests/nginx-http3.nix
+++ b/nixos/tests/nginx-http3.nix
@@ -76,19 +76,19 @@ in
     server.wait_for_open_port(443)
 
     # Check http connections
-    client.succeed("curl --verbose --http3 https://acme.test | grep 'Hello World!'")
+    client.succeed("curl --verbose --http3-only https://acme.test | grep 'Hello World!'")
 
     # Check downloadings
-    client.succeed("curl --verbose --http3 https://acme.test/example.txt --output /tmp/example.txt")
+    client.succeed("curl --verbose --http3-only https://acme.test/example.txt --output /tmp/example.txt")
     client.succeed("cat /tmp/example.txt | grep 'Check http3 protocol.'")
 
     # Check header reading
-    client.succeed("curl --verbose --http3 --head https://acme.test | grep 'content-type'")
-    client.succeed("curl --verbose --http3 --head https://acme.test | grep 'HTTP/3 200'")
-    client.succeed("curl --verbose --http3 --head https://acme.test/error | grep 'HTTP/3 404'")
+    client.succeed("curl --verbose --http3-only --head https://acme.test | grep 'content-type'")
+    client.succeed("curl --verbose --http3-only --head https://acme.test | grep 'HTTP/3 200'")
+    client.succeed("curl --verbose --http3-only --head https://acme.test/error | grep 'HTTP/3 404'")
 
     # Check change User-Agent
-    client.succeed("curl --verbose --http3 --user-agent 'Curl test 3.0' https://acme.test")
+    client.succeed("curl --verbose --http3-only --user-agent 'Curl test 3.0' https://acme.test")
     server.succeed("cat /var/log/nginx/access.log | grep 'Curl test 3.0'")
 
     server.shutdown()

--- a/pkgs/development/libraries/nghttp3/default.nix
+++ b/pkgs/development/libraries/nghttp3/default.nix
@@ -6,13 +6,13 @@
 
 stdenv.mkDerivation rec {
   pname = "nghttp3";
-  version = "0.10.0";
+  version = "0.11.0";
 
   src = fetchFromGitHub {
     owner = "ngtcp2";
     repo = pname;
     rev = "v${version}";
-    hash = "sha256-V0g/d1B9uMn7KZU6ShzyPGXOSAYCbz4ZubnhAwz+Qsc=";
+    hash = "sha256-fZMFSQ8RCVxuoLrisa8lLqjNVe4fIuGqbyKtkC/u02M=";
   };
 
   outputs = [ "out" "dev" "doc" ];

--- a/pkgs/development/libraries/ngtcp2/default.nix
+++ b/pkgs/development/libraries/ngtcp2/default.nix
@@ -8,13 +8,13 @@
 
 stdenv.mkDerivation rec {
   pname = "ngtcp2";
-  version = "0.14.1";
+  version = "0.15.0";
 
   src = fetchFromGitHub {
     owner = "ngtcp2";
     repo = pname;
     rev = "v${version}";
-    hash = "sha256-VsacRYvjTWVx2ga952s1vs02GElXIW6umgcYr3UCcgE=";
+    hash = "sha256-FWNWpRuCUyqTIyLZkBFKrd2urjSCqHp20mBAXOcJm14=";
   };
 
   outputs = [ "out" "dev" "doc" ];


### PR DESCRIPTION
###### Description of changes
Update nghttp3 to version 0.11.0.
Update ngtcp2 to version 0.15.0.
Small update nginx-http3 test.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
