### PR TITLE
neovimUtils.grammarToPlugin: install tree-sitter grammars for neovim …

### DIFF
--- a/pkgs/applications/editors/vim/plugins/nvim-treesitter/overrides.nix
+++ b/pkgs/applications/editors/vim/plugins/nvim-treesitter/overrides.nix
@@ -1,8 +1,9 @@
-{ lib, callPackage, tree-sitter, neovim, runCommand }:
+{ lib, callPackage, tree-sitter, neovim, neovimUtils, runCommand }:
 
 self: super:
 
 let
+  inherit (neovimUtils) grammarToPlugin;
   generatedGrammars = callPackage ./generated.nix {
     inherit (tree-sitter) buildGrammar;
   };
@@ -26,31 +27,6 @@ let
         "tree-sitter-${replaced}" = v;
       })
     generatedDerivations;
-
-  grammarToPlugin = grammar:
-    let
-      name = lib.pipe grammar [
-        lib.getName
-
-        # added in buildGrammar
-        (lib.removeSuffix "-grammar")
-
-        # grammars from tree-sitter.builtGrammars
-        (lib.removePrefix "tree-sitter-")
-        (lib.replaceStrings [ "-" ] [ "_" ])
-      ];
-    in
-
-    runCommand "nvim-treesitter-grammar-${name}"
-      {
-        meta = {
-          platforms = lib.platforms.all;
-        } // grammar.meta;
-      }
-      ''
-        mkdir -p $out/parser
-        ln -s ${grammar}/parser $out/parser/${name}.so
-      '';
 
   allGrammars = lib.attrValues generatedDerivations;
 


### PR DESCRIPTION
###### Description of changes

…without nvim-treesitter

nvim-treesitter installs tons of queries (https://github.com/nvim-treesitter/nvim-treesitter/tree/master/queries) that are picked up by neovim even though we sometimes dont want those queries (when installing the upstream plugin with those queries for instance). This makes it possible to install grammars without nvim-treesitter which becomes more and more a repository like nvim-lspconfig, aka a repo that lists others.

Having to run `grammarToPlugin` for every grammar is annoying. Maybe we can just create these plugins in vim/overrides.nix ? 

cc @figsoda 

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
