### PR TITLE
Add prometheus nomad scrape config options

### DIFF
--- a/nixos/modules/services/monitoring/prometheus/default.nix
+++ b/nixos/modules/services/monitoring/prometheus/default.nix
@@ -414,6 +414,10 @@ let
         List of AirBnB's Nerve service discovery configurations.
       '';
 
+      nomad_sd_configs = mkOpt (types.listOf promTypes.nomad_sd_config) ''
+        List of Nomad service discovery configurations.
+      '';
+
       openstack_sd_configs = mkOpt (types.listOf promTypes.openstack_sd_config) ''
         List of OpenStack service discovery configurations.
       '';
@@ -1060,6 +1064,48 @@ let
         Timeout value.
       '';
     };
+  };
+
+  promTypes.nomad_sd_config = mkSdConfigModule {
+    allow_stale = mkDefOpt types.bool "true" ''
+      Allows any nomad server to service API requests regardless of whether it
+      is the cluster leader. The trade-off is fast reads but potentially stale
+      values.
+    '';
+
+    enable_http2 = mkDefOpt types.bool "true" ''
+      Whether to enable HTTP2.
+    '';
+
+    namespace = mkDefOpt types.string "default" ''
+      Nomad has support for namespaces, which allow jobs and their associated
+      objects to be segmented from each other and other users of the cluster.
+      When using a non-default namespace, this option must be set to indicate
+      the namespace that should be scraped.
+    '';
+
+    refresh_interval = mkDefOpt types.str "60s" ''
+      Refresh interval to re-read the service list.
+    '';
+
+    region = mkDefOpt types.str "global" ''
+      By default, any request to the nomad API will default to the region on
+      which the machine is servicing the request. This option can be used to
+      explicitly indicate which region to scrape. Requests will be
+      transparently forwarded and serviced by a server in the requested
+      region.
+    '';
+
+    server = mkOption {
+      type = types.str;
+      description = lib.mdDoc ''
+        The URL of the nomad cluster to scrape.
+      '';
+    };
+
+    tag_separator = mkDefOpt types.str "," ''
+      The string by which Nomad service tags are joined into the tag label.
+    '';
   };
 
   promTypes.openstack_sd_config = types.submodule {


### PR DESCRIPTION
###### Description of changes

This PR adds support for configuring Prometheus to scrape Nomad services. The only change needed to support this was to add add some more options to the `services.prometheus` module to match the schema accepted by Prometheus.

https://prometheus.io/docs/prometheus/latest/configuration/configuration/#nomad_sd_config

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
