### PR TITLE
CODEOWNERS: reduce scope for fricklerhandwerk

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -58,13 +58,9 @@
 /maintainers/scripts/db-to-md.sh @jtojnar @ryantm
 /maintainers/scripts/doc @jtojnar @ryantm
 
-/doc/* @fricklerhandwerk
 /doc/build-aux/pandoc-filters @jtojnar
-/doc/builders/trivial-builders.chapter.md @fricklerhandwerk
 /doc/contributing/ @fricklerhandwerk
 /doc/contributing/contributing-to-documentation.chapter.md @jtojnar @fricklerhandwerk
-/doc/stdenv @fricklerhandwerk
-/doc/using @fricklerhandwerk
 
 # NixOS Internals
 /nixos/default.nix                                    @infinisil


### PR DESCRIPTION
I can't keep up with reviews and don't want to let people wait indefinitely.

The @nixos/documentation-team is still looking for maintainers taking editorial responsibility for the Nixpkgs and NixOS manuals:

https://discourse.nixos.org/t/documentation-team-call-for-maintainers/25970