### PR TITLE
swift-corelibs: set NIX_COREFOUNDATION_RPATH in a hook

### DIFF
--- a/pkgs/os-specific/darwin/swift-corelibs/corefoundation.nix
+++ b/pkgs/os-specific/darwin/swift-corelibs/corefoundation.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchFromGitHub, fetchurl, ninja, python3, curl, libxml2, objc4, ICU }:
+{ lib, stdenv, fetchFromGitHub, fetchurl, makeSetupHook, ninja, python3, curl, libxml2, objc4, ICU }:
 
 let
   # 10.12 adds a new sysdir.h that our version of CF in the main derivation depends on, but
@@ -104,4 +104,6 @@ stdenv.mkDerivation {
       ln -s Versions/Current/$i $base/$i
     done
   '';
+
+    darwinEnvHook = makeSetupHook { name = "darwin-env-hook"; } ./pure-corefoundation-hook.sh;
 }

--- a/pkgs/os-specific/darwin/swift-corelibs/pure-corefoundation-hook.sh
+++ b/pkgs/os-specific/darwin/swift-corelibs/pure-corefoundation-hook.sh
@@ -1,0 +1,7 @@
+usePureCoreFoundation() {
+# Avoid overriding value set by the impure CF
+    if [ -z "${NIX_COREFOUNDATION_RPATH:-}" ]; then
+        export NIX_COREFOUNDATION_RPATH=@out@/Library/Frameworks
+    fi
+}
+addEnvHooks "$hostOffset" usePureCoreFoundation

--- a/pkgs/stdenv/darwin/default.nix
+++ b/pkgs/stdenv/darwin/default.nix
@@ -683,7 +683,6 @@ rec {
       targetPlatform = localSystem;
 
       preHook = commonPreHook + ''
-        export NIX_COREFOUNDATION_RPATH=${pkgs.darwin.CF}/Library/Frameworks
         export PATH_LOCALE=${pkgs.darwin.locale}/share/locale
       '';
 


### PR DESCRIPTION
###### Description of changes

Closes #230870. Thanks to @eliasnaur for the test case and for rasining awareness and to @veprbl for the work done on #111385.

This takes a slightly different approach from those two PRs. The hook is set unconditionally. The stdenv bootstrap doesn’t really need CF at all, so setting the hook is harmless. This simplifies things.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
