### PR TITLE
nixos/exim: apply privilege restrictions

### DIFF
--- a/nixos/modules/services/mail/exim.nix
+++ b/nixos/modules/services/mail/exim.nix
@@ -116,8 +116,8 @@ in
       wantedBy = [ "multi-user.target" ];
       restartTriggers = [ config.environment.etc."exim.conf".source ];
       serviceConfig = {
-        ExecStart   = "+${cfg.package}/bin/exim -bdf -q${cfg.queueRunnerInterval}";
-        ExecReload  = "+${coreutils}/bin/kill -HUP $MAINPID";
+        ExecStart   = "!${cfg.package}/bin/exim -bdf -q${cfg.queueRunnerInterval}";
+        ExecReload  = "!${coreutils}/bin/kill -HUP $MAINPID";
         User        = cfg.user;
       };
       preStart = ''


### PR DESCRIPTION
Since 816614bd62b, the service is set to use the exim user so that
systemd takes care of the credentials ownership. The executable is
still required to run as root, to then drop privileges. The prefix '+'
that was used however interfers with the use of privilege restrictions
and other sandboxing options. Since we only want to escape the "User"
setting, we can use the '!' prefix instead.
