### PR TITLE
protobuf: init 3.22, 3.23 and 3.24

### DIFF
--- a/pkgs/development/libraries/protobuf/3.22.nix
+++ b/pkgs/development/libraries/protobuf/3.22.nix
@@ -1,0 +1,6 @@
+{ callPackage, ... } @ args:
+
+callPackage ./generic-v3-cmake.nix ({
+  version = "3.22.5";
+  sha256 = "sha256-sbxl9uUFvTgczzdv7UkJHjACXYLF2FHGmhZEE8lFLs4=";
+} // args)

--- a/pkgs/development/libraries/protobuf/3.24.nix
+++ b/pkgs/development/libraries/protobuf/3.24.nix
@@ -1,0 +1,6 @@
+{ callPackage, ... } @ args:
+
+callPackage ./generic-v3-cmake.nix ({
+  version = "3.24.1";
+  sha256 = "sha256-70gKH18Ak3TJisscj8JsbOJavOFxbWbVEtGjTXUlqSI=";
+} // args)

--- a/pkgs/development/libraries/protobuf/generic-v3-cmake.nix
+++ b/pkgs/development/libraries/protobuf/generic-v3-cmake.nix
@@ -81,6 +81,13 @@ let
     ] ++ lib.optionals (!stdenv.targetPlatform.isStatic) [
       "-Dprotobuf_BUILD_SHARED_LIBS=ON"
     ]
+    # Due to a bug in abseil, the tests fail to build from version 3.22
+    # Relevant issues:
+    #  - https://github.com/protocolbuffers/protobuf/issues/12201
+    #  - https://github.com/abseil/abseil-cpp/issues/1407
+    ++ lib.optionals (lib.versionAtLeast version "3.22") [
+      "-Dprotobuf_BUILD_TESTS=OFF"
+    ]
     # Tests fail to build on 32-bit platforms; fixed in 3.22
     # https://github.com/protocolbuffers/protobuf/issues/10418
     ++ lib.optional

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -24513,6 +24513,7 @@ with pkgs;
 
   protobuf = protobuf3_23;
 
+  protobuf3_24 = callPackage ../development/libraries/protobuf/3.24.nix { };
   protobuf3_23 = callPackage ../development/libraries/protobuf/3.23.nix { };
   protobuf3_21 = callPackage ../development/libraries/protobuf/3.21.nix {
     abseil-cpp = abseil-cpp_202103;


### PR DESCRIPTION
###### Description of changes

Add the latest three versions of `protobuf`: 3.22 (`3.22.5`), 3.23 (`3.23.4`) and 3.24 (`3.24.0`)

@jonringer 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes (or backporting 23.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
