### PR TITLE
nixos/public-inbox: remove spamassassin integration

### DIFF
--- a/nixos/modules/services/mail/public-inbox.nix
+++ b/nixos/modules/services/mail/public-inbox.nix
@@ -303,6 +303,22 @@ in
             };
           };
         };
+        options.publicinboxmda.spamcheck = mkOption {
+          type = with types; enum [ "spamc" "none" ];
+          default = "none";
+          description = lib.mdDoc ''
+            If set to spamc, {manpage}`public-inbox-watch(1)` will filter spam
+            using SpamAssassin. This is currently not working in NixOS.
+          '';
+        };
+        options.publicinboxwatch.spamcheck = mkOption {
+          type = with types; enum [ "spamc" "none" ];
+          default = "none";
+          description = lib.mdDoc ''
+            If set to spamc, {manpage}`public-inbox-watch(1)` will filter spam
+            using SpamAssassin. This is currently not working in NixOS.
+          '';
+        };
         options.publicinboxwatch.watchspam = mkOption {
           type = with types; nullOr str;
           default = null;

--- a/nixos/modules/services/mail/public-inbox.nix
+++ b/nixos/modules/services/mail/public-inbox.nix
@@ -9,9 +9,6 @@ let
   gitIni = pkgs.formats.gitIni { listsAsDuplicateKeys = true; };
   iniAtom = elemAt gitIni.type/*attrsOf*/.functor.wrapped/*attrsOf*/.functor.wrapped/*either*/.functor.wrapped 0;
 
-  useSpamAssassin = cfg.settings.publicinboxmda.spamcheck == "spamc" ||
-                    cfg.settings.publicinboxwatch.spamcheck == "spamc";
-
   publicInboxDaemonOptions = proto: defaultPort: {
     args = mkOption {
       type = with types; listOf str;
@@ -258,12 +255,6 @@ in
     nntp = {
       enable = mkEnableOption (lib.mdDoc "the public-inbox NNTP server");
     } // publicInboxDaemonOptions "nntp" 563;
-    spamAssassinRules = mkOption {
-      type = with types; nullOr path;
-      default = "${cfg.package.sa_config}/user/.spamassassin/user_prefs";
-      defaultText = literalExpression "\${cfg.package.sa_config}/user/.spamassassin/user_prefs";
-      description = lib.mdDoc "SpamAssassin configuration specific to public-inbox.";
-    };
     settings = mkOption {
       description = lib.mdDoc ''
         Settings for the [public-inbox config file](https://public-inbox.org/public-inbox-config.html).
@@ -312,22 +303,6 @@ in
             };
           };
         };
-        options.publicinboxmda.spamcheck = mkOption {
-          type = with types; enum [ "spamc" "none" ];
-          default = "none";
-          description = lib.mdDoc ''
-            If set to spamc, {manpage}`public-inbox-watch(1)` will filter spam
-            using SpamAssassin.
-          '';
-        };
-        options.publicinboxwatch.spamcheck = mkOption {
-          type = with types; enum [ "spamc" "none" ];
-          default = "none";
-          description = lib.mdDoc ''
-            If set to spamc, {manpage}`public-inbox-watch(1)` will filter spam
-            using SpamAssassin.
-          '';
-        };
         options.publicinboxwatch.watchspam = mkOption {
           type = with types; nullOr str;
           default = null;
@@ -357,25 +332,6 @@ in
     openFirewall = mkEnableOption (lib.mdDoc "opening the firewall when using a port option");
   };
   config = mkIf cfg.enable {
-    assertions = [
-      { assertion = config.services.spamassassin.enable || !useSpamAssassin;
-        message = ''
-          public-inbox is configured to use SpamAssassin, but
-          services.spamassassin.enable is false.  If you don't need
-          spam checking, set `services.public-inbox.settings.publicinboxmda.spamcheck' and
-          `services.public-inbox.settings.publicinboxwatch.spamcheck' to null.
-        '';
-      }
-      { assertion = cfg.path != [] || !useSpamAssassin;
-        message = ''
-          public-inbox is configured to use SpamAssassin, but there is
-          no spamc executable in services.public-inbox.path.  If you
-          don't need spam checking, set
-          `services.public-inbox.settings.publicinboxmda.spamcheck' and
-          `services.public-inbox.settings.publicinboxwatch.spamcheck' to null.
-        '';
-      }
-    ];
     services.public-inbox.settings =
       filterAttrsRecursive (n: v: v != null) {
         publicinbox = mapAttrs (n: filterAttrs (n: v: n != "description")) cfg.inboxes;
@@ -514,8 +470,7 @@ in
         { public-inbox-watch = mkMerge [(serviceConfig "watch") {
           inherit (cfg) path;
           wants = [ "public-inbox-init.service" ];
-          requires = [ "public-inbox-init.service" ] ++
-            optional (cfg.settings.publicinboxwatch.spamcheck == "spamc") "spamassassin.service";
+          requires = [ "public-inbox-init.service" ];
           wantedBy = [ "multi-user.target" ];
           serviceConfig = {
             ExecStart = "${cfg.package}/bin/public-inbox-watch";
@@ -533,11 +488,6 @@ in
           script = ''
             set -ux
             install -D -p ${PI_CONFIG} ${stateDir}/.public-inbox/config
-            '' + optionalString useSpamAssassin ''
-              install -m 0700 -o spamd -d ${stateDir}/.spamassassin
-              ${optionalString (cfg.spamAssassinRules != null) ''
-                ln -sf ${cfg.spamAssassinRules} ${stateDir}/.spamassassin/user_prefs
-              ''}
             '' + concatStrings (mapAttrsToList (name: inbox: ''
               if [ ! -e ${stateDir}/inboxes/${escapeShellArg name} ]; then
                 # public-inbox-init creates an inbox and adds it to a config file.


### PR DESCRIPTION
###### Description of changes

This hasn't worked since before this module ended up in Nixpkgs, because public-inbox-init runs as the public-inbox user, but tries to install -o spamd.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes (or backporting 23.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
