### PR TITLE
vim: Add option for sodium

### DIFF
--- a/pkgs/applications/editors/vim/full.nix
+++ b/pkgs/applications/editors/vim/full.nix
@@ -1,6 +1,6 @@
 { source ? "default", callPackage, lib, stdenv, ncurses, pkg-config, gettext
 , writeText, config, glib, gtk2-x11, gtk3-x11, lua, python3, perl, tcl, ruby
-, libX11, libXext, libSM, libXpm, libXt, libXaw, libXau, libXmu
+, libX11, libXext, libSM, libXpm, libXt, libXaw, libXau, libXmu, libsodium
 , libICE
 , vimPlugins
 , makeWrapper
@@ -25,6 +25,7 @@
 , ximSupport        ? config.vim.xim or true        # less than 15KB, needed for deadkeys
 , darwinSupport     ? config.vim.darwin or false    # Enable Darwin support
 , ftNixSupport      ? config.vim.ftNix or true      # Add nix indentation support from vim-nix (not needed for basic syntax highlighting)
+, sodiumSupport     ? config.vim.sodium or true     # Enable sodium based encryption
 }:
 
 
@@ -125,7 +126,8 @@ in stdenv.mkDerivation {
   ++ lib.optional multibyteSupport    "--enable-multibyte"
   ++ lib.optional cscopeSupport       "--enable-cscope"
   ++ lib.optional netbeansSupport     "--enable-netbeans"
-  ++ lib.optional ximSupport          "--enable-xim";
+  ++ lib.optional ximSupport          "--enable-xim"
+  ++ lib.optional sodiumSupport       "--enable-sodium";
 
   nativeBuildInputs = [
     pkg-config
@@ -158,7 +160,8 @@ in stdenv.mkDerivation {
     ++ lib.optional luaSupport lua
     ++ lib.optional pythonSupport python3
     ++ lib.optional tclSupport tcl
-    ++ lib.optional rubySupport ruby;
+    ++ lib.optional rubySupport ruby
+    ++ lib.optional sodiumSupport libsodium;
 
   # error: '__declspec' attributes are not enabled; use '-fdeclspec' or '-fms-extensions' to enable support for __declspec attributes
   env.NIX_CFLAGS_COMPILE = lib.optionalString stdenv.isDarwin "-fdeclspec";


### PR DESCRIPTION
###### Description of changes

This enables building vim with libsodium which enables the xchacha20 cryptmethod in Vim. vim-full defaults this on as it's fairly small and part of the 'normal' upstream Vim featureset.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
