### PR TITLE
systemd-boot: Patch for firmwares that fail to load large files

### DIFF
--- a/nixos/tests/systemd-boot-ovmf-broken-fat-driver.patch
+++ b/nixos/tests/systemd-boot-ovmf-broken-fat-driver.patch
@@ -1,0 +1,25 @@
+From d87a7513c6f2f2824203032ef27caeb84892ed7e Mon Sep 17 00:00:00 2001
+From: Will Fancher <elvishjerricco@gmail.com>
+Date: Tue, 30 May 2023 16:53:20 -0400
+Subject: [PATCH] Intentionally break the fat driver
+
+---
+ FatPkg/EnhancedFatDxe/ReadWrite.c | 5 +++++
+ 1 file changed, 5 insertions(+)
+
+diff --git a/FatPkg/EnhancedFatDxe/ReadWrite.c b/FatPkg/EnhancedFatDxe/ReadWrite.c
+index 8f525044d1f1..32c62ff7817b 100644
+--- a/FatPkg/EnhancedFatDxe/ReadWrite.c
++++ b/FatPkg/EnhancedFatDxe/ReadWrite.c
+@@ -216,6 +216,11 @@ FatIFileAccess (
+   Volume = OFile->Volume;
+   Task   = NULL;
+ 
++  if (*BufferSize > (10U * 1024U * 1024U)) {
++    IFile->Position += 10U * 1024U * 1024U;
++    return EFI_BAD_BUFFER_SIZE;
++  }
++
+   //
+   // Write to a directory is unsupported
+   //

--- a/pkgs/os-specific/linux/systemd/default.nix
+++ b/pkgs/os-specific/linux/systemd/default.nix
@@ -190,6 +190,16 @@ stdenv.mkDerivation (finalAttrs: {
     ./0017-inherit-systemd-environment-when-calling-generators.patch
     ./0018-core-don-t-taint-on-unmerged-usr.patch
     ./0019-tpm2_context_init-fix-driver-name-checking.patch
+
+    (fetchpatch {
+      # https://github.com/systemd/systemd/pull/25948
+      #
+      # [Firmware file size bug]: Some UEFI firmwares fail on large
+      # reads. Now that systemd-boot loads initrd itself, systems with
+      # such firmware won't boot without this fix
+      url = "https://github.com/systemd/systemd/commit/3ed1d966f00b002ed822ca9de116252bd91fe6c3.patch";
+      hash = "sha256-pwXrLTScqgnvfddlzUBZpwsoMrvRLcZPp6e4whMcyL4=";
+    })
   ] ++ lib.optional stdenv.hostPlatform.isMusl (
     let
       oe-core = fetchzip {


### PR DESCRIPTION
###### Description of changes

https://github.com/systemd/systemd/pull/25948

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
