### PR TITLE
treewide: don't use lib.optional with a list

### DIFF
--- a/pkgs/applications/graphics/ipe/default.nix
+++ b/pkgs/applications/graphics/ipe/default.nix
@@ -55,7 +55,7 @@ stdenv.mkDerivation rec {
     "IPE_NO_SPELLCHECK=1" # qtSpell is not yet packaged
   ];
 
-  qtWrapperArgs = lib.optional withTeXLive [ "--prefix PATH : ${lib.makeBinPath [ texlive ]}" ];
+  qtWrapperArgs = lib.optionals withTeXLive [ "--prefix PATH : ${lib.makeBinPath [ texlive ]}" ];
 
   enableParallelBuilding = true;
 

--- a/pkgs/development/libraries/mpfr/default.nix
+++ b/pkgs/development/libraries/mpfr/default.nix
@@ -30,7 +30,7 @@ stdenv.mkDerivation rec {
 
   configureFlags = lib.optional stdenv.hostPlatform.isSunOS "--disable-thread-safe"
     ++ lib.optional stdenv.hostPlatform.is64bit "--with-pic"
-    ++ lib.optional stdenv.hostPlatform.isPower64 [
+    ++ lib.optionals stdenv.hostPlatform.isPower64 [
       # Without this, the `tget_set_d128` test experiences a link
       # error due to missing `__dpd_trunctdkf`.
       "--disable-decimal-float"

--- a/pkgs/development/python-modules/python-mapnik/default.nix
+++ b/pkgs/development/python-modules/python-mapnik/default.nix
@@ -133,7 +133,7 @@ buildPythonPackage rec {
     "test_visual_zoom_all_rendering1"
     "test_visual_zoom_all_rendering2"
     "test_wgs84_inverse_forward"
-  ] ++ lib.optional stdenv.isDarwin [
+  ] ++ lib.optionals stdenv.isDarwin [
     "test_passing_pycairo_context_pdf"
   ];
 

--- a/pkgs/development/tools/rust/cargo-dephell/default.nix
+++ b/pkgs/development/tools/rust/cargo-dephell/default.nix
@@ -32,7 +32,7 @@ rustPlatform.buildRustPackage rec {
 
   buildInputs = [
     openssl
-  ] ++ lib.optional stdenv.isDarwin [
+  ] ++ lib.optionals stdenv.isDarwin [
     curl
     darwin.apple_sdk.frameworks.Security
     libgit2_1_3_0

--- a/pkgs/misc/ghostscript/default.nix
+++ b/pkgs/misc/ghostscript/default.nix
@@ -60,7 +60,7 @@ let
 
 in
 stdenv.mkDerivation rec {
-  pname = "ghostscript${lib.optionalString (x11Support) "-with-X"}";
+  pname = "ghostscript${lib.optionalString x11Support "-with-X"}";
   version = "10.01.1";
 
   src = fetchurl {
@@ -112,7 +112,7 @@ stdenv.mkDerivation rec {
   ] ++ lib.optionals dynamicDrivers [
     "--enable-dynamic"
     "--disable-hidden-visibility"
-  ] ++ lib.optional x11Support [
+  ] ++ lib.optionals x11Support [
     "--with-x"
   ] ++ lib.optionals cupsSupport [
     "--enable-cups"

--- a/pkgs/os-specific/linux/ax99100/default.nix
+++ b/pkgs/os-specific/linux/ax99100/default.nix
@@ -1,6 +1,6 @@
-{ kernel, stdenv, kmod, lib, fetchzip, fetchpatch, dos2unix }:
-stdenv.mkDerivation
-{
+{ kernel, stdenv, kmod, lib, fetchzip, dos2unix }:
+
+stdenv.mkDerivation {
   pname = "ax99100";
   version = "1.8.0";
 
@@ -26,9 +26,9 @@ stdenv.mkDerivation
   patches = [
     ./kernel-5.18-pci_free_consistent-pci_alloc_consistent.patch
     ./kernel-6.1-set_termios-const-ktermios.patch
-  ] ++ (lib.optional (lib.versionAtLeast kernel.version "6.2") [
+  ] ++ lib.optionals (lib.versionAtLeast kernel.version "6.2") [
     ./kernel-6.2-fix-pointer-type.patch
-  ]);
+  ];
 
   patchFlags = [ "-p0" ];
 

--- a/pkgs/tools/misc/flashrom/default.nix
+++ b/pkgs/tools/misc/flashrom/default.nix
@@ -1,5 +1,4 @@
 { fetchurl
-, fetchpatch
 , stdenv
 , installShellFiles
 , lib
@@ -22,7 +21,7 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ pkg-config installShellFiles ];
   buildInputs = [ libftdi1 libusb1 ]
-    ++ lib.optional (!stdenv.isDarwin) [ pciutils ]
+    ++ lib.optionals (!stdenv.isDarwin) [ pciutils ]
     ++ lib.optional jlinkSupport libjaylink;
 
   postPatch = ''


### PR DESCRIPTION
###### Description of changes

with the help of https://github.com/nix-community/nixpkgs-lint

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
