### PR TITLE
semgrep{,-core}: 1.15.0 -> 1.27.0

### DIFF
--- a/pkgs/tools/security/semgrep/common.nix
+++ b/pkgs/tools/security/semgrep/common.nix
@@ -1,54 +1,39 @@
-{ lib, fetchFromGitHub, fetchzip, stdenv }:
+{ lib }:
 
 rec {
-  version = "1.15.0";
+  version = "1.27.0";
 
-  src = fetchFromGitHub {
-    owner = "returntocorp";
-    repo = "semgrep";
-    rev = "v${version}";
-    sha256 = "sha256-x+AOt6nn2hN4MODFZCvlq0kZ3VLoS7rVcFGGCEssIu0=";
-  };
+  srcHash = "sha256-F6n3LQY4a5sO6c8SMQF9YjjgOS+v2SH+UQPwhg2EX7Q=";
 
   # submodule dependencies
   # these are fetched so we:
   #   1. don't fetch the many submodules we don't need
   #   2. avoid fetchSubmodules since it's prone to impurities
   submodules = {
-    "cli/src/semgrep/lang" = fetchFromGitHub {
-      owner = "returntocorp";
-      repo = "semgrep-langs";
-      rev = "08656cdefc9e6818c64e168cf51ee1e76ea8829e";
-      sha256 = "sha256-vYf33JhfvEDmt/VW0hBOmqailIERS0GdUgrPuCxWt9I=";
-    };
-    "cli/src/semgrep/semgrep_interfaces" = fetchFromGitHub {
+    "cli/src/semgrep/semgrep_interfaces" = {
       owner = "returntocorp";
       repo = "semgrep-interfaces";
-      rev = "ba9241ca8f13dea72a4ca5c5eae99f45c071c8b4";
-      sha256 = "sha256-2rcMmN42445AivcyYLPeE+HBYOyxJijQME1UUr9HISA=";
+      rev = "213f67abea73546ca6111e1bbf0ef96aa917c940";
+      hash = "sha256-HeNHJkTje9j16+dwsfyMhoqQn/J18q/7XvQPRwgTw/Y=";
     };
   };
 
   # fetch pre-built semgrep-core since the ocaml build is complex and relies on
   # the opam package manager at some point
-  core = rec {
-    data = {
-      x86_64-linux = {
-        suffix = "-ubuntu-16.04.tgz";
-        sha256 = "sha256-vLtV1WAnOD6HhgrWYIP0NfXHKfvXORksdNp5UTG1QWc=";
-      };
-      x86_64-darwin = {
-        suffix = "-osx.zip";
-        sha256 = "sha256-6+ENjOOIJ5TSjpnJ5pDudblrWj/FLUe66UGr6V9c0HQ=";
-      };
+  # pulling it out of the python wheel as r2c no longer release a built binary
+  # on github releases
+  core = {
+    x86_64-linux = {
+      platform = "any";
+      hash = "sha256-cRj81dXpAE6S0EXajsRikOIAPzlUf42FhiDCWjv+wZQ=";
     };
-    src = let
-      inherit (stdenv.hostPlatform) system;
-      selectSystemData = data: data.${system} or (throw "Unsupported system: ${system}");
-      inherit (selectSystemData data) suffix sha256;
-    in fetchzip {
-      url = "https://github.com/returntocorp/semgrep/releases/download/v${version}/semgrep-v${version}${suffix}";
-      inherit sha256;
+    x86_64-darwin = {
+      platform = "macosx_10_14_x86_64";
+      hash = "sha256-jqfGVZGF/DFgXkr7kQg6QyqEELSr8AKE3Ga8kTftnIY=";
+    };
+    aarch64-darwin = {
+      platform = "macosx_11_0_arm64";
+      hash = "sha256-e/uCSRMdbVD0lvc0hukbiUzheqRNIIh1LgMq6Ae7JYI=";
     };
   };
 
@@ -66,7 +51,5 @@ rec {
     '';
     license = licenses.lgpl21Plus;
     maintainers = with maintainers; [ jk ambroisie ];
-    # limited by semgrep-core
-    platforms = [ "x86_64-linux" "x86_64-darwin" ];
   };
 }

--- a/pkgs/tools/security/semgrep/semgrep-core.nix
+++ b/pkgs/tools/security/semgrep/semgrep-core.nix
@@ -1,21 +1,52 @@
-{ lib, stdenvNoCC, callPackage }:
+{ lib, stdenvNoCC, fetchPypi, unzip }:
 
 let
-  common = callPackage ./common.nix { };
+  common = import ./common.nix { inherit lib; };
 in
 stdenvNoCC.mkDerivation rec {
   pname = "semgrep-core";
   inherit (common) version;
-  inherit (common.core) src;
+  # fetch pre-built semgrep-core since the ocaml build is complex and relies on
+  # the opam package manager at some point
+  # pulling it out of the python wheel as r2c no longer release a built binary
+  # on github releases
+  src =
+    let
+      inherit (stdenvNoCC.hostPlatform) system;
+      data = common.core.${system} or (throw "Unsupported system: ${system}");
+    in
+    fetchPypi rec {
+      pname = "semgrep";
+      inherit version;
+      format = "wheel";
+      dist = python;
+      python = "cp37.cp38.cp39.py37.py38.py39";
+      inherit (data) platform hash;
+    };
+
+  nativeBuildInputs = [ unzip ];
+
+  # _tryUnzip from unzip's setup-hook doesn't recognise .whl
+  # "do not know how to unpack source archive"
+  # perform unpack by hand
+  unpackPhase = ''
+    runHook preUnpack
+    LANG=en_US.UTF-8 unzip -qq "$src"
+    runHook postUnpack
+  '';
+
+  dontConfigure = true;
+  dontBuild = true;
 
   installPhase = ''
     runHook preInstall
-    install -Dm 755 -t $out/bin semgrep-core
+    install -Dm 755 -t $out/bin semgrep-${version}.data/purelib/semgrep/bin/semgrep-core
     runHook postInstall
   '';
 
   meta = common.meta // {
     description = common.meta.description + " - core binary";
     sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
+    platforms = lib.attrNames common.core;
   };
 }


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Can no longer fetch prebuilt semgrep-core from github but can get it from the python wheel
We're still able to build the rest of semgrep from source

---

related: https://github.com/returntocorp/semgrep/issues/7570

resolves: #235417

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [X] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes (or backporting 23.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
