### PR TITLE
nix-fallback-paths.nix: Create an update script

### DIFF
--- a/nixos/modules/installer/tools/nix-fallback-paths.nix
+++ b/nixos/modules/installer/tools/nix-fallback-paths.nix
@@ -1,7 +1,13 @@
+# Generated from https://hydra.nixos.org/eval/1791054
 {
+  # https://hydra.nixos.org/eval/1791054/job/build.x86_64-linux
   x86_64-linux = "/nix/store/mc43d38fibi94pp5crfwacl5gbslccd0-nix-2.13.3";
+  # https://hydra.nixos.org/eval/1791054/job/build.i686-linux
   i686-linux = "/nix/store/09m966pj26cgd4ihlg8ihl1106j3vih8-nix-2.13.3";
+  # https://hydra.nixos.org/eval/1791054/job/build.aarch64-linux
   aarch64-linux = "/nix/store/7f191d125akld27gc6jl0r13l8pl7x0h-nix-2.13.3";
+  # https://hydra.nixos.org/eval/1791054/job/build.x86_64-darwin
   x86_64-darwin = "/nix/store/1wn9jkvi2zqfjnjgg7lnp30r2q2y8whd-nix-2.13.3";
+  # https://hydra.nixos.org/eval/1791054/job/build.aarch64-darwin
   aarch64-darwin = "/nix/store/8w0v2mffa10chrf1h66cbvbpw86qmh85-nix-2.13.3";
 }

--- a/nixos/modules/installer/tools/update-fallback-paths.sh
+++ b/nixos/modules/installer/tools/update-fallback-paths.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env nix-shell
+#!nix-shell -i bash -p curl jq git
+
+# This script is adapted from https://github.com/NixOS/nix/blob/27f82ef4a8fc589738ef06040dad5c0e214f97aa/maintainers/upload-release.pl#L202-L218
+
+set -euo pipefail
+
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+
+cd "$(git -C "$SCRIPT_DIR" rev-parse --show-toplevel)"
+
+if [[ "$#" -lt 1 ]]; then
+    echo "Usage: $0 EVAL_ID"
+fi
+evalId=$1
+
+evalUrl="https://hydra.nixos.org/eval/$evalId"
+buildInfo=$(curl -sSfL "$evalUrl/job/build.x86_64-linux" --header "Accept: application/json")
+releaseName=$(jq -r .nixname <<< "$buildInfo")
+version=${releaseName#nix-}
+
+expectedVersion=$(nix-instantiate --eval --strict --json -A nix.version | jq -r .)
+
+if [[ "$version" != "$expectedVersion" ]]; then
+    echo "Expected Nix version is $expectedVersion, but the given Nix Hydra evaluation is for version $version"
+    exit 1
+fi
+
+getStorePath() {
+    local jobName=$1
+    local buildInfo=$(curl -sSfL "$evalUrl/job/$jobName" --header "Accept: application/json")
+    jq -r .buildoutputs.out.path <<< "$buildInfo"
+}
+
+generateEntry() {
+    local platform=$1
+    jobName="build.$platform"
+    echo "  # $evalUrl/job/$jobName"
+    echo "  $platform = \"$(getStorePath "$jobName")\";"
+}
+
+{
+    echo "# Generated from $evalUrl"
+    echo "{"
+    generateEntry "x86_64-linux"
+    generateEntry "i686-linux"
+    generateEntry "aarch64-linux"
+    generateEntry "x86_64-darwin"
+    generateEntry "aarch64-darwin"
+    echo "}"
+} >"$SCRIPT_DIR/nix-fallback-paths.nix"
+
+echo "Successfully updated nix-fallback-paths.nix to Nix version $version"


### PR DESCRIPTION
###### Description of changes

This is an update script for the `nix-fallback-paths.nix` file, which I would've liked for #233439. While effectively the same also exists in the [Nix release script](https://github.com/NixOS/nix/blob/27f82ef4a8fc589738ef06040dad5c0e214f97aa/maintainers/upload-release.pl#L203-L218), that script can only be run by @edolstra and also shouldn't be in the Nix source in the first place, since it updates something for Nixpkgs.

One thing I am not sure about is how the Hydra evaluation ID to get the Nix store paths from should be determined. It _should_ match the Hydra evaluation used for the Nix release pushed to http://releases.nixos.org/?prefix=nix, but the Hydra evaluation ID is not exposed from there.

Alternatively, we could get the Nix store paths directly from http://releases.nixos.org/?prefix=nix without going through the Hydra evaluation ID, but the binary blobs seem to be detached from their original store paths, so that's also not doable.  

Ping @NixOS/nix-team 

This work is sponsored by [Antithesis](https://antithesis.com/) :sparkles:

###### Things done

- [x] Run the script, testing it manually, updating the `nix-fallback-paths.nix` file
- [ ] Document the code and how to run it
- [ ] Add a CI check to ensure that the fallback paths are always for the same version as the current `nix` attribute