### PR TITLE
stdenv/setup.sh: deal with Nix < 2.4 structured attrs

### DIFF
--- a/pkgs/stdenv/generic/setup.sh
+++ b/pkgs/stdenv/generic/setup.sh
@@ -29,13 +29,23 @@ if [ -n "$__structuredAttrs" ]; then
         export "$outputName=${outputs[$outputName]}"
     done
 
+    # Before Nix 2.4, $NIX_ATTRS_*_FILE was named differently:
+    # https://github.com/NixOS/nix/commit/27ce722
+    if [[ -n "${ATTRS_JSON_FILE:-}" ]]; then
+        export NIX_ATTRS_JSON_FILE="$ATTRS_JSON_FILE"
+    fi
+
+    if [[ -n "${ATTRS_SH_FILE:-}" ]]; then
+        export NIX_ATTRS_SH_FILE="$ATTRS_SH_FILE"
+    fi
+
     # $NIX_ATTRS_JSON_FILE pointed to the wrong location in sandbox
     # https://github.com/NixOS/nix/issues/6736; please keep around until the
     # fix reaches *every patch version* that's >= lib/minver.nix
-    if ! [[ -e "$NIX_ATTRS_JSON_FILE" ]]; then
+    if ! [[ -e "${NIX_ATTRS_JSON_FILE:-}" ]]; then
         export NIX_ATTRS_JSON_FILE="$NIX_BUILD_TOP/.attrs.json"
     fi
-    if ! [[ -e "$NIX_ATTRS_SH_FILE" ]]; then
+    if ! [[ -e "${NIX_ATTRS_SH_FILE:-}" ]]; then
         export NIX_ATTRS_SH_FILE="$NIX_BUILD_TOP/.attrs.sh"
     fi
 else


### PR DESCRIPTION
Nix does not (as far it is documented) guarantee that NIX_ATTRS_*_FILE is set, the only [documented] guarantee seems to be:

> […] made available to the builder via the file .attrs.json in the
> builder’s temporary directory.

This guarantee is of course affected by https://github.com/NixOS/nix/issues/6736, so it seems to be prudent to fall back to the Nix 2.3 style ATTRS_*_FILE env vars before defaulting to the expected location in case neither is available.

See also:

- https://github.com/NixOS/nixpkgs/pull/214937#discussion_r1178101895
- https://github.com/nixos/nixpkgs/commit/afef6588e250

[documented]: https://nixos.org/manual/nix/stable/language/advanced-attributes.html#adv-attr-structuredAttrs

Tested `tests.stdenv.test-structured-env-attrset` with Nix 2.3 to verify.

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
