### PR TITLE
linuxPackages_5_4_hardened.kernel: fix broken KConfig

### DIFF
--- a/pkgs/os-specific/linux/kernel/hardened/config.nix
+++ b/pkgs/os-specific/linux/kernel/hardened/config.nix
@@ -41,7 +41,7 @@ assert (versionAtLeast version "4.9");
   DEBUG_SG              = yes;
   SCHED_STACK_END_CHECK = yes;
 
-  REFCOUNT_FULL = whenOlder "5.5" yes;
+  REFCOUNT_FULL = whenOlder "5.4.208" yes;
 
   # Randomize page allocator when page_alloc.shuffle=1
   SHUFFLE_PAGE_ALLOCATOR = whenAtLeast "5.2" yes;

--- a/pkgs/top-level/linux-kernels.nix
+++ b/pkgs/top-level/linux-kernels.nix
@@ -49,7 +49,7 @@ let
           broken =
             kernel.meta.broken ||
             lib.versions.majorMinor version == "4.14" ||
-            (stdenv.isx86_64 && lib.versionAtLeast version "4.19" && lib.versionOlder version "5.5");
+            (stdenv.isx86_64 && lib.versions.majorMinor version == "4.19");
         };
       };
       kernelPatches = kernel.kernelPatches ++ [

--- a/pkgs/top-level/linux-kernels.nix
+++ b/pkgs/top-level/linux-kernels.nix
@@ -46,10 +46,7 @@ let
           inherit sha256;
         };
         extraMeta = {
-          broken =
-            kernel.meta.broken ||
-            lib.versions.majorMinor version == "4.14" ||
-            (stdenv.isx86_64 && lib.versions.majorMinor version == "4.19");
+          broken = kernel.meta.broken;
         };
       };
       kernelPatches = kernel.kernelPatches ++ [

--- a/pkgs/top-level/linux-kernels.nix
+++ b/pkgs/top-level/linux-kernels.nix
@@ -258,9 +258,18 @@ in {
 
     linux_hardened = hardenedKernelFor packageAliases.linux_default.kernel { };
 
-    linux_4_14_hardened = hardenedKernelFor kernels.linux_4_14 { };
-    linux_4_19_hardened = hardenedKernelFor kernels.linux_4_19 { };
-    linux_5_4_hardened = hardenedKernelFor kernels.linux_5_4 { };
+    linux_4_14_hardened = hardenedKernelFor kernels.linux_4_14 {
+      stdenv = gcc10Stdenv;
+      buildPackages = buildPackages // { stdenv = buildPackages.gcc10Stdenv; };
+    };
+    linux_4_19_hardened = hardenedKernelFor kernels.linux_4_19 {
+      stdenv = gcc10Stdenv;
+      buildPackages = buildPackages // { stdenv = buildPackages.gcc10Stdenv; };
+    };
+    linux_5_4_hardened = hardenedKernelFor kernels.linux_5_4 {
+      stdenv = gcc10Stdenv;
+      buildPackages = buildPackages // { stdenv = buildPackages.gcc10Stdenv; };
+    };
     linux_5_10_hardened = hardenedKernelFor kernels.linux_5_10 { };
     linux_5_15_hardened = hardenedKernelFor kernels.linux_5_15 { };
     linux_6_1_hardened = hardenedKernelFor kernels.linux_6_1 { };
@@ -600,23 +609,14 @@ in {
     linux_testing = packagesFor kernels.linux_testing;
     linux_testing_bcachefs = recurseIntoAttrs (packagesFor kernels.linux_testing_bcachefs);
 
-    linux_hardened = recurseIntoAttrs (hardenedPackagesFor packageAliases.linux_default.kernel { });
+    linux_hardened = recurseIntoAttrs (packagesFor kernels.linux_hardened);
 
-    linux_4_14_hardened = recurseIntoAttrs (hardenedPackagesFor kernels.linux_4_14 {
-      stdenv = gcc10Stdenv;
-      buildPackages = buildPackages // { stdenv = buildPackages.gcc10Stdenv; };
-    });
-    linux_4_19_hardened = recurseIntoAttrs (hardenedPackagesFor kernels.linux_4_19 {
-      stdenv = gcc10Stdenv;
-      buildPackages = buildPackages // { stdenv = buildPackages.gcc10Stdenv; };
-    });
-    linux_5_4_hardened = recurseIntoAttrs (hardenedPackagesFor kernels.linux_5_4 {
-      stdenv = gcc10Stdenv;
-      buildPackages = buildPackages // { stdenv = buildPackages.gcc10Stdenv; };
-    });
-    linux_5_10_hardened = recurseIntoAttrs (hardenedPackagesFor kernels.linux_5_10 { });
-    linux_5_15_hardened = recurseIntoAttrs (hardenedPackagesFor kernels.linux_5_15 { });
-    linux_6_1_hardened = recurseIntoAttrs (hardenedPackagesFor kernels.linux_6_1 { });
+    linux_4_14_hardened = recurseIntoAttrs (packagesFor kernels.linux_4_14_hardened);
+    linux_4_19_hardened = recurseIntoAttrs (packagesFor kernels.linux_4_19_hardened);
+    linux_5_4_hardened = recurseIntoAttrs (packagesFor kernels.linux_5_4_hardened);
+    linux_5_10_hardened = recurseIntoAttrs (packagesFor kernels.linux_5_10_hardened);
+    linux_5_15_hardened = recurseIntoAttrs (packagesFor kernels.linux_5_15_hardened);
+    linux_6_1_hardened = recurseIntoAttrs (packagesFor kernels.linux_6_1_hardened);
 
     linux_zen = recurseIntoAttrs (packagesFor kernels.linux_zen);
     linux_lqx = recurseIntoAttrs (packagesFor kernels.linux_lqx);


### PR DESCRIPTION
###### Description of changes

The removal of `CONFIG_RECOUNT_FULL` from kernel `5.5` was apparently backported in kernel `5.4.208`.
This broke the `kernel.configfile` derivation since it was a required option.

Backport commit: 
https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git/commit/?id=d0d583484d2ed9f5903edbbfa7e2a68f78b950b0
First `5.4` patch release after:
https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git/commit/?id=77ba2b9b46f8acead2606759e8196b7076eaeeea

Fixes #233268

@alyssais - I've only marked `linux_5_4_hardened` as working, but it looks like `linux_4_14_hardened` and `linux_4_19_hardened` build as well. Since you marked them as broken I'm adding a mention.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
