### PR TITLE
prismlauncher: bubblewrap and disable gamemodeSupport by default

### DIFF
--- a/pkgs/games/prismlauncher/wrapper.nix
+++ b/pkgs/games/prismlauncher/wrapper.nix
@@ -1,8 +1,10 @@
 { lib
 , stdenv
-, symlinkJoin
 , prismlauncher-unwrapped
+, runCommandLocal
 , wrapQtAppsHook
+, makeWrapper
+, bubblewrap
 , qtbase  # needed for wrapQtAppsHook
 , qtsvg
 , qtwayland
@@ -15,23 +17,27 @@
 , jdk17
 , gamemode
 
+, enableBubblewrap ? lib.meta.availableOn stdenv.hostPlatform bubblewrap
 , msaClientID ? null
-, gamemodeSupport ? true
+, gamemodeSupport ? false
 , jdks ? [ jdk17 jdk8 ]
 , additionalLibs ? [ ]
 }:
+# `gamemodeSupport` requires session D-Bus access, which is blocked by the sandbox.
+assert enableBubblewrap -> !gamemodeSupport;
+
 let
   prismlauncherFinal = prismlauncher-unwrapped.override {
     inherit msaClientID gamemodeSupport;
   };
+
 in
-symlinkJoin {
-  name = "prismlauncher-${prismlauncherFinal.version}";
-
-  paths = [ prismlauncherFinal ];
-
+runCommandLocal "prismlauncher-${prismlauncherFinal.version}" {
   nativeBuildInputs = [
     wrapQtAppsHook
+
+    # Force to use the shell wrapper instead of the binary wrapper. We have scripts.
+    makeWrapper
   ];
 
   buildInputs = [
@@ -40,9 +46,65 @@ symlinkJoin {
   ]
   ++ lib.optional (lib.versionAtLeast qtbase.version "6") qtwayland;
 
-  postBuild = ''
-    wrapQtAppsHook
+  # Passthrough
+  # Ref: https://github.com/NixOS/nixpkgs/blob/5e871d8aa6f57cc8e0dc087d1c5013f6e212b4ce/pkgs/build-support/build-fhsenv-bubblewrap/default.nix#L170
+  wrapperPreExec = lib.optionalString enableBubblewrap ''
+    args=()
+    if [[ "$DISPLAY" == :* ]]; then
+        local_socket="/tmp/.X11-unix/X''${DISPLAY#?}"
+        args+=(--ro-bind-try "$local_socket" "$local_socket")
+    fi
+    if [[ "$WAYLAND_DISPLAY" = /* ]]; then
+        args+=(--ro-bind-try "$WAYLAND_DISPLAY" "$WAYLAND_DISPLAY")
+    elif [[ -n "$WAYLAND_DISPLAY" ]]; then
+        args+=(--ro-bind-try "$XDG_RUNTIME_DIR/$WAYLAND_DISPLAY" "/tmp/$WAYLAND_DISPLAY")
+    fi
   '';
+
+  bwrapArgs = lib.optionals enableBubblewrap [
+    "--unshare-user"
+    "--unshare-ipc"
+    "--unshare-pid"
+    "--unshare-uts"
+    "--unshare-cgroup"
+    "--die-with-parent"
+
+    "--dev /dev"
+    "--proc /proc"
+    "--ro-bind /nix /nix"
+    "--ro-bind /etc /etc"
+    "--tmpfs /tmp"
+
+    # Network is required.
+    "--share-net"
+    "--ro-bind /run/systemd/resolve /run/systemd/resolve"
+
+    # Mesa & OpenGL.
+    "--ro-bind /run/opengl-driver /run/opengl-driver"
+    "--dev-bind-try /dev/dri /dev/dri"
+    "--ro-bind-try /sys/class /sys/class"
+    "--ro-bind-try /sys/dev/char /sys/dev/char"
+    "--ro-bind-try /sys/devices/pci0000:00 /sys/devices/pci0000:00"
+    "--ro-bind-try /sys/devices/system/cpu /sys/devices/system/cpu"
+
+    # Audio.
+    "--setenv XDG_RUNTIME_DIR /tmp"
+    ''--ro-bind-try "$XDG_RUNTIME_DIR/pulse" /tmp/pulse''
+    ''--ro-bind-try "$XDG_RUNTIME_DIR/pipewire-0" /tmp/pipewire-0''
+
+    # Runtime args from `wrapperPreExec`.
+    ''"''${args[@]}"''
+
+    # Data storage.
+    ''--bind "''${XDG_DATA_HOME:-$HOME/.local/share}/PrismLauncher" $HOME/.local/share/PrismLauncher''
+    "--unsetenv XDG_DATA_HOME"
+
+    # Block dangerous D-Bus.
+    "--unsetenv DBUS_SESSION_BUS_ADDRESS"
+
+    "--"
+    "${prismlauncherFinal}/bin/prismlauncher"
+  ];
 
   qtWrapperArgs =
     let
@@ -72,4 +134,12 @@ symlinkJoin {
     ];
 
   inherit (prismlauncherFinal) meta;
-}
+} ''
+  ${if enableBubblewrap then ''
+    qtWrapperArgs+=(--run "$wrapperPreExec" --add-flags "$bwrapArgs")
+    makeQtWrapper ${bubblewrap}/bin/bwrap $out/bin/prismlauncher
+  '' else ''
+    makeQtWrapper ${prismlauncherFinal}/bin/prismlauncher $out/bin/prismlauncher
+  ''}
+  ln -s ${prismlauncherFinal}/share $out/share
+''


### PR DESCRIPTION
###### Description of changes

Wrap the launcher in a sandbox since it's RCE by design. This could minimize the impact when users run any mod containing or infected by malwares, eg. https://prismlauncher.org/news/cf-compromised-alert.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes (or backporting 23.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
