### PR TITLE
linuxPackages.nvidia_x11_beta: 530.41.03 -> 535.43.02

### DIFF
--- a/pkgs/os-specific/linux/nvidia-x11/builder.sh
+++ b/pkgs/os-specific/linux/nvidia-x11/builder.sh
@@ -124,6 +124,10 @@ installPhase() {
         if [ -e nvngx.dll ] && [ -e _nvngx.dll ]; then
             install -Dm644 -t $i/lib/nvidia/wine/ nvngx.dll _nvngx.dll
         fi
+
+        if [ -e nvoptix.bin ]; then
+            install -Dm444 -t $i/share/nvidia/ nvoptix.bin
+        fi
     done
 
     if [ -n "$bin" ]; then

--- a/pkgs/os-specific/linux/nvidia-x11/default.nix
+++ b/pkgs/os-specific/linux/nvidia-x11/default.nix
@@ -54,12 +54,12 @@ rec {
   });
 
   beta = selectHighestVersion latest (generic {
-    version = "530.30.02";
-    sha256_64bit = "sha256-R/3bvXoiumYZI9vObn9R7sVN9oBQxAbMBJDDv77eeWM=";
-    sha256_aarch64 = "sha256-/b5Jdow+O7ExXjtXTzDX38qgmBDUYDUl+5zxXvbi1ts=";
-    openSha256 = "sha256-LCtTyuJ8s8isTBt9HetItLqSjL1GOn0tPUarjuxHpMk=";
-    settingsSha256 = "sha256-6mynLNSaWeiB52HdwZ0EQNyPg+tuat0oEqpZGSb2yQo=";
-    persistencedSha256 = "sha256-h6iq0iD9F41a7s6jWKPTI+oVzgDRIr1Kk97LNH9rg7E=";
+    version = "535.43.02";
+    sha256_64bit = "sha256-4KTdk4kGDmBGyHntMIzWRivUpEpzmra+p7RBsTL8mYM=";
+    sha256_aarch64 = "sha256-0blD8R+xpOVlitWefIbtw1d3KAnmWHBy7hkxGZHBrE4=";
+    openSha256 = "sha256-W1fwbbEEM7Z/S3J0djxGTtVTewbSALqX1G1OSpdajCM=";
+    settingsSha256 = "sha256-j0sSEbtF2fapv4GSthVTkmJga+ycmrGc1OnGpV6jEkc=";
+    persistencedSha256 = "sha256-M0ovNaJo8SZwLW4CQz9accNK79Z5JtTJ9kKwOzicRZ4=";
   });
 
   # Vulkan developer beta driver

--- a/pkgs/os-specific/linux/nvidia-x11/generic.nix
+++ b/pkgs/os-specific/linux/nvidia-x11/generic.nix
@@ -50,7 +50,7 @@ let
   libPathFor = pkgs: lib.makeLibraryPath (with pkgs; [
     libdrm xorg.libXext xorg.libX11
     xorg.libXv xorg.libXrandr xorg.libxcb zlib stdenv.cc.cc
-    wayland mesa libGL
+    wayland mesa libGL openssl
   ]);
 
   self = stdenv.mkDerivation {


### PR DESCRIPTION
###### Description of changes

- Release highlights since 530.41.03:
  - Added support for the VK_EXT_memory_priority, and VK_EXT_pageable_device_memory extensions for Turing+ GPUs.
  - Improved the performance of Minecraft Java Edition on RTX 3000 series GPUs.
  - Fixed a memory leak in the NVIDIA GLX driver, as reported at: [ASAN reports memory leak in libnvidia-glcore.so.515.57](https://forums.developer.nvidia.com/t/222697)
  - Added support for driving very high pixel clock mode timings such as 8K @ 60Hz. Please see the MaxOneHardwareHead X11 ModeValidation token in the README for details.
  - Extended Dynamic Boost support on notebooks to include older Renoir and Cezanne chipsets, in addition to Rembrandt and newer AMD chipsets.
  - Fixed a bug that caused Vulkan X11 swapchain creation to fail on GPUs without a display engine when the VK_KHR_present_id extension is used.
  - Fixed console restore on legacy VGA consoles when using the NVIDIA Open GPU Kernel Modules.
  - Added nvoptix.bin to the driver package. This data file is used by the OptiX ray tracing engine library, libnvoptix.so.1.
  - Removed libnvidia-compiler.so.VERSION from the driver package. This functionality is now provided by other driver libraries.
  - Added power usage and power limits information to nvidia-settings PowerMizer page.
  - Updated NV_CTRL_GPU_POWER_SOURCE NV-CONTROL API to report undersized power source.
  - Add support for version 4 of the linux-dmabuf wayland protocol.
  - Updated the bundled copy of the GBM EGL external platform library:
    - [GitHub - NVIDIA/egl-gbm: The GBM EGL external platform library](https://github.com/NVIDIA/egl-gbm)
    - The updated version includes the fix for a bug which caused the number of free GBM surface buffers to be reported incorrectly.
  - Fixed a bug which prevented running a Wayland compositor in headless mode on GPUs without display hardware.
  - Fixed a regression in Luxmark performance between 525.89.02 and 525.105.17.
  - Fixed a bug that could cause an unexpected VK_ERROR_NATIVE_WINDOW_IN_USE_KHR error in certain circumstances when recreating Vulkan surfaces.
  - Fixed a regression that caused brightness control to not vary smoothly across the range of values.
  - Improved the reliability of suspend and resume on UEFI systems when using certain display panels.
  - Fixed a bug that prevented some controls in the nvidia-settings control panel from working when running an X server as an unprivileged user.
  - Fixed a bug which caused incorrect reporting of presentation times when using the VK_NV_present_barrier Vulkan extension.
  - Fixed a bug that could cause fullscreen PRIME Render Offload applications and/or X to crash when an NVIDIA GPU is driving multiple displays with Reverse PRIME.
  - Added support for console restoration when using simpledrm.
  - Disabled Fixed Rate Link (FRL) when using passive DisplayPort to HDMI dongles, which are incompatible with FRL.
  - Updated nvidia-modprobe to create symbolic links in /dev/char when creating the /dev/nvidia* device nodes. This resolves an issue that prevented the device nodes from working with newer versions of runc:
    - [Newer runc versions break support for NVIDIA GPUs · Issue #3708 · opencontainers/runc · GitHub](https://github.com/opencontainers/runc/issues/3708)

- `open-gpu-kernel-modules`:
  - Fixed
    - Fixed console restore with traditional VGA consoles.
  - Added
    - Added support for Run Time D3 (RTD3) on Ampere and later GPUs.
    - Added support for G-Sync on desktop GPUs.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
