### PR TITLE
elm-pages: set files/dirs as +w when copied during elm-init

### DIFF
--- a/pkgs/development/compilers/elm/default.nix
+++ b/pkgs/development/compilers/elm/default.nix
@@ -254,6 +254,7 @@ in lib.makeScope pkgs.newScope (self: with self; {
           # see upstream issue https://github.com/dillonkearns/elm-pages/issues/305 for dealing with the read-only problem
           preFixup = ''
             patch $out/lib/node_modules/elm-pages/generator/src/codegen.js ${./packages/elm-pages-fix-read-only.patch}
+            patch $out/lib/node_modules/elm-pages/generator/src/init.js ${./packages/elm-pages-fix-init-read-only.patch}
           '';
 
           postFixup = ''

--- a/pkgs/development/compilers/elm/packages/elm-pages-fix-init-read-only.patch
+++ b/pkgs/development/compilers/elm/packages/elm-pages-fix-init-read-only.patch
@@ -1,0 +1,40 @@
+diff --git a/generator/src/init.js b/generator/src/init.js
+index 3d8548c..90ee20d 100644
+--- a/generator/src/init.js
++++ b/generator/src/init.js
+@@ -3,6 +3,21 @@ const copySync = require("fs-extra").copySync;
+ const path = require("path");
+ const kleur = require("kleur");
+ 
++let walknDo = function(somePath, doStuff) {
++  doStuff(somePath, true);
++  const dir = fs.readdirSync(somePath)
++  dir.forEach((i) => {
++    let p = path.join(somePath, i);
++    const s = fs.statSync(p)
++    if (s.isDirectory()) {
++      walknDo(p, doStuff)
++    } else {
++      doStuff(p);
++    }
++  });
++}
++
++
+ /**
+  * @param {string} name
+  */
+@@ -15,6 +30,13 @@ async function run(name) {
+   if (!fs.existsSync(name)) {
+     try {
+       copySync(template, appRoot);
++      walknDo(appRoot, (file, isDir) => {
++        if (isDir) {
++          fs.chmodSync(file, 0o755);
++        } else {
++          fs.chmodSync(file, 0o644);
++        }
++      });
+       fs.renameSync(
+         path.resolve(appRoot, "gitignore"),
+         path.resolve(appRoot, ".gitignore")


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes (or backporting 23.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
