### PR TITLE
gvisor: 20221102.1 -> 20230529.0

### DIFF
--- a/pkgs/applications/virtualization/gvisor/default.nix
+++ b/pkgs/applications/virtualization/gvisor/default.nix
@@ -9,20 +9,31 @@
 
 buildGoModule rec {
   pname = "gvisor";
-  version = "20221102.1";
+  version = "20230529.0";
 
   # gvisor provides a synthetic go branch (https://github.com/google/gvisor/tree/go)
   # that can be used to build gvisor without bazel.
+  #
   # For updates, you should stick to the commits labeled "Merge release-** (automated)"
+  # Make sure to check that the tagged commit for a release aligns with the version in
+  # the message for good measure; e.g. the commit
+  #
+  #     142d38d770a07291877dc0d50b88b719dbef76dc is "Merge release-20230522.0-11-g919cfd12b (automated)"
+  #
+  # on the 'go' branch. But the mentioned commit, 919cfd12b..., is actually tagged as release-20230529.0
+  #
+  #    https://github.com/google/gvisor/releases/tag/release-202329.0
+  #
+  # Presumably this is a result of the release process. Handle with care.
 
   src = fetchFromGitHub {
     owner = "google";
     repo = "gvisor";
-    rev = "bf8eeee3a9eb966bc72c773da060a3c8bb73b8ff";
-    sha256 = "sha256-rADQsJ+AnBVlfQURGJl1xR6Ad5NyRWSrBSpOFMRld+o=";
+    rev = "142d38d770a07291877dc0d50b88b719dbef76dc";
+    hash = "sha256-Ukcjlz/6iUmDAUpQpIVfZHKbwK90Mt6fukcFaw64hQI=";
   };
 
-  vendorSha256 = "sha256-iGLWxx/Kn1QaJTNOZcc+mwoF3ecEDOkaqmA0DH4pdgU=";
+  vendorHash = "sha256-COr47mZ4tsbzMjkv63l+fexo0RL5lrBXeewak9CuZVk=";
 
   nativeBuildInputs = [ makeWrapper ];
 


### PR DESCRIPTION
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes (or backporting 23.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
