### PR TITLE
anilibrix: init at 1.4.3

### DIFF
--- a/pkgs/applications/video/anilibrix/default.nix
+++ b/pkgs/applications/video/anilibrix/default.nix
@@ -1,0 +1,123 @@
+{ stdenv
+, lib
+, fetchYarnDeps
+, makeWrapper
+, makeDesktopItem
+, copyDesktopItems
+, fixup_yarn_lock
+, yarn
+, desktopToDarwinBundle
+, fetchFromGitHub
+, electron
+, nodejs
+, python3
+, icoutils
+}:
+
+stdenv.mkDerivation rec {
+  pname = "anilibrix";
+  version = "1.4.3";
+
+  src = fetchFromGitHub {
+    owner = "pavloniym";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "sha256-qi48sdkLDZQZo1FDvdWc7iBBM7v6tANRrNZMDTdRlwM=";
+  };
+
+  offlineCache = fetchYarnDeps {
+    yarnLock = "${src}/yarn.lock";
+    hash = "sha256-P7t+Q1SVoLV1Xdl0ecMpodLo/3/dNO0+zn2Mrs0l/3c=";
+  };
+
+  nativeBuildInputs = [
+    copyDesktopItems
+    fixup_yarn_lock
+    makeWrapper
+    nodejs
+    nodejs.pkgs.node-gyp
+    python3
+    yarn
+    icoutils
+  ] ++ lib.optional stdenv.isDarwin desktopToDarwinBundle;
+
+  configurePhase = ''
+    runHook preConfigure
+
+    cp .env.example .env
+    # wwnd.space is official api mirror without cloudflare
+    echo API_ENDPOINT_URL=https://wwnd.space/ >> .env
+    echo STATIC_ENDPOINT_URL=https://static.wwnd.space/ >> .env
+    echo NODE_ENV=production >> .env
+
+    export HOME="$TMPDIR"
+    yarn config --offline set yarn-offline-mirror "$offlineCache"
+    fixup_yarn_lock yarn.lock
+    yarn install --offline --frozen-lockfile --ignore-platform --ignore-scripts --no-progress --non-interactive
+    patchShebangs node_modules/
+
+    runHook postConfigure
+  '';
+
+  buildPhase = ''
+    runHook preBuild
+
+    export NODE_ENV=production
+
+    pushd node_modules/fibers/
+    node build
+    popd
+
+    yarn --offline run build
+
+    yarn --offline run electron-builder --dir \
+      -c.electronDist=${electron}/lib/electron \
+      -c.electronVersion=${electron.version}
+
+    runHook postBuild
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p "$out/share/lib/anilibrix"
+    cp -r release/*-unpacked/{locales,resources{,.pak}} "$out/share/lib/anilibrix"
+
+    icotool -x ${src}/build/icons/app/anilibria.ico
+
+    for s in 256 128 64 48 32 16; do
+      install -Dm644 anilibria_*_"$s"x"$s"x32.png "$out"/share/icons/hicolor/"$s"x"$s"/apps/anilibrix.png
+    done
+
+    install -Dm644 ${src}/build/icons/app/anilibria.svg "$out/share/icons/hicolor/scalable/apps/anilibrix.svg"
+
+    makeWrapper '${electron}/bin/electron' "$out/bin/anilibrix" \
+      --add-flags "$out/share/lib/anilibrix/resources/app.asar" \
+      --add-flags "\''${NIXOS_OZONE_WL:+\''${WAYLAND_DISPLAY:+--ozone-platform-hint=auto --enable-features=WaylandWindowDecorations}}" \
+      --inherit-argv0
+
+    runHook postInstall
+  '';
+
+  desktopItems =
+    [
+      (makeDesktopItem {
+        name = pname;
+        exec = "${pname} %U";
+        desktopName = "AniLibriX";
+        comment = meta.description;
+        genericName = "AniLibria desktop client";
+        icon = pname;
+        categories = [ "AudioVideo" "Player" "Video" ];
+        keywords = [ "anime" "anilibria" ];
+      })
+    ];
+
+  meta = with lib; {
+    description = "Anilibria desktop movie app";
+    homepage = "https://anilibria.app/app/anilibrix";
+    maintainers = with maintainers; [ _3JlOy-PYCCKUi ];
+    license = licenses.mit;
+    inherit (electron.meta) platforms;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -250,6 +250,12 @@ with pkgs;
 
   ani-cli = callPackage ../applications/video/ani-cli { };
 
+  anilibrix = callPackage ../applications/video/anilibrix {
+    nodejs = nodejs_14;
+    yarn = yarn.override { nodejs = nodejs_14; };
+    electron = electron_15;
+  };
+
   dra-cla = callPackage ../applications/video/dra-cla { };
 
   anime-downloader = callPackage ../applications/video/anime-downloader { };


### PR DESCRIPTION
###### Description of changes

[AniLibrix](https://github.com/pavloniym/anilibrix) is Anilibria's desktop anime movie theater for computer.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes (or backporting 23.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

```sh
$ NIXPKGS_ALLOW_INSECURE=1 nixpkgs-review rev HEAD
```
Result of `nixpkgs-review` run on x86_64-linux [1](https://github.com/Mic92/nixpkgs-review)
<details>
  <summary>1 package built:</summary>
  <ul>
    <li>anilibrix</li>
  </ul>
</details>

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
