### PR TITLE
qt-{5,6}.qtbase: fix build after Darwin stdenv bump

### DIFF
--- a/pkgs/development/libraries/qt-5/5.15/default.nix
+++ b/pkgs/development/libraries/qt-5/5.15/default.nix
@@ -36,6 +36,9 @@ let
       ./qtbase.patch.d/0012-qtbase-tbd-frameworks.patch
 
       ./qtbase.patch.d/0014-aarch64-darwin.patch
+    ] ++ lib.optionals (stdenv.isDarwin && lib.hasPrefix "cctools-llvm" (lib.getName darwin.cctools)) [
+      # When the Darwin stdenv uses llvm-ranlib, it does not support/need -no_warning_for_no_symbols
+      ./qtbase.patch.d/0015-cctools-llvm-ranlib.patch
     ] ++ [
       ./qtbase.patch.d/0003-qtbase-mkspecs.patch
       ./qtbase.patch.d/0004-qtbase-replace-libdir.patch

--- a/pkgs/development/libraries/qt-5/5.15/qtbase.patch.d/0015-cctools-llvm-ranlib.patch
+++ b/pkgs/development/libraries/qt-5/5.15/qtbase.patch.d/0015-cctools-llvm-ranlib.patch
@@ -1,0 +1,23 @@
+diff --git a/mkspecs/common/mac.conf b/mkspecs/common/mac.conf
+index 61bea952b2..eb7622974a 100644
+--- a/mkspecs/common/mac.conf
++++ b/mkspecs/common/mac.conf
+@@ -47,5 +47,5 @@ QMAKE_STRIP             = $${CROSS_COMPILE}strip
+ QMAKE_STRIPFLAGS_LIB   += -S -x
+ 
+ QMAKE_AR                = $${CROSS_COMPILE}ar cq
+-QMAKE_RANLIB            = $${CROSS_COMPILE}ranlib -s
++QMAKE_RANLIB            = $${CROSS_COMPILE}ranlib
+ QMAKE_NM                = $${CROSS_COMPILE}nm -P
+diff --git a/mkspecs/features/mac/no_warn_empty_obj_files.prf b/mkspecs/features/mac/no_warn_empty_obj_files.prf
+index 598938ab12..7d75fa566d 100644
+--- a/mkspecs/features/mac/no_warn_empty_obj_files.prf
++++ b/mkspecs/features/mac/no_warn_empty_obj_files.prf
+@@ -1,7 +1,2 @@
+-# Prevent warnings about object files without any symbols. This is a common
+-# thing in Qt as we tend to build files unconditionally, and then use ifdefs
+-# to compile out parts that are not relevant.
+-QMAKE_RANLIB += -no_warning_for_no_symbols
+-
+ # We have to tell 'ar' to not run ranlib by itself
+ QMAKE_AR += -S

--- a/pkgs/development/libraries/qt-6/default.nix
+++ b/pkgs/development/libraries/qt-6/default.nix
@@ -48,6 +48,9 @@ let
           ./patches/0005-qtbase-deal-with-a-font-face-at-index-0-as-Regular-f.patch
           ./patches/0006-qtbase-qt-cmake-always-use-cmake-from-path.patch
           ./patches/0007-qtbase-find-qt-tools-in-QTTOOLSPATH.patch
+        ] ++ lib.optionals (stdenv.isDarwin && lib.hasPrefix "cctools-llvm" (lib.getName darwin.cctools)) [
+          # When the Darwin stdenv uses llvm-ranlib, it does not support/need -no_warning_for_no_symbols
+          ./patches/0008-qtbase-cctools-llvm-ranlib.patch
         ];
       };
       env = callPackage ./qt-env.nix { };

--- a/pkgs/development/libraries/qt-6/patches/0008-qtbase-cctools-llvm-ranlib.patch
+++ b/pkgs/development/libraries/qt-6/patches/0008-qtbase-cctools-llvm-ranlib.patch
@@ -1,0 +1,25 @@
+diff --git a/cmake/QtBuild.cmake b/cmake/QtBuild.cmake
+index 1469abf176..b57dbc49e8 100644
+--- a/cmake/QtBuild.cmake
++++ b/cmake/QtBuild.cmake
+@@ -431,7 +431,7 @@ if(CMAKE_HOST_APPLE AND APPLE)
+         # We have to tell 'ar' to not run ranlib by itself, by passing the 'S' option
+         set(CMAKE_${lang}_ARCHIVE_CREATE "<CMAKE_AR> qcS <TARGET> <LINK_FLAGS> <OBJECTS>")
+         set(CMAKE_${lang}_ARCHIVE_APPEND "<CMAKE_AR> qS <TARGET> <LINK_FLAGS> <OBJECTS>")
+-        set(CMAKE_${lang}_ARCHIVE_FINISH "<CMAKE_RANLIB> -no_warning_for_no_symbols <TARGET>")
++        set(CMAKE_${lang}_ARCHIVE_FINISH "<CMAKE_RANLIB> <TARGET>")
+     endforeach()
+ endif()
+ 
+diff --git a/mkspecs/features/mac/no_warn_empty_obj_files.prf b/mkspecs/features/mac/no_warn_empty_obj_files.prf
+index 598938ab12..7d75fa566d 100644
+--- a/mkspecs/features/mac/no_warn_empty_obj_files.prf
++++ b/mkspecs/features/mac/no_warn_empty_obj_files.prf
+@@ -1,7 +1,2 @@
+-# Prevent warnings about object files without any symbols. This is a common
+-# thing in Qt as we tend to build files unconditionally, and then use ifdefs
+-# to compile out parts that are not relevant.
+-QMAKE_RANLIB += -no_warning_for_no_symbols
+-
+ # We have to tell 'ar' to not run ranlib by itself
+ QMAKE_AR += -S


### PR DESCRIPTION
qt-{5,6}.qtbase: fix build after Darwin stdenv bump

###### Description of changes

This is targeting master because it shouldn’t cause any rebuilds, but I can retarget staging anyway if that would be preferred. I tested these changes using my local branch, which is waiting on #234859 before I submit the PR for the rework.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
