### PR TITLE
repgrep: init at 0.12.4

### DIFF
--- a/pkgs/tools/text/repgrep/default.nix
+++ b/pkgs/tools/text/repgrep/default.nix
@@ -1,0 +1,46 @@
+{ lib
+, rustPlatform
+, fetchFromGitHub
+, asciidoctor
+, installShellFiles
+, makeWrapper
+, ripgrep
+}:
+
+rustPlatform.buildRustPackage rec {
+  pname = "repgrep";
+  version = "0.12.4";
+
+  src = fetchFromGitHub {
+    owner = "acheronfail";
+    repo = "repgrep";
+    rev = version;
+    hash = "sha256-tMv0MdFlDEYx8lNINfnhX6WgcpVLm1fTlaUddej5KRc=";
+  };
+
+  cargoHash = "sha256-NjPFoVPHjwG74ZNStYaNMzwdX488xDjGJu92+UWC2z8=";
+
+  nativeBuildInputs = [
+    asciidoctor
+    installShellFiles
+    makeWrapper
+  ];
+
+  postInstall = ''
+    wrapProgram $out/bin/rgr \
+      --prefix PATH : ${lib.makeBinPath [ ripgrep ]}
+
+    pushd "$(dirname "$(find -path '**/repgrep-stamp' | head -n 1)")"
+    installManPage rgr.1
+    installShellCompletion rgr.{bash,fish} _rgr
+    popd
+  '';
+
+  meta = with lib; {
+    description = "An interactive replacer for ripgrep that makes it easy to find and replace across files on the command line";
+    homepage = "https://github.com/acheronfail/repgrep";
+    changelog = "https://github.com/acheronfail/repgrep/blob/${src.rev}/CHANGELOG.md";
+    license = with licenses; [ mit asl20 unlicense ];
+    maintainers = with maintainers; [ figsoda ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -11925,6 +11925,8 @@ with pkgs;
 
   renderdoc = libsForQt5.callPackage ../development/tools/renderdoc { };
 
+  repgrep = callPackage ../tools/text/repgrep { };
+
   replace = callPackage ../tools/text/replace { };
 
   resvg = callPackage ../tools/graphics/resvg { };


### PR DESCRIPTION
https://github.com/acheronfail/repgrep

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes (or backporting 23.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
