### PR TITLE
tuifimanager: 2.3.4 -> 3.0.0

### DIFF
--- a/pkgs/applications/file-managers/tuifimanager/default.nix
+++ b/pkgs/applications/file-managers/tuifimanager/default.nix
@@ -1,15 +1,18 @@
-{ lib, python3Packages, fetchFromGitHub }:
+{ lib
+, python3
+, fetchFromGitHub
+}:
 
-python3Packages.buildPythonApplication rec {
-  pname = "tuifimanager";
-  version = "2.3.4";
-  format = "setuptools";
+python3.pkgs.buildPythonApplication rec {
+  pname = "tuifi-manager";
+  version = "3.0.0";
+  format = "pyproject";
 
   src = fetchFromGitHub {
-    repo = pname;
     owner = "GiorgosXou";
+    repo = "TUIFIManager";
     rev = "v.${version}";
-    hash = "sha256-KJYPpeBALyg6Gd1GQgJbvGdJbAT47qO9FnSH7GhO4oQ=";
+    hash = "sha256-ahZUm+FkAaM4I6FfSa/Oej+lMux8avw8LxzzGqTpuH8=";
   };
 
   postPatch = ''
@@ -17,11 +20,16 @@ python3Packages.buildPythonApplication rec {
       --replace "Send2Trash == 1.8.0" "Send2Trash >= 1.8.0"
   '';
 
-  propagatedBuildInputs = with python3Packages; [ unicurses send2trash ];
-  pythonImportsCheck = [ "TUIFIManager" ];
+  nativeBuildInputs = [
+    python3.pkgs.setuptools
+    python3.pkgs.setuptools-scm
+  ];
 
-  # Tests currently cause build to fail
-  doCheck = false;
+  propagatedBuildInputs = with python3.pkgs; [
+    send2trash
+    unicurses
+  ];
+  pythonImportsCheck = [ "TUIFIManager" ];
 
   meta = with lib; {
     description = "A cross-platform terminal-based termux-oriented file manager";
@@ -31,6 +39,7 @@ python3Packages.buildPythonApplication rec {
       attempt to get more attention to the Uni-Curses project.
     '';
     homepage = "https://github.com/GiorgosXou/TUIFIManager";
+    changelog = "https://github.com/GiorgosXou/TUIFIManager/blob/${src.rev}/CHANGELOG.md";
     license = licenses.gpl3Only;
     maintainers = with maintainers; [ michaelBelsanti ];
     mainProgram = "tuifi";


### PR DESCRIPTION
###### Description of changes
Updated tuifimanager to v.3.0.0
https://github.com/GiorgosXou/TUIFIManager/releases/tag/v.3.0.0
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done
Switched format, no longer needs checks disabled. Added changelogs.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes (or backporting 23.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
