### PR TITLE
clusterctl: 1.4.2 -> 1.4.3

### DIFF
--- a/pkgs/applications/networking/cluster/clusterctl/default.nix
+++ b/pkgs/applications/networking/cluster/clusterctl/default.nix
@@ -2,16 +2,16 @@
 
 buildGoModule rec {
   pname = "clusterctl";
-  version = "1.4.2";
+  version = "1.4.3";
 
   src = fetchFromGitHub {
     owner = "kubernetes-sigs";
     repo = "cluster-api";
     rev = "v${version}";
-    hash = "sha256-NvCQs6YzQ2zNLQiYgFK/q2c74g/+YkzQIQJWEINOYIE=";
+    hash = "sha256-OtA7mhypPNDD7IH5XKOoE2ytcjR0uhed8B3MoMrPd0Y=";
   };
 
-  vendorHash = "sha256-ZJFpzBeC048RZ6YfjXQPyohCO1WagxXvBBacifkfkjE=";
+  vendorHash = "sha256-QzD0Stbr8QuQ8n9l9qv16KFqSFBsRbxETmQ8LHdk3nI=";
 
   subPackages = [ "cmd/clusterctl" ];
 
@@ -43,6 +43,6 @@ buildGoModule rec {
     description = "Kubernetes cluster API tool";
     homepage = "https://cluster-api.sigs.k8s.io/";
     license = licenses.asl20;
-    maintainers = with maintainers; [ zowoq ];
+    maintainers = with maintainers; [ zowoq qjoly ];
   };
 }


### PR DESCRIPTION
###### Description of changes

Bug Fixes

    clusterctl: Return error on infra cluster and control plane discovery (https://github.com/kubernetes-sigs/cluster-api/pull/8609)
    e2e: Adjust machinepool helper e2e timeout (https://github.com/kubernetes-sigs/cluster-api/pull/8756)
    e2e: test/e2e check for machines being ready after provisioning on Runtime SDK test (https://github.com/kubernetes-sigs/cluster-api/pull/8646)
    e2e: test/framework fix docker pod log collector (https://github.com/kubernetes-sigs/cluster-api/pull/8643)
    KCP: Allow machine rollout if cert reconcile fails (https://github.com/kubernetes-sigs/cluster-api/pull/8737)
    KCP: Prevent KCP to create many private keys for each reconcile (https://github.com/kubernetes-sigs/cluster-api/pull/8619)
    CAPD: change the haproxy entrypoint to prevent getting stopped immediately after start (https://github.com/kubernetes-sigs/cluster-api/pull/8742)
    CAPD: Delegate CAPD port selection to the container runtime (https://github.com/kubernetes-sigs/cluster-api/pull/8655)
    CAPD: fix fail-swap-on=false flag not being part of kind images anymore (https://github.com/kubernetes-sigs/cluster-api/pull/8777)

Others

    API: Deprecate v1alpha3 and v1alpha4 in CRDs (https://github.com/kubernetes-sigs/cluster-api/pull/8700)
    Dependency: Bump docker/distribution to v2.8.2 (https://github.com/kubernetes-sigs/cluster-api/pull/8648)
    Dependency: Update cert-manager to v1.11.2 (https://github.com/kubernetes-sigs/cluster-api/pull/8639)
    Dependency: Update cert-manager to v1.12.0 (https://github.com/kubernetes-sigs/cluster-api/pull/8705)
    Dependency: Update cert-manager to v1.12.1 (https://github.com/kubernetes-sigs/cluster-api/pull/8752)
    Dependency: Update kpromo to v3.6.0 (https://github.com/kubernetes-sigs/cluster-api/pull/8682)
    Dependency: Update kubebuilder envtest (1.26.0 -> 1.27.1) (https://github.com/kubernetes-sigs/cluster-api/pull/8601)
    Devtools: Pin delve to version supporting go 1.19 (https://github.com/kubernetes-sigs/cluster-api/pull/8727)
    e2e: Disable fail-fast by default for e2e tests (https://github.com/kubernetes-sigs/cluster-api/pull/8659)
    e2e: Pin cgroup driver used in v0.3, v0.4 and v1.0 templates (https://github.com/kubernetes-sigs/cluster-api/pull/8693)
    e2e: Improve gomega fail handling in clusterClass rollout (https://github.com/kubernetes-sigs/cluster-api/pull/8771)
    e2e: e2e: log leftover processes to eventually detect zombies (https://github.com/kubernetes-sigs/cluster-api/pull/8671)
    Machine: use providerID string as-is (https://github.com/kubernetes-sigs/cluster-api/pull/8594)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes (or backporting 23.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
