### PR TITLE
pww: init at 0.0.6

### DIFF
--- a/pkgs/tools/wayland/pww/default.nix
+++ b/pkgs/tools/wayland/pww/default.nix
@@ -1,0 +1,35 @@
+{ lib
+, buildGoModule
+, makeWrapper
+, fetchFromGitHub
+, playerctl
+}:
+buildGoModule rec {
+  pname = "pww";
+  version = "0.0.6";
+
+  src = fetchFromGitHub {
+    owner = "abenz1267";
+    repo = "pww";
+    rev = "v${version}";
+    hash = "sha256-nqNSzipOa0gj9qF49f/1R5QZMSY9xmjBnAVkiXdrSa4=";
+  };
+
+  vendorSha256 = "sha256-3PnXB8AfZtgmYEPJuh0fwvG38dtngoS/lxyx3H+rvFs=";
+
+  nativeBuildInputs = [ makeWrapper ];
+
+  postInstall = ''
+    wrapProgram $out/bin/${pname} \
+      --prefix PATH : "${lib.makeBinPath [ playerctl ]}"
+  '';
+
+  meta = with lib; {
+    description = "Utility wrapper around playerctl";
+    homepage = "https://github.com/abenz1267/pww";
+    changelog = "https://github.com/abenz1267/pww/releases/tag/v${version}";
+    license = licenses.mit;
+    maintainers = with maintainers; [ therealr5 ];
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4380,6 +4380,8 @@ with pkgs;
 
   oguri = callPackage  ../tools/wayland/oguri { };
 
+  pww = callPackage ../tools/wayland/pww { };
+
   shikane = callPackage ../tools/wayland/shikane { };
 
   shotman = callPackage ../tools/wayland/shotman { };


### PR DESCRIPTION
###### Description of changes
https://github.com/abenz1267/pww
> Simple program that emits a json with metadata info you can use in f.e. [Waybar](https://github.com/Alexays/Waybar). Additionally you can let it auto-pause media players you provide, f.e. starting a video in your browser will pause spotify.
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes (or backporting 23.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->