### PR TITLE
nixos/matrix-synapse: add override for PostgreSQL database assertion

### DIFF
--- a/nixos/modules/services/matrix/synapse.nix
+++ b/nixos/modules/services/matrix/synapse.nix
@@ -17,7 +17,9 @@ let
 
   usePostgresql = cfg.settings.database.name == "psycopg2";
   hasLocalPostgresDB = let args = cfg.settings.database.args; in
-    usePostgresql && (!(args ? host) || (elem args.host [ "localhost" "127.0.0.1" "::1" ]));
+    usePostgresql
+      && !cfg.overrideLocalPostgresCheck
+      && (!(args ? host) || (elem args.host [ "localhost" "127.0.0.1" "::1" ]));
 
   registerNewMatrixUser =
     let
@@ -186,6 +188,18 @@ in {
         description = lib.mdDoc ''
           The directory where matrix-synapse stores its stateful data such as
           certificates, media and uploads.
+        '';
+      };
+
+      overrideLocalPostgresCheck = mkOption {
+        type = types.bool;
+        default = false;
+        description = lib.mdDoc ''
+          Override the assertion that a local PostgreSQL instance must be
+          enabled when Synapse is configured to use a PostgreSQL running on
+          `localhost`, `::1` or `127.0.0.1`. This may be useful when e.g.,
+          running a Synapse instance in a NixOS container, which shares the
+          host's network namespace.
         '';
       };
 


### PR DESCRIPTION
###### Description of changes

This adds an option to override the (useful) assertion that PostgreSQL must be enabled if Synapse is configured to use a database-connection to `localhost` (or `::1`, `127.0.0.1`). It was introduced to ensure that an upgrade to NixOS 20.03 does not result in PostgreSQL being disabled, as it is no longer automatically enabled in the Synapse module.

However, this assertion is problematic in more specific use-cases. For instance, we run multiple Synapse instances on a single machine within NixOS containers, which share the host's network namespace. In this setup, a PostgreSQL service is running on localhost, just not defined as part of the container's configuration. Also, this assertion prevents running PostgreSQL through means other than the NixOS module, or using other more complex network configurations.

Thus, this introduces an option to override this check.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes (or backporting 23.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
