### PR TITLE
earthly: 0.6.23 -> 0.7.7

### DIFF
--- a/pkgs/development/tools/earthly/default.nix
+++ b/pkgs/development/tools/earthly/default.nix
@@ -1,35 +1,42 @@
-{ lib, buildGoModule, fetchFromGitHub }:
+{ lib, buildGoModule, fetchFromGitHub, stdenv }:
 
 buildGoModule rec {
   pname = "earthly";
-  version = "0.6.23";
+  version = "0.7.7";
 
   src = fetchFromGitHub {
     owner = "earthly";
     repo = "earthly";
     rev = "v${version}";
-    sha256 = "sha256-RbLAnk2O7wqY0OQLprWuRDUWMicqcLOPia+7aRuXbsk=";
+    sha256 = "sha256-tYoC9OCNAtdQwWyznac5PVl7KLObbFfjs138y5LeQ2A=";
   };
 
-  vendorSha256 = "sha256-MDyQ9Wn5A5F5CQCfEXzkXZi/Fg6sT/Ikv+Y7fvLY8LA=";
+  vendorSha256 = "sha256-1y34WH1JGAs1eDxreHMqUlGTyrixUFIV1DPN/N5wzS4=";
+  subPackages = [ "cmd/earthly" "cmd/debugger" ];
+
+  CGO_ENABLED = 0;
 
   ldflags = [
-    "-s" "-w"
+    "-s"
+    "-w"
     "-X main.Version=v${version}"
-    "-X main.DefaultBuildkitdImage=earthly/buildkitd:v${version}"
+    "-X main.DefaultBuildkitdImage=docker.io/earthly/buildkitd:v${version}"
+    "-X main.GitSha=v${version}"
+    "-X main.DefaultInstallationName=earthly"
+  ] ++ lib.optionals stdenv.isLinux [
+    "-extldflags '-static'"
   ];
 
-  BUILDTAGS = "dfrunmount dfrunsecurity dfsecrets dfssh dfrunnetwork";
-  preBuild = ''
-    makeFlagsArray+=(BUILD_TAGS="${BUILDTAGS}")
-  '';
-
-  # For some reasons the tests fail, but the program itself seems to work.
-  doCheck = false;
+  tags = [
+    "dfrunmount"
+    "dfrunnetwork"
+    "dfrunsecurity"
+    "dfsecrets"
+    "dfssh"
+  ];
 
   postInstall = ''
     mv $out/bin/debugger $out/bin/earthly-debugger
-    mv $out/bin/shellrepeater $out/bin/earthly-shellrepeater
   '';
 
   meta = with lib; {
@@ -37,6 +44,6 @@ buildGoModule rec {
     homepage = "https://earthly.dev/";
     changelog = "https://github.com/earthly/earthly/releases/tag/v${version}";
     license = licenses.mpl20;
-    maintainers = with maintainers; [ zoedsoupe ];
+    maintainers = with maintainers; [ zoedsoupe konradmalik ];
   };
 }


### PR DESCRIPTION
###### Description of changes

[Changelog](https://github.com/earthly/earthly/blob/main/CHANGELOG.md)

- Added myself as a maintainer since I'm using this software on a daily basis and can help
- Re-enabled checks
- removed shellrepeater as it does not exist anymore
- updated ldflags according to the upstream Earthfile that takes the platform into consideration
- disabled CGO as per upstream Earthfile
- moved buildtags to tags
- specified subPackages that we're compiling here (upstream Earthfile does the same)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
