### PR TITLE
updateAutotoolsGnuConfigScriptsHook: preserve original timestamps

### DIFF
--- a/pkgs/build-support/setup-hooks/update-autotools-gnu-config-scripts.sh
+++ b/pkgs/build-support/setup-hooks/update-autotools-gnu-config-scripts.sh
@@ -6,7 +6,14 @@ updateAutotoolsGnuConfigScriptsPhase() {
     for script in config.sub config.guess; do
         for f in $(find . -type f -name "$script"); do
             echo "Updating Autotools / GNU config script to a newer upstream version: $f"
-            cp -f "@gnu_config@/$script" "$f"
+            cp "@gnu_config@/$script" "$f.new"
+            if [ -e "$f" ]; then
+                # Preserve timestamps to avoid unexpected regeneration
+                # of the build system. For example `libtool` calls
+                # `help2man` when `config.guess` updates.
+                touch -r "$f" "$f.new"
+            fi
+            mv -f "$f.new" "$f"
         done
     done
 }


### PR DESCRIPTION
Without the change updates to `config.guess` and `config.sub` sometimes triggers extra rebuilds of artifacts. Ane xample is `libtool` manpages during the bootstrap on RiscV:

    help2man: can't get `--help' info from libtoolize
    Try `--no-discard-stderr' if option outputs to stderr
    WARNING: 'help2man' is missing on your system.
             You should only need it if you modified a dependency of a man page.
             You may want to install the GNU Help2man package:
             <https://www.gnu.org/software/help2man/>
    make[2]: *** [Makefile:2430: doc/libtoolize.1] Error 127
    make[2]: *** Waiting for unfinished jobs....

Here `libtool` is expected to use prebuilt manpages that come with release tarball. But as one of it's dependencies was updated by `updateAutotoolsGnuConfigScriptsHook` hook it now pulls in a missing extra dependency.

To preserve build system behaviour let's copy timestamps of original files as is.

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
