### PR TITLE
[22.11] gitlab: 15.11.6 -> 15.11.7

### DIFF
--- a/pkgs/applications/version-management/gitlab/data.json
+++ b/pkgs/applications/version-management/gitlab/data.json
@@ -1,14 +1,14 @@
 {
-  "version": "15.11.6",
-  "repo_hash": "sha256-qpYVYzxtMgWLXhMn+0TvDqRJOnerfc9OEU1Gs6Ys/Bc=",
+  "version": "15.11.7",
+  "repo_hash": "sha256-F9oo4eh+steQTKsUT5TGPa0QIRhbOd9xl8tm20p8Qus=",
   "yarn_hash": "02ipm7agjy3c75df76c00k3qq5gpw3d876f6x91xnwizswsv9agb",
   "owner": "gitlab-org",
   "repo": "gitlab",
-  "rev": "v15.11.6-ee",
+  "rev": "v15.11.7-ee",
   "passthru": {
-    "GITALY_SERVER_VERSION": "15.11.6",
-    "GITLAB_PAGES_VERSION": "15.11.6",
+    "GITALY_SERVER_VERSION": "15.11.7",
+    "GITLAB_PAGES_VERSION": "15.11.7",
     "GITLAB_SHELL_VERSION": "14.18.0",
-    "GITLAB_WORKHORSE_VERSION": "15.11.6"
+    "GITLAB_WORKHORSE_VERSION": "15.11.7"
   }
 }

--- a/pkgs/applications/version-management/gitlab/gitaly/default.nix
+++ b/pkgs/applications/version-management/gitlab/gitaly/default.nix
@@ -11,7 +11,7 @@ let
     gemdir = ./.;
   };
 
-  version = "15.11.6";
+  version = "15.11.7";
   package_version = "v${lib.versions.major version}";
   gitaly_package = "gitlab.com/gitlab-org/gitaly/${package_version}";
 
@@ -22,7 +22,7 @@ let
       owner = "gitlab-org";
       repo = "gitaly";
       rev = "v${version}";
-      sha256 = "sha256-n56Jqgu64+pN4bcH/Sh8/+4StpTEY529a4yVozqtK5Y=";
+      sha256 = "sha256-bgqyrI9HhctFHsQcKq1PA+bHujljUhyZHwrnhn0NItI=";
     };
 
     vendorSha256 = "sha256-gJelagGPogeCdJtRpj4RaYlqzZRhtU0EIhmj1aK4ZOk=";

--- a/pkgs/applications/version-management/gitlab/gitlab-workhorse/default.nix
+++ b/pkgs/applications/version-management/gitlab/gitlab-workhorse/default.nix
@@ -5,7 +5,7 @@ in
 buildGoModule rec {
   pname = "gitlab-workhorse";
 
-  version = "15.11.6";
+  version = "15.11.7";
 
   src = fetchFromGitLab {
     owner = data.owner;


### PR DESCRIPTION
###### Description of changes

https://gitlab.com/gitlab-org/gitlab/-/blob/v16.0.2-ee/CHANGELOG.md

Fixes [CVE-2023-2442](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2023-2442)
Fixes [CVE-2023-2199](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2023-2199)
Fixes [CVE-2023-2198](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2023-2198)
Fixes [CVE-2023-2132](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2023-2132)
Fixes [CVE-2023-0121](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2023-0121)
Fixes [CVE-2023-2589](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2023-2589)
Fixes [CVE-2023-2015](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2023-2015)
Fixes [CVE-2023-2485](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2023-2485)
Fixes [CVE-2023-2001](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2023-2001)
Fixes [CVE-2023-0921](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2023-0921)
Fixes [CVE-2023-1204](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2023-1204)
Fixes [CVE-2023-0508](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2023-0508)
Fixes [CVE-2023-1825](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2023-1825)
Fixes [CVE-2023-2013](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2023-2013)

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes (or backporting 23.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
