### PR TITLE
git-credential-oauth: init at 0.7.0

### DIFF
--- a/pkgs/applications/version-management/git-credential-oauth/default.nix
+++ b/pkgs/applications/version-management/git-credential-oauth/default.nix
@@ -1,0 +1,29 @@
+{ lib, buildGoModule, fetchFromGitHub }:
+
+buildGoModule rec {
+  pname = "git-credential-oauth";
+  version = "0.7.0";
+
+  src = fetchFromGitHub {
+    owner = "hickford";
+    repo = pname;
+    rev = "v${version}";
+    hash = "sha256-f12PgTtfs/S9RI8+QFROkNqccRWeIW1/YkynqvKJc7I=";
+  };
+
+  ldflags = [
+    "-s"
+    "-w"
+    "-X main.version=${version}"
+  ];
+
+  vendorHash = "sha256-9X7ti3NR5MKK0MpiyTOTO+EtdMuu4/TW/diHq9FjSHY=";
+
+  meta = {
+    description = "Git credential helper that securely authenticates to GitHub, GitLab and BitBucket using OAuth";
+    homepage = "https://github.com/hickford/git-credential-oauth";
+    changelog = "https://github.com/hickford/git-credential-oauth/releases/tag/${src.rev}";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ shyim ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1980,6 +1980,8 @@ with pkgs;
     inherit (darwin.apple_sdk.frameworks) DiskArbitration Foundation;
   };
 
+  git-credential-oauth = callPackage ../applications/version-management/git-credential-oauth { };
+
   git-crypt = callPackage ../applications/version-management/git-crypt { };
 
   git-delete-merged-branches = callPackage ../applications/version-management/git-delete-merged-branches { };


### PR DESCRIPTION
###### Description of changes

git-credential-oauth is a helper that securely authenticates to GitHub, GitLab and BitBucket using OAuth. It's build with Go and easy to maintain

###### Things done


- Built on platform(s)
  - [X] x86_64-linux
  - [X] aarch64-linux
  - [ ] x86_64-darwin
  - [X] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [X] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes (or backporting 23.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
