### PR TITLE
gettext: 0.21 -> 0.21.1

### DIFF
--- a/pkgs/development/libraries/gettext/default.nix
+++ b/pkgs/development/libraries/gettext/default.nix
@@ -9,11 +9,11 @@
 
 stdenv.mkDerivation rec {
   pname = "gettext";
-  version = "0.21";
+  version = "0.21.1";
 
   src = fetchurl {
     url = "mirror://gnu/gettext/${pname}-${version}.tar.gz";
-    sha256 = "04kbg1sx0ncfrsbr85ggjslqkzzb243fcw9nyh3rrv1a22ihszf7";
+    sha256 = "sha256-6MNlDh2M7odcTzVWQjgsHfgwWL1aEe6FVcDPJ21kbUU=";
   };
   patches = [
     ./absolute-paths.diff
@@ -47,14 +47,6 @@ stdenv.mkDerivation rec {
   '' + lib.optionalString stdenv.hostPlatform.isCygwin ''
     sed -i -e "s/\(cldr_plurals_LDADD = \)/\\1..\/gnulib-lib\/libxml_rpl.la /" gettext-tools/src/Makefile.in
     sed -i -e "s/\(libgettextsrc_la_LDFLAGS = \)/\\1..\/gnulib-lib\/libxml_rpl.la /" gettext-tools/src/Makefile.in
-  '' +
-  # This change to gettext's vendored copy of gnulib is already
-  # merged upstream; we can drop this patch on the next version
-  # bump.  It must be applied twice because gettext vendors gnulib
-  # not once, but twice!
-  ''
-    patch -p2 -d gettext-tools/gnulib-lib/ < ${gnulib.passthru.longdouble-redirect-patch}
-    patch -p2 -d gettext-tools/libgrep/    < ${gnulib.passthru.longdouble-redirect-patch}
   '';
 
   strictDeps = true;


### PR DESCRIPTION
###### Description of changes

Unfortunately, there’s no release announcement for this release. From the [NEWS][1]

> Version 0.21.1 - October 2022
> 
> * Runtime behaviour:
>   - On AIX, locale names with a script or with an uppercase language are now
>     supported.
>     For example, sr_Cyrl_RS.UTF-8 is treated like sr_RS.UTF-8@cyrillic, and
>     EN_US.UTF-8 is treated like en_US.UTF-8.
> 
> * The base Unicode standard is now updated to 14.0.0.
> 
> * Portability:
>   - Building on macOS 11/arm64 is now supported.
>   - Building on Linux/powerpc64le with glibc ≥ 2.35 is now supported.

The vendored gnulib was also updated, which indirectly fixes a build failure with clang 16. The version in 0.20 fails to build because it attempts to assign an incompatible function pointer that should have but does not have `__attribute__((noreturn))`. On clang 16, this is an error by default.

[1]: https://git.savannah.gnu.org/gitweb/?p=gettext.git;a=blob_plain;f=NEWS;hb=8b38ee827251cadbb90cb6cb576ae98702566288

###### Things done

This causes way too many rebuilds to run `nixpkgs-review`, but I was able to build successfully a Darwin stdenv.

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
