### PR TITLE
opensycl: init at 0.9.4

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -17935,6 +17935,12 @@
     githubId = 73759599;
     name = "Yaya";
   };
+  yboettcher = {
+    name = "Yannik Böttcher";
+    github = "yboettcher";
+    githubId = 39460066;
+    email = "yannikboettcher@outlook.de";
+  };
   ydlr = {
     name = "ydlr";
     email = "ydlr@ydlr.io";

--- a/pkgs/development/compilers/opensycl/default.nix
+++ b/pkgs/development/compilers/opensycl/default.nix
@@ -1,0 +1,67 @@
+{ lib
+, fetchFromGitHub
+, llvmPackages_15
+, lld_15
+, rocm-device-libs
+, python3
+, rocm-runtime
+, cmake
+, boost
+, libxml2
+, libffi
+, makeWrapper
+, hip
+, rocmSupport ? false
+}:
+let
+  inherit (llvmPackages_15) stdenv;
+in
+stdenv.mkDerivation rec {
+  pname = "OpenSYCL";
+  version = "0.9.4";
+
+  src = fetchFromGitHub {
+    owner = "OpenSYCL";
+    repo = "OpenSYCL";
+    rev = "v${version}";
+    sha256 = "sha256-5YkuUOAnvoAD5xDKxKMPq0B7+1pb6hVisPAhs0Za1ls=";
+  };
+
+  nativeBuildInputs = [
+    cmake
+    makeWrapper
+  ];
+
+  buildInputs = [
+    libxml2
+    libffi
+    boost
+    llvmPackages_15.openmp
+    llvmPackages_15.libclang.dev
+    llvmPackages_15.llvm
+  ] ++ lib.optionals rocmSupport [
+    hip
+    rocm-runtime
+  ];
+
+  # opensycl makes use of clangs internal headers. Its cmake does not successfully discover them automatically on nixos, so we supply the path manually
+  cmakeFlags = [
+    "-DCLANG_INCLUDE_PATH=${llvmPackages_15.libclang.dev}/include"
+  ];
+
+  postFixup = ''
+    wrapProgram $out/bin/syclcc-clang \
+      --prefix PATH : ${lib.makeBinPath [ python3 lld_15 ]} \
+      --add-flags "-L${llvmPackages_15.openmp}/lib" \
+      --add-flags "-I${llvmPackages_15.openmp.dev}/include" \
+  '' + lib.optionalString rocmSupport ''
+    --add-flags "--rocm-device-lib-path=${rocm-device-libs}/amdgcn/bitcode"
+  '';
+
+  meta = with lib; {
+    homepage = "https://github.com/OpenSYCL/OpenSYCL";
+    description = "Multi-backend implementation of SYCL for CPUs and GPUs";
+    maintainers = with maintainers; [ yboettcher ];
+    license = licenses.bsd2;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -16902,6 +16902,9 @@ with pkgs;
 
   opensmalltalk-vm = callPackage ../development/compilers/opensmalltalk-vm { };
 
+  opensycl = darwin.apple_sdk_11_0.callPackage ../development/compilers/opensycl { };
+  opensyclWithRocm = opensycl.override { rocmSupport = true; };
+
   ravedude = callPackage ../development/tools/rust/ravedude { };
 
   rhack = callPackage ../development/tools/rust/rhack { };


### PR DESCRIPTION
###### Description of changes

SYCL is a standard for writing C++ code that can be executed on both CPUs and GPUs from a single source file (somewhat like CUDA/HIP).
From their Readme: "Open SYCL is a modern SYCL implementation targeting CPUs and GPUs from all major vendors that supports many use cases and approaches for implementing SYCL". https://github.com/OpenSYCL/OpenSYCL
As far as I could tell there is not yet any support for SYCL in nixpkgs.

I tested the resulting compiler on OpenSYCLs own `tests` folder and found no issues, so it appears to be working fine. In a simple "manual" test, I got it to compile for both my CPU and my RX 480 and both binaries ran fine (with the exception of crashing my wayland session in case of the GPU, but I guess this is less an issue with the OpenSYCL compiler and more with the GPU drivers, but I'm no expert on this).

As for the derivation itself, I did not include a checkPhase, because it looks like the included tests are a separate cmake project and can't just simply be run by calling ctest.
Also, I set the maintainers field with an empty list. While I did create this derivation, this was quite a simple endeavour and I don't know if I could be of any help if any actual problems arise. Additionally, I am not sure how long I would be interested in SYCL for my personal use. (and I thought it might be strange to just add myself to the maintainers list.)

On a final note, OpenSYCL also claims to support both Intel and NVidia GPUs through oneAPI and CUDA, but since I lack such hardware, I only added CPU and AMD support.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes (or backporting 23.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
