### PR TITLE
perlPackages.HashSharedMem: fix build on aarch64-linux

### DIFF
--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -10912,6 +10912,7 @@ with self; {
       url = "mirror://cpan/authors/id/Z/ZE/ZEFRAM/Hash-SharedMem-0.005.tar.gz";
       hash = "sha256-Mkd2gIYC973EStqpN4lTZUVAKakm+mEfMhyb9rlAu14=";
     };
+    env.NIX_CFLAGS_COMPILE = lib.optionalString stdenv.isAarch64 "-mno-outline-atomics";
     buildInputs = [ ScalarString ];
     meta = {
       description = "Efficient shared mutable hash";


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

The [(failing-)build log](https://hydra.nixos.org/build/219379873/nixlog/1) has errors that look like: `undefined symbol: __aarch64_cas8_sync`.
This led me to find out about the newly-introduced `-moutline-atomics`, which is **on by default** in GCC 10.1 (according to [this blog post](https://community.arm.com/arm-community-blogs/b/tools-software-ides-blog/posts/making-the-most-of-the-arm-architecture-in-gcc-10)) and in Clang 12.0.0 (according to [the release notes](https://releases.llvm.org/12.0.0/tools/clang/docs/ReleaseNotes.html)) 

Not all ARMv8-A processors support atomic stuff like `__aarch64_cas8_sync`, it's only those that are ARMv8.1-A or later that do. Examples of pre-ARMv8.1-A processors include the Cortex-A72 used in the Raspberry Pi 4 (which is how I discovered this problem (I am running `hydra` on it, which indirectly depends on `HashSharedMem`)), and any older ARMv8-A processors.

The problem here is solvable either by linking the compiler runtime library (which I did not try, since I don't know exactly which one to use) *or* by simply not generating outlines for atomic operations.

I went with the "easier" path (which was also what was was happening in older versions of GCC, I think) of disabling atomic outlines with `-mno-outline-atomics`, and it works!

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using ~~`nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)~~
  - ***Note**: `nixpkgs-review` can't run on my machine (at least, not before OfBorg), as it tried to take more than 9GB of RAM on my 8GB Raspberry Pi 4*, **but** I did build the equivalent of this change in [an override in my own config (based on NixOS 23.05)](https://gitea.compilade.net/fch/nixos-config/src/commit/4436200b07c03384edb96acc851fc773e2bedcda/machines/pifonix/cfg/hydra.nix#L53).
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
  - Well, my Hydra instance works, and the `checkPhase` of the `HashSharedMem` package passes, so I believe it works.
- [23.11 Release Notes (or backporting 23.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
