### PR TITLE
squirrel-sql: fix the launcher script to allow JDK 19

### DIFF
--- a/pkgs/development/tools/database/squirrel-sql/default.nix
+++ b/pkgs/development/tools/database/squirrel-sql/default.nix
@@ -13,6 +13,10 @@ stdenv.mkDerivation rec {
     sha256 = "sha256-LKX8yNSLs60546ZcvLlQF3e++VxHmPsczui4cfrpia0=";
   };
 
+  patches = [
+    ./fix-launcher-version-check.patch
+  ];
+
   nativeBuildInputs = [ makeWrapper unzip ];
   buildInputs = [ jre ];
 

--- a/pkgs/development/tools/database/squirrel-sql/fix-launcher-version-check.patch
+++ b/pkgs/development/tools/database/squirrel-sql/fix-launcher-version-check.patch
@@ -1,0 +1,27 @@
+Squirrel SQL 4.5.1 adds support for JDK 19, but the launcher scripts need to be
+updated to allow it.
+
+diff -ru a/squirrelsql-4.5.1-standard/squirrel-sql.bat b/squirrelsql-4.5.1-standard/squirrel-sql.bat
+--- a/squirrelsql-4.5.1-standard/squirrel-sql.bat	2022-11-13 01:40:04.000000000 -0800
++++ b/squirrelsql-4.5.1-standard/squirrel-sql.bat	2023-05-30 17:32:22.825494660 -0700
+@@ -23,7 +23,7 @@
+ if NOT "%removed%"=="\" goto strip
+ set SQUIRREL_SQL_HOME=%basedir%
+ 
+-"%LOCAL_JAVA%" -cp "%SQUIRREL_SQL_HOME%\lib\versioncheck.jar" JavaVersionChecker 11 12 13 14 15 16 17
++"%LOCAL_JAVA%" -cp "%SQUIRREL_SQL_HOME%\lib\versioncheck.jar" JavaVersionChecker 11 12 13 14 15 16 17 18 19
+ if ErrorLevel 1 goto ExitForWrongJavaVersion
+ 
+ :launchsquirrel
+diff -ru a/squirrelsql-4.5.1-standard/squirrel-sql.sh b/squirrelsql-4.5.1-standard/squirrel-sql.sh
+--- a/squirrelsql-4.5.1-standard/squirrel-sql.sh	2022-11-13 01:40:04.000000000 -0800
++++ b/squirrelsql-4.5.1-standard/squirrel-sql.sh	2023-05-30 17:29:27.487981752 -0700
+@@ -45,7 +45,7 @@
+ # should be able to be run by that version or higher. The arguments to JavaVersionChecker below specify the 
+ # minimum acceptable version (first arg) and any other acceptable subsequent versions.  <MAJOR>.<MINOR> should 
+ # be all that is necessary for the version form. 
+-$JAVACMD -cp "$UNIX_STYLE_HOME/lib/versioncheck.jar" JavaVersionChecker 11 12 13 14 15 16 17
++$JAVACMD -cp "$UNIX_STYLE_HOME/lib/versioncheck.jar" JavaVersionChecker 11 12 13 14 15 16 17 18 19
+ if [ "$?" != "0" ]; then
+   exit
+ fi


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Squirrel SQL 4.5.1 added support for JDK 19, but the launcher script still requires JDK <=17.  This patches the launcher script to check for JDK <=19.  This is a belated follow-up to https://github.com/NixOS/nixpkgs/pull/209299, prompted by https://github.com/NixOS/nixpkgs/pull/235015.

I confirm that with this change, Squirrel starts now, whereas it errored out before.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
  - (No reverse dependencies via grep.)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
