### PR TITLE
mediawriter: init at 5.0.6

### DIFF
--- a/pkgs/tools/system/mediawriter/default.nix
+++ b/pkgs/tools/system/mediawriter/default.nix
@@ -1,0 +1,45 @@
+{ lib
+, stdenv
+, adwaita-qt6
+, appstream-glib
+, cmake
+, fetchFromGitHub
+, qt6
+, udisks2
+, xz
+}:
+
+stdenv.mkDerivation rec {
+  pname = "mediawriter";
+  version = "5.0.6";
+
+  src = fetchFromGitHub {
+    owner = "FedoraQt";
+    repo = "MediaWriter";
+    rev = "refs/tags/${version}";
+    hash = "sha256-M8tnFwpM94xrcgw87yRG2kUZ2y5C0M4ptPokK+2B+xk=";
+  };
+
+  nativeBuildInputs = [
+    cmake
+    qt6.wrapQtAppsHook
+  ];
+
+  propagatedBuildInputs = [
+    adwaita-qt6
+    appstream-glib
+    qt6.qtbase
+    qt6.qtdeclarative
+    qt6.qtsvg
+    udisks2
+    xz
+  ];
+
+  meta = with lib; {
+    description = "Tool to write images files to portable media";
+    homepage = "https://github.com/FedoraQt/MediaWriter";
+    changelog = "https://github.com/FedoraQt/MediaWriter/releases/tag/${version}";
+    license = licenses.lgpl2Only;
+    maintainers = with maintainers; [ fab ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10085,6 +10085,8 @@ with pkgs;
 
   mediawiki = callPackage ../servers/web-apps/mediawiki { };
 
+  mediawriter = callPackage ../tools/system/mediawriter { };
+
   memtier-benchmark = callPackage ../tools/networking/memtier-benchmark { };
 
   memtest86-efi = callPackage ../tools/misc/memtest86-efi { };


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes (or backporting 23.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
