### PR TITLE
vulkan-validation-layers: add compilation flag for darwin support

### DIFF
--- a/pkgs/development/tools/vulkan-validation-layers/default.nix
+++ b/pkgs/development/tools/vulkan-validation-layers/default.nix
@@ -18,14 +18,14 @@
 }:
 
 let
-  robin-hood-hashing = callPackage ./robin-hood-hashing.nix {};
+  robin-hood-hashing = callPackage ./robin-hood-hashing.nix { };
 
   # Current VVL version requires a newer spirv-headers than the latest release tag.
   # This should hopefully not be too common and the override should be removed after
   # the next SPIRV headers release.
   # FIXME: if this ever becomes common, figure out a way to pull revisions directly
   # from upstream known-good.json
-  spirv-headers' = spirv-headers.overrideAttrs(_: {
+  spirv-headers' = spirv-headers.overrideAttrs (_: {
     version = "unstable-2023-04-27";
 
     src = fetchFromGitHub {
@@ -44,7 +44,7 @@ stdenv.mkDerivation rec {
 
   # If we were to use "dev" here instead of headers, the setupHook would be
   # placed in that output instead of "out".
-  outputs = ["out" "headers"];
+  outputs = [ "out" "headers" ];
   outputInclude = "headers";
 
   src = fetchFromGitHub {
@@ -79,7 +79,9 @@ stdenv.mkDerivation rec {
     "-DPKG_CONFIG_EXECUTABLE=${pkg-config}/bin/pkg-config"
     # Hide dev warnings that are useless for packaging
     "-Wno-dev"
-  ];
+  ] ++ (lib.lists.optionals stdenv.isDarwin [
+    "-DCMAKE_CXX_FLAGS=-faligned-allocation"
+  ]);
 
   # Tests require access to vulkan-compatible GPU, which isn't
   # available in Nix sandbox. Fails with VK_ERROR_INCOMPATIBLE_DRIVER.
@@ -96,9 +98,9 @@ stdenv.mkDerivation rec {
 
   meta = with lib; {
     description = "The official Khronos Vulkan validation layers";
-    homepage    = "https://github.com/KhronosGroup/Vulkan-ValidationLayers";
-    platforms   = platforms.linux;
-    license     = licenses.asl20;
+    homepage = "https://github.com/KhronosGroup/Vulkan-ValidationLayers";
+    platforms = platforms.linux ++ platforms.darwin;
+    license = licenses.asl20;
     maintainers = [ maintainers.ralith ];
   };
 }

--- a/pkgs/development/tools/vulkan-validation-layers/robin-hood-hashing.nix
+++ b/pkgs/development/tools/vulkan-validation-layers/robin-hood-hashing.nix
@@ -25,9 +25,9 @@ stdenv.mkDerivation rec {
 
   meta = with lib; {
     description = "A faster, more efficient replacement for std::unordered_map / std::unordered_set";
-    homepage    = "https://github.com/martinus/robin-hood-hashing";
-    platforms   = platforms.linux;
-    license     = licenses.mit;
+    homepage = "https://github.com/martinus/robin-hood-hashing";
+    platforms = platforms.linux ++ platforms.darwin;
+    license = licenses.mit;
     maintainers = [ ];
   };
 }


### PR DESCRIPTION
###### Description of changes

Added a compilation flag to ignore warnings/errors about unavailable functions on older MacOS version (errors which were still thrown on a MacOSX 13.3 machine, I think due to clang just assuming an old version of MacOS).

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes (or backporting 23.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
