### PR TITLE
minimal-bootstrap.heirloom: init at 070715

### DIFF
--- a/lib/licenses.nix
+++ b/lib/licenses.nix
@@ -215,6 +215,12 @@ in mkLicense lset) ({
     url = "https://opensource.org/licenses/CAL-1.0";
   };
 
+  caldera = {
+    spdxId = "Caldera";
+    fullName = "Caldera License";
+    url = "http://www.lemis.com/grog/UNIX/ancient-source-all.pdf";
+  };
+
   capec = {
     fullName = "Common Attack Pattern Enumeration and Classification";
     url = "https://capec.mitre.org/about/termsofuse.html";
@@ -554,6 +560,12 @@ in mkLicense lset) ({
   imlib2 = {
     spdxId = "Imlib2";
     fullName = "Imlib2 License";
+  };
+
+  info-zip = {
+    spdxId = "Info-ZIP";
+    fullName = "Info-ZIP License";
+    url = "http://www.info-zip.org/pub/infozip/license.html";
   };
 
   inria-compcert = {

--- a/pkgs/os-specific/linux/minimal-bootstrap/default.nix
+++ b/pkgs/os-specific/linux/minimal-bootstrap/default.nix
@@ -51,6 +51,11 @@ lib.makeScope
       tinycc = tinycc-mes;
     };
 
+    heirloom = callPackage ./heirloom {
+      bash = bash_2_05;
+      tinycc = tinycc-mes;
+    };
+
     heirloom-devtools = callPackage ./heirloom-devtools { tinycc = tinycc-mes; };
 
     ln-boot = callPackage ./ln-boot { };
@@ -75,6 +80,7 @@ lib.makeScope
       echo ${gnused.tests.get-version}
       echo ${gnutar.tests.get-version}
       echo ${gzip.tests.get-version}
+      echo ${heirloom.tests.get-version}
       echo ${mes.compiler.tests.get-version}
       echo ${tinycc-mes.compiler.tests.chain}
       mkdir ''${out}

--- a/pkgs/os-specific/linux/minimal-bootstrap/default.nix
+++ b/pkgs/os-specific/linux/minimal-bootstrap/default.nix
@@ -51,6 +51,8 @@ lib.makeScope
       tinycc = tinycc-mes;
     };
 
+    heirloom-devtools = callPackage ./heirloom-devtools { tinycc = tinycc-mes; };
+
     ln-boot = callPackage ./ln-boot { };
 
     mes = lib.recurseIntoAttrs (callPackage ./mes { });

--- a/pkgs/os-specific/linux/minimal-bootstrap/heirloom-devtools/default.nix
+++ b/pkgs/os-specific/linux/minimal-bootstrap/heirloom-devtools/default.nix
@@ -1,0 +1,97 @@
+{ lib
+, fetchurl
+, kaem
+, tinycc
+, gnumake
+, gnupatch
+, coreutils
+}:
+let
+  pname = "heirloom-devtools";
+  version = "070527";
+
+  src = fetchurl {
+    url = "mirror://sourceforge/heirloom/heirloom-devtools/heirloom-devtools-${version}.tar.bz2";
+    sha256 = "9f233d8b78e4351fe9dd2d50d83958a0e5af36f54e9818521458a08e058691ba";
+  };
+
+  # Thanks to the live-bootstrap project!
+  # See https://github.com/fosslinux/live-bootstrap/blob/d918b984ad6fe4fc7680f3be060fd82f8c9fddd9/sysa/heirloom-devtools-070527/heirloom-devtools-070527.kaem
+  liveBootstrap = "https://github.com/fosslinux/live-bootstrap/raw/d918b984ad6fe4fc7680f3be060fd82f8c9fddd9/sysa/heirloom-devtools-070527";
+
+  patches = [
+    # Remove all kinds of wchar support. Mes Libc does not support wchar in any form
+    (fetchurl {
+      url = "${liveBootstrap}/patches/yacc_remove_wchar.patch";
+      sha256 = "0wgiz02bb7xzjy2gnbjp8y31qy6rc4b29v01zi32zh9lw54j68hc";
+    })
+    # Similarly to yacc, remove wchar. See yacc patch for further information
+    (fetchurl {
+      url = "${liveBootstrap}/patches/lex_remove_wchar.patch";
+      sha256 = "168dfngi51ljjqgd55wbvmffaq61gk48gak50ymnl1br92qkp4zh";
+    })
+  ];
+in
+kaem.runCommand "${pname}-${version}" {
+  inherit pname version;
+
+  nativeBuildInputs = [
+    tinycc.compiler
+    gnumake
+    gnupatch
+    coreutils
+  ];
+
+  meta = with lib; {
+    description = "Portable yacc and lex derived from OpenSolaris";
+    homepage = "https://heirloom.sourceforge.net/devtools.html";
+    license = with licenses; [ cddl bsdOriginalUC caldera ];
+    maintainers = teams.minimal-bootstrap.members;
+    platforms = platforms.unix;
+  };
+} ''
+  # Unpack
+  unbz2 --file ${src} --output heirloom-devtools.tar
+  untar --file heirloom-devtools.tar
+  rm heirloom-devtools.tar
+  build=''${NIX_BUILD_TOP}/heirloom-devtools-${version}
+  cd ''${build}
+
+  # Patch
+  ${lib.concatLines (map (f: "patch -Np0 -i ${f}") patches)}
+
+  # Build yacc
+  cd yacc
+  make -f Makefile.mk \
+    CC="tcc -B ${tinycc.libs}/lib" \
+    AR="tcc -ar" \
+    CFLAGS="-DMAXPATHLEN=4096 -DEILSEQ=84 -DMB_LEN_MAX=100" \
+    LDFLAGS="-lgetopt" \
+    RANLIB=true \
+    LIBDIR=''${out}/lib
+
+  # Install yacc
+  install -D yacc ''${out}/bin/yacc
+  install -Dm 444 liby.a ''${out}/lib/liby.a
+  install -Dm 444 yaccpar ''${out}/lib/yaccpar
+
+  # Make yacc available to lex
+  PATH="''${out}/bin:''${PATH}"
+
+  # Build lex
+  cd ../lex
+  make -f Makefile.mk \
+    CC="tcc -B ${tinycc.libs}/lib" \
+    AR="tcc -ar" \
+    CFLAGS="-DEILSEQ=84 -DMB_LEN_MAX=100" \
+    LDFLAGS="-lgetopt" \
+    RANLIB=true \
+    LIBDIR=''${out}/lib
+
+  # Install lex
+  install -D lex ''${out}/bin/lex
+  install -Dm 444 ncform ''${out}/lib/lex/ncform
+  install -Dm 444 nceucform ''${out}/lib/lex/nceucform
+  install -Dm 444 nrform ''${out}/lib/lex/nrform
+  install -Dm 444 libl.a ''${out}/lib/libl.a
+''

--- a/pkgs/os-specific/linux/minimal-bootstrap/heirloom/cp-no-socket.patch
+++ b/pkgs/os-specific/linux/minimal-bootstrap/heirloom/cp-no-socket.patch
@@ -1,0 +1,84 @@
+--- cp/cp.c
++++ cp/cp.c
+@@ -42,8 +42,6 @@ static const char sccsid[] USED = "@(#)cp.sl	1.84 (gritter) 3/4/06";
+ 
+ #include	<sys/types.h>
+ #include	<sys/stat.h>
+-#include	<sys/socket.h>
+-#include	<sys/un.h>
+ #include	<sys/time.h>
+ #include	<sys/resource.h>
+ #include	<fcntl.h>
+@@ -427,6 +425,7 @@ fdcopy(const char *src, const struct stat *ssp, const int sfd,
+ #endif
+ 
+ #ifdef	__linux__
++#ifdef	O_DIRECT
+ 	if (!bflag && !Dflag && ssp->st_size > 0) {
+ 		long long	sent;
+ 
+@@ -436,6 +435,7 @@ fdcopy(const char *src, const struct stat *ssp, const int sfd,
+ 		if (sent < 0)
+ 			goto err;
+ 	}
++#endif
+ #endif	/* __linux__ */
+ 	if (pagesize == 0)
+ 		if ((pagesize = 4096) < 0)
+@@ -702,37 +702,6 @@ symlinkcopy(const char *src, const struct stat *ssp,
+ 	}
+ }
+ 
+-static void
+-socketcopy(const char *src, const struct stat *ssp,
+-		const char *tgt, const struct stat *dsp)
+-{
+-	int	fd, addrsz;
+-	struct sockaddr_un	addr;
+-	size_t	len;
+-
+-	if (do_unlink(tgt, dsp) != OKAY)
+-		return;
+-	len = strlen(tgt);
+-	memset(&addr, 0, sizeof addr);
+-	addr.sun_family = AF_UNIX;
+-	addrsz = sizeof addr - sizeof addr.sun_path + len;
+-	if ((len >= sizeof addr.sun_path ? errno = ENAMETOOLONG, fd = -1, 1 :
+-			(strncpy(addr.sun_path,tgt,sizeof addr.sun_path), 0)) ||
+-			(fd = socket(AF_UNIX, SOCK_STREAM, 0)) < 0 ||
+-			bind(fd, (struct sockaddr *)&addr, addrsz) < 0) {
+-		fprintf(stderr, "%s: cannot create socket %s\n%s: %s\n",
+-				progname, tgt,
+-				progname, strerror(errno));
+-		if (fd >= 0)
+-			close(fd);
+-		errcnt |= 01;
+-		return;
+-	}
+-	close(fd);
+-	if (pflag)
+-		permissions(tgt, ssp);
+-}
+-
+ static void
+ specialcopy(const char *src, const struct stat *ssp,
+ 		const char *tgt, const struct stat *dsp)
+@@ -748,9 +717,6 @@ specialcopy(const char *src, const struct stat *ssp,
+ 	case S_IFLNK:
+ 		symlinkcopy(src, ssp, tgt, dsp);
+ 		break;
+-	case S_IFSOCK:
+-		socketcopy(src, ssp, tgt, dsp);
+-		break;
+ 	case S_IFDOOR:
+ 		ignoring("door", src);
+ 		break;
+@@ -1043,7 +1009,7 @@ ln(const char *src, const char *tgt, struct stat *dsp, int level,
+ 		errcnt |= 01;
+ 		return;
+ 	}
+-#if (defined (SUS) || defined (S42)) && (defined (__linux__) || defined (__sun))
++#if (defined (SUS) || defined (S42)) && (defined (__linux__) || defined (__sun)) && !defined (__TINYC__)
+ 	if (sflag == 0) {
+ 		char	*rpbuf = alloca(PATH_MAX+1);
+ 		if (realpath(src, rpbuf) == NULL) {

--- a/pkgs/os-specific/linux/minimal-bootstrap/heirloom/default.nix
+++ b/pkgs/os-specific/linux/minimal-bootstrap/heirloom/default.nix
@@ -1,0 +1,130 @@
+{ lib
+, fetchurl
+, bash
+, tinycc
+, gnumake
+, gnupatch
+, heirloom-devtools
+, heirloom
+}:
+let
+  pname = "heirloom";
+  version = "070715";
+
+  src = fetchurl {
+    url = "mirror://sourceforge/heirloom/heirloom/${version}/heirloom-${version}.tar.bz2";
+    sha256 = "sha256-6zP3C8wBmx0OCkHx11UtRcV6FicuThxIY07D5ESWow8=";
+  };
+
+  patches = [
+    # we pre-generate nawk's proctab.c as meslibc is not capable of running maketab
+    # during build time (insufficient sscanf support)
+    ./proctab.patch
+
+    # disable utilities that don't build successfully
+    ./disable-programs.patch
+
+    # "tcc -ar" doesn't support creating empty archives
+    ./tcc-empty-ar.patch
+    # meslibc doesn't have seperate libm
+    ./dont-link-lm.patch
+    # meslibc's vprintf doesn't support %ll
+    ./vprintf.patch
+    # meslibc doesn't support sysconf()
+    ./sysconf.patch
+    # meslibc doesn't support locale
+    ./strcoll.patch
+    # meslibc doesn't support termios.h
+    ./termios.patch
+    # meslibc doesn't support utime.h
+    ./utime.patch
+    # meslibc doesn't support langinfo.h
+    ./langinfo.patch
+    # support building with meslibc
+    ./meslibc-support.patch
+    # remove socket functionality as unsupported by meslibc
+    ./cp-no-socket.patch
+  ];
+
+  makeFlags = [
+    # mk.config build options
+    "CC='tcc -B ${tinycc.libs}/lib -include ${./stubs.h} -include ${./musl.h}'"
+    "AR='tcc -ar'"
+    "RANLIB=true"
+    "STRIP=true"
+    "SHELL=${bash}/bin/sh"
+    "POSIX_SHELL=${bash}/bin/sh"
+    "DEFBIN=/bin"
+    "SV3BIN=/5bin"
+    "S42BIN=/5bin/s42"
+    "SUSBIN=/bin"
+    "SU3BIN=/5bin/posix2001"
+    "UCBBIN=/ucb"
+    "CCSBIN=/ccs/bin"
+    "DEFLIB=/lib"
+    "DEFSBIN=/bin"
+    "MANDIR=/share/man"
+    "LCURS=" # disable ncurses
+    "USE_ZLIB=0" # disable zlib
+    "IWCHAR='-I../libwchar'"
+    "LWCHAR='-L../libwchar -lwchar'"
+  ];
+in
+bash.runCommand "${pname}-${version}" {
+  inherit pname version;
+
+  nativeBuildInputs = [
+    tinycc.compiler
+    gnumake
+    gnupatch
+    heirloom-devtools
+  ];
+
+  passthru.sed =
+    bash.runCommand "${pname}-sed-${version}" {} ''
+      install -D ${heirloom}/bin/sed $out/bin/sed
+    '';
+
+  passthru.tests.get-version = result:
+    bash.runCommand "${pname}-get-version-${version}" {} ''
+      ${result}/bin/banner Hello Heirloom
+      mkdir $out
+    '';
+
+  meta = with lib; {
+    description = "The Heirloom Toolchest is a collection of standard Unix utilities";
+    homepage = "https://heirloom.sourceforge.net/tools.html";
+    license = with licenses; [
+      # All licenses according to LICENSE/
+      zlib
+      caldera
+      bsdOriginalUC
+      cddl
+      bsd3
+      gpl2Plus
+      lgpl21Plus
+      lpl-102
+      info-zip
+    ];
+    maintainers = teams.minimal-bootstrap.members;
+    platforms = platforms.unix;
+  };
+} ''
+  # Unpack
+  unbz2 --file ${src} --output heirloom.tar
+  untar --file heirloom.tar
+  rm heirloom.tar
+  cd heirloom-${version}
+
+  # Patch
+  ${lib.concatMapStringsSep "\n" (f: "patch -Np0 -i ${f}") patches}
+  cp ${./proctab.c} nawk/proctab.c
+
+  # Build
+  # These tools are required during later build steps
+  export PATH="$PATH:$PWD/ed:$PWD/nawk:$PWD/sed"
+  make ${lib.concatStringsSep " " makeFlags}
+
+  # Install
+  make install ROOT=$out ${lib.concatStringsSep " " makeFlags}
+''

--- a/pkgs/os-specific/linux/minimal-bootstrap/heirloom/disable-programs.patch
+++ b/pkgs/os-specific/linux/minimal-bootstrap/heirloom/disable-programs.patch
@@ -1,0 +1,43 @@
+--- makefile
++++ makefile
+@@ -1,21 +1,24 @@
+-SHELL = /bin/sh
++SHELL = sh
+ 
+-SUBDIRS = build libwchar libcommon libuxre _install \
+-	banner basename bc bdiff bfs \
+-	cal calendar cat chmod chown \
+-	cksum cmp col comm copy cp cpio csplit cut \
+-	date dc dd deroff diff diff3 dircmp dirname df du \
++SUBDIRS = libwchar libcommon libuxre _install \
++	banner basename bdiff bfs \
++	cat chmod chown \
++	cksum cmp col comm copy cp csplit cut \
++	dc dirname \
+ 	echo ed env expand expr \
+-	factor file find fmt fmtmsg fold \
+-	getconf getopt grep groups hd head hostname id join \
+-	kill line listusers ln logins logname ls \
+-	mail man mesg mkdir mkfifo mknod more mvdir \
+-	nawk news nice nl nohup oawk od \
+-	paste pathchk pg pgrep pr printenv printf priocntl ps psrinfo pwd \
+-	random renice rm rmdir \
+-	sdiff sed setpgrp shl sleep sort spell split stty su sum sync \
+-	tabs tail tapecntl tar tcopy tee test time touch tr true tsort tty \
+-	ul uname uniq units users wc what who whoami whodo xargs yes
++	file fmt fold \
++	getopt grep hd head join \
++	kill line ln logname ls \
++	mesg mkdir mknod \
++	nl nohup od \
++	paste pathchk pgrep pr printenv printf pwd \
++	random rm rmdir \
++	sed sleep sort split sum \
++	tee test touch tr true tsort tty \
++	uniq units wc what whoami xargs yes
++
++# These depend on some coreutils that we need to build first
++SUBDIRS += bc nawk build
+ 
+ dummy: makefiles all
+ 

--- a/pkgs/os-specific/linux/minimal-bootstrap/heirloom/dont-link-lm.patch
+++ b/pkgs/os-specific/linux/minimal-bootstrap/heirloom/dont-link-lm.patch
@@ -1,0 +1,44 @@
+--- csplit/Makefile.mk
++++ csplit/Makefile.mk
+@@ -1,19 +1,19 @@
+ all: csplit csplit_sus csplit_su3
+ 
+ csplit: csplit.o
+-	$(LD) $(LDFLAGS) csplit.o $(LCOMMON) $(LWCHAR) $(LIBS) -lm -o csplit
++	$(LD) $(LDFLAGS) csplit.o $(LCOMMON) $(LWCHAR) $(LIBS) -o csplit
+ 
+ csplit.o: csplit.c
+ 	$(CC) $(CFLAGS) $(CPPFLAGS) $(XO6FL) $(LARGEF) $(IWCHAR) $(ICOMMON) -c csplit.c
+ 
+ csplit_sus: csplit_sus.o
+-	$(LD) $(LDFLAGS) csplit_sus.o $(LUXRE) $(LCOMMON) $(LWCHAR) $(LIBS) -lm -o csplit_sus
++	$(LD) $(LDFLAGS) csplit_sus.o $(LUXRE) $(LCOMMON) $(LWCHAR) $(LIBS) -o csplit_sus
+ 
+ csplit_sus.o: csplit.c
+ 	$(CC) $(CFLAGS) $(CPPFLAGS) $(XO6FL) $(LARGEF) $(IUXRE) $(IWCHAR) $(ICOMMON) -DSUS -c csplit.c -o csplit_sus.o
+ 
+ csplit_su3: csplit_su3.o
+-	$(LD) $(LDFLAGS) csplit_su3.o $(LUXRE) $(LCOMMON) $(LWCHAR) $(LIBS) -lm -o csplit_su3
++	$(LD) $(LDFLAGS) csplit_su3.o $(LUXRE) $(LCOMMON) $(LWCHAR) $(LIBS) -o csplit_su3
+ 
+ csplit_su3.o: csplit.c
+ 	$(CC) $(CFLAGS) $(CPPFLAGS) $(XO6FL) $(LARGEF) $(IUXRE) $(IWCHAR) $(ICOMMON) -DSU3 -c csplit.c -o csplit_su3.o
+--- nawk/Makefile.mk
++++ nawk/Makefile.mk
+@@ -3,13 +3,13 @@ all: awk awk_sus awk_su3
+ OBJ = awk.lx.o b.o lib.o main.o parse.o proctab.o run.o tran.o
+ 
+ awk: awk.g.o $(OBJ) version.o
+-	$(LD) $(LDFLAGS) awk.g.o $(OBJ) version.o $(LUXRE) -lm $(LCOMMON) $(LWCHAR) $(LIBS) -o awk
++	$(LD) $(LDFLAGS) awk.g.o $(OBJ) version.o $(LUXRE) $(LCOMMON) $(LWCHAR) $(LIBS) -o awk
+ 
+ awk_sus: awk.g.o $(OBJ) version_sus.o
+-	$(LD) $(LDFLAGS) awk.g.o $(OBJ) version_sus.o $(LUXRE) -lm $(LCOMMON) $(LWCHAR) $(LIBS) -o awk_sus
++	$(LD) $(LDFLAGS) awk.g.o $(OBJ) version_sus.o $(LUXRE) $(LCOMMON) $(LWCHAR) $(LIBS) -o awk_sus
+ 
+ awk_su3: awk.g.2001.o $(OBJ) version_su3.o
+-	$(LD) $(LDFLAGS) awk.g.2001.o $(OBJ) version_su3.o $(LUXRE) -lm $(LCOMMON) $(LWCHAR) $(LIBS) -o awk_su3
++	$(LD) $(LDFLAGS) awk.g.2001.o $(OBJ) version_su3.o $(LUXRE) $(LCOMMON) $(LWCHAR) $(LIBS) -o awk_su3
+ 
+ awk.g.c: awk.g.y
+ 	$(YACC) -d awk.g.y

--- a/pkgs/os-specific/linux/minimal-bootstrap/heirloom/langinfo.patch
+++ b/pkgs/os-specific/linux/minimal-bootstrap/heirloom/langinfo.patch
@@ -1,0 +1,99 @@
+--- nawk/main.c
++++ nawk/main.c
+@@ -35,7 +35,6 @@
+ #include <errno.h>
+ #include <string.h>
+ #include <locale.h>
+-#include <langinfo.h>
+ #include <libgen.h>
+ 
+ #define	CMDCLASS	""/*"UX:"*/	/* Command classification */
+--- sort/sort.c
++++ sort/sort.c
+@@ -63,7 +63,6 @@ static const char sccsid[] USED = "@(#)sort.sl	1.37 (gritter) 5/29/05";
+ #include <locale.h>
+ #include <wchar.h>
+ #include <wctype.h>
+-#include <langinfo.h>
+ #include <inttypes.h>
+ #include <errno.h>
+ 
+@@ -287,18 +286,6 @@ main(int argc, char **argv)
+ 	else
+ 		chkblank();
+ 	compare = cmpf = ccoll ? mb_cur_max > 1 ? cmpm : cmpa : cmpl;
+-	setlocale(LC_NUMERIC, "");
+-	arg = nl_langinfo(RADIXCHAR);
+-	if (mb_cur_max > 1)
+-		next(radixchar, arg, i);
+-	else
+-		radixchar = *arg & 0377;
+-	arg = nl_langinfo(THOUSEP);
+-	if (mb_cur_max > 1)
+-		next(thousep, arg, i);
+-	else
+-		thousep = *arg & 0377;
+-	setlocale(LC_TIME, "");
+ 	fields = smalloc(NF * sizeof *fields);
+ 	copyproto();
+ 	eargv = argv;
+@@ -1088,8 +1075,7 @@ cmp(const char *i, const char *j)
+ 		} else {
+ 			sa = elicpy(collba, pa, la, '\n', ignore, code);
+ 			sb = elicpy(collbb, pb, lb, '\n', ignore, code);
+-			n = fp->Mflg ? monthcmp(collba, collbb) :
+-				strcoll(collba, collbb);
++			n = strcmp(collba, collbb);
+ 			if (n)
+ 				return n > 0 ? -fp->rflg : fp->rflg;
+ 			pa = &pa[sa];
+@@ -1570,49 +1556,6 @@ upcdup(const char *s)
+ 	return r;
+ }
+ 
+-static const char	*months[12];
+-
+-#define	COPY_ABMON(m)	months[m-1] = upcdup(nl_langinfo(ABMON_##m))
+-
+-static void
+-fillmonths(void)
+-{
+-	COPY_ABMON(1);
+-	COPY_ABMON(2);
+-	COPY_ABMON(3);
+-	COPY_ABMON(4);
+-	COPY_ABMON(5);
+-	COPY_ABMON(6);
+-	COPY_ABMON(7);
+-	COPY_ABMON(8);
+-	COPY_ABMON(9);
+-	COPY_ABMON(10);
+-	COPY_ABMON(11);
+-	COPY_ABMON(12);
+-}
+-
+-static int
+-monthcoll(const char *s)
+-{
+-	int	i;
+-	char	u[MB_LEN_MAX*3+1];
+-
+-	cpcu3(u, s);
+-	for (i = 0; i < 12; i++)
+-		if (strcmp(u, months[i]) == 0)
+-			return i;
+-	return 0;
+-}
+-
+-
+-static int
+-monthcmp(const char *pa, const char *pb)
+-{
+-	if (months[0] == NULL)
+-		fillmonths();
+-	return monthcoll(pa) - monthcoll(pb);
+-}
+-
+ /*
+  * isblank() consumes half of execution time (in skip()) with
+  * glibc 2.3.1. Check if it contains only space and tab, and

--- a/pkgs/os-specific/linux/minimal-bootstrap/heirloom/meslibc-support.patch
+++ b/pkgs/os-specific/linux/minimal-bootstrap/heirloom/meslibc-support.patch
@@ -1,0 +1,322 @@
+--- _install/install_ucb.c
++++ _install/install_ucb.c
+@@ -267,7 +267,7 @@ cp(const char *src, const char *tgt, struct stat *dsp)
+ 	if (check(src, tgt, dsp, &sst) != OKAY)
+ 		return;
+ 	unlink(tgt);
+-	if ((dfd = creat(tgt, 0700)) < 0 || fchmod(dfd, 0700) < 0 ||
++	if ((dfd = creat(tgt, 0700)) < 0 || chmod(tgt, 0700) < 0 ||
+ 			fstat(dfd, &nst) < 0) {
+ 		fprintf(stderr, "%s: %s: %s\n", progname, src,
+ 				strerror(errno));
+--- libcommon/Makefile.mk
++++ libcommon/Makefile.mk
+@@ -15,7 +15,7 @@ CHECK: CHECK.c
+ headers: CHECK
+ 	one() { \
+ 		rm -f "$$1.h"; \
+-		if grep "$$1_h[	 ]*=[ 	]*[^0][	 ]*;" CHECK >/dev/null; \
++		if true; \
+ 		then \
+ 			ln -s "_$$1.h" "$$1.h"; \
+ 		fi; \
+--- libcommon/atoll.h
++++ libcommon/atoll.h
+@@ -1,8 +1,10 @@
+ /*	Sccsid @(#)atoll.h	1.4 (gritter) 7/18/04	*/
+ 
+ #if defined (__hpux) || defined (_AIX) || \
+-	defined (__FreeBSD__) && (__FreeBSD__) < 5
++	(defined (__FreeBSD__) && (__FreeBSD__) < 5) || defined (__TINYC__)
++#ifndef __TINYC__
+ extern long long strtoll(const char *nptr, char **endptr, int base);
+ extern unsigned long long strtoull(const char *nptr, char **endptr, int base);
++#endif
+ extern long long atoll(const char *nptr);
+ #endif	/* __hpux || _AIX || __FreeBSD__ < 5 */
+--- libcommon/blank.h
++++ libcommon/blank.h
+@@ -5,7 +5,7 @@
+  */
+ /*	Sccsid @(#)blank.h	1.3 (gritter) 5/1/04	*/
+ 
+-#ifndef	__dietlibc__
++#if !defined(__dietlibc__) && !defined(__TINYC__)
+ #ifndef	LIBCOMMON_BLANK_H
+ #define	LIBCOMMON_BLANK_H	1
+ 
+--- libcommon/getdir.c
++++ libcommon/getdir.c
+@@ -52,7 +52,7 @@ extern int	getdents(int, struct dirent *, size_t);
+ #undef	d_ino
+ #endif	/* __FreeBSD__ || __NetBSD__ || __OpenBSD__ || __DragonFly__
+ 	 || __APPLE__ */
+-#elif defined	(__dietlibc__)
++#elif defined	(__dietlibc__) || defined(__TINYC__)
+ #include	<dirent.h>
+ #include	<unistd.h>
+ #else		/* !__GLIBC__, !__dietlibc__ */
+--- libcommon/memalign.c
++++ libcommon/memalign.c
+@@ -23,7 +23,7 @@
+ 
+ #if defined (__FreeBSD__) || defined (__dietlibc__) || defined (_AIX) || \
+ 	defined (__NetBSD__) || defined (__OpenBSD__) || \
+-	defined (__DragonFly__) || defined (__APPLE__)
++	defined (__DragonFly__) || defined (__APPLE__) || defined(__TINYC__)
+ /*
+  * FreeBSD malloc(3) promises to page-align the return of malloc() calls
+  * if size is at least a page. This serves for a poor man's memalign() 
+--- libcommon/memalign.h
++++ libcommon/memalign.h
+@@ -26,7 +26,7 @@
+ 
+ #if defined (__FreeBSD__) || defined (__dietlibc__) || defined (_AIX) || \
+ 	defined (__NetBSD__) || defined (__OpenBSD__) || \
+-	defined (__DragonFly__) || defined (__APPLE__)
++	defined (__DragonFly__) || defined (__APPLE__) || defined(__TINYC__)
+ #include	<stdlib.h>
+ 
+ extern void	*memalign(size_t, size_t);
+--- libcommon/pathconf.c
++++ libcommon/pathconf.c
+@@ -21,7 +21,7 @@
+  */
+ /*	Sccsid @(#)pathconf.c	1.2 (gritter) 5/1/04	*/
+ 
+-#ifdef	__dietlibc__
++#if defined(__dietlibc__) || defined(__TINYC__)
+ #include <unistd.h>
+ #include "pathconf.h"
+ 
+--- libcommon/pathconf.h
++++ libcommon/pathconf.h
+@@ -21,7 +21,7 @@
+  */
+ /*	Sccsid @(#)pathconf.h	1.2 (gritter) 5/1/04	*/
+ 
+-#ifdef	__dietlibc__
++#if defined(__dietlibc__) || defined(__TINYC__)
+ #include <unistd.h>
+ 
+ extern long	fpathconf(int, int);
+--- libcommon/regexp.h
++++ libcommon/regexp.h
+@@ -47,7 +47,7 @@
+ static const char regexp_h_sccsid[] REGEXP_H_USED =
+ 	"@(#)regexp.sl	1.56 (gritter) 5/29/05";
+ 
+-#if !defined (REGEXP_H_USED_FROM_VI) && !defined (__dietlibc__)
++#if !defined (REGEXP_H_USED_FROM_VI) && !defined (__dietlibc__) && !defined (__TINYC__)
+ #define	REGEXP_H_WCHARS
+ #endif
+ 
+--- libcommon/sfile.c
++++ libcommon/sfile.c
+@@ -21,7 +21,7 @@
+  */
+ /*	Sccsid @(#)sfile.c	1.9 (gritter) 6/7/04	*/
+ 
+-#ifdef	__linux__
++#if defined(__linux__) && !defined(__TINYC__)
+ #undef	_FILE_OFFSET_BITS
+ 
+ #include	<sys/types.h>
+--- libcommon/sighold.c
++++ libcommon/sighold.c
+@@ -22,7 +22,7 @@
+ /*	Sccsid @(#)sighold.c	1.7 (gritter) 1/22/06	*/
+ 
+ #if defined (__FreeBSD__) || defined (__dietlibc__) || defined (__NetBSD__) || \
+-	defined (__OpenBSD__) || defined (__DragonFly__) || defined (__APPLE__)
++	defined (__OpenBSD__) || defined (__DragonFly__) || defined (__APPLE__) || defined (__TINYC__)
+ #include <signal.h>
+ #include "sigset.h"
+ 
+--- libcommon/sigignore.c
++++ libcommon/sigignore.c
+@@ -22,7 +22,7 @@
+ /*	Sccsid @(#)sigignore.c	1.6 (gritter) 1/22/06	*/
+ 
+ #if defined (__FreeBSD__) || defined (__dietlibc__) || defined (__NetBSD__) || \
+-	defined (__OpenBSD__) || defined (__DragonFly__) || defined (__APPLE__)
++	defined (__OpenBSD__) || defined (__DragonFly__) || defined (__APPLE__) || defined (__TINYC__)
+ #include <signal.h>
+ #include "sigset.h"
+ 
+--- libcommon/sigpause.c
++++ libcommon/sigpause.c
+@@ -22,7 +22,7 @@
+ /*	Sccsid @(#)sigpause.c	1.6 (gritter) 1/22/06	*/
+ 
+ #if defined (__FreeBSD__) || defined (__dietlibc__) || defined (__NetBSD__) || \
+-	defined (__OpenBSD__) || defined (__DragonFly__) || defined (__APPLE__)
++	defined (__OpenBSD__) || defined (__DragonFly__) || defined (__APPLE__) || defined (__TINYC__)
+ #include <signal.h>
+ #include "sigset.h"
+ 
+--- libcommon/sigrelse.c
++++ libcommon/sigrelse.c
+@@ -22,7 +22,7 @@
+ /*	Sccsid @(#)sigrelse.c	1.8 (gritter) 1/22/06	*/
+ 
+ #if defined (__FreeBSD__) || defined (__dietlibc__) || defined (__NetBSD__) || \
+-	defined (__OpenBSD__) || defined (__DragonFly__) || defined (__APPLE__)
++	defined (__OpenBSD__) || defined (__DragonFly__) || defined (__APPLE__) || defined (__TINYC__)
+ #include <signal.h>
+ #include "sigset.h"
+ 
+--- libcommon/sigset.c
++++ libcommon/sigset.c
+@@ -22,7 +22,7 @@
+ /*	Sccsid @(#)sigset.c	1.7 (gritter) 1/22/06	*/
+ 
+ #if defined (__FreeBSD__) || defined (__dietlibc__) || defined (__NetBSD__) || \
+-	defined (__OpenBSD__) || defined (__DragonFly__) || defined (__APPLE__)
++	defined (__OpenBSD__) || defined (__DragonFly__) || defined (__APPLE__) || defined (__TINYC__)
+ #include <signal.h>
+ #include "sigset.h"
+ 
+@@ -46,10 +46,7 @@ void (*sigset(int sig, void (*func)(int)))(int)
+ 	if (sigaction(sig, func==SIG_HOLD?(struct sigaction *)0:&nact, &oact)
+ 			== -1)
+ 		return SIG_ERR;
+-	if (sigismember(&oset, sig))
+-		return SIG_HOLD;
+-	else
+-		return (oact.sa_handler);
++	return (oact.sa_handler);
+ }
+ #endif	/* __FreeBSD__ || __dietlibc__ || __NetBSD__ || __OpenBSD__ ||
+ 	__DragonFly__ || __APPLE__ */
+--- libcommon/sigset.h
++++ libcommon/sigset.h
+@@ -22,7 +22,7 @@
+ /*	Sccsid @(#)sigset.h	1.9 (gritter) 1/22/06	*/
+ 
+ #if defined (__FreeBSD__) || defined (__dietlibc__) || defined (__NetBSD__) || \
+-	defined (__OpenBSD__) || defined (__DragonFly__) || defined (__APPLE__)
++	defined (__OpenBSD__) || defined (__DragonFly__) || defined (__APPLE__) || defined (__TINYC__)
+ 
+ #ifndef	SIG_HOLD
+ #define	SIG_HOLD	((void (*)(int))2)
+--- libcommon/strtol.c
++++ libcommon/strtol.c
+@@ -1,7 +1,7 @@
+ /*	Sccsid @(#)strtol.c	1.6 (gritter) 7/18/04	*/
+ 
+ #if defined (__hpux) || defined (_AIX) || \
+-	defined (__FreeBSD__) && (__FreeBSD__) < 5
++	(defined (__FreeBSD__) && (__FreeBSD__) < 5) || defined (__TINYC__)
+ 
+ #include	<stdlib.h>
+ #include	<ctype.h>
+@@ -97,6 +97,7 @@ out:	if (pp <= bptr) {
+ 	return v * sign;
+ }
+ 
++#ifndef __TINYC__
+ long long
+ strtoll(const char *nptr, char **endptr, int base)
+ {
+@@ -108,6 +109,7 @@ strtoull(const char *nptr, char **endptr, int base)
+ {
+ 	return (unsigned long long)internal(nptr, endptr, base, 3);
+ }
++#endif
+ 
+ long long
+ atoll(const char *nptr)
+--- nawk/awk.h
++++ nawk/awk.h
+@@ -156,7 +156,6 @@ extern Cell	*rlengthloc;	/* RLENGTH */
+ #endif
+ 
+ #ifndef	IN_MAKETAB
+-#include <wchar.h>
+ 
+ /*
+  * Get next character from string s and store it in wc; n is set to
+--- nawk/awk.lx.l
++++ nawk/awk.lx.l
+@@ -71,7 +71,6 @@
+ 
+ #include	"awk.h"
+ #include	"y.tab.h"
+-#include	<pfmt.h>
+ #include	<unistd.h>
+ 
+ static void	awk_unputstr(const char *s);
+--- nawk/run.c
++++ nawk/run.c
+@@ -1467,14 +1467,6 @@ Cell *bltin(Node **a, int n)
+ 	case FRAND:
+ 		u = (Awkfloat) (rand() % 32767) / 32767.0;
+ 		break;
+-	case FSRAND:
+-		u = saved_srand; /* return previous seed */
+-		if (x->tval & REC)	/* no argument provided */
+-			saved_srand = time(NULL);
+-		else
+-			saved_srand = getfval(x);
+-		srand((int) saved_srand);
+-		break;
+ 	case FTOUPPER:
+ 	case FTOLOWER:
+ 		p = getsval(x);
+--- pgrep/pgrep.c
++++ pgrep/pgrep.c
+@@ -214,7 +214,7 @@ chdir_to_proc(void)
+ 		fprintf(stderr, "%s: cannot open %s\n", progname, PROCDIR);
+ 		exit(3);
+ 	}
+-	if (fchdir(fd) < 0) {
++	if (chdir(PROCDIR) < 0) {
+ 		fprintf(stderr, "%s: cannot chdir to %s\n", progname, PROCDIR);
+ 		exit(3);
+ 	}
+--- rm/rm.c
++++ rm/rm.c
+@@ -242,7 +242,7 @@ rm(size_t pend, const char *base, const int olddir, int ssub, int level)
+ 				}
+ 				return;
+ 			}
+-			if (fchdir(df) < 0) {
++			if (chdir(base) < 0) {
+ 				if (rmfile(base, &st) < 0) {
+ 					fprintf(stderr,
+ 						"%s: cannot chdir to %s\n",
+@@ -270,7 +270,7 @@ rm(size_t pend, const char *base, const int olddir, int ssub, int level)
+ 					progname, path);
+ 				errcnt |= 4;
+ 			}
+-			if (olddir >= 0 && fchdir(olddir) < 0) {
++			if (olddir >= 0) {
+ 				fprintf(stderr, "%s: cannot change backwards\n",
+ 						progname);
+ 				exit(1);
+@@ -316,24 +316,6 @@ subproc(size_t pend, const char *base, int level)
+ 		int status;
+ 
+ 		while (waitpid(pid, &status, 0) != pid);
+-		if (status && WIFSIGNALED(status)) {
+-			/*
+-			 * If the signal was sent due to a tty keypress,
+-			 * we should be terminated automatically and
+-			 * never reach this point. Otherwise, we terminate
+-			 * with the same signal, but make sure that we do
+-			 * not overwrite a possibly generated core file.
+-			 * This results in nearly the usual behavior except
+-			 * that the shell never prints a 'core dumped'
+-			 * message.
+-			 */
+-			struct rlimit	rl;
+-
+-			rl.rlim_cur = rl.rlim_max = 0;
+-			setrlimit(RLIMIT_CORE, &rl);
+-			raise(WTERMSIG(status));
+-			pause();
+-		}
+ 		return status ? WEXITSTATUS(status) : 0;
+ 	}
+ 	case -1:

--- a/pkgs/os-specific/linux/minimal-bootstrap/heirloom/musl.h
+++ b/pkgs/os-specific/linux/minimal-bootstrap/heirloom/musl.h
@@ -1,0 +1,53 @@
+/*
+  Copyright © 2005-2019 Rich Felker, et al.
+
+  Permission is hereby granted, free of charge, to any person obtaining
+  a copy of this software and associated documentation files (the
+  "Software"), to deal in the Software without restriction, including
+  without limitation the rights to use, copy, modify, merge, publish,
+  distribute, sublicense, and/or sell copies of the Software, and to
+  permit persons to whom the Software is furnished to do so, subject to
+  the following conditions:
+
+  The above copyright notice and this permission notice shall be
+  included in all copies or substantial portions of the Software.
+
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+  EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+  MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+  IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+  CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+  TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+  SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*/
+
+// Additional utilities from musl 1.1.24
+
+// include/stdlib.h
+#define WEXITSTATUS(s) (((s) & 0xff00) >> 8)
+#define WTERMSIG(s) ((s) & 0x7f)
+#define WIFEXITED(s) (!WTERMSIG(s))
+#define WIFSIGNALED(s) (((s)&0xffff)-1U < 0xffu)
+
+// include/sys/sysmacros.h
+#define major(x) \
+	((unsigned)( (((x)>>31>>1) & 0xfffff000) | (((x)>>8) & 0x00000fff) ))
+#define minor(x) \
+	((unsigned)( (((x)>>12) & 0xffffff00) | ((x) & 0x000000ff) ))
+#define makedev(x,y) ( \
+        (((x)&0xfffff000ULL) << 32) | \
+	(((x)&0x00000fffULL) << 8) | \
+        (((y)&0xffffff00ULL) << 12) | \
+	(((y)&0x000000ffULL)) )
+
+// src/misc/basename.c
+#include <string.h>
+char *basename(char *s)
+{
+	size_t i;
+	if (!s || !*s) return ".";
+	i = strlen(s)-1;
+	for (; i&&s[i]=='/'; i--) s[i] = 0;
+	for (; i&&s[i-1]!='/'; i--);
+	return s+i;
+}

--- a/pkgs/os-specific/linux/minimal-bootstrap/heirloom/proctab.c
+++ b/pkgs/os-specific/linux/minimal-bootstrap/heirloom/proctab.c
@@ -1,0 +1,205 @@
+#include <stdio.h>
+#include "awk.h"
+#include "y.tab.h"
+
+static unsigned char *printname[92] = {
+	(unsigned char *) "FIRSTTOKEN",	/* 258 */
+	(unsigned char *) "PROGRAM",	/* 259 */
+	(unsigned char *) "PASTAT",	/* 260 */
+	(unsigned char *) "PASTAT2",	/* 261 */
+	(unsigned char *) "XBEGIN",	/* 262 */
+	(unsigned char *) "XEND",	/* 263 */
+	(unsigned char *) "NL",	/* 264 */
+	(unsigned char *) "ARRAY",	/* 265 */
+	(unsigned char *) "MATCH",	/* 266 */
+	(unsigned char *) "NOTMATCH",	/* 267 */
+	(unsigned char *) "MATCHOP",	/* 268 */
+	(unsigned char *) "FINAL",	/* 269 */
+	(unsigned char *) "DOT",	/* 270 */
+	(unsigned char *) "ALL",	/* 271 */
+	(unsigned char *) "CCL",	/* 272 */
+	(unsigned char *) "NCCL",	/* 273 */
+	(unsigned char *) "CHAR",	/* 274 */
+	(unsigned char *) "MCHAR",	/* 275 */
+	(unsigned char *) "OR",	/* 276 */
+	(unsigned char *) "STAR",	/* 277 */
+	(unsigned char *) "QUEST",	/* 278 */
+	(unsigned char *) "PLUS",	/* 279 */
+	(unsigned char *) "AND",	/* 280 */
+	(unsigned char *) "BOR",	/* 281 */
+	(unsigned char *) "APPEND",	/* 282 */
+	(unsigned char *) "EQ",	/* 283 */
+	(unsigned char *) "GE",	/* 284 */
+	(unsigned char *) "GT",	/* 285 */
+	(unsigned char *) "LE",	/* 286 */
+	(unsigned char *) "LT",	/* 287 */
+	(unsigned char *) "NE",	/* 288 */
+	(unsigned char *) "IN",	/* 289 */
+	(unsigned char *) "ARG",	/* 290 */
+	(unsigned char *) "BLTIN",	/* 291 */
+	(unsigned char *) "BREAK",	/* 292 */
+	(unsigned char *) "CONTINUE",	/* 293 */
+	(unsigned char *) "DELETE",	/* 294 */
+	(unsigned char *) "DO",	/* 295 */
+	(unsigned char *) "EXIT",	/* 296 */
+	(unsigned char *) "FOR",	/* 297 */
+	(unsigned char *) "FUNC",	/* 298 */
+	(unsigned char *) "SUB",	/* 299 */
+	(unsigned char *) "GSUB",	/* 300 */
+	(unsigned char *) "IF",	/* 301 */
+	(unsigned char *) "INDEX",	/* 302 */
+	(unsigned char *) "LSUBSTR",	/* 303 */
+	(unsigned char *) "MATCHFCN",	/* 304 */
+	(unsigned char *) "NEXT",	/* 305 */
+	(unsigned char *) "ADD",	/* 306 */
+	(unsigned char *) "MINUS",	/* 307 */
+	(unsigned char *) "MULT",	/* 308 */
+	(unsigned char *) "DIVIDE",	/* 309 */
+	(unsigned char *) "MOD",	/* 310 */
+	(unsigned char *) "ASSIGN",	/* 311 */
+	(unsigned char *) "ASGNOP",	/* 312 */
+	(unsigned char *) "ADDEQ",	/* 313 */
+	(unsigned char *) "SUBEQ",	/* 314 */
+	(unsigned char *) "MULTEQ",	/* 315 */
+	(unsigned char *) "DIVEQ",	/* 316 */
+	(unsigned char *) "MODEQ",	/* 317 */
+	(unsigned char *) "POWEQ",	/* 318 */
+	(unsigned char *) "PRINT",	/* 319 */
+	(unsigned char *) "PRINTF",	/* 320 */
+	(unsigned char *) "SPRINTF",	/* 321 */
+	(unsigned char *) "ELSE",	/* 322 */
+	(unsigned char *) "INTEST",	/* 323 */
+	(unsigned char *) "CONDEXPR",	/* 324 */
+	(unsigned char *) "POSTINCR",	/* 325 */
+	(unsigned char *) "PREINCR",	/* 326 */
+	(unsigned char *) "POSTDECR",	/* 327 */
+	(unsigned char *) "PREDECR",	/* 328 */
+	(unsigned char *) "VAR",	/* 329 */
+	(unsigned char *) "IVAR",	/* 330 */
+	(unsigned char *) "VARNF",	/* 331 */
+	(unsigned char *) "CALL",	/* 332 */
+	(unsigned char *) "NUMBER",	/* 333 */
+	(unsigned char *) "STRING",	/* 334 */
+	(unsigned char *) "FIELD",	/* 335 */
+	(unsigned char *) "REGEXPR",	/* 336 */
+	(unsigned char *) "GETLINE",	/* 337 */
+	(unsigned char *) "RETURN",	/* 338 */
+	(unsigned char *) "SPLIT",	/* 339 */
+	(unsigned char *) "SUBSTR",	/* 340 */
+	(unsigned char *) "WHILE",	/* 341 */
+	(unsigned char *) "CAT",	/* 342 */
+	(unsigned char *) "NOT",	/* 343 */
+	(unsigned char *) "UMINUS",	/* 344 */
+	(unsigned char *) "POWER",	/* 345 */
+	(unsigned char *) "DECR",	/* 346 */
+	(unsigned char *) "INCR",	/* 347 */
+	(unsigned char *) "INDIRECT",	/* 348 */
+	(unsigned char *) "LASTTOKEN",	/* 349 */
+};
+
+
+Cell *(*proctab[92])(Node **, int) = {
+	nullproc,	/* FIRSTTOKEN */
+	program,	/* PROGRAM */
+	pastat,	/* PASTAT */
+	dopa2,	/* PASTAT2 */
+	nullproc,	/* XBEGIN */
+	nullproc,	/* XEND */
+	nullproc,	/* NL */
+	array,	/* ARRAY */
+	matchop,	/* MATCH */
+	matchop,	/* NOTMATCH */
+	nullproc,	/* MATCHOP */
+	nullproc,	/* FINAL */
+	nullproc,	/* DOT */
+	nullproc,	/* ALL */
+	nullproc,	/* CCL */
+	nullproc,	/* NCCL */
+	nullproc,	/* CHAR */
+	nullproc,	/* MCHAR */
+	nullproc,	/* OR */
+	nullproc,	/* STAR */
+	nullproc,	/* QUEST */
+	nullproc,	/* PLUS */
+	boolop,	/* AND */
+	boolop,	/* BOR */
+	nullproc,	/* APPEND */
+	relop,	/* EQ */
+	relop,	/* GE */
+	relop,	/* GT */
+	relop,	/* LE */
+	relop,	/* LT */
+	relop,	/* NE */
+	instat,	/* IN */
+	arg,	/* ARG */
+	bltin,	/* BLTIN */
+	jump,	/* BREAK */
+	jump,	/* CONTINUE */
+	delete,	/* DELETE */
+	dostat,	/* DO */
+	jump,	/* EXIT */
+	forstat,	/* FOR */
+	nullproc,	/* FUNC */
+	sub,	/* SUB */
+	gsub,	/* GSUB */
+	ifstat,	/* IF */
+	sindex,	/* INDEX */
+	nullproc,	/* LSUBSTR */
+	matchop,	/* MATCHFCN */
+	jump,	/* NEXT */
+	arith,	/* ADD */
+	arith,	/* MINUS */
+	arith,	/* MULT */
+	arith,	/* DIVIDE */
+	arith,	/* MOD */
+	assign,	/* ASSIGN */
+	nullproc,	/* ASGNOP */
+	assign,	/* ADDEQ */
+	assign,	/* SUBEQ */
+	assign,	/* MULTEQ */
+	assign,	/* DIVEQ */
+	assign,	/* MODEQ */
+	assign,	/* POWEQ */
+	print,	/* PRINT */
+	aprintf,	/* PRINTF */
+	awsprintf,	/* SPRINTF */
+	nullproc,	/* ELSE */
+	intest,	/* INTEST */
+	condexpr,	/* CONDEXPR */
+	incrdecr,	/* POSTINCR */
+	incrdecr,	/* PREINCR */
+	incrdecr,	/* POSTDECR */
+	incrdecr,	/* PREDECR */
+	nullproc,	/* VAR */
+	nullproc,	/* IVAR */
+	getnf,	/* VARNF */
+	call,	/* CALL */
+	nullproc,	/* NUMBER */
+	nullproc,	/* STRING */
+	nullproc,	/* FIELD */
+	nullproc,	/* REGEXPR */
+	getline,	/* GETLINE */
+	jump,	/* RETURN */
+	split,	/* SPLIT */
+	substr,	/* SUBSTR */
+	whilestat,	/* WHILE */
+	cat,	/* CAT */
+	boolop,	/* NOT */
+	arith,	/* UMINUS */
+	arith,	/* POWER */
+	nullproc,	/* DECR */
+	nullproc,	/* INCR */
+	indirect,	/* INDIRECT */
+	nullproc,	/* LASTTOKEN */
+};
+
+unsigned char *tokname(int n)
+{
+	static unsigned char buf[100];
+
+	if (n < FIRSTTOKEN || n > LASTTOKEN) {
+		snprintf((char *)buf, sizeof buf, "token %d", n);
+		return buf;
+	}
+	return printname[n-257];
+}

--- a/pkgs/os-specific/linux/minimal-bootstrap/heirloom/proctab.patch
+++ b/pkgs/os-specific/linux/minimal-bootstrap/heirloom/proctab.patch
@@ -1,0 +1,11 @@
+--- nawk/Makefile.mk
++++ nawk/Makefile.mk
+@@ -28,8 +28,6 @@ maketab: maketab.o
+ 	$(HOSTCC) maketab.o -o maketab
+ 	./maketab > proctab.c
+ 
+-proctab.c: maketab
+-
+ awk.g.o: awk.g.c
+ 	$(CC) $(CFLAGSS) $(CPPFLAGS) $(XO5FL) $(LARGEF) $(IWCHAR) $(ICOMMON) $(IUXRE) -c awk.g.c
+ 

--- a/pkgs/os-specific/linux/minimal-bootstrap/heirloom/strcoll.patch
+++ b/pkgs/os-specific/linux/minimal-bootstrap/heirloom/strcoll.patch
@@ -1,0 +1,73 @@
+--- comm/comm.c
++++ comm/comm.c
+@@ -242,7 +242,7 @@ compare(const char *a, const char *b)
+ 			return(2);
+ 		}
+ 	} else {
+-		n = strcoll(a, b);
++		n = strcmp(a, b);
+ 		return n ? n > 0 ? 2 : 1 : 0;
+ 	}
+ }
+--- expr/expr.y
++++ expr/expr.y
+@@ -234,7 +234,7 @@ _rel(int op, register char *r1, register char *r2)
+ 	if (numeric(r1) && numeric(r2))
+ 		i = atoll(r1) - atoll(r2);
+ 	else
+-		i = strcoll(r1, r2);
++		i = strcmp(r1, r2);
+ 	switch(op) {
+ 	case EQ: i = i==0; break;
+ 	case GT: i = i>0; break;
+--- join/join.c
++++ join/join.c
+@@ -65,7 +65,7 @@ enum {
+ 	JF = -1
+ };
+ #define	ppi(f, j)	((j) >= 0 && (j) < ppisize[f] ? ppibuf[f][j] : null)
+-#define comp() strcoll(ppi(F1, j1),ppi(F2, j2))
++#define comp() strcmp(ppi(F1, j1),ppi(F2, j2))
+ 
+ #define	next(wc, s, n)	(*(s) & 0200 ? ((n) = mbtowi(&(wc), (s), mb_cur_max), \
+ 		(n) = ((n) > 0 ? (n) : (n) < 0 ? (wc=WEOF, 1) : 1)) : \
+--- ls/ls.c
++++ ls/ls.c
+@@ -575,13 +575,13 @@ _mergesort(struct file **al)
+ static int
+ namecmp(struct file *f1, struct file *f2)
+ {
+-	return strcoll(f1->name, f2->name);
++	return strcmp(f1->name, f2->name);
+ }
+ 
+ static int
+ extcmp(struct file *f1, struct file *f2)
+ {
+-	return strcoll(extension(f1->name), extension(f2->name));
++	return strcmp(extension(f1->name), extension(f2->name));
+ }
+ 
+ static int
+--- nawk/run.c
++++ nawk/run.c
+@@ -608,7 +608,7 @@ Cell *relop(Node **a, int n)
+ 		j = x->fval - y->fval;
+ 		i = j<0? -1: (j>0? 1: 0);
+ 	} else {
+-		i = strcoll((char*)getsval(x), (char*)getsval(y));
++		i = strcmp((char*)getsval(x), (char*)getsval(y));
+ 	}
+ 	tempfree(x, "");
+ 	tempfree(y, "");
+--- sort/sort.c
++++ sort/sort.c
+@@ -1148,7 +1148,7 @@ cmpl(const char *pa, const char *pb)
+ 
+ 	ecpy(collba, pa, '\n');
+ 	ecpy(collbb, pb, '\n');
+-	n = strcoll(collba, collbb);
++	n = strcmp(collba, collbb);
+ 	return n ? n > 0 ? -fields[0].rflg : fields[0].rflg : 0;
+ }
+ 

--- a/pkgs/os-specific/linux/minimal-bootstrap/heirloom/stubs.h
+++ b/pkgs/os-specific/linux/minimal-bootstrap/heirloom/stubs.h
@@ -1,0 +1,64 @@
+#include <getopt.h>
+extern int optopt;
+
+int ftruncate(int fd, int offset) {
+  return -1;
+}
+
+int getsid (int pid) {
+  return -1;
+}
+
+static int isblank(int c)
+{
+	return c == ' ' || c == '\t';
+}
+
+#define lchown chown
+
+// meslibc implements lstat but is missing declaration
+#include <sys/stat.h>
+int lstat (char const *file_name, struct stat *statbuf);
+
+#include <fcntl.h>
+int mkstemp(char *t)
+{
+  mktemp(t);
+  int fd = open(t, O_CREAT|O_RDWR|O_TRUNC, 0600);
+  return fd;
+}
+
+int putenv(char *string)
+{
+  return 0;
+}
+
+char* realpath (char* path, char* resolved) {
+  return NULL;
+}
+
+#define strncasecmp(a,b,n) strncmp(strupr(a),strupr(b),n)
+
+
+#define nlink_t unsigned long
+
+#include <limits.h>
+#define USHRT_MAX UINT16_MAX
+#define SSIZE_MAX LONG_MAX
+#define MB_LEN_MAX 1 
+
+#define EPERM 1
+#define ESRCH 3
+#define EDOM 33
+#define S_IFSOCK 0140000
+#define S_ISVTX 01000
+#define S_IREAD S_IRUSR
+#define S_IWRITE S_IWUSR
+#define S_IEXEC S_IXUSR
+
+#define _PC_PATH_MAX PATH_MAX
+#define _PC_VDISABLE 8
+#define _POSIX_PATH_MAX PATH_MAX
+#define LINE_MAX 4096
+
+#define LC_TIME 0

--- a/pkgs/os-specific/linux/minimal-bootstrap/heirloom/sysconf.patch
+++ b/pkgs/os-specific/linux/minimal-bootstrap/heirloom/sysconf.patch
@@ -1,0 +1,77 @@
+--- cmp/cmp.c
++++ cmp/cmp.c
+@@ -264,7 +264,7 @@ openfile(const char *fn)
+ 	struct file	*f;
+ 
+ 	if (pagesize == 0)
+-		if ((pagesize = sysconf(_SC_PAGESIZE)) < 0)
++		if ((pagesize = 4096) < 0)
+ 			pagesize = 4096;
+ 	if ((f = memalign(pagesize, sizeof *f)) == NULL) {
+ 		write(2, "no memory\n", 10);
+--- copy/copy.c
++++ copy/copy.c
+@@ -362,7 +362,7 @@ fdcopy(const char *src, const struct stat *sp, int sfd,
+ 			goto err;
+ 	}
+ #endif	/* __linux__ */
+-	if (pagesize == 0 && (pagesize = sysconf(_SC_PAGESIZE)) <= 0)
++	if (pagesize == 0 && (pagesize = 4096) <= 0)
+ 		pagesize = 4096;
+ 	if ((blksize = sp->st_blksize) <= 0)
+ 		blksize = 512;
+--- cp/cp.c
++++ cp/cp.c
+@@ -438,7 +438,7 @@ fdcopy(const char *src, const struct stat *ssp, const int sfd,
+ 	}
+ #endif	/* __linux__ */
+ 	if (pagesize == 0)
+-		if ((pagesize = sysconf(_SC_PAGESIZE)) < 0)
++		if ((pagesize = 4096) < 0)
+ 			pagesize = 4096;
+ 	if (bflag)
+ 		blksize = bflag;
+--- libcommon/ib_alloc.c
++++ libcommon/ib_alloc.c
+@@ -41,7 +41,7 @@ ib_alloc(int fd, unsigned blksize)
+ 	struct stat	st;
+ 
+ 	if (pagesize == 0)
+-		if ((pagesize = sysconf(_SC_PAGESIZE)) < 0)
++		if ((pagesize = 4096) < 0)
+ 			pagesize = 4096;
+ 	if (blksize == 0) {
+ 		if (fstat(fd, &st) < 0)
+--- libcommon/memalign.c
++++ libcommon/memalign.c
+@@ -40,7 +40,7 @@ memalign(size_t alignment, size_t size)
+ 	static long	pagesize;
+ 
+ 	if (pagesize == 0)
+-		pagesize = sysconf(_SC_PAGESIZE);
++		pagesize = 4096;
+ 	if (alignment != pagesize)
+ 		return NULL;
+ 	if (size < pagesize)
+--- libcommon/oblok.c
++++ libcommon/oblok.c
+@@ -100,7 +100,7 @@ ob_alloc(int fd, enum ob_mode bf)
+ 	struct oblok	*op;
+ 
+ 	if (pagesize == 0)
+-		if ((pagesize = sysconf(_SC_PAGESIZE)) < 0)
++		if ((pagesize = 4096) < 0)
+ 			pagesize = 4096;
+ 	if ((op = memalign(pagesize, sizeof *op)) == NULL)
+ 		return NULL;
+--- xargs/xargs.c
++++ xargs/xargs.c
+@@ -404,7 +404,7 @@ static void
+ endcmd(void)
+ {
+ 	a_agg = a_cnt;
+-	a_maxsize = sysconf(_SC_ARG_MAX) - envsz() - 2048 - a_asz;
++	a_maxsize = 65536 - envsz() - 2048 - a_asz;
+ 	if (nflag || sflag) {
+ 		long	newsize = sflag ? atol(sflag) :
+ #ifdef	WEIRD_LIMITS

--- a/pkgs/os-specific/linux/minimal-bootstrap/heirloom/tcc-empty-ar.patch
+++ b/pkgs/os-specific/linux/minimal-bootstrap/heirloom/tcc-empty-ar.patch
@@ -1,0 +1,11 @@
+--- libwchar/Makefile.mk
++++ libwchar/Makefile.mk
+@@ -10,7 +10,7 @@ fake:
+ 	if test "x$(LWCHAR)" = x; \
+ 	then \
+ 		touch $(OBJ); \
+-		ar r libwchar.a $(OBJ); \
++		touch libwchar.a $(OBJ); \
+ 	fi
+ 
+ install:

--- a/pkgs/os-specific/linux/minimal-bootstrap/heirloom/termios.patch
+++ b/pkgs/os-specific/linux/minimal-bootstrap/heirloom/termios.patch
@@ -1,0 +1,141 @@
+--- ed/ed.c
++++ ed/ed.c
+@@ -68,7 +68,6 @@ static const char sccsid[] USED = "@(#)ed.sl	1.99 (gritter) 7/27/06";
+ #include <stdlib.h>
+ #include <signal.h>
+ #include "sigset.h"
+-#include <termios.h>
+ #include <setjmp.h>
+ #include <libgen.h>
+ #include <inttypes.h>
+@@ -77,7 +76,6 @@ static const char sccsid[] USED = "@(#)ed.sl	1.99 (gritter) 7/27/06";
+ #include <ctype.h>
+ #include <wctype.h>
+ #include <limits.h>
+-#include <termios.h>
+ static int	FNSIZE;
+ static int	LBSIZE;
+ static int	RHSIZE;
+@@ -2273,22 +2271,10 @@ sclose(int fd)
+ static void
+ fspec(const char *lp)
+ {
+-	struct termios	ts;
+ 	const char	*cp;
+ 
+ 	freetabs();
+ 	maxlength = 0;
+-	if (tcgetattr(1, &ts) < 0
+-#ifdef	TAB3
+-			|| (ts.c_oflag&TAB3) == 0
+-#endif
+-			)
+-		return;
+-	while (lp[0]) {
+-		if (lp[0] == '<' && lp[1] == ':')
+-			break;
+-		lp++;
+-	}
+ 	if (lp[0]) {
+ 		lp += 2;
+ 		while ((cp = ftok(&lp)) != NULL) {
+--- ls/ls.c
++++ ls/ls.c
+@@ -102,7 +102,6 @@ static char ifmt_c[] = "-pc-d-b--nl-SD--";
+ #include <grp.h>
+ #include <errno.h>
+ #include <fcntl.h>
+-#include <termios.h>
+ #include <locale.h>
+ #include <limits.h>
+ #include <ctype.h>
+@@ -110,14 +109,6 @@ static char ifmt_c[] = "-pc-d-b--nl-SD--";
+ #include <wchar.h>
+ #include <wctype.h>
+ #include "config.h"
+-#ifndef	USE_TERMCAP
+-#ifndef	sun
+-#include <curses.h>
+-#include <term.h>
+-#endif
+-#else	/* USE_TERMCAP */
+-#include <termcap.h>
+-#endif	/* USE_TERMCAP */
+ 
+ #ifdef	_AIX
+ #include <sys/sysmacros.h>
+@@ -989,13 +980,6 @@ printname(const char *name, struct file *f, int doit)
+ 			bold++;
+ 		}
+ 		if (color) {
+-#ifndef	USE_TERMCAP
+-			if (bold)
+-				vidattr(A_BOLD);
+-#else	/* USE_TERMCAP */
+-			if (Bold)
+-				tputs(Bold, 1, putchar);
+-#endif	/* USE_TERMCAP */
+ 			printf(color);
+ 		}
+ 	}
+@@ -1056,13 +1040,6 @@ printname(const char *name, struct file *f, int doit)
+ 		}
+ 	}
+ 	if (doit && color) {
+-#if !defined (USE_TERMCAP)
+-		if (bold)
+-			vidattr(A_NORMAL);
+-#else	/* USE_TERMCAP */
+-		if (Normal)
+-			tputs(Normal, 1, putchar);
+-#endif	/* USE_TERMCAP */
+ 		printf(fc_get(FC_NORMAL));
+ 	}
+ 	if (f)
+@@ -1598,16 +1575,12 @@ main(int argc, char **argv)
+ {
+ 	struct file *flist = nil, **aflist = &flist;
+ 	enum depth depth;
+-	struct winsize ws;
+ 	int i;
+ 	char *cp;
+ 
+ #ifdef	__GLIBC__
+ 	putenv("POSIXLY_CORRECT=1");
+ #endif
+-	setlocale(LC_COLLATE, "");
+-	setlocale(LC_CTYPE, "");
+-	setlocale(LC_TIME, "");
+ #ifndef	UCB
+ 	if (getenv("SYSV3") != NULL)
+ 		sysv3 = 1;
+@@ -1624,16 +1597,6 @@ main(int argc, char **argv)
+ 	}
+ 	if (istty || isatty(1)) {
+ 		istty = 1;
+-#if !defined (USE_TERMCAP)
+-		setupterm(NULL, 1, &tinfostat);
+-#else	/* USE_TERMCAP */
+-		{
+-			char	buf[2048];
+-			if ((cp = getenv("TERM")) != NULL)
+-				if (tgetent(buf, cp) > 0)
+-					tinfostat = 1;
+-		}
+-#endif	/* USE_TERMCAP */
+ 		field |= FL_STATUS;
+ 	}
+ 	while ((i = getopt(argc, argv, personalities[personality].per_opt))
+@@ -1753,12 +1716,6 @@ main(int argc, char **argv)
+ 	if ((cp = getenv("COLUMNS")) != NULL) {
+ 		ncols = atoi(cp);
+ 	} else if ((present('C') || present('x') || present('m')) && istty) {
+-		if (ioctl(1, TIOCGWINSZ, &ws) == 0 && ws.ws_col > 0)
+-			ncols = ws.ws_col - 1;
+-#if !defined (USE_TERMCAP)
+-		else if (tinfostat == 1 && columns > 0)
+-			ncols = columns;
+-#endif	/* !USE_TERMCAP */
+ 	}
+ 	depth = SURFACE;
+ 	if (optind == argc) {

--- a/pkgs/os-specific/linux/minimal-bootstrap/heirloom/utime.patch
+++ b/pkgs/os-specific/linux/minimal-bootstrap/heirloom/utime.patch
@@ -1,0 +1,90 @@
+--- copy/copy.c
++++ copy/copy.c
+@@ -46,7 +46,6 @@ static const char sccsid[] USED = "@(#)copy.sl	1.15 (gritter) 5/29/05";
+ #include <libgen.h>
+ #include <limits.h>
+ #include <dirent.h>
+-#include <utime.h>
+ #include <stdarg.h>
+ #include "sfile.h"
+ #include "memalign.h"
+@@ -441,12 +440,6 @@ attribs(const char *dst, const struct stat *sp)
+ 	if (oflag && ((sp->st_mode&S_IFMT) == S_IFLNK ?
+ 			lchown:chown)(dst, sp->st_uid, sp->st_gid) < 0)
+ 		complain("Unable to chown %s", dst);
+-	if (mflag && (sp->st_mode&S_IFMT) != S_IFLNK) {
+-		struct utimbuf	ut;
+-		ut.actime = sp->st_atime;
+-		ut.modtime = sp->st_mtime;
+-		utime(dst, &ut);
+-	}
+ }
+ 
+ static void
+--- cp/cp.c
++++ cp/cp.c
+@@ -56,7 +56,6 @@ static const char sccsid[] USED = "@(#)cp.sl	1.84 (gritter) 3/4/06";
+ #include	<libgen.h>
+ #include	<limits.h>
+ #include	<dirent.h>
+-#include	<utime.h>
+ #include	"sfile.h"
+ #include	"memalign.h"
+ #include	"alloca.h"
+@@ -354,18 +353,6 @@ permissions(const char *path, const struct stat *ssp)
+ 
+ 	mode = ssp->st_mode & 07777;
+ 	if (pflag) {
+-		struct utimbuf ut;
+-		ut.actime = ssp->st_atime;
+-		ut.modtime = ssp->st_mtime;
+-		if (utime(path, &ut) < 0) {
+-#if defined (SUS) || defined (S42)
+-			fprintf(stderr, "%s: cannot set times for %s\n%s: %s\n",
+-					progname, path,
+-					progname, strerror(errno));
+-#endif /* SUS || S42 */
+-			if (pers != PERS_MV)
+-				errcnt |= 010;
+-		}
+ 		if (myuid == 0) {
+ 			if (chown(path, ssp->st_uid, ssp->st_gid) < 0) {
+ #if defined (SUS) || defined (S42)
+--- touch/touch.c
++++ touch/touch.c
+@@ -47,7 +47,6 @@ static const char sccsid[] USED = "@(#)touch.sl	1.21 (gritter) 5/29/05";
+ #include	<stdlib.h>
+ #include	<errno.h>
+ #include	<libgen.h>
+-#include	<utime.h>
+ #include	<ctype.h>
+ #include	<time.h>
+ 
+@@ -80,7 +79,6 @@ static void
+ touch(const char *fn)
+ {
+ 	struct stat st;
+-	struct utimbuf ut;
+ 
+ 	if (stat(fn, &st) < 0) {
+ 		if (errno == ENOENT) {
+@@ -113,19 +111,6 @@ touch(const char *fn)
+ 			return;
+ 		}
+ 	}
+-	if (aflag)
+-		ut.actime = nacc;
+-	else
+-		ut.actime = st.st_atime;
+-	if (mflag)
+-		ut.modtime = nmod;
+-	else
+-		ut.modtime = st.st_mtime;
+-	if (utime(fn, nulltime ? NULL : &ut) < 0) {
+-		fprintf(stderr, "%s: cannot change times on %s\n",
+-				progname, fn);
+-		errcnt++;
+-	}
+ }
+ 
+ static void

--- a/pkgs/os-specific/linux/minimal-bootstrap/heirloom/vprintf.patch
+++ b/pkgs/os-specific/linux/minimal-bootstrap/heirloom/vprintf.patch
@@ -1,0 +1,128 @@
+--- cksum/cksum.c
++++ cksum/cksum.c
+@@ -147,7 +147,7 @@ cksum(const char *name)
+ 		s = (s << 8) ^ crctab[(s >> 24) ^ c];
+ 	}
+ 	s = ~s;
+-	printf("%u %llu", (unsigned)s, nbytes);
++	printf("%u %lu", (unsigned)s, nbytes);
+ 	if(name)
+ 		printf(" %s", name);
+ 	printf("\n");
+--- cmp/cmp.c
++++ cmp/cmp.c
+@@ -246,8 +246,8 @@ different:
+ 				errcnt = 1;
+ 			} else {
+ 				if (sflag == 0)
+-					printf("%s %s differ: char %lld,"
+-							" line %lld\n",
++					printf("%s %s differ: char %ld,"
++							" line %ld\n",
+ 						f1->f_nam, f2->f_nam,
+ 						(long long)offset(f1),
+ 						line);
+--- csplit/csplit.c
++++ csplit/csplit.c
+@@ -284,7 +284,7 @@ csplit(const char *fn)
+ 				op = nextfile();
+ 			if (op) {
+ 				if (!sflag)
+-					printf("%lld\n", bytes);
++					printf("%ld\n", bytes);
+ 				bytes = 0;
+ 				fclose(op);
+ 			}
+--- expr/expr.y
++++ expr/expr.y
+@@ -140,7 +140,7 @@ expression:	expr NOARG {
+ 			if (sus && numeric($1)) {
+ 				int64_t	n;
+ 				n = atoll($1);
+-				printf("%lld\n", n);
++				printf("%ld\n", n);
+ 				exit(n == 0);
+ 			} else
+ 				puts($1);
+@@ -447,10 +447,10 @@ numpr(int64_t val)
+ 	int	ret;
+ 
+ 	rv = smalloc(NUMSZ);
+-	ret = snprintf(rv, NUMSZ, "%lld", (long long)val);
++	ret = snprintf(rv, NUMSZ, "%ld", (long long)val);
+ 	if (ret < 0 || ret >= NUMSZ) {
+ 		rv = srealloc(rv, ret + 1);
+-		ret = snprintf(rv, ret, "%lld", (long long)val);
++		ret = snprintf(rv, ret, "%ld", (long long)val);
+ 		if (ret < 0)
+ 			yyerror("illegal number");
+ 	}
+--- grep/Makefile.mk
++++ grep/Makefile.mk
+@@ -92,7 +92,7 @@ config.h:
+ 	-echo 'long long foo;' >___build$$$$.c ; \
+ 	$(CC) $(CFLAGS2) $(CPPFLAGS) $(IWCHAR) $(ICOMMON) $(IUXRE) $(LARGEF) -c ___build$$$$.c >/dev/null 2>&1 ; \
+ 	if test $$? = 0 && test -f ___build$$$$.o ; \
+-	then	echo '#define	LONGLONG' >>config.h ; \
++	then	echo '' >>config.h ; \
+ 	fi ; \
+ 	rm -f ___build$$$$.o ___build$$$$.c
+ 
+--- ls/Makefile.mk
++++ ls/Makefile.mk
+@@ -76,7 +76,7 @@ config.h:
+ 	-echo 'long long foo;' >___build$$$$.c ; \
+ 	$(CC) $(CFLAGS) $(CPPFLAGS) $(LARGEF) $(IWCHAR) -c ___build$$$$.c >/dev/null 2>&1 ; \
+ 	if test $$? = 0 && test -f ___build$$$$.o ; \
+-	then	echo '#define	LONGLONG' >>config.h ; \
++	then	echo '' >>config.h ; \
+ 	fi ; \
+ 	rm -f ___build$$$$.o ___build$$$$.c
+ 	-echo '#include <sys/types.h>' >___build$$$$.c ; \
+--- pr/pr.c
++++ pr/pr.c
+@@ -548,7 +548,7 @@ print(const char *fp, const char **argp)
+ 			putcs("  ");
+ 			putcs(header);
+ 			snprintf(linebuf, sizeof linebuf,
+-					" Page %lld\n\n\n", page);
++					" Page %ld\n\n\n", page);
+ 			putcs(linebuf);
+ 		}
+ 		c = putpage();
+--- sed/sed1.c
++++ sed/sed1.c
+@@ -489,7 +489,7 @@ command(struct reptr *ipc)
+ 			break;
+ 
+ 		case EQCOM:
+-			fprintf(stdout, "%lld\n", lnum);
++			fprintf(stdout, "%ld\n", lnum);
+ 			break;
+ 
+ 		case GCOM:
+--- sum/sum.c
++++ sum/sum.c
+@@ -116,7 +116,7 @@ sum(const char *name)
+ 	else {
+ 		s = (s & 0xFFFF) + (s >> 16);
+ 		s = (s & 0xFFFF) + (s >> 16);
+-		printf("%u %llu", (unsigned)s,
++		printf("%u %lu", (unsigned)s,
+ 				(unsigned long long)(nbytes+UNIT-1)/UNIT);
+ 	}
+ 	if(name)
+--- wc/wc.c
++++ wc/wc.c
+@@ -89,9 +89,9 @@ report(unsigned long long count)
+ #if defined (S42)
+ 	if (putspace++)
+ 		printf(" ");
+-	printf("%llu", count);
++	printf("%lu", count);
+ #else	/* !S42 */
+-	printf("%7llu ", count);
++	printf("%7lu ", count);
+ #endif	/* !S42 */
+ }
+ 


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Provides alternatives to coreutils, sed, awk, and other standard tools.

Why is it needed? - There's a bug with GNU sed where it doesn't interact with standard input pipes properly when compiled with meslibc, causing some configure scripts (for example binutils) to fail. It's possible to fix GNU sed but I wasn't able to.

This may also be useful for bringing these tools into the chain earlier if heirloom-sh is introduced as an alternative to bash

Related #227914

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
