### PR TITLE
Xfce updates 2023-05-31

### DIFF
--- a/pkgs/desktops/xfce/applications/xfce4-screensaver/default.nix
+++ b/pkgs/desktops/xfce/applications/xfce4-screensaver/default.nix
@@ -19,9 +19,9 @@
 mkXfceDerivation {
   category = "apps";
   pname = "xfce4-screensaver";
-  version = "4.18.1";
+  version = "4.18.2";
 
-  sha256 = "sha256-d72m2dW8jvM/EjgNSVaKsP5Ip7ioguB61/hy2cWw+dw=";
+  sha256 = "sha256-j5K5i+hl/miyHste73akZL62K6YTxXmN8mmFK9BCecs=";
 
   buildInputs = [
     dbus-glib
@@ -44,8 +44,8 @@ mkXfceDerivation {
 
   makeFlags = [ "DBUS_SESSION_SERVICE_DIR=$(out)/etc" ];
 
-  meta =  {
+  meta = with lib; {
     description = "Screensaver for Xfce";
-    maintainers = with lib.maintainers; [ symphorien ];
+    maintainers = with maintainers; [ symphorien ] ++ teams.xfce.members;
   };
 }

--- a/pkgs/desktops/xfce/core/xfce4-power-manager/default.nix
+++ b/pkgs/desktops/xfce/core/xfce4-power-manager/default.nix
@@ -1,21 +1,30 @@
-{ lib, mkXfceDerivation, automakeAddFlags, exo, gtk3, libnotify
-, libxfce4ui, libxfce4util, upower, xfconf, xfce4-panel }:
+{ lib
+, mkXfceDerivation
+, gtk3
+, libnotify
+, libxfce4ui
+, libxfce4util
+, upower
+, xfconf
+, xfce4-panel
+}:
 
 mkXfceDerivation {
   category = "xfce";
   pname = "xfce4-power-manager";
-  version = "4.18.1";
+  version = "4.18.2";
 
-  sha256 = "sha256-H9tu94ZQLLQhXIDtIWL3qZJo/ux2xC2Y9m7uwwey8M8=";
+  sha256 = "sha256-1+DP5CACzzj96FyRTeCdVEFORnpzFT49d9Uk1iijbFs=";
 
-  nativeBuildInputs = [ automakeAddFlags exo ];
-  buildInputs = [ gtk3 libnotify libxfce4ui libxfce4util upower xfconf xfce4-panel ];
-
-  postPatch = ''
-    substituteInPlace configure.ac.in --replace gio-2.0 gio-unix-2.0
-    automakeAddFlags src/Makefile.am xfce4_power_manager_CFLAGS GIO_CFLAGS
-    automakeAddFlags settings/Makefile.am xfce4_power_manager_settings_CFLAGS GIO_CFLAGS
-  '';
+  buildInputs = [
+    gtk3
+    libnotify
+    libxfce4ui
+    libxfce4util
+    upower
+    xfconf
+    xfce4-panel
+  ];
 
   meta = with lib; {
     description = "A power manager for the Xfce Desktop Environment";


### PR DESCRIPTION
###### Description of changes

For xfce4-power-manager:

- gio-unix-2.0 is now required upstream.
- Also dropped exo since we [no longer run exo-csource](https://gitlab.xfce.org/xfce/xfce4-power-manager/-/commit/74ba31cb2a0fd2b9f77b1cf75becde7c0ac538e7) during build - we have xfce4-dev-tools in mkXfceDerivation


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
