### PR TITLE
gitlab: Fix missing getconf

### DIFF
--- a/nixos/modules/services/misc/gitlab.nix
+++ b/nixos/modules/services/misc/gitlab.nix
@@ -184,6 +184,7 @@ let
     coreutils
     procps
     findutils # Needed for gitlab:cleanup:orphan_job_artifact_files
+    getconf
   ];
 
   gitlab-rake = pkgs.stdenv.mkDerivation {
@@ -1463,6 +1464,8 @@ in {
         gzip
 
         procps # Sidekiq MemoryKiller
+
+        getconf # needed by prometheus exporter
       ];
       serviceConfig = {
         Type = "simple";
@@ -1643,6 +1646,7 @@ in {
         nodejs
         procps
         gnupg
+        getconf
       ];
       serviceConfig = {
         Type = "notify";


### PR DESCRIPTION
###### Description of changes

Add getconf to fix fail of gitlab startup.

We use prometheus plugin in our gitlab-ee. Since 16.X gitlab fails to startup, because rake can not find getconf used for example in prometheus-client-mmap-0.23.1/lib/prometheus/client/page_size.rb

```
require 'open3'

module Prometheus
  module Client
    module PageSize
      def self.page_size(fallback_page_size: 4096)
        stdout, status = Open3.capture2('getconf PAGESIZE')
        return fallback_page_size if status.nil? || !status.success?

        page_size = stdout.chomp.to_i
        return fallback_page_size if page_size <= 0

        page_size
      end
    end
  end
end
```

###### Things done

Tested on our gitlab-ee instance in production :)