### PR TITLE
gnomeExtensions: compile schemas if present

### DIFF
--- a/pkgs/desktops/gnome/extensions/buildGnomeExtension.nix
+++ b/pkgs/desktops/gnome/extensions/buildGnomeExtension.nix
@@ -36,7 +36,14 @@ let
         echo "${metadata}" | base64 --decode > $out/metadata.json
       '';
     };
-    dontBuild = true;
+    nativeBuildInputs = with pkgs; [ glib ];
+    buildPhase = ''
+      runHook preBuild
+      if [ -d schemas ]; then
+        glib-compile-schemas --strict schemas
+      fi
+      runHook postBuild
+    '';
     installPhase = ''
       runHook preInstall
       mkdir -p $out/share/gnome-shell/extensions/


### PR DESCRIPTION
###### Description of changes

Extensions may not automatically include `schemas/gschemas.compiled`  for newer releases (targeted at GNOME 44 and later) so they need to be manually compiled on the host. (Of note that the compiling is done unconditionally, same as upstream)

See:
https://gjs.guide/extensions/upgrading/gnome-shell-44.html#gsettings-schema
https://gitlab.com/rmnvgr/nightthemeswitcher-gnome-shell-extension/-/issues/139
https://gitlab.gnome.org/GNOME/gnome-shell/-/merge_requests/2638

Fixes https://github.com/NixOS/nixpkgs/issues/228504 - The extensions mentioned there seem to work fine now

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [X] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes (or backporting 23.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
