### PR TITLE
cups: enable tests & add some key reverse-dependencies to `passthru.tests`

### DIFF
--- a/pkgs/misc/cups/default.nix
+++ b/pkgs/misc/cups/default.nix
@@ -19,6 +19,8 @@
 , libpaper ? null
 , coreutils
 , nixosTests
+, hostname
+, iconv
 }:
 
 stdenv.mkDerivation rec {
@@ -142,6 +144,16 @@ stdenv.mkDerivation rec {
       printing-socket
     ;
   };
+
+  doCheck = !stdenv.isDarwin;  # some locale tests fail on darwin
+  nativeCheckInputs = [
+    hostname
+  ] ++ lib.optionals stdenv.isDarwin [
+    iconv
+  ];
+  preCheck = ''
+    export CUPS_TESTBASE=$(mktemp -d)
+  '';
 
   meta = with lib; {
     homepage = "https://openprinting.github.io/cups/";

--- a/pkgs/misc/cups/default.nix
+++ b/pkgs/misc/cups/default.nix
@@ -21,6 +21,14 @@
 , nixosTests
 , hostname
 , iconv
+
+# for passthru.tests
+, ghostscript
+, gtk3
+, gtklp
+, python3
+, samba
+, scribus
 }:
 
 stdenv.mkDerivation rec {
@@ -143,6 +151,14 @@ stdenv.mkDerivation rec {
       printing-service
       printing-socket
     ;
+    inherit
+      scribus
+      gtklp
+    ;
+    ghostscript = ghostscript.override { cupsSupport = true; };
+    gtk3 = gtk3.override { cupsSupport = true; };
+    pycups = python3.pkgs.pycups;
+    samba = samba.override { enablePrinting = true; };
   };
 
   doCheck = !stdenv.isDarwin;  # some locale tests fail on darwin


### PR DESCRIPTION
###### Description of changes

Couldn't get a couple of the i18n tests to pass on darwin so disabled them there until someone figures that out.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes (or backporting 23.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
