### PR TITLE
vscode: remove wayland and ozone flags

### DIFF
--- a/pkgs/applications/editors/vscode/generic.nix
+++ b/pkgs/applications/editors/vscode/generic.nix
@@ -117,7 +117,7 @@ let
       gappsWrapperArgs+=(
         # Add gio to PATH so that moving files to the trash works when not using a desktop environment
         --prefix PATH : ${glib.bin}/bin
-        --add-flags "\''${NIXOS_OZONE_WL:+\''${WAYLAND_DISPLAY:+--ozone-platform-hint=auto --enable-features=WaylandWindowDecorations}}"
+        # --add-flags "\''${NIXOS_OZONE_WL:+\''${WAYLAND_DISPLAY:+--ozone-platform-hint=auto --enable-features=WaylandWindowDecorations}}"
         --add-flags ${lib.escapeShellArg commandLineArgs}
       )
     '';


### PR DESCRIPTION
###### Description of changes

comment out [the wayland flags ](https://github.com/NixOS/nixpkgs/blob/94116367482eeec4bd2c3a412a95a3a19dc7b040/pkgs/applications/editors/vscode/generic.nix#L120) as they appear to be not needed and lead to annoying warnings in the console:
```
Warning: 'ozone-platform-hint' is not in the list of known options, but still passed to Electron/Chromium.
Warning: 'enable-features' is not in the list of known options, but still passed to Electron/Chromium.
```

###### Things done

i ran the command without the flags on x86_64-linux system:  
`/nix/store/54yvgv30kzd15rs4f7h53gmaalq89lqn-vscode-1.78.2/bin/.code-wrapped`
which confirmed that the app launches fine without these flags and the warnings do not show up.
I also checked in gnome looking glass to confim that the window is a wayland window even without these flags.


investigated the history of the issue a bit:
VScode doesn't respect .config settings for electron ([apparently](https://wiki.hyprland.org/0.22.0beta/Getting-Started/Master-Tutorial/#force-apps-to-use-wayland))
At some point these flags seemed to be needed to avoid crashing and [were introduced here](https://github.com/NixOS/nixpkgs/pull/192659/files)

