### PR TITLE
haskellPackages.uuagc-cabal: Mark as no longer broken

### DIFF
--- a/pkgs/development/haskell-modules/configuration-hackage2nix/broken.yaml
+++ b/pkgs/development/haskell-modules/configuration-hackage2nix/broken.yaml
@@ -5668,7 +5668,6 @@ broken-packages:
   - util-plus
   - util-primitive
   - uuagc-bootstrap
-  - uuagc-cabal
   - uuagc-diagrams
   - uu-cco
   - uuid-aeson


### PR DESCRIPTION
###### Description of changes

Simple one-line change. Follows this discussion: https://github.com/NixOS/nixpkgs/pull/233112#issuecomment-1580917895

`uuagc-cabal` has had an update to become compatible with ghc 9.2 and 9.4. PR here: https://github.com/UU-ComputerScience/uuagc/pull/11

Trying locally I found that `uuagc-cabal` builds fine: https://github.com/NixOS/nixpkgs/pull/233112#issuecomment-1580871378

As per instructions, I created this PR to mark as no longer broken.

## Notes

- The `uuagc` already did not have a `broken` flag, so it did not need to be removed
- I didn't check the other packages that start with `uuagc-...`. Some of those are also marked as broken, but they didn't have the fix mentioned above.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
  - This seemed a bit redundant for a one-line change
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes (or backporting 23.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

CC @cdepillabout

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
