### PR TITLE
argocd: 2.7.3 -> 2.7.4

### DIFF
--- a/pkgs/applications/networking/cluster/argocd/default.nix
+++ b/pkgs/applications/networking/cluster/argocd/default.nix
@@ -2,17 +2,17 @@
 
 buildGoModule rec {
   pname = "argocd";
-  version = "2.7.3";
+  version = "2.7.4";
 
   src = fetchFromGitHub {
     owner = "argoproj";
     repo = "argo-cd";
     rev = "v${version}";
-    sha256 = "sha256-vUidpBiCxHzCwveOrLfNpwVePQZMgX+K8qpVR0h58p0=";
+    sha256 = "sha256-9S30m4iA5qrcXFWk3QiDSuhHebhWYOpVfKSE6mz0mig=";
   };
 
   proxyVendor = true; # darwin/linux hash mismatch
-  vendorHash = "sha256-+thdFvd4cxvWxi+j4awBqfQ6jq6puFYbwoWsIsbMIZI=";
+  vendorHash = "sha256-Ec2v9BehSvbx3phA1JrZnsZ4BObFTTOs2Ee+5pKsAGs=";
 
   # Set target as ./cmd per cli-local
   # https://github.com/argoproj/argo-cd/blob/master/Makefile#L227
@@ -59,6 +59,6 @@ buildGoModule rec {
     downloadPage = "https://github.com/argoproj/argo-cd";
     homepage = "https://argo-cd.readthedocs.io/en/stable/";
     license = licenses.asl20;
-    maintainers = with maintainers; [ shahrukh330 bryanasdev000 ];
+    maintainers = with maintainers; [ shahrukh330 bryanasdev000 qjoly ];
   };
 }


### PR DESCRIPTION
###### Description of changes

Features

    https://github.com/argoproj/argo-cd/commit/23a07991348d0fc573006539220888ccd4372d82: feat: add css to support external custom style (https://github.com/argoproj/argo-cd/pull/13279) (https://github.com/argoproj/argo-cd/pull/13746) (@gcp-cherry-pick-bot[bot])
    https://github.com/argoproj/argo-cd/commit/ed828e9ddbd66972b58accab19fdc1f66fac5f64: feat: add ssh.github.com to SSH known hosts (https://github.com/argoproj/argo-cd/pull/13592) (https://github.com/argoproj/argo-cd/pull/13765) (@gcp-cherry-pick-bot[bot])

Bug fixes

    https://github.com/argoproj/argo-cd/commit/f4848bbaaa1d1268c7cef6e3601836e570dad721: fix(appset): add ApplicationSet ProgressiveSync handling to clean up old appStatus entries when Applications are removed or RollingSync is disabled (https://github.com/argoproj/argo-cd/pull/13419) (https://github.com/argoproj/argo-cd/pull/13759) (@gcp-cherry-pick-bot[bot])
    https://github.com/argoproj/argo-cd/commit/7562607e2b6b042c813e2ccebac42f9089a22da6: fix(appset): Post selector with Go templates in ApplicationSet (cherry-pick https://github.com/argoproj/argo-cd/pull/13584) (https://github.com/argoproj/argo-cd/pull/13822) (@m13t)
    https://github.com/argoproj/argo-cd/commit/9697cbf1e9a07c7d2dfb63a3e1ed08aef6b0c14a: fix(appset): allow cluster urls to be matched (https://github.com/argoproj/argo-cd/pull/13715) (https://github.com/argoproj/argo-cd/pull/13770) (@blakepettersson)
    https://github.com/argoproj/argo-cd/commit/25d5ad97a052dc89d027b0cf7ed859538050aba0: fix(doc): deep links example fix (https://github.com/argoproj/argo-cd/pull/13855) (https://github.com/argoproj/argo-cd/pull/13857) (@gcp-cherry-pick-bot[bot])
    https://github.com/argoproj/argo-cd/commit/419ac0e7536a18c8c3ef84bef5336d9b841bb080: fix(kustomize): allow using build env in images (https://github.com/argoproj/argo-cd/pull/13745) (https://github.com/argoproj/argo-cd/pull/13756) (@gcp-cherry-pick-bot[bot])
    https://github.com/argoproj/argo-cd/commit/7c9b1c5d78125f21d094c0db5c69653539806dd6: fix(ui): Fix Link warnings (https://github.com/argoproj/argo-cd/issues/13694) (https://github.com/argoproj/argo-cd/pull/13854) (https://github.com/argoproj/argo-cd/pull/13890) (@gcp-cherry-pick-bot[bot])
    https://github.com/argoproj/argo-cd/commit/f1c4ed2d7b2603a94c2bbfed63825bde8476672a: fix(ui): Patch Resource missing appNamespace (https://github.com/argoproj/argo-cd/pull/13839) (https://github.com/argoproj/argo-cd/pull/13840) (@gcp-cherry-pick-bot[bot])
    https://github.com/argoproj/argo-cd/commit/2db86afb78745066cee44b286b1cacfe4f7fd97a: fix(ui): Stop using the deprecated url format for gitlab instances (https://github.com/argoproj/argo-cd/pull/13687) (https://github.com/argoproj/argo-cd/pull/13767) (@gcp-cherry-pick-bot[bot])
    https://github.com/argoproj/argo-cd/commit/b3f0979e71b59a19dcad4a222cfec08f2ccb377b: fix: CMPv2 does not allow symlinks to adjacent files in same git repo. Fixes https://github.com/argoproj/argo-cd/issues/13342 (https://github.com/argoproj/argo-cd/pull/13360) (https://github.com/argoproj/argo-cd/pull/13669) (@gcp-cherry-pick-bot[bot])
    https://github.com/argoproj/argo-cd/commit/ca5aced6d340fd462543a796be6b8698a969c131: fix: https://github.com/advisories/GHSA-2q89-485c-9j2x (https://github.com/argoproj/argo-cd/pull/13748) (https://github.com/argoproj/argo-cd/pull/13893) (@jmeridth)
    https://github.com/argoproj/argo-cd/commit/0bf029a0e3ac1fc81bbf4bcb30b0caa398bbd874: fix: Regression in signature verification for git tags (https://github.com/argoproj/argo-cd/pull/12797) (https://github.com/argoproj/argo-cd/pull/13113) (@gcp-cherry-pick-bot[bot])
    https://github.com/argoproj/argo-cd/commit/07f9c542aa4adc0085990fe3351c4caabce35eb0: fix: argocd app sync/wait falsely failed with completed with phase: Running (https://github.com/argoproj/argo-cd/pull/13637) (https://github.com/argoproj/argo-cd/pull/13672) (@gcp-cherry-pick-bot[bot])
    https://github.com/argoproj/argo-cd/commit/f74235726a6ad23a967ddc702e08043b70ce714e: fix: do not replace namespaces (https://github.com/argoproj/argo-cd/pull/13758) (https://github.com/argoproj/argo-cd/pull/13769) (@blakepettersson)
    https://github.com/argoproj/argo-cd/commit/8c2b8634776279c3b764732543ebbda4be779b53: fix: ensure repositories are correctly marked with inherited creds in CLI output (https://github.com/argoproj/argo-cd/pull/13428) (https://github.com/argoproj/argo-cd/pull/13789) (@gcp-cherry-pick-bot[bot])

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes (or backporting 23.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
