### PR TITLE
pkgsStatic.cyrus_sasl: fix build

### DIFF
--- a/pkgs/development/libraries/cyrus-sasl/default.nix
+++ b/pkgs/development/libraries/cyrus-sasl/default.nix
@@ -20,8 +20,8 @@ stdenv.mkDerivation rec {
     ./cyrus-sasl-ac-try-run-fix.patch
     # make compatible with openssl3. can probably be dropped with any release after 2.1.28
     (fetchpatch {
-      url = "https://github.com/cyrusimap/cyrus-sasl/compare/cb549ef71c5bb646fe583697ebdcaba93267a237...c2bd3afbca57f176d8c650670ce371444bb7fcc0.patch";
-      hash = "sha256-bYeIkvle1Ms7Lnoob4eLd4RbPFHtPkKRZvfHNCBJY/s=";
+      url = "https://github.com/cyrusimap/cyrus-sasl/compare/cb549ef71c5bb646fe583697ebdcaba93267a237...dfaa62392e7caecc6ecf0097b4d73738ec4fc0a8.patch";
+      hash = "sha256-pc0cZqj1QoxDqgd/j/5q3vWONEPrTm4Pr6MzHlfjRCc=";
     })
   ];
 


### PR DESCRIPTION
# pkgsStatic.cyrus_sasl: fix build

```
pkgsStatic.cyrus_sasl: fix build
```

## Build info of packages affected directly
### pkgsStatic.cyrus_sasl

<details><summary>content of pkgsStatic.cyrus_sasl.bin</summary>

```
/nix/store/h1p7q88fqg9zbzkpn319m8ifxb026dsa-cyrus-sasl-static-x86_64-unknown-linux-musl-2.1.28-bin
├── bin
│   ├── pluginviewer
│   ├── saslauthd
│   ├── sasldblistusers2
│   ├── saslpasswd2
│   └── testsaslauthd
└── sbin -> bin

2 directories, 5 files
```
</details>

<details><summary>content of pkgsStatic.cyrus_sasl.dev</summary>

```
/nix/store/cvwh9jqrlj1fp5dqwpbdi5qs5s37k9wh-cyrus-sasl-static-x86_64-unknown-linux-musl-2.1.28-dev
├── include
│   └── sasl
│       ├── hmac-md5.h
│       ├── md5.h
│       ├── md5global.h
│       ├── prop.h
│       ├── sasl.h
│       ├── saslplug.h
│       └── saslutil.h
├── lib
│   └── pkgconfig
│       └── libsasl2.pc
└── nix-support
    └── propagated-build-inputs

5 directories, 9 files
```
</details>

<details><summary>content of pkgsStatic.cyrus_sasl.devdoc</summary>

```
/nix/store/zsif9aar7hp83q0cd6yf40n01ws1z8gp-cyrus-sasl-static-x86_64-unknown-linux-musl-2.1.28-devdoc
└── share
    └── man
        └── man3
            ├── sasl.3.gz
            ├── sasl_authorize_t.3.gz
            ├── sasl_auxprop.3.gz
            ├── sasl_auxprop_getctx.3.gz
            ├── sasl_auxprop_request.3.gz
            ├── sasl_callbacks.3.gz
            ├── sasl_canon_user_t.3.gz
            ├── sasl_chalprompt_t.3.gz
            ├── sasl_checkapop.3.gz
            ├── sasl_checkpass.3.gz
            ├── sasl_client_init.3.gz
            ├── sasl_client_new.3.gz
            ├── sasl_client_start.3.gz
            ├── sasl_client_step.3.gz
            ├── sasl_decode.3.gz
            ├── sasl_dispose.3.gz
            ├── sasl_done.3.gz
            ├── sasl_encode.3.gz
            ├── sasl_encodev.3.gz
            ├── sasl_errdetail.3.gz
            ├── sasl_errors.3.gz
            ├── sasl_errstring.3.gz
            ├── sasl_getconfpath_t.3.gz
            ├── sasl_getopt_t.3.gz
            ├── sasl_getpath_t.3.gz
            ├── sasl_getprop.3.gz
            ├── sasl_getrealm_t.3.gz
            ├── sasl_getsecret_t.3.gz
            ├── sasl_getsimple_t.3.gz
            ├── sasl_global_listmech.3.gz
            ├── sasl_idle.3.gz
            ├── sasl_listmech.3.gz
            ├── sasl_log_t.3.gz
            ├── sasl_server_init.3.gz
            ├── sasl_server_new.3.gz
            ├── sasl_server_start.3.gz
            ├── sasl_server_step.3.gz
            ├── sasl_server_userdb_checkpass_t.3.gz
            ├── sasl_server_userdb_setpass_t.3.gz
            ├── sasl_setpass.3.gz
            ├── sasl_setprop.3.gz
            ├── sasl_user_exists.3.gz
            └── sasl_verifyfile_t.3.gz

3 directories, 43 files
```
</details>

<details><summary>content of pkgsStatic.cyrus_sasl.man</summary>

```
/nix/store/jh5zrhpa9gbqma2sxqjah2fazwxr1ix9-cyrus-sasl-static-x86_64-unknown-linux-musl-2.1.28-man
└── share
    └── man
        └── man8
            ├── pluginviewer.8.gz
            ├── saslauthd.8.gz
            ├── sasldblistusers2.8.gz
            ├── saslpasswd2.8.gz
            └── testsaslauthd.8.gz

3 directories, 5 files
```
</details>

<details><summary>content of pkgsStatic.cyrus_sasl.out</summary>

```
/nix/store/8bkcif2fhz2iwcxdggi0cwh7hb1hhmsz-cyrus-sasl-static-x86_64-unknown-linux-musl-2.1.28
└── lib
    ├── libsasl2.a
    ├── libsasl2.la
    └── sasl2
        ├── libanonymous.a
        ├── libanonymous.la
        ├── libcrammd5.a
        ├── libcrammd5.la
        ├── libdigestmd5.a
        ├── libdigestmd5.la
        ├── liblogin.a
        ├── liblogin.la
        ├── libotp.a
        ├── libotp.la
        ├── libplain.a
        ├── libplain.la
        ├── libsasldb.a
        ├── libsasldb.la
        ├── libscram.a
        └── libscram.la

2 directories, 18 files
```
</details>
