### PR TITLE
catppuccin-sddm: init at unstable-2022-12-03

### DIFF
--- a/pkgs/data/themes/catppuccin-sddm/default.nix
+++ b/pkgs/data/themes/catppuccin-sddm/default.nix
@@ -1,0 +1,42 @@
+{ stdenvNoCC
+, lib
+, fetchFromGitHub
+, variant ? "mocha"
+}:
+
+let
+  pname = "catppuccin-sddm";
+  validVariants = [ "latte" "frappe" "macchiato" "mocha" ];
+in
+lib.checkListOfEnum "${pname}: color variant" validVariants [ variant ]
+
+stdenvNoCC.mkDerivation {
+  inherit pname;
+  version = "unstable-2022-12-03";
+
+  src = fetchFromGitHub {
+    owner = "catppuccin";
+    repo = "sddm";
+    rev = "bde6932e1ae0f8fdda76eff5c81ea8d3b7d653c0";
+    hash = "sha256-ceaK/I5lhFz6c+UafQyQVJIzzPxjmsscBgj8130D4dE=";
+  };
+
+  sourceRoot = "source/src/catppuccin-${variant}";
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/share/sddm/themes/catppuccin-${variant}
+    cp * $out/share/sddm/themes/catppuccin-${variant}
+
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    description = "Soothing pastel theme for SDDM";
+    homepage = "https://github.com/catppuccin/sddm";
+    license = licenses.mit;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ _3JlOy-PYCCKUi ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -407,6 +407,8 @@ with pkgs;
 
   catppuccin-plymouth = callPackage ../data/themes/catppuccin-plymouth { };
 
+  catppuccin-sddm = callPackage ../data/themes/catppuccin-sddm { };
+
   btdu = callPackage ../tools/misc/btdu { };
 
   ccal = callPackage ../tools/misc/ccal { };


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

Result of `nixpkgs-review` run on x86_64-linux [1](https://github.com/Mic92/nixpkgs-review)
<details>
  <summary>1 package built:</summary>
  <ul>
    <li>catppuccin-sddm</li>
  </ul>
</details>

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
