### PR TITLE
flat-remix-icon-theme: disable fixup to improve build time

### DIFF
--- a/pkgs/data/icons/flat-remix-icon-theme/default.nix
+++ b/pkgs/data/icons/flat-remix-icon-theme/default.nix
@@ -22,6 +22,7 @@ stdenvNoCC.mkDerivation rec  {
     hicolor-icon-theme
   ];
 
+  dontFixup = true;
   dontDropIconThemeCache = true;
 
   installPhase = ''
@@ -31,6 +32,8 @@ stdenvNoCC.mkDerivation rec  {
     for theme in $out/share/icons/*; do
       gtk-update-icon-cache $theme
     done
+    symlinkParentIconThemes
+    recordPropagatedDependencies
   '';
 
   meta = with lib; {


### PR DESCRIPTION
###### Description of changes

`dontFixup = true;` (and two lines added to `installPhase` to make the output identical)

On my machine, build time went from 6m49s to 45s.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
