### PR TITLE
apache_datasketches: init at 1.6.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -10674,6 +10674,12 @@
     githubId = 708570;
     name = "Manuel Mendez";
   };
+  mmusnjak = {
+    email = "marko.musnjak@gmail.com";
+    github = "mmusnjak";
+    githubId = 668956;
+    name = "Marko Mušnjak";
+  };
   mnacamura = {
     email = "m.nacamura@gmail.com";
     github = "mnacamura";

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -614,6 +614,7 @@ in {
   postfix-raise-smtpd-tls-security-level = handleTest ./postfix-raise-smtpd-tls-security-level.nix {};
   postfixadmin = handleTest ./postfixadmin.nix {};
   postgis = handleTest ./postgis.nix {};
+  apache_datasketches = handleTest ./apache_datasketches.nix {};
   postgresql = handleTest ./postgresql.nix {};
   postgresql-jit = handleTest ./postgresql-jit.nix {};
   postgresql-wal-receiver = handleTest ./postgresql-wal-receiver.nix {};

--- a/nixos/tests/apache_datasketches.nix
+++ b/nixos/tests/apache_datasketches.nix
@@ -1,0 +1,29 @@
+import ./make-test-python.nix ({ pkgs, ...} : {
+  name = "postgis";
+  meta = with pkgs.lib.maintainers; {
+    maintainers = [ lsix ]; # TODO: Who's the maintener now?
+  };
+
+  nodes = {
+    master =
+      { pkgs, ... }:
+
+      {
+        services.postgresql = let mypg = pkgs.postgresql_15; in {
+            enable = true;
+            package = mypg;
+            extraPlugins = with mypg.pkgs; [
+              apache_datasketches
+            ];
+        };
+      };
+  };
+
+  testScript = ''
+    start_all()
+    master.wait_for_unit("postgresql")
+    master.sleep(10)  # Hopefully this is long enough!!
+    master.succeed("sudo -u postgres psql -c 'CREATE EXTENSION datasketches;'")
+    master.succeed("sudo -u postgres psql -c 'SELECT hll_sketch_to_string(hll_sketch_build(1));'")
+  '';
+})

--- a/pkgs/servers/sql/postgresql/ext/apache_datasketches.nix
+++ b/pkgs/servers/sql/postgresql/ext/apache_datasketches.nix
@@ -1,0 +1,71 @@
+{ stdenv, lib, fetchFromGitHub, postgresql, boost182, nixosTests }:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "apache_datasketches";
+  version = "1.6.0";
+
+  srcs = [
+    ( fetchFromGitHub {
+        name   = "datasketches-postgresql";
+        owner  = "apache";
+        repo   = "datasketches-postgresql";
+        rev    = "refs/tags/${finalAttrs.version}";
+        hash   = "sha256-sz94fIe7nyWhjiw8FAm6ZzVpB0sAK5YxUrtbaZt/guA=";
+    })
+    ( fetchFromGitHub {
+        name   = "datasketches-cpp";
+        owner  = "apache";
+        repo   = "datasketches-cpp";
+        rev    = "refs/tags/4.1.0";
+        hash   = "sha256-vPoFzRxOXlEAiiHH9M5S6255ahzaKsGNYS0cdHwrRYw=";
+    })
+  ];
+  sourceRoot = "datasketches-postgresql";
+
+  buildInputs = [ postgresql boost182 ];
+
+  patchPhase = ''
+    runHook prePatch
+    cp -r ../datasketches-cpp .
+    runHook postPatch
+  '';
+
+  installPhase = ''
+    runHook preInstall
+    install -D -m 644 ./datasketches.so -t $out/lib/
+    cat \
+      sql/datasketches_cpc_sketch.sql \
+      sql/datasketches_kll_float_sketch.sql \
+      sql/datasketches_kll_double_sketch.sql \
+      sql/datasketches_theta_sketch.sql \
+      sql/datasketches_frequent_strings_sketch.sql \
+      sql/datasketches_hll_sketch.sql \
+      sql/datasketches_aod_sketch.sql \
+      sql/datasketches_req_float_sketch.sql \
+      sql/datasketches_quantiles_double_sketch.sql \
+      > sql/datasketches--${finalAttrs.version}.sql
+    install -D -m 644 ./datasketches.control -t $out/share/postgresql/extension
+    install -D -m 644 \
+      ./sql/datasketches--${finalAttrs.version}.sql \
+      ./sql/datasketches--1.3.0--1.4.0.sql \
+      ./sql/datasketches--1.4.0--1.5.0.sql \
+      ./sql/datasketches--1.5.0--1.6.0.sql \
+      -t $out/share/postgresql/extension
+    runHook postInstall
+  '';
+
+  passthru.tests.apache_datasketches = nixosTests.apache_datasketches;
+
+  meta = {
+    description = "PostgreSQL extension providing approximate algorithms for distinct item counts, quantile estimation and frequent items detection";
+    longDescription = ''
+       apache_datasketches is an extension to support approximate algorithms on PostgreSQL. The implementation
+       is based on the Apache Datasketches CPP library, and provides support for HyperLogLog,
+       Compressed Probabilistic Counting, KLL, Frequent strings, and Theta sketches.
+    '';
+    homepage = "https://datasketches.apache.org/";
+    platforms = postgresql.meta.platforms;
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ mmusnjak ];
+  };
+})

--- a/pkgs/servers/sql/postgresql/packages.nix
+++ b/pkgs/servers/sql/postgresql/packages.nix
@@ -2,6 +2,8 @@ self: super: {
 
     age = super.callPackage ./ext/age.nix { };
 
+    apache_datasketches = super.callPackage ./ext/apache_datasketches.nix { };
+
     jsonb_deep_sum = super.callPackage ./ext/jsonb_deep_sum.nix { };
 
     periods = super.callPackage ./ext/periods.nix { };


### PR DESCRIPTION
###### Description of changes

PostgreSQL extension providing approximate algorithms for distinct item counts, quantile estimation and frequent items detection.

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

