### PR TITLE
cypthon: moduralize so it can be called with other versions

### DIFF
--- a/pkgs/development/interpreters/python/cpython/default.nix
+++ b/pkgs/development/interpreters/python/cpython/default.nix
@@ -53,6 +53,7 @@
 , enableLTO ? stdenv.is64bit && stdenv.isLinux
 , reproducibleBuild ? false
 , pythonAttr ? "python${sourceVersion.major}${sourceVersion.minor}"
+, noldconfigPatch ? ./. + "/${sourceVersion.major}.${sourceVersion.minor}/no-ldconfig.patch"
 } @ inputs:
 
 # Note: this package is used for bootstrapping fetchurl, and thus
@@ -252,7 +253,7 @@ in with passthru; stdenv.mkDerivation {
     # ctypes.util.find_library during the loading of the uuid module
     # (since it will do a futile invocation of gcc (!) to find
     # libuuid, slowing down program startup a lot).
-    (./. + "/${sourceVersion.major}.${sourceVersion.minor}/no-ldconfig.patch")
+    noldconfigPatch
     # Make sure that the virtualenv activation scripts are
     # owner-writable, so venvs can be recreated without permission
     # errors.

--- a/pkgs/development/interpreters/python/cpython/default.nix
+++ b/pkgs/development/interpreters/python/cpython/default.nix
@@ -284,7 +284,7 @@ in with passthru; stdenv.mkDerivation {
           sha256 = "1h18lnpx539h5lfxyk379dxwr8m2raigcjixkf133l4xy3f4bzi2";
         }
     )
-  ] ++ optionals (pythonOlder "3.12") [
+  ] ++ optionals (pythonAtLeast "3.7" && pythonOlder "3.12") [
     # LDSHARED now uses $CC instead of gcc. Fixes cross-compilation of extension modules.
     ./3.8/0001-On-all-posix-systems-not-just-Darwin-set-LDSHARED-if.patch
     # Use sysconfigdata to find headers. Fixes cross-compilation of extension modules.

--- a/pkgs/development/interpreters/python/default.nix
+++ b/pkgs/development/interpreters/python/default.nix
@@ -8,113 +8,12 @@
 , makeScopeWithSplicing
 , pythonPackagesExtensions
 , stdenv
-}:
+}@args:
 
 (let
 
   # Common passthru for all Python interpreters.
-  passthruFun =
-    { implementation
-    , libPrefix
-    , executable
-    , sourceVersion
-    , pythonVersion
-    , packageOverrides
-    , sitePackages
-    , hasDistutilsCxxPatch
-    , pythonOnBuildForBuild
-    , pythonOnBuildForHost
-    , pythonOnBuildForTarget
-    , pythonOnHostForHost
-    , pythonOnTargetForTarget
-    , pythonAttr ? null
-    , self # is pythonOnHostForTarget
-    }: let
-      pythonPackages = let
-        ensurePythonModules = items: let
-          exceptions = [
-            stdenv
-          ];
-          providesSetupHook = lib.attrByPath [ "provides" "setupHook"] false;
-          valid = value: pythonPackages.hasPythonModule value || providesSetupHook value || lib.elem value exceptions;
-          func = name: value:
-            if lib.isDerivation value then
-              lib.extendDerivation (valid value || throw "${name} should use `buildPythonPackage` or `toPythonModule` if it is to be part of the Python packages set.") {} value
-            else
-              value;
-        in lib.mapAttrs func items;
-      in ensurePythonModules (callPackage
-        # Function that when called
-        # - imports python-packages.nix
-        # - adds spliced package sets to the package set
-        # - applies overrides from `packageOverrides` and `pythonPackagesOverlays`.
-        ({ pkgs, stdenv, python, overrides }: let
-          pythonPackagesFun = import ./python-packages-base.nix {
-            inherit stdenv pkgs lib;
-            python = self;
-          };
-          otherSplices = {
-            selfBuildBuild = pythonOnBuildForBuild.pkgs;
-            selfBuildHost = pythonOnBuildForHost.pkgs;
-            selfBuildTarget = pythonOnBuildForTarget.pkgs;
-            selfHostHost = pythonOnHostForHost.pkgs;
-            selfTargetTarget = pythonOnTargetForTarget.pkgs or {}; # There is no Python TargetTarget.
-          };
-          hooks = import ./hooks/default.nix;
-          keep = lib.extends hooks pythonPackagesFun;
-          extra = _: {};
-          optionalExtensions = cond: as: lib.optionals cond as;
-          pythonExtension = import ../../../top-level/python-packages.nix;
-          python2Extension = import ../../../top-level/python2-packages.nix;
-          extensions = lib.composeManyExtensions ([
-            pythonExtension
-          ] ++ (optionalExtensions (!self.isPy3k) [
-            python2Extension
-          ]) ++ pythonPackagesExtensions ++ [
-            overrides
-          ]);
-          aliases = self: super: lib.optionalAttrs config.allowAliases (import ../../../top-level/python-aliases.nix lib self super);
-        in makeScopeWithSplicing
-          otherSplices
-          keep
-          extra
-          (lib.extends (lib.composeExtensions aliases extensions) keep))
-        {
-          overrides = packageOverrides;
-          python = self;
-        });
-    in rec {
-        isPy27 = pythonVersion == "2.7";
-        isPy37 = pythonVersion == "3.7";
-        isPy38 = pythonVersion == "3.8";
-        isPy39 = pythonVersion == "3.9";
-        isPy310 = pythonVersion == "3.10";
-        isPy311 = pythonVersion == "3.11";
-        isPy312 = pythonVersion == "3.12";
-        isPy2 = lib.strings.substring 0 1 pythonVersion == "2";
-        isPy3 = lib.strings.substring 0 1 pythonVersion == "3";
-        isPy3k = isPy3;
-        isPyPy = lib.hasInfix "pypy" interpreter;
-
-        buildEnv = callPackage ./wrapper.nix { python = self; inherit (pythonPackages) requiredPythonModules; };
-        withPackages = import ./with-packages.nix { inherit buildEnv pythonPackages;};
-        pkgs = pythonPackages;
-        interpreter = "${self}/bin/${executable}";
-        inherit executable implementation libPrefix pythonVersion sitePackages;
-        inherit sourceVersion;
-        pythonAtLeast = lib.versionAtLeast pythonVersion;
-        pythonOlder = lib.versionOlder pythonVersion;
-        inherit hasDistutilsCxxPatch;
-        # TODO: rename to pythonOnBuild
-        # Not done immediately because its likely used outside Nixpkgs.
-        pythonForBuild = pythonOnBuildForHost.override { inherit packageOverrides; self = pythonForBuild; };
-
-        tests = callPackage ./tests.nix {
-          python = self;
-        };
-
-        inherit pythonAttr;
-  };
+  passthruFun = import ./passthrufun.nix args;
 
   sources = {
     python310 = {

--- a/pkgs/development/interpreters/python/passthrufun.nix
+++ b/pkgs/development/interpreters/python/passthrufun.nix
@@ -1,0 +1,103 @@
+{ lib, stdenv, callPackage, pythonPackagesExtensions, config, makeScopeWithSplicing, ... }:
+
+{ implementation
+, libPrefix
+, executable
+, sourceVersion
+, pythonVersion
+, packageOverrides
+, sitePackages
+, hasDistutilsCxxPatch
+, pythonOnBuildForBuild
+, pythonOnBuildForHost
+, pythonOnBuildForTarget
+, pythonOnHostForHost
+, pythonOnTargetForTarget
+, pythonAttr ? null
+, self # is pythonOnHostForTarget
+}: let
+  pythonPackages = let
+    ensurePythonModules = items: let
+      exceptions = [
+        stdenv
+      ];
+      providesSetupHook = lib.attrByPath [ "provides" "setupHook"] false;
+      valid = value: pythonPackages.hasPythonModule value || providesSetupHook value || lib.elem value exceptions;
+      func = name: value:
+        if lib.isDerivation value then
+          lib.extendDerivation (valid value || throw "${name} should use `buildPythonPackage` or `toPythonModule` if it is to be part of the Python packages set.") {} value
+        else
+          value;
+    in lib.mapAttrs func items;
+  in ensurePythonModules (callPackage
+    # Function that when called
+    # - imports python-packages.nix
+    # - adds spliced package sets to the package set
+    # - applies overrides from `packageOverrides` and `pythonPackagesOverlays`.
+    ({ pkgs, stdenv, python, overrides }: let
+      pythonPackagesFun = import ./python-packages-base.nix {
+        inherit stdenv pkgs lib;
+        python = self;
+      };
+      otherSplices = {
+        selfBuildBuild = pythonOnBuildForBuild.pkgs;
+        selfBuildHost = pythonOnBuildForHost.pkgs;
+        selfBuildTarget = pythonOnBuildForTarget.pkgs;
+        selfHostHost = pythonOnHostForHost.pkgs;
+        selfTargetTarget = pythonOnTargetForTarget.pkgs or {}; # There is no Python TargetTarget.
+      };
+      hooks = import ./hooks/default.nix;
+      keep = lib.extends hooks pythonPackagesFun;
+      extra = _: {};
+      optionalExtensions = cond: as: lib.optionals cond as;
+      pythonExtension = import ../../../top-level/python-packages.nix;
+      python2Extension = import ../../../top-level/python2-packages.nix;
+      extensions = lib.composeManyExtensions ([
+        pythonExtension
+      ] ++ (optionalExtensions (!self.isPy3k) [
+        python2Extension
+      ]) ++ pythonPackagesExtensions ++ [
+        overrides
+      ]);
+      aliases = self: super: lib.optionalAttrs config.allowAliases (import ../../../top-level/python-aliases.nix lib self super);
+    in makeScopeWithSplicing
+      otherSplices
+      keep
+      extra
+      (lib.extends (lib.composeExtensions aliases extensions) keep))
+    {
+      overrides = packageOverrides;
+      python = self;
+    });
+in rec {
+    isPy27 = pythonVersion == "2.7";
+    isPy37 = pythonVersion == "3.7";
+    isPy38 = pythonVersion == "3.8";
+    isPy39 = pythonVersion == "3.9";
+    isPy310 = pythonVersion == "3.10";
+    isPy311 = pythonVersion == "3.11";
+    isPy312 = pythonVersion == "3.12";
+    isPy2 = lib.strings.substring 0 1 pythonVersion == "2";
+    isPy3 = lib.strings.substring 0 1 pythonVersion == "3";
+    isPy3k = isPy3;
+    isPyPy = lib.hasInfix "pypy" interpreter;
+
+    buildEnv = callPackage ./wrapper.nix { python = self; inherit (pythonPackages) requiredPythonModules; };
+    withPackages = import ./with-packages.nix { inherit buildEnv pythonPackages;};
+    pkgs = pythonPackages;
+    interpreter = "${self}/bin/${executable}";
+    inherit executable implementation libPrefix pythonVersion sitePackages;
+    inherit sourceVersion;
+    pythonAtLeast = lib.versionAtLeast pythonVersion;
+    pythonOlder = lib.versionOlder pythonVersion;
+    inherit hasDistutilsCxxPatch;
+    # TODO: rename to pythonOnBuild
+    # Not done immediately because its likely used outside Nixpkgs.
+    pythonForBuild = pythonOnBuildForHost.override { inherit packageOverrides; self = pythonForBuild; };
+
+    tests = callPackage ./tests.nix {
+      python = self;
+    };
+
+    inherit pythonAttr;
+}


### PR DESCRIPTION
This allows passing in `hash` and `url` of any Python to build it, while not changing the output hashes.