### PR TITLE
driftctl: 0.38.2 -> 0.39.0

### DIFF
--- a/pkgs/applications/networking/cluster/driftctl/default.nix
+++ b/pkgs/applications/networking/cluster/driftctl/default.nix
@@ -2,16 +2,16 @@
 
 buildGoModule rec {
   pname = "driftctl";
-  version = "0.38.2";
+  version = "0.39.0";
 
   src = fetchFromGitHub {
     owner = "snyk";
     repo = "driftctl";
     rev = "v${version}";
-    sha256 = "sha256-PPzoZypTP3yrgU50Uv7yBNCc2nAa84quCTWjxyq9h/c=";
+    sha256 = "sha256-1i5x05q0Mo3E3ExM9qONRtQCH3nO7pXyNqOaAtz7qYE=";
   };
 
-  vendorHash = "sha256-XVEXWBVqYoAlK4DP0GdWqJDcLy9WxCaUdNbVESJ9zoM=";
+  vendorHash = "sha256-H/+LORl7Bjy1NshjtWDzj13YCrlQQgtBr4+Rz/rxQkY=";
 
   nativeBuildInputs = [ installShellFiles ];
 
@@ -51,6 +51,6 @@ buildGoModule rec {
       and fills in the missing piece in your DevSecOps toolbox.
     '';
     license = licenses.asl20;
-    maintainers = with maintainers; [ kaction jk ];
+    maintainers = with maintainers; [ kaction jk qjoly ];
   };
 }


### PR DESCRIPTION
###### Description of changes

chore: bump go-getter to resolve vuln and go mod tidy (https://github.com/snyk/driftctl/pull/1657) 
    chore: remove aur publish (https://github.com/snyk/driftctl/pull/1669)
    chore: don't disable acc test KMS keys (https://github.com/snyk/driftctl/pull/1668) 
    Update failing tests notifications (https://github.com/snyk/driftctl/pull/1667)
    chore: disable GitHub acceptance tests (https://github.com/snyk/driftctl/pull/1666) 
    [CTX-601] chore: always retry terraform-destroy (https://github.com/snyk/driftctl/pull/1664) 
    [CTX-601] chore: fix some Google acceptance tests (https://github.com/snyk/driftctl/pull/1665) 
    [CTX-601] chore: fix various AWS acceptance tests (https://github.com/snyk/driftctl/pull/1662) 
    chore: ignore jetbrains ide settings (https://github.com/snyk/driftctl/pull/1663) 
    remove codecov (https://github.com/snyk/driftctl/pull/1661) 
    Ensure go mod tidy (https://github.com/snyk/driftctl/pull/1660) 
    tidy go mod (https://github.com/snyk/driftctl/pull/1659)
    Temporarily disable nightly CircleCI workflow (https://github.com/snyk/driftctl/pull/1656) 
    chore: disable snyk monitor (https://github.com/snyk/driftctl/pull/1643) 
    chore: update .snyk (https://github.com/snyk/driftctl/pull/1638) 
    chore: change snyk org (https://github.com/snyk/driftctl/pull/1630) 
    [Snyk] Security upgrade alpine from 3.16 to 3.17 (https://github.com/snyk/driftctl/pull/1623) 
    docs: add n2N8Z as a contributor for bug (https://github.com/snyk/driftctl/pull/1622) 
    Issue - 1616 - run NewAwsNatGatewayEipAssoc after NewAwsNatGatewayEip… (https://github.com/snyk/driftctl/pull/1619) 
    Add google_compute_ssl_certificate resource (https://github.com/snyk/driftctl/pull/1611) 
    docs: add bschaatsbergen as a contributor for code, and doc (https://github.com/snyk/driftctl/pull/1612) 
    Update README.md (https://github.com/snyk/driftctl/pull/1614) 
    Glob pattern matching within a GCS backend (https://github.com/snyk/driftctl/pull/1608)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes (or backporting 23.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
