### PR TITLE
teamd: init at 1.31

### DIFF
--- a/pkgs/tools/networking/teamd/default.nix
+++ b/pkgs/tools/networking/teamd/default.nix
@@ -1,0 +1,35 @@
+{
+  autoreconfHook,
+  fetchFromGitHub,
+  lib,
+  stdenv,
+
+  libdaemon,
+  libnl,
+  jansson,
+  pkg-config
+}:
+
+stdenv.mkDerivation rec {
+  pname = "teamd";
+  version = "1.31";
+  outputs = ["dev" "lib" "man" "out"];
+
+  buildInputs = [libdaemon libnl jansson];
+  nativeBuildInputs = [autoreconfHook pkg-config];
+
+  src = fetchFromGitHub {
+    owner = "jpirko";
+    repo = "libteam";
+    rev = "refs/tags/v${version}";
+    sha256 = "sha256-V1l0e84G7uRPEyw6BOOsd3MJ/HqMSkJ9HckpMP7LJ7s=";
+  };
+
+  meta = with lib; {
+    description = "A library for controlling team network devices";
+    homepage = "https://libteam.org";
+    license = licenses.lgpl21;
+    maintainers = [maintainers.agbrooks];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1744,6 +1744,8 @@ with pkgs;
 
   tauon = callPackage ../applications/audio/tauon { };
 
+  teamd = callPackage ../tools/networking/teamd { };
+
   tere = callPackage ../tools/misc/tere { };
 
   termusic = callPackage ../applications/audio/termusic { };


### PR DESCRIPTION
###### Description of changes

This PR packages [`teamd`/`libteam`](https://github.com/jpirko/libteam) at the latest release (1.31).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes (or backporting 23.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
