### PR TITLE
vscode-langservers-extracted: repackage with buildNpmPackage

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -9313,6 +9313,12 @@
     githubId = 5624721;
     name = "Ben Wolsieffer";
   };
+  lord-valen = {
+    name = "Lord Valen";
+    matrix = "@lord-valen:matrix.org";
+    github = "Lord-Valen";
+    githubId = 46138807;
+  };
   lorenz = {
     name = "Lorenz Brun";
     email = "lorenz@brun.one";

--- a/pkgs/development/node-packages/aliases.nix
+++ b/pkgs/development/node-packages/aliases.nix
@@ -46,4 +46,5 @@ mapAliases {
   manta = pkgs.node-manta; # Added 2023-05-06
   thelounge = pkgs.thelounge; # Added 2023-05-22
   triton = pkgs.triton; # Added 2023-05-06
+  vscode-langservers-extracted = pkgs.vscode-langservers-extracted; # Added 2023-05-27
 }

--- a/pkgs/development/node-packages/node-packages.json
+++ b/pkgs/development/node-packages/node-packages.json
@@ -380,7 +380,6 @@
 , "vscode-html-languageserver-bin"
 , "vscode-json-languageserver"
 , "vscode-json-languageserver-bin"
-, "vscode-langservers-extracted"
 , "vue-cli"
 , "vue-language-server"
 , "wavedrom-cli"

--- a/pkgs/development/tools/language-servers/vscode-langservers-extracted/default.nix
+++ b/pkgs/development/tools/language-servers/vscode-langservers-extracted/default.nix
@@ -1,0 +1,38 @@
+{ lib, buildNpmPackage, fetchFromGitHub, vscode }:
+
+buildNpmPackage rec {
+  pname = "vscode-langservers-extracted";
+  version = "4.7.0";
+
+  src = fetchFromGitHub {
+    owner = "hrsh7th";
+    repo = pname;
+    rev = "v${version}";
+    hash = "sha256-RLRDEHfEJ2ckn0HTMu0WbMK/o9W20Xwm+XI6kCq57u8=";
+  };
+
+  npmDepsHash = "sha256-QhiSj/DigsI4Bfwmk3wG4lDQOWuDDduc/sfJlXiEoGE=";
+
+  postPatch = ''
+    # TODO: Add vscode-eslint as a dependency
+    # Eliminate the vscode-eslint bin
+    sed -i '/^\s*"vscode-eslint-language-server":.*bin\//d' package.json package-lock.json
+  '';
+
+  buildPhase = let
+    extensions = "${vscode}/lib/vscode/resources/app/extensions";
+  in ''
+    npx babel ${extensions}/css-language-features/server/dist/* --out-dir lib/css-language-server/node/
+    npx babel ${extensions}/html-language-features/server/dist/* --out-dir lib/html-language-server/node/
+    npx babel ${extensions}/json-language-features/server/dist/* --out-dir lib/json-language-server/node/
+    npx babel ${extensions}/markdown-language-features/server/dist/* --out-dir lib/markdown-language-server/node/
+    mv lib/markdown-language-server/node/workerMain.js lib/markdown-language-server/node/main.js
+  '';
+
+  meta = with lib; {
+    description = "HTML/CSS/JSON/ESLint language servers extracted from vscode.";
+    homepage = "https://github.com/hrsh7th/vscode-langservers-extracted";
+    license = licenses.mit;
+    maintainers = with maintainers; [ lord-valen ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -17782,6 +17782,8 @@ with pkgs;
 
   verible = callPackage ../development/tools/language-servers/verible { };
 
+  vscode-langservers-extracted = callPackage ../development/tools/language-servers/vscode-langservers-extracted { };
+
   zls = callPackage ../development/tools/language-servers/zls {
     zig = buildPackages.zig_0_10;
   };


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Repackages nodePackages.vscode-langervers-extracted to be built using buildNpmPackage as per https://github.com/NixOS/nixpkgs/issues/229475. It was previously broken, and probably was since it was first added since there is no build script. Due to the background nature of LSPs, I guess nobody thought to check. This doesn't expose `vscode-eslint-language-server` as that requires the vscode-eslint package, which was not in the scope of this PR.

CC @winterqt

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
