### PR TITLE
libelf: fix build with clang 16 on Darwin

### DIFF
--- a/pkgs/development/libraries/libelf/fix-configure-main.patch
+++ b/pkgs/development/libraries/libelf/fix-configure-main.patch
@@ -1,0 +1,12 @@
+diff -ur a/configure.in b/configure.in
+--- a/configure.in	2008-05-23 04:17:56.000000000 -0400
++++ b/configure.in	2023-06-01 19:16:04.801921924 -0400
+@@ -282,7 +282,7 @@
+ #define memmove(d,s,n) bcopy((s),(d),(n))
+ #endif
+ extern int strcmp();
+-main() {
++int main() {
+   char buf[] = "0123456789";
+   memmove(buf + 1, buf, 9);
+   if (strcmp(buf, "0012345678")) exit(1);


### PR DESCRIPTION
###### Description of changes

Clang 16 does not allow `main` with an implicit `int`, which causes the configure script to misdetect clang as a non-working compiler. Patching `configure.in` and regenerating `configure` allows libelf to build.

Due to the comment regarding bootstrap tools, this patching is only done on Darwin with clang.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes (or backporting 23.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
