### PR TITLE
botamusique: Backport fix for invalid version handling

### DIFF
--- a/pkgs/tools/audio/botamusique/catch-invalid-versions.patch
+++ b/pkgs/tools/audio/botamusique/catch-invalid-versions.patch
@@ -1,0 +1,24 @@
+diff --git a/mumbleBot.py b/mumbleBot.py
+index 11bc480..7395f41 100644
+--- a/mumbleBot.py
++++ b/mumbleBot.py
+@@ -188,11 +188,14 @@ class MumbleBot:
+             th.start()
+ 
+         last_startup_version = var.db.get("bot", "version", fallback=None)
+-        if not last_startup_version or version.parse(last_startup_version) < version.parse(self.version):
+-            var.db.set("bot", "version", self.version)
+-            if var.config.getboolean("bot", "auto_check_update"):
+-                changelog = util.fetch_changelog()
+-                self.send_channel_msg(tr("update_successful", version=self.version, changelog=changelog))
++        try:
++            if not last_startup_version or version.parse(last_startup_version) < version.parse(self.version):
++                var.db.set("bot", "version", self.version)
++                if var.config.getboolean("bot", "auto_check_update"):
++                    changelog = util.fetch_changelog()
++                    self.send_channel_msg(tr("update_successful", version=self.version, changelog=changelog))
++        except version.InvalidVersion:
++            pass
+ 
+     # Set the CTRL+C shortcut
+     def ctrl_caught(self, signal, frame):

--- a/pkgs/tools/audio/botamusique/default.nix
+++ b/pkgs/tools/audio/botamusique/default.nix
@@ -1,6 +1,7 @@
 { lib
 , stdenv
 , fetchFromGitHub
+, fetchpatch
 , python3Packages
 , ffmpeg
 , makeWrapper
@@ -53,6 +54,11 @@ stdenv.mkDerivation rec {
     # We can't update the package at runtime with NixOS, so this patch makes
     # the !update command mention that
     ./no-runtime-update.patch
+
+    # Fix passing of invalid "git" version into version.parse, which results
+    # in an InvalidVersion exception. The upstream fix is insufficient, so
+    # we carry the correct patch downstream for now.
+    ./catch-invalid-versions.patch
   ];
 
   postPatch = ''


### PR DESCRIPTION
Follow-up for #234699, which was only a partial fix.

Will backport manually into #234767, when accepted.

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
