### PR TITLE
nss_esr: backport gcc-13 fix

### DIFF
--- a/pkgs/development/libraries/nss/gcc-13-esr.patch
+++ b/pkgs/development/libraries/nss/gcc-13-esr.patch
@@ -1,0 +1,44 @@
+https://bugzilla.mozilla.org/show_bug.cgi?id=1771273
+https://hg.mozilla.org/projects/nss/raw-rev/21e7aaa1f7d94bca15d997e5b4c2329b32fad21a
+
+# HG changeset patch
+# User Sergei Trofimovich <slyich@gmail.com>
+# Date 1653552519 0
+# Node ID 21e7aaa1f7d94bca15d997e5b4c2329b32fad21a
+# Parent  ad1046e9eee5f5dc17dac7c9343e2f7f0da44b4e
+Bug 1771273 - cpputil/databuffer.h: add missing <cstdint> include r=nss-reviewers,mt
+
+Without the change build fails on this week's gcc-13 snapshot as:
+
+    ../../cpputil/databuffer.h:20:20: error: 'uint8_t' does not name a type
+       20 |   DataBuffer(const uint8_t* d, size_t l) : data_(nullptr), len_(0) {
+          |                    ^~~~~~~
+    ../../cpputil/databuffer.h:14:1: note: 'uint8_t' is defined in header '<cstdint>'; did you forget to '#include <cstdint>'?
+       13 | #include <iostream>
+      +++ |+#include <cstdint>
+       14 |
+
+Differential Revision: https://phabricator.services.mozilla.com/D147404
+
+diff --git a/cpputil/databuffer.h b/cpputil/databuffer.h
+--- nss/cpputil/databuffer.h
++++ nss/cpputil/databuffer.h
+@@ -6,16 +6,17 @@
+ 
+ #ifndef databuffer_h__
+ #define databuffer_h__
+ 
+ #include <algorithm>
+ #include <cstring>
+ #include <iomanip>
+ #include <iostream>
++#include <cstdint>
+ 
+ namespace nss_test {
+ 
+ class DataBuffer {
+  public:
+   DataBuffer() : data_(nullptr), len_(0) {}
+   DataBuffer(const uint8_t* d, size_t l) : data_(nullptr), len_(0) {
+     Assign(d, l);
+

--- a/pkgs/development/libraries/nss/generic.nix
+++ b/pkgs/development/libraries/nss/generic.nix
@@ -47,6 +47,11 @@ stdenv.mkDerivation rec {
       ./85_security_load_3.85+.patch
     )
     ./fix-cross-compilation.patch
+  ] ++ lib.optionals (lib.versionOlder version "3.89") [
+    # Backport gcc-13 build fix:
+    #  https://bugzilla.mozilla.org/show_bug.cgi?id=1771273
+    #  https://hg.mozilla.org/projects/nss/raw-rev/21e7aaa1f7d94bca15d997e5b4c2329b32fad21a
+    ./gcc-13-esr.patch
   ];
 
   patchFlags = [ "-p0" ];


### PR DESCRIPTION
Without the change `nss` build on `gcc-13 `fails as:

    ../../cpputil/databuffer.h:20:20: error: 'uint8_t' does not name a type
       20 |   DataBuffer(const uint8_t* d, size_t l) : data_(nullptr), len_(0) {
          |                    ^~~~~~~
    ../../cpputil/databuffer.h:14:1: note: 'uint8_t' is defined in header '<cstdint>'; did you forget to '#include <cstdint>'?
       13 | #include <iostream>
      +++ |+#include <cstdint>
       14 |

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
