### PR TITLE
nixos/pufferpanel: buildFHSUserEnv -> buildFHSEnv

### DIFF
--- a/nixos/modules/services/misc/pufferpanel.nix
+++ b/nixos/modules/services/misc/pufferpanel.nix
@@ -19,7 +19,7 @@ in
           services.pufferpanel = {
             enable = true;
             extraPackages = with pkgs; [ bash curl gawk gnutar gzip ];
-            package = pkgs.buildFHSUserEnv {
+            package = pkgs.buildFHSEnv {
               name = "pufferpanel-fhs";
               runScript = lib.getExe pkgs.pufferpanel;
               targetPkgs = pkgs': with pkgs'; [ icu openssl zlib ];
@@ -162,7 +162,7 @@ in
         PrivateUsers = true;
         PrivateDevices = true;
         RestrictRealtime = true;
-        RestrictNamespaces = [ "user" "mnt" ]; # allow buildFHSUserEnv
+        RestrictNamespaces = [ "user" "mnt" ]; # allow buildFHSEnv
         RestrictAddressFamilies = [ "AF_INET" "AF_INET6" "AF_UNIX" ];
         LockPersonality = true;
         DeviceAllow = [ "" ];


### PR DESCRIPTION
###### Description of changes

The pufferpanel module (#225274) was merged shortly after the tree-wide rename f63a12f296b806a1b838d6fd8eef99fa65929649 (#225748), so the use of deperecated buildFHSUserEnv in the docs slipped through review 😅

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
