### PR TITLE
photofield: init at 0.10.3

### DIFF
--- a/pkgs/servers/photofield/default.nix
+++ b/pkgs/servers/photofield/default.nix
@@ -1,0 +1,70 @@
+{ lib
+, fetchFromGitHub
+, buildGoModule
+, buildNpmPackage
+, makeWrapper
+, exiftool
+, ffmpeg
+}:
+
+let
+  pname = "photofield-ui";
+  version = "0.10.3";
+
+  src = fetchFromGitHub {
+    owner = "SmilyOrg";
+    repo = "photofield";
+    rev = "v${version}";
+    hash = "sha256-OrLsthhnjX6LWehwiBDRzhCmTp3IBsbu9WKVu0zhgaQ=";
+  };
+
+  webui = buildNpmPackage {
+    inherit src version;
+    pname = "photofield-ui";
+
+    sourceRoot = "source/ui";
+
+    npmDepsHash = "sha256-YVyaZsFh5bolDzMd5rXWrbbXQZBeEIV6Fh/kwN+rvPk=";
+
+    installPhase = ''
+      mkdir -p $out/share
+      mv dist $out/share/photofield-ui
+    '';
+  };
+in
+
+buildGoModule rec {
+  pname = "photofield";
+  inherit version src;
+
+  vendorHash = "sha256-g6jRfPALBAgZVuljq/JiCpea7gZl/8akiabxjRmDsFs=";
+
+  preBuild = ''
+    cp -r ${webui}/share/photofield-ui ui/dist
+  '';
+
+  ldflags = [
+    "-s"
+    "-w"
+    "-X main.version=${version}"
+    "-X main.builtBy=Nix"
+  ];
+
+  tags = [ "embedstatic" ];
+
+  doCheck = false; # tries to modify filesytem
+
+  nativeBuildInputs = [ makeWrapper ];
+
+  postInstall = ''
+    wrapProgram $out/bin/photofield \
+      --prefix PATH : "${lib.makeBinPath [exiftool ffmpeg]}"
+  '';
+
+  meta = with lib; {
+    description = "Experimental fast photo viewer";
+    homepage = "https://github.com/SmilyOrg/photofield";
+    license = licenses.mit;
+    maintainers = with maintainers; [ dit7ya ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5585,6 +5585,8 @@ with pkgs;
 
   photon = callPackage ../tools/networking/photon { };
 
+  photofield = callPackage ../servers/photofield { };
+
   photoprism = callPackage ../servers/photoprism { };
 
   piglit = callPackage ../tools/graphics/piglit { };


### PR DESCRIPTION
###### Description of changes

https://github.com/SmilyOrg/photofield
 Experimental fast photo viewer. 
 
 To test it, create the `configuration.yaml` file according to the project readme, and click on the `Rescan` button from the web UI.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
