### PR TITLE
treewide: convert *Flags to a list

### DIFF
--- a/pkgs/development/compilers/swift/swift-docc/default.nix
+++ b/pkgs/development/compilers/swift/swift-docc/default.nix
@@ -32,7 +32,7 @@ stdenv.mkDerivation {
   # This works around a failure building generate-symbol-graph:
   #  Sources/generate-symbol-graph/main.swift:13:18: error: module 'SwiftDocC' was not compiled for testing
   # TODO: Figure out the cause. It doesn't seem to happen outside Nixpkgs.
-  swiftpmFlags = "--product docc";
+  swiftpmFlags = [ "--product docc" ];
 
   # TODO: Tests depend on indexstore-db being provided by an existing Swift
   # toolchain. (ie. looks for `../lib/libIndexStore.so` relative to swiftc.

--- a/pkgs/development/compilers/swift/swift-format/default.nix
+++ b/pkgs/development/compilers/swift/swift-format/default.nix
@@ -22,7 +22,7 @@ stdenv.mkDerivation {
   configurePhase = generated.configure;
 
   # We only install the swift-format binary, so don't need the other products.
-  swiftpmFlags = "--product swift-format";
+  swiftpmFlags = [ "--product swift-format" ];
 
   installPhase = ''
     binPath="$(swiftpmBinPath)"

--- a/pkgs/development/python-modules/skytemple-files/default.nix
+++ b/pkgs/development/python-modules/skytemple-files/default.nix
@@ -20,7 +20,7 @@
 , graphql-core
 , gql
 , armips
-# tests
+  # tests
 , pytestCheckHook
 , parameterized
 , xmldiff
@@ -70,7 +70,7 @@ buildPythonPackage rec {
   };
 
   checkInputs = [ pytestCheckHook parameterized xmldiff ] ++ passthru.optional-dependencies.spritecollab;
-  pytestFlagsArray = "test/";
+  pytestFlagsArray = [ "test/" ];
   disabledTestPaths = [
     "test/skytemple_files_test/common/spritecollab/sc_online_test.py"
     "test/skytemple_files_test/compression_container/atupx/atupx_test.py" # Particularly long test

--- a/pkgs/development/tools/misc/dart-sass/default.nix
+++ b/pkgs/development/tools/misc/dart-sass/default.nix
@@ -17,7 +17,7 @@ buildDartApplication rec {
   pubspecLockFile = ./pubspec.lock;
   vendorHash = "sha256-Atm7zfnDambN/BmmUf4BG0yUz/y6xWzf0reDw3Ad41s=";
 
-  dartCompileFlags = "--define=version=${version}";
+  dartCompileFlags = [ "--define=version=${version}" ];
 
   meta = with lib; {
     homepage = "https://github.com/sass/dart-sass";


### PR DESCRIPTION
###### Description of changes

found with https://github.com/nix-community/nixpkgs-lint

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
