### PR TITLE
WIP: virt-v2v: init at 2.3.4

### DIFF
--- a/pkgs/applications/virtualization/virt-v2v/default.nix
+++ b/pkgs/applications/virtualization/virt-v2v/default.nix
@@ -1,0 +1,51 @@
+{ lib, stdenv, /*fetchFromGitHub,*/ fetchgit, autoreconfHook, pkg-config
+, cdrkit, xorriso, libguestfs, libnbd, pcre2, libvirt, libxml2, jansson
+, libosinfo, gobject-introspection, ocamlPackages
+}:
+
+stdenv.mkDerivation rec {
+  pname = "virt-v2v";
+  version = "2.3.4";
+
+  #src = fetchFromGitHub {
+  #  owner = "libguestfs";
+  #  repo = pname;
+  #  rev = "refs/tags/v${version}";
+  #  hash = "sha256-PJbeLmc8EX+4d2GNBXX2Rtmrm3g8m459j+J4OC1m/tA=";
+  #};
+
+  # Use fetchgit for submodules (which are missing with fetchFromGitHub).
+  src = fetchgit {
+    url = "https://github.com/libguestfs/virt-v2v";
+    rev = "refs/tags/v${version}";
+    fetchSubmodules = true;
+    hash = "sha256-FtsrbY8ER5KQFUx2x3SqmP9lXyVu5USrjLogagCjJjY=";
+  };
+
+  nativeBuildInputs = [ autoreconfHook pkg-config ];
+
+  # TODO: Consider taking all inputs from libguestfs?
+  buildInputs = [
+    # Needs xorriso, genisoimage or mkisofs -- xorriso chosen for closure size (MOVE THIS COMMENT INTO THE COMMIT MESSAGE)
+    # FIXME: Maybe use cdrkit anyway, because it's an input to libguestfs?
+    xorriso
+
+    libguestfs
+    libnbd
+    pcre2
+    libvirt
+    libxml2
+    jansson
+    libosinfo
+    gobject-introspection
+    ocamlPackages.ocaml
+    ocamlPackages.findlib
+    ocamlPackages.ocaml_libvirt
+    #ocamlPackages.libnbd  # FIXME: missing
+  ];
+
+  meta = {
+    description = "Convert guests from foreign hypervisors to run on KVM";
+    # TODO: more meta attrs.
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -35045,6 +35045,8 @@ with pkgs;
     qtermwidget = lxqt.qtermwidget;
   };
 
+  virt-v2v = callPackage ../applications/virtualization/virt-v2v { };
+
   virtscreen = callPackage ../tools/admin/virtscreen { };
 
   virtual-ans = callPackage ../applications/audio/virtual-ans { };


### PR DESCRIPTION
###### Description of changes

FIXME: `configure: error: the OCaml module 'nbd' (from libnbd) is required`

https://github.com/libguestfs/virt-v2v

virt-v2v used to be part of libguestfs, but was factored out into its own
repository with the release of libguestfs 1.42.1 (see
https://www.libguestfs.org/guestfs-release-notes-1.42.1.html).

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes (or backporting 23.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
