### PR TITLE
browsr: init at 1.10.7

### DIFF
--- a/pkgs/applications/file-managers/browsr/default.nix
+++ b/pkgs/applications/file-managers/browsr/default.nix
@@ -1,0 +1,85 @@
+{ lib
+, python3
+, fetchFromGitHub
+, extras ? [ "all" ]
+}:
+
+python3.pkgs.buildPythonApplication rec {
+  pname = "browsr";
+  version = "1.10.7";
+  format = "pyproject";
+
+  src = fetchFromGitHub {
+    owner = "juftin";
+    repo = "browsr";
+    rev = "v${version}";
+    hash = "sha256-AT5cFQ4CldlHv3MQYAGXdZVB3bNAAvbJeosdxZjcPBM=";
+  };
+
+  nativeBuildInputs = with python3.pkgs; [
+    hatchling
+    pythonRelaxDepsHook
+    pytestCheckHook
+  ];
+
+  propagatedBuildInputs = with python3.pkgs; [
+    art
+    click
+    fsspec
+    pandas
+    pillow
+    pymupdf
+    rich
+    rich-click
+    rich-pixels
+    textual
+    universal-pathlib
+  ] ++ lib.attrVals extras passthru.optional-dependencies;
+
+  passthru.optional-dependencies = with python3.pkgs; {
+    all = [
+      adlfs
+      aiohttp
+      gcsfs
+      paramiko
+      pyarrow
+      requests
+      s3fs
+    ];
+    parquet = [
+      pyarrow
+    ];
+    remote = [
+      adlfs
+      aiohttp
+      gcsfs
+      paramiko
+      requests
+      s3fs
+    ];
+  };
+
+  pythonRelaxDeps = [
+    "fsspec"
+    "pymupdf"
+    "rich-click"
+    "textual"
+  ];
+
+  pythonImportsCheck = [ "browsr" ];
+
+  # requires internet access
+  disabledTests = [
+    "test_github_screenshot"
+    "test_github_screenshot_license"
+    "test_textual_app_context_path_github"
+  ];
+
+  meta = with lib; {
+    description = "A file explorer in your terminal";
+    homepage = "https://github.com/juftin/browsr";
+    changelog = "https://github.com/fsspec/universal_pathlib/releases/tag/${src.rev}";
+    license = licenses.mit;
+    maintainers = with maintainers; [ figsoda ];
+  };
+}

--- a/pkgs/development/python-modules/art/default.nix
+++ b/pkgs/development/python-modules/art/default.nix
@@ -1,0 +1,38 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+}:
+
+buildPythonPackage rec {
+  pname = "art";
+  version = "5.9";
+  format = "setuptools";
+
+  src = fetchFromGitHub {
+    owner = "sepandhaghighi";
+    repo = "art";
+    rev = "v${version}";
+    hash = "sha256-3fX0kYYyeJ9tHX8/+hlv5aRE6LujXW915N5Ov6Q+EW8=";
+  };
+
+  pythonImportsCheck = [ "art" ];
+
+  # TypeError: art() missing 1 required positional argument: 'artname'
+  checkPhase = ''
+    runHook preCheck
+
+    $out/bin/art
+    $out/bin/art test
+    $out/bin/art test2
+
+    runHook postCheck
+  '';
+
+  meta = with lib; {
+    description = "ASCII art library for Python";
+    homepage = "https://github.com/sepandhaghighi/art";
+    changelog = "https://github.com/sepandhaghighi/art/blob/${src.rev}/CHANGELOG.md";
+    license = licenses.mit;
+    maintainers = with maintainers; [ figsoda ];
+  };
+}

--- a/pkgs/development/python-modules/rich-pixels/default.nix
+++ b/pkgs/development/python-modules/rich-pixels/default.nix
@@ -1,0 +1,51 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, poetry-core
+, pytestCheckHook
+, syrupy
+, pillow
+, rich
+}:
+
+buildPythonPackage rec {
+  pname = "rich-pixels";
+  version = "2.1.1";
+  format = "pyproject";
+
+  src = fetchFromGitHub {
+    owner = "darrenburns";
+    repo = "rich-pixels";
+    rev = version;
+    hash = "sha256-zI6jtEdmBAEGxyASo/6fiHdzwzoSwXN7A5x1CmYS5qc=";
+  };
+
+  nativeBuildInputs = [
+    poetry-core
+  ];
+
+  nativeCheckInputs = [
+    pytestCheckHook
+  ];
+
+  checkInputs = [
+    syrupy
+  ];
+
+  propagatedBuildInputs = [
+    pillow
+    rich
+  ];
+
+  pythonImportsCheck = [ "rich_pixels" ];
+
+  meta = with lib; {
+    description = "A Rich-compatible library for writing pixel images and ASCII art to the terminal";
+    homepage = "https://github.com/darrenburns/rich-pixels";
+    changelog = "https://github.com/darrenburns/rich-pixels/releases/tag/${src.rev}";
+    # upstream has no license specified
+    # https://github.com/darrenburns/rich-pixels/issues/11
+    license = licenses.unfree;
+    maintainers = with maintainers; [ figsoda ];
+  };
+}

--- a/pkgs/development/python-modules/universal-pathlib/default.nix
+++ b/pkgs/development/python-modules/universal-pathlib/default.nix
@@ -1,0 +1,37 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, flit-core
+, fsspec
+}:
+
+buildPythonPackage rec {
+  pname = "universal-pathlib";
+  version = "0.0.23";
+  format = "pyproject";
+
+  src = fetchFromGitHub {
+    owner = "fsspec";
+    repo = "universal_pathlib";
+    rev = "v${version}";
+    hash = "sha256-UT4S7sqRn0/YFzFL1KzByK44u8G7pwWHERzJEm7xmiw=";
+  };
+
+  nativeBuildInputs = [
+    flit-core
+  ];
+
+  propagatedBuildInputs = [
+    fsspec
+  ];
+
+  pythonImportsCheck = [ "upath" ];
+
+  meta = with lib; {
+    description = "Pathlib api extended to use fsspec backends";
+    homepage = "https://github.com/fsspec/universal_pathlib";
+    changelog = "https://github.com/fsspec/universal_pathlib/releases/tag/${src.rev}";
+    license = licenses.mit;
+    maintainers = with maintainers; [ figsoda ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2552,6 +2552,8 @@ with pkgs;
 
   ### APPLICATIONS/FILE-MANAGERS
 
+  browsr = callPackage ../applications/file-managers/browsr { };
+
   cfm = callPackage ../applications/file-managers/cfm { };
 
   clex = callPackage ../applications/file-managers/clex { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -12608,6 +12608,8 @@ self: super: with self; {
 
   univers = callPackage ../development/python-modules/univers { };
 
+  universal-pathlib = callPackage ../development/python-modules/universal-pathlib { };
+
   unpaddedbase64 = callPackage ../development/python-modules/unpaddedbase64 { };
 
   unrardll = callPackage ../development/python-modules/unrardll { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -10577,6 +10577,8 @@ self: super: with self; {
 
   rich-click = callPackage ../development/python-modules/rich-click { };
 
+  rich-pixels = callPackage ../development/python-modules/rich-pixels { };
+
   rich-rst = callPackage ../development/python-modules/rich-rst { };
 
   ring-doorbell = callPackage ../development/python-modules/ring-doorbell { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -628,6 +628,8 @@ self: super: with self; {
 
   arsenic = callPackage ../development/python-modules/arsenic { };
 
+  art = callPackage ../development/python-modules/art { };
+
   arviz = callPackage ../development/python-modules/arviz { };
 
   arxiv2bib = callPackage ../development/python-modules/arxiv2bib { };


### PR DESCRIPTION
###### Description of changes

https://github.com/juftin/browsr

also adds the following python libraries:
- https://github.com/sepandhaghighi/art
- https://github.com/darrenburns/rich-pixels
- https://github.com/fsspec/universal_pathlib

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
