### PR TITLE
dbus-glib add `getconf` into `nativeBuildInputs`

### DIFF
--- a/pkgs/development/libraries/dbus-glib/default.nix
+++ b/pkgs/development/libraries/dbus-glib/default.nix
@@ -1,5 +1,5 @@
 { lib, stdenv, fetchurl, buildPackages
-, pkg-config, expat, gettext, libiconv, dbus, glib
+, pkg-config, expat, gettext, libiconv, dbus, glib, getconf
 }:
 
 stdenv.mkDerivation rec {
@@ -14,7 +14,7 @@ stdenv.mkDerivation rec {
   outputs = [ "out" "dev" "devdoc" ];
   outputBin = "dev";
 
-  nativeBuildInputs = [ pkg-config gettext glib ];
+  nativeBuildInputs = [ pkg-config gettext glib getconf ];
 
   buildInputs = [ expat libiconv ];
 


### PR DESCRIPTION
###### Description of changes

Add `getconf` into nativeBuildInputs for `dbus-lib`.  I was unable to cross-compile nixos in the flake below without this change in an overlay, because dbus-glib uses `getconf` in its configure phase.
```nix
{
  description = "Testing some armv7l cross compilation";
  inputs = {
    nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
    flake-utils.url = github:numtide/flake-utils;
  };

  outputs = { self, nixpkgs, flake-utils, ... }@inputs: 
    flake-utils.lib.eachDefaultSystem (system: 
      let
        pkgs = nixpkgs.legacyPackages.${system};
        crossSystemFull = nixpkgs.lib.systems.examples.armv7l-hf-multiplatform;
        crossSystem = "armv7l-linux";
        crossPkgs = nixpkgs.legacyPackages.${crossSystem};
        overlays = [
          (final: prev: { 
            dbus-glib = prev.dbus-glib.overrideAttrs (finalAttrs: prevAttrs: {
              nativeBuildInputs = prevAttrs.nativeBuildInputs ++ [
                crossPkgs.getconf
              ];
            });
          })
        ];
      in {
        # Cross compile NixOS.
        nixosConfigurations.method1 = inputs.nixpkgs.lib.nixosSystem {
          inherit system;
          modules = [
            { 
              nixpkgs.overlays = overlays;
              nixpkgs.crossSystem.system = inherit crossSystem;
            }
          ];
        };

        packages.default = self.nixosConfigurations.${system}.method1.config.system.build.vm;
      });
}

```

with this lock file:
```json
{
  "nodes": {
    "flake-utils": {
      "inputs": {
        "systems": "systems"
      },
      "locked": {
        "lastModified": 1685518550,
        "narHash": "sha256-o2d0KcvaXzTrPRIo0kOLV0/QXHhDQ5DTi+OxcjO8xqY=",
        "owner": "numtide",
        "repo": "flake-utils",
        "rev": "a1720a10a6cfe8234c0e93907ffe81be440f4cef",
        "type": "github"
      },
      "original": {
        "owner": "numtide",
        "repo": "flake-utils",
        "type": "github"
      }
    },
    "nixpkgs": {
      "locked": {
        "lastModified": 1685498995,
        "narHash": "sha256-rdyjnkq87tJp+T2Bm1OD/9NXKSsh/vLlPeqCc/mm7qs=",
        "owner": "NixOS",
        "repo": "nixpkgs",
        "rev": "9cfaa8a1a00830d17487cb60a19bb86f96f09b27",
        "type": "github"
      },
      "original": {
        "owner": "NixOS",
        "ref": "nixpkgs-unstable",
        "repo": "nixpkgs",
        "type": "github"
      }
    },
    "root": {
      "inputs": {
        "flake-utils": "flake-utils",
        "nixpkgs": "nixpkgs"
      }
    },
    "systems": {
      "locked": {
        "lastModified": 1681028828,
        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
        "owner": "nix-systems",
        "repo": "default",
        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
        "type": "github"
      },
      "original": {
        "owner": "nix-systems",
        "repo": "default",
        "type": "github"
      }
    }
  },
  "root": "root",
  "version": 7
}
```


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes (or backporting 23.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).