### PR TITLE
configd: fix build with newer LLVM and bootstrap

### DIFF
--- a/pkgs/os-specific/darwin/apple-sdk/default.nix
+++ b/pkgs/os-specific/darwin/apple-sdk/default.nix
@@ -1,6 +1,9 @@
-{ stdenv, fetchurl, xar, cpio, pkgs, python3, pbzx, lib, darwin-stubs, print-reexports }:
+{ stdenv, fetchurl, libxml2, xar, cpio, pkgs, python3Minimal, pbzx, lib, darwin-stubs, print-reexports }:
 
 let
+  xarMinimal = xar.override {
+    libxml2 = libxml2.override { pythonSupport = false; };
+  };
   # sadly needs to be exported because security_tool needs it
   sdk = stdenv.mkDerivation rec {
     pname = "MacOS_SDK";
@@ -16,7 +19,7 @@ let
       sha256 = "13xq34sb7383b37hwy076gnhf96prpk1b4087p87xnwswxbrisih";
     };
 
-    nativeBuildInputs = [ xar cpio python3 pbzx ];
+    nativeBuildInputs = [ xarMinimal cpio python3Minimal pbzx ];
 
     outputs = [ "out" "dev" "man" ];
 

--- a/pkgs/os-specific/darwin/apple-source-releases/configd/default.nix
+++ b/pkgs/os-specific/darwin/apple-source-releases/configd/default.nix
@@ -1,67 +1,32 @@
-{ lib, stdenv, appleDerivation', launchd, bootstrap_cmds, xnu, ppp, IOKit, eap8021x, Security
+{ lib, stdenv, appleDerivation', launchd, bootstrap_cmds, xnu, xpc, ppp, IOKit, eap8021x, Security
 , headersOnly ? false }:
 
 appleDerivation' stdenv {
   meta.broken = stdenv.cc.nativeLibc;
 
   nativeBuildInputs = lib.optionals (!headersOnly) [ bootstrap_cmds ];
-  buildInputs = lib.optionals (!headersOnly) [ launchd ppp IOKit eap8021x ];
+  buildInputs = lib.optionals (!headersOnly) [ launchd ppp xpc IOKit eap8021x ];
 
   propagatedBuildInputs = lib.optionals (!headersOnly) [ Security ];
 
+  env = lib.optionalAttrs (!headersOnly) {
+    NIX_CFLAGS_COMPILE = toString [
+      "-ISystemConfiguration.framework/Headers"
+      "-I${xnu}/Library/Frameworks/System.framework/Versions/B/PrivateHeaders"
+    ];
+  };
+
   patchPhase = lib.optionalString (!headersOnly) ''
-    HACK=$PWD/hack
-    mkdir $HACK
-    cp -r ${xnu}/Library/Frameworks/System.framework/Versions/B/PrivateHeaders/net $HACK
-
-
-    substituteInPlace SystemConfiguration.fproj/SCNetworkReachabilityInternal.h \
-      --replace '#include <xpc/xpc.h>' ""
+    substituteInPlace SystemConfiguration.fproj/reachability/SCNetworkReachabilityServer_client.c \
+      --replace '#include <xpc/private.h>' ""
 
     substituteInPlace SystemConfiguration.fproj/SCNetworkReachability.c \
       --replace ''$'#define\tHAVE_VPN_STATUS' ""
-
-    substituteInPlace SystemConfiguration.fproj/reachability/SCNetworkReachabilityServer_client.c \
-      --replace '#include <xpc/xpc.h>' '#include "fake_xpc.h"' \
-      --replace '#include <xpc/private.h>' "" \
 
     # Our neutered CoreFoundation doesn't have this function, but I think we'll live...
     substituteInPlace SystemConfiguration.fproj/SCNetworkConnectionPrivate.c \
       --replace 'CFPreferencesAppValueIsForced(serviceID, USER_PREFERENCES_APPLICATION_ID)' 'FALSE' \
       --replace 'CFPreferencesAppValueIsForced(userPrivate->serviceID, USER_PREFERENCES_APPLICATION_ID)' 'FALSE'
-
-    cat >SystemConfiguration.fproj/fake_xpc.h <<EOF
-    typedef void *xpc_type_t;
-    typedef void *xpc_object_t;
-    typedef void *xpc_connection_t;
-
-    xpc_type_t xpc_get_type(xpc_object_t object);
-    xpc_object_t xpc_dictionary_create(const char * const *keys, const xpc_object_t *values, size_t count);
-    char *xpc_copy_description(xpc_object_t object);
-    int64_t  xpc_dictionary_get_int64(xpc_object_t xdict, const char *key);
-    uint64_t xpc_dictionary_get_uint64(xpc_object_t xdict, const char *key);
-    void xpc_connection_set_event_handler(xpc_connection_t connection, void *handler);
-
-    extern const struct _xpc_type_s _xpc_type_error;
-    #define XPC_TYPE_ERROR (&_xpc_type_error)
-
-    extern const struct _xpc_type_s _xpc_type_dictionary;
-    #define XPC_TYPE_DICTIONARY (&_xpc_type_dictionary)
-
-    extern const struct _xpc_type_s _xpc_type_array;
-    #define XPC_TYPE_ARRAY (&_xpc_type_array)
-
-    extern const struct _xpc_dictionary_s _xpc_error_connection_interrupted;
-    #define XPC_ERROR_CONNECTION_INTERRUPTED (&_xpc_error_connection_interrupted)
-
-    extern const struct _xpc_dictionary_s _xpc_error_connection_invalid;
-    #define XPC_ERROR_CONNECTION_INVALID (&_xpc_error_connection_invalid)
-
-    extern const char *const _xpc_error_key_description;
-    #define XPC_ERROR_KEY_DESCRIPTION _xpc_error_key_description
-
-    #define XPC_CONNECTION_MACH_SERVICE_PRIVILEGED (1 << 1)
-    EOF
   '';
 
   dontBuild = headersOnly;
@@ -177,9 +142,9 @@ appleDerivation' stdenv {
     $CC -I. -Ihelper -Iderived -F. -c DHCP.c -o DHCP.o
     $CC -I. -Ihelper -Iderived -F. -c moh.c -o moh.o
     $CC -I. -Ihelper -Iderived -F. -c DeviceOnHold.c -o DeviceOnHold.o
-    $CC -I. -Ihelper -Iderived -I $HACK -F. -c LinkConfiguration.c -o LinkConfiguration.o
+    $CC -I. -Ihelper -Iderived -F. -c LinkConfiguration.c -o LinkConfiguration.o
     $CC -I. -Ihelper -Iderived -F. -c dy_framework.c -o dy_framework.o
-    $CC -I. -Ihelper -Iderived -I $HACK -F. -c VLANConfiguration.c -o VLANConfiguration.o
+    $CC -I. -Ihelper -Iderived -F. -c VLANConfiguration.c -o VLANConfiguration.o
     $CC -I. -Ihelper -Iderived -F. -c derived/configUser.c -o configUser.o
     $CC -I. -Ihelper -Iderived -F. -c SCPreferencesPathKey.c -o SCPreferencesPathKey.o
     $CC -I. -Ihelper -Iderived -I../dnsinfo -F. -c derived/shared_dns_infoUser.c -o shared_dns_infoUser.o
@@ -188,8 +153,8 @@ appleDerivation' stdenv {
     $CC -I. -Ihelper -Iderived -F. -c SCNetworkProtocol.c -o SCNetworkProtocol.o
     $CC -I. -Ihelper -Iderived -F. -c SCNetworkService.c -o SCNetworkService.o
     $CC -I. -Ihelper -Iderived -F. -c SCNetworkSet.c -o SCNetworkSet.o
-    $CC -I. -Ihelper -Iderived -I $HACK -F. -c BondConfiguration.c -o BondConfiguration.o
-    $CC -I. -Ihelper -Iderived -I $HACK -F. -c BridgeConfiguration.c -o BridgeConfiguration.o
+    $CC -I. -Ihelper -Iderived -F. -c BondConfiguration.c -o BondConfiguration.o
+    $CC -I. -Ihelper -Iderived -F. -c BridgeConfiguration.c -o BridgeConfiguration.o
     $CC -I. -Ihelper -Iderived -F. -c helper/SCHelper_client.c -o SCHelper_client.o
     $CC -I. -Ihelper -Iderived -F. -c SCPreferencesKeychainPrivate.c -o SCPreferencesKeychainPrivate.o
     $CC -I. -Ihelper -Iderived -F. -c SCNetworkSignature.c -o SCNetworkSignature.o

--- a/pkgs/os-specific/darwin/apple-source-releases/default.nix
+++ b/pkgs/os-specific/darwin/apple-source-releases/default.nix
@@ -248,6 +248,7 @@ developerToolsPackages_11_3_1 // macosPackages_11_0_1 // {
     CommonCrypto    = applePackage "CommonCrypto"      "osx-10.12.6"     "sha256-FLgODBrfv+XsGaAjddncYAm/BIJJYw6LcwX/z7ncKFM=" {};
     configd         = applePackage "configd"           "osx-10.8.5"      "sha256-6I3FWNjTgds5abEcZrD++s9b+P9a2+qUf8KFAb72DwI=" {
       Security      = applePackage "Security/boot.nix" "osx-10.9.5"      "sha256-7qr0IamjCXCobIJ6V9KtvbMBkJDfRCy4C5eqpHJlQLI=" {};
+      inherit (pkgs.darwin.apple_sdk.libs) xpc;
     };
     copyfile        = applePackage "copyfile"          "osx-10.12.6"     "sha256-uHqLFOIpXK+n0RHyOZzVsP2DDZcFDivKCnqHBaXvHns=" {};
     Csu             = applePackage "Csu"               "osx-10.11.6"     "sha256-h6a/sQMEVeFxKNWAPgKBXjWhyL2L2nvX9BQUMaTQ6sY=" {};
@@ -310,6 +311,7 @@ developerToolsPackages_11_3_1 // macosPackages_11_0_1 // {
     configdHeaders  = applePackage "configd"           "osx-10.8.5"      "sha256-6I3FWNjTgds5abEcZrD++s9b+P9a2+qUf8KFAb72DwI=" {
       headersOnly = true;
       Security    = null;
+      xpc         = null;
     };
     libutilHeaders  = pkgs.darwin.libutil.override { headersOnly = true; };
     hfsHeaders      = pkgs.darwin.hfs.override { headersOnly = true; };


### PR DESCRIPTION
###### Description of changes

Clang 15 does not like the fake xpc headers. Use the real ones instead. Doing this no longer causes an infinite recursion because xnu now depends on python3Minimal, which does not include configd support.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
