### PR TITLE
halftone: init at 0.2.1

### DIFF
--- a/pkgs/applications/graphics/halftone/default.nix
+++ b/pkgs/applications/graphics/halftone/default.nix
@@ -1,0 +1,61 @@
+{ lib
+, fetchFromGitHub
+, wrapGAppsHook4
+, meson
+, ninja
+, pkg-config
+, appstream-glib
+, desktop-file-utils
+, gobject-introspection
+, glib
+, blueprint-compiler
+, libadwaita
+, python3Packages
+}:
+
+python3Packages.buildPythonApplication rec {
+  pname = "halftone";
+  version = "0.2.1";
+
+  src = fetchFromGitHub {
+    owner = "tfuxu";
+    repo = pname;
+    rev = version;
+    hash = "sha256-EYxnGpVKPV3Xg6dH3m1aC3/pDigUxkNF7C8U16n8al8=";
+  };
+
+  format = "other";
+  dontWrapGApps = true;
+
+  nativeBuildInputs = [
+    appstream-glib
+    blueprint-compiler
+    desktop-file-utils
+    meson
+    ninja
+    pkg-config
+    wrapGAppsHook4
+    glib
+    gobject-introspection
+  ];
+
+  buildInputs = [
+    libadwaita
+  ];
+
+  propagatedBuildInputs = with python3Packages; [
+    pygobject3
+    wand
+  ];
+
+  preFixup = ''
+    makeWrapperArgs+=("''${gappsWrapperArgs[@]}")
+  '';
+
+  meta = with lib; {
+    homepage = "https://github.com/tfuxu/halftone";
+    description = "Simple app for giving images that pixel-art style";
+    license = licenses.gpl3Plus;
+    maintainers = with maintainers; [ foo-dogsquared ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8239,6 +8239,8 @@ with pkgs;
 
   gyb = callPackage ../tools/backup/gyb { };
 
+  halftone = callPackage ../applications/graphics/halftone { };
+
   harminv = callPackage ../development/libraries/science/chemistry/harminv { };
 
   igrep = callPackage ../tools/text/igrep {


### PR DESCRIPTION
###### Description of changes

Add [Halftone](https://github.com/tfuxu/halftone), a Libadwaita app for creating images with that pixel-art style while reducing images file size.
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
