### PR TITLE
maintainers: remove me from matrix list

### DIFF
--- a/maintainers/team-list.nix
+++ b/maintainers/team-list.nix
@@ -538,7 +538,6 @@ with lib.maintainers; {
       ma27
       fadenb
       mguentner
-      ekleog
       ralith
       dandellion
       sumnerevans


### PR DESCRIPTION
The matrix ecosystem in nixpkgs is nowadays being handled by people who are both more competent than me and have more time to allocate it.

So I'm removing myself, to reduce the amount of notifications I get from nixpkgs and thus increase the likelihood of me responding quickly to packages I'm still one of the few maintainers of.