### PR TITLE
cargo-deb: 1.42.2 -> 1.44.0

### DIFF
--- a/pkgs/development/tools/rust/cargo-deb/default.nix
+++ b/pkgs/development/tools/rust/cargo-deb/default.nix
@@ -2,25 +2,36 @@
 , rustPlatform
 , fetchFromGitHub
 , makeWrapper
+, binutils
 , dpkg
 }:
-
+let
+  # cargo-deb expects "strip" and "objcopy" from binutils to be on the PATH.
+  binutilsBinPath = lib.makeBinPath [ binutils ];
+in
 rustPlatform.buildRustPackage rec {
   pname = "cargo-deb";
-  version = "1.42.2";
+  version = "1.44.0";
 
   src = fetchFromGitHub {
     owner = "kornelski";
     repo = pname;
-    rev = "v${version}";
-    hash = "sha256-s/piZ8sCdBz5zFW9i7xdVrf7dQiMjQp/ixCDjFh5SLc=";
+    rev = "refs/tags/v${version}";
+    hash = "sha256-1gA8r/4VMiBWTU0Q0rlSxANt9oK3nYx/cqq0WxvNNZs=";
   };
 
-  cargoHash = "sha256-4iJghmSXsaijNCvYyrM3dEsqCDk6zeTU92oP5Qs6tOY=";
+  cargoHash = "sha256-Fg0KkAqcjAGFEDaAge4KFAFBBfVSGE6lIoewDcLEFug=";
 
   nativeBuildInputs = [
     makeWrapper
   ];
+
+  preCheck = ''
+    export PATH="${binutilsBinPath}":$PATH
+
+    substituteInPlace tests/command.rs \
+      --replace '"stripped executable should be smaller than debug executable"' '"stripped executable {} should be smaller than debug executable {}", stripped.metadata().unwrap().len(), debug.metadata().unwrap().len()'
+  '';
 
   # This is an FHS specific assert depending on glibc location
   checkFlags = [
@@ -29,7 +40,8 @@ rustPlatform.buildRustPackage rec {
 
   postInstall = ''
     wrapProgram $out/bin/cargo-deb \
-      --prefix PATH : ${lib.makeBinPath [ dpkg ]}
+      --prefix PATH : "${lib.makeBinPath [ dpkg ]}" \
+      --prefix PATH : "${binutilsBinPath}"
   '';
 
   meta = with lib; {


### PR DESCRIPTION
###### Description of changes

https://github.com/kornelski/cargo-deb/compare/v1.42.2...v1.44.0

A new test enabled on OSX in v1.44.0 revealed that `cargo-deb` needs `strip` and `objcopy` to be in its `PATH`, so this is now added to the final wrapper as well as prior to running tests.

In OSX, this cannot be Apple's `strip` because it does not support the `--strip-unneeded` flag that `cargo-deb` uses.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes (or backporting 23.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
