### PR TITLE
ocamlPackages: fixes for OCaml 5.0

### DIFF
--- a/pkgs/development/ocaml-modules/pgocaml/default.nix
+++ b/pkgs/development/ocaml-modules/pgocaml/default.nix
@@ -1,6 +1,8 @@
-{ lib, fetchFromGitHub, buildDunePackage
-, calendar, csv, hex, ppx_deriving, ppx_sexp_conv, re, rresult, sexplib
+{ lib, fetchFromGitHub, fetchpatch, buildDunePackage, ocaml
+, calendar, camlp-streams, csv, hex, ppx_deriving, ppx_sexp_conv, re, rresult, sexplib
 }:
+
+let with-camlp-streams = lib.optional (lib.versionAtLeast ocaml.version "5.0"); in
 
 buildDunePackage rec {
   pname = "pgocaml";
@@ -12,10 +14,16 @@ buildDunePackage rec {
     hash = "sha256-W1fbRnU1l61qqxfVY2qiBnVpGD81xrBO8k0tWr+RXMY=";
   };
 
-  minimalOCamlVersion = "4.08";
-  duneVersion = "3";
+  # Compatibility with OCaml ≥ 5.0
+  patches = with-camlp-streams (fetchpatch {
+    url = "https://github.com/darioteixeira/pgocaml/commit/906a289dc57da4971e312c31eedd26d81e902ed5.patch";
+    hash = "sha256-/v9Jheg98GhrcD2gcsQpPvq7YiIrvJj22SKvrBRlR9Y=";
+  });
 
-  propagatedBuildInputs = [ calendar csv hex ppx_deriving ppx_sexp_conv re rresult sexplib ];
+  minimalOCamlVersion = "4.08";
+
+  propagatedBuildInputs = [ calendar csv hex ppx_deriving ppx_sexp_conv re rresult sexplib ]
+  ++ with-camlp-streams camlp-streams;
 
   meta = with lib; {
     description = "An interface to PostgreSQL databases for OCaml applications";

--- a/pkgs/development/ocaml-modules/twt/default.nix
+++ b/pkgs/development/ocaml-modules/twt/default.nix
@@ -1,5 +1,8 @@
 { lib, stdenv, fetchFromGitHub, ocaml, findlib }:
 
+lib.throwIf (lib.versionAtLeast ocaml.version "5.0")
+  "twt is not available for OCaml ${ocaml.version}"
+
 stdenv.mkDerivation rec {
   pname = "ocaml${ocaml.version}-twt";
   version = "0.94.0";

--- a/pkgs/development/ocaml-modules/vlq/default.nix
+++ b/pkgs/development/ocaml-modules/vlq/default.nix
@@ -1,6 +1,9 @@
-{ lib, buildDunePackage, fetchurl
+{ lib, buildDunePackage, fetchurl, ocaml
 , dune-configurator
 }:
+
+lib.throwIf (lib.versionAtLeast ocaml.version "5.0")
+  "vlq is not available for OCaml ${ocaml.version}"
 
 buildDunePackage rec {
   pname = "vlq";
@@ -10,8 +13,6 @@ buildDunePackage rec {
     url = "https://github.com/flowtype/ocaml-vlq/releases/download/v${version}/vlq-v${version}.tbz";
     sha256 = "02wr9ph4q0nxmqgbc67ydf165hmrdv9b655krm2glc3ahb6larxi";
   };
-
-  useDune2 = true;
 
   buildInputs = [ dune-configurator ];
 

--- a/pkgs/development/ocaml-modules/wasm/default.nix
+++ b/pkgs/development/ocaml-modules/wasm/default.nix
@@ -1,6 +1,7 @@
 { stdenv, lib, fetchFromGitHub, ocaml, findlib, ocamlbuild }:
 
 if lib.versionOlder ocaml.version "4.08"
+|| lib.versionAtLeast ocaml.version "5.0"
 then throw "wasm is not available for OCaml ${ocaml.version}"
 else
 


### PR DESCRIPTION
###### Description of changes

Fix when possible, disable otherwise.

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes (or backporting 23.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
