### PR TITLE
ocamlPackages.functoria: 4.3.4 → 4.3.6 (w/ fixes for OCaml 5.0)

### DIFF
--- a/pkgs/development/ocaml-modules/functoria/default.nix
+++ b/pkgs/development/ocaml-modules/functoria/default.nix
@@ -4,14 +4,13 @@
 
 buildDunePackage rec {
   pname   = "functoria";
-  version = "4.3.4";
+  version = "4.3.6";
 
-  duneVersion = "3";
   minimalOCamlVersion = "4.08";
 
   src = fetchurl {
     url = "https://github.com/mirage/mirage/releases/download/v${version}/mirage-${version}.tbz";
-    hash = "sha256-ZN8La2+N19wVo/vBUfIj17JU6FSp0jX7h2nDoIpR1XY=";
+    hash = "sha256-i/5sZHfxECoKYMdGje+U21GWxJ6dDZreVcQGtbuo4SE=";
   };
 
   propagatedBuildInputs = [ cmdliner rresult astring fmt logs bos fpath emile uri ];

--- a/pkgs/development/ocaml-modules/omd/default.nix
+++ b/pkgs/development/ocaml-modules/omd/default.nix
@@ -11,6 +11,10 @@ buildDunePackage rec {
     sha256 = "sha256-YCPhZCYx8I9njrVyWCCHnte7Wj/+53fN7evCjB+F+ts=";
   };
 
+  preBuild = ''
+    substituteInPlace src/dune --replace "bytes)" ")"
+  '';
+
   meta = {
     description = "Extensible Markdown library and tool in OCaml";
     homepage = "https://github.com/ocaml/omd";

--- a/pkgs/development/ocaml-modules/qtest/default.nix
+++ b/pkgs/development/ocaml-modules/qtest/default.nix
@@ -4,14 +4,18 @@ buildDunePackage rec {
   pname = "qtest";
   version = "2.11.2";
 
-  duneVersion = "3";
-
   src = fetchFromGitHub {
     owner = "vincent-hugot";
     repo = pname;
     rev = "v${version}";
     sha256 = "sha256-VLY8+Nu6md0szW4RVxTFwlSQ9kyrgUqf7wQEA6GW8BE=";
   };
+
+  preBuild = ''
+    substituteInPlace src/dune \
+      --replace "(libraries bytes)" "" \
+      --replace "libraries qcheck ounit2 bytes" "libraries qcheck ounit2"
+  '';
 
   propagatedBuildInputs = [ qcheck ];
 


### PR DESCRIPTION
###### Description of changes

Support for OCaml ≥ 5.0: https://github.com/mirage/mirage/blob/v4.3.6/CHANGES.md

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes (or backporting 23.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
