### PR TITLE
python3Packages.cffi: fix build with newer clang

### DIFF
--- a/pkgs/development/python-modules/cffi/clang-pointer-substraction-warning.diff
+++ b/pkgs/development/python-modules/cffi/clang-pointer-substraction-warning.diff
@@ -1,0 +1,11 @@
+diff -r c649a735cf82 testing/support.py
+--- a/testing/support.py	Thu Feb 23 05:42:01 2023 +0100
++++ b/testing/support.py	Sat May 20 21:46:56 2023 -0400
+@@ -112,6 +112,7 @@
+                               '-Wno-unreachable-code']
+         # special things for clang
+         extra_compile_args.append('-Qunused-arguments')
++        extra_compile_args.append('-Wno-null-pointer-subtraction')
+     else:
+         # assume a standard gcc
+         extra_compile_args = ['-Werror', '-Wall', '-Wextra', '-Wconversion',

--- a/pkgs/development/python-modules/cffi/default.nix
+++ b/pkgs/development/python-modules/cffi/default.nix
@@ -50,6 +50,12 @@ if isPyPy then null else buildPythonPackage rec {
       ];
       hash = "sha256-+2daRTvxtyrCPimOEAmVbiVm1Bso9hxGbaAbd03E+ws=";
     })
+  ] ++ lib.optionals (stdenv.cc.isClang && lib.versionAtLeast (lib.getVersion stdenv.cc) "13") [
+    # -Wnull-pointer-subtraction is enabled with -Wextra. Suppress it to allow the following tests
+    # to run and pass when cffi is built with newer versions of clang:
+    # - testing/cffi1/test_verify1.py::test_enum_usage
+    # - testing/cffi1/test_verify1.py::test_named_pointer_as_argument
+    ./clang-pointer-substraction-warning.diff
   ] ++  lib.optionals (pythonAtLeast "3.11") [
     # Fix test that failed because python seems to have changed the exception format in the
     # final release. This patch should be included in the next version and can be removed when


### PR DESCRIPTION
###### Description of changes

cffi uses a technique to find the offset of a struct that causes newer clangs to issue a warning regarding null pointer subtraction. This patch silences the warning, so cffi can build.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
