### PR TITLE
lomiri: init basic development stuff

### DIFF
--- a/maintainers/team-list.nix
+++ b/maintainers/team-list.nix
@@ -469,6 +469,15 @@ with lib.maintainers; {
     enableFeatureFreezePing = true;
   };
 
+  lomiri = {
+    members = [
+      OPNA2608
+    ];
+    scope = "Maintain Lomiri desktop environment and related packages.";
+    shortName = "Lomiri";
+    enableFeatureFreezePing = true;
+  };
+
   lumiguide = {
     # Verify additions by approval of an already existing member of the team.
     members = [

--- a/pkgs/desktops/lomiri/default.nix
+++ b/pkgs/desktops/lomiri/default.nix
@@ -9,6 +9,7 @@ let
   in {
     #### Development tools / libraries
     cmake-extras = callPackage ./development/cmake-extras { };
+    lomiri-api = callPackage ./development/lomiri-api { };
   };
 in
   lib.makeScope libsForQt5.newScope packages

--- a/pkgs/desktops/lomiri/default.nix
+++ b/pkgs/desktops/lomiri/default.nix
@@ -9,6 +9,7 @@ let
   in {
     #### Development tools / libraries
     cmake-extras = callPackage ./development/cmake-extras { };
+    gmenuharness = callPackage ./development/gmenuharness { };
     lomiri-api = callPackage ./development/lomiri-api { };
   };
 in

--- a/pkgs/desktops/lomiri/default.nix
+++ b/pkgs/desktops/lomiri/default.nix
@@ -1,0 +1,14 @@
+{ lib
+, pkgs
+, libsForQt5
+}:
+
+let
+  packages = self: let
+    inherit (self) callPackage;
+  in {
+    #### Development tools / libraries
+    cmake-extras = callPackage ./development/cmake-extras { };
+  };
+in
+  lib.makeScope libsForQt5.newScope packages

--- a/pkgs/desktops/lomiri/development/cmake-extras/default.nix
+++ b/pkgs/desktops/lomiri/development/cmake-extras/default.nix
@@ -1,0 +1,49 @@
+{ stdenvNoCC
+, lib
+, fetchFromGitLab
+, cmake
+, qtbase
+}:
+
+stdenvNoCC.mkDerivation {
+  pname = "cmake-extras";
+  version = "unstable-2022-11-21";
+
+  src = fetchFromGitLab {
+    owner = "ubports";
+    repo = "development/core/cmake-extras";
+    rev = "99aab4514ee182cb7a94821b4b51e4d8cb9a82ef";
+    hash = "sha256-axj5QxgDrHy0HiZkfrbm22hVvSCKkWFoQC8MdQMm9tg=";
+  };
+
+  postPatch = ''
+    # We have nothing to build here, no need to depend on a C compiler
+    substituteInPlace CMakeLists.txt \
+      --replace 'project(cmake-extras)' 'project(cmake-extras NONE)'
+
+    # This is in a function that reverse dependencies use to determine where to install their files to
+    substituteInPlace src/QmlPlugins/QmlPluginsConfig.cmake \
+      --replace "\''${CMAKE_INSTALL_LIBDIR}/qt5/qml" "\''${CMAKE_INSTALL_PREFIX}/${qtbase.qtQmlPrefix}"
+  '';
+
+  strictDeps = true;
+
+  # Produces no binaries
+  dontWrapQtApps = true;
+
+  nativeBuildInputs = [
+    cmake
+  ];
+
+  buildInputs = [
+    qtbase
+  ];
+
+  meta = with lib; {
+    description = "A collection of add-ons for the CMake build tool";
+    homepage = "https://gitlab.com/ubports/development/core/cmake-extras/";
+    license = licenses.gpl3Only;
+    maintainers = teams.lomiri.members;
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/desktops/lomiri/development/cmake-extras/default.nix
+++ b/pkgs/desktops/lomiri/development/cmake-extras/default.nix
@@ -23,7 +23,7 @@ stdenvNoCC.mkDerivation {
 
     # This is in a function that reverse dependencies use to determine where to install their files to
     substituteInPlace src/QmlPlugins/QmlPluginsConfig.cmake \
-      --replace "\''${CMAKE_INSTALL_LIBDIR}/qt5/qml" "\''${CMAKE_INSTALL_BINDIR}/../${qtbase.qtQmlPrefix}"
+      --replace "\''${CMAKE_INSTALL_LIBDIR}/qt5/qml" "\''${CMAKE_INSTALL_PREFIX}/${qtbase.qtQmlPrefix}"
   '';
 
   strictDeps = true;

--- a/pkgs/desktops/lomiri/development/cmake-extras/default.nix
+++ b/pkgs/desktops/lomiri/development/cmake-extras/default.nix
@@ -23,7 +23,7 @@ stdenvNoCC.mkDerivation {
 
     # This is in a function that reverse dependencies use to determine where to install their files to
     substituteInPlace src/QmlPlugins/QmlPluginsConfig.cmake \
-      --replace "\''${CMAKE_INSTALL_LIBDIR}/qt5/qml" "\''${CMAKE_INSTALL_PREFIX}/${qtbase.qtQmlPrefix}"
+      --replace "\''${CMAKE_INSTALL_LIBDIR}/qt5/qml" "\''${CMAKE_INSTALL_BINDIR}/../${qtbase.qtQmlPrefix}"
   '';
 
   strictDeps = true;

--- a/pkgs/desktops/lomiri/development/gmenuharness/default.nix
+++ b/pkgs/desktops/lomiri/development/gmenuharness/default.nix
@@ -1,0 +1,86 @@
+{ stdenv
+, lib
+, fetchFromGitLab
+, gitUpdater
+, testers
+, cmake
+, cmake-extras
+, dbus
+, dbus-test-runner
+, glib
+, gtest
+, libqtdbustest
+, lomiri-api
+, pkg-config
+, qtbase
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "gmenuharness";
+  version = "0.1.4";
+
+  src = fetchFromGitLab {
+    owner = "ubports";
+    repo = "development/core/gmenuharness";
+    rev = finalAttrs.version;
+    hash = "sha256-MswB8cQvz3JvcJL2zj7szUOBzKRjxzJO7/x+87m7E7c=";
+  };
+
+  strictDeps = true;
+
+  nativeBuildInputs = [
+    cmake
+    pkg-config
+  ];
+
+  buildInputs = [
+    cmake-extras
+    glib
+    lomiri-api
+    qtbase
+  ];
+
+  nativeCheckInputs = [
+    dbus
+    dbus-test-runner
+  ];
+
+  checkInputs = [
+    gtest
+    libqtdbustest
+  ];
+
+  cmakeFlags = [
+    "-Denable_tests=${lib.boolToString finalAttrs.doCheck}"
+  ];
+
+  dontWrapQtApps = true;
+
+  doCheck = stdenv.buildPlatform.canExecute stdenv.hostPlatform;
+
+  enableParallelChecking = false;
+
+  checkPhase = ''
+    runHook preCheck
+
+    dbus-test-runner -t make -p test -p "''${enableParallelChecking:+-j $NIX_BUILD_CORES}"
+
+    runHook postCheck
+  '';
+
+  passthru = {
+    tests.pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
+    updateScript = gitUpdater { };
+  };
+
+  meta = with lib; {
+    description = "Library to test GMenuModel structures";
+    homepage = "https://gitlab.com/ubports/development/core/gmenuharness";
+    license = licenses.gpl3Only;
+    maintainers = teams.lomiri.members;
+    platforms = platforms.unix;
+    pkgConfigModules = [
+      "libgmenuharness"
+    ];
+  };
+})

--- a/pkgs/desktops/lomiri/development/gmenuharness/default.nix
+++ b/pkgs/desktops/lomiri/development/gmenuharness/default.nix
@@ -1,6 +1,7 @@
 { stdenv
 , lib
 , fetchFromGitLab
+, fetchpatch
 , gitUpdater
 , testers
 , cmake
@@ -25,6 +26,15 @@ stdenv.mkDerivation (finalAttrs: {
     rev = finalAttrs.version;
     hash = "sha256-MswB8cQvz3JvcJL2zj7szUOBzKRjxzJO7/x+87m7E7c=";
   };
+
+  patches = [
+    # Remove when version > 0.1.4
+    (fetchpatch {
+      name = "0001-gmenuharness-Rename-type-attribute-from-x-canonical-type-to-x-lomiri-type.patch";
+      url = "https://gitlab.com/ubports/development/core/gmenuharness/-/commit/70e9ed85792a6ac1950faaf26391ce91e69486ab.patch";
+      hash = "sha256-jeue0qrl2JZCt/Yfj4jT210wsF/E+MlbtNT/yFTcw5I=";
+    })
+  ];
 
   strictDeps = true;
 

--- a/pkgs/desktops/lomiri/development/lomiri-api/default.nix
+++ b/pkgs/desktops/lomiri/development/lomiri-api/default.nix
@@ -1,6 +1,7 @@
 { stdenv
 , lib
 , fetchFromGitLab
+, gitUpdater
 , makeFontsConf
 , testers
 , cmake
@@ -19,13 +20,13 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "lomiri-api";
-  version = "0.2.0";
+  version = "0.2.1";
 
   src = fetchFromGitLab {
     owner = "ubports";
     repo = "development/core/lomiri-api";
     rev = finalAttrs.version;
-    hash = "sha256-84iM4N6vEn6nmZMTBsUOCtR0WkYfoowsJhhIlQoaq1c=";
+    hash = "sha256-UTl0vObSlEvHuLmDt7vS3yEqZWGklJ9tVwlUAtRSTlU=";
   };
 
   outputs = [ "out" "dev" "doc" ];
@@ -85,6 +86,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   passthru = {
     tests.pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
+    updateScript = gitUpdater { };
   };
 
   meta = with lib; {

--- a/pkgs/desktops/lomiri/development/lomiri-api/default.nix
+++ b/pkgs/desktops/lomiri/development/lomiri-api/default.nix
@@ -1,0 +1,104 @@
+{ stdenv
+, lib
+, fetchFromGitLab
+, makeFontsConf
+, testers
+, cmake
+, cmake-extras
+, dbus
+, doxygen
+, glib
+, graphviz
+, gtest
+, libqtdbustest
+, pkg-config
+, python3
+, qtbase
+, qtdeclarative
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "lomiri-api";
+  version = "0.2.0";
+
+  src = fetchFromGitLab {
+    owner = "ubports";
+    repo = "development/core/lomiri-api";
+    rev = finalAttrs.version;
+    hash = "sha256-84iM4N6vEn6nmZMTBsUOCtR0WkYfoowsJhhIlQoaq1c=";
+  };
+
+  outputs = [ "out" "dev" "doc" ];
+
+  postPatch = ''
+    patchShebangs $(find test -name '*.py')
+
+    substituteInPlace data/*.pc.in \
+      --replace "\''${prefix}/@CMAKE_INSTALL_LIBDIR@" "\''${prefix}/lib"
+
+    # Variable is queried via pkg-config by reverse dependencies
+    # TODO This is likely not supposed to be the regular Qt QML import prefix
+    # but otherwise i.e. lomiri-notifications cannot be found in lomiri
+    substituteInPlace CMakeLists.txt \
+      --replace 'SHELL_PLUGINDIR ''${CMAKE_INSTALL_LIBDIR}/lomiri/qml' 'SHELL_PLUGINDIR ${qtbase.qtQmlPrefix}'
+  '';
+
+  strictDeps = true;
+
+  nativeBuildInputs = [
+    cmake
+    doxygen
+    graphviz
+    pkg-config
+  ];
+
+  buildInputs = [
+    cmake-extras
+    glib
+    gtest
+    libqtdbustest
+    qtbase
+    qtdeclarative
+  ];
+
+  nativeCheckInputs = [
+    dbus
+    python3
+  ];
+
+  dontWrapQtApps = true;
+
+  FONTCONFIG_FILE = makeFontsConf { fontDirectories = [ ]; };
+
+  preBuild = ''
+    # Makes fontconfig produce less noise in logs
+    export HOME=$TMPDIR
+  '';
+
+  doCheck = stdenv.buildPlatform.canExecute stdenv.hostPlatform;
+
+  preCheck = ''
+    # needs minimal plugin and QtTest QML
+    export QT_PLUGIN_PATH=${lib.getBin qtbase}/${qtbase.qtPluginPrefix}
+    export QML2_IMPORT_PATH=${lib.getBin qtdeclarative}/${qtbase.qtQmlPrefix}
+  '';
+
+  passthru = {
+    tests.pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
+  };
+
+  meta = with lib; {
+    description = "Lomiri API Library for integrating with the Lomiri shell";
+    homepage = "https://gitlab.com/ubports/development/core/lomiri-api";
+    license = with licenses; [ lgpl3Only gpl3Only ];
+    maintainers = teams.lomiri.members;
+    platforms = platforms.linux;
+    pkgConfigModules = [
+      "liblomiri-api"
+      "lomiri-shell-api"
+      "lomiri-shell-application"
+      "lomiri-shell-launcher"
+      "lomiri-shell-notifications"
+    ];
+  };
+})

--- a/pkgs/development/libraries/libqtdbusmock/default.nix
+++ b/pkgs/development/libraries/libqtdbusmock/default.nix
@@ -1,0 +1,93 @@
+{ stdenv
+, lib
+, fetchbzr
+, testers
+, cmake
+, cmake-extras
+, dbus
+, dbus-test-runner
+, gtest
+, libqtdbustest
+, networkmanager
+, pkg-config
+, procps
+, python3
+, qtbase
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "libqtdbusmock";
+  version = "unstable-2017-03-16";
+
+  src = fetchbzr {
+    url = "lp:libqtdbusmock";
+    rev = "49";
+    sha256 = "sha256-q3jL8yGLgcNxXHPh9M9cTVtUvonrBUPNxuPJIvu7Q/s=";
+  };
+
+  postPatch = ''
+    # Look for the new(?) name
+    substituteInPlace CMakeLists.txt \
+      --replace 'NetworkManager' 'libnm'
+
+    # Workaround for "error: expected unqualified-id before 'public'" on "**signals"
+    sed -i -e '/add_definitions/a -DQT_NO_KEYWORDS' CMakeLists.txt
+  '' + lib.optionalString (!finalAttrs.doCheck) ''
+    # Don't build tests when we're not running them
+    sed -i -e '/add_subdirectory(tests)/d' CMakeLists.txt
+  '';
+
+  strictDeps = true;
+
+  nativeBuildInputs = [
+    cmake
+    pkg-config
+  ];
+
+  buildInputs = [
+    cmake-extras
+    libqtdbustest
+    networkmanager
+    qtbase
+  ];
+
+  nativeCheckInputs = [
+    dbus
+    dbus-test-runner
+    procps
+    (python3.withPackages (ps: with ps; [
+      python-dbusmock
+    ]))
+  ];
+
+  checkInputs = [
+    gtest
+  ];
+
+  dontWrapQtApps = true;
+
+  doCheck = stdenv.buildPlatform.canExecute stdenv.hostPlatform;
+
+  enableParallelChecking = false;
+
+  checkPhase = ''
+    runHook preCheck
+
+    dbus-test-runner -t make -p test -p "''${enableParallelChecking:+-j $NIX_BUILD_CORES}"
+
+    runHook postCheck
+  '';
+
+  passthru.tests.pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
+
+  meta = with lib; {
+    description = "Library for mocking DBus interactions using Qt";
+    homepage = "https://launchpad.net/libqtdbusmock";
+    license = licenses.lgpl3Only;
+    platforms = platforms.unix;
+    maintainers = teams.lomiri.members;
+    pkgConfigModules = [
+      "libqtdbusmock-1"
+    ];
+  };
+})

--- a/pkgs/development/libraries/libqtdbustest/default.nix
+++ b/pkgs/development/libraries/libqtdbustest/default.nix
@@ -1,0 +1,102 @@
+{ stdenv
+, lib
+, fetchbzr
+, fetchpatch
+, testers
+, cmake
+, cmake-extras
+, dbus
+, dbus-test-runner
+, gtest
+, pkg-config
+, procps
+, python3
+, qtbase
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "libqtdbustest";
+  version = "unstable-2017-01-06";
+
+  src = fetchbzr {
+    url = "lp:libqtdbustest";
+    rev = "42";
+    sha256 = "sha256-5MQdGGtEVE/pM9u0B0xFXyITiRln9p+8/MLtrrCZqi8=";
+  };
+
+  patches = [
+    # Tests are overly pedantic when looking for launched process names in `ps`, break on python wrapper vs real python
+    # Just check if basename + arguments match, like libqtdbusmock does
+    ./less-pedantic-process-finding.patch
+
+    # Disable QProcess start timeout
+    (fetchpatch {
+      url = "https://salsa.debian.org/debian-ayatana-team/libqtdbustest/-/raw/0788df10bc6f2aa47c2b73fc1df944686a9ace1e/debian/patches/1003_no-QProcess-waitForstarted-timeout.patch";
+      hash = "sha256-ThDbn6URvkj5ARDMj+xO0fb1Qh2YQRzVy24O03KglHI=";
+    })
+
+    # More robust dbus address reading
+    (fetchpatch {
+      url = "https://salsa.debian.org/debian-ayatana-team/libqtdbustest/-/raw/7e55c79cd032c702b30d834c1fb0b65661fc6eeb/debian/patches/1004_make-reading-address-from-dbus-daemon-more-robust.patch";
+      hash = "sha256-hq8pdducp/udxoGWGt1dgL/7VHcbJO/oT1dOY1zew8M=";
+    })
+  ];
+
+  strictDeps = true;
+
+  postPatch =  lib.optionalString (!finalAttrs.doCheck) ''
+    # Don't build tests when we're not running them
+    sed -i -e '/add_subdirectory(tests)/d' CMakeLists.txt
+  '';
+
+  nativeBuildInputs = [
+    cmake
+    pkg-config
+  ];
+
+  buildInputs = [
+    cmake-extras
+    qtbase
+  ];
+
+  nativeCheckInputs = [
+    dbus
+    dbus-test-runner
+    procps
+    (python3.withPackages (ps: with ps; [
+      python-dbusmock
+    ]))
+  ];
+
+  checkInputs = [
+    gtest
+  ];
+
+  dontWrapQtApps = true;
+
+  doCheck = stdenv.buildPlatform.canExecute stdenv.hostPlatform;
+
+  enableParallelChecking = false;
+
+  checkPhase = ''
+    runHook preCheck
+
+    dbus-test-runner -t make -p test -p "''${enableParallelChecking:+-j $NIX_BUILD_CORES}"
+
+    runHook postCheck
+  '';
+
+  passthru.tests.pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
+
+  meta = with lib; {
+    description = "Library for testing DBus interactions using Qt";
+    homepage = "https://launchpad.net/libqtdbustest";
+    license = licenses.lgpl3Only;
+    platforms = platforms.unix;
+    maintainers = teams.lomiri.members;
+    mainProgram = "qdbus-simple-test-runner";
+    pkgConfigModules = [
+      "libqtdbustest-1"
+    ];
+  };
+})

--- a/pkgs/development/libraries/libqtdbustest/less-pedantic-process-finding.patch
+++ b/pkgs/development/libraries/libqtdbustest/less-pedantic-process-finding.patch
@@ -1,0 +1,86 @@
+diff '--color=auto' -ur '--color=never' a/tests/libqtdbustest/TestDBusTestRunner.cpp b/tests/libqtdbustest/TestDBusTestRunner.cpp
+--- a/tests/libqtdbustest/TestDBusTestRunner.cpp	2023-01-20 21:36:16.948292559 +0100
++++ b/tests/libqtdbustest/TestDBusTestRunner.cpp	2023-01-20 21:55:40.554530221 +0100
+@@ -44,7 +44,7 @@
+ TEST_F(TestDBusTestRunner, StartsSessionService) {
+ 	QSharedPointer<QProcessDBusService> process(
+ 			new QProcessDBusService("test.session.name",
+-					QDBusConnection::SessionBus, "/usr/bin/python3",
++					QDBusConnection::SessionBus, "python3",
+ 					QStringList() << "-m" << "dbusmock" << "test.session.name"
+ 							<< "/test/object" << "test.Interface"));
+ 
+@@ -58,15 +58,14 @@
+ 	pgrep.waitForFinished();
+ 	pgrep.waitForReadyRead();
+ 
+-	EXPECT_EQ(
+-			"/usr/bin/python3 -m dbusmock test.session.name /test/object test.Interface",
+-			QString::fromUtf8(pgrep.readAll().trimmed()).toStdString());
++	EXPECT_TRUE(
++			pgrep.readAll().contains("python3 -m dbusmock test.session.name /test/object test.Interface"));
+ }
+ 
+ TEST_F(TestDBusTestRunner, StartsSystemService) {
+ 	QSharedPointer<QProcessDBusService> process(
+ 			new QProcessDBusService("test.system.name",
+-					QDBusConnection::SystemBus, "/usr/bin/python3",
++					QDBusConnection::SystemBus, "python3",
+ 					QStringList() << "-m" << "dbusmock" << "-s"
+ 							<< "test.system.name" << "/test/object"
+ 							<< "test.Interface"));
+@@ -81,9 +80,8 @@
+ 	pgrep.waitForFinished();
+ 	pgrep.waitForReadyRead();
+ 
+-	EXPECT_EQ(
+-			"/usr/bin/python3 -m dbusmock -s test.system.name /test/object test.Interface",
+-			QString::fromUtf8(pgrep.readAll().trimmed()).toStdString());
++	EXPECT_TRUE(
++			pgrep.readAll().contains("python3 -m dbusmock -s test.system.name /test/object test.Interface"));
+ }
+ 
+ TEST_F(TestDBusTestRunner, SetsEnvironmentVariables) {
+diff '--color=auto' -ur '--color=never' a/tests/libqtdbustest/TestQProcessDBusService.cpp b/tests/libqtdbustest/TestQProcessDBusService.cpp
+--- a/tests/libqtdbustest/TestQProcessDBusService.cpp	2023-01-20 21:36:16.948292559 +0100
++++ b/tests/libqtdbustest/TestQProcessDBusService.cpp	2023-01-20 21:54:34.633384937 +0100
+@@ -45,7 +45,7 @@
+ 
+ TEST_F(TestQProcessDBusService, WaitsForServiceAppeared) {
+ 	QProcessDBusService process("test.name", QDBusConnection::SessionBus,
+-			"/usr/bin/python3",
++			"python3",
+ 			QStringList() << "-m" << "dbusmock" << "test.name" << "/test/object"
+ 					<< "test.Interface");
+ 
+@@ -58,14 +58,13 @@
+ 	pgrep.waitForFinished();
+ 	pgrep.waitForReadyRead();
+ 
+-	EXPECT_EQ(
+-			"/usr/bin/python3 -m dbusmock test.name /test/object test.Interface",
+-			QString::fromUtf8(pgrep.readAll().trimmed()).toStdString());
++	EXPECT_TRUE(
++			pgrep.readAll().contains("python3 -m dbusmock test.name /test/object test.Interface"));
+ }
+ 
+ TEST_F(TestQProcessDBusService, ThrowsErrorForFailToStart) {
+ 	QProcessDBusService process("test.name", QDBusConnection::SessionBus,
+-			"/usr/bin/python3",
++			"python3",
+ 			QStringList() << "-m" << "dbusmock" << "not.test.name"
+ 					<< "/test/object" << "test.Interface");
+ 
+diff '--color=auto' -ur '--color=never' a/tests/libqtdbustest/TestSuicidalProcess.cpp b/tests/libqtdbustest/TestSuicidalProcess.cpp
+--- a/tests/libqtdbustest/TestSuicidalProcess.cpp	2023-01-20 21:36:16.948292559 +0100
++++ b/tests/libqtdbustest/TestSuicidalProcess.cpp	2023-01-20 21:55:07.219951081 +0100
+@@ -51,8 +51,7 @@
+ 	pgrep.waitForFinished();
+ 	pgrep.waitForReadyRead();
+ 
+-	EXPECT_EQ("sleep 5",
+-			QString::fromUtf8(pgrep.readAll().trimmed()).toStdString());
++	EXPECT_TRUE(pgrep.readAll().contains("sleep 5"));
+ }
+ 
+ } // namespace

--- a/pkgs/development/tools/dbus-test-runner/default.nix
+++ b/pkgs/development/tools/dbus-test-runner/default.nix
@@ -1,0 +1,80 @@
+{ stdenv
+, lib
+, fetchbzr
+, testers
+, autoreconfHook
+, bash
+, coreutils
+, dbus
+, dbus-glib
+, glib
+, intltool
+, pkg-config
+, python3
+, xvfb-run
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "dbus-test-runner";
+  version = "unstable-2019-10-02";
+
+  src = fetchbzr {
+    url = "lp:dbus-test-runner";
+    rev = "109";
+    sha256 = "sha256-4yH19X98SVqpviCBIWzIX6FYHWxCbREpuKCNjQuTFDk=";
+  };
+
+  postPatch = ''
+    patchShebangs tests/test-wait-outputer
+
+    # Tests `cat` together build shell scripts
+    # true is a PATHable call, bash a shebang
+    substituteInPlace tests/Makefile.am \
+      --replace '/bin/true' 'true' \
+      --replace '/bin/bash' '${lib.getExe bash}'
+  '';
+
+  strictDeps = true;
+
+  nativeBuildInputs = [
+    autoreconfHook
+    glib # for autoconf macro, gtester, gdbus
+    intltool
+    pkg-config
+  ];
+
+  buildInputs = [
+    dbus-glib
+    glib
+  ];
+
+  nativeCheckInputs = [
+    bash
+    dbus
+    (python3.withPackages (ps: with ps; [
+      python-dbusmock
+    ]))
+    xvfb-run
+  ];
+
+  enableParallelBuilding = true;
+
+  doCheck = stdenv.buildPlatform.canExecute stdenv.hostPlatform;
+
+  checkFlags = [
+    "XVFB_RUN=${lib.getExe xvfb-run}"
+  ];
+
+  passthru.tests.pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
+
+  meta = with lib; {
+    description = "A small little utility to run a couple of executables under a new DBus session for testing";
+    homepage = "https://launchpad.net/dbus-test-runner";
+    license = licenses.gpl3Only;
+    platforms = platforms.unix;
+    maintainers = teams.lomiri.members;
+    pkgConfigModules = [
+      "dbustest-1"
+    ];
+  };
+})

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -22241,6 +22241,10 @@ with pkgs;
 
   libplist = callPackage ../development/libraries/libplist { };
 
+  libqtdbusmock = libsForQt5.callPackage ../development/libraries/libqtdbusmock {
+    inherit (lomiri) cmake-extras;
+  };
+
   libqtdbustest = libsForQt5.callPackage ../development/libraries/libqtdbustest {
     inherit (lomiri) cmake-extras;
   };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -22241,6 +22241,10 @@ with pkgs;
 
   libplist = callPackage ../development/libraries/libplist { };
 
+  libqtdbustest = libsForQt5.callPackage ../development/libraries/libqtdbustest {
+    inherit (lomiri) cmake-extras;
+  };
+
   libre = callPackage ../development/libraries/libre { };
 
   libredwg = callPackage ../development/libraries/libredwg { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -17726,6 +17726,8 @@ with pkgs;
 
   ansible-doctor = callPackage ../tools/admin/ansible/doctor.nix { };
 
+  dbus-test-runner = callPackage ../development/tools/dbus-test-runner { };
+
   phpunit = callPackage ../development/tools/misc/phpunit { };
 
   ### DEVELOPMENT / TOOLS / LANGUAGE-SERVERS

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -37582,6 +37582,8 @@ with pkgs;
 
   gnustep = recurseIntoAttrs (callPackage ../desktops/gnustep { });
 
+  lomiri = recurseIntoAttrs (callPackage ../desktops/lomiri { });
+
   lumina = recurseIntoAttrs (callPackage ../desktops/lumina { });
 
   ### DESKTOPS/LXDE


### PR DESCRIPTION
###### Description of changes

Working towards #99090, in more digestible steps than last time. This one is abit bigger, but the followups can be done more or less package-by-package with all of these present.

- create a maintainers team & package scope for Lomiri
  - if anyone wishes to join, add yourself and/or let me know :slightly_smiling_face:
- init Lomiri-belonging things
  - [cmake-extras](https://gitlab.com/ubports/development/core/cmake-extras): A set of CMake modules commonly used by Lomiri packages
  - [lomiri-api](https://gitlab.com/ubports/development/core/lomiri-api): An API for integrating with the Lomiri shell
  - [gmenuharness](https://gitlab.com/ubports/development/core/gmenuharness): A library to test GLib GMenuModels
- init some non-Lomiri things that are commonly used to drive tests
  - [libqtdbustest](https://launchpad.net/libqtdbustest): Library to test D-Bus interactions with Qt
  - [libqtdbusmock](https://launchpad.net/libqtdbusmock): Library to mock D-Bus interactions with Qt
  - [dbus-test-runner](https://launchpad.net/dbus-test-runner): Tool to run tasks under independent D-Bus sessions

~~The last 2 commits I still need to test on my system with all the Lomiri stuff, just threw them in here so those packages are less stale on arrival.~~

Working fine, keeping them in.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes (or backporting 23.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
