### PR TITLE
redpanda: 23.1.10 -> 23.1.11; fix build

### DIFF
--- a/pkgs/servers/redpanda/default.nix
+++ b/pkgs/servers/redpanda/default.nix
@@ -7,12 +7,12 @@
 , stdenv
 }:
 let
-  version = "23.1.10";
+  version = "23.1.11";
   src = fetchFromGitHub {
     owner = "redpanda-data";
     repo = "redpanda";
     rev = "v${version}";
-    sha256 = "sha256-OlRuJeLvnQeseIsOREt5Frz4zzVmGKQMYIZI4LsDn2U=";
+    sha256 = "sha256-YQ5VBWA2mOClFpqLY302ClF2eihjhzPsICLlsN+hYe0=";
   };
   server = callPackage ./server.nix { inherit src version; };
 in

--- a/pkgs/servers/redpanda/seastar.nix
+++ b/pkgs/servers/redpanda/seastar.nix
@@ -33,8 +33,8 @@ llvmPackages_14.stdenv.mkDerivation {
   src = fetchFromGitHub {
     owner = "redpanda-data";
     repo = "seastar";
-    rev = "30d3a28bde08d2228b4e560c173b89fdd94c3f05";
-    sha256 = "sha256-Xzu7AJMkvE++BGEqluod3fwMEIpDnbCczmlEad0/4v4=";
+    rev = "245e0ccfa6d58d7e0dca2b4034ce1bc43e39bdc5";
+    sha256 = "sha256-eYJ24KAuTUqaJ2CR4qcprAqQofVxoDScFr7tpbjgsdc=";
   };
   nativeBuildInputs = [
     cmake

--- a/pkgs/servers/redpanda/server.nix
+++ b/pkgs/servers/redpanda/server.nix
@@ -26,6 +26,8 @@
 , xxHash
 , zip
 , zstd
+, libxml2
+, re2
 }:
 let
   pname = "redpanda";
@@ -106,6 +108,8 @@ llvmPackages_14.stdenv.mkDerivation rec {
     snappy
     xxHash
     zstd
+    libxml2
+    re2
   ];
 
   meta = with lib; {


### PR DESCRIPTION
###### Description of changes

Update of redpanda to fix the build
The current failure is on seastar compilation.

@yu-re-ka , I'm not very far with this but I thought you might be interested.

@avakhrenev hey thanks a lot for the original PR to build redpanda from source.
I have a compilation failure with seastar and I'm not sure where to get the version number as well. (just in case you have time).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
