### PR TITLE
mod_tile: testing enabled

### DIFF
--- a/pkgs/servers/http/apache-modules/mod_tile/default.nix
+++ b/pkgs/servers/http/apache-modules/mod_tile/default.nix
@@ -50,16 +50,16 @@ stdenv.mkDerivation rec {
   ];
 
   # the install script wants to install mod_tile.so into apache's modules dir
+  # also mapnik pkg-config config is missing this patch: https://github.com/mapnik/mapnik/commit/692c2faa0ef168a8c908d262c2bbfe51a74a8336.patch
   postPatch = ''
     sed -i "s|\''${HTTPD_MODULES_DIR}|$out/modules|" CMakeLists.txt
+    sed -i -e "s|@MAPNIK_FONTS_DIR@|$(mapnik-config --fonts)|" -e "s|@MAPNIK_PLUGINS_DIR@|$(mapnik-config --input-plugins)|" tests/renderd.conf.in
   '';
 
   enableParallelBuilding = true;
 
-  # We need to either disable the `render_speedtest` and `download_tile` tests
-  # or fix the URLs they try to download from
-  #cmakeFlags = [ "-DENABLE_TESTS=1" ];
-  #doCheck = true;
+  cmakeFlags = [ "-DENABLE_TESTS=1" ];
+  doCheck = true;
 
   meta = with lib; {
     homepage = "https://github.com/openstreetmap/mod_tile";


### PR DESCRIPTION
###### Description of changes
It looks like the commit used to build `mapnik` was just missing [some additional variable definitions in `libmapnik.pc`](https://github.com/mapnik/mapnik/commit/692c2faa0ef168a8c908d262c2bbfe51a74a8336) which are relied upon by the commit used to build `mod_tile`, so I have added them with a `postPatch` command.



<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes (or backporting 23.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
