### PR TITLE
usbrelay: 1.0.1 -> 1.2

### DIFF
--- a/pkgs/os-specific/linux/usbrelay/daemon.nix
+++ b/pkgs/os-specific/linux/usbrelay/daemon.nix
@@ -5,7 +5,7 @@ in
 # This is a separate derivation, not just an additional output of
 # usbrelay, because otherwise, we have a cyclic dependency between
 # usbrelay (default.nix) and the python module (python.nix).
-stdenv.mkDerivation rec {
+stdenv.mkDerivation {
   pname = "usbrelayd";
 
   inherit (usbrelay) src version;

--- a/pkgs/os-specific/linux/usbrelay/default.nix
+++ b/pkgs/os-specific/linux/usbrelay/default.nix
@@ -1,13 +1,13 @@
 { stdenv, lib, fetchFromGitHub, hidapi, installShellFiles }:
 stdenv.mkDerivation rec {
   pname = "usbrelay";
-  version = "1.0.1";
+  version = "1.2";
 
   src = fetchFromGitHub {
     owner = "darrylb123";
     repo = "usbrelay";
     rev = version;
-    sha256 = "sha256-2elDrO+WaaRYdTrG40Ez00qSsNVQjXE6GdOJbWPfugE=";
+    sha256 = "sha256-oJyHzbXOBKxLmPFZMS2jLF80frkiKjPJ89UwkenjIzs=";
   };
 
   nativeBuildInputs = [
@@ -21,6 +21,7 @@ stdenv.mkDerivation rec {
   makeFlags = [
     "DIR_VERSION=${version}"
     "PREFIX=${placeholder "out"}"
+    "LDCONFIG=${stdenv.cc.libc.bin}/bin/ldconfig"
   ];
 
   postInstall = ''

--- a/pkgs/os-specific/linux/usbrelay/default.nix
+++ b/pkgs/os-specific/linux/usbrelay/default.nix
@@ -1,12 +1,12 @@
 { stdenv, lib, fetchFromGitHub, hidapi, installShellFiles }:
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "usbrelay";
   version = "1.2";
 
   src = fetchFromGitHub {
     owner = "darrylb123";
     repo = "usbrelay";
-    rev = version;
+    rev = finalAttrs.version;
     sha256 = "sha256-oJyHzbXOBKxLmPFZMS2jLF80frkiKjPJ89UwkenjIzs=";
   };
 
@@ -19,7 +19,7 @@ stdenv.mkDerivation rec {
   ];
 
   makeFlags = [
-    "DIR_VERSION=${version}"
+    "DIR_VERSION=${finalAttrs.version}"
     "PREFIX=${placeholder "out"}"
     "LDCONFIG=${stdenv.cc.libc.bin}/bin/ldconfig"
   ];
@@ -35,4 +35,4 @@ stdenv.mkDerivation rec {
     maintainers = with maintainers; [ wentasah ];
     platforms = platforms.linux;
   };
-}
+})

--- a/pkgs/os-specific/linux/usbrelay/python.nix
+++ b/pkgs/os-specific/linux/usbrelay/python.nix
@@ -1,6 +1,6 @@
 { buildPythonPackage, usbrelay }:
 
-buildPythonPackage rec {
+buildPythonPackage {
   pname = "usbrelay_py";
   inherit (usbrelay) version src;
 


### PR DESCRIPTION
###### Description of changes

[Release notes](https://github.com/darrylb123/usbrelay/releases):

TL;DR:
- added shared library versioning
- bug fixes
- cleanups

Tested with the available NixOS test (`test.nix`), which checks the whole chain: MQTT daemon, Python bindings, native library.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
