### PR TITLE
hyprland-autoname-workspaces: init at 1.1.7

### DIFF
--- a/pkgs/applications/misc/hyprland-autoname-workspaces/default.nix
+++ b/pkgs/applications/misc/hyprland-autoname-workspaces/default.nix
@@ -1,0 +1,27 @@
+{ lib
+, rustPlatform
+, fetchFromGitHub
+}:
+
+rustPlatform.buildRustPackage rec {
+  pname = "hyprland-autoname-workspaces";
+  version = "1.1.7";
+
+  src = fetchFromGitHub {
+    owner = "hyprland-community";
+    repo = "hyprland-autoname-workspaces";
+    rev = "v${version}";
+    hash = "sha256-OtKPJZI0YKi98HUY4IDU8LRg6dTaD68OgVi9FzfjDbA=";
+  };
+
+  cargoHash = "sha256-ueT85rKa2PGvp/R/ZXkDGUFIXyYNpDErg4W8WcXAPIw=";
+
+  meta = with lib; {
+    description = "Automatically rename workspaces with icons of started applications";
+    homepage = "https://github.com/hyprland-community/hyprland-autoname-workspaces";
+    license = licenses.isc;
+    maintainers = with maintainers; [ donovanglover ];
+    mainProgram = "hyprland-autoname-workspaces";
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5525,6 +5525,8 @@ with pkgs;
     udis86 = pkgs.callPackage ../applications/window-managers/hyprwm/hyprland/udis86.nix { };
   };
 
+  hyprland-autoname-workspaces = callPackage ../applications/misc/hyprland-autoname-workspaces { };
+
   hyprland-per-window-layout = callPackage ../tools/wayland/hyprland-per-window-layout { };
 
   hyprland-protocols = callPackage ../applications/window-managers/hyprwm/hyprland-protocols { };


### PR DESCRIPTION
###### Description of changes

Adds [hyprland-autoname-workspaces](https://github.com/hyprland-community/hyprland-autoname-workspaces)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes (or backporting 23.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).