### PR TITLE
haskellPackages.med-module: reactive examples

### DIFF
--- a/pkgs/development/haskell-modules/configuration-nix.nix
+++ b/pkgs/development/haskell-modules/configuration-nix.nix
@@ -141,8 +141,19 @@ builtins.intersectAttrs super {
       ];
     }) super.audacity
   );
-  # 2023-04-27: Deactivating examples for now because they cause a non-trivial build failure.
-  # med-module = enableCabalFlag "buildExamples" super.med-module;
+
+  med-module = enableCabalFlag "buildExamples" (
+    overrideCabal (drv: {
+      executableHaskellDepends = [
+        self.HPDF
+        self.filepath
+        self.non-empty
+        self.optparse-applicative
+        self.shell-utility
+      ];
+    }) super.med-module
+  );
+
   spreadsheet = enableCabalFlag "buildExamples" (
     overrideCabal (drv: {
       executableHaskellDepends = [


### PR DESCRIPTION
###### Description of changes

reactivate examples of med-module
replaced dependency on hps by HPDF which is contained in Stackage-LTS
