### PR TITLE
laminar: 1.2 → 1.3

### DIFF
--- a/pkgs/development/tools/continuous-integration/laminar/default.nix
+++ b/pkgs/development/tools/continuous-integration/laminar/default.nix
@@ -20,18 +20,18 @@ let
     sha256 = "1dx8wn38ds8d01kkih26fx1yrisg3kpz61qynjr4zil03ap0hrlr";
   };
   js.Chart = fetchurl {
-    url = "https://cdnjs.cloudflare.com/ajax/libs/Chart.js/2.7.2/Chart.min.js";
-    sha256 = "1jh4h12qchsba03dx03mrvs4r8g9qfjn56xm56jqzgqf7r209xq9";
+    url = "https://cdnjs.cloudflare.com/ajax/libs/Chart.js/3.9.1/chart.min.js";
+    hash = "sha256-+8RZJua0aEWg+QVVKg4LEzEEm/8RFez5Tb4JBNiV5xA=";
   };
 in stdenv.mkDerivation rec {
   pname = "laminar";
-  version = "1.2";
+  version = "1.3";
   outputs = [ "out" "doc" ];
   src = fetchFromGitHub {
     owner = "ohwgiles";
     repo = "laminar";
     rev = version;
-    sha256 = "sha256-PLnfiWpelgKhs4FNry60sm6/QdhYs76FnZ/ZcRmb4Ok=";
+    hash = "sha256-eo5WzvmjBEe0LAfZdQ/U0XepEE2kdWKKiyE4HOi3RXk=";
   };
   patches = [ ./patches/no-network.patch ];
 

--- a/pkgs/development/tools/continuous-integration/laminar/patches/no-network.patch
+++ b/pkgs/development/tools/continuous-integration/laminar/patches/no-network.patch
@@ -4,8 +4,8 @@ does so unconditionally is twice as bad.
 Required files are downloaded as separate fixed-output derivations and
 put into correct location before build phase starts.
 
---- laminar-1.1/CMakeLists.txt
-+++ laminar-1.1-new/CMakeLists.txt
+--- laminar-1.3/CMakeLists.txt
++++ laminar-1.3-new/CMakeLists.txt
 @@ -82,13 +82,6 @@
      COMMAND sh -c '( echo -n "\\#define INDEX_HTML_UNCOMPRESSED_SIZE " && wc -c < "${CMAKE_SOURCE_DIR}/src/resources/index.html" ) > index_html_size.h'
      DEPENDS src/resources/index.html)
@@ -15,13 +15,13 @@ put into correct location before build phase starts.
 -	js/vue.min.js EXPECTED_MD5 fb192338844efe86ec759a40152fcb8e)
 -file(DOWNLOAD https://raw.githubusercontent.com/drudru/ansi_up/v4.0.4/ansi_up.js
 -        js/ansi_up.js EXPECTED_MD5 b31968e1a8fed0fa82305e978161f7f5)
--file(DOWNLOAD https://cdnjs.cloudflare.com/ajax/libs/Chart.js/2.7.2/Chart.min.js
--        js/Chart.min.js EXPECTED_MD5 f6c8efa65711e0cbbc99ba72997ecd0e)
+-file(DOWNLOAD https://cdnjs.cloudflare.com/ajax/libs/Chart.js/3.9.1/chart.min.js
+-        js/Chart.min.js EXPECTED_MD5 7dd5ea7d2cf22a1c42b43c40093d2669)
  # ...and compile them
  generate_compressed_bins(${CMAKE_BINARY_DIR} js/vue.min.js
      js/ansi_up.js js/Chart.min.js)
 @@ -139,12 +132,12 @@
-     target_link_libraries(laminar-tests ${GTEST_LIBRARY} capnp-rpc capnp kj-http kj-async kj pthread sqlite3 z)
+     target_link_libraries(laminar-tests ${GTEST_LIBRARIES} capnp-rpc capnp kj-http kj-async kj pthread sqlite3 z)
  endif()
  
 -set(SYSTEMD_UNITDIR /lib/systemd/system CACHE PATH "Path to systemd unit files")


### PR DESCRIPTION
###### Description of changes

https://github.com/ohwgiles/laminar/releases/tag/1.3

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).