### PR TITLE
python310Packages.keepalive: remove use_2to3

### DIFF
--- a/pkgs/development/python-modules/keepalive/default.nix
+++ b/pkgs/development/python-modules/keepalive/default.nix
@@ -1,25 +1,35 @@
 { lib
 , buildPythonPackage
 , fetchPypi
+, fetchpatch
 }:
 
 buildPythonPackage rec {
   pname = "keepalive";
   version = "0.5";
+  format = "setuptools";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "3c6b96f9062a5a76022f0c9d41e9ef5552d80b1cadd4fccc1bf8f183ba1d1ec1";
+    hash = "sha256-PGuW+QYqWnYCLwydQenvVVLYCxyt1PzMG/jxg7odHsE=";
   };
+
+  patches = [
+    # https://github.com/wikier/keepalive/pull/11
+    (fetchpatch {
+      name = "remove-use_2to3.patch";
+      url = "https://github.com/wikier/keepalive/commit/64393f6c5bf9c69d946b584fd664dd4df72604e6.patch";
+      hash = "sha256-/G1eEt8a4Qz7x5oQnDZZD/PIQwo9+oPZoy9OrXGHvR4=";
+      excludes = ["README.md"];
+    })
+  ];
 
   # No tests included
   doCheck = false;
 
   meta = with lib; {
-    description = "An HTTP handler for `urllib2` that supports HTTP 1.1 and keepalive";
+    description = "An HTTP handler for `urllib` that supports HTTP 1.1 and keepalive";
     homepage = "https://github.com/wikier/keepalive";
-    license = licenses.asl20;
-    broken = true; # uses use_2to3, which is no longer supported for setuptools>=58
+    license = licenses.lgpl21Plus;
   };
-
 }


### PR DESCRIPTION
###### Description of changes

This package is unmaintained but still in use by the `sparqlwrapper` package, pending https://github.com/RDFLib/sparqlwrapper/issues/198. As an exercise in hygiene, I created https://github.com/wikier/keepalive/pull/11 to remove `use_2to3` to fix these two packages again. This will address https://github.com/RDFLib/sparqlwrapper/issues/227 too.

I also updated the license to LGPL-2.1 or later, because that is what is reported in the repository.

This PR is related to https://github.com/NixOS/nixpkgs/issues/155516.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes (or backporting 23.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
