### PR TITLE
haskellPackages.sydtest: Unbreak by disabling test suite.

### DIFF
--- a/pkgs/development/haskell-modules/configuration-hackage2nix/broken.yaml
+++ b/pkgs/development/haskell-modules/configuration-hackage2nix/broken.yaml
@@ -5194,7 +5194,6 @@ broken-packages:
   - sws
   - syb-extras
   - syb-with-class-instances-text
-  - sydtest
   - syfco
   - sym
   - symantic

--- a/pkgs/development/haskell-modules/configuration-nix.nix
+++ b/pkgs/development/haskell-modules/configuration-nix.nix
@@ -1297,5 +1297,8 @@ self: super: builtins.intersectAttrs super {
   scalendar = dontCheck super.scalendar;
 
   halide-haskell = super.halide-haskell.override { Halide = pkgs.halide; };
+  # Sydtest has a brittle test suite that will only work with the exact
 
+  # versions that it ships with.
+  sydtest = dontCheck super.sydtest;
 }


### PR DESCRIPTION
Second attempt at #236079 