### PR TITLE
ocamlPackages.benchmark: 1.4 → 1.6

### DIFF
--- a/pkgs/development/ocaml-modules/benchmark/default.nix
+++ b/pkgs/development/ocaml-modules/benchmark/default.nix
@@ -1,26 +1,17 @@
-{ stdenv, lib, fetchzip, ocaml, findlib, ocamlbuild, ocaml_pcre }:
+{ lib, fetchurl, buildDunePackage }:
 
-stdenv.mkDerivation rec {
-  pname = "ocaml${ocaml.version}-benchmark";
-  version = "1.4";
+buildDunePackage rec {
+  pname = "benchmark";
+  version = "1.6";
 
-  src = fetchzip {
-    url = "https://github.com/Chris00/ocaml-benchmark/releases/download/${version}/benchmark-${version}.tar.gz";
-    sha256 = "16wi8ld7c3mq77ylpgbnj8qqqqimyzwxs47v06vyrwpma5pab5xa";
+  src = fetchurl {
+    url = "https://github.com/Chris00/ocaml-benchmark/releases/download/${version}/benchmark-${version}.tbz";
+    hash = "sha256-Mw19cYya/MEy52PVRYE/B6TnqCWw5tEz9CUrUfKAnPA=";
   };
 
-  strictDeps = true;
-
-  nativeBuildInputs = [ ocaml findlib ocamlbuild ];
-  buildInputs = [ ocaml_pcre ];
-
-  createFindlibDestdir = true;
-
   meta = {
-    homepage = "http://ocaml-benchmark.forge.ocamlcore.org/";
-    inherit (ocaml.meta) platforms;
+    homepage = "https://github.com/Chris00/ocaml-benchmark";
     description = "Benchmark running times of code";
     license = lib.licenses.lgpl21;
-    maintainers = with lib.maintainers; [ ];
   };
 }

--- a/pkgs/development/ocaml-modules/rope/default.nix
+++ b/pkgs/development/ocaml-modules/rope/default.nix
@@ -1,45 +1,24 @@
-{ stdenv, lib, fetchurl, ocaml, findlib, ocamlbuild, dune_2, benchmark }:
+{ lib, fetchurl, ocaml, buildDunePackage, benchmark }:
 
-let param =
-  if lib.versionAtLeast ocaml.version "4.03"
-  then rec {
-    version = "0.6.2";
-    url = "https://github.com/Chris00/ocaml-rope/releases/download/${version}/rope-${version}.tbz";
-    sha256 = "15cvfa0s1vjx7gjd07d3fkznilishqf4z4h2q5f20wm9ysjh2h2i";
-    nativeBuildInputs = [ dune_2 ];
-    extra = {
-      buildPhase = "dune build -p rope";
-      installPhase = ''
-        dune install --prefix $out --libdir $OCAMLFIND_DESTDIR rope
-      '';
-    };
-  } else {
-    version = "0.5";
-    url = "https://forge.ocamlcore.org/frs/download.php/1156/rope-0.5.tar.gz";
-    sha256 = "05fr2f5ch2rqhyaj06rv5218sbg99p1m9pq5sklk04hpslxig21f";
-    nativeBuildInputs = [ ocamlbuild ];
-    extra = { createFindlibDestdir = true; };
-  };
-in
+lib.throwIf (lib.versionAtLeast ocaml.version "5.0")
+  "rope is not available for OCaml ${ocaml.version}"
 
-stdenv.mkDerivation ({
-  pname = "ocaml${ocaml.version}-rope";
-  inherit (param) version;
+buildDunePackage rec {
+  pname = "rope";
+  version = "0.6.2";
+  minimalOCamlVersion = "4.03";
 
   src = fetchurl {
-    inherit (param) url sha256;
+    url = "https://github.com/Chris00/ocaml-rope/releases/download/${version}/rope-${version}.tbz";
+    sha256 = "15cvfa0s1vjx7gjd07d3fkznilishqf4z4h2q5f20wm9ysjh2h2i";
   };
 
-  nativeBuildInputs = [ ocaml findlib ] ++ param.nativeBuildInputs;
   buildInputs = [ benchmark ] ;
 
-  strictDeps = true;
-
   meta = {
-    homepage = "http://rope.forge.ocamlcore.org/";
-    inherit (ocaml.meta) platforms;
-    description = ''Ropes ("heavyweight strings") in OCaml'';
+    homepage = "https://github.com/Chris00/ocaml-rope";
+    description = "Ropes (“heavyweight strings”) in OCaml";
     license = lib.licenses.lgpl21;
     maintainers = with lib.maintainers; [ ];
   };
-} // param.extra)
+}


### PR DESCRIPTION
###### Description of changes

https://github.com/Chris00/ocaml-benchmark/blob/1.6/CHANGES.md

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
