### PR TITLE
rome: 12.1.0 -> 12.1.3

### DIFF
--- a/pkgs/development/tools/rome/default.nix
+++ b/pkgs/development/tools/rome/default.nix
@@ -4,6 +4,7 @@
 , pkg-config
 , stdenv
 , darwin
+, nix-update-script
 }:
 
 rustPlatform.buildRustPackage rec {
@@ -42,6 +43,10 @@ rustPlatform.buildRustPackage rec {
     "--skip commands::check::fs_error_infinite_symlink_exapansion"
     "--skip commands::check::fs_error_dereferenced_symlink"
   ];
+
+  passthru.updateScript = nix-update-script {
+    extraArgs = [ "--version-regex" "cli%2Fv(.*)" ];
+  };
 
   meta = with lib; {
     description = "A formatter, linter, bundler, and more for JavaScript, TypeScript, JSON, HTML, Markdown, and CSS";

--- a/pkgs/development/tools/rome/default.nix
+++ b/pkgs/development/tools/rome/default.nix
@@ -9,16 +9,16 @@
 
 rustPlatform.buildRustPackage rec {
   pname = "rome";
-  version = "12.1.0";
+  version = "12.1.3";
 
   src = fetchFromGitHub {
     owner = "rome";
     repo = "tools";
     rev = "cli/v${version}";
-    hash = "sha256-XORu6c/9jrRObdM3qAGszhiUjo88NTzrTyrITuHyd/4=";
+    hash = "sha256-BlHpdfbyx6nU44vasEw0gRZ0ickyD2eUXPfeFZHSCbI=";
   };
 
-  cargoHash = "sha256-75r280PMM1zDrqRmhuaU++5aZSCxeyqjHQls8pTzOgQ=";
+  cargoHash = "sha256-jHdoRymKPjBonT4TvAiTNzGBuTcNoPsvdFKEf33dpVc=";
 
   cargoBuildFlags = [ "--package" "rome_cli" ];
 


### PR DESCRIPTION
###### Description of changes

Updates rome to 12.1.3 & adds `passthru.updateScript`.
[Changelog](https://github.com/rome/tools/blob/cli/v12.1.3/CHANGELOG.md)

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
