### PR TITLE
darwin.adv_cmds: fix implicit int, which is an error in clang 16

### DIFF
--- a/pkgs/os-specific/darwin/apple-source-releases/adv_cmds/boot.nix
+++ b/pkgs/os-specific/darwin/apple-source-releases/adv_cmds/boot.nix
@@ -32,6 +32,9 @@ in appleDerivation {
 
     substituteInPlace Makefile --replace perl true
 
+    substituteInPlace colldef.tproj/scan.l \
+      --replace 'static orderpass = 0;' 'static int orderpass = 0;'
+
     for subproject in colldef mklocale monetdef msgdef numericdef timedef; do
       substituteInPlace usr-share-locale.tproj/$subproject/BSDmakefile \
         --replace /usr/share/locale "" \
@@ -42,6 +45,10 @@ in appleDerivation {
 
   preBuild = ''
     cp -r --no-preserve=all ${recentAdvCmds}/colldef .
+
+    substituteInPlace colldef/scan.l \
+      --replace 'static orderpass = 0;' 'static int orderpass = 0;'
+
     pushd colldef
     mv locale/collate.h .
     flex -t -8 -i scan.l > scan.c

--- a/pkgs/os-specific/darwin/apple-source-releases/adv_cmds/default.nix
+++ b/pkgs/os-specific/darwin/apple-source-releases/adv_cmds/default.nix
@@ -6,6 +6,8 @@ appleDerivation {
   patchPhase = ''
     substituteInPlace adv_cmds.xcodeproj/project.pbxproj \
       --replace '/usr/lib/libtermcap.dylib' 'libncurses.dylib'
+    substituteInPlace colldef/scan.l \
+      --replace 'static orderpass = 0;' 'static int orderpass = 0;'
   '';
 
   # pkill requires special private headers that are unavailable in


### PR DESCRIPTION
###### Description of changes

This was found while working on the Darwin stdenv bump. This is needed to build the stdenv with clang 16.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
