### PR TITLE
emacs.pkgs.treesit-grammars: refactor

### DIFF
--- a/pkgs/applications/editors/emacs/elisp-packages/manual-packages/treesit-grammars/default.nix
+++ b/pkgs/applications/editors/emacs/elisp-packages/manual-packages/treesit-grammars/default.nix
@@ -1,19 +1,20 @@
-{ pkgs, lib, tree-sitter, ... }:
+{ pkgs, lib }:
 
 let
-  libExt = pkgs.stdenv.targetPlatform.extensions.sharedLibrary;
+  libExt = pkgs.stdenv.hostPlatform.extensions.sharedLibrary;
   grammarToAttrSet = drv:
-      {
-        name = "lib/lib${lib.strings.removeSuffix "-grammar" (lib.strings.getName drv)}${libExt}";
-        path = "${drv}/parser";
-      };
-in
-{
-  with-all-grammars = pkgs.linkFarm "emacs-treesit-grammars"
-    (map grammarToAttrSet pkgs.tree-sitter.allGrammars);
+    {
+      name = "lib/lib${lib.strings.removeSuffix "-grammar" (lib.strings.getName drv)}${libExt}";
+      path = "${drv}/parser";
+    };
 
-  # Use this one like this:
-  # treesit-grammars.with-grammars (grammars: with grammars; [tree-sitter-bash])
+  # Usage:
+  # treesit-grammars.with-grammars (p: [ p.tree-sitter-bash p.tree-sitter-c ... ])
   with-grammars = fn: pkgs.linkFarm "emacs-treesit-grammars"
     (map grammarToAttrSet (fn pkgs.tree-sitter.builtGrammars));
+in
+{
+  inherit with-grammars;
+
+  with-all-grammars = with-grammars builtins.attrValues;
 }


### PR DESCRIPTION

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
- Do not pass tree-sitter since it refers to the Emacs package of the same name and it's not needed

- Use stdenv.hostPlatform since it's not a compiler.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes (or backporting 23.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
