### PR TITLE
treewide: clean up usages of `cp -n`

### DIFF
--- a/nixos/modules/virtualisation/libvirtd.nix
+++ b/nixos/modules/virtualisation/libvirtd.nix
@@ -308,7 +308,9 @@ in
             libvirt/nwfilter/*.xml );
         do
             mkdir -p /var/lib/$(dirname $i) -m 755
-            cp -npd ${cfg.package}/var/lib/$i /var/lib/$i
+            if [ ! -e /var/lib/$i ]; then
+              cp -pd ${cfg.package}/var/lib/$i /var/lib/$i
+            fi
         done
 
         # Copy generated qemu config to libvirt directory

--- a/pkgs/development/libraries/composable_kernel/default.nix
+++ b/pkgs/development/libraries/composable_kernel/default.nix
@@ -2,7 +2,6 @@
 , stdenv
 , fetchFromGitHub
 , unstableGitUpdater
-, runCommand
 , cmake
 , rocm-cmake
 , hip
@@ -88,9 +87,6 @@ let
     };
   });
 
-  ckProfiler = runCommand "ckProfiler" { preferLocalBuild = true; } ''
-    cp -a ${ck}/bin/ckProfiler $out
-  '';
 in stdenv.mkDerivation {
   inherit (ck) pname version outputs src passthru requiredSystemFeatures meta;
 
@@ -102,8 +98,7 @@ in stdenv.mkDerivation {
   installPhase = ''
     runHook preInstall
 
-    mkdir -p $out/bin
-    cp -as ${ckProfiler} $out/bin/ckProfiler
+    mkdir -p $out
     cp -an ${ck}/* $out
   '' + lib.optionalString buildTests ''
     cp -a ${ck.test} $test

--- a/pkgs/development/tools/language-servers/metals/default.nix
+++ b/pkgs/development/tools/language-servers/metals/default.nix
@@ -12,7 +12,7 @@ stdenv.mkDerivation rec {
         -r bintray:scalacenter/releases \
         -r sonatype:snapshots > deps
       mkdir -p $out/share/java
-      cp -n $(< deps) $out/share/java/
+      cp $(< deps) $out/share/java/
     '';
     outputHashMode = "recursive";
     outputHashAlgo = "sha256";

--- a/pkgs/tools/backup/easysnap/default.nix
+++ b/pkgs/tools/backup/easysnap/default.nix
@@ -13,7 +13,7 @@ stdenv.mkDerivation {
 
   installPhase = ''
     mkdir -p $out/bin
-    cp -n easysnap* $out/bin/
+    cp easysnap* $out/bin/
 
     for i in $out/bin/*; do
       substituteInPlace $i \


### PR DESCRIPTION
###### Description of changes

coreutils 9.2 changed the behavior of `cp -n` to return an exit code if not all files were replaced: 

https://git.savannah.gnu.org/gitweb/?p=coreutils.git;a=blob;f=NEWS;h=3d19c3bad44f7d21446561449abd07f3794ff0c0;hb=HEAD#l171

This removes all the uses of `cp -n` I found at a glance.

Supersedes #236057

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes (or backporting 23.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
