### PR TITLE
cc-wrapper: try to better guess meta.mainProgram

### DIFF
--- a/pkgs/build-support/cc-wrapper/default.nix
+++ b/pkgs/build-support/cc-wrapper/default.nix
@@ -612,5 +612,6 @@ stdenv.mkDerivation {
         lib.attrByPath ["meta" "description"] "System C compiler" cc_
         + " (wrapper script)";
       priority = 10;
+      mainProgram = if name != "" then name else ccName;
   };
 }


### PR DESCRIPTION
Otherwise nix will guess it from (p)name which contains "-wrapper".
Fixes #235585

###### Things done

There are no rebuilds, so most of usual checklist doesn't apply.  I tested `nix run .#gcc` for example.

<!--
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
