### PR TITLE
pre-commit: prevent propagating inputs and polluting user's PYTHONPATH

### DIFF
--- a/pkgs/tools/misc/pre-commit/default.nix
+++ b/pkgs/tools/misc/pre-commit/default.nix
@@ -101,6 +101,12 @@ buildPythonApplication rec {
     deactivate
   '';
 
+  # Propagating dependencies leaks them through $PYTHONPATH which causes issues
+  # when used in nix-shell.
+  postFixup = ''
+    rm $out/nix-support/propagated-build-inputs
+  '';
+
   disabledTests = [
     # ERROR: The install method you used for conda--probably either `pip install conda`
     # or `easy_install conda`--is not compatible with using conda as an application.


### PR DESCRIPTION
###### Description of changes

This prevents pre-commit's dependences from clobbering the user's dependencies via the PYTHONPATH variable in a nix-shell.

Fixes: https://github.com/NixOS/nixpkgs/issues/223275

###### Things done

Tested by changing which input is commented in this `flake.nix`:
```nix
{
  inputs.nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
  #inputs.nixpkgs.url = "path:/home/matt/src/nixpkgs"; # has these changes

  outputs = { self, nixpkgs }:

  let
    pkgs = nixpkgs.legacyPackages.x86_64-linux;
  in {
      packages = {
        x86_64-linux.default = pkgs.hello;
      };

      devShells.x86_64-linux.default = pkgs.mkShell {
        packages = [ 
          pkgs.python311
          pkgs.pre-commit
        ];
      };
    };
}
```

Before:
```
$ nix develop
$ echo $PYTHONPATH
/nix/store/02r58pwlr896fyas37kmv7dz7qy7vl9c-pre-commit-3.3.2/lib/python3.10/site-packages:/nix/store/cvvyizc66s7bpnp3v2b98r5kad6875vi-python3.10-cfgv-3.3.1/lib/python3.10/site-packages:/nix/store/pbrzc0798laj1vndgjs0i3byjm3cgzcf-python3.10-six-1.16.0/lib/python3.10/site-packages:/nix/store/95cxzy2hpizr23343b8bskl4yacf4b3l-python3-3.10.11/lib/python3.10/site-packages:/nix/store/hfki5gjbn3zln5a3s7r7ca4pv5xypvfv-python3.10-identify-2.5.24/lib/python3.10/site-packages:/nix/store/893hxxw019ddliij1vz8wdiz31kaldcn-python3.10-nodeenv-1.8.0/lib/python3.10/site-packages:/nix/store/a9nrh0jkfxcf4v1arm0v8cg491wpi6y9-python3.10-setuptools-67.4.0/lib/python3.10/site-packages:/nix/store/ni6vlicv2zmrqabrab12ibbb7mrs5nfr-python3.10-pyyaml-6.0/lib/python3.10/site-packages:/nix/store/s6bkxc4di4cdj6bdcpi0823b0p3zi3ap-python3.10-toml-0.10.2/lib/python3.10/site-packages:/nix/store/sph78jm83dajxl11gxrnvzqqh4kh1ka2-python3.10-virtualenv-20.19.0/lib/python3.10/site-packages:/nix/store/fv7kdisq5nsb0dkkr018g4l6z0kp0zg2-python3.10-distlib-0.3.6/lib/python3.10/site-packages:/nix/store/gxgsb27s8fp92ivy1rb1p6rc7ypqkihg-python3.10-filelock-3.9.0/lib/python3.10/site-packages:/nix/store/8qxwzcgyyrxyvj23l278zr7ylmbgf4r0-python3.10-platformdirs-3.0.0/lib/python3.10/site-packages
```

After:
```
$ nix develop
$ echo $PYTHONPATH
/nix/store/2nzwxmvb9n18iahgszzc3lfafg3rjzmz-python3-3.11.3/lib/python3.11/site-packages
```
- Built on platform(s)
  - [x] x86_64-linux
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).


