### PR TITLE
darwin.system_cmds: fix build with clang 16

### DIFF
--- a/pkgs/os-specific/darwin/apple-source-releases/system_cmds/default.nix
+++ b/pkgs/os-specific/darwin/apple-source-releases/system_cmds/default.nix
@@ -30,7 +30,12 @@ appleDerivation {
                          "-DAU_SESSION_FLAG_HAS_AUTHENTICATED=0x4000"
                        ] ++ lib.optional (!stdenv.isLinux) " -D__FreeBSD__ ");
 
-  patchPhase = ''
+  patches = [
+    # Fix implicit declarations that cause builds to fail when built with clang 16.
+    ./fix-implicit-declarations.patch
+  ];
+
+  postPatch = ''
     substituteInPlace login.tproj/login.c \
       --replace bsm/audit_session.h bsm/audit.h
     substituteInPlace login.tproj/login_audit.c \

--- a/pkgs/os-specific/darwin/apple-source-releases/system_cmds/fix-implicit-declarations.patch
+++ b/pkgs/os-specific/darwin/apple-source-releases/system_cmds/fix-implicit-declarations.patch
@@ -1,0 +1,48 @@
+diff -ur a/getty.tproj/main.c b/getty.tproj/main.c
+--- a/getty.tproj/main.c	2008-06-10 14:50:19.000000000 -0400
++++ b/getty.tproj/main.c	2023-05-31 18:06:40.121028558 -0400
+@@ -67,6 +67,7 @@
+ #include <syslog.h>
+ #include <termios.h>
+ #include <time.h>
++#include <util.h>
+ #include <unistd.h>
+ 
+ #ifdef __APPLE__
+@@ -152,7 +153,7 @@
+ static void	putpad(const char *);
+ static void	puts(const char *);
+ static void	timeoverrun(int);
+-static char	*getline(int);
++static char	*get_line(int);
+ static void	setttymode(int);
+ static int	opentty(const char *, int);
+ 
+@@ -352,7 +353,7 @@
+ 			if ((fd = open(IF, O_RDONLY)) != -1) {
+ 				char * cp;
+ 
+-				while ((cp = getline(fd)) != NULL) {
++				while ((cp = get_line(fd)) != NULL) {
+ 					  putf(cp);
+ 				}
+ 				close(fd);
+@@ -744,7 +745,7 @@
+ 
+ 
+ static char *
+-getline(int fd)
++get_line(int fd)
+ {
+ 	int i = 0;
+ 	static char linebuf[512];
+--- a/newgrp.tproj/newgrp.c	2021-10-06 01:38:52.000000000 -0400
++++ b/newgrp.tproj/newgrp.c	2023-05-31 22:26:50.656157841 -0400
+@@ -47,6 +47,7 @@
+ #include <string.h>
+ #include <unistd.h>
+ #ifdef __APPLE__
++#include <membership.h>
+ #include <paths.h>
+ #endif /* __APPLE__ */
+ static void	 addgroup(const char *grpname);


### PR DESCRIPTION
###### Description of changes

Clang 16 makes implicit declarations an error by default. The headers
are available, so include them.

`getline` was renamed to `get_line` to avoid a name clash. `util.h`
includes `stdio.h`, which defines `getline`.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes (or backporting 23.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
