### PR TITLE
[22.11] webkitgtk: apply patch for CVE-2023-32373, CVE-2023-28204

### DIFF
--- a/pkgs/development/libraries/webkitgtk/CVE-2023-28204.patch
+++ b/pkgs/development/libraries/webkitgtk/CVE-2023-28204.patch
@@ -1,0 +1,111 @@
+diff --git a/JSTests/stress/string-replace-regexp-matchBOL-correct-advancing.js b/JSTests/stress/string-replace-regexp-matchBOL-correct-advancing.js
+new file mode 100644
+index 000000000000..25b1a70b81d2
+--- /dev/null
++++ b/JSTests/stress/string-replace-regexp-matchBOL-correct-advancing.js
+@@ -0,0 +1,35 @@
++// Check that we don't advance for BOL assertions when matching a non-BMP character in the YARR interpreter
++// and that we do advance in String.replace() when processing an empty match.
++
++let expected = "|";
++
++for (let i = 0; i < 11; ++i)
++    expected += String.fromCodePoint(128512) + '|';
++
++let str = String.fromCodePoint(128512).repeat(11);
++
++let result1 = str.replace(/(?!(?=^a|()+()+x)(abc))/gmu, r => {
++    return '|';
++});
++
++
++if (result1 !== expected)
++    print("FAILED: \"" + result1 + " !== " + expected + '"');
++
++let result2= str.replace(/(?!(?=^a|x)(abc))/gmu, r => {
++    return '|';
++});
++
++if (result2 !== expected)
++    print("FAILED: \"" + result2 + " !== " + expected + '"');
++
++expected = "|" + String.fromCodePoint(128512);
++
++str = String.fromCodePoint(128512).repeat(1);
++
++let result3= str.replace(/(?!(?=^a|x)(abc))/mu, r => {
++    return '|';
++});
++
++if (result3 !== expected)
++    print("FAILED: \"" + result3 + " !== " + expected + '"');
+diff --git a/Source/JavaScriptCore/runtime/StringPrototype.cpp b/Source/JavaScriptCore/runtime/StringPrototype.cpp
+index 62451e15266f..e559a4e31c76 100644
+--- a/Source/JavaScriptCore/runtime/StringPrototype.cpp
++++ b/Source/JavaScriptCore/runtime/StringPrototype.cpp
+@@ -504,6 +504,11 @@ static ALWAYS_INLINE JSString* replaceUsingRegExpSearch(
+                 startPosition++;
+                 if (startPosition > sourceLen)
+                     break;
++                if (U16_IS_LEAD(source[startPosition - 1]) && U16_IS_TRAIL(source[startPosition])) {
++                    startPosition++;
++                    if (startPosition > sourceLen)
++                        break;
++                }
+             }
+         }
+     } else {
+@@ -600,6 +605,11 @@ static ALWAYS_INLINE JSString* replaceUsingRegExpSearch(
+                 startPosition++;
+                 if (startPosition > sourceLen)
+                     break;
++                if (U16_IS_LEAD(source[startPosition - 1]) && U16_IS_TRAIL(source[startPosition])) {
++                    startPosition++;
++                    if (startPosition > sourceLen)
++                        break;
++                }
+             }
+         } while (global);
+     }
+diff --git a/Source/JavaScriptCore/yarr/YarrInterpreter.cpp b/Source/JavaScriptCore/yarr/YarrInterpreter.cpp
+index 95a848a1a66d..4e631bb607e5 100644
+--- a/Source/JavaScriptCore/yarr/YarrInterpreter.cpp
++++ b/Source/JavaScriptCore/yarr/YarrInterpreter.cpp
+@@ -210,6 +210,21 @@ class Interpreter {
+             return result;
+         }
+         
++        int readCheckedDontAdvance(unsigned negativePositionOffest)
++        {
++            RELEASE_ASSERT(pos >= negativePositionOffest);
++            unsigned p = pos - negativePositionOffest;
++            ASSERT(p < length);
++            int result = input[p];
++            if (U16_IS_LEAD(result) && decodeSurrogatePairs && p + 1 < length && U16_IS_TRAIL(input[p + 1])) {
++                if (atEnd())
++                    return -1;
++
++                result = U16_GET_SUPPLEMENTARY(result, input[p + 1]);
++            }
++            return result;
++        }
++
+         int readSurrogatePairChecked(unsigned negativePositionOffset)
+         {
+             RELEASE_ASSERT(pos >= negativePositionOffset);
+@@ -482,13 +497,13 @@ class Interpreter {
+ 
+     bool matchAssertionBOL(ByteTerm& term)
+     {
+-        return (input.atStart(term.inputPosition)) || (pattern->multiline() && testCharacterClass(pattern->newlineCharacterClass, input.readChecked(term.inputPosition + 1)));
++        return (input.atStart(term.inputPosition)) || (pattern->multiline() && testCharacterClass(pattern->newlineCharacterClass, input.readCheckedDontAdvance(term.inputPosition + 1)));
+     }
+ 
+     bool matchAssertionEOL(ByteTerm& term)
+     {
+         if (term.inputPosition)
+-            return (input.atEnd(term.inputPosition)) || (pattern->multiline() && testCharacterClass(pattern->newlineCharacterClass, input.readChecked(term.inputPosition)));
++            return (input.atEnd(term.inputPosition)) || (pattern->multiline() && testCharacterClass(pattern->newlineCharacterClass, input.readCheckedDontAdvance(term.inputPosition)));
+ 
+         return (input.atEnd()) || (pattern->multiline() && testCharacterClass(pattern->newlineCharacterClass, input.read()));
+     }

--- a/pkgs/development/libraries/webkitgtk/default.nix
+++ b/pkgs/development/libraries/webkitgtk/default.nix
@@ -2,6 +2,7 @@
 , stdenv
 , runCommand
 , fetchurl
+, fetchpatch
 , perl
 , python3
 , ruby
@@ -97,6 +98,13 @@ stdenv.mkDerivation (finalAttrs: {
       src = ./fdo-backend-path.patch;
       wpebackend_fdo = libwpe-fdo;
     })
+    (fetchpatch {
+      name = "CVE-2023-32373.patch";
+      url = "https://github.com/WebKit/WebKit/commit/85fd2302d16a09a82d9a6e81eb286babb23c4b3c.patch";
+      hash = "sha256-8TMPCExfBjZhAS4l3anKgsFNkrKR6ig7nLqu4hT3A90=";
+    })
+    # Based on https://github.com/WebKit/WebKit/commit/698c6e293734c3c46f223b77d5b4ee48b320e32c
+    ./CVE-2023-28204.patch
   ];
 
   preConfigure = lib.optionalString (stdenv.hostPlatform != stdenv.buildPlatform) ''


### PR DESCRIPTION
###### Description of changes

Later I noticed Debian 11 [can backport 2.40.x](https://salsa.debian.org/webkit-team/webkit/-/commit/746f28a68d987110de28f01699b25e0b3c4efc24) because they never packaged webkitgtk_5_0 in Debian 11 :clown_face: 

I checked (most?) symbols in the patches and they should be there. `int readCheckedDontAdvance(unsigned negativePositionOffest)` is basically a copy of `int readChecked(unsigned negativePositionOffest)` with `next();` removed.

(~~away from keyboard for the next few hours~~, feel free to push stuff here)

/cc  #234924

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes (or backporting 23.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
