### PR TITLE
nixos/stunnel: Allow duplicate parameters via list

### DIFF
--- a/nixos/modules/services/networking/stunnel.nix
+++ b/nixos/modules/services/networking/stunnel.nix
@@ -9,12 +9,12 @@ let
 
   verifyRequiredField = type: field: n: c: {
     assertion = hasAttr field c;
-    message =  "stunnel: \"${n}\" ${type} configuration - Field ${field} is required.";
+    message = "stunnel: \"${n}\" ${type} configuration - Field ${field} is required.";
   };
 
   verifyChainPathAssert = n: c: {
     assertion = (c.verifyHostname or null) == null || (c.verifyChain || c.verifyPeer);
-    message =  "stunnel: \"${n}\" client configuration - hostname verification " +
+    message = "stunnel: \"${n}\" client configuration - hostname verification " +
       "is not possible without either verifyChain or verifyPeer enabled";
   };
 
@@ -112,22 +112,24 @@ in
         '';
         type = with types; let atoms = [ bool int str ]; in attrsOf (attrsOf (nullOr (oneOf (atoms ++ [ (listOf (oneOf atoms)) ]))));
 
-        apply = let
-          applyDefaults = c:
-            {
-              CAFile = "${pkgs.cacert}/etc/ssl/certs/ca-bundle.crt";
-              OCSPaia = true;
-              verifyChain = true;
-            } // c;
-          setCheckHostFromVerifyHostname = c:
-            # To preserve backward-compatibility with the old NixOS stunnel module
-            # definition, allow "verifyHostname" as an alias for "checkHost".
-            c // {
-              checkHost = c.checkHost or c.verifyHostname or null;
-              verifyHostname = null; # Not a real stunnel configuration setting
-            };
-          forceClient = c: c // { client = true; };
-        in mapAttrs (_: c: forceClient (setCheckHostFromVerifyHostname (applyDefaults c)));
+        apply =
+          let
+            applyDefaults = c:
+              {
+                CAFile = "${pkgs.cacert}/etc/ssl/certs/ca-bundle.crt";
+                OCSPaia = true;
+                verifyChain = true;
+              } // c;
+            setCheckHostFromVerifyHostname = c:
+              # To preserve backward-compatibility with the old NixOS stunnel module
+              # definition, allow "verifyHostname" as an alias for "checkHost".
+              c // {
+                checkHost = c.checkHost or c.verifyHostname or null;
+                verifyHostname = null; # Not a real stunnel configuration setting
+              };
+            forceClient = c: c // { client = true; };
+          in
+          mapAttrs (_: c: forceClient (setCheckHostFromVerifyHostname (applyDefaults c)));
 
         example = {
           foobar = {

--- a/nixos/tests/stunnel.nix
+++ b/nixos/tests/stunnel.nix
@@ -94,6 +94,12 @@ in {
             CAFile = "/authorized-server-cert.crt";
             verifyHostname = "wronghostname";
           };
+          httpsClientWithMultipleSocketOptions = {
+            accept = "83";
+            connect = "server:443";
+            CAFile = "/authorized-server-cert.crt";
+            socket = [ "l:TCP_NODELAY=1" "r:TCP_NODELAY=1" ];
+          };
         };
       };
       server = {
@@ -121,6 +127,9 @@ in {
 
       client.fail("curl --fail http://localhost:82/ > out")
       client.succeed('[[ "$(< out)" == "" ]]')
+
+      client.succeed("curl --fail http://localhost:83/ > out")
+      client.succeed('[[ "$(< out)" == "hello there" ]]')
     '';
   };
 


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

fix #221884

This change:

- switches from the `generators.toINI` used via interpolation to `generators.toINIWithGlobalSection` for the entire config
- turns on the `listsAsDuplicateKeys` option for the INI generator
- allows lists as valid types (for the same underlying INI atoms)
- retains full backwards compatibility as far as I can tell (second opinion on this much appreciated)
- adds checks for the list version

###### Notes

Ideally the stunnel module should sooner or later be switched over to the *pkgs.formats* way of generating the configuration, however the old options would either need migration or a breaking change, and *pkgs.formats* only offers an INI generator, not one for INI with a global section (as required by stunnel, preliminary tests show no viable workaround, though I haven't checked the upstream source). This seems to be worked on in #228051.

If this should be mentioned in the release notes (as indicated in the checklist below) leave a comment.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] ~~Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)~~
- [ ] ~~Tested basic functionality of all binary files (usually in `./result/bin/`)~~
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] ~~(Package updates) Added a release notes entry if the change is major or breaking~~
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] ~~(Module addition) Added a release notes entry if adding a new NixOS module~~
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
