### PR TITLE
git-pw: init at 2.6.0

### DIFF
--- a/pkgs/by-name/gi/git-pw/package.nix
+++ b/pkgs/by-name/gi/git-pw/package.nix
@@ -1,0 +1,59 @@
+{ lib
+, git
+, python3
+, fetchFromGitHub
+, testers
+, git-pw
+}:
+
+python3.pkgs.buildPythonApplication rec {
+  pname = "git-pw";
+  version = "2.6.0";
+  format = "pyproject";
+
+  PBR_VERSION = version;
+
+  src = fetchFromGitHub {
+    owner = "getpatchwork";
+    repo = "git-pw";
+    rev = version;
+    hash = "sha256-3IiFU6qGI2MDTBOLQ2qyT5keUMNTNG3sxhtGR3bkIBc=";
+  };
+
+  postPatch = ''
+    # We don't want to run the coverage.
+    substituteInPlace tox.ini --replace "--cov=git_pw --cov-report" ""
+  '';
+
+  nativeBuildInputs = with python3.pkgs; [
+    pbr
+    setuptools
+  ];
+
+  propagatedBuildInputs = with python3.pkgs; [
+    pyyaml
+    arrow
+    click
+    requests
+    tabulate
+  ];
+
+  nativeCheckInputs = with python3.pkgs; [
+    pytest
+    git
+  ];
+
+  # This is needed because `git-pw` always rely on an ambiant git.
+  # Furthermore, this doesn't really make sense to resholve git inside this derivation.
+  # As `testVersion` does not offer the right knob, we can just `overrideAttrs`-it ourselves.
+  passthru.tests.version = (testers.testVersion { package = git-pw; }).overrideAttrs (old: {
+    buildInputs = (old.buildInputs or [ ]) ++ [ git ];
+  });
+
+  meta = with lib; {
+    description = "A tool for integrating Git with Patchwork, the web-based patch tracking system";
+    homepage = "https://github.com/getpatchwork/git-pw";
+    license = licenses.mit;
+    maintainers = with maintainers; [ raitobezarius ];
+  };
+}


### PR DESCRIPTION
###### Description of changes

This is very useful to work with Patchwork (mass-applying patches, etc.).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes (or backporting 23.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
