### PR TITLE
python310Packages.python-daemon: 2.3.0 -> 3.0.1

### DIFF
--- a/pkgs/development/python-modules/python-daemon/default.nix
+++ b/pkgs/development/python-modules/python-daemon/default.nix
@@ -1,54 +1,49 @@
 { lib
 , buildPythonPackage
 , fetchPypi
+
+# build-system
 , docutils
+, packaging
+, setuptools
+
+# dependencies
 , lockfile
+
+# tests
 , pytestCheckHook
+, pythonOlder
 , testscenarios
 , testtools
-, twine
-, python
-, pythonOlder
-, fetchpatch
 }:
 
 buildPythonPackage rec {
   pname = "python-daemon";
-  version = "2.3.0";
-  format = "setuptools";
+  version = "3.0.1";
+  format = "pyproject";
 
   disabled = pythonOlder "3.7";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "bda993f1623b1197699716d68d983bb580043cf2b8a66a01274d9b8297b0aeaf";
+    hash = "sha256-bFdFI3L36v9Ak0ocA60YJr9eeTVY6H/vSRMeZGS02uU=";
   };
 
   nativeBuildInputs = [
-    twine
+    setuptools
+    packaging
+    docutils
   ];
 
   propagatedBuildInputs = [
-    docutils
     lockfile
+    setuptools
   ];
 
   nativeCheckInputs = [
     pytestCheckHook
     testscenarios
     testtools
-  ];
-
-  patches = [
-    # Should be fixed in the next release
-    (fetchpatch {
-      url = "https://src.fedoraproject.org/rpms/python-daemon/raw/rawhide/f/python-daemon-safe_hasattr.patch";
-      hash = "sha256-p5epAlM/sdel01oZkSI1vahUZYX8r90WCJuvBnfMaus=";
-    })
-    (fetchpatch {
-      url = "https://src.fedoraproject.org/rpms/python-daemon/raw/rawhide/f/tests-remove-duplicate-mocking.patch";
-      hash = "sha256-5b/dFR3Z8xaPw8AZU95apDZd4ZfmMQhAmavWkVaJog8=";
-    })
   ];
 
   disabledTestPaths = [
@@ -77,7 +72,6 @@ buildPythonPackage rec {
     "daemon"
     "daemon.daemon"
     "daemon.pidfile"
-    "daemon.runner"
   ];
 
   meta = with lib; {


### PR DESCRIPTION
https://pagure.io/python-daemon/blob/067759fb4c802275d6d3b7dc34115ffb69bb79d5/f/ChangeLog

Resolves https://tapesoftware.net/fodwatch/eval/1/job/43245.
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes (or backporting 23.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
