### PR TITLE
codeium: init at 1.2.26

### DIFF
--- a/pkgs/applications/editors/jetbrains/plugins/plugins.json
+++ b/pkgs/applications/editors/jetbrains/plugins/plugins.json
@@ -405,6 +405,33 @@
         "232.8660.197": "https://plugins.jetbrains.com/files/18444/165585/NetBeans6.5Keymap.zip"
       },
       "name": "netbeans-6-5-keymap"
+    },
+    "20540": {
+      "compatible": [
+        "clion",
+        "datagrip",
+        "goland",
+        "idea-community",
+        "idea-ultimate",
+        "mps",
+        "phpstorm",
+        "pycharm-community",
+        "pycharm-professional",
+        "rider",
+        "ruby-mine",
+        "webstorm"
+      ],
+      "builds": {
+        "223.8836.1185": "https://plugins.jetbrains.com/files/20540/351195/codeium-1.2.40.zip",
+        "231.9011.31": "https://plugins.jetbrains.com/files/20540/351195/codeium-1.2.40.zip",
+        "231.9011.34": "https://plugins.jetbrains.com/files/20540/351195/codeium-1.2.40.zip",
+        "231.9011.35": "https://plugins.jetbrains.com/files/20540/351195/codeium-1.2.40.zip",
+        "231.9011.38": "https://plugins.jetbrains.com/files/20540/351195/codeium-1.2.40.zip",
+        "231.9011.39": "https://plugins.jetbrains.com/files/20540/351195/codeium-1.2.40.zip",
+        "231.9011.41": "https://plugins.jetbrains.com/files/20540/351195/codeium-1.2.40.zip",
+        "231.9161.38": "https://plugins.jetbrains.com/files/20540/351195/codeium-1.2.40.zip"
+      },
+      "name": "codeium-ai-autocomplete-for-python-js-ts-java-go-and-more"
     }
   },
   "files": {
@@ -439,6 +466,7 @@
     "https://plugins.jetbrains.com/files/8182/367438/intellij-rust-0.4.199.5415-232.zip": "sha256-qa7R+YfVWu/x5p8t28tDtRtMH6dZCGZzMXycpK+epQo=",
     "https://plugins.jetbrains.com/files/8554/365482/featuresTrainer-232.8660.129.zip": "sha256-SCxqar6a7Q6sOFuZWNXtLRiSd7/34ydhWpL8groKT0U=",
     "https://plugins.jetbrains.com/files/8607/318851/NixIDEA-0.4.0.9.zip": "sha256-byShwSfnAG8kXhoNu7CfOwvy4Viav784NT0UmzKY6hQ=",
-    "https://plugins.jetbrains.com/files/9568/366117/go-plugin-232.8660.142.zip": "sha256-MPeTPoSUvfjwdWifKxlYHmmVNr+nOD22Hp4srRQbG/o="
+    "https://plugins.jetbrains.com/files/9568/366117/go-plugin-232.8660.142.zip": "sha256-MPeTPoSUvfjwdWifKxlYHmmVNr+nOD22Hp4srRQbG/o=",
+    "https://plugins.jetbrains.com/files/20540/351195/codeium-1.2.40.zip": "sha256-B5WuaZJWoXhQk4CBRFOGt6yF7C6beLhvcGkMwLAoZL4="
   }
 }

--- a/pkgs/applications/editors/jetbrains/plugins/plugins.json
+++ b/pkgs/applications/editors/jetbrains/plugins/plugins.json
@@ -422,14 +422,14 @@
         "webstorm"
       ],
       "builds": {
-        "223.8836.1185": "https://plugins.jetbrains.com/files/20540/351195/codeium-1.2.40.zip",
-        "231.9011.31": "https://plugins.jetbrains.com/files/20540/351195/codeium-1.2.40.zip",
-        "231.9011.34": "https://plugins.jetbrains.com/files/20540/351195/codeium-1.2.40.zip",
-        "231.9011.35": "https://plugins.jetbrains.com/files/20540/351195/codeium-1.2.40.zip",
-        "231.9011.38": "https://plugins.jetbrains.com/files/20540/351195/codeium-1.2.40.zip",
-        "231.9011.39": "https://plugins.jetbrains.com/files/20540/351195/codeium-1.2.40.zip",
-        "231.9011.41": "https://plugins.jetbrains.com/files/20540/351195/codeium-1.2.40.zip",
-        "231.9161.38": "https://plugins.jetbrains.com/files/20540/351195/codeium-1.2.40.zip"
+        "223.8836.1185": "https://plugins.jetbrains.com/files/20540/353364/codeium-1.2.44.zip",
+        "231.9225.18": "https://plugins.jetbrains.com/files/20540/353364/codeium-1.2.44.zip",
+        "231.9225.23": "https://plugins.jetbrains.com/files/20540/353364/codeium-1.2.44.zip",
+        "232.8660.111": "https://plugins.jetbrains.com/files/20540/353364/codeium-1.2.44.zip",
+        "232.8660.143": "https://plugins.jetbrains.com/files/20540/353364/codeium-1.2.44.zip",
+        "232.8660.185": "https://plugins.jetbrains.com/files/20540/353364/codeium-1.2.44.zip",
+        "232.8660.186": "https://plugins.jetbrains.com/files/20540/353364/codeium-1.2.44.zip",
+        "232.8660.197": "https://plugins.jetbrains.com/files/20540/353364/codeium-1.2.44.zip"
       },
       "name": "codeium-ai-autocomplete-for-python-js-ts-java-go-and-more"
     }
@@ -452,6 +452,7 @@
     "https://plugins.jetbrains.com/files/164/369533/IdeaVim-2.4.1-signed.zip": "sha256-dI+Oh6Z+OuqiS8yJI/PbelZdg2YCmoGw9NGotvKc0no=",
     "https://plugins.jetbrains.com/files/17718/369180/github-copilot-intellij-1.2.16.2847.zip": "sha256-qsKmVhgh8FyZN4cWbt/UKQEnk+3ANR2U2+wo5sVZZf8=",
     "https://plugins.jetbrains.com/files/18444/165585/NetBeans6.5Keymap.zip": "sha256-KrzZTKZMQqoEMw+vDUv2jjs0EX0leaPBkU8H/ecq/oI=",
+    "https://plugins.jetbrains.com/files/20540/353364/codeium-1.2.44.zip": "sha256-KVtSsfRONaIMpxKBTy2un4ix2aOU/xvXr+25UonChjU=",
     "https://plugins.jetbrains.com/files/631/368891/python-232.8660.185.zip": "sha256-SqHA6I+mJeBH/Gjos+OiTayClesl5YBLqHvXIVL5o9k=",
     "https://plugins.jetbrains.com/files/6981/363869/ini-231.9225.21.zip": "sha256-/HljUhlum/bmgw0sfhK+33AgxCJsT32uU/UjQIzIbKs=",
     "https://plugins.jetbrains.com/files/6981/367671/ini-232.8660.158.zip": "sha256-ZJuLy0WM1OC6pjeEyBFDeOqbUz0gcUIgd71k4ggcCeA=",
@@ -465,8 +466,7 @@
     "https://plugins.jetbrains.com/files/8182/367350/intellij-rust-0.4.199.5414-231.zip": "sha256-uHitLtuxa6w7XL0kdGf1hPAah8OpsrUWBLxbUNf7Y9o=",
     "https://plugins.jetbrains.com/files/8182/367438/intellij-rust-0.4.199.5415-232.zip": "sha256-qa7R+YfVWu/x5p8t28tDtRtMH6dZCGZzMXycpK+epQo=",
     "https://plugins.jetbrains.com/files/8554/365482/featuresTrainer-232.8660.129.zip": "sha256-SCxqar6a7Q6sOFuZWNXtLRiSd7/34ydhWpL8groKT0U=",
-    "https://plugins.jetbrains.com/files/8607/318851/NixIDEA-0.4.0.9.zip": "sha256-byShwSfnAG8kXhoNu7CfOwvy4Viav784NT0UmzKY6hQ=",
-    "https://plugins.jetbrains.com/files/9568/366117/go-plugin-232.8660.142.zip": "sha256-MPeTPoSUvfjwdWifKxlYHmmVNr+nOD22Hp4srRQbG/o=",
-    "https://plugins.jetbrains.com/files/20540/351195/codeium-1.2.40.zip": "sha256-B5WuaZJWoXhQk4CBRFOGt6yF7C6beLhvcGkMwLAoZL4="
+    "https://plugins.jetbrains.com/files/8607/370632/NixIDEA-0.4.0.10.zip": "sha256-pq9gFDjNmgZAXe11f6SNdN6g0xu18h/06J5L2lxUwgk=",
+    "https://plugins.jetbrains.com/files/9568/366117/go-plugin-232.8660.142.zip": "sha256-MPeTPoSUvfjwdWifKxlYHmmVNr+nOD22Hp4srRQbG/o="
   }
 }

--- a/pkgs/applications/editors/jetbrains/plugins/specialPlugins.nix
+++ b/pkgs/applications/editors/jetbrains/plugins/specialPlugins.nix
@@ -1,4 +1,4 @@
-{ delve, autoPatchelfHook, stdenv, lib, glibc, gcc-unwrapped }:
+{ delve, autoPatchelfHook, stdenv, lib, glibc, gcc-unwrapped, codeium }:
 # This is a list of plugins that need special treatment. For example, the go plugin (id is 9568) comes with delve, a
 # debugger, but that needs various linking fixes. The changes here replace it with the system one.
 {
@@ -60,4 +60,13 @@
       fix_offset PRELUDE_POSITION
     '';
   };
+  "20540" = {
+    nativeBuildInputs = [ autoPatchelfHook ];
+    buildInputs = [ stdenv.cc.cc.lib codeium ];
+    postInstall = ''
+      mkdir -p $out/bin
+      ln -s ${codeium}/bin/codeium_language_server $out/bin/language_server_linux_x64
+    '';
+  };
 }
+

--- a/pkgs/development/tools/codeium/default.nix
+++ b/pkgs/development/tools/codeium/default.nix
@@ -4,14 +4,14 @@ let
   inherit (stdenv.hostPlatform) system;
   throwSystem = throw "Unsupported system: ${system}";
   pname = "codeium";
-  version = "1.2.40";
+  version = "1.2.44";
   bin = "$out/bin/codeium_language_server";
   name = "${pname}-${version}.gz";
   srcs = {
     x86_64-linux =  fetchurl {
       inherit name;
       url = "https://github.com/Exafunction/codeium/releases/download/language-server-v${version}/language_server_linux_x64.gz";
-      hash = "sha256-86IK46teZDksP6ko1E24uf2EH7rwYJV110udGUGf7Bg=";
+      hash = "sha256-YptZzj+ZtMLk5d3/wDcEyKnV+DfhOeh/CeR+rGv0+Hg=";
     };
     aarch64-linux =  fetchurl {
       inherit name;

--- a/pkgs/development/tools/codeium/default.nix
+++ b/pkgs/development/tools/codeium/default.nix
@@ -1,0 +1,69 @@
+{ stdenv, lib, fetchurl, gzip, autoPatchelfHook }:
+let
+
+  inherit (stdenv.hostPlatform) system;
+  throwSystem = throw "Unsupported system: ${system}";
+  pname = "codeium";
+  version = "1.2.40";
+  bin = "$out/bin/codeium_language_server";
+  name = "${pname}-${version}.gz";
+  srcs = {
+    x86_64-linux =  fetchurl {
+      inherit name;
+      url = "https://github.com/Exafunction/codeium/releases/download/language-server-v${version}/language_server_linux_x64.gz";
+      hash = "sha256-86IK46teZDksP6ko1E24uf2EH7rwYJV110udGUGf7Bg=";
+    };
+    aarch64-linux =  fetchurl {
+      inherit name;
+      url = "https://github.com/Exafunction/codeium/releases/download/language-server-v${version}/language_server_linux_arm.gz";
+      hash = "";
+    };
+    x86_64-darwin =  fetchurl {
+      inherit name;
+      url = "https://github.com/Exafunction/codeium/releases/download/language-server-v${version}/language_server_macos_x64.gz";
+      hash = "";
+    };
+    aarch64-darwin =  fetchurl {
+      inherit name;
+      url = "https://github.com/Exafunction/codeium/releases/download/language-server-v${version}/language_server_macos_arm.gz";
+      hash = "";
+    };
+  };
+in stdenv.mkDerivation rec {
+  inherit pname version;
+  src = srcs.${system} or throwSystem;
+
+  nativeBuildInputs = [ gzip autoPatchelfHook ];
+
+  dontUnpack = true;
+  dontConfigure = true;
+  dontBuild = true;
+
+  installPhase = ''
+    runHook preInstall
+    mkdir -p $out/bin
+    gzip -dc $src > ${bin}
+    chmod +x ${bin}
+    runHook postInstall
+  '';
+
+  meta = rec {
+    description = "Codeium language server";
+    longDescription = ''
+      Codeium proprietary language server, patched for Nix(OS) compatibility.
+      bin/language_server_x must be symlinked into the plugin directory, replacing the existing binary.
+      For example:
+      ```shell
+      ln -s /run/current-system/sw/bin/codeium_language_server ~/.local/share/JetBrains/Rider2023.1/codeium/f1c80c965ed51164cc8af59131e9a4d4fc13f878/language_server_linux_x64
+      ```
+    '';
+    homepage = "https://codeium.com/";
+    downloadPage = homepage;
+    changelog = homepage;
+    license = lib.licenses.unfree;
+    maintainers = with lib.maintainers; [ anpin ];
+    mainProgram = "codeium";
+    platforms = [ "aarch64-darwin" "aarch64-linux" "x86_64-linux" "x86_64-darwin" ];
+    sourceProvenance = [ lib.sourceTypes.binaryNativeCode ];
+  };
+}

--- a/pkgs/development/tools/codeium/default.nix
+++ b/pkgs/development/tools/codeium/default.nix
@@ -4,14 +4,14 @@ let
   inherit (stdenv.hostPlatform) system;
   throwSystem = throw "Unsupported system: ${system}";
   pname = "codeium";
-  version = "1.2.44";
+  version = "1.2.64";
   bin = "$out/bin/codeium_language_server";
   name = "${pname}-${version}.gz";
   srcs = {
     x86_64-linux =  fetchurl {
       inherit name;
       url = "https://github.com/Exafunction/codeium/releases/download/language-server-v${version}/language_server_linux_x64.gz";
-      hash = "sha256-YptZzj+ZtMLk5d3/wDcEyKnV+DfhOeh/CeR+rGv0+Hg=";
+      hash = "sha256-3dTWFOelojNm8NjjE0PXIiXn/S3rKVXM5llv2nL/2u4=";
     };
     aarch64-linux =  fetchurl {
       inherit name;

--- a/pkgs/development/tools/codeium/default.nix
+++ b/pkgs/development/tools/codeium/default.nix
@@ -54,7 +54,7 @@ in stdenv.mkDerivation rec {
       bin/language_server_x must be symlinked into the plugin directory, replacing the existing binary.
       For example:
       ```shell
-      ln -s /run/current-system/sw/bin/codeium_language_server ~/.local/share/JetBrains/Rider2023.1/codeium/f1c80c965ed51164cc8af59131e9a4d4fc13f878/language_server_linux_x64
+      ln -s "$(which codeium_language_server)" /home/a/.local/share/JetBrains/Rider2023.1/codeium/662505c9b23342478d971f66a530cd102ae35df7/language_server_linux_x64
       ```
     '';
     homepage = "https://codeium.com/";

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -26127,6 +26127,8 @@ with pkgs;
 
   cockpit = callPackage ../servers/monitoring/cockpit { };
 
+  codeium = callPackage ../development/tools/codeium { };
+
   codeowners = callPackage ../development/tools/codeowners { };
 
   couchdb3 = callPackage ../servers/http/couchdb/3.nix { };


### PR DESCRIPTION
Codeium language server and jetbrains plugin 

Related to https://github.com/NixOS/nixpkgs/pull/223593 for jetbrains plugins functionality 

###### Things done

- Built on platform(s)
  - [X] x86_64-linux
  - [X] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [X] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).