### PR TITLE
Revert "lagrange: 1.16.2 -> 1.16.3"

### DIFF
--- a/pkgs/applications/networking/browsers/lagrange/default.nix
+++ b/pkgs/applications/networking/browsers/lagrange/default.nix
@@ -17,13 +17,13 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "lagrange";
-  version = "1.16.3";
+  version = "1.16.2";
 
   src = fetchFromGitHub {
     owner = "skyjake";
     repo = "lagrange";
     rev = "v${finalAttrs.version}";
-    hash = "sha256-DpgCxnwkNP2mZNYygxFLMufEijYoLr4qor0DYCmbps8=";
+    hash = "sha256-jjjDu/vyAoytHQss43lUILEdT2kV8dXHyVNT0uaSmwM=";
   };
 
   nativeBuildInputs = [ cmake pkg-config zip ];


### PR DESCRIPTION
Reverts NixOS/nixpkgs#236217

https://github.com/NixOS/nixpkgs/pull/236217#issuecomment-1579096049

This breaks lagrange-tui, I tried fixing it, but kept running into this error:

```console
       > /build/lagrange/src/ui/util.c: In function 'coord_MouseWheelEvent':
       > /build/lagrange/src/ui/util.c:108:9: error: implicit declaration of function 'SDL_GetGlobalMouseState'; did you mean 'SDL_GetMouseState'? [8;;https://gcc.gnu.org/onl
inedocs/gcc/Warning-Options.html#index-Wimplicit-function-declaration-Werror=implicit-function-declaration8;;]
       >   108 |         SDL_GetGlobalMouseState(&mousePos.x, &mousePos.y);
       >       |         ^~~~~~~~~~~~~~~~~~~~~~~
       >       |         SDL_GetMouseState
```