### PR TITLE
nixos/activation: Add pre-switch checks

### DIFF
--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -1612,6 +1612,7 @@
   ./services/x11/xserver.nix
   ./system/activation/activatable-system.nix
   ./system/activation/activation-script.nix
+  ./system/activation/pre-switch-check.nix
   ./system/activation/specialisation.nix
   ./system/activation/switchable-system.nix
   ./system/activation/bootspec.nix

--- a/nixos/modules/system/activation/pre-switch-check.nix
+++ b/nixos/modules/system/activation/pre-switch-check.nix
@@ -1,0 +1,44 @@
+{ lib, pkgs, ... }:
+let
+  preSwitchCheckScript =
+    set:
+    lib.concatLines (
+      lib.mapAttrsToList (name: text: ''
+        # pre-switch check ${name}
+        (
+          ${text}
+        )
+        if [[ $? != 0 ]]; then
+          echo "Pre-switch check '${name}' failed"
+          exit 1
+        fi
+      '') set
+    );
+in
+{
+  options.system.preSwitchChecks = lib.mkOption {
+    default = { };
+    example = lib.literalExpression ''
+      { failsEveryTime =
+        '''
+          false
+        ''';
+      }
+    '';
+
+    description = ''
+      A set of shell script fragments that are executed before the switch to a
+      new NixOS system configuration. A failure in any of these fragments will
+      cause the switch to fail and exit early.
+    '';
+
+    type = lib.types.attrsOf lib.types.str;
+
+    apply =
+      set:
+      set
+      // {
+        script = pkgs.writeShellScript "pre-switch-checks" (preSwitchCheckScript set);
+      };
+  };
+}

--- a/nixos/modules/system/activation/switchable-system.nix
+++ b/nixos/modules/system/activation/switchable-system.nix
@@ -61,6 +61,7 @@ in
           --subst-var-by coreutils "${pkgs.coreutils}" \
           --subst-var-by distroId ${lib.escapeShellArg config.system.nixos.distroId} \
           --subst-var-by installBootLoader ${lib.escapeShellArg config.system.build.installBootLoader} \
+          --subst-var-by preSwitchCheck ${lib.escapeShellArg config.system.preSwitchChecks.script} \
           --subst-var-by localeArchive "${config.i18n.glibcLocales}/lib/locale/locale-archive" \
           --subst-var-by perl "${perlWrapped}" \
           --subst-var-by shell "${pkgs.bash}/bin/sh" \
@@ -93,6 +94,7 @@ in
             --set TOPLEVEL ''${!toplevelVar} \
             --set DISTRO_ID ${lib.escapeShellArg config.system.nixos.distroId} \
             --set INSTALL_BOOTLOADER ${lib.escapeShellArg config.system.build.installBootLoader} \
+            --set PRE_SWITCH_CHECK ${lib.escapeShellArg config.system.preSwitchChecks.script} \
             --set LOCALE_ARCHIVE ${config.i18n.glibcLocales}/lib/locale/locale-archive \
             --set SYSTEMD ${config.systemd.package}
         )

--- a/nixos/modules/system/activation/top-level.nix
+++ b/nixos/modules/system/activation/top-level.nix
@@ -342,6 +342,7 @@ in
       perl = pkgs.perl.withPackages (p: with p; [ ConfigIniFiles FileSlurp ]);
       # End if legacy environment variables
 
+      preSwitchCheck = config.system.preSwitchChecks.script;
 
       # Not actually used in the builder. `passedChecks` is just here to create
       # the build dependencies. Checks are similar to build dependencies in the

--- a/nixos/tests/switch-test.nix
+++ b/nixos/tests/switch-test.nix
@@ -612,6 +612,10 @@ in {
     other = {
       system.switch.enable = true;
       users.mutableUsers = true;
+      specialisation.failingCheck.configuration.system.preSwitchChecks.failEveryTime = ''
+        echo this will fail
+        false
+      '';
     };
   };
 
@@ -683,6 +687,11 @@ in {
     )
 
     boot_loader_text = "Warning: do not know how to make this configuration bootable; please enable a boot loader."
+
+    with subtest("pre-switch checks"):
+        machine.succeed("${stderrRunner} ${otherSystem}/bin/switch-to-configuration check")
+        out = switch_to_specialisation("${otherSystem}", "failingCheck", action="check", fail=True)
+        assert_contains(out, "this will fail")
 
     with subtest("actions"):
         # boot action

--- a/pkgs/by-name/sw/switch-to-configuration-ng/src/src/main.rs
+++ b/pkgs/by-name/sw/switch-to-configuration-ng/src/src/main.rs
@@ -79,6 +79,7 @@ const DRY_RELOAD_BY_ACTIVATION_LIST_FILE: &str = "/run/nixos/dry-activation-relo
 #[derive(Debug, Clone, PartialEq)]
 enum Action {
     Switch,
+    Check,
     Boot,
     Test,
     DryActivate,
@@ -93,6 +94,7 @@ impl std::str::FromStr for Action {
             "boot" => Self::Boot,
             "test" => Self::Test,
             "dry-activate" => Self::DryActivate,
+            "check" => Self::Check,
             _ => bail!("invalid action {s}"),
         })
     }
@@ -105,6 +107,7 @@ impl Into<&'static str> for &Action {
             Action::Boot => "boot",
             Action::Test => "test",
             Action::DryActivate => "dry-activate",
+            Action::Check => "check",
         }
     }
 }
@@ -127,6 +130,28 @@ fn parse_os_release() -> Result<HashMap<String, String>> {
 
             acc
         }))
+}
+
+fn do_pre_switch_check(command: &str, toplevel: &Path) -> Result<()> {
+    let mut cmd_split = command.split_whitespace();
+    let Some(argv0) = cmd_split.next() else {
+        bail!("missing first argument in install bootloader commands");
+    };
+
+    match std::process::Command::new(argv0)
+        .args(cmd_split.collect::<Vec<&str>>())
+        .arg(toplevel)
+        .spawn()
+        .map(|mut child| child.wait())
+    {
+        Ok(Ok(status)) if status.success() => {}
+        _ => {
+            eprintln!("Pre-switch checks failed");
+            die()
+        }
+    }
+
+    Ok(())
 }
 
 fn do_install_bootloader(command: &str, toplevel: &Path) -> Result<()> {
@@ -939,7 +964,8 @@ fn do_user_switch(parent_exe: String) -> anyhow::Result<()> {
 
 fn usage(argv0: &str) -> ! {
     eprintln!(
-        r#"Usage: {} [switch|boot|test|dry-activate]
+        r#"Usage: {} [check|switch|boot|test|dry-activate]
+check:        run pre-switch checks and exit
 switch:       make the configuration the boot default and activate now
 boot:         make the configuration the boot default
 test:         activate the configuration, but don't make it the boot default
@@ -955,6 +981,7 @@ fn do_system_switch(action: Action) -> anyhow::Result<()> {
     let out = PathBuf::from(required_env("OUT")?);
     let toplevel = PathBuf::from(required_env("TOPLEVEL")?);
     let distro_id = required_env("DISTRO_ID")?;
+    let pre_switch_check = required_env("PRE_SWITCH_CHECK")?;
     let install_bootloader = required_env("INSTALL_BOOTLOADER")?;
     let locale_archive = required_env("LOCALE_ARCHIVE")?;
     let new_systemd = PathBuf::from(required_env("SYSTEMD")?);
@@ -1011,6 +1038,18 @@ fn do_system_switch(action: Action) -> anyhow::Result<()> {
 
     if syslog::init(Facility::LOG_USER, LevelFilter::Debug, Some("nixos")).is_err() {
         bail!("Failed to initialize logger");
+    }
+
+    if std::env::var("NIXOS_NO_CHECK")
+        .as_deref()
+        .unwrap_or_default()
+        != "1"
+    {
+        do_pre_switch_check(&pre_switch_check, &toplevel)?;
+    }
+
+    if *action == Action::Check {
+        return Ok(());
     }
 
     // Install or update the bootloader.


### PR DESCRIPTION
###### Description of changes

Add an option for shell script fragments that are ran before switching to a new NixOS system configuration (pre installation of bootloader or system activation). Also add a new subcommand for
switch-to-configuration called "check" that will cause the program to always exit after checks are ran. If the `NO_CHECK` environment variable is set to 1 during switch, the checks are skipped.

Fixes #169820

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes (or backporting 23.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
