### PR TITLE
rewrite-tbd: avoid infinite recursion when cmake is not cmakeMinimal

### DIFF
--- a/pkgs/os-specific/darwin/rewrite-tbd/default.nix
+++ b/pkgs/os-specific/darwin/rewrite-tbd/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, lib, fetchFromGitHub, cmake, pkg-config, libyaml }:
+{ stdenv, lib, fetchFromGitHub, libyaml }:
 
 stdenv.mkDerivation {
   pname = "rewrite-tbd";
@@ -11,8 +11,16 @@ stdenv.mkDerivation {
     sha256 = "08sk91zwj6n9x2ymwid2k7y0rwv5b7p6h1b25ipx1dv0i43p6v1a";
   };
 
-  nativeBuildInputs = [ cmake pkg-config ];
+  # Nix takes care of these paths. Avoiding the use of `pkg-config` prevents an infinite recursion.
+  postPatch = ''
+    substituteInPlace Makefile.boot \
+      --replace '$(shell pkg-config --cflags yaml-0.1)' "" \
+      --replace '$(shell pkg-config --libs yaml-0.1)' "-lyaml"
+  '';
+
   buildInputs = [ libyaml ];
+
+  makeFlags = [ "-f" "Makefile.boot" "PREFIX=${placeholder "out"}"];
 
   meta = with lib; {
     homepage = "https://github.com/thefloweringash/rewrite-tbd/";


### PR DESCRIPTION
###### Description of changes

This was found while working on the Darwin stdenv rework. This change allows rewrite-tbd to use the provided Makefile instead of depending on cmake and pkg-config.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
