### PR TITLE
cudaPackages.cudatoolkit: mark libnvrtc-builtins needed for libnvrtc

### DIFF
--- a/pkgs/development/compilers/cudatoolkit/common.nix
+++ b/pkgs/development/compilers/cudatoolkit/common.nix
@@ -158,6 +158,10 @@ backendStdenv.mkDerivation rec {
     "libcom_err.so.2"
   ];
 
+  preFixup = ''
+    patchelf $out/lib64/libnvrtc.so --add-needed libnvrtc-builtins.so
+  '';
+
   unpackPhase = ''
     sh $src --keep --noexec
 
@@ -342,4 +346,3 @@ backendStdenv.mkDerivation rec {
     maintainers = teams.cuda.members;
   };
 }
-


### PR DESCRIPTION
###### Description of changes

`libnvrtc.so` should depend on `libnvrtc-builtins.so` (which by default is not). This may cause runtime issue when `libnvrtc.so` is actually used (e.g. in `pytorch`). This issue can be reproduced by running a simple training script with `pytorch`.

The solution, per @SomeoneSerge's suggestion is to force adding such dependency in `preFixup`. This is based on the original commit: https://github.com/SomeoneSerge/nixpkgs/commit/f55d2a112dc33855bad42980bf93d684505cbe6d

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

1. Verified that it builds with `NIXPKGS_ALLOW_UNFREE=1 nix build --impure github:breakds/nixpkgs/PR/breakds/cuda_nvrtc_fix#cudaPackages.cudatoolkit`
2. Verified that `pytorch` 2.0.1 built based on this (and CUDA 11.8) can successfully run the training script.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes (or backporting 23.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
