### PR TITLE
coqPackages: update InfSeqExt, StructTact, Cheerios, and Verdi

### DIFF
--- a/pkgs/development/coq-modules/Cheerios/default.nix
+++ b/pkgs/development/coq-modules/Cheerios/default.nix
@@ -4,7 +4,12 @@ mkCoqDerivation {
   pname   = "cheerios";
   owner   = "uwplse";
   inherit version;
-  defaultVersion = if lib.versions.range "8.6" "8.16" coq.version then "20200201" else null;
+  defaultVersion = with lib.versions; lib.switch coq.version [
+    { case = range "8.14" "8.17"; out = "20230107"; }
+    { case = range "8.6"  "8.16"; out = "20200201"; }
+  ] null;
+  release."20230107".rev    = "bad8ad2476e14df6b5a819b7aaddc27a7c53fb69";
+  release."20230107".sha256 = "sha256-G7a+6h4VDk7seKvFr6wy7vYqYmhUje78TYCj98wXrr8=";
   release."20200201".rev    = "9c7f66e57b91f706d70afa8ed99d64ed98ab367d";
   release."20200201".sha256 = "1h55s6lk47bk0lv5ralh81z55h799jbl9mhizmqwqzy57y8wqgs1";
 

--- a/pkgs/development/coq-modules/InfSeqExt/default.nix
+++ b/pkgs/development/coq-modules/InfSeqExt/default.nix
@@ -4,7 +4,12 @@ mkCoqDerivation {
   pname = "InfSeqExt";
   owner = "DistributedComponents";
   inherit version;
-  defaultVersion = if lib.versions.range "8.5" "8.16" coq.version then "20200131" else null;
+  defaultVersion = with lib.versions; lib.switch coq.version [
+    { case = range "8.9" "8.17"; out = "20230107"; }
+    { case = range "8.5" "8.16"; out = "20200131"; }
+  ] null;
+  release."20230107".rev    = "601e89ec019501c48c27fcfc14b9a3c70456e408";
+  release."20230107".sha256 = "sha256-YMBzVIsLkIC+w2TeyHrKe29eWLIxrH3wIMZqhik8p9I=";
   release."20200131".rev    = "203d4c20211d6b17741f1fdca46dbc091f5e961a";
   release."20200131".sha256 = "0xylkdmb2dqnnqinf3pigz4mf4zmczcbpjnn59g5g76m7f2cqxl0";
   preConfigure = ''

--- a/pkgs/development/coq-modules/StructTact/default.nix
+++ b/pkgs/development/coq-modules/StructTact/default.nix
@@ -5,9 +5,12 @@ mkCoqDerivation {
   owner = "uwplse";
   inherit version;
   defaultVersion = with lib.versions; lib.switch coq.coq-version [
+    { case = range "8.9" "8.17"; out = "20230107"; }
     { case = range "8.6" "8.16"; out = "20210328"; }
     { case = range "8.5" "8.13"; out = "20181102"; }
   ] null;
+  release."20230107".rev =    "2f2ff253be29bb09f36cab96d036419b18a95b00";
+  release."20230107".sha256 = "sha256-4mWdnWD8m1ddgqWHqzjqclhinXJaB/YoLlmLeeL0yZA=";
   release."20210328".rev =    "179bd5312e9d8b63fc3f4071c628cddfc496d741";
   release."20210328".sha256 = "sha256:1y5r1zm3hli10ah6lnj7n8hxad6rb6rgldd0g7m2fjibzvwqzhdg";
   release."20181102".rev =    "82a85b7ec07e71fa6b30cfc05f6a7bfb09ef2510";

--- a/pkgs/development/coq-modules/Verdi/default.nix
+++ b/pkgs/development/coq-modules/Verdi/default.nix
@@ -6,11 +6,14 @@ mkCoqDerivation {
   owner = "uwplse";
   inherit version;
   defaultVersion = with lib.versions; lib.switch coq.coq-version [
+    { case = range "8.9" "8.17"; out = "20230503"; }
     { case = range "8.7" "8.16"; out = "20211026"; }
     { case = range "8.7" "8.14"; out = "20210524"; }
     { case = range "8.7" "8.13"; out = "20200131"; }
     { case = "8.6"; out = "20181102"; }
   ] null;
+  release."20230503".rev    = "76833a7b2188e99e358b8439ea6b4f38401c962a";
+  release."20230503".sha256 = "sha256-g59adl/FLMlk9vZciz2I1ZX4PDCElNOgVPCwML8E4DU=";
   release."20211026".rev    = "064cc4fb2347453bf695776ed820ffb5fbc1d804";
   release."20211026".sha256 = "sha256:13xrcyzay5sjszf5lg4s44wl9nrcz22n6gi4h95pkpj0ni5clinx";
   release."20210524".rev    = "54597d8ac7ab7dd4dae683f651237644bf77701e";


### PR DESCRIPTION
###### Description of changes

Support for recent versions of Coq.

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes (or backporting 23.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
