### PR TITLE
comodoro: init at 0.0.8

### DIFF
--- a/pkgs/applications/misc/comodoro/default.nix
+++ b/pkgs/applications/misc/comodoro/default.nix
@@ -1,0 +1,47 @@
+{ lib
+, rustPlatform
+, fetchFromGitHub
+, stdenv
+, installShellFiles
+, installShellCompletions ? stdenv.hostPlatform == stdenv.buildPlatform
+, installManPages ? stdenv.hostPlatform == stdenv.buildPlatform
+, withTcp ? true
+}:
+
+rustPlatform.buildRustPackage rec {
+  pname = "comodoro";
+  version = "0.0.8";
+
+  src = fetchFromGitHub {
+    owner = "soywod";
+    repo = "comodoro";
+    rev = "v${version}";
+    sha256 = "rGnVXyfWJkPHfpf1gRGbDJ6Y1ycKOOcCZ+Jx35fUo6M=";
+  };
+
+  cargoSha256 = "jpshuavywCLN03xD/gFgQeGbKtmHq5pULbxd+RUbaDk=";
+
+  nativeBuildInputs = lib.optional (installManPages || installShellCompletions) installShellFiles;
+
+  buildNoDefaultFeatures = true;
+  buildFeatures = lib.optional withTcp "tcp";
+
+  postInstall = lib.optionalString installManPages ''
+    mkdir -p $out/man
+    $out/bin/comodoro man $out/man
+    installManPage $out/man/*
+  '' + lib.optionalString installShellCompletions ''
+    installShellCompletion --cmd comodoro \
+      --bash <($out/bin/comodoro completion bash) \
+      --fish <($out/bin/comodoro completion fish) \
+      --zsh <($out/bin/comodoro completion zsh)
+  '';
+
+  meta = with lib; {
+    description = "CLI to manage your time.";
+    homepage = "https://pimalaya.org/comodoro/";
+    changelog = "https://github.com/soywod/comodoro/blob/v${version}/CHANGELOG.md";
+    license = licenses.mit;
+    maintainers = with maintainers; [ soywod ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -479,6 +479,8 @@ with pkgs;
 
   commix = callPackage ../tools/security/commix { };
 
+  comodoro = callPackage ../applications/misc/comodoro { };
+
   compdb = callPackage ../tools/misc/compdb { };
 
   conserver = callPackage ../tools/misc/conserver { };


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

**Comodoro, a CLI to manage your time**. Key features:

- Centralized server timer controllable by multiple clients at the same time
- Multi protocols (only TCP for now, but you can build your own)
- Cycles customizable via config file (Pomodoro style, 52/17 style, custom)
- Server and timer hooks customizable via config file

Website & doc: https://pimalaya.org/comodoro/

Sources: https://github.com/soywod/comodoro

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes (or backporting 23.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
