### PR TITLE
python3Packages.manga-ocr: init at 0.1.11

### DIFF
--- a/pkgs/development/python-modules/manga-ocr/default.nix
+++ b/pkgs/development/python-modules/manga-ocr/default.nix
@@ -1,0 +1,65 @@
+{
+  lib,
+  fetchFromGitHub,
+  buildPythonPackage,
+  fire,
+  fugashi,
+  jaconv,
+  loguru,
+  numpy,
+  pillow,
+  pyperclip,
+  torch,
+  transformers,
+  unidic-lite,
+  pythonOlder,
+}:
+buildPythonPackage rec {
+  pname = "manga-ocr";
+  version = "0.1.11";
+  disabled = pythonOlder "3.7";
+
+  src = fetchFromGitHub {
+    owner = "kha-white";
+    repo = pname;
+    rev = "refs/tags/v${version}";
+    hash = "sha256-cLmgHBt6HvhY6Hb9yQ425Gk181axnMr+Mp2LxSmPoDg=";
+  };
+
+  preBuild = ''
+    # remove subproject dedicated to model training
+    rm -rf manga_ocr_dev
+    # copy assets/example.jpg inside the package
+    # required by https://github.com/kha-white/manga-ocr/blob/ba1b0d94a8ef6676b618ba4e5ffe8ce2ab655270/manga_ocr/ocr.py#L27-L30
+    # see also package_data.patch
+    mkdir manga_ocr/assets
+    cp assets/example.jpg manga_ocr/assets/example.jpg
+  '';
+
+  patches = [
+    # instruct setuptool to copy assets/example.jpg to package when building wheel
+    ./package_data.patch
+  ];
+
+  propagatedBuildInputs = [
+    # taken from requirements.txt
+    fire
+    fugashi
+    jaconv
+    loguru
+    numpy
+    pillow
+    pyperclip
+    torch
+    transformers
+    unidic-lite
+  ];
+
+  meta = with lib; {
+    description = "Optical character recognition for Japanese text, with the main focus being Japanese manga";
+    homepage = "https://github.com/kha-white/manga-ocr";
+    changelog = "https://github.com/kha-white/manga-ocr/releases/tag/${version}";
+    license = licenses.asl20;
+    maintainers = with maintainers; [laurent-f1z1];
+  };
+}

--- a/pkgs/development/python-modules/manga-ocr/package_data.patch
+++ b/pkgs/development/python-modules/manga-ocr/package_data.patch
@@ -1,0 +1,12 @@
+diff --git a/setup.py b/setup.py
+--- a/setup.py
++++ b/setup.py
+@@ -18,6 +18,9 @@ setup(
+     ],
+     packages=['manga_ocr'],
+     include_package_data=True,
++    package_data={
++        'manga_ocr': ['assets/example.jpg'],
++    },
+     install_requires=[
+         "fire",

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -7044,6 +7044,8 @@ self: super: with self; {
 
   mandown = callPackage ../development/python-modules/mandown { };
 
+  manga-ocr = callPackage ../development/python-modules/manga-ocr { };
+
   manhole = callPackage ../development/python-modules/manhole { };
 
   manimpango = callPackage ../development/python-modules/manimpango {


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

https://github.com/kha-white/manga-ocr
cannot run tests as loading the ocr model requires internet to download weights from huggingface hub

Fixes #233897 
Requires #235798

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes (or backporting 23.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
