### PR TITLE
bundlerUpdateScript: don't run bundler-audit

### DIFF
--- a/pkgs/development/ruby-modules/bundler-update-script/default.nix
+++ b/pkgs/development/ruby-modules/bundler-update-script/default.nix
@@ -1,11 +1,11 @@
-{ runtimeShell, lib, writeScript, bundix, bundler, bundler-audit, coreutils, git, nix }:
+{ runtimeShell, lib, writeScript, bundix, bundler, coreutils, git, nix }:
 
 attrPath:
 
 let
   updateScript = writeScript "bundler-update-script" ''
     #!${runtimeShell}
-    PATH=${lib.makeBinPath [ bundler bundler-audit bundix coreutils git nix ]}
+    PATH=${lib.makeBinPath [ bundler bundix coreutils git nix ]}
     set -o errexit
     set -o nounset
     set -o pipefail
@@ -19,7 +19,6 @@ let
     cd "$gemdir"
 
     bundler lock --update
-    bundler-audit check --update
     bundix
   '';
 in [ updateScript attrPath ]


### PR DESCRIPTION
###### Description of changes

Blocking updates on security warnings doesn't make sense; if an updated gem has dependencies with security warnings, then it's likely for the un-updated gem to have even more of them.

As the original author of the script, I understand what value I thought this audit step added, but I disagree now.  It might be something that should be run on every `bundlerApp`, but as a separate report, not as part of an automated update.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

I did confirm that the script has been failing on some packages, and can be run on more packages now.

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
