### PR TITLE
nixos/grub: don't die on EFI-only systems if devices != ["nodev"]

### DIFF
--- a/nixos/modules/system/boot/loader/grub/grub.nix
+++ b/nixos/modules/system/boot/loader/grub/grub.nix
@@ -40,7 +40,10 @@ let
       backgroundColor = f cfg.backgroundColor;
       entryOptions = f cfg.entryOptions;
       subEntryOptions = f cfg.subEntryOptions;
-      grub = f grub;
+      # PC platforms (like x86_64-linux) have a non-EFI target (`grubTarget`), but other platforms
+      # (like aarch64-linux) have an undefined `grubTarget`. Avoid providing the path to a non-EFI
+      # GRUB on those platforms.
+      grub = f (if (grub.grubTarget or "") != "" then grub else "");
       grubTarget = f (grub.grubTarget or "");
       shell = "${pkgs.runtimeShell}";
       fullName = lib.getName realGrub;


### PR DESCRIPTION
###### Description of changes

Without this change, GRUB installation on non-PC systems (such as aarch64-linux) only works [if boot.loader.grub.devices is set to exactly `["nodev"]`](https://github.com/NixOS/nixpkgs/blob/e7603eba51f2c7820c0a182c6bbb351181caa8e7/nixos/modules/system/boot/loader/grub/grub.nix#L18-L23). If boot.loader.grub.devices was any other value (including the default `[]`), users got the error:

    Died at /nix/store/an9ngv2vg95bdcy0ifsxlbkasprm4dcw-install-grub.pl line 586.

install-grub.pl verifies that if both $grub and $grubEfi are set, then $grubTarget (e.g. i386-pc) and $grubTargetEfi (e.g. x86_64-efi) must both be set, [or the script will `die`](https://github.com/NixOS/nixpkgs/blob/945f0625d549db0fc3e4d05484223cca14698064/nixos/modules/system/boot/loader/grub/install-grub.pl#L582-L587). On non-PC systems, $grubTarget is "".

When boot.loader.grub.devices is ["nodev"], $grub is set to null, disabling non-EFI installation. But if a user has devices set for an x86_64 config, or is using only mirroredBoots without setting devices, they will hit this `die`.

This change sets $grub to "" if $grubTarget is "".

This resolves (maybe) #222491; it resolves my own subtly-different issue, but I'm not sure if it will resolve the original issue. I've tested this change on an EFI-only aarch64-linux and x86_64-linux system and a EFI+BIOS x86_64-linux system.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes (or backporting 23.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
