### PR TITLE
update: otel-cli 0.2.0 -> 0.3.0

### DIFF
--- a/pkgs/tools/misc/otel-cli/default.nix
+++ b/pkgs/tools/misc/otel-cli/default.nix
@@ -1,23 +1,23 @@
-{ lib, bash, buildGoModule, fetchFromGitHub, getent, nix-update-script, stdenv }:
+{ lib, bash, buildGoModule, fetchFromGitHub, getent, coreutils, nix-update-script, stdenv }:
 
 buildGoModule rec {
   pname = "otel-cli";
-  version = "0.2.0";
+  version = "0.3.0";
 
   src = fetchFromGitHub {
     owner = "equinix-labs";
     repo = pname;
     rev = "v${version}";
-    hash = "sha256-hez/jHet7W4FnOjgLb0jE1FhoNimiLGaOuTI44UWbSA=";
+    hash = "sha256-edxDPxUamZiBezMj2SII/zq8atnyZVWtboUJsShDAyw=";
   };
 
-  vendorHash = "sha256-gVRgqBgiFnPU6MRZi/Igs7nDPMwJYsdln7vPAcxTvPU=";
+  vendorHash = "sha256-MlLFTi+O925NA73zDRrk0AgJzwtdNBhCxDjmniNPwio=";
 
   preCheck = ''
     ln -s $GOPATH/bin/otel-cli .
   '' + lib.optionalString (!stdenv.isDarwin) ''
     substituteInPlace main_test.go \
-      --replace 'const minimumPath = `/bin:/usr/bin`' 'const minimumPath = `${lib.makeBinPath [ getent ]}`'
+      --replace 'const minimumPath = `/bin:/usr/bin`' 'const minimumPath = `${lib.makeBinPath [ getent coreutils ]}`'
   '';
 
   passthru.updateScript = nix-update-script {};


### PR DESCRIPTION
updates otel-cli from 0.2.0 to 0.3.0
see https://github.com/equinix-labs/otel-cli/releases/tag/v0.3.0 for changelog and release details

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
