### PR TITLE
makeModuleClosure: include firmware for builtin modules; various improvements

### DIFF
--- a/pkgs/build-support/kernel/modules-closure.sh
+++ b/pkgs/build-support/kernel/modules-closure.sh
@@ -68,17 +68,7 @@ done
 
 mkdir -p $out/lib/firmware
 for module in $(cat closure); do
-    # for builtin modules, modinfo will reply with a wrong output looking like:
-    #   $ modinfo -F firmware unix
-    #   name:           unix
-    #
-    # There is a pending attempt to fix this:
-    #   https://github.com/NixOS/nixpkgs/pull/96153
-    #   https://lore.kernel.org/linux-modules/20200823215433.j5gc5rnsmahpf43v@blumerang/T/#u
-    #
-    # For now, the workaround is just to filter out the extraneous lines out
-    # of its output.
-    for i in $(modinfo -b $kernel --set-version "$version" -F firmware $module | grep -v '^name:'); do
+    for i in $(modinfo -b $kernel --set-version "$version" -F firmware $module); do
         mkdir -p "$out/lib/firmware/$(dirname "$i")"
         echo "firmware for $module: $i"
         for name in "$i" "$i.xz" ""; do

--- a/pkgs/build-support/kernel/modules-closure.sh
+++ b/pkgs/build-support/kernel/modules-closure.sh
@@ -67,14 +67,22 @@ for module in $rootModules; do
 done
 
 copy_blob() {
-        mkdir -p "$out/lib/firmware/$(dirname "$i")"
-        echo "firmware for $module: $i"
-        for name in "$i" "$i.xz" ""; do
-            [ -z "$name" ] && echo "WARNING: missing firmware $i for module $module"
-            if cp "$firmware/lib/firmware/$name" "$out/lib/firmware/$name" 2>/dev/null; then
-                break
+    local sourcefile="$firmware/lib/firmware/$2"
+    local targetfile="$out/lib/firmware/$2"
+    mkdir -p "$out/lib/firmware/$(dirname "$2")"
+    echo "firmware for $1: $2"
+    if [ -e "$sourcefile" ]; then
+        cp -f "$sourcefile" "$targetfile"
+    else # if we already copied an uncompressed version there's no point also copying a compressed one
+        local found=0
+        for extension in "xz" "zstd"; do
+            if [ -e "$sourcefile.$extension" ]; then
+                found=1
+                cp -f "$sourcefile.$extension" "$targetfile.$extension"
             fi
         done
+        [ $found -eq 1 ] || echo "WARNING: missing firmware $2 for module $1"
+    fi
 }
 
 mkdir -p $out/lib/firmware

--- a/pkgs/build-support/kernel/modules-closure.sh
+++ b/pkgs/build-support/kernel/modules-closure.sh
@@ -80,12 +80,10 @@ for module in $(cat closure); do
     done
 done
 
-# copy module ordering hints for depmod
-cp $kernel/lib/modules/"$version"/modules.order $out/lib/modules/"$version"/.
-cp $kernel/lib/modules/"$version"/modules.builtin $out/lib/modules/"$version"/.
+# copy module hints for depmod
+cp $kernel/lib/modules/"$version"/modules.{order,builtin{,.modinfo}} -t $out/lib/modules/"$version"
 
 depmod -b $out -a $version
 
 # remove original hints from final derivation
-rm $out/lib/modules/"$version"/modules.order
-rm $out/lib/modules/"$version"/modules.builtin
+rm $out/lib/modules/"$version"/modules.{order,builtin{,.modinfo}}


### PR DESCRIPTION
###### Description of changes
the NixOS initrd only contained firmware for loadable modules, which with the default kernel config is ~all of them.
a custom kernel, however, could find itself lacking required firmware on bootup.
this uses sed to parse the `modules.builtin.modinfo` file in order to add firmware for builtin modules.

additionally, some smaller related changes were made to the script:
- in the context of copying firmware to the initrd:
  - removed workaround for upstream bug introduced in ee8572d6b31b8188f9d500a1a3036316f2aa21c0
  - added ability to copy zstd-compressed firmware to the initrd
- otherwise:
  - fixed warning from depmod


test has not been added as that seems like it would require building a whole new kernel.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [X] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes (or backporting 23.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
