### PR TITLE
python3Packages.torch-bin: only include Linux-specific dependencies when building on Linux

### DIFF
--- a/pkgs/development/python-modules/torch/bin.nix
+++ b/pkgs/development/python-modules/torch/bin.nix
@@ -40,18 +40,19 @@ in buildPythonPackage {
 
   nativeBuildInputs = [
     addOpenGLRunpath
+    patchelf
+  ] ++ lib.optionals stdenv.isLinux [
     autoPatchelfHook
     cudaPackages.autoAddOpenGLRunpathHook
-    patchelf
   ];
 
-  buildInputs = with cudaPackages; [
+  buildInputs = lib.optionals stdenv.isLinux (with cudaPackages; [
     # $out/${sitePackages}/nvfuser/_C*.so wants libnvToolsExt.so.1 but torch/lib only ships
     # libnvToolsExt-$hash.so.1
     cuda_nvtx
-  ];
+  ]);
 
-  autoPatchelfIgnoreMissingDeps = [
+  autoPatchelfIgnoreMissingDeps = lib.optionals stdenv.isLinux [
     # This is the hardware-dependent userspace driver that comes from
     # nvidia_x11 package. It must be deployed at runtime in
     # /run/opengl-driver/lib or pointed at by LD_LIBRARY_PATH variable, rather
@@ -79,7 +80,7 @@ in buildPythonPackage {
     rm -rf $out/bin
   '';
 
-  postFixup = ''
+  postFixup = lib.optionalString stdenv.isLinux ''
     addAutoPatchelfSearchPath "$out/${python.sitePackages}/torch/lib"
 
     patchelf $out/${python.sitePackages}/torch/lib/libcudnn.so.8 --add-needed libcudnn_cnn_infer.so.8


### PR DESCRIPTION
This fixes a build regression on aarch64-darwin that has prevented torch-bin from being buildable since the merge of #227420.

###### Description of changes

Since the update to 2.0, the torch-bin package has depended on CUDA dependencies that are x86_64- and Linux-only.

However, this package was installable _and working_ on Darwin before the update to 2.0, and remains so after if we conditionalize the CUDA-referencing logic.

Demonstrating [Apple's suggested logic](https://developer.apple.com/metal/pytorch/) for doing a quick MPS test on a M1-based host, with this PR applied:

```
$ /nix/store/8gk2334l6bkqkrf99rm448pvqz0sqsyw-python3-3.10.11-env/bin/python
Python 3.10.11 (main, May 10 2023, 11:30:20) [Clang 11.1.0 ] on darwin
Type "help", "copyright", "credits" or "license" for more information.
>>> import torch
>>> if torch.backends.mps.is_available():
...     mps_device = torch.device("mps")
...     x = torch.ones(1, device=mps_device)
...     print (x)
... else:
...     print ("MPS device not found.")
...
tensor([1.], device='mps:0')
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [X] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes (or backporting 23.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).