### PR TITLE
nixos/udev: silence harmless warnings

### DIFF
--- a/nixos/modules/services/hardware/udev.nix
+++ b/nixos/modules/services/hardware/udev.nix
@@ -72,7 +72,7 @@ let
           --replace \"/sbin/blkid \"${pkgs.util-linux}/sbin/blkid \
           --replace \"/bin/mount \"${pkgs.util-linux}/bin/mount \
           --replace /usr/bin/readlink ${pkgs.coreutils}/bin/readlink \
-          --replace /usr/bin/basename ${pkgs.coreutils}/bin/basename
+          --replace /usr/bin/basename ${pkgs.coreutils}/bin/basename 2>/dev/null
       ${optionalString (initrdBin != null) ''
         substituteInPlace $i --replace '/run/current-system/systemd' "${removeSuffix "/bin" initrdBin}"
       ''}


### PR DESCRIPTION
###### Description of changes

This is something I had on my list for a while.

`udevRulesFor` generates a lot of warnings like:

    substituteStream(): WARNING: pattern '"/sbin/modprobe' doesn't match anything
    in file '/nix/store/.../95-dm-notify.rules'

due to the (preemptive) substitution of common paths in the default udev rules.
In this case a file having no matches is not unepected and poses no issue at
all.

###### Things done

- [x] Tested with `nixosTests.simple`, not sure what else to do
- [23.11 Release Notes (or backporting 23.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
