### PR TITLE
python3Packages.async-tkinter-loop: init at 0.8.1

### DIFF
--- a/pkgs/development/python-modules/async-tkinter-loop/default.nix
+++ b/pkgs/development/python-modules/async-tkinter-loop/default.nix
@@ -1,0 +1,46 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, python3Packages
+, poetry-core
+, tkinter
+, pythonRelaxDepsHook
+, pytestCheckHook
+}:
+
+buildPythonPackage rec {
+  pname = "async-tkinter-loop";
+  version = "0.8.1";
+  format = "pyproject";
+
+  src = fetchPypi {
+    inherit version;
+    pname = "async_tkinter_loop";
+    hash = "sha256-+9AvnYIZMWCbpCEKdbIadyU8zgyUlW/fRYYyDOxAzeg=";
+  };
+
+  nativeBuildInputs = [
+    pythonRelaxDepsHook
+    poetry-core
+  ];
+
+  propagatedBuildInputs = [
+    tkinter
+  ];
+
+  pythonRemoveDeps = [
+    "asyncio"
+  ];
+
+  pythonImportsCheck = [
+    "async_tkinter_loop"
+  ];
+
+  meta = with lib; {
+    description = "Implementation of asynchronous mainloop for tkinter, the use of which allows using async handler functions";
+    homepage = "https://github.com/insolor/async-tkinter-loop";
+    changelog = "https://github.com/insolor/async-tkinter-loop/releases/tag/${version}";
+    license = licenses.mit;
+    maintainers = with maintainers; [ AngryAnt ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -748,6 +748,8 @@ self: super: with self; {
 
   async-timeout = callPackage ../development/python-modules/async_timeout { };
 
+  async-tkinter-loop = callPackage ../development/python-modules/async-tkinter-loop { };
+
   asyncua = callPackage ../development/python-modules/asyncua { };
 
   async-upnp-client = callPackage ../development/python-modules/async-upnp-client { };


### PR DESCRIPTION
###### Description of changes

Verified functionality via incoming package dependent on this package. PR for that will follow.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes (or backporting 23.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
