### PR TITLE
tfupdate: 0.6.7 -> 0.6.8

### DIFF
--- a/pkgs/applications/networking/cluster/tfupdate/default.nix
+++ b/pkgs/applications/networking/cluster/tfupdate/default.nix
@@ -2,16 +2,16 @@
 
 buildGoModule rec {
   pname = "tfupdate";
-  version = "0.6.7";
+  version = "0.6.8";
 
   src = fetchFromGitHub {
     owner = "minamijoyo";
     repo = "tfupdate";
     rev = "v${version}";
-    sha256 = "sha256-zDrmzubk5ScqZapp58U8NsyKl9yZ48VtWafamDdlWK0=";
+    sha256 = "sha256-zL2zUd9wwX6oHeROxgLWNlrFYRQaah/r9k3DePdYikU=";
   };
 
-  vendorHash = "sha256-nhAeN/UXLR0QBb7PT9hdtNSz1whfXxt6SYejpLJbDbk=";
+  vendorHash = "sha256-FnrcK990xL2FpFzIdb5ABBeeg5jjP22dBu7dOEeqG9c=";
 
   # Tests start http servers which need to bind to local addresses:
   # panic: httptest: failed to listen on a port: listen tcp6 [::1]:0: bind: operation not permitted
@@ -22,6 +22,6 @@ buildGoModule rec {
     homepage = "https://github.com/minamijoyo/tfupdate";
     changelog = "https://github.com/minamijoyo/tfupdate/blob/${src.rev}/CHANGELOG.md";
     license = licenses.mit;
-    maintainers = with maintainers; [ Intuinewin ];
+    maintainers = with maintainers; [ Intuinewin qjoly ];
   };
 }


### PR DESCRIPTION
###### Description of changes

https://github.com/minamijoyo/tfupdate/commit/037ab6d276d0e1c2b02c3eb9bb823832f180f370 Bump version to v0.6.8
    https://github.com/minamijoyo/tfupdate/commit/0b7fc7da3095311cc5ecd725a27ebd8951a44e28 Set docker build timeout to 10m
    https://github.com/minamijoyo/tfupdate/commit/298df92a009aef0dea3b0254235e3029abb3ec9f Update hcl to v2.17.0
    https://github.com/minamijoyo/tfupdate/commit/9b12abb1a3fee1a86d72cfcb53b43432a8091724 Update goreleaser/goreleaser-action to v4
    https://github.com/minamijoyo/tfupdate/commit/37b0b57284cbf9b30b98b8ad4f45f9627ffd12cd Update actions/setup-go to v4
    https://github.com/minamijoyo/tfupdate/commit/393777b9c56ada8da2702650265a2a77ffbb7f39 Read Go version from file
    https://github.com/minamijoyo/tfupdate/commit/f9e1bda2e52c0b7214bcf56caf83324f79979c96 Fix lint issues
    https://github.com/minamijoyo/tfupdate/commit/dba340024aaf7accac56f38dd530f728833d1956 Update Go to v1.20 and Alpine 3.18

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes (or backporting 23.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
