### PR TITLE
waycorner: init at 0.2.1

### DIFF
--- a/pkgs/applications/misc/waycorner/default.nix
+++ b/pkgs/applications/misc/waycorner/default.nix
@@ -1,0 +1,40 @@
+{ lib
+, makeWrapper
+, rustPlatform
+, pkg-config
+, fetchFromGitHub
+, wayland
+,
+}:
+rustPlatform.buildRustPackage rec {
+  pname = "waycorner";
+  version = "0.2.1";
+  src = fetchFromGitHub {
+    owner = "AndreasBackx";
+    repo = "waycorner";
+    rev = version;
+    hash = "sha256-xvmvtn6dMqt8kUwvn5d5Nl1V84kz1eWa9BSIN/ONkSQ=";
+  };
+  cargoHash = "sha256-Dl+GhJywWhaC4QMS70klazPsFipGVRW+6jrXH2XsEAI=";
+  buildInputs = [
+    wayland
+  ];
+  nativeBuildInputs = [
+    pkg-config
+    makeWrapper
+  ];
+  postFixup = ''
+    # the program looks for libwayland-client.so at runtime
+    wrapProgram $out/bin/waycorner \
+      --prefix LD_LIBRARY_PATH : ${lib.makeLibraryPath [ wayland ]}
+  '';
+
+  meta = with lib; {
+    description = "Hot corners for Wayland";
+    changelog = "https://github.com/AndreasBackx/waycorner/blob/main/CHANGELOG.md";
+    homepage = "https://github.com/AndreasBackx/waycorner";
+    platforms = platforms.linux;
+    license = licenses.mit;
+    maintainers = with maintainers; [ NotAShelf ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -31563,6 +31563,8 @@ with pkgs;
 
   waybar = callPackage ../applications/misc/waybar { };
 
+  waycorner = callPackage ../applications/misc/waycorner { };
+
   waylock = callPackage ../applications/misc/waylock {
     zig = buildPackages.zig_0_10;
   };


### PR DESCRIPTION
###### Description of changes

Package [waycorner](https://github.com/AndreasBackx/waycorner).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes (or backporting 23.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).