### PR TITLE
python3Packages.pysmart: 1.2.3 -> 1.2.5

### DIFF
--- a/pkgs/development/python-modules/pysmart/default.nix
+++ b/pkgs/development/python-modules/pysmart/default.nix
@@ -1,25 +1,29 @@
 { lib
 , buildPythonPackage
 , fetchFromGitHub
-, smartmontools
+, chardet
 , humanfriendly
 , pytestCheckHook
 , pythonOlder
+, setuptools-scm
+, smartmontools
 }:
 
 buildPythonPackage rec {
   pname = "pysmart";
-  version = "1.2.3";
-  format = "setuptools";
+  version = "1.2.5";
+  format = "pyproject";
 
   disabled = pythonOlder "3.7";
 
   src = fetchFromGitHub {
     owner = "truenas";
     repo = "py-SMART";
-    rev = "refs/tags/v${version}";
-    hash = "sha256-5VoZEgHWmHUDkm2KhBP0gfmhOJUYJUqDLWBp/kU1404=";
+    rev = "v${version}";
+    hash = "sha256-NqE7Twl1kxXrASyxw35xIOTB+LThU0a45NCxh8SUxfI=";
   };
+
+  SETUPTOOLS_SCM_PRETEND_VERSION = version;
 
   postPatch = ''
     substituteInPlace pySMART/utils.py \
@@ -27,7 +31,12 @@ buildPythonPackage rec {
   '';
 
   propagatedBuildInputs = [
+    chardet
     humanfriendly
+  ];
+
+  nativeBuildInputs = [
+    setuptools-scm
   ];
 
   nativeCheckInputs = [


### PR DESCRIPTION
###### Things done

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [X] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes (or backporting 23.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
