### PR TITLE
several typos

### DIFF
--- a/pkgs/applications/audio/tetraproc/default.nix
+++ b/pkgs/applications/audio/tetraproc/default.nix
@@ -29,7 +29,7 @@ stdenv.mkDerivation rec {
   '';
 
   postInstall = ''
-    # Make sure Jack is avalable in $PATH for tetraproc
+    # Make sure Jack is available in $PATH for tetraproc
     wrapProgram $out/bin/tetraproc --prefix PATH : "${jack2}/bin"
   '';
 

--- a/pkgs/applications/version-management/tig/default.nix
+++ b/pkgs/applications/version-management/tig/default.nix
@@ -38,7 +38,7 @@ stdenv.mkDerivation rec {
     cp contrib/vim.tigrc $out/etc/
 
     # Note: Until https://github.com/jonas/tig/issues/940 is resolved it is best
-    # not to install the ZSH completion so that the fallback implemenation from
+    # not to install the ZSH completion so that the fallback implementation from
     # ZSH can be used (Completion/Unix/Command/_git: "_tig () { _git-log }"):
     #install -D contrib/tig-completion.zsh $out/share/zsh/site-functions/_tig
 

--- a/pkgs/applications/virtualization/xen/generic.nix
+++ b/pkgs/applications/virtualization/xen/generic.nix
@@ -116,7 +116,7 @@ stdenv.mkDerivation (rec {
     # Remove in-tree qemu stuff in case we build from a tar-ball
     rm -rf tools/qemu-xen tools/qemu-xen-traditional
 
-    # Fix shebangs, mainly for build-scipts
+    # Fix shebangs, mainly for build-scripts
     # We want to do this before getting prefetched stuff to speed things up
     # (prefetched stuff has lots of files)
     find . -type f | xargs sed -i 's@/usr/bin/\(python\|perl\)@/usr/bin/env \1@g'

--- a/pkgs/build-support/fetchgit/nix-prefetch-git
+++ b/pkgs/build-support/fetchgit/nix-prefetch-git
@@ -17,8 +17,8 @@ branchName=$NIX_PREFETCH_GIT_BRANCH_NAME
 out=${out:-}
 http_proxy=${http_proxy:-}
 
-# allow overwritting cacert's ca-bundle.crt with a custom one
-# this can be done by setting NIX_GIT_SSL_CAINFO and NIX_SSL_CERT_FILE enviroment variables for the nix-daemon
+# allow overwriting cacert's ca-bundle.crt with a custom one
+# this can be done by setting NIX_GIT_SSL_CAINFO and NIX_SSL_CERT_FILE environment variables for the nix-daemon
 GIT_SSL_CAINFO=${NIX_GIT_SSL_CAINFO:-$GIT_SSL_CAINFO}
 
 # populated by clone_user_rev()

--- a/pkgs/build-support/setup-hooks/role.bash
+++ b/pkgs/build-support/setup-hooks/role.bash
@@ -1,8 +1,8 @@
-# Since the same derivation can be depend on in multiple ways, we need to
+# Since the same derivation can be depended on in multiple ways, we need to
 # accumulate *each* role (i.e. host and target platforms relative the depending
 # derivation) in which the derivation is used.
 #
-# The role is intened to be use as part of other variables names like
+# The role is intended to be used as part of other variables names like
 #  - $NIX_SOMETHING${role_post}
 
 function getRole() {
@@ -49,7 +49,7 @@ function getTargetRoleEnvHook() {
     getRole "$depTargetOffset"
 }
 
-# This variant is inteneded specifically for code-prodocing tool wrapper scripts
+# This variant is intended specifically for code-producing tool wrapper scripts
 # `NIX_@wrapperName@_TARGET_*_@suffixSalt@` tracks this (needs to be an exported
 # env var so can't use fancier data structures).
 function getTargetRoleWrapper() {


### PR DESCRIPTION
###### Description of changes
typo fixes that trigger rebuilds

xen: "scipt" -> "script"
tetraproc: "avalable" -> "available"
tig: "implemenation" -> "implementation"
nix-prefetch-git: "enviroment" -> "environment"
pkgs/build-support: "inteneded" -> "intended", "intened" -> "intended" etc.
