### PR TITLE
isync: Disable the XOAUTH2 support by default as it caused regressions

### DIFF
--- a/pkgs/tools/networking/isync/default.nix
+++ b/pkgs/tools/networking/isync/default.nix
@@ -1,7 +1,9 @@
 { lib, stdenv, fetchurl, pkg-config, perl
 , openssl, db, cyrus_sasl, zlib
 , Security
-, withCyrusSaslXoauth2 ? true, cyrus-sasl-xoauth2, makeWrapper
+# Disabled by default as XOAUTH2 is an "OBSOLETE" SASL mechanism and this relies
+# on a package that isn't really maintained anymore:
+, withCyrusSaslXoauth2 ? false, cyrus-sasl-xoauth2, makeWrapper
 }:
 
 stdenv.mkDerivation rec {


### PR DESCRIPTION
The XOAUTH2 support was recently added in 47eda8e00a28 but apparently it causes regressions when using other SASL methods.
An example error message:
```
IMAP command 'AUTHENTICATE XOAUTH2 SOMEHASH=' returned an error: NO [AUTHENTICATIONFAILED] Invalid credentials (Failure)
```

The cause seems to be that overriding `SASL_PATH` drops all available SASL mechanisms from `cyrus_sasl`, so only `XOAUTH2` (and `EXTERNAL`) will be left. See [0] and the following comments for more details.

We'd need to set `SASL_PATH` to a combination/merge of `${cyrus_sasl}/lib/sasl2` and `${cyrus-sasl-xoauth2}/lib/sasl2`. Anyway, it seems best to disable the XOAUTH2 support by default due to the two other concerns mentioned in the comment.

[0]: https://github.com/NixOS/nixpkgs/pull/235148#issuecomment-1575432154

Reported-by: Dominik Schrempf <dominik.schrempf@gmail.com>

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes (or backporting 23.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
