### PR TITLE
gst_all_1.gst-plugins-rs: increase test timeout and disable livesync plugin for now

### DIFF
--- a/pkgs/development/libraries/gstreamer/rs/default.nix
+++ b/pkgs/development/libraries/gstreamer/rs/default.nix
@@ -96,6 +96,7 @@ let
     [
       "audiofx" # tests have race-y failure, see https://gitlab.freedesktop.org/gstreamer/gst-plugins-rs/-/issues/337
       "csound" # tests have weird failure on x86, does not currently work on arm or darwin
+      "livesync" # tests have suspicious intermittent failure, see https://gitlab.freedesktop.org/gstreamer/gst-plugins-rs/-/issues/357
     ] ++ lib.optionals stdenv.isDarwin [
       "reqwest" # tests hang on darwin
       "threadshare" # tests cannot bind to localhost on darwin
@@ -210,7 +211,7 @@ stdenv.mkDerivation rec {
   checkPhase = ''
     runHook preCheck
 
-    meson test --no-rebuild --verbose --timeout-multiplier 6
+    meson test --no-rebuild --verbose --timeout-multiplier 12
 
     runHook postCheck
   '';


### PR DESCRIPTION
###### Description of changes

There are intermittent Hydra failures for this package from the tests timing out and taking a little longer than an hour. I've increased the timeout to 2 hours

I've also disabled `gst-plugin-livesync` by default because of more intermittent test failures, already reported upstream and encountered on one of the Hydra aarch64 builds: https://gitlab.freedesktop.org/gstreamer/gst-plugins-rs/-/issues/357

This will have a merge conflict with #233102 (currently in `staging-next`) and the associated backport PR #233606 (unmerged), but that should be easy to resolve

ZHF: #230712

Closes #234723

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).