### PR TITLE
jetbrains.gateway: 2023.1.1 -> 2023.1.2

### DIFF
--- a/pkgs/applications/editors/jetbrains/update.py
+++ b/pkgs/applications/editors/jetbrains/update.py
@@ -64,7 +64,7 @@ def update_product(name, product):
             build = latest_build(channel)
             new_version = build["@version"]
             new_build_number = build["@fullNumber"]
-            if all(x not in channel["@name"] for x in ["EAP", "Gateway"]):
+            if "EAP" not in channel["@name"]:
                 version_or_build_number = new_version
             else:
                 version_or_build_number = new_build_number

--- a/pkgs/applications/editors/jetbrains/versions.json
+++ b/pkgs/applications/editors/jetbrains/versions.json
@@ -19,10 +19,10 @@
     "gateway": {
       "update-channel": "Gateway RELEASE",
       "url-template": "https://download.jetbrains.com/idea/gateway/JetBrainsGateway-{version}.tar.gz",
-      "version": "2023.1.1",
-      "sha256": "217196806daebd14e604d13247862e44e6a0b0b9f115f1b9ceadbcfb064b3c3c",
-      "url": "https://download.jetbrains.com/idea/gateway/JetBrainsGateway-2023.1.1.tar.gz",
-      "build_number": "231.8770.69"
+      "version": "2023.1.2",
+      "sha256": "fab46521e7a4558a166e3b11d86ca2312a9807e69419925ed5743ab4f421ab96",
+      "url": "https://download.jetbrains.com/idea/gateway/JetBrainsGateway-2023.1.2.tar.gz",
+      "build_number": "231.9011.34"
     },
     "goland": {
       "update-channel": "GoLand RELEASE",
@@ -126,10 +126,10 @@
     "gateway": {
       "update-channel": "Gateway RELEASE",
       "url-template": "https://download.jetbrains.com/idea/gateway/JetBrainsGateway-{version}.dmg",
-      "version": "2023.1.1",
-      "sha256": "e580bf5bd657b721677fec0250ce582adb1cf92daa1ac065b56fc2d8148fac97",
-      "url": "https://download.jetbrains.com/idea/gateway/JetBrainsGateway-2023.1.1.dmg",
-      "build_number": "231.8770.69"
+      "version": "2023.1.2",
+      "sha256": "320beadb9eb50f48eb431bcd2c88ec1c2e7e0ef2f1f2414aa3842de5930d79ff",
+      "url": "https://download.jetbrains.com/idea/gateway/JetBrainsGateway-2023.1.2.dmg",
+      "build_number": "231.9011.34"
     },
     "goland": {
       "update-channel": "GoLand RELEASE",
@@ -233,10 +233,10 @@
     "gateway": {
       "update-channel": "Gateway RELEASE",
       "url-template": "https://download.jetbrains.com/idea/gateway/JetBrainsGateway-{version}-aarch64.dmg",
-      "version": "2023.1.1",
-      "sha256": "ab0c773315a6d8abcaae75440f7fc122a7e80237eddaa3487c3222a52a95497f",
-      "url": "https://download.jetbrains.com/idea/gateway/JetBrainsGateway-2023.1.1-aarch64.dmg",
-      "build_number": "231.8770.69"
+      "version": "2023.1.2",
+      "sha256": "338edd281715b14193834ed01947c6161865e58d1416557316c2b298401a0272",
+      "url": "https://download.jetbrains.com/idea/gateway/JetBrainsGateway-2023.1.2-aarch64.dmg",
+      "build_number": "231.9011.34"
     },
     "goland": {
       "update-channel": "GoLand RELEASE",


### PR DESCRIPTION
Closes #235449

###### Description of changes
- https://youtrack.jetbrains.com/articles/GTW-A-40/Remote-Development-2023.1.2-231.9011.34-build-Release-Notes
- and reverts 2f17f70a9ac22048c8a7679fe966fcf58d8881a3 to fix the download url again.
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes (or backporting 23.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
