### PR TITLE
smile: init at 2.8.1

### DIFF
--- a/pkgs/by-name/sm/smile/package.nix
+++ b/pkgs/by-name/sm/smile/package.nix
@@ -1,0 +1,77 @@
+{ stdenv
+, lib
+, fetchFromGitHub
+, meson
+, ninja
+, appstream-glib
+, desktop-file-utils
+, gettext
+, glib
+, libwnck
+, libadwaita
+, wrapGAppsHook4
+, pkg-config
+, python3Packages
+, gobject-introspection
+}:
+
+python3Packages.buildPythonApplication rec {
+  pname = "smile";
+  version = "2.8.1";
+
+  src = fetchFromGitHub {
+    owner = "mijorus";
+    repo = pname;
+    rev = version;
+    hash = "sha256-yHWFG587qNij61Ul0z/Tn7HGN8dBBNQL4e0PvjA06js=";
+  };
+
+  format = "other";
+
+  postPatch = ''
+    chmod +x ./build-aux/meson/postinstall.py
+    patchShebangs ./build-aux/meson/postinstall.py
+    substituteInPlace ./build-aux/meson/postinstall.py \
+      --replace "gtk-update-icon-cache" "gtk4-update-icon-cache"
+  '';
+
+  nativeBuildInputs = [
+    gettext
+    desktop-file-utils
+    appstream-glib
+    meson
+    ninja
+    pkg-config
+    glib
+    wrapGAppsHook4
+  ];
+
+  propagatedNativeBuildInputs = [
+    gobject-introspection
+  ];
+
+  propagatedBuildInputs = with python3Packages; [
+    pygobject3
+    manimpango
+    dbus-python
+  ];
+
+  buildInputs = [
+    libwnck
+    libadwaita
+  ];
+
+  dontWrapGApps = true;
+  preFixup = ''
+    makeWrapperArgs+=("''${gappsWrapperArgs[@]}")
+  '';
+
+  meta = with lib; {
+    homepage = "https://smile.mijorus.it";
+    description = "Emoji picker with custom tabs support and localization";
+    license = licenses.gpl3Plus;
+    maintainers = with maintainers; [ foo-dogsquared ];
+    mainProgram = "smile";
+    platforms = platforms.linux;
+  };
+}


### PR DESCRIPTION
###### Description of changes

Add [Smile](https://smile.mijorus.it/), an emoji picker for Linux.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes (or backporting 23.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
