### PR TITLE
botamusique: substitute version information

### DIFF
--- a/pkgs/tools/audio/botamusique/default.nix
+++ b/pkgs/tools/audio/botamusique/default.nix
@@ -60,7 +60,8 @@ stdenv.mkDerivation rec {
     # configuration.default.ini, which is in the installation directory
     # after all. So we need to counter-patch it here so it can find it absolutely
     substituteInPlace mumbleBot.py \
-      --replace "configuration.default.ini" "$out/share/botamusique/configuration.default.ini"
+      --replace "configuration.default.ini" "$out/share/botamusique/configuration.default.ini" \
+      --replace "version = 'git'" "version = '${version}'"
   '';
 
   NODE_OPTIONS = "--openssl-legacy-provider";


### PR DESCRIPTION
Fixes a crash due to a too new packaging package version, that started rejecting versions that don't follow a reasonable format.

```
May 24 11:27:07 juno systemd[1]: Started botamusique.service.
May 24 11:27:08 juno botamusique[8490]: [May 24 11:27:08 INFO] library: rebuild directory cache
May 24 11:27:08 juno botamusique[8490]: [May 24 11:27:08 INFO] library: rebuild directory cache
May 24 11:27:08 juno botamusique[8490]: [May 24 11:27:08 INFO] bot: botamusique version unknown, starting...
May 24 11:27:08 juno botamusique[8490]: [May 24 11:27:08 INFO] bot: botamusique version unknown, starting...
May 24 11:27:08 juno botamusique[8490]: Traceback (most recent call last):
May 24 11:27:08 juno botamusique[8490]:   File "/nix/store/kvh2pn1656dqxcscqpng862zzv89dwl6-botamusique-7.2.2/share/botamusique/.mumbleBot.py-wrapped", line 894, in <module>
May 24 11:27:08 juno botamusique[8490]:     var.bot = MumbleBot(args)
May 24 11:27:08 juno botamusique[8490]:   File "/nix/store/kvh2pn1656dqxcscqpng862zzv89dwl6-botamusique-7.2.2/share/botamusique/.mumbleBot.py-wrapped", line 194, in __init__
May 24 11:27:08 juno botamusique[8490]:     if not last_startup_version or version.parse(last_startup_version) < version.parse(self.version):
May 24 11:27:08 juno botamusique[8490]:   File "/nix/store/8k1mhj9ikv3fq8nj5a47fw94rd9nh0kf-python3.10-packaging-23.0/lib/python3.10/site-packages/packaging/version.py", line 52, in parse
May 24 11:27:08 juno botamusique[8490]:     return Version(version)
May 24 11:27:08 juno botamusique[8490]:   File "/nix/store/8k1mhj9ikv3fq8nj5a47fw94rd9nh0kf-python3.10-packaging-23.0/lib/python3.10/site-packages/packaging/version.py", line 197, in __init__
May 24 11:27:08 juno botamusique[8490]:     raise InvalidVersion(f"Invalid version: '{version}'")
May 24 11:27:08 juno botamusique[8490]: packaging.version.InvalidVersion: Invalid version: 'git'
May 24 11:27:09 juno systemd[1]: botamusique.service: Main process exited, code=exited, status=1/FAILURE
```

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
