### PR TITLE
gamepad-tool: init at 1.2

### DIFF
--- a/pkgs/games/gamepad-tool/default.nix
+++ b/pkgs/games/gamepad-tool/default.nix
@@ -1,0 +1,46 @@
+{ stdenvNoCC, fetchurl, dpkg, lib, qt5, autoPatchelfHook, SDL2 }:
+
+stdenvNoCC.mkDerivation (finalAttrs: {
+  pname = "gamepad-tool";
+  version = "1.2";
+
+  src = fetchurl {
+    url = "https://generalarcade.com/gamepadtool/linux/gamepadtool_${finalAttrs.version}_amd64.deb";
+    hash = "sha256-ZuB0TOyT2B5QkU1o5h3/8PL85tBq06hlz5YclRanD88=";
+  };
+
+  nativeBuildInputs = [ dpkg qt5.wrapQtAppsHook autoPatchelfHook ];
+
+  unpackCmd = ''
+    mkdir -p root
+    dpkg-deb -x $curSrc root
+  '';
+
+  dontBuild = true;
+
+  buildInputs = [
+    SDL2
+    qt5.qtbase
+  ];
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/bin $out/share/applications
+    cp usr/bin/gamepad-tool $out/bin
+    cp -r usr/share/icons $out/share/icons
+    substitute usr/share/applications/gamepad-tool-debian.desktop \
+      $out/share/applications/gamepad-tool.desktop \
+      --replace "Exec=gamepad-tool" "Exec=$out/bin/gamepad-tool" \
+      --replace "/usr/share/icons/hicolor/256x256/apps/gamepad-tool.png" "$out/share/icons/hicolor/256x256/apps/gamepad-tool.png"
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    description = "A simple GUI tool to create/modify gamepad mappings for games that use SDL2 Game Controller API";
+    homepage = "https://generalarcade.com/gamepadtool/";
+    license = licenses.unfree;
+    platforms = [ "x86_64-linux" ];
+    maintainers = with maintainers; [ gador ];
+  };
+})

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -36139,6 +36139,8 @@ with pkgs;
 
   freenukum = callPackage ../games/freenukum { };
 
+  gamepad-tool = callPackage ../games/gamepad-tool { };
+
   gnome-hexgl = callPackage ../games/gnome-hexgl { };
 
   gotypist = callPackage ../games/gotypist { };


### PR DESCRIPTION
###### Description of changes

Gamepad-tool is an utility to map gampepad or joystick buttons and axis to a controller. Most useful for `moonlight` and gaming with it.  If one follows the [https://github.com/moonlight-stream/moonlight-docs/wiki/Gamepad-Mapping](official instructions of moonlight) you'll need this tool.

Although it hasn't been updated since 2018 it still works just fine.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes (or backporting 23.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
