### PR TITLE
python3Packages.email-validator: 1.3.1 -> 2.0.0

### DIFF
--- a/pkgs/development/python-modules/email-validator/default.nix
+++ b/pkgs/development/python-modules/email-validator/default.nix
@@ -9,7 +9,7 @@
 
 buildPythonPackage rec {
   pname = "email-validator";
-  version = "1.3.1";
+  version = "2.0.0";
   format = "setuptools";
 
   disabled = pythonOlder "3.7";
@@ -18,7 +18,7 @@ buildPythonPackage rec {
     owner = "JoshData";
     repo = "python-${pname}";
     rev = "refs/tags/v${version}";
-    hash = "sha256-JW6Yrotm3HjUOUtNFxRorkrJKjzuwIXwjpUuMWEyLV0=";
+    hash = "sha256-o7UREa+IBiFjmqx0p+4XJCcoHQ/R6r2RtoezEcWvgbg=";
   };
 
   propagatedBuildInputs = [
@@ -30,16 +30,25 @@ buildPythonPackage rec {
     pytestCheckHook
   ];
 
+  # importing some test modules and running some tests fails with
+  # dns.resolver.NoResolverConfiguration due to network sandboxing
+  preCheck =
+    let skipDNSResolver = testfile: "sed -i -E 's/^RESOLVER = .+//g' tests/test_${testfile}.py";
+    in ''
+    ${skipDNSResolver "deliverability"}
+    ${skipDNSResolver "main"}
+    '';
+
   disabledTests = [
-    # fails with dns.resolver.NoResolverConfiguration due to network sandboxing
+    "test_caching_dns_resolver"
     "test_deliverability_no_records"
     "test_deliverability_found"
     "test_deliverability_fails"
     "test_deliverability_dns_timeout"
     "test_email_example_reserved_domain"
     "test_main_single_good_input"
+    "test_main_single_bad_input"
     "test_main_multi_input"
-    "test_main_input_shim"
     "test_validate_email__with_caching_resolver"
     "test_validate_email__with_configured_resolver"
   ];


### PR DESCRIPTION
###### Description of changes

This PR upgrades the `email-validator` Python package to [its 2.0.0 release](https://github.com/JoshData/python-email-validator/releases/tag/v2.0.0). 

FWIW, as of nixpkgs 23.05, the `pydantic` package is new enough that it needs `email-validator>=2.0.0` in order to enable email validation.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes (or backporting 23.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
