### PR TITLE
environment.shellAliases: document default

### DIFF
--- a/nixos/modules/config/shells-environment.nix
+++ b/nixos/modules/config/shells-environment.nix
@@ -115,6 +115,11 @@ in
         aliases are added to all users' shells.
         Aliases mapped to `null` are ignored.
       '';
+      default = {
+        ls = "ls --color=tty";
+        ll = "ls -l";
+        l  = "ls -alh";
+      };
       type = with types; attrsOf (nullOr (either str path));
     };
 


### PR DESCRIPTION
###### Description of changes

After upgrading to NixOS my `~/bin/l` no longer worked, so I went digging around for where the shell alias `l` came from.

Seems like it comes from `environment.shellAliases`. It would have been easier to tell if it was documented as the default for this option. I hope that this patch is the best way to add that documentation, so it shows up at:

https://search.nixos.org/options?channel=23.05&show=environment.shellAliases&from=0&size=50&sort=relevance&type=packages&query=environment.shellAliases


I don't know how to build this. I'm hoping it's possible for people like me who are newer to nixos to submit documentation updates without figuring out how to build stuff.

That said, if you tell me exactly how to build/test this, I'll probably do that.