### PR TITLE
ondir: init at 0.2.3

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -10372,6 +10372,12 @@
     github = "michaelBelsanti";
     githubId = 62124625;
   };
+  michaelCTS = {
+    email = "michael.vogel@cts.co";
+    name = "Michael Vogel";
+    github = "michaelCTS";
+    githubId = 132582212;
+  };
   michaelgrahamevans = {
     email = "michaelgrahamevans@gmail.com";
     name = "Michael Evans";

--- a/pkgs/tools/misc/ondir/default.nix
+++ b/pkgs/tools/misc/ondir/default.nix
@@ -1,0 +1,44 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+}:
+
+stdenv.mkDerivation {
+  pname = "ondir";
+  version = "0.2.3";
+
+  src = fetchFromGitHub {
+    owner = "alecthomas";
+    repo = "ondir";
+    rev = "cb2f9f8b21e336165fc0a310d677fda75c8e8513";
+    hash = "sha256-XTZKFIzJ3xL8ae3zG8nsMhGWvpvRUAQ2b6q/Q1QvGd0=";
+  };
+
+  installPhase = ''
+  runHook preInstall
+
+  make DESTDIR="$out" PREFIX= install
+  cp scripts.* $out
+
+  runHook postInstall
+  '';
+
+  meta = with lib; {
+    description = "a small program to automate tasks specific to certain directories";
+    longDescription = ''
+    It works by executing scripts in directories when you enter and leave them.
+    This is done by overriding the shell builtins cd, pushd, and popd,
+     which is a manual action.
+    The user is required to add a snippet to their shell initialisation file like .bashrc or .profile.
+
+    Which commands are executed on directory entry and leave is done
+     in predefined locations with a .ondirrc file.
+
+    See man ondir for more information
+    '';
+    homepage = "https://github.com/alecthomas/ondir/";
+    license = licenses.gpl2Only;
+    maintainers = [ maintainers.michaelCTS ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5687,6 +5687,8 @@ with pkgs;
 
   oil-buku = callPackage ../applications/misc/oil-buku { };
 
+  ondir = callPackage ../tools/misc/ondir { };
+
   osdlyrics = callPackage ../applications/audio/osdlyrics { };
 
   ossutil = callPackage ../tools/admin/ossutil { };


### PR DESCRIPTION
###### Description of changes

[ondir](https://github.com/alecthomas/ondir/) is an alternative to [direnv](https://direnv.net/) that allows executing commands on directory entry and exit. Unlike `direnv`, `ondir` doesn't execute the command or script in a subshell, but inserts the config into the running shell.  
This is done by the user manually overriding shell builtins `cd`, `pushd`, and `popd`. 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes (or backporting 23.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
