### PR TITLE
`bootil`: patch for aarch64 support

### DIFF
--- a/pkgs/development/libraries/bootil/0001-no-rdtsc.patch
+++ b/pkgs/development/libraries/bootil/0001-no-rdtsc.patch
@@ -1,0 +1,29 @@
+diff --git a/src/3rdParty/smhasher/Platform.h b/src/3rdParty/smhasher/Platform.h
+index 538835f..0faf539 100644
+--- a/src/3rdParty/smhasher/Platform.h
++++ b/src/3rdParty/smhasher/Platform.h
+@@ -29,10 +29,6 @@ void SetAffinity ( int cpu );
+ 
+ #define BIG_CONSTANT(x) (x)
+ 
+-// RDTSC == Read Time Stamp Counter
+-
+-#define rdtsc() __rdtsc()
+-
+ //-----------------------------------------------------------------------------
+ // Other compilers
+ 
+@@ -70,13 +66,6 @@ inline uint64_t rotr64 ( uint64_t x, int8_t r )
+ 
+ #define BIG_CONSTANT(x) (x##LLU)
+ 
+-__inline__ unsigned long long int rdtsc()
+-{
+-    unsigned long long int x;
+-    __asm__ volatile ("rdtsc" : "=A" (x));
+-    return x;
+-}
+-
+ #include <strings.h>
+ #define _stricmp strcasecmp
+ 

--- a/pkgs/development/libraries/bootil/default.nix
+++ b/pkgs/development/libraries/bootil/default.nix
@@ -15,6 +15,8 @@ stdenv.mkDerivation {
     sha256 = "1njdj6nvmwf7j2fwqbyvd1cf5l52797vk2wnsliylqdzqcjmfpij";
   };
 
+  patches = [ ./0001-no-rdtsc.patch ];
+
   # Avoid guessing where files end up. Just use current directory.
   postPatch = ''
     substituteInPlace projects/premake4.lua \
@@ -40,6 +42,5 @@ stdenv.mkDerivation {
     maintainers = with maintainers; [ abigailbuccaneer ];
     # Build uses `-msse` and `-mfpmath=sse`
     platforms = platforms.all;
-    badPlatforms = [ "aarch64-linux" ];
   };
 }


### PR DESCRIPTION
###### Description of changes

This package has been disabled on `aarch64-linux` since #51813 in 2018, but was not updated to include `aarch64-darwin` in `badPlatforms`, so it's been failing there. While investigating the build failure, I found that it would be trivial to patch `bootil` to compile on aarch64.

The only x86-specific code in `bootil` is in `src/3rdParty/smhasher/Platform.h`, which defines a function which references the x86 `rdtsc` instruction using inline assembly. That function is neither exported nor used by the library itself, so I've patched it out and re-enabled aarch64 compilation.

I've tested compilation of `bootil` on `aarch64-darwin` and `x86_64-linux`, as well as basic functionality of its single dependent package `gmad` ("builds and prints the help message" level, since I'd be astonished if this patch would change functionality and I don't have any idea how to use `gmad`).

I'll probably also send this patch to the [upstream repository](https://github.com/garrynewman/bootil), but it doesn't appear to be extensively maintained and I'm not expecting it to be integrated quickly. If it gets accepted there, I'll come back and update this package.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes (or backporting 23.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

@AbigailBuccaneer as maintainer for `bootil` and dependent package `gmad`.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
