### PR TITLE
typst-live: init at unstable-2023-05-27

### DIFF
--- a/pkgs/tools/typesetting/typst-live/default.nix
+++ b/pkgs/tools/typesetting/typst-live/default.nix
@@ -1,0 +1,42 @@
+{ lib
+, rustPlatform
+, fetchFromGitHub
+, stdenv
+, darwin
+, makeWrapper
+, typst
+}:
+
+rustPlatform.buildRustPackage {
+  pname = "typst-live";
+  version = "unstable-2023-05-27";
+
+  src = fetchFromGitHub {
+    owner = "ItsEthra";
+    repo = "typst-live";
+    rev = "10a2da57b93f8d6e4eaa0bfcec1e68e46b916868";
+    hash = "sha256-42QzqbyIjPn0C4coCU81gtlI7v5XJStlsDZvnLlwpYs=";
+  };
+
+  cargoHash = "sha256-M5jYSLw5oquAq2gGWZOJvx5/CGAl2Rg+G94V6ivAOzc=";
+
+  nativeBuildInputs = [
+    makeWrapper
+  ];
+
+  buildInputs = lib.optionals stdenv.isDarwin [
+    darwin.apple_sdk.frameworks.CoreServices
+  ];
+
+  postInstall = ''
+    wrapProgram $out/bin/typst-live \
+      --suffix PATH : ${lib.makeBinPath [ typst ]}
+  '';
+
+  meta = with lib; {
+    description = "Hot reloading for your typst files";
+    homepage = "https://github.com/ItsEthra/typst-live";
+    license = licenses.mit;
+    maintainers = with maintainers; [ figsoda ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -13393,6 +13393,8 @@ with pkgs;
 
   typst-fmt = callPackage ../tools/typesetting/typst-fmt { };
 
+  typst-live = callPackage ../tools/typesetting/typst-live { };
+
   tz = callPackage ../tools/misc/tz { };
 
   u9fs = callPackage ../servers/u9fs { };


### PR DESCRIPTION
https://github.com/ItsEthra/typst-live

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes (or backporting 23.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
