### PR TITLE
New package: tools/misc/ttfsample v0.3.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -15026,6 +15026,12 @@
     githubId = 203168;
     name = "Stefan Fehrenbach";
   };
+  stefanschroeder = {
+    email = "ondekoza@gmail.com";
+    github = "StefanSchroeder";
+    githubId = 1130199;
+    name = "Stefan Schroeder";
+  };
   stehessel = {
     email = "stephan@stehessel.de";
     github = "stehessel";

--- a/pkgs/tools/misc/ttfsample/default.nix
+++ b/pkgs/tools/misc/ttfsample/default.nix
@@ -1,0 +1,22 @@
+{ buildGoModule , fetchFromGitHub , lib
+}:
+buildGoModule rec {
+	pname = "ttfsample";
+	version = "0.3.0";
+
+	src = fetchFromGitHub {
+		owner = "StefanSchroeder";
+		repo = "ttfsample";
+		rev = "${version}";
+		sha256 = "sha256-qB6n0xaBvjmBOOId4SLjc5Oi59DbtvLdSUw98AZcn0o=";
+
+	};
+	vendorSha256 = "sha256-7kse3MYIj3Q0WL/fgR6TFmMGNQUSKuJM7+IqB83rwFY=";
+	meta = with lib; {
+		description = "Create images of fonts";
+		homepage = "https://github.com/StefanSchroeder/ttfsample";
+		license = licenses.mit;
+		maintainers = with maintainers; [ stefanschroeder ];
+		mainProgram = "ttfsample";
+	};
+}

--- a/pkgs/tools/misc/ttfsample/default.nix
+++ b/pkgs/tools/misc/ttfsample/default.nix
@@ -8,7 +8,7 @@ buildGoModule rec {
 		owner = "StefanSchroeder";
 		repo = "ttfsample";
 		rev = "${version}";
-		sha256 = "sha256-qB6n0xaBvjmBOOId4SLjc5Oi59DbtvLdSUw98AZcn0o=";
+		hash = "sha256-qB6n0xaBvjmBOOId4SLjc5Oi59DbtvLdSUw98AZcn0o=";
 
 	};
 	vendorSha256 = "sha256-7kse3MYIj3Q0WL/fgR6TFmMGNQUSKuJM7+IqB83rwFY=";

--- a/pkgs/tools/misc/ttfsample/default.nix
+++ b/pkgs/tools/misc/ttfsample/default.nix
@@ -1,22 +1,22 @@
 { buildGoModule , fetchFromGitHub , lib
 }:
 buildGoModule rec {
-	pname = "ttfsample";
-	version = "0.3.0";
+        pname = "ttfsample";
+        version = "0.3.0";
 
-	src = fetchFromGitHub {
-		owner = "StefanSchroeder";
-		repo = "ttfsample";
-		rev = "${version}";
-		hash = "sha256-qB6n0xaBvjmBOOId4SLjc5Oi59DbtvLdSUw98AZcn0o=";
+        src = fetchFromGitHub {
+                owner = "StefanSchroeder";
+                repo = "ttfsample";
+                rev = "${version}";
+                hash = "sha256-qB6n0xaBvjmBOOId4SLjc5Oi59DbtvLdSUw98AZcn0o=";
 
-	};
-	vendorSha256 = "sha256-7kse3MYIj3Q0WL/fgR6TFmMGNQUSKuJM7+IqB83rwFY=";
-	meta = with lib; {
-		description = "Create images of fonts";
-		homepage = "https://github.com/StefanSchroeder/ttfsample";
-		license = licenses.mit;
-		maintainers = with maintainers; [ stefanschroeder ];
-		mainProgram = "ttfsample";
-	};
+        };
+        vendorSha256 = "sha256-7kse3MYIj3Q0WL/fgR6TFmMGNQUSKuJM7+IqB83rwFY=";
+        meta = with lib; {
+                description = "Create images of fonts";
+                homepage = "https://github.com/StefanSchroeder/ttfsample";
+                license = licenses.mit;
+                maintainers = with maintainers; [ stefanschroeder ];
+                mainProgram = "ttfsample";
+        };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1749,6 +1749,8 @@ with pkgs;
 
   ttchat = callPackage ../tools/misc/ttchat { };
 
+  ttfsample = callPackage ../tools/misc/ttfsample { };
+
   ukmm = callPackage ../tools/games/ukmm { };
 
   unflac = callPackage ../tools/audio/unflac { };


### PR DESCRIPTION
###### Description of changes

This is a new package, ttfsample, a cli tool which creates a PNG image for a TTF or OTF font, written in Golang.
This is the first package by  the owner and author.
Tools has no other homepage than github: https://github.com/StefanSchroeder/ttfsample 

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [n.a.] (Package updates) Added a release notes entry if the change is major or breaking
  - [n.a. ] (Module updates) Added a release notes entry if the change is significant
  - [n.a.] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

@fricklerhandwerk 