### PR TITLE
gitlab: 16.0.1 -> 16.0.2

### DIFF
--- a/pkgs/applications/version-management/gitlab/data.json
+++ b/pkgs/applications/version-management/gitlab/data.json
@@ -1,14 +1,14 @@
 {
-  "version": "16.0.1",
-  "repo_hash": "sha256-TApZSavGA361Pue0u21Der6CUABhp/hwewUe9YExLAs=",
+  "version": "16.0.2",
+  "repo_hash": "sha256-qAwO/5eyyYdpwSUg3lC8jOFoBc8H6yhgiHUbx+Ww6Uc=",
   "yarn_hash": "0yy04jnfvn5dgciqd105xiwg7chjwp3w6iqbjpylak9h82ci6wlh",
   "owner": "gitlab-org",
   "repo": "gitlab",
-  "rev": "v16.0.1-ee",
+  "rev": "v16.0.2-ee",
   "passthru": {
-    "GITALY_SERVER_VERSION": "16.0.1",
-    "GITLAB_PAGES_VERSION": "16.0.1",
+    "GITALY_SERVER_VERSION": "16.0.2",
+    "GITLAB_PAGES_VERSION": "16.0.2",
     "GITLAB_SHELL_VERSION": "14.20.0",
-    "GITLAB_WORKHORSE_VERSION": "16.0.1"
+    "GITLAB_WORKHORSE_VERSION": "16.0.2"
   }
 }

--- a/pkgs/applications/version-management/gitlab/gitaly/default.nix
+++ b/pkgs/applications/version-management/gitlab/gitaly/default.nix
@@ -13,7 +13,7 @@
 }:
 
 let
-  version = "16.0.1";
+  version = "16.0.2";
   package_version = "v${lib.versions.major version}";
   gitaly_package = "gitlab.com/gitlab-org/gitaly/${package_version}";
 
@@ -24,7 +24,7 @@ let
       owner = "gitlab-org";
       repo = "gitaly";
       rev = "v${version}";
-      sha256 = "sha256-2OlCjwcJ0RydbKI15X4wZ20XVclC44McNig95UndDGg=";
+      sha256 = "sha256-dtGtWV+lfTp9pKipAHx3FUIPaUobiRLsKYbULpuIgRY=";
     };
 
     vendorSha256 = "sha256-KBhTI70eReZGSd7RxwGXcUGa0wDo7q5tU9fUhrLeFO0=";

--- a/pkgs/applications/version-management/gitlab/gitlab-pages/default.nix
+++ b/pkgs/applications/version-management/gitlab/gitlab-pages/default.nix
@@ -2,13 +2,13 @@
 
 buildGoModule rec {
   pname = "gitlab-pages";
-  version = "16.0.1";
+  version = "16.0.2";
 
   src = fetchFromGitLab {
     owner = "gitlab-org";
     repo = "gitlab-pages";
     rev = "v${version}";
-    sha256 = "sha256-RbsPWc3Dc/rMLnSID0dZmHMg3+uK91kI+DXBYPSy81w=";
+    sha256 = "sha256-AUX6JIkElYZHjy/RFBVXRb3ZnbWkaNyApZNMT6zsBAU=";
   };
 
   vendorHash = "sha256-s3HHoz9URACuVVhePQQFviTqlQU7vCLOjTJPBlus1Vo=";

--- a/pkgs/applications/version-management/gitlab/gitlab-workhorse/default.nix
+++ b/pkgs/applications/version-management/gitlab/gitlab-workhorse/default.nix
@@ -5,7 +5,7 @@ in
 buildGoModule rec {
   pname = "gitlab-workhorse";
 
-  version = "16.0.1";
+  version = "16.0.2";
 
   src = fetchFromGitLab {
     owner = data.owner;


### PR DESCRIPTION
`release-22.11` backport in #236153

###### Description of changes

https://gitlab.com/gitlab-org/gitlab/-/blob/v16.0.2-ee/CHANGELOG.md

Fixes [CVE-2023-2442](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2023-2442)
Fixes [CVE-2023-2199](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2023-2199)
Fixes [CVE-2023-2198](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2023-2198)
Fixes [CVE-2023-2132](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2023-2132)
Fixes [CVE-2023-0121](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2023-0121)
Fixes [CVE-2023-2589](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2023-2589)
Fixes [CVE-2023-2015](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2023-2015)
Fixes [CVE-2023-2485](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2023-2485)
Fixes [CVE-2023-2001](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2023-2001)
Fixes [CVE-2023-0921](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2023-0921)
Fixes [CVE-2023-1204](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2023-1204)
Fixes [CVE-2023-0508](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2023-0508)
Fixes [CVE-2023-1825](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2023-1825)
Fixes [CVE-2023-2013](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2023-2013)



<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes (or backporting 23.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
