### PR TITLE
dolphin-emu-primehack: fix name in desktop file

### DIFF
--- a/pkgs/applications/emulators/dolphin-emu/primehack.nix
+++ b/pkgs/applications/emulators/dolphin-emu/primehack.nix
@@ -134,6 +134,7 @@ stdenv.mkDerivation rec {
     mv $out/share/applications/dolphin-emu.desktop $out/share/applications/dolphin-emu-primehack.desktop
     mv $out/share/icons/hicolor/256x256/apps/dolphin-emu.png $out/share/icons/hicolor/256x256/apps/dolphin-emu-primehack.png
     substituteInPlace $out/share/applications/dolphin-emu-primehack.desktop --replace 'dolphin-emu' 'dolphin-emu-primehack'
+    substituteInPlace $out/share/applications/dolphin-emu-primehack.desktop --replace 'Dolphin Emulator' 'PrimeHack'
   '' + lib.optionalString stdenv.hostPlatform.isLinux ''
     install -D $src/Data/51-usb-device.rules $out/etc/udev/rules.d/51-usb-device.rules
   '';


### PR DESCRIPTION
###### Description of changes

Both the regular `dolphin-emu` and the `dolphin-emu-primehack` packages install desktop files for their respective application that carry the name "Dolphin Emulator" when shown in a desktop environment. This PR changes the name of `dolphin-emu-primehack` to `PrimeHack` in the desktop file.

It may be a little contentious to rename this, since PrimeHack is essentially a Dolphin fork with some changes, so here's my reasoning:
1. Shiiion's fork of Dolphin is listed as `shiiion/dolphin` on Github, but the readme clearly calls the project "PrimeHack".
2. The binaries carry two different names in `nixpkgs` (`dolphin-emu` and `dolphin-emu-primehack`), so why name the applications the same in desktop environments?
3. Searching for "PrimeHack" doesn't show anything, but searching for "Dolphin" shows both.
4. I have both packages installed by default, and this causes them to appear side-by-side with the same name, which is just not helpful:

![image](https://github.com/NixOS/nixpkgs/assets/8373222/df62fd03-6405-4ff3-b853-a12dfe254334)

In light of this, I think my proposed change makes a lot of sense.

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes (or backporting 23.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).