### PR TITLE
release: before 23.05 final release

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,9 +51,9 @@ Nixpkgs and NixOS are built and tested by our continuous integration
 system, [Hydra](https://hydra.nixos.org/).
 
 * [Continuous package builds for unstable/master](https://hydra.nixos.org/jobset/nixos/trunk-combined)
-* [Continuous package builds for the NixOS 22.11 release](https://hydra.nixos.org/jobset/nixos/release-22.11)
+* [Continuous package builds for the NixOS 23.05 release](https://hydra.nixos.org/jobset/nixos/release-23.05)
 * [Tests for unstable/master](https://hydra.nixos.org/job/nixos/trunk-combined/tested#tabs-constituents)
-* [Tests for the NixOS 22.11 release](https://hydra.nixos.org/job/nixos/release-22.11/tested#tabs-constituents)
+* [Tests for the NixOS 23.05 release](https://hydra.nixos.org/job/nixos/release-23.05/tested#tabs-constituents)
 
 Artifacts successfully built with Hydra are published to cache at
 https://cache.nixos.org/. When successful build and test criteria are

--- a/nixos/doc/manual/installation/upgrading.chapter.md
+++ b/nixos/doc/manual/installation/upgrading.chapter.md
@@ -6,7 +6,7 @@ expressions and associated binaries. The NixOS channels are updated
 automatically from NixOS's Git repository after certain tests have
 passed and all packages have been built. These channels are:
 
--   *Stable channels*, such as [`nixos-22.11`](https://nixos.org/channels/nixos-22.11).
+-   *Stable channels*, such as [`nixos-23.05`](https://channels.nixos.org/nixos-23.05).
     These only get conservative bug fixes and package upgrades. For
     instance, a channel update may cause the Linux kernel on your system
     to be upgraded from 4.19.34 to 4.19.38 (a minor bug fix), but not
@@ -14,13 +14,13 @@ passed and all packages have been built. These channels are:
     Stable channels are generally maintained until the next stable
     branch is created.
 
--   The *unstable channel*, [`nixos-unstable`](https://nixos.org/channels/nixos-unstable).
+-   The *unstable channel*, [`nixos-unstable`](https://channels.nixos.org/nixos-unstable).
     This corresponds to NixOS's main development branch, and may thus see
     radical changes between channel updates. It's not recommended for
     production systems.
 
--   *Small channels*, such as [`nixos-22.11-small`](https://nixos.org/channels/nixos-22.11-small)
-    or [`nixos-unstable-small`](https://nixos.org/channels/nixos-unstable-small).
+-   *Small channels*, such as [`nixos-23.05-small`](https://channels.nixos.org/nixos-23.05-small)
+    or [`nixos-unstable-small`](https://channels.nixos.org/nixos-unstable-small).
     These are identical to the stable and unstable channels described above,
     except that they contain fewer binary packages. This means they get updated
     faster than the regular channels (for instance, when a critical security patch
@@ -28,7 +28,7 @@ passed and all packages have been built. These channels are:
     built from source than usual. They're mostly intended for server environments
     and as such contain few GUI applications.
 
-To see what channels are available, go to <https://nixos.org/channels>.
+To see what channels are available, go to <https://channels.nixos.org>.
 (Note that the URIs of the various channels redirect to a directory that
 contains the channel's latest version and includes ISO images and
 VirtualBox appliances.) Please note that during the release process,
@@ -38,38 +38,38 @@ newest supported stable release.
 
 When you first install NixOS, you're automatically subscribed to the
 NixOS channel that corresponds to your installation source. For
-instance, if you installed from a 22.11 ISO, you will be subscribed to
-the `nixos-22.11` channel. To see which NixOS channel you're subscribed
+instance, if you installed from a 23.05 ISO, you will be subscribed to
+the `nixos-23.05` channel. To see which NixOS channel you're subscribed
 to, run the following as root:
 
 ```ShellSession
 # nix-channel --list | grep nixos
-nixos https://nixos.org/channels/nixos-unstable
+nixos https://channels.nixos.org/nixos-unstable
 ```
 
 To switch to a different NixOS channel, do
 
 ```ShellSession
-# nix-channel --add https://nixos.org/channels/channel-name nixos
+# nix-channel --add https://channels.nixos.org/channel-name nixos
 ```
 
 (Be sure to include the `nixos` parameter at the end.) For instance, to
-use the NixOS 22.11 stable channel:
+use the NixOS 23.05 stable channel:
 
 ```ShellSession
-# nix-channel --add https://nixos.org/channels/nixos-22.11 nixos
+# nix-channel --add https://channels.nixos.org/nixos-23.05 nixos
 ```
 
 If you have a server, you may want to use the "small" channel instead:
 
 ```ShellSession
-# nix-channel --add https://nixos.org/channels/nixos-22.11-small nixos
+# nix-channel --add https://channels.nixos.org/nixos-23.05-small nixos
 ```
 
 And if you want to live on the bleeding edge:
 
 ```ShellSession
-# nix-channel --add https://nixos.org/channels/nixos-unstable nixos
+# nix-channel --add https://channels.nixos.org/nixos-unstable nixos
 ```
 
 You can then upgrade NixOS to the latest version in your chosen channel
@@ -114,5 +114,5 @@ the new generation contains a different kernel, initrd or kernel
 modules. You can also specify a channel explicitly, e.g.
 
 ```nix
-system.autoUpgrade.channel = https://nixos.org/channels/nixos-22.11;
+system.autoUpgrade.channel = "https://channels.nixos.org/nixos-23.05";
 ```


### PR DESCRIPTION
###### Description of changes

- Updates the README to mention 23.05
- Updates the upgrading chapter to mention 23.05
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
