### PR TITLE
kaldi: fix build

### DIFF
--- a/pkgs/tools/audio/kaldi/default.nix
+++ b/pkgs/tools/audio/kaldi/default.nix
@@ -3,7 +3,6 @@
 , openblas
 , blas
 , lapack
-, openfst
 , icu
 , cmake
 , pkg-config
@@ -44,7 +43,6 @@ stdenv.mkDerivation {
 
   buildInputs = [
     openblas
-    openfst
     icu
   ] ++ lib.optionals stdenv.isDarwin [
     Accelerate

--- a/pkgs/tools/audio/kaldi/default.nix
+++ b/pkgs/tools/audio/kaldi/default.nix
@@ -20,13 +20,13 @@
 assert blas.implementation == "openblas" && lapack.implementation == "openblas";
 stdenv.mkDerivation (finalAttrs: {
   pname = "kaldi";
-  version = "unstable-2022-09-26";
+  version = "unstable-2023-05-02";
 
   src = fetchFromGitHub {
     owner = "kaldi-asr";
     repo = "kaldi";
-    rev = "f6f4ccaf213f0fe8b26e633a7dc0c802150626a0";
-    sha256 = "sha256-ybW2J4lWf6YaQGZZvxEVDUMAg84DC17W+yX6ZsuBDac=";
+    rev = "71f38e62cad01c3078555bfe78d0f3a527422d75";
+    sha256 = "sha256-2xm0F80cjovy/G9Ytq/iwa1eexZk0mromv6PPuNIT8U=";
   };
 
   cmakeFlags = [

--- a/pkgs/tools/audio/kaldi/default.nix
+++ b/pkgs/tools/audio/kaldi/default.nix
@@ -39,38 +39,8 @@ stdenv.mkDerivation {
     "-DBUILD_SHARED_LIBS=on"
     "-DBLAS_LIBRARIES=-lblas"
     "-DLAPACK_LIBRARIES=-llapack"
+    "-DFETCHCONTENT_SOURCE_DIR_OPENFST:PATH=${openfst}"
   ];
-
-  enableParallelBuilding = true;
-
-  preConfigure = ''
-    mkdir bin
-    cat > bin/git <<'EOF'
-    #!${stdenv.shell}
-    if [[ "$1" == "--version" ]]; then
-      # cmake checks this
-      ${git}/bin/git --version
-    elif [[ "$1" == "clone" ]]; then
-      # mock this call:
-
-      # https://github.com/kaldi-asr/kaldi/blob/c9d8b9ad3fef89237ba5517617d977b7d70a7ed5/cmake/third_party/openfst.cmake#L5
-      cp -r ${openfst} ''${@: -1}
-      chmod -R +w ''${@: -1}
-    elif [[ "$1" == "rev-list" ]]; then
-      # fix up this call:
-      # https://github.com/kaldi-asr/kaldi/blob/c9d8b9ad3fef89237ba5517617d977b7d70a7ed5/cmake/VersionHelper.cmake#L8
-      echo 0
-    elif [[ "$1" == "rev-parse" ]]; then
-      echo ${openfst.rev}
-      echo 0
-    fi
-    true
-    EOF
-    chmod +x bin/git
-    export PATH=$(pwd)/bin:$PATH
-  '';
-
-  outputs = [ "out" "dev" ];
 
   buildInputs = [
     openblas
@@ -85,6 +55,16 @@ stdenv.mkDerivation {
     pkg-config
     python3
   ];
+
+  preConfigure = ''
+    cmakeFlagsArray+=(
+      # Extract version without the need for git.
+      # https://github.com/kaldi-asr/kaldi/blob/71f38e62cad01c3078555bfe78d0f3a527422d75/cmake/VersionHelper.cmake
+      # Patch number is not actually used by default so we can just ignore it.
+      # https://github.com/kaldi-asr/kaldi/blob/71f38e62cad01c3078555bfe78d0f3a527422d75/CMakeLists.txt#L214
+      "-DKALDI_VERSION=$(cat src/.version)"
+    )
+  '';
 
   postInstall = ''
     mkdir -p $out/share/kaldi


### PR DESCRIPTION
###### Description of changes

It looks like after a bump, CMake started passing `--git-dir=.git` as the first argument of `git rev-parse`. But we do not really need to spoof `git` program now that Kaldi uses CMake’s `FetchContent` module. We can just pass the path using configure flag directly:

https://cmake.org/cmake/help/latest/module/FetchContent.html#variable:FETCHCONTENT_SOURCE_DIR_%3CuppercaseName%3E

Git was also inadvertently used for generating `KALDI_PATCH_NUMBER` in `VersionHelper`, to be potentially appended to `KALDI_VERSION` but it was not actually being done by default. We can set the variable directly to skip `VersionHelper`.

Also remove redundant `enableParallelBuild` since CMake enables it.

And drop separate `dev` output since Kaldi currently hardcodes the `include/` directory so consumers would not be able to find them. Splitting it out only removes 7 out of 303 MB.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
-  [x]  Tested that nerd-dictation from #185148  works
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes (or backporting 23.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
