### PR TITLE
deterministic-uname: fix default output

### DIFF
--- a/pkgs/build-support/deterministic-uname/deterministic-uname.sh
+++ b/pkgs/build-support/deterministic-uname/deterministic-uname.sh
@@ -38,6 +38,10 @@ processor=0
 hardware_platform=0
 operating_system=0
 
+# With no OPTION, same as -s.
+if [[ $# -eq 0 ]]; then
+    kernel_name=1
+fi
 
 @getopt@/bin/getopt --test > /dev/null && rc=$? || rc=$?
 if [[ $rc -ne 4 ]]; then
@@ -52,11 +56,6 @@ else
   PARSED=`@getopt@/bin/getopt --options $SHORT --longoptions $LONG --name "$0" -- "$@"`
 
   eval set -- "$PARSED"
-fi
-
-# With no OPTION, same as -s.
-if [[ $# -eq 0 ]]; then
-    kernel_name=1
 fi
 
 # Process each argument, and set the appropriate flag if we recognize it.
@@ -132,44 +131,44 @@ fi
 #  Darwin *nodename* 22.1.0 Darwin Kernel Version 22.1.0: Sun Oct  9 20:14:30 PDT 2022; root:xnu-8792.41.9~2/RELEASE_ARM64_T8103 arm64 arm Darwin
 # NixOS:
 #  Linux *nodename* 6.0.13 #1-NixOS SMP PREEMPT_DYNAMIC Wed Dec 14 10:41:06 UTC 2022 x86_64 GNU/Linux
+output=()
 if [[ "$all" = "1" ]]; then
-    echo -n "$KERNEL_NAME_VAL $NODENAME_VAL $KERNEL_RELEASE_VAL $KERNEL_VERSION_VAL $MACHINE_VAL "
+    output+=("$KERNEL_NAME_VAL" "$NODENAME_VAL" "$KERNEL_RELEASE_VAL" "$KERNEL_VERSION_VAL" "$MACHINE_VAL")
     # in help:  except omit -p and -i if unknown.
-    #echo -n "$PROCESSOR_VAL $HARDWARE_PLATFORM_VAL\n"
-    echo -n "$OPERATING_SYSTEM_VAL"
+    # output+=($PROCESSOR_VAL $HARDWARE_PLATFORM_VAL)
+    output+=("$OPERATING_SYSTEM_VAL")
 fi
 
 if [[ "$kernel_name" = "1" ]]; then
-    echo -n "$KERNEL_NAME_VAL"
+    output+=("$KERNEL_NAME_VAL")
 fi
 
 if [[ "$nodename" = "1" ]]; then
-    echo -n "$NODENAME_VAL"
+    output+=("$NODENAME_VAL")
 fi
 
 if [[ "$kernel_release" = "1" ]]; then
-    echo -n "$KERNEL_RELEASE_VAL"
+    output+=("$KERNEL_RELEASE_VAL")
 fi
 
 if [[ "$kernel_version" = "1" ]]; then
-    echo -n "$KERNEL_VERSION_VAL"
+    output+=("$KERNEL_VERSION_VAL")
 fi
 
 if [[ "$machine" = "1" ]]; then
-    echo -n "$MACHINE_VAL"
+    output+=("$MACHINE_VAL")
 fi
 
 if [[ "$processor" = "1" ]]; then
-    echo -n "$PROCESSOR_VAL"
+    output+=("$PROCESSOR_VAL")
 fi
 
 if [[ "$hardware_platform" = "1" ]]; then
-    echo -n "$HARDWARE_PLATFORM_VAL"
+    output+=("$HARDWARE_PLATFORM_VAL")
 fi
 
 if [[ "$operating_system" = "1" ]]; then
-    echo -n "$OPERATING_SYSTEM_VAL"
+    output+=("$OPERATING_SYSTEM_VAL")
 fi
 
-# for newline.
-echo
+echo "${output[@]}"


### PR DESCRIPTION
###### Description of changes

The `deterministic-uname` package is broken when no arguments are passed.

Reproduce:
```
$ nix run nixpkgs#deterministic-uname
<no output>
```

Fix:
```
$ nix run github:szlend/nixpkgs/fix-deterministic-uname-getops#deterministic-uname
Darwin
```

I also replaced manual concatenation with bash arrays so we don't have to deal with whitespace.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes (or backporting 23.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
