### PR TITLE
nixos/tests/taskserver: Fix build

### DIFF
--- a/nixos/tests/taskserver.nix
+++ b/nixos/tests/taskserver.nix
@@ -69,23 +69,14 @@ in {
         testOrganisation.users = [ "alice" "foo" ];
         anotherOrganisation.users = [ "bob" ];
       };
-    };
 
-    # New generation of the server with manual config
-    newServer = { lib, nodes, ... }: {
-      imports = [ server ];
-      services.taskserver.pki.manual = {
-        ca.cert = snakeOil.cacert;
-        server.cert = snakeOil.cert;
-        server.key = snakeOil.key;
-        server.crl = snakeOil.crl;
-      };
-      # This is to avoid assigning a different network address to the new
-      # generation.
-      networking = lib.mapAttrs (lib.const lib.mkForce) {
-        interfaces.eth1.ipv4 = nodes.server.config.networking.interfaces.eth1.ipv4;
-        inherit (nodes.server.config.networking)
-          hostName primaryIPAddress extraHosts;
+      specialisation.manual-config.configuration = {
+        services.taskserver.pki.manual = {
+          ca.cert = snakeOil.cacert;
+          server.cert = snakeOil.cert;
+          server.key = snakeOil.key;
+          server.crl = snakeOil.crl;
+        };
       };
     };
 
@@ -103,7 +94,8 @@ in {
   testScript = { nodes, ... }: let
     cfg = nodes.server.config.services.taskserver;
     portStr = toString cfg.listenPort;
-    newServerSystem = nodes.newServer.config.system.build.toplevel;
+    specialisations = "${nodes.server.system.build.toplevel}/specialisation";
+    newServerSystem = "${specialisations}/manual-config";
     switchToNewServer = "${newServerSystem}/bin/switch-to-configuration test";
   in ''
     from shlex import quote


### PR DESCRIPTION
###### Description of changes

The test fails because the way the configuration switch was implemented back then was by using a dummy configuration and simply activating that dummy configuration from within the test script.

Nowadays, this doesn't work anymore and fails to typecheck because the dummy `newServer` will inherit the same value for `networking.hostName`, which in turn will generate two attributes for "server":

> testScriptWithTypes:43: error: Name "server" already defined on line 43
> [no-redef]
>     client1: Machine; client2: Machine; server: Machine; server: Machine;

Fortunately, we don't need to do workarounds like this anymore and there is the `specialisation` option, which allows to do this in a less ugly way (and it also works with `mypy`).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [x] [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes (or backporting 23.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).