### PR TITLE
meilisearch: fix build on x86_64-darwin

### DIFF
--- a/pkgs/servers/search/meilisearch/default.nix
+++ b/pkgs/servers/search/meilisearch/default.nix
@@ -2,9 +2,9 @@
 , lib
 , rustPlatform
 , fetchFromGitHub
-, Security
 , DiskArbitration
 , Foundation
+, Security
 , nixosTests
 , nix-update-script
 }:
@@ -40,9 +40,9 @@ rustPlatform.buildRustPackage {
   buildNoDefaultFeatures = true;
 
   buildInputs = lib.optionals stdenv.isDarwin [
-    Security
     DiskArbitration
     Foundation
+    Security
   ];
 
   passthru = {

--- a/pkgs/servers/search/meilisearch/default.nix
+++ b/pkgs/servers/search/meilisearch/default.nix
@@ -2,8 +2,6 @@
 , lib
 , rustPlatform
 , fetchFromGitHub
-, DiskArbitration
-, Foundation
 , Security
 , nixosTests
 , nix-update-script
@@ -40,8 +38,6 @@ rustPlatform.buildRustPackage {
   buildNoDefaultFeatures = true;
 
   buildInputs = lib.optionals stdenv.isDarwin [
-    DiskArbitration
-    Foundation
     Security
   ];
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9371,7 +9371,7 @@ with pkgs;
   };
 
   meilisearch = callPackage ../servers/search/meilisearch {
-    inherit (darwin.apple_sdk_11_0.frameworks) DiskArbitration Foundation Security;
+    inherit (darwin.apple_sdk_11_0.frameworks) Security;
   };
 
   memtester = callPackage ../tools/system/memtester { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9371,7 +9371,7 @@ with pkgs;
   };
 
   meilisearch = callPackage ../servers/search/meilisearch {
-    inherit (darwin.apple_sdk.frameworks) Security DiskArbitration Foundation;
+    inherit (darwin.apple_sdk_11_0.frameworks) DiskArbitration Foundation Security;
   };
 
   memtester = callPackage ../tools/system/memtester { };


### PR DESCRIPTION
###### Description of changes

I've bumped the Apple SDK to v11 to resolve the missing CoreFoundation symbol (build excerpt pasted below).

I've also removed the dependency on DiskArbitration. It's no longer used by sysinfo as of v0.26.7. See the [PR](https://github.com/GuillaumeGomez/sysinfo/pull/855) and [changelog](https://github.com/GuillaumeGomez/sysinfo/commit/172a6a62158a4661d3765370c7d01280312beca2). The current version (v1.1.1) of Meilisearch is [already on sysinfo v0.26.9](https://github.com/meilisearch/meilisearch/blob/4b953d62fbab81278324e71b4037eb06355dd49a/Cargo.lock#L3753-L3755).

```
error: linking with `/nix/store/lpvhgycia7py2x3hl6g75w2ixzy0pyfw-clang-wrapper-11.1.0/bin/cc` failed: exit status: 1
  |
  = note: LC_ALL="C" PATH="/nix/store/sdx59jfsmfswcacqndqijnhjh8k236mf-rustc-1.69.0/lib/rustlib/x86_64-apple-darwin/bin:/nix/store/yqcsjd25bxm9281ly0srki54d21cjxgb-cargo-1.69.0/bin:/nix/store/mi16i0c7r0sq0y4zv8g7vhyvzy0av88x-cargo-auditable-0.6.1/bin:/nix/store/i4jmsnfjkfrznfdz1237vln0chx0bz1n-auditable-cargo-1.69.0/bin:/nix/store/yqcsjd25bxm9281ly0srki54d21cjxgb-cargo-1.69.0/bin:/nix/store/sdx59jfsmfswcacqndqijnhjh8k236mf-rustc-1.69.0/bin:/nix/store/lpvhgycia7py2x3hl6g75w2ixzy0pyfw-clang-wrapper-11.1.0/bin:/nix/store/x3m1xz8qdpcij6bdd4m3q76nsjykpm5q-clang-11.1.0/bin:/nix/store/8d6h6q4jpd1z2cjf2lxcp9xpi6dbpz5g-coreutils-9.1/bin:/nix/store/arcs8wp88csv1z8gncp0l089xdv4x09v-cctools-binutils-darwin-wrapper-973.0.1/bin:/nix/store/la4nmq9wiwj5kk3ns8hdnkqjqzjin9jc-cctools-binutils-darwin-973.0.1/bin:/nix/store/8d6h6q4jpd1z2cjf2lxcp9xpi6dbpz5g-coreutils-9.1/bin:/nix/store/rsqrxy84pwvrs5600dhmp6hqlqw6xjk7-findutils-4.9.0/bin:/nix/store/hwffbr2q05raf9s2xh41xahwfxr2rxrq-diffutils-3.9/bin:/nix/store/z4pvpj9f2d1dzzhi64gdksxwnm22znkd-gnused-4.9/bin:/nix/store/b0ra9p84q49vivvj1lyxcv4g3z2xv6v5-gnugrep-3.7/bin:/nix/store/a6zj1zqj4w27nbxvbs3g53bi8l9swzrj-gawk-5.2.1/bin:/nix/store/vjnwfzx76axpap6pwhvnw4wr3b6rndwk-gnutar-1.34/bin:/nix/store/1vad9ilcz8chyzlnxx48k8vzqfqbnmg0-gzip-1.12/bin:/nix/store/zkhhpfmzqlc84778rr5i2w6xih8ss0bn-bzip2-1.0.8-bin/bin:/nix/store/illvvpvgxw8sprvksnzgilc5r4mm6g30-gnumake-4.4.1/bin:/nix/store/7kc331g8kcpbrkaqyx7rnqd1mnkk08fm-bash-5.2-p15/bin:/nix/store/c3wbkb3czbx5rzbgfkrg3mnaly9rwskk-patch-2.7.6/bin:/nix/store/7f7q64yf3461y1rddj2bzc2y5ijy6i7y-xz-5.4.3-bin/bin:/nix/store/dblf0ks06y5vmvpqsd453ciw6yjf874h-file-5.44/bin" VSLANG="1033" ZERO_AR_DATE="1" "/nix/store/lpvhgycia7py2x3hl6g75w2ixzy0pyfw-clang-wrapper-11.1.0/bin/cc" "-arch" "x86_64" "-m64" "/private/tmp/nix-build-meilisearch-1.1.1.drv-0/rustcmc8amp/symbols.o" "/private/tmp/nix-build-meilisearch-1.1.1.drv-0/source/target/x86_64-apple-darwin/release/deps/meilisearch-5753c49cda586af1.meilisearch.eaaf3956-cgu.0.rcgu.o" "/private/tmp/nix-build-meilisearch-1.1.1.drv-0/source/target/x86_64-apple-darwin/release/deps/meilisearch-5753c49cda586af1.4gqra1ty8qyq3mtw.rcgu.o" "-L" "/private/tmp/nix-build-meilisearch-1.1.1.drv-0/source/target/x86_64-apple-darwin/release/deps" "-L" "/private/tmp/nix-build-meilisearch-1.1.1.drv-0/source/target/release/deps" "-L" "/private/tmp/nix-build-meilisearch-1.1.1.drv-0/source/target/x86_64-apple-darwin/release/build/ring-a5df9aa48d0a78ba/out" "-L" "/private/tmp/nix-build-meilisearch-1.1.1.drv-0/source/target/x86_64-apple-darwin/release/build/zstd-sys-96a085f0ece85ca0/out" "-L" "/private/tmp/nix-build-meilisearch-1.1.1.drv-0/source/target/x86_64-apple-darwin/release/build/lmdb-rkv-sys-740b20896a7f4d27/out" "-L" "/private/tmp/nix-build-meilisearch-1.1.1.drv-0/source/target/x86_64-apple-darwin/release/build/libmimalloc-sys-6c0a3081c99c6d68/out" "-L" "/nix/store/sdx59jfsmfswcacqndqijnhjh8k236mf-rustc-1.69.0/lib/rustlib/x86_64-apple-darwin/lib" "/private/tmp/nix-build-meilisearch-1.1.1.drv-0/source/target/x86_64-apple-darwin/release/deps/libenv_logger-9b2fe1f9025a1a51.rlib" "/private/tmp/nix-build-meilisearch-1.1.1.drv-0/source/target/x86_64-apple-darwin/release/deps/libatty-9e4692241fbe9874.rlib" "/private/tmp/nix-build-meilisearch-1.1.1.drv-0/source/target/x86_64-apple-darwin/release/deps/libhumantime-6370849ccc32d6fd.rlib" "/private/tmp/nix-build-meilisearch-1.1.1.drv-0/source/target/x86_64-apple-darwin/release/deps/libmimalloc-96f3799069c46ebb.rlib" "/private/tmp/nix-build-meilisearch-1.1.1.drv-0/source/target/x86_64-apple-darwin/release/deps/liblibmimalloc_sys-4281e4c46e127e52.rlib" "/private/tmp/nix-build-meilisearch-1.1.1.drv-0/source/target/x86_64-apple-darwin/release/deps/libmeilisearch-40aa2857415d49a6.rlib" "/private/tmp/nix-build-meilisearch-1.1.1.drv-0/source/target/x86_64-apple-darwin/release/deps/libpermissive_json_pointer-bfe547558e813e16.rlib" "/private/tmp/nix-build-meilisearch-1.1.1.drv-0/source/target/x86_64-apple-darwin/release/deps/libtoml-1089ff94f2378158.rlib" "/private/tmp/nix-build-meilisearch-1.1.1.drv-0/source/target/x86_64-apple-darwin/release/deps/libactix_cors-74c206ca74eb018b.rlib" "/private/tmp/nix-build-meilisearch-1.1.1.drv-0/source/target/x86_64-apple-darwin/release/deps/libbstr-b09027ba201abd25.rlib" "/private/tmp/nix-build-meilisearch-1.1.1.drv-0/source/target/x86_64-apple-darwin/release/deps/libsysinfo-60b2e797a7740dee.rlib" "/private/tmp/nix-build-meilisearch-1.1.1.drv-0/source/target/x86_64-apple-darwin/release/deps/libcore_foundation_sys-838c0335f04ffa98.rlib" "/private/tmp/nix-build-meilisearch-1.1.1.drv-0/source/target/x86_64-apple-darwin/release/deps/librustls_pemfile-6774d7b70a953359.rlib" "/private/tmp/nix-build-meilisearch-1.1.1.drv-0/source/target/x86_64-apple-darwin/release/deps/libclap-791001a277767e44.rlib" "/private/tmp/nix-build-meilisearch-1.1.1.drv-0/source/target/x86_64-apple-darwin/release/deps/libis_terminal-efc0fcb690fd2419.rlib" "/private/tmp/nix-build-meilisearch-1.1.1.drv-0/source/target/x86_64-apple-darwin/release/deps/librustix-63ca9fd7c26e0eaa.rlib" "/private/tmp/nix-build-meilisearch-1.1.1.drv-0/source/target/x86_64-apple-darwin/release/deps/liberrno-e023a2010ab119cd.rlib" "/private/tmp/nix-build-meilisearch-1.1.1.drv-0/source/target/x86_64-apple-darwin/release/deps/libio_lifetimes-eb609d1899af0b54.rlib" "/private/tmp/nix-build-meilisearch-1.1.1.drv-0/source/target/x86_64-apple-darwin/release/deps/libclap_lex-cfbd2e5b991d534a.rlib" "/private/tmp/nix-build-meilisearch-1.1.1.drv-0/source/target/x86_64-apple-darwin/release/deps/libos_str_bytes-6d322fa30e728416.rlib" "/private/tmp/nix-build-meilisearch-1.1.1.drv-0/source/target/x86_64-apple-darwin/release/deps/libtermcolor-9b8ebbc6a6252f9b.rlib" "/private/tmp/nix-build-meilisearch-1.1.1.drv-0/source/target/x86_64-apple-darwin/release/deps/libbyte_unit-3d87a5f216c79178.rlib" "/private/tmp/nix-build-meilisearch-1.1.1.drv-0/source/target/x86_64-apple-darwin/release/deps/libutf8_width-d6beea937c4bdaa1.rlib" "/private/tmp/nix-build-meilisearch-1.1.1.drv-0/source/target/x86_64-apple-darwin/release/deps/libprometheus-bf08a7113a16c679.rlib" "/private/tmp/nix-build-meilisearch-1.1.1.drv-0/source/target/x86_64-apple-darwin/release/deps/libprotobuf-e29def413c078b94.rlib" "/private/tmp/nix-build-meilisearch-1.1.1.drv-0/source/target/x86_64-apple-darwin/release/deps/libjsonwebtoken-fcd2fcf737d9fc79.rlib" "/private/tmp/nix-build-meilisearch-1.1.1.drv-0/source/target/x86_64-apple-darwin/release/deps/libpem-05c22f3d2eaa1cc3.rlib" "/private/tmp/nix-build-meilisearch-1.1.1.drv-0/source/target/x86_64-apple-darwin/release/deps/libsimple_asn1-70df6b5a1326a04b.rlib" "/private/tmp/nix-build-meilisearch-1.1.1.drv-0/source/target/x86_64-apple-darwin/release/deps/libnum_bigint-3068d7cae4f41d13.rlib" "/private/tmp/nix-build-meilisearch-1.1.1.drv-0/source/target/x86_64-apple-darwin/release/deps/libnum_integer-9e9a91b936158eb4.rlib" "/private/tmp/nix-build-meilisearch-1.1.1.drv-0/source/target/x86_64-apple-darwin/release/deps/libplatform_dirs-3170e2c5b0e789d3.rlib" "/private/tmp/nix-build-meilisearch-1.1.1.drv-0/source/target/x86_64-apple-darwin/release/deps/libdirs_next-bc1df7438ab7df8f.rlib" "/private/tmp/nix-build-meilisearch-1.1.1.drv-0/source/target/x86_64-apple-darwin/release/deps/libdirs_sys_next-157e6530b4fc9191.rlib" "/private/tmp/nix-build-meilisearch-1.1.1.drv-0/source/target/x86_64-apple-darwin/release/deps/libindex_scheduler-f56df9df6a92edd2.rlib" "/private/tmp/nix-build-meilisearch-1.1.1.drv-0/source/target/x86_64-apple-darwin/release/deps/libmeilisearch_auth-42cc405538c351f7.rlib" "/private/tmp/nix-build-meilisearch-1.1.1.drv-0/source/target/x86_64-apple-darwin/release/deps/libbase64-aaf922c33b61cf03.rlib" "/private/tmp/nix-build-meilisearch-1.1.1.drv-0/source/target/x86_64-apple-darwin/release/deps/libmaplit-21ca7e9506755719.rlib" "/private/tmp/nix-build-meilisearch-1.1.1.drv-0/source/target/x86_64-apple-darwin/release/deps/libsha2-0b00f0eb2bd9ce2d.rlib" "/private/tmp/nix-build-meilisearch-1.1.1.drv-0/source/target/x86_64-apple-darwin/release/deps/libhmac-711958718db783b4.rlib" "/private/tmp/nix-build-meilisearch-1.1.1.drv-0/source/target/x86_64-apple-darwin/release/deps/libpage_size-93ea58ee8da3f418.rlib" "/private/tmp/nix-build-meilisearch-1.1.1.drv-0/source/target/x86_64-apple-darwin/release/deps/libdump-1f5b7b452d22f224.rlib" "/private/tmp/nix-build-meilisearch-1.1.1.drv-0/source/target/x86_64-apple-darwin/release/deps/libmeilisearch_types-3c321ea192b5ed51.rlib" "/private/tmp/nix-build-meilisearch-1.1.1.drv-0/source/target/x86_64-apple-darwin/release/deps/libfile_store-0ed22ab641efbabd.rlib" "/private/tmp/nix-build-meilisearch-1.1.1.drv-0/source/target/x86_64-apple-darwin/release/deps/libenum_iterator-b419e0162ed3c916.rlib" "/private/tmp/nix-build-meilisearch-1.1.1.drv-0/source/target/x86_64-apple-darwin/release/deps/libconvert_case-7dd2638f41e2778e.rlib" "/private/tmp/nix-build-meilisearch-1.1.1.drv-0/source/target/x86_64-apple-darwin/release/deps/libmilli-b49b6dbeba8c1673.rlib" "/private/tmp/nix-build-meilisearch-1.1.1.drv-0/source/target/x86_64-apple-darwin/release/deps/libgeoutils-debb6175ef3062ae.rlib" "/private/tmp/nix-build-meilisearch-1.1.1.drv-0/source/target/x86_64-apple-darwin/release/deps/libsmallstr-531871919bcb6dbb.rlib" "/private/tmp/nix-build-meilisearch-1.1.1.drv-0/source/target/x86_64-apple-darwin/release/deps/libflatten_serde_json-9841000c667c60a2.rlib" "/private/tmp/nix-build-meilisearch-1.1.1.drv-0/source/target/x86_64-apple-darwin/release/deps/libjson_depth_checker-d6a67fcdd35b0119.rlib" "/private/tmp/nix-build-meilisearch-1.1.1.drv-0/source/target/x86_64-apple-darwin/release/deps/libuuid-e1f6398a63c834e2.rlib" "/private/tmp/nix-build-meilisearch-1.1.1.drv-0/source/target/x86_64-apple-darwin/release/deps/liblogging_timer-2420bf93060a35c0.rlib" "/private/tmp/nix-build-meilisearch-1.1.1.drv-0/source/target/x86_64-apple-darwin/release/deps/libsmartstring-a353007ad3cedb09.rlib" "/private/tmp/nix-build-meilisearch-1.1.1.drv-0/source/target/x86_64-apple-darwin/release/deps/libstatic_assertions-d2d1ea7b33b5abe5.rlib" "/private/tmp/nix-build-meilisearch-1.1.1.drv-0/source/target/x86_64-apple-darwin/release/deps/libfilter_parser-3419dcefa8c53b76.rlib" "/private/tmp/nix-build-meilisearch-1.1.1.drv-0/source/target/x86_64-apple-darwin/release/deps/libnom_locate-74658a94b01a4cfb.rlib" "/private/tmp/nix-build-meilisearch-1.1.1.drv-0/source/target/x86_64-apple-darwin/release/deps/libbytecount-eea772de2dd672a3.rlib" "/private/tmp/nix-build-meilisearch-1.1.1.drv-0/source/target/x86_64-apple-darwin/release/deps/libnom-0b77d707b6bd7ac9.rlib" "/private/tmp/nix-build-meilisearch-1.1.1.drv-0/source/target/x86_64-apple-darwin/release/deps/libitertools-2e127bb871741b51.rlib" "/private/tmp/nix-build-meilisearch-1.1.1.drv-0/source/target/x86_64-apple-darwin/release/deps/liblevenshtein_automata-d5c1401f2acc2fe4.rlib" "/private/tmp/nix-build-meilisearch-1.1.1.drv-0/source/target/x86_64-apple-darwin/release/deps/librstar-b57dded666b2c47f.rlib" "/private/tmp/nix-build-meilisearch-1.1.1.drv-0/source/target/x86_64-apple-darwin/release/deps/libheapless-da1adcf6d782a91d.rlib" "/private/tmp/nix-build-meilisearch-1.1.1.drv-0/source/target/x86_64-apple-darwin/release/deps/libstable_deref_trait-ca673b90073e2ee9.rlib" "/private/tmp/nix-build-meilisearch-1.1.1.drv-0/source/target/x86_64-apple-darwin/release/deps/libspin-254885a6dcd2fa9b.rlib" "/private/tmp/nix-build-meilisearch-1.1.1.drv-0/source/target/x86_64-apple-darwin/release/deps/libhash32-24728aabaa5ac6f5.rlib" "/private/tmp/nix-build-meilisearch-1.1.1.drv-0/source/target/x86_64-apple-darwin/release/deps/libcharabia-653f830e8ec22ad1.rlib" "/private/tmp/nix-build-meilisearch-1.1.1.drv-0/source/target/x86_64-apple-darwin/release/deps/libirg_kvariants-295c84682635c79e.rlib" "/private/tmp/nix-build-meilisearch-1.1.1.drv-0/source/target/x86_64-apple-darwin/release/deps/libwhatlang-499378b15ce61f6f.rlib" "/private/tmp/nix-build-meilisearch-1.1.1.drv-0/source/target/x86_64-apple-darwin/release/deps/liblindera-a8ee3c78b7a692ac.rlib" "/private/tmp/nix-build-meilisearch-1.1.1.drv-0/source/target/x86_64-apple-darwin/release/deps/libunicode_blocks-fedd92182eb83219.rlib" "/private/tmp/nix-build-meilisearch-1.1.1.drv-0/source/target/x86_64-apple-darwin/release/deps/liblindera_dictionary-3f8d1fff474b56dc.rlib" "/private/tmp/nix-build-meilisearch-1.1.1.drv-0/source/target/x86_64-apple-darwin/release/deps/liblindera_ko_dic-24dd25ea8ea0fde0.rlib" "/private/tmp/nix-build-meilisearch-1.1.1.drv-0/source/target/x86_64-apple-darwin/release/deps/liblindera_ipadic-1dc8259a04b5e25e.rlib" "/private/tmp/nix-build-meilisearch-1.1.1.drv-0/source/target/x86_64-apple-darwin/release/deps/libkanaria-a2c61dfa92dc518c.rlib" "/private/tmp/nix-build-meilisearch-1.1.1.drv-0/source/target/x86_64-apple-darwin/release/deps/liblindera_unidic_builder-37ce7988873980b0.rlib" "/private/tmp/nix-build-meilisearch-1.1.1.drv-0/source/target/x86_64-apple-darwin/release/deps/liblindera_ko_dic_builder-84fa4f4783c87049.rlib" "/private/tmp/nix-build-meilisearch-1.1.1.drv-0/source/target/x86_64-apple-darwin/release/deps/liblindera_ipadic_builder-16cdebebbfa1700e.rlib" "/private/tmp/nix-build-meilisearch-1.1.1.drv-0/source/target/x86_64-apple-darwin/release/deps/libencoding_rs_io-d4274d38c836a720.rlib" "/private/tmp/nix-build-meilisearch-1.1.1.drv-0/source/target/x86_64-apple-darwin/release/deps/liblindera_cc_cedict_builder-c2ccd25f75693c8a.rlib" "/private/tmp/nix-build-meilisearch-1.1.1.drv-0/source/target/x86_64-apple-darwin/release/deps/liblindera_decompress-0adc2464ce439b6c.rlib" "/private/tmp/nix-build-meilisearch-1.1.1.drv-0/source/target/x86_64-apple-darwin/release/deps/libglob-7eca0ac20681a85f.rlib" "/private/tmp/nix-build-meilisearch-1.1.1.drv-0/source/target/x86_64-apple-darwin/release/deps/libcsv-c48d846203f0e93a.rlib" "/private/tmp/nix-build-meilisearch-1.1.1.drv-0/source/target/x86_64-apple-darwin/release/deps/libitoa-1341d3bb9e9583ad.rlib" "/private/tmp/nix-build-meilisearch-1.1.1.drv-0/source/target/x86_64-apple-darwin/release/deps/libcsv_core-e9770c7a05c550ed.rlib" "/private/tmp/nix-build-meilisearch-1.1.1.drv-0/source/target/x86_64-apple-darwin/release/deps/libbstr-32bd174ab261f618.rlib" "/private/tmp/nix-build-meilisearch-1.1.1.drv-0/source/target/x86_64-apple-darwin/release/deps/libregex_automata-0d7bd7d081afeda6.rlib" "/private/tmp/nix-build-meilisearch-1.1.1.drv-0/source/target/x86_64-apple-darwin/release/deps/liblindera_core-0f1846897c5c20d9.rlib" "/private/tmp/nix-build-meilisearch-1.1.1.drv-0/source/target/x86_64-apple-darwin/release/deps/libanyhow-911a60aa34224645.rlib" "/private/tmp/nix-build-meilisearch-1.1.1.drv-0/source/target/x86_64-apple-darwin/release/deps/libbacktrace-221107875f6570e4.rlib" "/private/tmp/nix-build-meilisearch-1.1.1.drv-0/source/target/x86_64-apple-darwin/release/deps/libobject-690c6fef4c2964b0.rlib" "/private/tmp/nix-build-meilisearch-1.1.1.drv-0/source/target/x86_64-apple-darwin/release/deps/libaddr2line-e6c16e3e892dda99.rlib" "/private/tmp/nix-build-meilisearch-1.1.1.drv-0/source/target/x86_64-apple-darwin/release/deps/libgimli-89ac9127d104acfb.rlib" "/private/tmp/nix-build-meilisearch-1.1.1.drv-0/source/target/x86_64-apple-darwin/release/deps/librustc_demangle-81575edab0c3b59b.rlib" "/private/tmp/nix-build-meilisearch-1.1.1.drv-0/source/target/x86_64-apple-darwin/release/deps/libyada-042e0e89ac99bc92.rlib" "/private/tmp/nix-build-meilisearch-1.1.1.drv-0/source/target/x86_64-apple-darwin/release/deps/libunicode_segmentation-4efb0e4a6d6be3d4.rlib" "/private/tmp/nix-build-meilisearch-1.1.1.drv-0/source/target/x86_64-apple-darwin/release/deps/libjieba_rs-f5d9962beed658d1.rlib" "/private/tmp/nix-build-meilisearch-1.1.1.drv-0/source/target/x86_64-apple-darwin/release/deps/libphf-6726215619da5681.rlib" "/private/tmp/nix-build-meilisearch-1.1.1.drv-0/source/target/x86_64-apple-darwin/release/deps/libphf_shared-228cab83a1b76058.rlib" "/private/tmp/nix-build-meilisearch-1.1.1.drv-0/source/target/x86_64-apple-darwin/release/deps/libsiphasher-1fd80fa8c1ea2eca.rlib" "/private/tmp/nix-build-meilisearch-1.1.1.drv-0/source/target/x86_64-apple-darwin/release/deps/libfxhash-527691e09199a942.rlib" "/private/tmp/nix-build-meilisearch-1.1.1.drv-0/source/target/x86_64-apple-darwin/release/deps/libcedarwood-07172263a0896d1a.rlib" "/private/tmp/nix-build-meilisearch-1.1.1.drv-0/source/target/x86_64-apple-darwin/release/deps/liblazy_static-47f59728b1d1585b.rlib" "/private/tmp/nix-build-meilisearch-1.1.1.drv-0/source/target/x86_64-apple-darwin/release/deps/libslice_group_by-868cef7e2e2f66cb.rlib" "/private/tmp/nix-build-meilisearch-1.1.1.drv-0/source/target/x86_64-apple-darwin/release/deps/libpinyin-de4ede8ecfb8729f.rlib" "/private/tmp/nix-build-meilisearch-1.1.1.drv-0/source/target/x86_64-apple-darwin/release/deps/libdeunicode-b5c85faf985d0e7a.rlib" "/private/tmp/nix-build-meilisearch-1.1.1.drv-0/source/target/x86_64-apple-darwin/release/deps/libordered_float-53d0915fdc2aa4ac.rlib" "/private/tmp/nix-build-meilisearch-1.1.1.drv-0/source/target/x86_64-apple-darwin/release/deps/libnum_traits-82b6154a9914107b.rlib" "/private/tmp/nix-build-meilisearch-1.1.1.drv-0/source/target/x86_64-apple-darwin/release/deps/libroaring-8a8e2416ef042991.rlib" "/private/tmp/nix-build-meilisearch-1.1.1.drv-0/source/target/x86_64-apple-darwin/release/deps/libretain_mut-197e41d7c116e3ad.rlib" "/private/tmp/nix-build-meilisearch-1.1.1.drv-0/source/target/x86_64-apple-darwin/release/deps/libfst-f8cbccec03c2a3d7.rlib" "/private/tmp/nix-build-meilisearch-1.1.1.drv-0/source/target/x86_64-apple-darwin/release/deps/librayon-6a4fb7e36a56bfb4.rlib" "/private/tmp/nix-build-meilisearch-1.1.1.drv-0/source/target/x86_64-apple-darwin/release/deps/librayon_core-87305be099fa8d09.rlib" "/private/tmp/nix-build-meilisearch-1.1.1.drv-0/source/target/x86_64-apple-darwin/release/deps/libcrossbeam_deque-06d30d927a6ab9e6.rlib" "/private/tmp/nix-build-meilisearch-1.1.1.drv-0/source/target/x86_64-apple-darwin/release/deps/libcrossbeam_epoch-802702969c6f52c7.rlib" "/private/tmp/nix-build-meilisearch-1.1.1.drv-0/source/target/x86_64-apple-darwin/release/deps/libmemoffset-22a5b9f3ae8877fb.rlib" "/private/tmp/nix-build-meilisearch-1.1.1.drv-0/source/target/x86_64-apple-darwin/release/deps/libcrossbeam_channel-d18236aff692b108.rlib" "/private/tmp/nix-build-meilisearch-1.1.1.drv-0/source/target/x86_64-apple-darwin/release/deps/libeither-5726460591d1a584.rlib" "/private/tmp/nix-build-meilisearch-1.1.1.drv-0/source/target/x86_64-apple-darwin/release/deps/libheed-c9899b833d35d89d.rlib" "/private/tmp/nix-build-meilisearch-1.1.1.drv-0/source/target/x86_64-apple-darwin/release/deps/libpage_size-0a2c9d6b2f327f52.rlib" "/private/tmp/nix-build-meilisearch-1.1.1.drv-0/source/target/x86_64-apple-darwin/release/deps/libheed_types-acd0059508a17a55.rlib" "/private/tmp/nix-build-meilisearch-1.1.1.drv-0/source/target/x86_64-apple-darwin/release/deps/libbincode-dd87e37e593c05f2.rlib" "/private/tmp/nix-build-meilisearch-1.1.1.drv-0/source/target/x86_64-apple-darwin/release/deps/libzerocopy-c0668ac250392f54.rlib" "/private/tmp/nix-build-meilisearch-1.1.1.drv-0/source/target/x86_64-apple-darwin/release/deps/libheed_traits-7ae458227bf02795.rlib" "/private/tmp/nix-build-meilisearch-1.1.1.drv-0/source/target/x86_64-apple-darwin/release/deps/liblmdb_sys-9cb76a06cca7a8ed.rlib" "/private/tmp/nix-build-meilisearch-1.1.1.drv-0/source/target/x86_64-apple-darwin/release/deps/libsynchronoise-7157c3bad9ea7d41.rlib" "/private/tmp/nix-build-meilisearch-1.1.1.drv-0/source/target/x86_64-apple-darwin/release/deps/libcrossbeam_queue-2db4dd2d36b8f3c1.rlib" "/private/tmp/nix-build-meilisearch-1.1.1.drv-0/source/target/x86_64-apple-darwin/release/deps/libcrossbeam_utils-e75200960fac27a6.rlib" "/private/tmp/nix-build-meilisearch-1.1.1.drv-0/source/target/x86_64-apple-darwin/release/deps/libthiserror-a584aa79aa0aa305.rlib" "/private/tmp/nix-build-meilisearch-1.1.1.drv-0/source/target/x86_64-apple-darwin/release/deps/libbimap-fc066b0bd12a11a7.rlib" "/private/tmp/nix-build-meilisearch-1.1.1.drv-0/source/target/x86_64-apple-darwin/release/deps/libobkv-ff8c16b821bf6143.rlib" "/private/tmp/nix-build-meilisearch-1.1.1.drv-0/source/target/x86_64-apple-darwin/release/deps/libgrenad-5871627cdf496c8e.rlib" "/private/tmp/nix-build-meilisearch-1.1.1.drv-0/source/target/x86_64-apple-darwin/release/deps/libtempfile-0c80600a4eb2bf91.rlib" "/private/tmp/nix-build-meilisearch-1.1.1.drv-0/source/target/x86_64-apple-darwin/release/deps/libfastrand-0cab61fe54fa8db7.rlib" "/private/tmp/nix-build-meilisearch-1.1.1.drv-0/source/target/x86_64-apple-darwin/release/deps/libremove_dir_all-ade49e0d30d6fc63.rlib" "/private/tmp/nix-build-meilisearch-1.1.1.drv-0/source/target/x86_64-apple-darwin/release/deps/libbytemuck-ba35d7248e4f1fd9.rlib" "/private/tmp/nix-build-meilisearch-1.1.1.drv-0/source/target/x86_64-apple-darwin/release/deps/libbyteorder-69d784efbd876482.rlib" "/private/tmp/nix-build-meilisearch-1.1.1.drv-0/source/target/x86_64-apple-darwin/release/deps/libmemmap2-5a4b4d7d35dbbebc.rlib" "/private/tmp/nix-build-meilisearch-1.1.1.drv-0/source/target/x86_64-apple-darwin/release/deps/libdeserr-fb03d51d570a4467.rlib" "/private/tmp/nix-build-meilisearch-1.1.1.drv-0/source/target/x86_64-apple-darwin/release/deps/libserde_cs-b729b51007fc65da.rlib" "/private/tmp/nix-build-meilisearch-1.1.1.drv-0/source/target/x86_64-apple-darwin/release/deps/libstrsim-ed55bd3c0c2c01b7.rlib" "/private/tmp/nix-build-meilisearch-1.1.1.drv-0/source/target/x86_64-apple-darwin/release/deps/libfutures-dc3ca3c8e524f9c9.rlib" "/private/tmp/nix-build-meilisearch-1.1.1.drv-0/source/target/x86_64-apple-darwin/release/deps/libfutures_executor-b0f7092d22769692.rlib" "/private/tmp/nix-build-meilisearch-1.1.1.drv-0/source/target/x86_64-apple-darwin/release/deps/libtar-58a8ba57777753cb.rlib" "/private/tmp/nix-build-meilisearch-1.1.1.drv-0/source/target/x86_64-apple-darwin/release/deps/libxattr-7ebb4d95aa241cfe.rlib" "/private/tmp/nix-build-meilisearch-1.1.1.drv-0/source/target/x86_64-apple-darwin/release/deps/libfiletime-9b3008fed2f4e3ae.rlib" "/private/tmp/nix-build-meilisearch-1.1.1.drv-0/source/target/x86_64-apple-darwin/release/deps/libactix_web-77502445370eaa1b.rlib" "/private/tmp/nix-build-meilisearch-1.1.1.drv-0/source/target/x86_64-apple-darwin/release/deps/libcookie-15f5237211d4c5c6.rlib" "/private/tmp/nix-build-meilisearch-1.1.1.drv-0/source/target/x86_64-apple-darwin/release/deps/libtime-fe860266249a2aab.rlib" "/private/tmp/nix-build-meilisearch-1.1.1.drv-0/source/target/x86_64-apple-darwin/release/deps/libtime_core-2175c4389d0003c7.rlib" "/private/tmp/nix-build-meilisearch-1.1.1.drv-0/source/target/x86_64-apple-darwin/release/deps/liburl-ab83285f7191231c.rlib" "/private/tmp/nix-build-meilisearch-1.1.1.drv-0/source/target/x86_64-apple-darwin/release/deps/libidna-b89080a0fe196c37.rlib" "/private/tmp/nix-build-meilisearch-1.1.1.drv-0/source/target/x86_64-apple-darwin/release/deps/libunicode_normalization-654225c76b682112.rlib" "/private/tmp/nix-build-meilisearch-1.1.1.drv-0/source/target/x86_64-apple-darwin/release/deps/libtinyvec-1481eb2edf7f350c.rlib" "/private/tmp/nix-build-meilisearch-1.1.1.drv-0/source/target/x86_64-apple-darwin/release/deps/libtinyvec_macros-cfb721be39da60f7.rlib" "/private/tmp/nix-build-meilisearch-1.1.1.drv-0/source/target/x86_64-apple-darwin/release/deps/libunicode_bidi-af06aca92bf7f7d9.rlib" "/private/tmp/nix-build-meilisearch-1.1.1.drv-0/source/target/x86_64-apple-darwin/release/deps/libserde_urlencoded-23e007bdb6ac25ef.rlib" "/private/tmp/nix-build-meilisearch-1.1.1.drv-0/source/target/x86_64-apple-darwin/release/deps/libform_urlencoded-08afdf7ab232ee24.rlib" "/private/tmp/nix-build-meilisearch-1.1.1.drv-0/source/target/x86_64-apple-darwin/release/deps/libserde_json-692f5aabfec3f9f1.rlib" "/private/tmp/nix-build-meilisearch-1.1.1.drv-0/source/target/x86_64-apple-darwin/release/deps/libryu-5c3515ed2530f699.rlib" "/private/tmp/nix-build-meilisearch-1.1.1.drv-0/source/target/x86_64-apple-darwin/release/deps/libactix_server-2c9b0e1550ddfea7.rlib" "/private/tmp/nix-build-meilisearch-1.1.1.drv-0/source/target/x86_64-apple-darwin/release/deps/libactix_router-a1146e13f1ba5b31.rlib" "/private/tmp/nix-build-meilisearch-1.1.1.drv-0/source/target/x86_64-apple-darwin/release/deps/libregex-5323e8a0f53d5f99.rlib" "/private/tmp/nix-build-meilisearch-1.1.1.drv-0/source/target/x86_64-apple-darwin/release/deps/libaho_corasick-a53b57974660316f.rlib" "/private/tmp/nix-build-meilisearch-1.1.1.drv-0/source/target/x86_64-apple-darwin/release/deps/libregex_syntax-3b629e385cc8eff8.rlib" "/private/tmp/nix-build-meilisearch-1.1.1.drv-0/source/target/x86_64-apple-darwin/release/deps/libactix_http-01097c7328450985.rlib" "/private/tmp/nix-build-meilisearch-1.1.1.drv-0/source/target/x86_64-apple-darwin/release/deps/librand-85176e5db9f4c021.rlib" "/private/tmp/nix-build-meilisearch-1.1.1.drv-0/source/target/x86_64-apple-darwin/release/deps/librand_chacha-770fa5db7224a1ca.rlib" "/private/tmp/nix-build-meilisearch-1.1.1.drv-0/source/target/x86_64-apple-darwin/release/deps/libppv_lite86-120e327b5f3eface.rlib" "/private/tmp/nix-build-meilisearch-1.1.1.drv-0/source/target/x86_64-apple-darwin/release/deps/librand_core-111a1ce5173e7e99.rlib" "/private/tmp/nix-build-meilisearch-1.1.1.drv-0/source/target/x86_64-apple-darwin/release/deps/libhttparse-d272b2436b8670c2.rlib" "/private/tmp/nix-build-meilisearch-1.1.1.drv-0/source/target/x86_64-apple-darwin/release/deps/libbrotli-b55d6ab517ea7056.rlib" "/private/tmp/nix-build-meilisearch-1.1.1.drv-0/source/target/x86_64-apple-darwin/release/deps/libbrotli_decompressor-864002a313dd7261.rlib" "/private/tmp/nix-build-meilisearch-1.1.1.drv-0/source/target/x86_64-apple-darwin/release/deps/liballoc_stdlib-52ece476d8b8367a.rlib" "/private/tmp/nix-build-meilisearch-1.1.1.drv-0/source/target/x86_64-apple-darwin/release/deps/liballoc_no_stdlib-f5b1123ed309bd72.rlib" "/private/tmp/nix-build-meilisearch-1.1.1.drv-0/source/target/x86_64-apple-darwin/release/deps/libhttpdate-699295ef389c4249.rlib" "/private/tmp/nix-build-meilisearch-1.1.1.drv-0/source/target/x86_64-apple-darwin/release/deps/libsha1-e637d34bc68a275c.rlib" "/private/tmp/nix-build-meilisearch-1.1.1.drv-0/source/target/x86_64-apple-darwin/release/deps/libcpufeatures-ce9e8ea872f45a6e.rlib" "/private/tmp/nix-build-meilisearch-1.1.1.drv-0/source/target/x86_64-apple-darwin/release/deps/libdigest-d500d4f346331127.rlib" "/private/tmp/nix-build-meilisearch-1.1.1.drv-0/source/target/x86_64-apple-darwin/release/deps/libsubtle-52c8dd5b231806d4.rlib" "/private/tmp/nix-build-meilisearch-1.1.1.drv-0/source/target/x86_64-apple-darwin/release/deps/libblock_buffer-e98b0535c1a63375.rlib" "/private/tmp/nix-build-meilisearch-1.1.1.drv-0/source/target/x86_64-apple-darwin/release/deps/libcrypto_common-b81cfaf833fc7342.rlib" "/private/tmp/nix-build-meilisearch-1.1.1.drv-0/source/target/x86_64-apple-darwin/release/deps/libgeneric_array-f0c91ecea41f8912.rlib" "/private/tmp/nix-build-meilisearch-1.1.1.drv-0/source/target/x86_64-apple-darwin/release/deps/libtypenum-1c82b80045ccd6ed.rlib" "/private/tmp/nix-build-meilisearch-1.1.1.drv-0/source/target/x86_64-apple-darwin/release/deps/libbase64-0aa5739f3c7c0fd0.rlib" "/private/tmp/nix-build-meilisearch-1.1.1.drv-0/source/target/x86_64-apple-darwin/release/deps/liblocal_channel-ed3ebfec31b15d87.rlib" "/private/tmp/nix-build-meilisearch-1.1.1.drv-0/source/target/x86_64-apple-darwin/release/deps/libbytestring-82373384b4d5fb59.rlib" "/private/tmp/nix-build-meilisearch-1.1.1.drv-0/source/target/x86_64-apple-darwin/release/deps/libencoding_rs-6d0d2dca46b73196.rlib" "/private/tmp/nix-build-meilisearch-1.1.1.drv-0/source/target/x86_64-apple-darwin/release/deps/liblanguage_tags-d8347792eaad7877.rlib" "/private/tmp/nix-build-meilisearch-1.1.1.drv-0/source/target/x86_64-apple-darwin/release/deps/libmime-7577adfc67e8f95c.rlib" "/private/tmp/nix-build-meilisearch-1.1.1.drv-0/source/target/x86_64-apple-darwin/release/deps/libpercent_encoding-39439fab941efac6.rlib" "/private/tmp/nix-build-meilisearch-1.1.1.drv-0/source/target/x86_64-apple-darwin/release/deps/libh2-d48b362f2c9ba71e.rlib" "/private/tmp/nix-build-meilisearch-1.1.1.drv-0/source/target/x86_64-apple-darwin/release/deps/libindexmap-29c459ee87d2e07d.rlib" "/private/tmp/nix-build-meilisearch-1.1.1.drv-0/source/target/x86_64-apple-darwin/release/deps/libhashbrown-e6f650dd54726190.rlib" "/private/tmp/nix-build-meilisearch-1.1.1.drv-0/source/target/x86_64-apple-darwin/release/deps/libahash-636869d36a877125.rlib" "/private/tmp/nix-build-meilisearch-1.1.1.drv-0/source/target/x86_64-apple-darwin/release/deps/libgetrandom-e74241296748265e.rlib" "/private/tmp/nix-build-meilisearch-1.1.1.drv-0/source/target/x86_64-apple-darwin/release/deps/libserde-8fd5624d992f1333.rlib" "/private/tmp/nix-build-meilisearch-1.1.1.drv-0/source/target/x86_64-apple-darwin/release/deps/libfutures_util-890d78fa12d87545.rlib" "/private/tmp/nix-build-meilisearch-1.1.1.drv-0/source/target/x86_64-apple-darwin/release/deps/libfutures_io-0fd51aa15f8755c1.rlib" "/private/tmp/nix-build-meilisearch-1.1.1.drv-0/source/target/x86_64-apple-darwin/release/deps/libslab-e7a621722a588159.rlib" "/private/tmp/nix-build-meilisearch-1.1.1.drv-0/source/target/x86_64-apple-darwin/release/deps/libfutures_channel-3cbfe32cbdfae716.rlib" "/private/tmp/nix-build-meilisearch-1.1.1.drv-0/source/target/x86_64-apple-darwin/release/deps/libfutures_task-3e8889d93c53778a.rlib" "/private/tmp/nix-build-meilisearch-1.1.1.drv-0/source/target/x86_64-apple-darwin/release/deps/libpin_utils-547d4791b2e4de67.rlib" "/private/tmp/nix-build-meilisearch-1.1.1.drv-0/source/target/x86_64-apple-darwin/release/deps/libactix_tls-c5069866afe948fb.rlib" "/private/tmp/nix-build-meilisearch-1.1.1.drv-0/source/target/x86_64-apple-darwin/release/deps/libtokio_rustls-cc5acbd07be35b40.rlib" "/private/tmp/nix-build-meilisearch-1.1.1.drv-0/source/target/x86_64-apple-darwin/release/deps/librustls-f96982cb49ba6622.rlib" "/private/tmp/nix-build-meilisearch-1.1.1.drv-0/source/target/x86_64-apple-darwin/release/deps/libsct-e60b8c468a60d982.rlib" "/private/tmp/nix-build-meilisearch-1.1.1.drv-0/source/target/x86_64-apple-darwin/release/deps/libwebpki-cdb7d6973c1d7ab5.rlib" "/private/tmp/nix-build-meilisearch-1.1.1.drv-0/source/target/x86_64-apple-darwin/release/deps/libring-25d46ac8aa4290b1.rlib" "/private/tmp/nix-build-meilisearch-1.1.1.drv-0/source/target/x86_64-apple-darwin/release/deps/libspin-6f72d08ae3bfb89d.rlib" "/private/tmp/nix-build-meilisearch-1.1.1.drv-0/source/target/x86_64-apple-darwin/release/deps/libuntrusted-d17707dc2f4b3bc7.rlib" "/private/tmp/nix-build-meilisearch-1.1.1.drv-0/source/target/x86_64-apple-darwin/release/deps/libzstd-b27e4a94a5ebf036.rlib" "/private/tmp/nix-build-meilisearch-1.1.1.drv-0/source/target/x86_64-apple-darwin/release/deps/libzstd_safe-5eab61e09aef3334.rlib" "/private/tmp/nix-build-meilisearch-1.1.1.drv-0/source/target/x86_64-apple-darwin/release/deps/libzstd_sys-fc6ac411bce9177d.rlib" "/private/tmp/nix-build-meilisearch-1.1.1.drv-0/source/target/x86_64-apple-darwin/release/deps/libflate2-8ab66300643fc721.rlib" "/private/tmp/nix-build-meilisearch-1.1.1.drv-0/source/target/x86_64-apple-darwin/release/deps/libminiz_oxide-afb781b3580b06b5.rlib" "/private/tmp/nix-build-meilisearch-1.1.1.drv-0/source/target/x86_64-apple-darwin/release/deps/libadler-251e3a8ce80c8c71.rlib" "/private/tmp/nix-build-meilisearch-1.1.1.drv-0/source/target/x86_64-apple-darwin/release/deps/libcrc32fast-45c0e5af6bf0b698.rlib" "/private/tmp/nix-build-meilisearch-1.1.1.drv-0/source/target/x86_64-apple-darwin/release/deps/libactix_service-226009585bd64cad.rlib" "/private/tmp/nix-build-meilisearch-1.1.1.drv-0/source/target/x86_64-apple-darwin/release/deps/libactix_codec-dd0ebf2582229581.rlib" "/private/tmp/nix-build-meilisearch-1.1.1.drv-0/source/target/x86_64-apple-darwin/release/deps/libtokio_util-9b617e0077daa0de.rlib" "/private/tmp/nix-build-meilisearch-1.1.1.drv-0/source/target/x86_64-apple-darwin/release/deps/libtracing-c9c3d8c29c60d5ec.rlib" "/private/tmp/nix-build-meilisearch-1.1.1.drv-0/source/target/x86_64-apple-darwin/release/deps/libtracing_core-32a74a5fa0ff8427.rlib" "/private/tmp/nix-build-meilisearch-1.1.1.drv-0/source/target/x86_64-apple-darwin/release/deps/libonce_cell-b7ac3e8b9b2674fa.rlib" "/private/tmp/nix-build-meilisearch-1.1.1.drv-0/source/target/x86_64-apple-darwin/release/deps/libfutures_sink-ade0f0f79d3ac7cd.rlib" "/private/tmp/nix-build-meilisearch-1.1.1.drv-0/source/target/x86_64-apple-darwin/release/deps/libbitflags-05cd7d9b8d362a9c.rlib" "/private/tmp/nix-build-meilisearch-1.1.1.drv-0/source/target/x86_64-apple-darwin/release/deps/libactix_utils-b9d64fa77299d30c.rlib" "/private/tmp/nix-build-meilisearch-1.1.1.drv-0/source/target/x86_64-apple-darwin/release/deps/liblocal_waker-54326349317cf61b.rlib" "/private/tmp/nix-build-meilisearch-1.1.1.drv-0/source/target/x86_64-apple-darwin/release/deps/libactix_rt-29e76ed3296a98e9.rlib" "/private/tmp/nix-build-meilisearch-1.1.1.drv-0/source/target/x86_64-apple-darwin/release/deps/libtokio-84718f5ef1639867.rlib" "/private/tmp/nix-build-meilisearch-1.1.1.drv-0/source/target/x86_64-apple-darwin/release/deps/libsignal_hook_registry-5491ccb0d5024816.rlib" "/private/tmp/nix-build-meilisearch-1.1.1.drv-0/source/target/x86_64-apple-darwin/release/deps/libnum_cpus-74123959e00fe438.rlib" "/private/tmp/nix-build-meilisearch-1.1.1.drv-0/source/target/x86_64-apple-darwin/release/deps/libsocket2-c735140b08e266ea.rlib" "/private/tmp/nix-build-meilisearch-1.1.1.drv-0/source/target/x86_64-apple-darwin/release/deps/libmemchr-9cb3efde023e1da1.rlib" "/private/tmp/nix-build-meilisearch-1.1.1.drv-0/source/target/x86_64-apple-darwin/release/deps/libmio-e4ab64e907ba9826.rlib" "/private/tmp/nix-build-meilisearch-1.1.1.drv-0/source/target/x86_64-apple-darwin/release/deps/liblog-aa7aaa3668ae2b68.rlib" "/private/tmp/nix-build-meilisearch-1.1.1.drv-0/source/target/x86_64-apple-darwin/release/deps/libparking_lot-e31491d61251ff36.rlib" "/private/tmp/nix-build-meilisearch-1.1.1.drv-0/source/target/x86_64-apple-darwin/release/deps/libparking_lot_core-15d54785274a20ab.rlib" "/private/tmp/nix-build-meilisearch-1.1.1.drv-0/source/target/x86_64-apple-darwin/release/deps/liblibc-7b8cd1bf93b490a2.rlib" "/private/tmp/nix-build-meilisearch-1.1.1.drv-0/source/target/x86_64-apple-darwin/release/deps/libcfg_if-5c35b615afe338ff.rlib" "/private/tmp/nix-build-meilisearch-1.1.1.drv-0/source/target/x86_64-apple-darwin/release/deps/libsmallvec-228d65217065f908.rlib" "/private/tmp/nix-build-meilisearch-1.1.1.drv-0/source/target/x86_64-apple-darwin/release/deps/liblock_api-90c539aaab418a09.rlib" "/private/tmp/nix-build-meilisearch-1.1.1.drv-0/source/target/x86_64-apple-darwin/release/deps/libscopeguard-233b5c07e136ece8.rlib" "/private/tmp/nix-build-meilisearch-1.1.1.drv-0/source/target/x86_64-apple-darwin/release/deps/libpin_project_lite-1be45e9461ee1305.rlib" "/private/tmp/nix-build-meilisearch-1.1.1.drv-0/source/target/x86_64-apple-darwin/release/deps/libfutures_core-65822d155eb1a794.rlib" "/private/tmp/nix-build-meilisearch-1.1.1.drv-0/source/target/x86_64-apple-darwin/release/deps/libhttp-6f5b3942ccd2ebaf.rlib" "/private/tmp/nix-build-meilisearch-1.1.1.drv-0/source/target/x86_64-apple-darwin/release/deps/libitoa-579d96b052fe9859.rlib" "/private/tmp/nix-build-meilisearch-1.1.1.drv-0/source/target/x86_64-apple-darwin/release/deps/libbytes-c49a39d29feae55f.rlib" "/private/tmp/nix-build-meilisearch-1.1.1.drv-0/source/target/x86_64-apple-darwin/release/deps/libfnv-9f73ab2790f8965b.rlib" "/nix/store/sdx59jfsmfswcacqndqijnhjh8k236mf-rustc-1.69.0/lib/rustlib/x86_64-apple-darwin/lib/libstd-207a8108e7930111.rlib" "/nix/store/sdx59jfsmfswcacqndqijnhjh8k236mf-rustc-1.69.0/lib/rustlib/x86_64-apple-darwin/lib/libpanic_unwind-d0ba48dae7d9508a.rlib" "/nix/store/sdx59jfsmfswcacqndqijnhjh8k236mf-rustc-1.69.0/lib/rustlib/x86_64-apple-darwin/lib/libobject-220cdb8fcb7c64f8.rlib" "/nix/store/sdx59jfsmfswcacqndqijnhjh8k236mf-rustc-1.69.0/lib/rustlib/x86_64-apple-darwin/lib/libmemchr-b61b38f9d827d62a.rlib" "/nix/store/sdx59jfsmfswcacqndqijnhjh8k236mf-rustc-1.69.0/lib/rustlib/x86_64-apple-darwin/lib/libaddr2line-763623cdf140a5e2.rlib" "/nix/store/sdx59jfsmfswcacqndqijnhjh8k236mf-rustc-1.69.0/lib/rustlib/x86_64-apple-darwin/lib/libgimli-7c2e591d2e6b4dcb.rlib" "/nix/store/sdx59jfsmfswcacqndqijnhjh8k236mf-rustc-1.69.0/lib/rustlib/x86_64-apple-darwin/lib/librustc_demangle-8a74302bbae9773b.rlib" "/nix/store/sdx59jfsmfswcacqndqijnhjh8k236mf-rustc-1.69.0/lib/rustlib/x86_64-apple-darwin/lib/libstd_detect-6c9264f01aded955.rlib" "/nix/store/sdx59jfsmfswcacqndqijnhjh8k236mf-rustc-1.69.0/lib/rustlib/x86_64-apple-darwin/lib/libhashbrown-81d1f92c23a53ac5.rlib" "/nix/store/sdx59jfsmfswcacqndqijnhjh8k236mf-rustc-1.69.0/lib/rustlib/x86_64-apple-darwin/lib/libminiz_oxide-77ab4efbc57ecf86.rlib" "/nix/store/sdx59jfsmfswcacqndqijnhjh8k236mf-rustc-1.69.0/lib/rustlib/x86_64-apple-darwin/lib/libadler-739a079f006cd208.rlib" "/nix/store/sdx59jfsmfswcacqndqijnhjh8k236mf-rustc-1.69.0/lib/rustlib/x86_64-apple-darwin/lib/librustc_std_workspace_alloc-93d1d3e5f4adb68d.rlib" "/nix/store/sdx59jfsmfswcacqndqijnhjh8k236mf-rustc-1.69.0/lib/rustlib/x86_64-apple-darwin/lib/libunwind-4aa41bd2043ead26.rlib" "/nix/store/sdx59jfsmfswcacqndqijnhjh8k236mf-rustc-1.69.0/lib/rustlib/x86_64-apple-darwin/lib/libcfg_if-f2e598903bd5cee5.rlib" "/nix/store/sdx59jfsmfswcacqndqijnhjh8k236mf-rustc-1.69.0/lib/rustlib/x86_64-apple-darwin/lib/liblibc-710fcae5379b9b16.rlib" "/nix/store/sdx59jfsmfswcacqndqijnhjh8k236mf-rustc-1.69.0/lib/rustlib/x86_64-apple-darwin/lib/liballoc-d74014e9a774db5f.rlib" "/nix/store/sdx59jfsmfswcacqndqijnhjh8k236mf-rustc-1.69.0/lib/rustlib/x86_64-apple-darwin/lib/librustc_std_workspace_core-e4277b5ad0fb1de5.rlib" "/nix/store/sdx59jfsmfswcacqndqijnhjh8k236mf-rustc-1.69.0/lib/rustlib/x86_64-apple-darwin/lib/libcore-8e54e99f3b5a6f50.rlib" "/nix/store/sdx59jfsmfswcacqndqijnhjh8k236mf-rustc-1.69.0/lib/rustlib/x86_64-apple-darwin/lib/libcompiler_builtins-e7db56ed0592e829.rlib" "-framework" "IOKit" "-framework" "CoreFoundation" "-framework" "CoreFoundation" "-framework" "Security" "-liconv" "-lSystem" "-lc" "-lm" "-L" "/nix/store/sdx59jfsmfswcacqndqijnhjh8k236mf-rustc-1.69.0/lib/rustlib/x86_64-apple-darwin/lib" "-o" "/private/tmp/nix-build-meilisearch-1.1.1.drv-0/source/target/x86_64-apple-darwin/release/deps/meilisearch-5753c49cda586af1" "-Wl,-dead_strip" "-nodefaultlibs"
  = note: Undefined symbols for architecture x86_64:
            "_kCFURLVolumeAvailableCapacityForImportantUsageKey", referenced from:
                _$LT$sysinfo..apple..disk..Disk$u20$as$u20$sysinfo..traits..DiskExt$GT$::refresh::h6fd0af5d235cb3a3 in libsysinfo-60b2e797a7740dee.rlib(sysinfo-60b2e797a7740dee.sysinfo.13501541-cgu.0.rcgu.o)
                _$LT$sysinfo..apple..system..System$u20$as$u20$sysinfo..traits..SystemExt$GT$::refresh_disks_list::h671535ee01bc1526 in libsysinfo-60b2e797a7740dee.rlib(sysinfo-60b2e797a7740dee.sysinfo.13501541-cgu.0.rcgu.o)
          ld: symbol(s) not found for architecture x86_64
          clang-11: error: linker command failed with exit code 1 (use -v to see invocation)
```

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
