### PR TITLE
openexr: backport gcc-13 fix

### DIFF
--- a/pkgs/development/libraries/openexr/default.nix
+++ b/pkgs/development/libraries/openexr/default.nix
@@ -35,6 +35,10 @@ stdenv.mkDerivation rec {
       extraPrefix = "OpenEXR/IlmImf/";
       sha256 = "sha256-DrpldpNgN5pWKzIuuPIrynGX3EpP8YhJlu+lLfNFGxQ=";
     })
+
+    # Backport gcc-13 fix:
+    #   https://github.com/AcademySoftwareFoundation/openexr/pull/1264
+    ./gcc-13.patch
   ];
 
   # tests are determined to use /var/tmp on unix

--- a/pkgs/development/libraries/openexr/gcc-13.patch
+++ b/pkgs/development/libraries/openexr/gcc-13.patch
@@ -1,0 +1,33 @@
+https://github.com/AcademySoftwareFoundation/openexr/pull/1264
+https://github.com/AcademySoftwareFoundation/openexr/commit/d0088a3c6943a9a53fc24e29885414d082d531fe.patch
+
+--- a/OpenEXR/IlmImf/ImfDwaCompressor.cpp
++++ b/OpenEXR/IlmImf/ImfDwaCompressor.cpp
+@@ -159,6 +159,7 @@
+ #include <limits>
+ 
+ #include <cstddef>
++#include <cstdint>
+ 
+ 
+ // Windows specific addition to prevent the indirect import of the redefined min/max macros
+--- a/OpenEXR/IlmImf/ImfHuf.cpp
++++ b/OpenEXR/IlmImf/ImfHuf.cpp
+@@ -53,6 +53,7 @@
+ #include <cstring>
+ #include <cassert>
+ #include <algorithm>
++#include <cstdint>
+ 
+ 
+ using namespace std;
+--- a/OpenEXR/IlmImf/ImfMisc.cpp
++++ b/OpenEXR/IlmImf/ImfMisc.cpp
+@@ -52,6 +52,7 @@
+ #include <ImfConvert.h>
+ #include <ImfPartType.h>
+ #include <ImfTileDescription.h>
++#include <cstdint>
+ #include "ImfNamespace.h"
+ 
+ OPENEXR_IMF_INTERNAL_NAMESPACE_SOURCE_ENTER


### PR DESCRIPTION
Without the change `openexr` build on `gcc-13` fails as:

    [ 99%] Building CXX object src/test/OpenEXRTest/CMakeFiles/OpenEXRTest.dir/testInputPart.cpp.o
    openexr/src/bin/exrcheck/main.cpp: In function 'bool exrCheck(const char*, bool, bool, bool, bool)':
    openexr/src/bin/exrcheck/main.cpp:65:15: error: 'uintptr_t' does not name a type
       65 |         const uintptr_t kMaxSize = uintptr_t (-1) / 4;
          |               ^~~~~~~~~

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
