### PR TITLE
prowlarr service: allow setting user and group

### DIFF
--- a/nixos/modules/services/misc/prowlarr.nix
+++ b/nixos/modules/services/misc/prowlarr.nix
@@ -11,6 +11,18 @@ in
     services.prowlarr = {
       enable = mkEnableOption (lib.mdDoc "Prowlarr");
 
+      user = mkOption {
+        type = types.str;
+        default = "prowlarr";
+        description = lib.mdDoc "User account under which Prowlarr runs.";
+      };
+
+      group = mkOption {
+        type = types.str;
+        default = "prowlarr";
+        description = lib.mdDoc "Group under which Prowlarr runs.";
+      };
+
       openFirewall = mkOption {
         type = types.bool;
         default = false;
@@ -27,11 +39,20 @@ in
 
       serviceConfig = {
         Type = "simple";
-        DynamicUser = true;
+        User = cfg.user;
+        Group = cfg.group;
         StateDirectory = "prowlarr";
         ExecStart = "${pkgs.prowlarr}/bin/Prowlarr -nobrowser -data=/var/lib/prowlarr";
         Restart = "on-failure";
       };
+    };
+
+    users.users = mkIf (cfg.user == "prowlarr") {
+      prowlarr = { group = cfg.group; };
+    };
+
+    users.groups = mkIf (cfg.group == "prowlarr") {
+      prowlarr = { };
     };
 
     networking.firewall = mkIf cfg.openFirewall {


### PR DESCRIPTION
###### Description of changes

I recently configured Prowlarr on NixOS and noticed that I was getting permission errors due to the dynamic user missing a home directory which was causing issues interfacing with Sonarr/Radarr and the like.

I fixed this in my own NixOS module by adding these lines and Prowlarr has been working great since. I just wanted to contribute these fixes to `nixpkgs` rather than my own custom NixOS module in case anyone else is running into the same issues.

This is my first contribution to nixpkgs so apologies if I got anything wrong!

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes (or backporting 23.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
