### PR TITLE
hetzner-api-dyndns: init at 1.2, nixos/hetzner-api-dyndns: Init

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2311.section.md
+++ b/nixos/doc/manual/release-notes/rl-2311.section.md
@@ -6,15 +6,15 @@
 
 ## New Services {#sec-release-23.11-new-services}
 
-- Create the first release note entry in this section!
-
 - [acme-dns](https://github.com/joohoi/acme-dns), a limited DNS server to handle ACME DNS challenges easily and securely. Available as [services.acme-dns](#opt-services.acme-dns.enable).
 
-<!-- To avoid merge conflicts, consider adding your item at an arbitrary place in the list instead. -->
+- [hetzner-api-dyndns](https://github.com/FarrowStrange/hetzner-api-dyndns), A small script to dynamically update DNS records using the Hetzner DNS-API. Available as [services.hetzner-api-dyndns](#opt-services.hetzner-api-dyndns.enable).
 
 - [river](https://github.com/riverwm/river), A dynamic tiling wayland compositor. Available as [programs.river](#opt-programs.river.enable).
 
 - [sitespeed-io](https://sitespeed.io), a tool that can generate metrics (timings, diagnostics) for websites. Available as [services.sitespeed-io](#opt-services.sitespeed-io.enable).
+
+<!-- To avoid merge conflicts, consider adding your item at an arbitrary place in the list instead. -->
 
 ## Backward Incompatibilities {#sec-release-23.11-incompatibilities}
 

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -887,6 +887,7 @@
   ./services/networking/harmonia.nix
   ./services/networking/haproxy.nix
   ./services/networking/headscale.nix
+  ./services/networking/hetzner-api-dyndns.nix
   ./services/networking/hostapd.nix
   ./services/networking/htpdate.nix
   ./services/networking/https-dns-proxy.nix

--- a/nixos/modules/services/networking/hetzner-api-dyndns.nix
+++ b/nixos/modules/services/networking/hetzner-api-dyndns.nix
@@ -1,0 +1,89 @@
+{ config, pkgs, lib, ... }:
+
+with lib;
+
+let
+  cfg = config.services.hetzner-api-dyndns;
+  ifNotNull = opt: val: lib.optionalString (val != null) "-${opt} ${escapeShellArg val}";
+  baseCmd = "hetzner-dyndns ${ifNotNull "Z" cfg.zoneName} ${ifNotNull "z" cfg.zoneId} -n ${escapeShellArg cfg.recordName}  -t ${toString cfg.ttl}";
+in {
+  meta.maintainers = with lib.maintainers; [ e1mo ];
+
+  options.services.hetzner-api-dyndns = {
+    enable = mkEnableOption (lib.mdDoc "dynamic DNS record updating via the Hetzner DNS API.");
+    recordName = mkOption {
+      type = types.str;
+      example = "dyn";
+      description = lib.mdDoc ''
+        The name of the record to update.
+        Use `@` to update the root record for the zone itself.
+      '';
+    };
+    recordTypes = mkOption {
+      type = types.nonEmptyListOf (types.enum [ "AAAA" "A" ]);
+      default = [ "AAAA" "A" ];
+      example = [ "A" ];
+      description = lib.mdDoc "The record type(s) to update automatically (A for IPv4, AAAA for IPv6).";
+    };
+    zoneName = mkOption {
+      type = with types; nullOr str;
+      default = null;
+      example = "my-zone.net";
+      description = lib.mdDoc ''
+        The zone name for which to update the selected record(s).
+        Mutually exclusive with {option}`services.hetzner-api-dyndns.zoneId`.
+      '';
+    };
+    zoneId = mkOption {
+      type = with types; nullOr str;
+      default = null;
+      example = "DaGaoE6YzDTQHKxrtzfkTx";
+      description = lib.mdDoc ''
+        The zone ID (Hetzner specific).
+        Mutually exclusive with {option}`services.hetzner-api-dyndns.zoneName`.
+      '';
+    };
+    environmentFile = mkOption {
+      type = types.path;
+      description = lib.mdDoc ''
+        Environment file containing the {env}`HETZNER_AUTH_API_TOKEN` variable.
+        See <https://github.com/FarrowStrange/hetzner-api-dyndns> for other available options.
+      '';
+    };
+    ttl = mkOption {
+      type = types.ints.positive;
+      default = 60;
+      example = 120;
+      description = lib.mdDoc "TTL of the record(s), in seconds.";
+    };
+    startAt =  mkOption {
+      type = types.str;
+      default = "*:0/5";
+      example = "hourly";
+      description = lib.mdDoc ''
+        When (aka. how often) to run the script. Default is every five minutes.
+        Must be in the format described in {manpage}`systemd.time(7)`.
+      '';
+    };
+  };
+
+  config = mkIf cfg.enable {
+    assertions = [{
+      assertion = with cfg; (zoneName != zoneId) && (zoneName == null || zoneId == null);
+      message = "Exactly one of `services.hetzner-api-dyndns.zoneName' and `services.hetzner-api-dyndns.zoneId' must be set.";
+    }];
+
+    systemd.services."hetzner-api-dyndns" = {
+      inherit (cfg) startAt;
+      path = [ pkgs.hetzner-api-dyndns ];
+      script = concatMapStringsSep "\n" (
+        rt: "${baseCmd} -T ${rt}"
+      ) cfg.recordTypes;
+      requires = [ "network-online.target" ];
+      serviceConfig = {
+        EnvironmentFile = cfg.environmentFile;
+        DynamicUser = true;
+      };
+    };
+  };
+}

--- a/pkgs/applications/networking/dyndns/hetzner-api-dyndns/default.nix
+++ b/pkgs/applications/networking/dyndns/hetzner-api-dyndns/default.nix
@@ -1,0 +1,43 @@
+{ lib
+, fetchFromGitHub
+, stdenv
+, makeWrapper
+, curl
+, dnsutils
+, jq
+, gawk
+}:
+
+stdenv.mkDerivation (self: {
+  pname = "hetzner-api-dyndns";
+  version = "1.2";
+
+  src = fetchFromGitHub {
+    owner = "FarrowStrange";
+    repo = self.pname;
+    rev = "v${self.version}";
+    hash = "sha256-8YROWePYAQ/R+C9MwxqiJm++du9WhbmlPMnU7ByyP5w=";
+  };
+
+  nativeBuildInputs = [ makeWrapper ];
+
+  installPhase = ''
+    mkdir -p $out/bin;
+    cp dyndns.sh $out/bin/hetzner-dyndns
+    chmod +x $out/bin/hetzner-dyndns
+  '';
+
+  postFixup = ''
+    wrapProgram $out/bin/hetzner-dyndns --prefix PATH : ${lib.makeBinPath [ curl dnsutils jq gawk ]}
+  '';
+
+  meta = with lib; {
+    description = "small script to dynamically update DNS records using the Hetzner DNS-API";
+    homepage = "https://github.com/FarrowStrange/hetzner-api-dyndns";
+    changelog = "https://github.com/FarrowStrange/hetzner-api-dyndns/releases/tag/v${self.version}";
+    license = licenses.gpl3Only;
+    maintainers = with maintainers; [ e1mo];
+    platforms = platforms.unix;
+    mainProgram = "hetzner-dyndns";
+  };
+})

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -28398,6 +28398,8 @@ with pkgs;
 
   hetzner-kube = callPackage ../applications/networking/cluster/hetzner-kube { };
 
+  hetzner-api-dyndns = callPackage ../applications/networking/dyndns/hetzner-api-dyndns { };
+
   hicolor-icon-theme = callPackage ../data/icons/hicolor-icon-theme { };
 
   hannom = callPackage ../data/fonts/hannom { };


### PR DESCRIPTION
###### Description of changes

hetzner-api-dyndns is a script to automatically update DNS records via the hetzner DNS API to the current public IP.
Homepage: https://github.com/FarrowStrange/hetzner-api-dyndns

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [x] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).