### PR TITLE
nixd: init at 1.0.0

### DIFF
--- a/pkgs/development/tools/language-servers/nixd/default.nix
+++ b/pkgs/development/tools/language-servers/nixd/default.nix
@@ -1,0 +1,81 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, boost182
+, gtest
+, libbacktrace
+, lit
+, llvmPackages
+, meson
+, ninja
+, nix
+, nixpkgs-fmt
+, pkg-config
+}:
+
+stdenv.mkDerivation rec {
+  pname = "nixd";
+  version = "1.0.0";
+
+  src = fetchFromGitHub {
+    owner = "nix-community";
+    repo = "nixd";
+    rev = version;
+    hash = "sha256-kTDPbsQi9gzFAFkiAPF+V3yI1WBmILEnnsqdgHMqXJA=";
+  };
+
+  mesonBuildType = "release";
+
+  nativeBuildInputs = [
+    meson
+    ninja
+    pkg-config
+  ];
+
+  nativeCheckInputs = [
+    lit
+    nixpkgs-fmt
+  ];
+
+  buildInputs = [
+    libbacktrace
+    nix
+    gtest
+    boost182
+    llvmPackages.llvm
+  ];
+
+  env.CXXFLAGS = "-include ${nix.dev}/include/nix/config.h";
+
+  doCheck = true;
+
+  checkPhase = ''
+    runHook preCheck
+    dirs=(store var var/nix var/log/nix etc home)
+
+    for dir in $dirs; do
+      mkdir -p "$TMPDIR/$dir"
+    done
+
+    export NIX_STORE_DIR=$TMPDIR/store
+    export NIX_LOCALSTATE_DIR=$TMPDIR/var
+    export NIX_STATE_DIR=$TMPDIR/var/nix
+    export NIX_LOG_DIR=$TMPDIR/var/log/nix
+    export NIX_CONF_DIR=$TMPDIR/etc
+    export HOME=$TMPDIR/home
+
+    # Disable nixd regression tests, because it uses some features provided by
+    # nix, and does not correctly work in the sandbox
+    meson test --print-errorlogs server regression/nix-ast-dump
+    runHook postCheck
+  '';
+
+  meta = {
+    description = "Nix language server";
+    homepage = "https://github.com/nix-community/nixd";
+    license = lib.licenses.lgpl3Plus;
+    maintainers = with lib.maintainers; [ inclyc ];
+    platforms = lib.platforms.unix;
+    broken = stdenv.isDarwin;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -17735,6 +17735,11 @@ with pkgs;
 
   nil = callPackage ../development/tools/language-servers/nil { };
 
+  nixd = callPackage ../development/tools/language-servers/nixd {
+    llvmPackages = llvmPackages_16;
+    nix = nixVersions.nix_2_16;
+  };
+
   nls = callPackage ../development/tools/language-servers/nls { };
 
   pylyzer = callPackage ../development/tools/language-servers/pylyzer { };


### PR DESCRIPTION
###### Description of changes

nix language server "nixd", home-page: https://github.com/nix-community/nixd

#### Home-manager options auto-complete & goto declaration

We generally support all module systems provided by lib/{options,module).nix. Options are lazily evaluated.

![hm-options-decl](https://user-images.githubusercontent.com/36667224/244408335-5c2b40a9-48da-4214-9071-5f80fcb721ae.gif)


#### Native cross-file analysis

<img src="https://github.com/nix-community/nixd/blob/main/docs/images/3e4fc99c-7a20-42be-a337-d1746239c731.png?raw=true" alt="" width="50%" height="50%">


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes (or backporting 23.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
