### PR TITLE
treewide: unset verifyCargoDeps

### DIFF
--- a/pkgs/applications/blockchains/solana-validator/default.nix
+++ b/pkgs/applications/blockchains/solana-validator/default.nix
@@ -4,15 +4,10 @@
 , fetchFromGitHub
 , lib
 , rustPlatform
-, IOKit
-, Security
-, AppKit
 , pkg-config
 , udev
 , zlib
 , protobuf
-, clang
-, llvm
 , openssl
 , libclang
 , rustfmt
@@ -63,7 +58,6 @@ rustPlatform.buildRustPackage rec {
 
   # partly inspired by https://github.com/obsidiansystems/solana-bridges/blob/develop/default.nix#L29
   inherit cargoSha256;
-  verifyCargoDeps = true;
 
   cargoBuildFlags = builtins.map (n: "--bin=${n}") solanaPkgs;
 

--- a/pkgs/applications/blockchains/solana/default.nix
+++ b/pkgs/applications/blockchains/solana/default.nix
@@ -60,7 +60,6 @@ rustPlatform.buildRustPackage rec {
   };
 
   strictDeps = true;
-  verifyCargoDeps = true;
   cargoBuildFlags = builtins.map (n: "--bin=${n}") solanaPkgs;
 
   # Even tho the tests work, a shit ton of them try to connect to a local RPC

--- a/pkgs/development/compilers/elm/packages/elm-test-rs.nix
+++ b/pkgs/development/compilers/elm/packages/elm-test-rs.nix
@@ -17,7 +17,6 @@ rustPlatform.buildRustPackage rec {
   ]);
 
   cargoSha256 = "sha256:1dpdlzv96kpc25yf5jgsz9qldghyw35x382qpxhkadkn5dryzjvd";
-  verifyCargoDeps = true;
 
   # Tests perform networking and therefore can't work in sandbox
   doCheck = false;

--- a/pkgs/development/tools/rust/cargo-workspaces/default.nix
+++ b/pkgs/development/tools/rust/cargo-workspaces/default.nix
@@ -5,7 +5,6 @@
 , openssl
 , zlib
 , stdenv
-, darwin
 , libssh2
 , libgit2
 , IOKit
@@ -25,7 +24,6 @@ rustPlatform.buildRustPackage rec {
   };
 
   cargoSha256 = "sha256-wUVNsUx7JS5icjxbz3CV1lNUvuuL+gTL2QzuE+030WU=";
-  verifyCargoDeps = true;
 
   # needed to get libssh2/libgit2 to link properly
   LIBGIT2_SYS_USE_PKG_CONFIG = true;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -36050,9 +36050,7 @@ with pkgs;
 
   solana-cli = callPackage ../applications/blockchains/solana { };
 
-  solana-validator = callPackage ../applications/blockchains/solana-validator {
-    inherit (darwin.apple_sdk.frameworks) IOKit Security AppKit;
-  };
+  solana-validator = callPackage ../applications/blockchains/solana-validator { };
 
   snarkos = callPackage ../applications/blockchains/snarkos {
     inherit (darwin.apple_sdk.frameworks) Security;


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes (or backporting 23.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
