### PR TITLE
emscripten: 3.1.24 -> 3.1.41, llvmPackages_16: 16.0.1 -> 16.0.6, binaryen: 112 -> 113

### DIFF
--- a/pkgs/development/compilers/binaryen/default.nix
+++ b/pkgs/development/compilers/binaryen/default.nix
@@ -4,13 +4,13 @@
 
 stdenv.mkDerivation rec {
   pname = "binaryen";
-  version = "112";
+  version = "113";
 
   src = fetchFromGitHub {
     owner = "WebAssembly";
     repo = "binaryen";
     rev = "version_${version}";
-    hash = "sha256-xVumVmiLMHJp3SItE8eL8OBPeq58HtOOiK9LL8SP4CQ=";
+    hash = "sha256-w93LIlLRn3PmVNytjFg6KI4CQ9zQUUM9kySiWAtPbOA=";
   };
 
   nativeBuildInputs = [ cmake python3 ];

--- a/pkgs/development/compilers/emscripten/0001-emulate-clang-sysroot-include-logic.patch
+++ b/pkgs/development/compilers/emscripten/0001-emulate-clang-sysroot-include-logic.patch
@@ -1,4 +1,4 @@
-From 67f54fde2b1683aae3800f7a86a4e507c1125be8 Mon Sep 17 00:00:00 2001
+From 4bbbb640934aa653bcfec0335798b77a8935b815 Mon Sep 17 00:00:00 2001
 From: Yureka <yuka@yuka.dev>
 Date: Sat, 7 Aug 2021 09:16:46 +0200
 Subject: [PATCH] emulate clang 'sysroot + /include' logic
@@ -20,23 +20,23 @@ but it doesn't appear to work
  1 file changed, 6 insertions(+), 1 deletion(-)
 
 diff --git a/emcc.py b/emcc.py
-index 999314afc..0e23c066c 100755
+index ba8d1b556..7d89644c5 100755
 --- a/emcc.py
 +++ b/emcc.py
-@@ -759,7 +759,12 @@ def emsdk_ldflags(user_args):
+@@ -883,7 +883,12 @@ def parse_s_args(args):
  
  
  def emsdk_cflags(user_args):
--  cflags = ['--sysroot=' + shared.Cache.get_sysroot(absolute=True)]
+-  cflags = ['--sysroot=' + cache.get_sysroot(absolute=True)]
 +  cflags = [
-+    '--sysroot=' + shared.Cache.get_sysroot(absolute=True),
++    '--sysroot=' + cache.get_sysroot(absolute=True),
 +    '-resource-dir=@resourceDir@',
-+    '-idirafter' + shared.Cache.get_sysroot(absolute=True) + os.path.join('/include'),
++    '-idirafter' + cache.get_sysroot(absolute=True) + os.path.join('/include'),
 +    '-iwithsysroot' + os.path.join('/include','c++','v1')
 +  ]
  
    def array_contains_any_of(hay, needles):
      for n in needles:
 -- 
-2.32.0
+2.40.0
 

--- a/pkgs/development/compilers/emscripten/default.nix
+++ b/pkgs/development/compilers/emscripten/default.nix
@@ -1,14 +1,14 @@
 { lib, stdenv, fetchFromGitHub, python3, nodejs, closurecompiler
 , jre, binaryen
 , llvmPackages
-, symlinkJoin, makeWrapper, substituteAll, fetchpatch
+, symlinkJoin, makeWrapper, substituteAll
 , buildNpmPackage
 , emscripten
 }:
 
 stdenv.mkDerivation rec {
   pname = "emscripten";
-  version = "3.1.24";
+  version = "3.1.41";
 
   llvmEnv = symlinkJoin {
     name = "emscripten-llvm-${version}";
@@ -19,7 +19,7 @@ stdenv.mkDerivation rec {
     name = "emscripten-node-modules-${version}";
     inherit pname version src;
 
-    npmDepsHash = "sha256-ejuHR2BpAUStWjuvQuGE6ko4byF4GBl6FJBshxlknQk=";
+    npmDepsHash = "sha256-QlKm6UvPUa7+VJ9ZvXdxYZzK+U96Ju/oAHPhZ/hyv/I=";
 
     dontBuild = true;
 
@@ -32,7 +32,7 @@ stdenv.mkDerivation rec {
   src = fetchFromGitHub {
     owner = "emscripten-core";
     repo = "emscripten";
-    sha256 = "sha256-1jW6ThxK6dThOO90l4Mc5yehVF3tI4HWipBWZAOztrk=";
+    sha256 = "sha256-yQZrAQfNZZd65a14AFObrLrBzePBDnK0J87oTEB1Dcw=";
     rev = version;
   };
 
@@ -42,17 +42,7 @@ stdenv.mkDerivation rec {
   patches = [
     (substituteAll {
       src = ./0001-emulate-clang-sysroot-include-logic.patch;
-      resourceDir = "${llvmEnv}/lib/clang/${llvmPackages.release_version}/";
-    })
-    # https://github.com/emscripten-core/emscripten/pull/18219
-    (fetchpatch {
-      url = "https://github.com/emscripten-core/emscripten/commit/afbc14950f021513c59cbeaced8807ef8253530a.patch";
-      sha256 = "sha256-+gJNTQJng9rWcGN3GAcMBB0YopKPnRp/r8CN9RSTClU=";
-    })
-    # https://github.com/emscripten-core/emscripten/pull/18220
-    (fetchpatch {
-      url = "https://github.com/emscripten-core/emscripten/commit/852982318f9fb692ba1dd1173f62e1eb21ae61ca.patch";
-      sha256 = "sha256-hmIOtpRx3PD3sDAahUcreSydydqcdSqArYvyLGgUgd8=";
+      resourceDir = "${llvmEnv}/lib/clang/16/";
     })
   ];
 
@@ -67,9 +57,6 @@ stdenv.mkDerivation rec {
     # disables cache in user home, use installation directory instead
     sed -i '/^def/!s/root_is_writable()/True/' tools/config.py
     sed -i "/^def check_sanity/a\\  return" tools/shared.py
-
-    # required for wasm2c
-    ln -s ${nodeModules} node_modules
 
     echo "EMSCRIPTEN_ROOT = '$out/share/emscripten'" > .emscripten
     echo "LLVM_ROOT = '${llvmEnv}/bin'" >> .emscripten
@@ -108,17 +95,17 @@ stdenv.mkDerivation rec {
 
     # precompile libc (etc.) in all variants:
     pushd $TMPDIR
-    echo 'int __main_argc_argv() { return 42; }' >test.c
+    echo 'int __main_argc_argv( int a, int b ) { return 42; }' >test.c
     for LTO in -flto ""; do
-      # wasm2c doesn't work with PIC
-      $out/bin/emcc -s WASM2C -s STANDALONE_WASM $LTO test.c
-
       for BIND in "" "--bind"; do
-        for MT in "" "-s USE_PTHREADS"; do
-          for RELOCATABLE in "" "-s RELOCATABLE"; do
-            $out/bin/emcc $RELOCATABLE $BIND $MT $LTO test.c
-          done
-        done
+        # starting with emscripten 3.1.32+,
+        # if pthreads and relocatable are both used,
+        # _emscripten_thread_exit_joinable must be exported
+        # (see https://github.com/emscripten-core/emscripten/pull/18376)
+        # TODO: get library cache to build with both enabled and function exported
+        $out/bin/emcc $LTO $BIND test.c
+        $out/bin/emcc $LTO $BIND -s RELOCATABLE test.c
+        $out/bin/emcc $LTO $BIND -s USE_PTHREADS test.c
       done
     done
     popd

--- a/pkgs/development/compilers/llvm/16/default.nix
+++ b/pkgs/development/compilers/llvm/16/default.nix
@@ -25,7 +25,7 @@
   #   rev-version = /* human readable version; i.e. "unstable-2022-26-07" */;
   #   sha256 = /* checksum for this release, can omit if specifying your own `monorepoSrc` */;
   # }
-, officialRelease ? { version = "16.0.1"; sha256 = "sha256-Vr978ZY0i0NkdE/uuwcTccshfAT61KIN6KNq0TdwBNE="; }
+, officialRelease ? { version = "16.0.6"; sha256 = "sha256-fspqSReX+VD+Nl/Cfq+tDcdPtnQPV1IRopNDfd5VtUs="; }
   # i.e.:
   # {
   #   version = /* i.e. "15.0.0" */;

--- a/pkgs/development/compilers/llvm/16/llvm/gnu-install-dirs.patch
+++ b/pkgs/development/compilers/llvm/16/llvm/gnu-install-dirs.patch
@@ -1,8 +1,8 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index 45399dc0537e..5d946e9e6583 100644
+index 7e25e0407db2..72f031a82b75 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -942,7 +942,7 @@ if (NOT TENSORFLOW_AOT_PATH STREQUAL "")
+@@ -995,7 +995,7 @@ if (NOT TENSORFLOW_AOT_PATH STREQUAL "")
    add_subdirectory(${TENSORFLOW_AOT_PATH}/xla_aot_runtime_src
      ${CMAKE_ARCHIVE_OUTPUT_DIRECTORY}/tf_runtime)
    install(TARGETS tf_xla_runtime EXPORT LLVMExports
@@ -12,10 +12,10 @@ index 45399dc0537e..5d946e9e6583 100644
    # Once we add more modules, we should handle this more automatically.
    if (DEFINED LLVM_OVERRIDE_MODEL_HEADER_INLINERSIZEMODEL)
 diff --git a/cmake/modules/AddLLVM.cmake b/cmake/modules/AddLLVM.cmake
-index 057431208322..56f0dcb258da 100644
+index 93e6d67551de..8d367457af5a 100644
 --- a/cmake/modules/AddLLVM.cmake
 +++ b/cmake/modules/AddLLVM.cmake
-@@ -844,8 +844,8 @@ macro(add_llvm_library name)
+@@ -874,8 +874,8 @@ macro(add_llvm_library name)
        get_target_export_arg(${name} LLVM export_to_llvmexports ${umbrella})
        install(TARGETS ${name}
                ${export_to_llvmexports}
@@ -26,7 +26,7 @@ index 057431208322..56f0dcb258da 100644
                RUNTIME DESTINATION "${CMAKE_INSTALL_BINDIR}" COMPONENT ${name})
  
        if (NOT LLVM_ENABLE_IDE)
-@@ -2007,7 +2007,7 @@ function(llvm_install_library_symlink name dest type)
+@@ -2043,7 +2043,7 @@ function(llvm_install_library_symlink name dest type)
    set(full_name ${CMAKE_${type}_LIBRARY_PREFIX}${name}${CMAKE_${type}_LIBRARY_SUFFIX})
    set(full_dest ${CMAKE_${type}_LIBRARY_PREFIX}${dest}${CMAKE_${type}_LIBRARY_SUFFIX})
  
@@ -35,7 +35,7 @@ index 057431208322..56f0dcb258da 100644
    if(WIN32 AND "${type}" STREQUAL "SHARED")
      set(output_dir "${CMAKE_INSTALL_BINDIR}")
    endif()
-@@ -2271,15 +2271,15 @@ function(llvm_setup_rpath name)
+@@ -2312,16 +2312,37 @@ function(llvm_setup_rpath name)
  
    if (APPLE)
      set(_install_name_dir INSTALL_NAME_DIR "@rpath")
@@ -49,7 +49,30 @@ index 057431208322..56f0dcb258da 100644
 -    set(_install_rpath "${LLVM_LIBRARY_OUTPUT_INTDIR}" "${CMAKE_INSTALL_PREFIX}/lib${LLVM_LIBDIR_SUFFIX}" ${extra_libdir})
 +    set(_install_rpath "${LLVM_LIBRARY_OUTPUT_INTDIR}" "${CMAKE_INSTALL_FULL_LIBDIR}${LLVM_LIBDIR_SUFFIX}" ${extra_libdir})
    elseif(UNIX)
--    set(_install_rpath "\$ORIGIN/../lib${LLVM_LIBDIR_SUFFIX}" ${extra_libdir})
+-    set(_build_rpath "\$ORIGIN/../lib${LLVM_LIBDIR_SUFFIX}" ${extra_libdir})
+-    set(_install_rpath "\$ORIGIN/../lib${LLVM_LIBDIR_SUFFIX}")
++    # Note that we add `extra_libdir` (aka `LLVM_LIBRARY_DIR` in our case) back
++    # to `_install_rpath` here.
++    #
++    # In nixpkgs we do not build and install LLVM alongside rdeps of LLVM (i.e.
++    # clang); instead LLVM is its own package and thus lands at its own nix
++    # store path. This makes it so that the default relative rpath (`../lib/`)
++    # does not point at the LLVM shared objects.
++    #
++    # More discussion here:
++    #   - https://github.com/NixOS/nixpkgs/pull/235624#discussion_r1220150329
++    #   - https://reviews.llvm.org/D146918 (16.0.5+)
++    #
++    # Note that we leave `extra_libdir` in `_build_rpath`: without FHS there is
++    # no potential that this will result in us pulling in the "wrong" LLVM.
++    # Adding this to the build rpath means we aren't forced to use
++    # `installCheckPhase` instead of `checkPhase` (i.e. binaries in the build
++    # dir, pre-install, will have the right rpath for LLVM).
++    #
++    # As noted in the differential above, an alternative solution is to have
++    # all rdeps of nixpkgs' LLVM (that use the AddLLVM.cmake machinery) set
++    # `CMAKE_INSTALL_RPATH`.
++    set(_build_rpath "\$ORIGIN/../${CMAKE_INSTALL_LIBDIR}${LLVM_LIBDIR_SUFFIX}" ${extra_libdir})
 +    set(_install_rpath "\$ORIGIN/../${CMAKE_INSTALL_LIBDIR}${LLVM_LIBDIR_SUFFIX}" ${extra_libdir})
      if(${CMAKE_SYSTEM_NAME} MATCHES "(FreeBSD|DragonFly)")
        set_property(TARGET ${name} APPEND_STRING PROPERTY
@@ -71,10 +94,10 @@ index 891c9e6d618c..8d963f3b0069 100644
    list(APPEND ocaml_flags "-ldopt" "-Wl,-rpath,${ocaml_rpath}")
  
 diff --git a/cmake/modules/CMakeLists.txt b/cmake/modules/CMakeLists.txt
-index d4b0ab959148..26ed981fd09f 100644
+index d99af79aa38e..21e794224b99 100644
 --- a/cmake/modules/CMakeLists.txt
 +++ b/cmake/modules/CMakeLists.txt
-@@ -128,7 +128,7 @@ set(LLVM_CONFIG_INCLUDE_DIRS
+@@ -127,7 +127,7 @@ set(LLVM_CONFIG_INCLUDE_DIRS
    )
  list(REMOVE_DUPLICATES LLVM_CONFIG_INCLUDE_DIRS)
  
@@ -84,7 +107,7 @@ index d4b0ab959148..26ed981fd09f 100644
    "${LLVM_CONFIG_LIBRARY_DIR}"
    # FIXME: Should there be other entries here?
 diff --git a/docs/CMake.rst b/docs/CMake.rst
-index 879b7b231d4c..9c31d14e8950 100644
+index 7926de258ec8..5ae01adc3905 100644
 --- a/docs/CMake.rst
 +++ b/docs/CMake.rst
 @@ -250,7 +250,7 @@ description is in `LLVM-related variables`_ below.
@@ -120,10 +143,10 @@ index 370005cd8d7d..7e790bc52111 100644
  #define LLVM_INSTALL_PACKAGE_DIR "@LLVM_INSTALL_PACKAGE_DIR@"
  #define LLVM_TARGETS_BUILT "@LLVM_TARGETS_BUILT@"
 diff --git a/tools/llvm-config/llvm-config.cpp b/tools/llvm-config/llvm-config.cpp
-index 2c6c55f89d38..f6d2068a0827 100644
+index b1d795a0a349..de6cb1514f05 100644
 --- a/tools/llvm-config/llvm-config.cpp
 +++ b/tools/llvm-config/llvm-config.cpp
-@@ -369,7 +369,11 @@ int main(int argc, char **argv) {
+@@ -366,7 +366,11 @@ int main(int argc, char **argv) {
        sys::fs::make_absolute(ActivePrefix, Path);
        ActiveBinDir = std::string(Path.str());
      }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7385,7 +7385,7 @@ with pkgs;
   easeprobe = callPackage ../tools/misc/easeprobe { };
 
   emscripten = callPackage ../development/compilers/emscripten {
-    llvmPackages = llvmPackages_14;
+    llvmPackages = llvmPackages_16;
   };
 
   emscriptenPackages = recurseIntoAttrs (callPackage ./emscripten-packages.nix { });


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Emscripten 3.1.39 was able to build from earlier versions, but since emscripten 3.1.39 itself dropped wasm2c support, this should be removed from the derivation.

This plus #235219 should unblock future point releases as well.

Edit: Also includes reverted changes from #229718 and #235219 since my llvm point update was broken and the hashes appeared to have changed upstream as well.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

Removed wasm2c from derivation.

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes (or backporting 23.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
