### PR TITLE
composable_kernel: revert split output workaround

### DIFF
--- a/pkgs/development/libraries/composable_kernel/default.nix
+++ b/pkgs/development/libraries/composable_kernel/default.nix
@@ -13,104 +13,74 @@
 , gpuTargets ? [ ] # gpuTargets = [ "gfx803" "gfx900" "gfx1030" ... ]
 }:
 
-let
-  # This is now over 3GB, to allow hydra caching we separate it
-  ck = stdenv.mkDerivation (finalAttrs: {
-    pname = "composable_kernel";
-    version = "unstable-2023-01-16";
+stdenv.mkDerivation (finalAttrs: {
+  pname = "composable_kernel";
+  version = "unstable-2023-01-16";
 
-    outputs = [
-      "out"
-    ] ++ lib.optionals buildTests [
-      "test"
-    ] ++ lib.optionals buildExamples [
-      "example"
-    ];
+  outputs = [
+    "out"
+  ] ++ lib.optionals buildTests [
+    "test"
+  ] ++ lib.optionals buildExamples [
+    "example"
+  ];
 
-    # ROCm 5.6 should release composable_kernel as stable with a tag in the future
-    src = fetchFromGitHub {
-      owner = "ROCmSoftwarePlatform";
-      repo = "composable_kernel";
-      rev = "80e05267417f948e4f7e63c0fe807106d9a0c0ef";
-      hash = "sha256-+c0E2UtlG/abweLwCWWjNHDO5ZvSIVKwwwettT9mqR4=";
-    };
+  # ROCm 5.6 should release composable_kernel as stable with a tag in the future
+  src = fetchFromGitHub {
+    owner = "ROCmSoftwarePlatform";
+    repo = "composable_kernel";
+    rev = "80e05267417f948e4f7e63c0fe807106d9a0c0ef";
+    hash = "sha256-+c0E2UtlG/abweLwCWWjNHDO5ZvSIVKwwwettT9mqR4=";
+  };
 
-    nativeBuildInputs = [
-      cmake
-      rocm-cmake
-      hip
-      clang-tools-extra
-    ];
+  nativeBuildInputs = [
+    cmake
+    rocm-cmake
+    hip
+    clang-tools-extra
+  ];
 
-    buildInputs = [
-      openmp
-    ];
+  buildInputs = [
+    openmp
+  ];
 
-    cmakeFlags = [
-      "-DCMAKE_C_COMPILER=hipcc"
-      "-DCMAKE_CXX_COMPILER=hipcc"
-    ] ++ lib.optionals (gpuTargets != [ ]) [
-      "-DGPU_TARGETS=${lib.concatStringsSep ";" gpuTargets}"
-      "-DAMDGPU_TARGETS=${lib.concatStringsSep ";" gpuTargets}"
-    ] ++ lib.optionals buildTests [
-      "-DGOOGLETEST_DIR=${gtest.src}" # Custom linker names
-    ];
+  cmakeFlags = [
+    "-DCMAKE_C_COMPILER=hipcc"
+    "-DCMAKE_CXX_COMPILER=hipcc"
+  ] ++ lib.optionals (gpuTargets != [ ]) [
+    "-DGPU_TARGETS=${lib.concatStringsSep ";" gpuTargets}"
+    "-DAMDGPU_TARGETS=${lib.concatStringsSep ";" gpuTargets}"
+  ] ++ lib.optionals buildTests [
+    "-DGOOGLETEST_DIR=${gtest.src}" # Custom linker names
+  ];
 
-    # No flags to build selectively it seems...
-    postPatch = lib.optionalString (!buildTests) ''
-      substituteInPlace CMakeLists.txt \
-        --replace "add_subdirectory(test)" ""
-    '' + lib.optionalString (!buildExamples) ''
-      substituteInPlace CMakeLists.txt \
-        --replace "add_subdirectory(example)" ""
-    '';
+  # No flags to build selectively it seems...
+  postPatch = lib.optionalString (!buildTests) ''
+    substituteInPlace CMakeLists.txt \
+      --replace "add_subdirectory(test)" ""
+  '' + lib.optionalString (!buildExamples) ''
+    substituteInPlace CMakeLists.txt \
+      --replace "add_subdirectory(example)" ""
+  '';
 
-    postInstall = lib.optionalString buildTests ''
-      mkdir -p $test/bin
-      mv $out/bin/test_* $test/bin
-    '' + lib.optionalString buildExamples ''
-      mkdir -p $example/bin
-      mv $out/bin/example_* $example/bin
-    '';
-
-    passthru.updateScript = unstableGitUpdater { };
-
-    # Times out otherwise
-    requiredSystemFeatures = [ "big-parallel" ];
-
-    meta = with lib; {
-      description = "Performance portable programming model for machine learning tensor operators";
-      homepage = "https://github.com/ROCmSoftwarePlatform/composable_kernel";
-      license = with licenses; [ mit ];
-      maintainers = teams.rocm.members;
-      platforms = platforms.linux;
-    };
-  });
-
-in stdenv.mkDerivation {
-  inherit (ck) pname version outputs src passthru requiredSystemFeatures meta;
-
-  dontUnpack = true;
-  dontPatch = true;
-  dontConfigure = true;
-  dontBuild = true;
-
-  installPhase = ''
-    runHook preInstall
-
-    mkdir -p $out
-    cp -an ${ck}/* $out
-  '' + lib.optionalString buildTests ''
-    cp -a ${ck.test} $test
+  postInstall = lib.optionalString buildTests ''
+    mkdir -p $test/bin
+    mv $out/bin/test_* $test/bin
   '' + lib.optionalString buildExamples ''
-    cp -a ${ck.example} $example
-  '' + ''
-    runHook postInstall
+    mkdir -p $example/bin
+    mv $out/bin/example_* $example/bin
   '';
 
-  # Fix paths
-  preFixup = ''
-    substituteInPlace $out/lib/cmake/composable_kernel/*.cmake \
-      --replace "${ck}" "$out"
-  '';
-}
+  passthru.updateScript = unstableGitUpdater { };
+
+  # Times out otherwise
+  requiredSystemFeatures = [ "big-parallel" ];
+
+  meta = with lib; {
+    description = "Performance portable programming model for machine learning tensor operators";
+    homepage = "https://github.com/ROCmSoftwarePlatform/composable_kernel";
+    license = with licenses; [ mit ];
+    maintainers = teams.rocm.members;
+    platforms = platforms.linux;
+  };
+})


### PR DESCRIPTION
###### Description of changes

We discovered that the split output workaround doesn't actually help and over-complicates the derivation.

Unlike rocfft (which was failing because of size limits), this was failing because it was timing out, but that issue was fixed in #233179.

The only time `composable_kernel` was killed by an output limit, it was because of an indirect dependency (`rocm-llvm`): https://hydra.nixos.org/build/200097303.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes (or backporting 23.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
