### PR TITLE
simplotask: init at 1.7.0

### DIFF
--- a/pkgs/tools/admin/simplotask/default.nix
+++ b/pkgs/tools/admin/simplotask/default.nix
@@ -1,0 +1,37 @@
+{ lib, buildGoModule, fetchFromGitHub, installShellFiles }:
+
+buildGoModule rec {
+  pname = "simplotask";
+  version = "1.7.0";
+
+  src = fetchFromGitHub {
+    owner = "umputun";
+    repo = "spot";
+    rev = "v${version}";
+    hash = "sha256-aacG/s/zo4gMBsRug2i7vUyu1WUg3s+F8wtLsSVt7HQ=";
+  };
+
+  vendorHash = null;
+
+  nativeBuildInputs = [ installShellFiles ];
+
+  ldflags = [
+    "-s -w"
+    "-X main.revision=v${version}"
+  ];
+
+  doCheck = false;
+
+  postInstall = ''
+    mv $out/bin/{secrets,spot-secrets}
+    installManPage *.1
+  '';
+
+  meta = with lib; {
+    description = "A tool for effortless deployment and configuration management";
+    homepage = "https://simplotask.com/";
+    maintainers = with maintainers; [ sikmir ];
+    license = licenses.mit;
+    mainProgram = "spot";
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -12424,6 +12424,8 @@ with pkgs;
 
   simple-mtpfs = callPackage ../tools/filesystems/simple-mtpfs { };
 
+  simplotask = callPackage ../tools/admin/simplotask { };
+
   simpleproxy = callPackage ../tools/networking/simpleproxy { };
 
   simplescreenrecorder = libsForQt5.callPackage ../applications/video/simplescreenrecorder { };


### PR DESCRIPTION
###### Description of changes
**[Spot](https://simplotask.com/)** (aka simplotask) is a powerful and easy-to-use tool for effortless deployment and configuration management.

Named as `simplotask` since [spot](https://github.com/NixOS/nixpkgs/tree/master/pkgs/applications/audio/spot) package already exists.

https://github.com/umputun/spot/issues/94

###### Things done
- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes (or backporting 23.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
