### PR TITLE
kgt: 2021-04-07 -> 2023-06-03

### DIFF
--- a/pkgs/development/tools/kgt/default.nix
+++ b/pkgs/development/tools/kgt/default.nix
@@ -2,14 +2,14 @@
 
 stdenv.mkDerivation {
   pname = "kgt";
-  version = "2021-04-07";
+  version = "2023-06-03";
 
   src = fetchFromGitHub {
     owner = "katef";
     repo = "kgt";
-    # 2021-04-07, no version tags (yet)
-    rev = "a7cbc52d368e413a3f1212c0fafccc05b2a42606";
-    sha256 = "1x6q30xb8ihxi26rzk3s2hqd827fim4l4wn3qq252ibrwcq6lqyj";
+    # 2023-06-03, no version tags (yet)
+    rev = "dc881796aa691f1fddb1d01ec77216b34fe8134d";
+    hash = "sha256-Az5995/eGUHFL1C1WAdgh1td3goHUYgzWFeVFz2zb8g=";
     fetchSubmodules = true;
   };
 


### PR DESCRIPTION
###### Description of changes

This updates kgt to a newer revision (since the repo lacks version tags).

Most notably, this fixes the build with newer bmake (see https://github.com/katef/kgt/issues/62).

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes (or backporting 23.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
