### PR TITLE
erg: init at 0.6.13

### DIFF
--- a/pkgs/development/compilers/erg/default.nix
+++ b/pkgs/development/compilers/erg/default.nix
@@ -1,0 +1,63 @@
+{ lib
+, rustPlatform
+, fetchFromGitHub
+, makeWrapper
+, python3
+, which
+}:
+
+rustPlatform.buildRustPackage rec {
+  pname = "erg";
+  version = "0.6.13";
+
+  src = fetchFromGitHub {
+    owner = "erg-lang";
+    repo = "erg";
+    rev = "v${version}";
+    hash = "sha256-XwQKtorE1HGRRCCtxQBVbl6O6aTs5Z2/W9n2Am40e8Q=";
+  };
+
+  cargoHash = "sha256-I4hQ78RTkCDKpq7HBNJsKqCiFL9004XvWdwtRdTQQkE=";
+
+  nativeBuildInputs = [
+    makeWrapper
+    python3
+    which
+  ];
+
+  buildFeatures = [ "full" ];
+
+  env = {
+    BUILD_DATE = "1970/01/01 00:00:00";
+    GIT_HASH_SHORT = src.rev;
+  };
+
+  # TODO(figsoda): fix tests
+  doCheck = false;
+
+  # the build script is impure and also assumes we are in a git repository
+  postPatch = ''
+    rm crates/erg_common/build.rs
+  '';
+
+  preBuild = ''
+    export HOME=$(mktemp -d)
+    export CARGO_ERG_PATH=$HOME/.erg
+  '';
+
+  postInstall = ''
+    mkdir -p $out/share
+    mv "$CARGO_ERG_PATH" $out/share/erg
+
+    wrapProgram $out/bin/erg \
+      --set-default ERG_PATH $out/share/erg
+  '';
+
+  meta = with lib; {
+    description = "A statically typed language that can deeply improve the Python ecosystem";
+    homepage = "https://github.com/erg-lang/erg";
+    changelog = "https://github.com/erg-lang/erg/releases/tag/${src.rev}";
+    license = with licenses; [ asl20 mit ];
+    maintainers = with maintainers; [ figsoda ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -14907,6 +14907,8 @@ with pkgs;
 
   eql = callPackage ../development/compilers/eql { };
 
+  erg = callPackage ../development/compilers/erg { };
+
   elm2nix = haskell.lib.compose.justStaticExecutables haskellPackages.elm2nix;
 
   elmPackages = recurseIntoAttrs (callPackage ../development/compilers/elm { });


### PR DESCRIPTION
https://github.com/erg-lang/erg

the latest version is 0.6.14, but I'm packaging 0.6.13 since it requires rust 1.70

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes (or backporting 23.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
