### PR TITLE
maven: specify mainProgram

### DIFF
--- a/pkgs/development/tools/build-managers/apache-maven/default.nix
+++ b/pkgs/development/tools/build-managers/apache-maven/default.nix
@@ -18,6 +18,7 @@ stdenv.mkDerivation rec {
   inherit jdk;
 
   meta = with lib; {
+    mainProgram = "mvn";
     description = "Build automation tool (used primarily for Java projects)";
     homepage = "https://maven.apache.org/";
     license = licenses.asl20;


### PR DESCRIPTION
###### Description of changes

Before:

```
$ nix run nixpkgs#maven
error: unable to execute '/nix/store/6z9ag3ihc8mq2hzsw48lhbznvzny65nz-apache-maven-3.8.6/bin/apache-maven': No such file or directory
```

After this change, we can `nix run` maven as expected.

###### Things done

This is a trivial, no-build change.