### PR TITLE
python3Packages.filterpy: 1.4.5 -> unstable-2022-08-23

### DIFF
--- a/pkgs/development/python-modules/filterpy/default.nix
+++ b/pkgs/development/python-modules/filterpy/default.nix
@@ -1,6 +1,6 @@
 { lib
 , buildPythonPackage
-, fetchPypi
+, fetchFromGitHub
 , numpy
 , scipy
 , matplotlib
@@ -8,15 +8,16 @@
 , isPy3k
 }:
 
-buildPythonPackage rec {
-  version = "1.4.5";
+buildPythonPackage {
+  version = "unstable-2022-08-23";
   pname = "filterpy";
   disabled = !isPy3k;
 
-  src = fetchPypi {
-    inherit pname version;
-    extension = "zip";
-    sha256 = "4f2a4d39e4ea601b9ab42b2db08b5918a9538c168cff1c6895ae26646f3d73b1";
+  src = fetchFromGitHub {
+    owner = "rlabbe";
+    repo = "filterpy";
+    rev = "3b51149ebcff0401ff1e10bf08ffca7b6bbc4a33";
+    hash = "sha256-KuuVu0tqrmQuNKYmDmdy+TU6BnnhDxh4G8n9BGzjGag=";
   };
 
   nativeCheckInputs = [ pytest ];

--- a/pkgs/development/python-modules/filterpy/default.nix
+++ b/pkgs/development/python-modules/filterpy/default.nix
@@ -4,13 +4,15 @@
 , numpy
 , scipy
 , matplotlib
-, pytest
+, pytestCheckHook
 , isPy3k
 }:
 
 buildPythonPackage {
-  version = "unstable-2022-08-23";
   pname = "filterpy";
+  version = "unstable-2022-08-23";
+  format = "setuptools";
+
   disabled = !isPy3k;
 
   src = fetchFromGitHub {
@@ -20,14 +22,15 @@ buildPythonPackage {
     hash = "sha256-KuuVu0tqrmQuNKYmDmdy+TU6BnnhDxh4G8n9BGzjGag=";
   };
 
-  nativeCheckInputs = [ pytest ];
-  propagatedBuildInputs = [ numpy scipy matplotlib ];
+  nativeCheckInputs = [
+    pytestCheckHook
+  ];
 
-  # single test fails (even on master branch of repository)
-  # project does not use CI
-  checkPhase = ''
-    pytest --ignore=filterpy/common/tests/test_discretization.py
-  '';
+  propagatedBuildInputs = [
+    numpy
+    scipy
+    matplotlib
+  ];
 
   meta = with lib; {
     homepage = "https://github.com/rlabbe/filterpy";


### PR DESCRIPTION
###### Description of changes
Diff: https://github.com/rlabbe/filterpy/compare/1.4.5...3b51149ebcff0401ff1e10bf08ffca7b6bbc4a33

It has been five years since the last release, and there are about 100 unreleased commits.

ZHF: #230712
https://hydra.nixos.org/build/220648129

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
