### PR TITLE
nixos/azure-image: support other platforms on Generation 2 VMs

### DIFF
--- a/nixos/modules/virtualisation/azure-agent.nix
+++ b/nixos/modules/virtualisation/azure-agent.nix
@@ -33,15 +33,11 @@ in
 
   ###### implementation
 
-  config = lib.mkIf cfg.enable {
-    assertions = [{
-      assertion = pkgs.stdenv.hostPlatform.isx86;
-      message = "Azure not currently supported on ${pkgs.stdenv.hostPlatform.system}";
-    }
-      {
-        assertion = config.networking.networkmanager.enable == false;
-        message = "Windows Azure Linux Agent is not compatible with NetworkManager";
-      }];
+  config = mkIf cfg.enable {
+    assertions = singleton {
+      assertion = config.networking.networkmanager.enable == false;
+      message = "Windows Azure Linux Agent is not compatible with NetworkManager";
+    };
 
     boot.initrd.kernelModules = [ "ata_piix" ];
     networking.firewall.allowedUDPPorts = [ 68 ];

--- a/nixos/modules/virtualisation/azure-image.nix
+++ b/nixos/modules/virtualisation/azure-image.nix
@@ -16,6 +16,14 @@ in
         Size of disk image. Unit is MB.
       '';
     };
+    virtualisation.azureImage.efiSupport = mkOption {
+      type = types.bool;
+      default = !pkgs.stdenv.hostPlatform.isx86;
+      example = true;
+      description = lib.mdDoc ''
+        Whether to enable EFI support for Generation 2 VMs. Defaults to true for non-x86 platforms.
+      '';
+    };
   };
   config = {
     system.build.azureImage = import ../../lib/make-disk-image.nix {
@@ -26,6 +34,7 @@ in
       '';
       configFile = ./azure-config-user.nix;
       format = "raw";
+      partitionTableType = if cfg.efiSupport then "efi" else "legacy";
       inherit (cfg) diskSize;
       inherit config lib pkgs;
     };


### PR DESCRIPTION
###### Description of changes

Azure now officially supports Ampere Arm-based processors (aarch64-linux). Stop ruling out platforms just because they are not x86.

Edit: ~~The aarch64-linux azure image doesn't build yet, GRUB fails to install. Though not a blocker for the PR.~~
```
installing the GRUB 2 boot loader on /dev/sda...
Installing for arm64-efi platform.
/nix/store/v25ypi8bj8ahg1l9vsba6mcyl12wp406-grub-2.06/sbin/grub-install: error: cannot find EFI directory.
/nix/store/r6ylj08m017dr1iqamxv4sgasvfg2v8m-install-grub.pl: installation of GRUB on /dev/sda failed: No such file or directory
```

Edit: Now it builds and boots on Azure after enabling EFI support.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes (or backporting 23.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
