### PR TITLE
nlohmann_json: backport gcc-13 fix

### DIFF
--- a/pkgs/development/libraries/nlohmann_json/default.nix
+++ b/pkgs/development/libraries/nlohmann_json/default.nix
@@ -1,6 +1,7 @@
 { stdenv
 , lib
 , fetchFromGitHub
+, fetchpatch
 , cmake
 }:
 let
@@ -20,6 +21,24 @@ in stdenv.mkDerivation (finalAttrs: {
     rev = "v${finalAttrs.version}";
     hash = "sha256-SUdhIV7tjtacf5DkoWk9cnkfyMlrkg8ZU7XnPZd22Tw=";
   };
+
+  patches = [
+    # Backport fix for gcc-13:
+    #   https://github.com/nlohmann/json/pull/3895
+    (fetchpatch {
+      name = "gcc-13-rebind.patch";
+      url = "https://github.com/nlohmann/json/commit/a5b09d50b786638ed9deb09ef13860a3cb64eb6b.patch";
+      hash = "sha256-Jbi0VwZP+ZHTGbpIwgKCVc66gOmwjkT5iOUe85eIzM0=";
+    })
+
+    # Backport fix for gcc-13:
+    #   https://github.com/nlohmann/json/pull/3950
+    (fetchpatch {
+      name = "gcc-13-eq-op.patch";
+      url = "https://github.com/nlohmann/json/commit/a49829bd984c0282be18fcec070df0c31bf77dd5.patch";
+      hash = "sha256-D+cRtdN6AXr4z3/y9Ui7Zqp3e/y10tp+DOL80ZtPz5E=";
+    })
+  ];
 
   nativeBuildInputs = [ cmake ];
 


### PR DESCRIPTION
Without the change `nlohmann_json` build on `gcc-13 `fails as:

    In file included from <<NIX>>-gcc-13.0.0/include/c++/13.0.0/ext/alloc_traits.h:34,
                     from <<NIX>>-gcc-13.0.0/include/c++/13.0.0/bits/basic_string.h:39,
                     from <<NIX>>-gcc-13.0.0/include/c++/13.0.0/string:54,
                     from <<NIX>>-gcc-13.0.0/include/c++/13.0.0/bits/locale_classes.h:40,
                     from <<NIX>>-gcc-13.0.0/include/c++/13.0.0/locale:41,
                     from tests/src/unit-regression2.cpp:19:
    <<NIX>>-gcc-13.0.0/include/c++/13.0.0/bits/alloc_traits.h: In instantiation of 'struct std::__allocator_traits_base::__rebind<my_allocator<unsigned char>, unsigned char, void>':
    <<NIX>>-gcc-13.0.0/include/c++/13.0.0/bits/alloc_traits.h:94:11:   required by substitution of 'template<class _Alloc, class _Up> using std::__alloc_rebind = typename std::__allocator_traits_base::__rebind<_Alloc, _Up>::type [with _Alloc = my_allocator<unsigned char>; _Up = unsigned char]'
    <<NIX>>-gcc-13.0.0/include/c++/13.0.0/bits/alloc_traits.h:228:8:   required by substitution of 'template<class _Alloc> template<class _Tp> using std::allocator_traits< <template-parameter-1-1> >::rebind_alloc = std::__alloc_rebind<_Alloc, _Tp> [with _Tp = unsigned char; _Alloc = my_allocator<unsigned char>]'
    <<NIX>>-gcc-13.0.0/include/c++/13.0.0/ext/alloc_traits.h:126:65:   required from 'struct __gnu_cxx::__alloc_traits<my_allocator<unsigned char>, unsigned char>::rebind<unsigned char>'
    <<NIX>>-gcc-13.0.0/include/c++/13.0.0/bits/stl_vector.h:88:21:   required from 'struct std::_Vector_base<unsigned char, my_allocator<unsigned char> >'
    <<NIX>>-gcc-13.0.0/include/c++/13.0.0/bits/stl_vector.h:423:11:   required from 'class std::vector<unsigned char, my_allocator<unsigned char> >'
    tests/src/unit-regression2.cpp:807:63:   required from here
    <<NIX>>-gcc-13.0.0/include/c++/13.0.0/bits/alloc_traits.h:70:31: error: static assertion failed: allocator_traits<A>::rebind_alloc<A::value_type> must be A
       70 |                         _Tp>::value,
          |                               ^~~~~

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
