### PR TITLE
phira: init at 0.3.3

### DIFF
--- a/pkgs/games/phira/default.nix
+++ b/pkgs/games/phira/default.nix
@@ -1,0 +1,57 @@
+{ lib
+, rustPlatform
+, fetchFromGitHub
+, pkg-config
+, perl
+, wrapGAppsHook
+, openssl
+, alsa-lib
+, at-spi2-atk
+}:
+
+rustPlatform.buildRustPackage rec {
+  pname = "phira";
+  version = "0.3.3";
+
+  src = fetchFromGitHub {
+    owner = "TeamFlos";
+    repo = pname;
+    rev = "666797936a05743c4e2c45646a7873381210590c";
+    hash = "sha256-JxsZ4UAvYtu5X7qGFLSsi1FgRQ0bpeVDquad4F0Cdsc=";
+  };
+
+  cargoLock = {
+    lockFile = "${src}/Cargo.lock";
+    outputHashes = {
+      "macroquad-0.3.25" = "sha256-mfj5NqoZaEJ2lxZf9gC0izhaNyvWHe4Dqk7UIFGbH8I=";
+      "miniquad-0.3.15" = "sha256-enX7pJgRX2OQ7PX2SAKhzU/xoB/tT3WzS4OkEmgmPOA=";
+      "phira-mp-client-0.1.0" = "sha256-nMmr5An13zdSUBW/tUz1q8mHWXTiV+buWcBM05DBpQQ=";
+      "sasa-0.1.0" = "sha256-NI1e3chagF//h6hwDckU1qOPkG1V7abxa5mVws4Uvfw=";
+    };
+  };
+
+  postPatch = ''
+    cp ${cargoLock.lockFile} Cargo.lock
+  '';
+
+  nativeBuildInputs = [
+    pkg-config
+    perl # openssl-sys
+    wrapGAppsHook
+  ];
+
+  buildInputs = [
+    openssl
+    alsa-lib
+    at-spi2-atk
+  ];
+
+  meta = with lib; {
+    description = "a non-commercial community-driven rhythm game inspired by Phigros";
+    homepage = "https://github.com/TeamFlos/phira";
+    license = licenses.gpl3Plus;
+    mainProgram = "phira-main";
+    maintainers = with maintainers; [ aleksana ];
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -28874,6 +28874,8 @@ with pkgs;
 
   phinger-cursors = callPackage ../data/icons/phinger-cursors { };
 
+  phira = callPackage ../games/phira { };
+
   qogir-icon-theme = callPackage ../data/icons/qogir-icon-theme { };
 
   qogir-kde = callPackage ../data/themes/qogir-kde { };


### PR DESCRIPTION
###### Description of changes

https://github.com/TeamFlos/phira

Yet another open source rhythm game with Linux support.

This package (and the app itself) is still in early state. It doesn't take with the assets, and the program will find the assets in current folder.

It runs btw.
![2023-06-08T20:17:45,534361969+08:00](https://github.com/NixOS/nixpkgs/assets/42209822/0b5bdf19-1774-440b-8075-db08e63bda7d)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes (or backporting 23.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
