### PR TITLE
upscayl: init at 2.5.1

### DIFF
--- a/pkgs/applications/graphics/upscayl/default.nix
+++ b/pkgs/applications/graphics/upscayl/default.nix
@@ -1,0 +1,36 @@
+{ appimageTools, fetchurl, lib }:
+
+let
+  pname = "upscayl";
+  version = "2.5.1";
+  src = fetchurl {
+    url =
+      "https://github.com/upscayl/upscayl/releases/download/v${version}/upscayl-${version}-linux.AppImage";
+    sha256 = "sha256-mAMq7I7oH9BBJeLUT4mGxlh7vPNPwa6JeQUHnGoCgdc=";
+  };
+
+  appimageContents = appimageTools.extractType2 { inherit pname version src; };
+
+in appimageTools.wrapType2 rec {
+  inherit pname version src;
+
+  extraPkgs = pkgs: with pkgs; [ vulkan-headers vulkan-loader ];
+
+  extraInstallCommands = ''
+    mv $out/bin/${pname}-${version} $out/bin/${pname}
+
+    install -Dm644 ${appimageContents}/${pname}.desktop $out/share/applications/${pname}.desktop
+    install -Dm644 ${appimageContents}/${pname}.png $out/share/pixmaps/${pname}.png
+
+    substituteInPlace $out/share/applications/${pname}.desktop \
+      --replace 'Exec=AppRun --no-sandbox %U' 'Exec=${pname}'
+  '';
+
+  meta = {
+    description = "Free, open-source AI image upscaler";
+    homepage = "https://upscayl.github.io";
+    maintainers = with lib.maintainers; [ zopieux ];
+    license = lib.licenses.agpl3;
+    platforms = lib.platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -13444,6 +13444,8 @@ with pkgs;
 
   upbound = callPackage ../development/tools/upbound { };
 
+  upscayl = callPackage ../applications/graphics/upscayl { };
+
   upterm = callPackage ../tools/misc/upterm { };
 
   upx = callPackage ../tools/compression/upx { };


### PR DESCRIPTION
###### Description of changes

Add the precompiled upscayl AppImage to nixpkgs. This is a ML-heavy, Electron-based application that imho would require unreasonable amounts of packaging madness to compile from source.

Verified that it builds and runs on a NixOS installation.

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes (or backporting 23.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
