### PR TITLE
calibre: 6.17.0 -> 6.19.1

### DIFF
--- a/pkgs/applications/misc/calibre/default.nix
+++ b/pkgs/applications/misc/calibre/default.nix
@@ -32,11 +32,11 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "calibre";
-  version = "6.17.0";
+  version = "6.19.1";
 
   src = fetchurl {
     url = "https://download.calibre-ebook.com/${finalAttrs.version}/calibre-${finalAttrs.version}.tar.xz";
-    hash = "sha256-HKSruKXYUMH1lj43CA3Rp3lXNlONXE1P9gFLaH16No4=";
+    hash = "sha256-Fm2484ztsSc80waJBvy7rHGnNBFxCvbbrsHDBCZ2kxA=";
   };
 
   # https://sources.debian.org/patches/calibre/${finalAttrs.version}+dfsg-1
@@ -49,8 +49,8 @@ stdenv.mkDerivation (finalAttrs: {
     })
     (fetchpatch {
       name = "0007-Hardening-Qt-code.patch";
-      url = "https://raw.githubusercontent.com/debian-calibre/calibre/debian/${finalAttrs.version}-1/debian/patches/0007-Hardening-Qt-code.patch";
-      hash = "sha256-9P1kGrQbWAWDzu5EUiQr7TiCPHRWUA8hxPpEvFpK20k=";
+      url = "https://raw.githubusercontent.com/debian-calibre/calibre/debian/${finalAttrs.version}-1/debian/patches/hardening/0007-Hardening-Qt-code.patch";
+      hash = "sha256-WBm0dWDXoPT6alEdK5dVMrVTOxG7Z8bq1s0iO2HTy/Q=";
     })
   ]
   ++ lib.optional (!unrarSupport) ./dont_build_unrar_plugin.patch;

--- a/pkgs/development/libraries/podofo/0.10.x.nix
+++ b/pkgs/development/libraries/podofo/0.10.x.nix
@@ -1,0 +1,67 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, cmake
+, expat
+, fontconfig
+, freetype
+, libidn
+, libjpeg
+, libpng
+, libtiff
+, libxml2
+, lua5
+, openssl
+, pkg-config
+, zlib
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "podofo";
+  version = "0.10.0";
+
+  src = fetchFromGitHub {
+    owner = "podofo";
+    repo = "podofo";
+    rev = finalAttrs.version;
+    hash = "sha256-Z9mVAo2dITEtTdqA2sftaLZSCiTbGS02RYxfNcEwd1c=";
+  };
+
+  outputs = [ "out" "dev" "lib" ];
+
+  nativeBuildInputs = [
+    cmake
+    pkg-config
+  ];
+
+  buildInputs = [
+    expat
+    fontconfig
+    freetype
+    libidn
+    libjpeg
+    libpng
+    libtiff
+    libxml2
+    lua5
+    openssl
+    zlib
+  ];
+
+  cmakeFlags = [
+    "-DPODOFO_BUILD_STATIC=${if stdenv.hostPlatform.isStatic then "ON" else "OFF"}"
+    "-DCMAKE_BUILD_WITH_INSTALL_NAME_DIR=ON"
+  ];
+
+  postInstall = ''
+    moveToOutput lib "$lib"
+  '';
+
+  meta = {
+    homepage = "https://github.com/podofo/podofo";
+    description = "A library to work with the PDF file format";
+    platforms = lib.platforms.all;
+    license = with lib.licenses; [ gpl2Plus lgpl2Plus ];
+    maintainers = [];
+  };
+})

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -29702,7 +29702,9 @@ with pkgs;
 
   calculix = callPackage ../applications/science/math/calculix { };
 
-  calibre = qt6Packages.callPackage ../applications/misc/calibre { };
+  calibre = qt6Packages.callPackage ../applications/misc/calibre {
+    podofo = podofo010;
+  };
 
   calibre-web = callPackage ../servers/calibre-web { };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -23560,6 +23560,8 @@ with pkgs;
 
   podofo = callPackage ../development/libraries/podofo { };
 
+  podofo010 = callPackage ../development/libraries/podofo/0.10.x.nix { };
+
   polkit = callPackage ../development/libraries/polkit { };
 
   poppler = callPackage ../development/libraries/poppler { lcms = lcms2; };


### PR DESCRIPTION
###### Description of changes
- https://github.com/kovidgoyal/calibre/releases/tag/v6.18.0
- https://github.com/kovidgoyal/calibre/releases/tag/v6.18.1
- https://github.com/kovidgoyal/calibre/releases/tag/v6.19.0
- https://github.com/kovidgoyal/calibre/releases/tag/v6.19.1

A detailed description of the changes can be found in https://calibre-ebook.com/whats-new.

Updating Calibre to the latest release necessitates podofo version 0.10.0, given its API/ABI incompatibility with versions 0.9.x. To accommodate this disparity, I included the newer version as an individual package instead of creating a generic package, as the source, dependencies, and make flags have also undergone changes.

###### Things done
- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).