### PR TITLE
Fix systemd boot update logic to be more stable

### DIFF
--- a/nixos/modules/system/boot/loader/systemd-boot/systemd-boot-builder.py
+++ b/nixos/modules/system/boot/loader/systemd-boot/systemd-boot-builder.py
@@ -247,9 +247,6 @@ def main() -> None:
     if "@canTouchEfiVariables@" != "1":
         bootctl_flags.append("--no-variables")
 
-    if "@graceful@" == "1":
-        bootctl_flags.append("--graceful")
-
     if os.getenv("NIXOS_INSTALL_BOOTLOADER") == "1":
         # bootctl uses fopen() with modes "wxe" and fails if the file exists.
         if os.path.exists("@efiSysMountPoint@/loader/loader.conf"):

--- a/nixos/modules/system/boot/loader/systemd-boot/systemd-boot.nix
+++ b/nixos/modules/system/boot/loader/systemd-boot/systemd-boot.nix
@@ -26,7 +26,7 @@ let
 
     configurationLimit = if cfg.configurationLimit == null then 0 else cfg.configurationLimit;
 
-    inherit (cfg) consoleMode graceful;
+    inherit (cfg) consoleMode;
 
     inherit (efi) efiSysMountPoint canTouchEfiVariables;
 
@@ -71,6 +71,12 @@ in {
 
   imports =
     [ (mkRenamedOptionModule [ "boot" "loader" "gummiboot" "enable" ] [ "boot" "loader" "systemd-boot" "enable" ])
+      (mkRemovedOptionModule [ "boot" "loader" "systemd-boot" "graceful" ] ''
+        The graceful option was added to handle failure of the `bootctl install` command.
+        However systemd doesn't support the --graceful flag for `bootctl install` and this
+        option was always silently ignored. If installing the boot loader is failing
+        try setting `boot.loader.efi.canTouchEfiVariables = false` instead.
+      '')
     ];
 
   options.boot.loader.systemd-boot = {
@@ -220,21 +226,6 @@ in {
         Each attribute name denotes the destination file name in
         {file}`/boot`, while the corresponding
         attribute value specifies the source file.
-      '';
-    };
-
-    graceful = mkOption {
-      default = false;
-
-      type = types.bool;
-
-      description = lib.mdDoc ''
-        Invoke `bootctl install` with the `--graceful` option,
-        which ignores errors when EFI variables cannot be written or when the EFI System Partition
-        cannot be found. Currently only applies to random seed operations.
-
-        Only enable this option if `systemd-boot` otherwise fails to install, as the
-        scope or implication of the `--graceful` option may change in the future.
       '';
     };
 


### PR DESCRIPTION
###### Description of changes
We were relying on the output of `status` which is not very stable.

Instead we rely on systemd to do the version detection logic.
Systemd will not update if version_available <= version_installed

we add --graceful to make sure systemd returns EXIT_SUCCESS in this
scenario.

Unfortunately --graceful also makes it return EXIT_SUCCESS if:
- ESP is not mounted
- Can not edit EFI variables

We alliviate this by introducing a `bootctl is-installed` check.
If that returns true we know the ESP is mounted and that `update`
will not modify any EFI variables.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes (or backporting 23.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
