### PR TITLE
graphite2: disable broken 'nametabletest' (fails on gcc-13)

### DIFF
--- a/pkgs/development/libraries/silgraphite/graphite2.nix
+++ b/pkgs/development/libraries/silgraphite/graphite2.nix
@@ -21,6 +21,12 @@ stdenv.mkDerivation rec {
   buildInputs = [ freetype ];
 
   patches = lib.optionals stdenv.isDarwin [ ./macosx.patch ];
+  postPatch = ''
+    # disable broken 'nametabletest' test, fails on gcc-13:
+    #   https://github.com/silnrsi/graphite/pull/74
+    substituteInPlace tests/CMakeLists.txt \
+      --replace 'add_subdirectory(nametabletest)' '#add_subdirectory(nametabletest)'
+  '';
 
   cmakeFlags = lib.optionals static [
     "-DBUILD_SHARED_LIBS=OFF"


### PR DESCRIPTION
Without the change the test fails on gcc-13 as:

    $ ./tests/nametabletest/nametabletest
    tests/nametabletest/nametabletest.cpp:142:79: runtime error: index 5 out of bounds for type 'NameRecord [5]'
    ...
    tests/nametabletest/nametabletest.cpp:142:79: runtime error: index 7 out of bounds for type 'NameRecord [7]'
    ...

In https://github.com/silnrsi/graphite/pull/74 upstream agrees it's a problem in the test (and possibly the library). Let's disable the test itself until upstream fixes it completely.

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
