### PR TITLE
hishtory: init at 0.208

### DIFF
--- a/pkgs/shells/hishtory/default.nix
+++ b/pkgs/shells/hishtory/default.nix
@@ -1,0 +1,37 @@
+{ buildGoModule
+, fetchFromGitHub
+, lib
+}:
+
+buildGoModule rec {
+  pname = "hishtory";
+  version = "0.208";
+
+  src = fetchFromGitHub {
+    owner = "ddworken";
+    repo = pname;
+    rev = "v${version}";
+    hash = "sha256-TEto5lLH5nwqJ9PaYKrYCNW4/zrIICANQlGmqwDbOm4=";
+  };
+
+  vendorHash = "sha256-FodgIELV5JbqP3h/mIDDYARZcols9ZEtVREW1853EOI=";
+
+  ldflags = [ "-X github.com/ddworken/hishtory/client/lib.Version=${version}" ];
+
+  excludedPackages = [ "backend/server" ];
+
+  postInstall = ''
+    mkdir -p $out/share/hishtory
+    cp client/lib/config.* $out/share/hishtory
+  '';
+
+  doCheck = false;
+
+  meta = with lib; {
+    description = "Your shell history: synced, queryable, and in context";
+    homepage = "https://github.com/ddworken/hishtory";
+    license = licenses.mit;
+    maintainers = with maintainers; [ Enzime ];
+  };
+}
+

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -14481,6 +14481,8 @@ with pkgs;
 
   fzf-git-sh = callPackage ../shells/fzf-git-sh { };
 
+  hishtory = callPackage ../shells/hishtory { };
+
   ion = callPackage ../shells/ion { };
 
   jush = callPackage ../shells/jush { };


### PR DESCRIPTION
###### Description of changes

> `hishtory` is a better shell history. It stores your shell history in context (what directory you ran the command in, whether it succeeded or failed, how long it took, etc). This is all stored locally and end-to-end encrypted for syncing to to all your other computers.

https://github.com/ddworken/hishtory

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes (or backporting 23.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).