### PR TITLE
calligra: 3.2.1 -> 3.2.1-unstable-2023-05-28

### DIFF
--- a/pkgs/applications/office/calligra/default.nix
+++ b/pkgs/applications/office/calligra/default.nix
@@ -1,4 +1,4 @@
-{ mkDerivation, lib, fetchpatch, fetchurl, extra-cmake-modules, kdoctools
+{ mkDerivation, lib, fetchpatch, fetchFromGitLab, extra-cmake-modules, kdoctools
 , boost, qtwebkit, qtx11extras, shared-mime-info
 , breeze-icons, kactivities, karchive, kcodecs, kcompletion, kconfig, kconfigwidgets
 , kcoreaddons, kdbusaddons, kdiagram, kguiaddons, khtml, ki18n
@@ -14,28 +14,17 @@
 
 mkDerivation rec {
   pname = "calligra";
-  version = "3.2.1";
+  version = "3.2.1-unstable-2023-05-28";
 
-  src = fetchurl {
-    url = "mirror://kde/stable/${pname}/${version}/${pname}-${version}.tar.xz";
-    sha256 = "0iqi6z6gkck2afgy200dacgcspq7i7887alcj0pklm08hbmsdy5i";
+  src = fetchFromGitLab {
+    domain = "invent.kde.org";
+    owner = "office";
+    repo = "calligra";
+    rev = "2301b2c49f7ec99214a42bdde0b3aadaf05adc6a";
+    hash = "sha256-gQUSL7k34HNZ3O65RO+wb+C4MEcq1U577p40QDyGPKs=";
   };
 
   patches = [
-    # Fix fontconfig underlinking: https://github.com/NixOS/nixpkgs/issues/137794
-    # Can be dropped on next release.
-    (fetchpatch {
-      name = "fix-fontconfig-linking.patch";
-      url = "https://github.com/KDE/calligra/commit/62f510702ef9c34ac50f8d8601a4290ab558464c.patch";
-      sha256 = "11dzrp9q05dmvnwp4vk4ihcibqcf4xyr0ijscpi716cyy730flma";
-      excludes = [ "CMakeLists.txt" ];
-    })
-    # Fixes for building calligra with gcc11/c++17
-    (fetchpatch {
-      name = "build_c++17_poppler.patch";
-      url = "https://github.com/archlinux/svntogit-packages/raw/bbbe35f97eb1033798f1cf95d427890168598199/trunk/068cd9ae.patch";
-      sha256 = "sha256-d9/ILwSeW+ov11DF191hzIaUafO/rjQrAeONwqDSKbA=";
-    })
     # Fixes for building calligra with modern poppler[-qt5]
     (fetchpatch {
       name = "calligra-poppler-22.03.patch";


### PR DESCRIPTION
###### Description of changes
Closes #232868
Changed the source provider to GitHub because I couldn't find the `tar.xz` sources for the Calligra suite.
Removed two patches, as they failed to apply and weren't necessary for the build to succeed.
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
