### PR TITLE
wizer: 1.6.0 -> 3.0.1

### DIFF
--- a/pkgs/development/tools/wizer/default.nix
+++ b/pkgs/development/tools/wizer/default.nix
@@ -8,19 +8,18 @@
 
 rustPlatform.buildRustPackage rec {
   pname = "wizer";
-  version = "1.6.0";
+  version = "3.0.1";
 
   # the crate does not contain files which are necessary for the tests
   # see https://github.com/bytecodealliance/wizer/commit/3a95e27ce42f1fdaef07b52988e4699eaa221e04
   src = fetchFromGitHub {
     owner = "bytecodealliance";
     repo = "wizer";
-    # see https://github.com/bytecodealliance/wizer/pull/62
-    rev = "e74c6e59562c4b7edcda506674db8aead878a893";
-    sha256 = "sha256-bVxjcb231Ygz+z+8D1U2YQqEdIKsostxISgYt2KecXc=";
+    rev = "refs/tags/v${version}";
+    hash = "sha256-/4VkGvXlWU1jZztBCWCsJDQXTV8krIHaoyqmoXwjGIM=";
   };
 
-  cargoSha256 = "sha256-S9h47aGG5UhwNoOnUHFrtEyByg8iCMC88Cspb/6tb8c=";
+  cargoHash = "sha256-M0EhyZH2maZCr4tWDo9ppKBM3CXEfwjUfnVksqVWKgU=";
 
   cargoBuildFlags = [ "--bin" pname ];
 


### PR DESCRIPTION
###### Description of changes

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
