### PR TITLE
systemd stage 1 networking: Stop systemd-networkd on switch-root

### DIFF
--- a/nixos/modules/system/boot/networkd.nix
+++ b/nixos/modules/system/boot/networkd.nix
@@ -3188,7 +3188,19 @@ let
 
       systemd.contents."/etc/systemd/networkd.conf" = renderConfig cfg.config;
 
-      systemd.services.systemd-networkd.wantedBy = [ "initrd.target" ];
+      systemd.services.systemd-networkd = {
+        wantedBy = [ "initrd.target" ];
+        # These before and conflicts lines can be removed when this PR makes it into a release:
+        # https://github.com/systemd/systemd/pull/27791
+        before = ["initrd-switch-root.target"];
+        conflicts = ["initrd-switch-root.target"];
+      };
+      systemd.sockets.systemd-networkd = {
+        wantedBy = [ "initrd.target" ];
+        before = ["initrd-switch-root.target"];
+        conflicts = ["initrd-switch-root.target"];
+      };
+
       systemd.services.systemd-network-generator.wantedBy = [ "sysinit.target" ];
 
       systemd.storePaths = [

--- a/nixos/tests/systemd-initrd-networkd.nix
+++ b/nixos/tests/systemd-initrd-networkd.nix
@@ -12,6 +12,7 @@ import ./make-test-python.nix ({ pkgs, lib, ... }: {
       systemd.services.check-flush = {
         requiredBy = ["multi-user.target"];
         before = ["network-pre.target" "multi-user.target"];
+        wants = ["network-pre.target"];
         unitConfig.DefaultDependencies = false;
         serviceConfig.Type = "oneshot";
         path = [ pkgs.iproute2 pkgs.iputils pkgs.gnugrep ];


### PR DESCRIPTION
Fixes #236146.

###### Description of changes

This essentially backports https://github.com/systemd/systemd/pull/27791. `systemd-networkd.service` is sent the `SIGTERM` signal, but it is not required to be stopped before `initrd-switch-root.target` is reached, despite the use of `systemctl isolate initrd-switch-root.target`. This is because when there is no ordering at all between two units, and a transaction stops one and starts the other, the two operations can happen simultaneously. This means the service could still be running when `switch-root` actually occurs. Then, stage 2 systemd will see the service still running and decide it doesn't need to add a start operation for it to its initial transaction. Finally, the service exits, but only after it's already too late. If, however, there is any ordering at all between a stopping unit and a starting unit, then the stop operation will be done first. This way, we ensure that the service is properly exited before doing `switch-root`.

This is something to keep in mind going forward. There may be other services that need this treatment. These `before` and `conflicts` definitions are the correct way to ensure a unit is actually stopped before you reach initrd-switch-root.

###### Things done

Although the user who experienced the bug said this fixes it, and the behavior in `nixosTests.systemd-initrd-networkd` is still passing, we were unable to reproduce the original bug in a nixos test, so my expectation that the bug is fixed is based on the user's experience and the fact that this essentially backports a fix for the [same issue on systemd](https://github.com/systemd/systemd/issues/27718).

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes (or backporting 23.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
