### PR TITLE
tfautomv: 0.5.1 -> 0.5.2

### DIFF
--- a/pkgs/applications/networking/cluster/tfautomv/default.nix
+++ b/pkgs/applications/networking/cluster/tfautomv/default.nix
@@ -5,21 +5,21 @@
 
 buildGoModule rec {
   pname = "tfautomv";
-  version = "0.5.1";
+  version = "0.5.2";
 
   src = fetchFromGitHub {
-    owner = "padok-team";
+    owner = "busser";
     repo = pname;
     rev = "v${version}";
-    hash = "sha256-shpoi/N/gfzisjj1tvZGSEuorqaoOJMhYOjx+Y8F/Ds=";
+    hash = "sha256-/Pli1gTG/68BtPdvF+BAwxFaeBrjj69h6Mtcbfm7UZ8=";
   };
 
-  vendorHash = "sha256-BjmtUamecTSwT7gHM/6uz1r/P8O0TWzp9Dk43rdmxXU=";
+  vendorHash = "sha256-zAshnSqZT9lx9EWvJsMwi6rqvhUWJ/3uJnk+44TGzlU=";
 
   ldflags = [ "-s" "-w" ];
 
   meta = with lib; {
-    homepage = "https://github.com/padok-team/tfautomv";
+    homepage = "https://github.com/busser/tfautomv";
     description = "When refactoring a Terraform codebase, you often need to write moved blocks. This can be tedious. Let tfautomv do it for you";
     license = licenses.asl20;
     maintainers = with maintainers; [ qjoly ];


### PR DESCRIPTION
###### Description of changes

https://github.com/busser/tfautomv/commit/3b34ea9343100db3471b5485e365909d9f67d755 Merge pull request https://github.com/busser/tfautomv/pull/47 from padok-team/arthur/readme-thanks
    https://github.com/busser/tfautomv/commit/c018ace022bf1ff721a8673f491c8390db7db194 chore(deps): update actions/configure-pages action to v3
    https://github.com/busser/tfautomv/commit/7cd421d3b66d5417baf2a113bb43d81dd3045f6c chore(deps): update actions/setup-go action to v4
    https://github.com/busser/tfautomv/commit/496f6681c4dc00aed96cbcbddd875fbb9d2115ad chore(deps): update autero1/action-terragrunt action to v1.3.1
    https://github.com/busser/tfautomv/commit/2752f48af10a5d8050ac2ca0417b75101cba7429 fix(deps): update module github.com/hashicorp/terraform-json to v0.16.0
    https://github.com/busser/tfautomv/commit/8b70fd0c1c14874cfd084e1545345601d59d9c9b recycle Transfer repository
    https://github.com/busser/tfautomv/commit/7dbbe19a5a17add01cc3ea256e4a8df036b04192 books Add Thanks section to README
    https://github.com/busser/tfautomv/commit/f5adc0f23b4058a5a1fd72680e0aa8d526e0de1c bookmark Release v0.5.2

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes (or backporting 23.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

