### PR TITLE
nixos/transmission: fix credentialsFile injection

### DIFF
--- a/nixos/tests/transmission.nix
+++ b/nixos/tests/transmission.nix
@@ -11,7 +11,15 @@ import ./make-test-python.nix ({ pkgs, ...} : {
 
     security.apparmor.enable = true;
 
-    services.transmission.enable = true;
+    services.transmission = {
+      enable = true;
+      credentialsFile = pkgs.writeTextFile {
+        name = "settings.json";
+        text = ''
+          { "rpc-password": "5up3r53cr37" }
+        '';
+      };
+    };
   };
 
   testScript =


### PR DESCRIPTION
###### Description of changes

This change fixes the `credentialsFile` injection that used `install` to chown settings.json file (note that `chown` syscall is filtered in systemd service configuration). This operation doesn’t really make sense and under normal circumstances systemd should change ownership for state directories.

https://www.freedesktop.org/software/systemd/man/systemd.exec.html#RuntimeDirectory=

>If the specified directories already exist and their owning user or
>group do not match the configured ones, all files and directories below
>the specified directories as well as the directories themselves will
>have their file ownership recursively changed to match what is
>configured.

In addition to that, this change fixes inconsistent variable escaping in scripts, and allows using credentialsFile that is not owned by the transmission user/group.

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes (or backporting 23.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
