### PR TITLE
gnome.gnome-mahjongg: 3.38.3 → 3.40.0

### DIFF
--- a/pkgs/desktops/gnome/games/gnome-mahjongg/default.nix
+++ b/pkgs/desktops/gnome/games/gnome-mahjongg/default.nix
@@ -1,11 +1,11 @@
 { stdenv
 , lib
 , fetchurl
-, fetchpatch
 , pkg-config
 , gnome
-, gtk3
-, wrapGAppsHook
+, gtk4
+, wrapGAppsHook4
+, libadwaita
 , librsvg
 , gettext
 , itstool
@@ -19,22 +19,12 @@
 
 stdenv.mkDerivation rec {
   pname = "gnome-mahjongg";
-  version = "3.38.3";
+  version = "3.40.0";
 
   src = fetchurl {
     url = "mirror://gnome/sources/gnome-mahjongg/${lib.versions.majorMinor version}/${pname}-${version}.tar.xz";
-    sha256 = "144ia3zn9rhwa1xbdkvsz6m0dsysl6mxvqw9bnrlh845hmyy9cfj";
+    sha256 = "WorIbXY8VmDdkCX3vAgxC5IjRvp+Lfe2SMmJTa4/GD8=";
   };
-
-  patches = [
-    # Fix build with meson 0.61
-    # data/meson.build:24:0: ERROR: Function does not take positional arguments.
-    # data/meson.build:45:0: ERROR: Function does not take positional arguments.
-    (fetchpatch {
-      url = "https://gitlab.gnome.org/GNOME/gnome-mahjongg/-/commit/a2037b0747163601a5d5b57856d037eecf3a4db7.patch";
-      sha256 = "Wcder6Y9H6c1f8I+IPDvST3umaCU21HgxfXn809JDz0=";
-    })
-  ];
 
   nativeBuildInputs = [
     meson
@@ -42,17 +32,17 @@ stdenv.mkDerivation rec {
     vala
     desktop-file-utils
     pkg-config
-    gnome.adwaita-icon-theme
     libxml2
     itstool
     gettext
-    wrapGAppsHook
+    wrapGAppsHook4
     glib # for glib-compile-schemas
   ];
 
   buildInputs = [
     glib
-    gtk3
+    gtk4
+    libadwaita
     librsvg
   ];
 


### PR DESCRIPTION
https://gitlab.gnome.org/GNOME/gnome-mahjongg/-/compare/3.38.3...3.40.0

###### Description of changes

Or https://github.com/GNOME/gnome-mahjongg/compare/3.38.3...3.40.0

*bobby285271 reads [HowDoI/DBusApplicationLaunching](https://wiki.gnome.org/HowDoI/DBusApplicationLaunching)* :thinking: 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes (or backporting 23.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
