### PR TITLE
lib.simpleOptions: new function to simplify options declaration

### DIFF
--- a/lib/default.nix
+++ b/lib/default.nix
@@ -32,7 +32,7 @@ let
     # module system
     modules = callLibs ./modules.nix;
     options = callLibs ./options.nix;
-    simple-options = callLibs ./simple-options.nix;
+    simpleOptions = callLibs ./simple-options.nix;
     types = callLibs ./types.nix;
 
     # constants

--- a/lib/default.nix
+++ b/lib/default.nix
@@ -32,6 +32,7 @@ let
     # module system
     modules = callLibs ./modules.nix;
     options = callLibs ./options.nix;
+    simple-options = callLibs ./simple-options.nix;
     types = callLibs ./types.nix;
 
     # constants

--- a/lib/simple-options.nix
+++ b/lib/simple-options.nix
@@ -9,7 +9,7 @@
 }:
 module:
 let
-  inherit (builtins) attrNames concatStringsSep hasAttr mapAttrs throw trace typeOf;
+  inherit (builtins) attrNames concatStringsSep mapAttrs throw trace typeOf;
   inherit (lib.types) attrsOf listOf submodule;
   mkOptionW = breadcrumb: optName: optDef:
     let result = lib.mkOption (toOption breadcrumb optName optDef);
@@ -34,15 +34,15 @@ let
         then throw ''breadcrumb must be a list, instead it is a ${typeOf breadcrumb}'' else
       if typeOf type       != "set"
         then throw ''type must be a attrset, instead it is a ${typeOf type}, breadcrumb: ${concatStringsSep "." breadcrumb}'' else
-      if hasAttr "_type" type
+      if type ? _type
         then type else
-      if hasAttr typeAttr type
+      if type ? ${typeAttr}
         then toType type.type else
-      if hasAttr attrAttr type
+      if type ? ${attrAttr}
         then attrsOf   (toType    (breadcrumb ++ [attrAttr]) type."${attrAttr}") else
-      if hasAttr listAttr type
+      if type ? ${listAttr}
         then listOf    (toType    (breadcrumb ++ [listAttr]) type."${listAttr}") else
-      if hasAttr subMAttr type
+      if type ? ${subMAttr}
         then submodule (toOptions (breadcrumb ++ [subMAttr]) type."${subMAttr}")
       else
         throw ''${concatStringsSep "." breadcrumb} has no attr _type|${typeAttr}|${attrAttr}|${listAttr}|${subMAttr}'';
@@ -66,13 +66,13 @@ let
         then throw ''optName must be a string, instead it is a ${typeOf optName}, breadcrumb: ${concatStringsSep "." breadcrumb}'' else
       if typeOf optDef     != "set"
         then throw ''optDef must be a attrset, instead it is a ${typeOf optDef}, breadcrumb: ${concatStringsSep "." breadcrumb}, optName: ${optName}'' else
-      if hasAttr typeAttr optDef
+      if optDef ? ${typeAttr}
         then optDef else
-      if hasAttr attrAttr optDef
+      if optDef ? ${attrAttr}
         then removeAttrs optDef [attrAttr] // { type = attrsOf   (toType    (breadcrumb ++ [optName attrAttr]) optDef."${attrAttr}");} else
-      if hasAttr listAttr optDef
+      if optDef ? ${listAttr}
         then removeAttrs optDef [listAttr] // { type = listOf    (toType    (breadcrumb ++ [optName listAttr]) optDef."${listAttr}");} else
-      if hasAttr subMAttr optDef
+      if optDef ? ${subMAttr}
         then removeAttrs optDef [subMAttr] // { type = submodule (toOptions (breadcrumb ++ [optName subMAttr]) optDef."${subMAttr}");}
       else
         throw ''${concatStringsSep "." (breadcrumb ++ optName)} has no attr _type|${typeAttr}|${attrAttr}|${listAttr}|${subMAttr}'';

--- a/lib/simple-options.nix
+++ b/lib/simple-options.nix
@@ -37,15 +37,14 @@ let
       if type ? _type
         then type else
       if type ? ${typeAttr}
-        then toType type.type else
+        then              toType    (breadcrumb ++ [typeAttr]) type.${typeAttr}    else
       if type ? ${attrAttr}
-        then lazyAttrsOf (toType    (breadcrumb ++ [attrAttr]) type."${attrAttr}") else
+        then lazyAttrsOf (toType    (breadcrumb ++ [attrAttr]) type.${attrAttr}) else
       if type ? ${listAttr}
-        then listOf      (toType    (breadcrumb ++ [listAttr]) type."${listAttr}") else
+        then listOf      (toType    (breadcrumb ++ [listAttr]) type.${listAttr}) else
       if type ? ${subMAttr}
-        then submodule   (toOptions (breadcrumb ++ [subMAttr]) type."${subMAttr}")
-      else
-        throw ''${concatStringsSep "." breadcrumb} has no attr _type|${typeAttr}|${attrAttr}|${listAttr}|${subMAttr}'';
+        then submodule   (toOptions (breadcrumb ++ [subMAttr]) type.${subMAttr}) else
+      throw ''${concatStringsSep "." breadcrumb} has no attr _type|${typeAttr}|${attrAttr}|${listAttr}|${subMAttr}'';
     in
       if debug then
         trace ''
@@ -67,15 +66,14 @@ let
       if typeOf optDef     != "set"
         then throw ''optDef must be a attrset, instead it is a ${typeOf optDef}, breadcrumb: ${concatStringsSep "." breadcrumb}, optName: ${optName}'' else
       if optDef ? ${typeAttr}
-        then optDef else
+        then removeAttrs optDef [typeAttr] // { type = optDef.${typeAttr}; } else
       if optDef ? ${attrAttr}
-        then removeAttrs optDef [attrAttr] // { type = lazyAttrsOf (toType    (breadcrumb ++ [optName attrAttr]) optDef."${attrAttr}");} else
+        then removeAttrs optDef [attrAttr] // { type = lazyAttrsOf (toType    (breadcrumb ++ [optName attrAttr]) optDef.${attrAttr});} else
       if optDef ? ${listAttr}
-        then removeAttrs optDef [listAttr] // { type = listOf      (toType    (breadcrumb ++ [optName listAttr]) optDef."${listAttr}");} else
+        then removeAttrs optDef [listAttr] // { type = listOf      (toType    (breadcrumb ++ [optName listAttr]) optDef.${listAttr});} else
       if optDef ? ${subMAttr}
-        then removeAttrs optDef [subMAttr] // { type = submodule   (toOptions (breadcrumb ++ [optName subMAttr]) optDef."${subMAttr}");}
-      else
-        throw ''${concatStringsSep "." (breadcrumb ++ optName)} has no attr _type|${typeAttr}|${attrAttr}|${listAttr}|${subMAttr}'';
+        then removeAttrs optDef [subMAttr] // { type = submodule   (toOptions (breadcrumb ++ [optName subMAttr]) optDef.${subMAttr});} else
+      throw ''${concatStringsSep "." (breadcrumb ++ optName)} has no attr _type|${typeAttr}|${attrAttr}|${listAttr}|${subMAttr}'';
     in
       if debug then
         trace ''

--- a/lib/simple-options.nix
+++ b/lib/simple-options.nix
@@ -9,80 +9,82 @@
 }:
 module:
 let
+  inherit (builtins) attrNames concatStringsSep hasAttr mapAttrs throw trace typeOf;
+  inherit (lib.types) attrsOf listOf submodule;
   mkOptionW = breadcrumb: optName: optDef:
     let result = lib.mkOption (toOption breadcrumb optName optDef);
     in
       if debug then
-        builtins.trace ''
-          function: modulazy.mkOptionWrapper
+        trace ''
+          function: simple-options.mkOptionWrapper
           args:
-            breadcrumb: ${builtins.concatStringsSep "." breadcrumb}
+            breadcrumb: ${concatStringsSep "." breadcrumb};
             optName: ${optName}
-            optDef: ${builtins.concatStringsSep " " (builtins.attrNames optDef)}
-          result: ${builtins.concatStringsSep " " (builtins.attrNames result)}
+            optDef: ${concatStringsSep " " (attrNames optDef)}
+          result: ${concatStringsSep " " (attrNames result)}
         ''
         result
       else result;
 
-  toOptions = breadcrumb: options: { options = builtins.mapAttrs (mkOptionW breadcrumb) options; };
+  toOptions = breadcrumb: options: { options = mapAttrs (mkOptionW breadcrumb) options; };
 
   toType    = breadcrumb: type:
     let result =
-      if builtins.typeOf breadcrumb != "list"
-        then builtins.throw ''breadcrumb must be a list, instead it is a ${builtins.typeOf breadcrumb}'' else
-      if builtins.typeOf type       != "set"
-        then builtins.throw ''type must be a attrset, instead it is a ${builtins.typeOf type}, breadcrumb: ${builtins.concatStringsSep "." breadcrumb}'' else
-      if builtins.hasAttr "_type" type
+      if typeOf breadcrumb != "list"
+        then throw ''breadcrumb must be a list, instead it is a ${typeOf breadcrumb}'' else
+      if typeOf type       != "set"
+        then throw ''type must be a attrset, instead it is a ${typeOf type}, breadcrumb: ${concatStringsSep "." breadcrumb}'' else
+      if hasAttr "_type" type
         then type else
-      if builtins.hasAttr typeAttr type
+      if hasAttr typeAttr type
         then toType type.type else
-      if builtins.hasAttr attrAttr type
-        then lib.types.attrsOf   (toType    (breadcrumb ++ [attrAttr]) type."${attrAttr}") else
-      if builtins.hasAttr listAttr type
-        then lib.types.listOf    (toType    (breadcrumb ++ [listAttr]) type."${listAttr}") else
-      if builtins.hasAttr subMAttr type
-        then lib.types.submodule (toOptions (breadcrumb ++ [subMAttr]) type."${subMAttr}")
+      if hasAttr attrAttr type
+        then attrsOf   (toType    (breadcrumb ++ [attrAttr]) type."${attrAttr}") else
+      if hasAttr listAttr type
+        then listOf    (toType    (breadcrumb ++ [listAttr]) type."${listAttr}") else
+      if hasAttr subMAttr type
+        then submodule (toOptions (breadcrumb ++ [subMAttr]) type."${subMAttr}")
       else
-        builtins.throw ''${builtins.concatStringsSep "." breadcrumb} has no attr _type|${typeAttr}|${attrAttr}|${listAttr}|${subMAttr}'';
+        throw ''${concatStringsSep "." breadcrumb} has no attr _type|${typeAttr}|${attrAttr}|${listAttr}|${subMAttr}'';
     in
       if debug then
-        builtins.trace ''
-          function: modulazy.toType
+        trace ''
+          function: simple-options.toType
           args:
-            breadcrumb: ${builtins.concatStringsSep "." breadcrumb}
-            type: ${builtins.concatStringsSep " " (builtins.attrNames type)}
-          result: ${builtins.concatStringsSep " " (builtins.attrNames result)}
+            breadcrumb: ${concatStringsSep "." breadcrumb}
+            type: ${concatStringsSep " " (attrNames type)}
+          result: ${concatStringsSep " " (attrNames result)}
         ''
         result
       else result;
 
   toOption  = breadcrumb: optName: optDef:
     let result =
-      if builtins.typeOf breadcrumb != "list"
-        then builtins.throw ''breadcrumb must be a list, instead it is a ${builtins.typeOf breadcrumb}'' else
-      if builtins.typeOf optName    != "string"
-        then builtins.throw ''optName must be a string, instead it is a ${builtins.typeOf optName}, breadcrumb: ${builtins.concatStringsSep "." breadcrumb}'' else
-      if builtins.typeOf optDef     != "set"
-        then builtins.throw ''optDef must be a attrset, instead it is a ${builtins.typeOf optDef}, breadcrumb: ${builtins.concatStringsSep "." breadcrumb}, optName: ${optName}'' else
-      if builtins.hasAttr typeAttr optDef
+      if typeOf breadcrumb != "list"
+        then throw ''breadcrumb must be a list, instead it is a ${typeOf breadcrumb}'' else
+      if typeOf optName    != "string"
+        then throw ''optName must be a string, instead it is a ${typeOf optName}, breadcrumb: ${concatStringsSep "." breadcrumb}'' else
+      if typeOf optDef     != "set"
+        then throw ''optDef must be a attrset, instead it is a ${typeOf optDef}, breadcrumb: ${concatStringsSep "." breadcrumb}, optName: ${optName}'' else
+      if hasAttr typeAttr optDef
         then optDef else
-      if builtins.hasAttr attrAttr optDef
-        then builtins.removeAttrs optDef [attrAttr] // { type = lib.types.attrsOf   (toType    (breadcrumb ++ [optName attrAttr]) optDef."${attrAttr}");} else
-      if builtins.hasAttr listAttr optDef
-        then builtins.removeAttrs optDef [listAttr] // { type = lib.types.listOf    (toType    (breadcrumb ++ [optName listAttr]) optDef."${listAttr}");} else
-      if builtins.hasAttr subMAttr optDef
-        then builtins.removeAttrs optDef [subMAttr] // { type = lib.types.submodule (toOptions (breadcrumb ++ [optName subMAttr]) optDef."${subMAttr}");}
+      if hasAttr attrAttr optDef
+        then removeAttrs optDef [attrAttr] // { type = attrsOf   (toType    (breadcrumb ++ [optName attrAttr]) optDef."${attrAttr}");} else
+      if hasAttr listAttr optDef
+        then removeAttrs optDef [listAttr] // { type = listOf    (toType    (breadcrumb ++ [optName listAttr]) optDef."${listAttr}");} else
+      if hasAttr subMAttr optDef
+        then removeAttrs optDef [subMAttr] // { type = submodule (toOptions (breadcrumb ++ [optName subMAttr]) optDef."${subMAttr}");}
       else
-        builtins.throw ''${builtins.concatStringsSep "." (breadcrumb ++ optName)} has no attr _type|${typeAttr}|${attrAttr}|${listAttr}|${subMAttr}'';
+        throw ''${concatStringsSep "." (breadcrumb ++ optName)} has no attr _type|${typeAttr}|${attrAttr}|${listAttr}|${subMAttr}'';
     in
       if debug then
-        builtins.trace ''
-          function: modulazy.toOption
+        trace ''
+          function: simple-options.toOption
           args:
-            breadcrumb: ${builtins.concatStringsSep "." breadcrumb}
+            breadcrumb: ${concatStringsSep "." breadcrumb}
             optName: ${optName}
-            optDef: ${builtins.concatStringsSep " " (builtins.attrNames optDef)}
-          result: ${builtins.concatStringsSep " " (builtins.attrNames result)}
+            optDef: ${concatStringsSep " " (attrNames optDef)}
+          result: ${concatStringsSep " " (attrNames result)}
         ''
         result
       else result;

--- a/lib/simple-options.nix
+++ b/lib/simple-options.nix
@@ -1,0 +1,89 @@
+{
+  lib,
+  attrAttr ? "attrsOf",
+  listAttr ? "listOf",
+  subMAttr ? "options",
+  typeAttr ? "type",
+  debug    ? false,
+  ...
+}:
+module:
+let
+  mkOptionW = breadcrumb: optName: optDef:
+    let result = lib.mkOption (toOption breadcrumb optName optDef);
+    in
+      if debug then
+        builtins.trace ''
+          function: modulazy.mkOptionWrapper
+          args:
+            breadcrumb: ${builtins.concatStringsSep "." breadcrumb}
+            optName: ${optName}
+            optDef: ${builtins.concatStringsSep " " (builtins.attrNames optDef)}
+          result: ${builtins.concatStringsSep " " (builtins.attrNames result)}
+        ''
+        result
+      else result;
+
+  toOptions = breadcrumb: options: { options = builtins.mapAttrs (mkOptionW breadcrumb) options; };
+
+  toType    = breadcrumb: type:
+    let result =
+      if builtins.typeOf breadcrumb != "list"
+        then builtins.throw ''breadcrumb must be a list, instead it is a ${builtins.typeOf breadcrumb}'' else
+      if builtins.typeOf type       != "set"
+        then builtins.throw ''type must be a attrset, instead it is a ${builtins.typeOf type}, breadcrumb: ${builtins.concatStringsSep "." breadcrumb}'' else
+      if builtins.hasAttr "_type" type
+        then type else
+      if builtins.hasAttr typeAttr type
+        then toType type.type else
+      if builtins.hasAttr attrAttr type
+        then lib.types.attrsOf   (toType    (breadcrumb ++ [attrAttr]) type."${attrAttr}") else
+      if builtins.hasAttr listAttr type
+        then lib.types.listOf    (toType    (breadcrumb ++ [listAttr]) type."${listAttr}") else
+      if builtins.hasAttr subMAttr type
+        then lib.types.submodule (toOptions (breadcrumb ++ [subMAttr]) type."${subMAttr}")
+      else
+        builtins.throw ''${builtins.concatStringsSep "." breadcrumb} has no attr _type|${typeAttr}|${attrAttr}|${listAttr}|${subMAttr}'';
+    in
+      if debug then
+        builtins.trace ''
+          function: modulazy.toType
+          args:
+            breadcrumb: ${builtins.concatStringsSep "." breadcrumb}
+            type: ${builtins.concatStringsSep " " (builtins.attrNames type)}
+          result: ${builtins.concatStringsSep " " (builtins.attrNames result)}
+        ''
+        result
+      else result;
+
+  toOption  = breadcrumb: optName: optDef:
+    let result =
+      if builtins.typeOf breadcrumb != "list"
+        then builtins.throw ''breadcrumb must be a list, instead it is a ${builtins.typeOf breadcrumb}'' else
+      if builtins.typeOf optName    != "string"
+        then builtins.throw ''optName must be a string, instead it is a ${builtins.typeOf optName}, breadcrumb: ${builtins.concatStringsSep "." breadcrumb}'' else
+      if builtins.typeOf optDef     != "set"
+        then builtins.throw ''optDef must be a attrset, instead it is a ${builtins.typeOf optDef}, breadcrumb: ${builtins.concatStringsSep "." breadcrumb}, optName: ${optName}'' else
+      if builtins.hasAttr typeAttr optDef
+        then optDef else
+      if builtins.hasAttr attrAttr optDef
+        then builtins.removeAttrs optDef [attrAttr] // { type = lib.types.attrsOf   (toType    (breadcrumb ++ [optName attrAttr]) optDef."${attrAttr}");} else
+      if builtins.hasAttr listAttr optDef
+        then builtins.removeAttrs optDef [listAttr] // { type = lib.types.listOf    (toType    (breadcrumb ++ [optName listAttr]) optDef."${listAttr}");} else
+      if builtins.hasAttr subMAttr optDef
+        then builtins.removeAttrs optDef [subMAttr] // { type = lib.types.submodule (toOptions (breadcrumb ++ [optName subMAttr]) optDef."${subMAttr}");}
+      else
+        builtins.throw ''${builtins.concatStringsSep "." (breadcrumb ++ optName)} has no attr _type|${typeAttr}|${attrAttr}|${listAttr}|${subMAttr}'';
+    in
+      if debug then
+        builtins.trace ''
+          function: modulazy.toOption
+          args:
+            breadcrumb: ${builtins.concatStringsSep "." breadcrumb}
+            optName: ${optName}
+            optDef: ${builtins.concatStringsSep " " (builtins.attrNames optDef)}
+          result: ${builtins.concatStringsSep " " (builtins.attrNames result)}
+        ''
+        result
+      else result;
+in  module // toOptions [subMAttr] module."${subMAttr}"

--- a/lib/simple-options.nix
+++ b/lib/simple-options.nix
@@ -10,7 +10,7 @@
 module:
 let
   inherit (builtins) attrNames concatStringsSep mapAttrs throw trace typeOf;
-  inherit (lib.types) attrsOf listOf submodule;
+  inherit (lib.types) lazyAttrsOf listOf submodule;
   mkOptionW = breadcrumb: optName: optDef:
     let result = lib.mkOption (toOption breadcrumb optName optDef);
     in
@@ -39,11 +39,11 @@ let
       if type ? ${typeAttr}
         then toType type.type else
       if type ? ${attrAttr}
-        then attrsOf   (toType    (breadcrumb ++ [attrAttr]) type."${attrAttr}") else
+        then lazyAttrsOf (toType    (breadcrumb ++ [attrAttr]) type."${attrAttr}") else
       if type ? ${listAttr}
-        then listOf    (toType    (breadcrumb ++ [listAttr]) type."${listAttr}") else
+        then listOf      (toType    (breadcrumb ++ [listAttr]) type."${listAttr}") else
       if type ? ${subMAttr}
-        then submodule (toOptions (breadcrumb ++ [subMAttr]) type."${subMAttr}")
+        then submodule   (toOptions (breadcrumb ++ [subMAttr]) type."${subMAttr}")
       else
         throw ''${concatStringsSep "." breadcrumb} has no attr _type|${typeAttr}|${attrAttr}|${listAttr}|${subMAttr}'';
     in
@@ -69,11 +69,11 @@ let
       if optDef ? ${typeAttr}
         then optDef else
       if optDef ? ${attrAttr}
-        then removeAttrs optDef [attrAttr] // { type = attrsOf   (toType    (breadcrumb ++ [optName attrAttr]) optDef."${attrAttr}");} else
+        then removeAttrs optDef [attrAttr] // { type = lazyAttrsOf (toType    (breadcrumb ++ [optName attrAttr]) optDef."${attrAttr}");} else
       if optDef ? ${listAttr}
-        then removeAttrs optDef [listAttr] // { type = listOf    (toType    (breadcrumb ++ [optName listAttr]) optDef."${listAttr}");} else
+        then removeAttrs optDef [listAttr] // { type = listOf      (toType    (breadcrumb ++ [optName listAttr]) optDef."${listAttr}");} else
       if optDef ? ${subMAttr}
-        then removeAttrs optDef [subMAttr] // { type = submodule (toOptions (breadcrumb ++ [optName subMAttr]) optDef."${subMAttr}");}
+        then removeAttrs optDef [subMAttr] // { type = submodule   (toOptions (breadcrumb ++ [optName subMAttr]) optDef."${subMAttr}");}
       else
         throw ''${concatStringsSep "." (breadcrumb ++ optName)} has no attr _type|${typeAttr}|${attrAttr}|${listAttr}|${subMAttr}'';
     in

--- a/lib/tests/modules.sh
+++ b/lib/tests/modules.sh
@@ -399,17 +399,16 @@ checkConfigOutput '^"pear\\npear"$' config.twice.raw ./merge-module-with-key.nix
 # simpleOptions helper
 checkConfigOutput '^"ATT"$'         config.ATT.test                     ./simple-options.nix
 checkConfigOutput '^"ATT-ATT"$'     config.ATT-ATT.foo.test             ./simple-options.nix '{ ATT-ATT.foo.test =          "ATT-ATT"; }'
-checkConfigOutput '^"ATT-LST"$'     config.ATT-LST.foo.0                ./simple-options.nix '{ ATT-LST.foo = [             "ATT-LST" ]; }'
-checkConfigOutput '^"ATT-OPT-TYP"$' config.ATT-OPT.foo.ATT-OPT-TYP      ./simple-options.nix '{ ATT-OPT.foo.ATT-OPT-TYP =   "ATT-OPT-TYP"; }'
+checkConfigOutput '^"ATT-LST"$'     config.ATT-LST.test.0               ./simple-options.nix '{ ATT-LST.test = [            "ATT-LST" ]; }'
+checkConfigOutput '^"ATT-OPT-TYP"$' config.ATT-OPT.test.ATT-OPT-TYP     ./simple-options.nix '{ ATT-OPT.test.ATT-OPT-TYP =  "ATT-OPT-TYP"; }'
 checkConfigOutput '^"LST"$'         config.LST.0                        ./simple-options.nix
 checkConfigOutput '^"LST-ATT"$'     config.LST-ATT.0.test               ./simple-options.nix '{ LST-ATT = [ { test =        "LST-ATT";} ]; }'
 checkConfigOutput '^"LST-LST"$'     config.LST-LST.0.0                  ./simple-options.nix '{ LST-LST = [ [               "LST-LST" ] ]; }'
 checkConfigOutput '^"LST-OPT-TYP"$' config.LST-OPT.0.LST-OPT-TYP        ./simple-options.nix '{ LST-OPT = [ { LST-OPT-TYP = "LST-OPT-TYP"; } ]; }'
 checkConfigOutput '^"OPT-ATT"$'     config.OPT.OPT-ATT.test             ./simple-options.nix
-checkConfigOutput '^"OPT-ATT"$'     config.OPT.OPT-ATT.test             ./simple-options.nix
 checkConfigOutput '^"OPT-LST"$'     config.OPT.OPT-LST.0                ./simple-options.nix
 checkConfigOutput '^"OPT-OPT-ATT"$' config.OPT.OPT-OPT.OPT-OPT-ATT.test ./simple-options.nix
-checkConfigOutput '^"OPT-OPT-LST"$' config.OPT.OPT-OPT.OPT-OPT-LST.0    ./simple-options.nix '{ OPT.OPT-OPT.OPT-OPT-LST = [ "OPT-OPT-LST" ]; }'
+checkConfigOutput '^"OPT-OPT-LST"$' config.OPT.OPT-OPT.OPT-OPT-LST.0    ./simple-options.nix
 checkConfigOutput '^"OPT-OPT-TYP"$' config.OPT.OPT-OPT.OPT-OPT-TYP      ./simple-options.nix
 checkConfigOutput '^"OPT-TYP"$'     config.OPT.OPT-TYP                  ./simple-options.nix
 checkConfigOutput '^"TYP"$'         config.TYP                          ./simple-options.nix

--- a/lib/tests/modules.sh
+++ b/lib/tests/modules.sh
@@ -396,6 +396,24 @@ checkConfigOutput '^"The option `a\.b. defined in `.*/doRename-warnings\.nix. ha
 checkConfigOutput '^"pear"$' config.once.raw ./merge-module-with-key.nix
 checkConfigOutput '^"pear\\npear"$' config.twice.raw ./merge-module-with-key.nix
 
+# simpleOptions helper
+checkConfigOutput '^"ATT"$'         config.ATT.test                     ./simple-options.nix
+checkConfigOutput '^"ATT-ATT"$'     config.ATT-ATT.foo.test             ./simple-options.nix '{ ATT-ATT.foo.test =          "ATT-ATT"; }'
+checkConfigOutput '^"ATT-LST"$'     config.ATT-LST.foo.0                ./simple-options.nix '{ ATT-LST.foo = [             "ATT-LST" ]; }'
+checkConfigOutput '^"ATT-OPT-TYP"$' config.ATT-OPT.foo.ATT-OPT-TYP      ./simple-options.nix '{ ATT-OPT.foo.ATT-OPT-TYP =   "ATT-OPT-TYP"; }'
+checkConfigOutput '^"LST"$'         config.LST.0                        ./simple-options.nix
+checkConfigOutput '^"LST-ATT"$'     config.LST-ATT.0.test               ./simple-options.nix '{ LST-ATT = [ { test =        "LST-ATT";} ]; }'
+checkConfigOutput '^"LST-LST"$'     config.LST-LST.0.0                  ./simple-options.nix '{ LST-LST = [ [               "LST-LST" ] ]; }'
+checkConfigOutput '^"LST-OPT-TYP"$' config.LST-OPT.0.LST-OPT-TYP        ./simple-options.nix '{ LST-OPT = [ { LST-OPT-TYP = "LST-OPT-TYP"; } ]; }'
+checkConfigOutput '^"OPT-ATT"$'     config.OPT.OPT-ATT.test             ./simple-options.nix
+checkConfigOutput '^"OPT-ATT"$'     config.OPT.OPT-ATT.test             ./simple-options.nix
+checkConfigOutput '^"OPT-LST"$'     config.OPT.OPT-LST.0                ./simple-options.nix
+checkConfigOutput '^"OPT-OPT-ATT"$' config.OPT.OPT-OPT.OPT-OPT-ATT.test ./simple-options.nix
+checkConfigOutput '^"OPT-OPT-LST"$' config.OPT.OPT-OPT.OPT-OPT-LST.0    ./simple-options.nix '{ OPT.OPT-OPT.OPT-OPT-LST = [ "OPT-OPT-LST" ]; }'
+checkConfigOutput '^"OPT-OPT-TYP"$' config.OPT.OPT-OPT.OPT-OPT-TYP      ./simple-options.nix
+checkConfigOutput '^"OPT-TYP"$'     config.OPT.OPT-TYP                  ./simple-options.nix
+checkConfigOutput '^"TYP"$'         config.TYP                          ./simple-options.nix
+
 cat <<EOF
 ====== module tests ======
 $pass Pass

--- a/lib/tests/modules/simple-options.nix
+++ b/lib/tests/modules/simple-options.nix
@@ -1,0 +1,146 @@
+# Test Cases
+
+# options.TYPe.type = {_type }
+
+# options.ATTrsOf.attrsOf =   { type } | { listOf } | { attrsOf } | { options }
+# options.LiSTOf.listOf   =   { type } | { listOf } | { attrsOf } | { options }
+# options.OPTions.options = { OPTions =
+#                             { type } | { listOf } | { attrsOf } | { options } }
+
+# options.ATTrsOf -> ATTrsOf -> TYPe
+# options.ATTrsOf -> LIStOf  -> TYPe
+# options.ATTrsOf -> OPTions -> TYPe
+
+# options.LIStOf  -> ATTrsOf -> TYPe
+# options.LIStOf  -> LIStOf  -> TYPe
+# options.LIStOf  -> OPTions -> TYPe
+
+# options.OPTions -> ATTrsOf -> TYPe
+# options.OPTions -> LIStOf  -> TYPe
+# options.OPTions -> OPTions -> TYPe
+
+# nix eval --show-trace --impure --expr '(import ./simple-options.nix { lib = (import <nixpkgs> {}).lib; })'|sed 's/.repeated./<repeated>/g'|nix run nixpkgs#alejandra
+# alejandra isn't required but provide some nice output
+
+
+{ lib, ... }:
+lib.simpleOptions {
+  # Basic cases
+
+  options.ATT.attrsOf     = lib.types.str;
+  options.ATT.default     = {};
+  options.ATT.description = "attrset of strings";
+  options.ATT.example     = {};
+
+  options.LST.default     = [];
+  options.LST.description = "list of string";
+  options.LST.example     = [];
+  options.LST.listOf      = lib.types.str;
+
+  options.TYP.default     = "";
+  options.TYP.description = "string option example";
+  options.TYP.example     = "some string";
+  options.TYP.type        = lib.types.str;
+
+  # Nested attrs
+
+  options.ATT-ATT.default      = {};
+  options.ATT-ATT.description  = "attrset of attrset";
+  options.ATT-ATT.example      = {};
+
+  options.ATT-LST.default      = {};
+  options.ATT-LST.description  = "attrset of lists";
+  options.ATT-LST.example      = {};
+
+  options.ATT-ATT.attrsOf.default      = {};
+  options.ATT-ATT.attrsOf.description  = "attrset of strings";
+  options.ATT-ATT.attrsOf.example      = {};
+  options.ATT-ATT.attrsOf.attrsOf      = lib.types.str;
+
+  options.ATT-LST.attrsOf.default      = {};
+  options.ATT-LST.attrsOf.description  = "list of strings";
+  options.ATT-LST.attrsOf.example      = {};
+  options.ATT-LST.attrsOf.listOf       = lib.types.str;
+
+  options.ATT-OPT.attrsOf.default      = {};
+  options.ATT-OPT.attrsOf.description  = "options with one attr";
+  options.ATT-OPT.attrsOf.example      = {};
+
+  options.ATT-OPT.attrsOf.options.ATT-OPT-TYP.default     = "";
+  options.ATT-OPT.attrsOf.options.ATT-OPT-TYP.description = "option of options of attrset";
+  options.ATT-OPT.attrsOf.options.ATT-OPT-TYP.type        = lib.types.str;
+  options.ATT-OPT.attrsOf.options.ATT-OPT-TYP.example     = "";
+
+  # Nested lists
+
+  options.LST-ATT.default       = [];
+  options.LST-ATT.description   = "list of attrset";
+  options.LST-ATT.example       = [];
+
+  options.LST-ATT.listOf.default      = [];
+  options.LST-ATT.listOf.description  = "attrset of strings";
+  options.LST-ATT.listOf.example      = [];
+  options.LST-ATT.listOf.attrsOf      = lib.types.str;
+
+  options.LST-LST.default       = {};
+  options.LST-LST.description   = "list of lists";
+  options.LST-LST.example       = {};
+
+  options.LST-LST.listOf.default      = {};
+  options.LST-LST.listOf.description  = "list of strings";
+  options.LST-LST.listOf.example      = {};
+  options.LST-LST.listOf.listOf       = lib.types.str;
+
+  options.LST-OPT.default       = {};
+  options.LST-OPT.description   = "list of options";
+  options.LST-OPT.example       = {};
+
+  options.LST-OPT.listOf.default      = {};
+  options.LST-OPT.listOf.description  = "options with one attr";
+  options.LST-OPT.listOf.example      = {};
+
+  options.LST-OPT.listOf.options.LST-OPT-TYP.default     = "";
+  options.LST-OPT.listOf.options.LST-OPT-TYP.description = "option of options of lists";
+  options.LST-OPT.listOf.options.LST-OPT-TYP.type        = lib.types.str;
+  options.LST-OPT.listOf.options.LST-OPT-TYP.example     = "";
+
+  # Nested options
+
+  options.OPT.default     = {};
+  options.OPT.example     = {};
+  options.OPT.description = "options holder";
+
+  options.OPT.options.OPT-TYP.default     = "";
+  options.OPT.options.OPT-TYP.description = "second level str";
+  options.OPT.options.OPT-TYP.type        = lib.types.str;
+  options.OPT.options.OPT-TYP.example     = "some string";
+
+  options.OPT.options.OPT-ATT.default     = {};
+  options.OPT.options.OPT-ATT.description = "second level attrset of strings";
+  options.OPT.options.OPT-ATT.attrsOf     = lib.types.str;
+  options.OPT.options.OPT-ATT.example     = {};
+
+  options.OPT.options.OPT-LST.default     = [];
+  options.OPT.options.OPT-LST.description = "second level list of strings";
+  options.OPT.options.OPT-LST.listOf      = lib.types.str;
+  options.OPT.options.OPT-LST.example     = [];
+
+  options.OPT.options.OPT-OPT.default     = {};
+  options.OPT.options.OPT-OPT.example     = {};
+  options.OPT.options.OPT-OPT.description = "second level options holder";
+
+  options.OPT.options.OPT-OPT.options.OPT-OPT-TYP.default     = "";
+  options.OPT.options.OPT-OPT.options.OPT-OPT-TYP.description = "third level str";
+  options.OPT.options.OPT-OPT.options.OPT-OPT-TYP.type        = lib.types.str;
+  options.OPT.options.OPT-OPT.options.OPT-OPT-TYP.example     = "some string";
+
+  options.OPT.options.OPT-OPT.options.OPT-OPT-ATT.default     = {};
+  options.OPT.options.OPT-OPT.options.OPT-OPT-ATT.description = "Third level hasmap of strings str";
+  options.OPT.options.OPT-OPT.options.OPT-OPT-ATT.attrsOf     = lib.types.str;
+  options.OPT.options.OPT-OPT.options.OPT-OPT-ATT.example     = {};
+
+  options.OPT.options.OPT-OPT.options.OPT-OPT-LST.default     = [];
+  options.OPT.options.OPT-OPT.options.OPT-OPT-LST.description = "Third level list of strings str";
+  options.OPT.options.OPT-OPT.options.OPT-OPT-LST.listOf      = lib.types.str;
+  options.OPT.options.OPT-OPT.options.OPT-OPT-LST.example     = [];
+}

--- a/lib/tests/modules/simple-options.nix
+++ b/lib/tests/modules/simple-options.nix
@@ -28,16 +28,16 @@ lib.simpleOptions {
   # Basic cases
 
   options.ATT.attrsOf     = lib.types.str;
-  options.ATT.default     = {};
+  options.ATT.default     = { test = "ATT"; };
   options.ATT.description = "attrset of strings";
   options.ATT.example     = {};
 
-  options.LST.default     = [];
+  options.LST.default     = [ "LST" ];
   options.LST.description = "list of string";
   options.LST.example     = [];
   options.LST.listOf      = lib.types.str;
 
-  options.TYP.default     = "";
+  options.TYP.default     = "TYP";
   options.TYP.description = "string option example";
   options.TYP.example     = "some string";
   options.TYP.type        = lib.types.str;
@@ -110,17 +110,17 @@ lib.simpleOptions {
   options.OPT.example     = {};
   options.OPT.description = "options holder";
 
-  options.OPT.options.OPT-TYP.default     = "";
+  options.OPT.options.OPT-TYP.default     = "OPT-TYP";
   options.OPT.options.OPT-TYP.description = "second level str";
   options.OPT.options.OPT-TYP.type        = lib.types.str;
   options.OPT.options.OPT-TYP.example     = "some string";
 
-  options.OPT.options.OPT-ATT.default     = {};
+  options.OPT.options.OPT-ATT.default     = { test = "OPT-ATT"; };
   options.OPT.options.OPT-ATT.description = "second level attrset of strings";
   options.OPT.options.OPT-ATT.attrsOf     = lib.types.str;
   options.OPT.options.OPT-ATT.example     = {};
 
-  options.OPT.options.OPT-LST.default     = [];
+  options.OPT.options.OPT-LST.default     = [ "OPT-LST" ];
   options.OPT.options.OPT-LST.description = "second level list of strings";
   options.OPT.options.OPT-LST.listOf      = lib.types.str;
   options.OPT.options.OPT-LST.example     = [];
@@ -129,12 +129,12 @@ lib.simpleOptions {
   options.OPT.options.OPT-OPT.example     = {};
   options.OPT.options.OPT-OPT.description = "second level options holder";
 
-  options.OPT.options.OPT-OPT.options.OPT-OPT-TYP.default     = "";
+  options.OPT.options.OPT-OPT.options.OPT-OPT-TYP.default     = "OPT-OPT-TYP";
   options.OPT.options.OPT-OPT.options.OPT-OPT-TYP.description = "third level str";
   options.OPT.options.OPT-OPT.options.OPT-OPT-TYP.type        = lib.types.str;
   options.OPT.options.OPT-OPT.options.OPT-OPT-TYP.example     = "some string";
 
-  options.OPT.options.OPT-OPT.options.OPT-OPT-ATT.default     = {};
+  options.OPT.options.OPT-OPT.options.OPT-OPT-ATT.default     =  { test = "OPT-OPT-ATT"; };
   options.OPT.options.OPT-OPT.options.OPT-OPT-ATT.description = "Third level hasmap of strings str";
   options.OPT.options.OPT-OPT.options.OPT-OPT-ATT.attrsOf     = lib.types.str;
   options.OPT.options.OPT-OPT.options.OPT-OPT-ATT.example     = {};

--- a/lib/tests/modules/simple-options.nix
+++ b/lib/tests/modules/simple-options.nix
@@ -139,7 +139,7 @@ lib.simpleOptions {
   options.OPT.options.OPT-OPT.options.OPT-OPT-ATT.attrsOf     = lib.types.str;
   options.OPT.options.OPT-OPT.options.OPT-OPT-ATT.example     = {};
 
-  options.OPT.options.OPT-OPT.options.OPT-OPT-LST.default     = [];
+  options.OPT.options.OPT-OPT.options.OPT-OPT-LST.default     = [ "OPT-OPT-LST" ];
   options.OPT.options.OPT-OPT.options.OPT-OPT-LST.description = "Third level list of strings str";
   options.OPT.options.OPT-OPT.options.OPT-OPT-LST.listOf      = lib.types.str;
   options.OPT.options.OPT-OPT.options.OPT-OPT-LST.example     = [];


### PR DESCRIPTION
###### Description of changes

**Summary**

Declarative options function to make easier define new options.

**Motivation**

Inspired by Eelco Dolstra talk of NixCon 2020¹ and @DavHau pkgs-modules² project and my own user experince, I could say that modules are fun but define new options aren't. And maybe is the reason for some `extraOptions`, lack of typing in NixOS Modules³.

**Detailed design**

Define a new fluent interface for options definition where no function call is required for most common cases (type, listOf, attrsOf, options).

The logic is:
- if it has `attrsOf`, is attrOf
```nix
lib.simpleOptions {
  options.FOO.attrsOf  = types.str;
} == {
  options.FOO.type     = types.attrsOf types.str;
}
```
- if it has `listOf`, is listOf
 ```nix
lib.simpleOptions {
  options.BAR.listOf    = types.str;
} == {
  options.BAR.type      = types.listOf types.str;
}
```
- if it has `options`, is a submodule: 
```nix
lib.simpleOptions {
  options.EGGS.options.SPAM.type = types.str;
} == {
  options.EGGS.SPAM.type         = types.str;
} == {
  options.EGGS.type = submodule { options.SPAM.type = types.str; };
}
```
- or else `type` is required
```nix
lib.simpleOptions {
  options.TICO-TICO.type        = types.str;
} == {
  options.TICO-TICO.type        = types.str;
}
```

Create a helper function that translates this new (experimental) interface so no initial retro compatibility problem (except function not available) is created.

It looks not so different unless we add some nested example like options of attrs of options of list of string
```nix
lib.simpleOptions {
  options.FOO.attrsOf.options.BAR.listOf        = types.str;
} == {
  options.FOO.type = types.attrsOf ( types.submodule { options.BAR.type = types.listOf types.str; } );
}
```


**Example**:
This code (current way)

```nix
{ lib, ...}:
let
  Node = lib.types.submodule {
    options.tags = lib.mkOption {
      type        = lib.types.listOf lib.types.str;
      example     = ["logstash"];
      default     = [];
      description = "Define the tags of this node in the project cluster";
    };
  };
  env = lib.mkOption {
    type        = lib.types.attrsOf Node;
    default     = {};
    example     = { logstash01 = { tags = ["logstash"]; }; };
    description = "nodes of this environment";
  };

  Project = lib.types.submodule {
    options.git  = lib.mkOption {
      default     = "";
      type        = lib.types.str;
      example     = "https://github.com/DavHau";
      description = "git project url";
    };
    options.desc = lib.mkOption {
      default     = "";
      type        = lib.types.str;
      example     = "Elastic stack config files";
      description = "Description of the project";
    };
    options.docs = lib.mkOption {
      default     = "";
      type        = lib.types.str;
      example     = "https://google.com";
      description = "url of main documentations";
    };
    options.dev = env;
    options.prd = env;
  };
in
{
  options.project = lib.mkOption {
    type        = lib.types.attrsOf Project;
    default     = {};
    example     = { elk.desc = "elastic stack"; elk.dev.logstash01.tags = ["logstash"]; };
    description = "Information about our git projects";
  };
}
```

After proposed solution could be like this:

```nix
{lib, ...}:
let
  env.default      = {};
  env.example      = { logstash01 = { tags = ["logstash"]; }; };
  env.description  = "nodes of this environment";
  env.attrsOf.options.tags.listOf      = lib.types.str;
  env.attrsOf.options.tags.example     = ["logstash"];
  env.attrsOf.options.tags.default     = [];
  env.attrsOf.options.tags.description = "Define the tags of this node in the project cluster";
in
{
  options.project.default     = {};
  options.project.example     = { elk.desc = "elastic stack"; elk.dev.logstash01.tags = ["logstash"]; };
  options.project.description = "Information about our git projects";
  options.project.attrsOf.options = {
    git.default      = "";
    git.type         = lib.types.str;
    git.example      = "https://github.com/DavHau/pkgs-modules";
    git.description  = "git project url";
    desc.default     = "";
    desc.type        = lib.types.str;
    desc.example     = "Elastic stack config files";
    desc.description = "Description of the project";
    docs.default     = "";
    docs.type        = lib.types.str;
    docs.example     = "https://google.com";
    docs.description = "url of main documentations";
    dev = env;
    prd = env;
  };
}
```

**Drawbacks**

"I think the module system already has too much syntax sugar. Every time you add syntax sugar, you introduce at least one corner case." - @roberth 

"Furthermore, you obfuscate the original data model. You might flatten the very start of the learning curve, but a newcomer will have learned the wrong thing, and still needs to learn the original syntax before they become proficient." - @roberth

**Alternatives**

- Implement a [nickel-nix](https://github.com/nickel-lang/nickel-nix) modules translator.
- Create a stand alone project to mature the idea and documentation 

**Future work**

Should we have other types like `oneOf`, `nullOr`

**TODO**:

- [X] Configure tests
- [ ] Documentation
- [ ] Format code

¹. https://www.youtube.com/watch?v=dTd499Y31ig
². https://github.com/DavHau/pkgs-modules/issues/1
³. https://discourse.nixos.org/t/nixpkgs-nixos-is-an-expert-system-database/671/7



<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

edit: I edited it so many times that I lost the count :-D
