### PR TITLE
cairo-lang: init at 1.1.0

### DIFF
--- a/pkgs/development/compilers/cairo/default.nix
+++ b/pkgs/development/compilers/cairo/default.nix
@@ -1,0 +1,40 @@
+{ lib
+, rustPlatform
+, fetchFromGitHub
+, rustfmt
+}:
+
+rustPlatform.buildRustPackage rec {
+  pname = "cairo";
+  version = "1.1.0";
+
+  src = fetchFromGitHub {
+    owner = "starkware-libs";
+    repo = "cairo";
+    rev = "v${version}";
+    hash = "sha256-8dzDe4Kw9OASD0i3bMooqEclStxS/Ta/tOVCcFhvwSI=";
+  };
+
+  cargoHash = "sha256-IY3RE+EeNRhUSZX+bqojhPl6y8qm+i9C0zQmNApmat8=";
+
+  nativeCheckInputs = [
+    rustfmt
+  ];
+
+  checkFlags = [
+    # Requires a mythical rustfmt 2.0 or a nightly compiler
+    "--skip=golden_test::sourcegen_ast"
+  ];
+
+  postInstall = ''
+    # The core library is needed for compilation.
+    cp -r corelib $out/
+  '';
+
+  meta = with lib; {
+    description = "Turing-complete language for creating provable programs for general computation";
+    homepage = "https://github.com/starkware-libs/cairo";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ raitobezarius ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -21023,6 +21023,8 @@ with pkgs;
 
   cairo = callPackage ../development/libraries/cairo { };
 
+  cairo-lang = callPackage ../development/compilers/cairo { };
+
   cairomm = callPackage ../development/libraries/cairomm { };
 
   cairomm_1_16 = callPackage ../development/libraries/cairomm/1.16.nix {


### PR DESCRIPTION
###### Description of changes

`cairo-lang` is a general purpose language for provable computations using PCP (probabilistically checkable proofs — https://en.wikipedia.org/wiki/Probabilistically_checkable_proof)

This is the v1 Rust-based compiler version of the project.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes (or backporting 23.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
