### PR TITLE
rofi-screenshot: init at 2023-07-02

### DIFF
--- a/pkgs/applications/misc/rofi-screenshot/default.nix
+++ b/pkgs/applications/misc/rofi-screenshot/default.nix
@@ -1,0 +1,58 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, makeWrapper
+, libnotify
+, slop
+, ffcast
+, ffmpeg
+, xclip
+, rofi
+, coreutils
+, gnused
+, procps
+}:
+
+stdenv.mkDerivation rec {
+  pname = "rofi-screenshot";
+  version = "2023-07-02";
+
+  src = fetchFromGitHub {
+    owner = "ceuk";
+    repo = pname;
+    rev = "365cfa51c6c7deb072d98d7bfd68cf4038bf2737";
+    hash = "sha256-M1cab+2pOjZ2dElMg0Y0ZrIxRE0VwymVwcElgzFrmVs=";
+  };
+
+  nativeBuildInputs = [ makeWrapper ];
+
+  postFixup = ''
+    wrapProgram $out/bin/${pname} \
+      --set PATH ${
+        lib.makeBinPath [
+          libnotify
+          slop
+          ffcast
+          ffmpeg
+          xclip
+          rofi
+          coreutils
+          gnused
+          procps
+        ]
+      }
+  '';
+
+  installPhase = ''
+    install -Dm755 ${pname} $out/bin/${pname}
+  '';
+
+  meta = {
+    description =
+      "Use rofi to perform various types of screenshots and screen captures";
+    homepage = "https://github.com/ceuk/rofi-screenshot";
+    maintainers = with lib.maintainers; [ zopieux ];
+    platforms = lib.platforms.all;
+    license = lib.licenses.wtfpl;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -32744,6 +32744,8 @@ with pkgs;
 
   rofi-rbw = python3Packages.callPackage ../applications/misc/rofi-rbw { };
 
+  rofi-screenshot = callPackage ../applications/misc/rofi-screenshot { };
+
   rofi-top = callPackage ../applications/misc/rofi-top { };
 
   rofi-vpn = callPackage ../applications/networking/rofi-vpn { };


### PR DESCRIPTION
###### Description of changes

Add rofi-screenshot, a small utility to take screenshots and screencasts, using rofi as an option selector.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes (or backporting 23.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
