### PR TITLE
[22.11] dav1d: add patch for CVE-2023-32570

### DIFF
--- a/pkgs/development/libraries/dav1d/1.0.0-CVE-2023-32570.patch
+++ b/pkgs/development/libraries/dav1d/1.0.0-CVE-2023-32570.patch
@@ -1,0 +1,23 @@
+Based on upstream cf617fdae0b9bfabd27282854c8e81450d955efa, omitting one
+of the 3 fixed call sites because it doesn't exist in 1.0.0
+
+diff --git a/src/thread_task.c b/src/thread_task.c
+index 53aa41e..cd85b1c 100644
+--- a/src/thread_task.c
++++ b/src/thread_task.c
+@@ -695,6 +695,7 @@ void *dav1d_worker_task(void *data) {
+                 if (!--f->task_thread.task_counter && f->task_thread.done[0] &&
+                     (!uses_2pass || f->task_thread.done[1]))
+                 {
++                    error = atomic_load(&f->task_thread.error);
+                     dav1d_decode_frame_exit(f, error == 1 ? DAV1D_ERR(EINVAL) :
+                                             error ? DAV1D_ERR(ENOMEM) : 0);
+                     f->n_tile_data = 0;
+@@ -811,6 +812,7 @@ void *dav1d_worker_task(void *data) {
+         if (!--f->task_thread.task_counter &&
+             f->task_thread.done[0] && (!uses_2pass || f->task_thread.done[1]))
+         {
++            error = atomic_load(&f->task_thread.error);
+             dav1d_decode_frame_exit(f, error == 1 ? DAV1D_ERR(EINVAL) :
+                                     error ? DAV1D_ERR(ENOMEM) : 0);
+             f->n_tile_data = 0;

--- a/pkgs/development/libraries/dav1d/default.nix
+++ b/pkgs/development/libraries/dav1d/default.nix
@@ -20,6 +20,10 @@ stdenv.mkDerivation rec {
     sha256 = "sha256-RVr7NFVxY+6MBD8NV7eMW8TEWuCgcfqpula1o1VZe0o=";
   };
 
+  patches = [
+    ./1.0.0-CVE-2023-32570.patch
+  ];
+
   nativeBuildInputs = [ meson ninja nasm pkg-config ];
   # TODO: doxygen (currently only HTML and not build by default).
   buildInputs = [ xxHash ]


### PR DESCRIPTION
###### Description of changes

https://nvd.nist.gov/vuln/detail/CVE-2023-32570

Built `libavif`, `ffmpeg`, `libheif`, `gdal`, `handbrake` & `pkgsStatic` variant on nixos x86_64. Built on aarch64-linux.

Built `libavif`, `ffmpeg`, `libheif`, `gdal` on macos 10.15.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
