### PR TITLE
ocamlPackages.memtrace: init at 0.2.2

### DIFF
--- a/pkgs/development/ocaml-modules/memtrace/default.nix
+++ b/pkgs/development/ocaml-modules/memtrace/default.nix
@@ -1,0 +1,23 @@
+{ lib, buildDunePackage, fetchFromGitHub
+}:
+
+buildDunePackage rec {
+  pname = "memtrace";
+  version = "0.2.2";
+
+  src = fetchFromGitHub {
+    owner = "janestreet";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "sha256-y/Xz04CMFfRIzrDzGot16zEQsBMNc4J5s/q0VERcj04=";
+  };
+
+  duneVersion = "3";
+
+  meta = with lib; {
+    homepage = "https://github.com/janestreet/${pname}";
+    description = "Streaming client for OCaml's Memprof";
+    license = licenses.mit;
+    maintainers = with maintainers; [ niols ];
+  };
+}

--- a/pkgs/development/ocaml-modules/memtrace/default.nix
+++ b/pkgs/development/ocaml-modules/memtrace/default.nix
@@ -12,7 +12,7 @@ buildDunePackage rec {
     sha256 = "sha256-y/Xz04CMFfRIzrDzGot16zEQsBMNc4J5s/q0VERcj04=";
   };
 
-  duneVersion = "3";
+  minimalOCamlVersion = "4.11";
 
   meta = with lib; {
     homepage = "https://github.com/janestreet/${pname}";

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -936,6 +936,8 @@ let
 
     mec = callPackage ../development/ocaml-modules/mec { };
 
+    memtrace = callPackage ../development/ocaml-modules/memtrace { };
+
     menhir = callPackage ../development/ocaml-modules/menhir { };
 
     menhirLib = callPackage ../development/ocaml-modules/menhir/lib.nix { };


### PR DESCRIPTION
###### Description of changes

Streaming client for OCaml's Memprof

https://github.com/janestreet/memtrace/blob/v0.2.2/CHANGES.md

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [X] x86_64-darwin
  - [X] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes (or backporting 23.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
