### PR TITLE
hyperscan: 5.4.0 -> 5.4.2

### DIFF
--- a/pkgs/development/libraries/hyperscan/default.nix
+++ b/pkgs/development/libraries/hyperscan/default.nix
@@ -9,25 +9,22 @@
 #         which is fixed 8.41 version requirement (nixpkgs have 8.42+, and
 #         I not see any reason (for now) to backport 8.41.
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "hyperscan";
-  version = "5.4.0";
+  version = "5.4.2";
 
   src = fetchFromGitHub {
     owner = "intel";
-    repo = pname;
-    sha256 = "sha256-AJAjaXVnGqIlMk+gb6lpTLUdZr8nxn2XSW4fj6j/cmk=";
-    rev = "v${version}";
+    repo = "hyperscan";
+    hash = "sha256-tzmVc6kJPzkFQLUM1MttQRLpgs0uckbV6rCxEZwk1yk=";
+    rev = "v${finalAttrs.version}";
   };
 
   outputs = [ "out" "dev" ];
 
   buildInputs = [ boost ];
   nativeBuildInputs = [
-    cmake ragel python3
-    # Consider simply using busybox for these
-    # Need at least: rev, sed, cut, nm
-    util-linux
+    cmake ragel python3 util-linux
   ];
 
   cmakeFlags = [
@@ -36,14 +33,6 @@ stdenv.mkDerivation rec {
   ]
   ++ lib.optional (withStatic) "-DBUILD_STATIC_AND_SHARED=ON"
   ++ lib.optional (!withStatic) "-DBUILD_SHARED_LIBS=ON";
-
-  patches = [
-    (fetchpatch {
-      # part of https://github.com/intel/hyperscan/pull/336
-      url = "https://github.com/intel/hyperscan/commit/e2c4010b1fc1272cab816ba543940b3586e68a0c.patch";
-      sha256 = "sha256-doVNwROL6MTcgOW8jBwGTnxe0zvxjawiob/g6AvXLak=";
-    })
-  ];
 
   postPatch = ''
     sed -i '/examples/d' CMakeLists.txt
@@ -69,7 +58,7 @@ stdenv.mkDerivation rec {
 
     homepage = "https://www.hyperscan.io/";
     maintainers = with maintainers; [ avnik ];
-    platforms = [ "x86_64-linux" ]; # can't find nm on darwin ; might build on aarch64 but untested
+    platforms = [ "x86_64-linux" ];
     license = licenses.bsd3;
   };
-}
+})


### PR DESCRIPTION
###### Description of changes

Upgrades Intel Hyperscan library from 5.4 to 5.4.2.

Supersedes https://github.com/NixOS/nixpkgs/pull/221028, which I closed by mistake ;-)

[Changelog](https://github.com/intel/hyperscan/releases/tag/v5.4.2)

Previous patches are no longer necessary, hence removed. Comment re: switching for `busybox` removed - tried it, but build scripts are using GNU specific options to some commands.

This is an Intel functionality specific library, so will only build on x86-64. (There is an ARM spinoff, `vectorscan`).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes (or backporting 23.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
