### PR TITLE
srm: 1.2.15 -> 1.2.15-unstable-2017-12-18

### DIFF
--- a/pkgs/tools/security/srm/default.nix
+++ b/pkgs/tools/security/srm/default.nix
@@ -1,13 +1,17 @@
-{ lib, stdenv, fetchurl }:
+{ lib, stdenv, fetchsvn, autoreconfHook }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation {
   pname = "srm";
-  version = "1.2.15";
+  version = "1.2.15-unstable-2017-12-18";
 
-  src = fetchurl {
-    url = "mirror://sourceforge/project/srm/${version}/srm-${version}.tar.gz";
-    sha256 = "10sjarhprs6s4zandndg720528rcnd4xk8dl48pjj7li1q9c30vm";
+  src = fetchsvn {
+    url = "svn://svn.code.sf.net/p/srm/srm/trunk/";
+    rev = "268";
+    sha256 = "sha256-bY8p6IS5zeByoe/uTmvBAaBN4Wu7J19dVSpbtqx4OeQ=";
   };
+
+  patches = [ ./fix-output-in-verbose-mode.patch ];
+  nativeBuildInputs = [ autoreconfHook ];
 
   meta = with lib; {
     description = "Delete files securely";
@@ -22,5 +26,4 @@ stdenv.mkDerivation rec {
     maintainers = with maintainers; [ edwtjo ];
     platforms = platforms.unix;
   };
-
 }

--- a/pkgs/tools/security/srm/fix-output-in-verbose-mode.patch
+++ b/pkgs/tools/security/srm/fix-output-in-verbose-mode.patch
@@ -1,0 +1,57 @@
+diff --git a/src/sunlink.c b/src/sunlink.c
+index 7050713..ffcb8d3 100644
+--- a/src/sunlink.c
++++ b/src/sunlink.c
+@@ -468,6 +468,8 @@ static int overwrite_selector(struct srm_target *srm)
+       if(overwrite_byte(srm, 5, 0x00) < 0) return -1;
+       if(overwrite_byte(srm, 6, 0xFF) < 0) return -1;
+       if(overwrite_random(srm, 7, 1) < 0) return -1;
++      if((srm->options&SRM_OPT_V) > 1)
++	printf("\n");
+     }
+   else if(srm->options & SRM_MODE_DOE)
+     {
+@@ -475,6 +477,8 @@ static int overwrite_selector(struct srm_target *srm)
+ 	error("US DoE mode");
+       if(overwrite_random(srm, 1, 2) < 0) return -1;
+       if(overwrite_bytes(srm, 3, 'D', 'o', 'E') < 0) return -1;
++      if((srm->options&SRM_OPT_V) > 1)
++	printf("\n");
+     }
+   else if(srm->options & SRM_MODE_OPENBSD)
+     {
+@@ -483,12 +487,16 @@ static int overwrite_selector(struct srm_target *srm)
+       if(overwrite_byte(srm, 1, 0xFF) < 0) return -1;
+       if(overwrite_byte(srm, 2, 0x00) < 0) return -1;
+       if(overwrite_byte(srm, 3, 0xFF) < 0) return -1;
++      if((srm->options&SRM_OPT_V) > 1)
++	printf("\n");
+     }
+   else if(srm->options & SRM_MODE_SIMPLE)
+     {
+       if((srm->options&SRM_OPT_V) > 1)
+ 	error("Simple mode");
+       if(overwrite_byte(srm, 1, 0x00) < 0) return -1;
++      if((srm->options&SRM_OPT_V) > 1)
++	printf("\n");
+     }
+   else if(srm->options & SRM_MODE_RCMP)
+     {
+@@ -497,6 +505,8 @@ static int overwrite_selector(struct srm_target *srm)
+       if(overwrite_byte(srm, 1, 0x00) < 0) return -1;
+       if(overwrite_byte(srm, 2, 0xFF) < 0) return -1;
+       if(overwrite_string(srm, 3, "RCMP") < 0) return -1;
++      if((srm->options&SRM_OPT_V) > 1)
++	printf("\n");
+     }
+   else
+     {
+@@ -535,6 +545,8 @@ static int overwrite_selector(struct srm_target *srm)
+       if(overwrite_random(srm, 32, 4) < 0) return -1;
+       /* if you want to backup your partition or shrink your vmware image having the file zero-ed gives best compression results. */
+       if(overwrite_byte(srm, 36, 0x00) < 0) return -1;
++      if((srm->options&SRM_OPT_V) > 1)
++	printf("\n");
+     }
+ #if 0
+   if((srm->options & SRM_OPT_V) > 1)


### PR DESCRIPTION
###### Description of changes

The project probably will not receive any more updates, so it makes sense to take the latest commit, after version 1.2.15 there were fixes in the description and functionality. The patch that I added fixes buggy output with verbose output (-vv)

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes (or backporting 23.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

Result of `nixpkgs-review` run on x86_64-linux [1](https://github.com/Mic92/nixpkgs-review)
<details>
  <summary>1 package built:</summary>
  <ul>
    <li>srm</li>
  </ul>
</details>

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
