### PR TITLE
fusee-nano: init at unstable-2023-05-17

### DIFF
--- a/pkgs/development/tools/fusee-nano/default.nix
+++ b/pkgs/development/tools/fusee-nano/default.nix
@@ -1,0 +1,25 @@
+{ lib, stdenv, fetchFromGitHub, unixtools }:
+
+stdenv.mkDerivation {
+  pname = "fusee-nano";
+  version = "unstable-2023-05-17";
+
+  src = fetchFromGitHub {
+    owner = "DavidBuchanan314";
+    repo = "fusee-nano";
+    rev = "2979d34f470d02f34594d8d59be1f5c7bf4bf73f";
+    hash = "sha256-RUG10wvhB0qEuiLwn8wk6Uxok+gv4bFLD6tbx0P0yDc=";
+  };
+
+  nativeBuildInputs = [ unixtools.xxd ];
+
+  makeFlags = [ "PREFIX=$(out)/bin" ];
+
+  meta = {
+    description = "A minimalist re-implementation of the Fusée Gelée exploit";
+    homepage = "https://github.com/DavidBuchanan314/fusee-nano";
+    license = lib.licenses.mit;
+    platforms = lib.platforms.linux;
+    maintainers = [ lib.maintainers.leo60228 ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7810,6 +7810,8 @@ with pkgs;
 
   fusee-launcher = callPackage ../development/tools/fusee-launcher { };
 
+  fusee-nano = callPackage ../development/tools/fusee-nano { };
+
   fverb = callPackage ../applications/audio/fverb { };
 
   fwknop = callPackage ../tools/security/fwknop {


### PR DESCRIPTION
###### Description of changes

[fusee-nano](https://github.com/DavidBuchanan314/fusee-nano) is a minimalist re-implementation of the [Fusée Gelée exploit](https://github.com/Qyriad/fusee-launcher/blob/master/report/fusee_gelee.md), designed to run on embedded Linux devices. It is an alternative to the existing fusee-launcher package.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes (or backporting 23.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
