### PR TITLE
libclc: fix .pc paths

### DIFF
--- a/pkgs/development/libraries/libclc/default.nix
+++ b/pkgs/development/libraries/libclc/default.nix
@@ -14,6 +14,10 @@ stdenv.mkDerivation rec {
 
   outputs = [ "out" "dev" ];
 
+  patches = [
+    ./libclc-gnu-install-dirs.patch
+  ];
+
   # cmake expects all required binaries to be in the same place, so it will not be able to find clang without the patch
   postPatch = ''
     substituteInPlace CMakeLists.txt \
@@ -35,9 +39,6 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ cmake ninja python3 ];
   buildInputs = [ llvm_14 ];
   strictDeps = true;
-  cmakeFlags = [
-    "-DCMAKE_INSTALL_INCLUDEDIR=include"
-  ];
 
   postInstall = ''
     install -Dt $dev/bin prepare_builtins

--- a/pkgs/development/libraries/libclc/libclc-gnu-install-dirs.patch
+++ b/pkgs/development/libraries/libclc/libclc-gnu-install-dirs.patch
@@ -1,0 +1,10 @@
+--- a/libclc.pc.in
++++ b/libclc.pc.in
+@@ -1,5 +1,5 @@
+-includedir=@CMAKE_INSTALL_PREFIX@/@CMAKE_INSTALL_INCLUDEDIR@
+-libexecdir=@CMAKE_INSTALL_PREFIX@/@CMAKE_INSTALL_DATADIR@/clc
++includedir=@CMAKE_INSTALL_FULL_INCLUDEDIR@
++libexecdir=@CMAKE_INSTALL_FULL_DATADIR@/clc
+ 
+ Name: libclc
+ Description: Library requirements of the OpenCL C programming language


### PR DESCRIPTION
For https://github.com/NixOS/nixpkgs/issues/144170. https://github.com/NixOS/nixpkgs/pull/153954 is no longer sufficient due to libclc's newly-split outputs.

I attempted to upstream this in https://reviews.llvm.org/D118959 which has gotten no attention.

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes (or backporting 23.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
