### PR TITLE
mididings: (re-)init at unstable-2023-02-03

### DIFF
--- a/pkgs/development/python-modules/mididings/default.nix
+++ b/pkgs/development/python-modules/mididings/default.nix
@@ -1,0 +1,90 @@
+{ lib
+, buildPythonPackage
+, python
+, fetchFromGitHub
+, pkg-config
+, alsa-lib
+, boost
+, decorator
+, glib
+, just
+, libjack2
+, scdoc
+
+, withOptionalDependencies ? false
+
+# optional-dependencies
+, pyliblo
+, tkinter
+, dbus-python
+, pyinotify
+, pysmf
+, pyxdg
+}:
+
+buildPythonPackage rec {
+  version = "unstable-2023-02-03";
+  pname = "mididings";
+
+  src = fetchFromGitHub {
+    owner = "mididings";
+    repo = "mididings";
+    rev = "199931b64740cc5f7bc69633349ac3c0e463eca2";
+    hash = "sha256-dbFuUWeyOm1vJWeB6We8B+AQU7CLK+Rfo+EKdr1AtNU=";
+  };
+
+  postPatch = with lib.versions; ''
+    substituteInPlace setup.py \
+      --replace boost_python "boost_python${major python.version}${minor python.version}"
+    substituteInPlace justfile \
+      --replace '/usr/bin/env bash' "$SHELL"
+  '';
+
+  preBuild = ''
+    just build-manpages
+  '';
+
+  nativeBuildInputs = [
+    just
+    pkg-config
+    scdoc
+  ];
+  buildInputs = [
+    glib
+    alsa-lib
+    libjack2
+    boost
+  ];
+  propagatedBuildInputs = [
+    decorator
+  ] ++ lib.optionals withOptionalDependencies (
+    lib.flatten (lib.attrValues passthru.optional-dependencies)
+  );
+
+  passthru.optional-dependencies = {
+    livedings = [
+      pyliblo
+      tkinter
+    ];
+    mididings-extra = [
+      dbus-python
+      pyinotify
+    ];
+    smf = [
+      pysmf
+    ];
+    xdg = [
+      pyxdg
+    ];
+  };
+
+  nativeCheckInputs = lib.flatten (lib.attrValues passthru.optional-dependencies);
+
+  meta = with lib; {
+    description = "A MIDI router and processor based on Python, supporting ALSA and JACK MIDI";
+    homepage = "https://github.com/mididings/mididings";
+    license = licenses.gpl2;
+    maintainers = with maintainers; [ ris ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/aliases.nix
+++ b/pkgs/top-level/aliases.nix
@@ -1036,7 +1036,6 @@ mapAliases ({
   metal = throw "metal has been removed due to lack of maintainers";
   metricbeat6 = throw "metricbeat6 has been removed because it reached end of life"; # Added 2022-10-04
   microsoft_gsl = microsoft-gsl; # Added 2023-05-26
-  mididings = throw "mididings has been removed from nixpkgs as it doesn't support recent python3 versions and its upstream stopped maintaining it"; # Added 2022-01-12
   midoriWrapper = throw "'midoriWrapper' has been renamed to/replaced by 'midori'"; # Converted to throw 2022-02-22
   mime-types = mailcap; # Added 2022-01-21
   mimms = throw "mimms has been removed from nixpkgs as the upstream project is stuck on python2"; # Added 2022-01-01

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1666,6 +1666,10 @@ with pkgs;
 
   memos = callPackage ../servers/memos { };
 
+  mididings = with python3.pkgs; toPythonApplication (mididings.override {
+    withOptionalDependencies = true;
+  });
+
   midimonster = callPackage ../tools/audio/midimonster { };
 
   midi-trigger = callPackage ../applications/audio/midi-trigger { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -6224,6 +6224,8 @@ self: super: with self; {
 
   microdata = callPackage ../development/python-modules/microdata { };
 
+  mididings = callPackage ../development/python-modules/mididings { };
+
   midiutil = callPackage ../development/python-modules/midiutil { };
 
   mido = callPackage ../development/python-modules/mido { };


### PR DESCRIPTION
###### Description of changes
mididings has a new upstream fork/maintainer @ https://github.com/mididings/mididings

Based on a reversion of commit 03ddc5b29511cbedeff6fe49951ad6ed80b36c65.

This time I've made it principally a pythonPackage, with an application variant including all the optional dependencies.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes (or backporting 23.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
