### PR TITLE
keama: init at 4.4.3-P1

### DIFF
--- a/pkgs/tools/networking/keama/default.nix
+++ b/pkgs/tools/networking/keama/default.nix
@@ -1,0 +1,31 @@
+{ stdenv, lib, fetchurl }:
+
+stdenv.mkDerivation rec {
+  pname = "keama";
+  version = "4.4.3-P1";
+
+  src = fetchurl {
+    url = "https://ftp.isc.org/isc/dhcp/${version}/dhcp-${version}.tar.gz";
+    sha256 = "sha256-CsQWu1WZfKhjIXT9EHN/1hzbjbonUhYKM1d1vCHcc8c=";
+  };
+
+  enableParallelBuilding = true;
+
+  # The Kea Migration Assistant lives as a subdirectory of the
+  # original ISC DHCP server source code.
+  makeFlags = [ "-C" "keama" ];
+
+  meta = with lib; {
+    description = "Kea Migration Assistent";
+
+    longDescription = ''
+      Kea migration assistant is an experimental tool that reads a ISC DHCP server
+      configuration and produces a JSON configuration in Kea format.
+    '';
+
+    homepage = "https://gitlab.isc.org/isc-projects/dhcp/-/wikis/kea-migration-assistant";
+    license = licenses.mpl20;
+    platforms = platforms.unix;
+    maintainers = with maintainers; [ blitz ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9615,6 +9615,8 @@ with pkgs;
 
   kea = callPackage ../tools/networking/kea { };
 
+  keama = callPackage ../tools/networking/keama { };
+
   iredis = callPackage ../tools/admin/iredis { };
 
   ispell = callPackage ../tools/text/ispell { };


### PR DESCRIPTION
###### Description of changes

With the ISC DHCP server being deprecated in NixOS 23.05 and the warning directing users to its successor (Kea), it's nice to have the official migration tool (keama) packaged in NixOS.

See the [keama](https://gitlab.isc.org/isc-projects/dhcp/-/wikis/kea-migration-assistant) wiki page.

This package should be backported to 23.05 to help users migrate.

If someone packages [keama-leases](https://gitlab.isc.org/isc-projects/keama-leases), that's probably also helpful.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
