### PR TITLE
haskell.compiler.ghc961: remove at 9.6.1

### DIFF
--- a/pkgs/development/compilers/ghc/9.6.1.nix
+++ b/pkgs/development/compilers/ghc/9.6.1.nix
@@ -1,4 +1,0 @@
-import ./common-hadrian.nix rec {
-  version = "9.6.1";
-  sha256 = "fe5ac909cb8bb087e235de97fa63aff47a8ae650efaa37a2140f4780e21f34cb";
-}

--- a/pkgs/top-level/haskell-packages.nix
+++ b/pkgs/top-level/haskell-packages.nix
@@ -28,7 +28,6 @@ let
     "ghc945"
     "ghc94"
     "ghc96"
-    "ghc961"
     "ghc962"
     "ghcHEAD"
   ];
@@ -48,7 +47,6 @@ let
     "ghc944"
     "ghc945"
     "ghc96"
-    "ghc961"
     "ghc962"
     "ghcHEAD"
   ];
@@ -350,26 +348,6 @@ in {
       llvmPackages = pkgs.llvmPackages_12;
     };
     ghc94 = ghc945;
-    ghc961 = callPackage ../development/compilers/ghc/9.6.1.nix {
-      bootPkgs =
-        # For GHC 9.2 no armv7l bindists are available.
-        if stdenv.hostPlatform.isAarch32 then
-          packages.ghc924
-        else if stdenv.hostPlatform.isPower64 && stdenv.hostPlatform.isLittleEndian then
-          packages.ghc924
-        else if stdenv.isAarch64 then
-          packages.ghc924BinaryMinimal
-        else
-          packages.ghc924Binary;
-      inherit (buildPackages.python3Packages) sphinx;
-      # Need to use apple's patched xattr until
-      # https://github.com/xattr/xattr/issues/44 and
-      # https://github.com/xattr/xattr/issues/55 are solved.
-      inherit (buildPackages.darwin) xattr autoSignDarwinBinariesHook;
-      # Support range >= 10 && < 15
-      buildTargetLlvmPackages = pkgsBuildTarget.llvmPackages_14;
-      llvmPackages = pkgs.llvmPackages_14;
-    };
     ghc962 = callPackage ../development/compilers/ghc/9.6.2.nix {
       bootPkgs =
         # For GHC 9.2 no armv7l bindists are available.
@@ -553,11 +531,6 @@ in {
       compilerConfig = callPackage ../development/haskell-modules/configuration-ghc-9.4.x.nix { };
     };
     ghc94 = ghc945;
-    ghc961 = callPackage ../development/haskell-modules {
-      buildHaskellPackages = bh.packages.ghc961;
-      ghc = bh.compiler.ghc961;
-      compilerConfig = callPackage ../development/haskell-modules/configuration-ghc-9.6.x.nix { };
-    };
     ghc962 = callPackage ../development/haskell-modules {
       buildHaskellPackages = bh.packages.ghc962;
       ghc = bh.compiler.ghc962;

--- a/pkgs/top-level/release-haskell.nix
+++ b/pkgs/top-level/release-haskell.nix
@@ -69,7 +69,6 @@ let
     ghc927
     ghc928
     ghc945
-    ghc961
     ghc962
   ];
 
@@ -487,15 +486,12 @@ let
       Cabal_3_10_1_0 = released;
       Cabal-syntax_3_10_1_0 = released;
       cabal2nix = lib.subtractLists [
-        compilerNames.ghc961
         compilerNames.ghc962
       ] released;
       cabal2nix-unstable = lib.subtractLists [
-        compilerNames.ghc961
         compilerNames.ghc962
       ] released;
       funcmp = lib.subtractLists [
-        compilerNames.ghc961
         compilerNames.ghc962
       ] released;
       haskell-language-server = lib.subtractLists [
@@ -503,21 +499,17 @@ let
         compilerNames.ghc884
       ] released;
       hoogle = lib.subtractLists [
-        compilerNames.ghc961
         compilerNames.ghc962
       ] released;
       hlint = lib.subtractLists [
-        compilerNames.ghc961
         compilerNames.ghc962
       ] released;
       hpack = lib.subtractLists [
-        compilerNames.ghc961
         compilerNames.ghc962
       ] released;
       hsdns = released;
       jailbreak-cabal = released;
       language-nix = lib.subtractLists [
-        compilerNames.ghc961
         compilerNames.ghc962
       ] released;
       nix-paths = released;


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

GHC 9.6.2 seems to work for our purposes and GHC 9.6.1 won't ever be needed by stack it seems, as the nightly resolvers haven't reached 9.6.* yet.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
