### PR TITLE
nixos/minecraft-server: add cfg.serverIcon

### DIFF
--- a/nixos/modules/services/games/minecraft-server.nix
+++ b/nixos/modules/services/games/minecraft-server.nix
@@ -67,8 +67,9 @@ in {
         description = lib.mdDoc ''
           Whether to use a declarative Minecraft server configuration.
           Only if set to `true`, the options
-          {option}`services.minecraft-server.whitelist` and
-          {option}`services.minecraft-server.serverProperties` will be
+          {option}`services.minecraft-server.whitelist`,
+          {option}`services.minecraft-server.serverProperties` and
+          {option}`services.minecraft-server.serverIcon` will be
           applied.
         '';
       };
@@ -147,6 +148,18 @@ in {
           is set to `true`. See
           <https://minecraft.gamepedia.com/Server.properties#Java_Edition_3>
           for documentation on these values.
+        '';
+      };
+
+      serverIcon = mkOption {
+        type = with types; path // {
+          description = "path of a .png file";
+          check = x: path.check x && (strMatching ".*\\.png").check (toString x);
+        };
+        default = null;
+        description = lib.mdDoc ''
+          Server icon that shows up in the Multiplayer list. Must be a 64x64 PNG file.
+          Only has an effect when {option}`services.minecraft-server.declarative` is `true`.
         '';
       };
 
@@ -242,12 +255,18 @@ in {
           # Was declarative before, no need to back up anything
           ln -sf ${whitelistFile} whitelist.json
           cp -f ${serverPropertiesFile} server.properties
+      '' + lib.optionalString (cfg.serverIcon != null) ''
+          ln -sf ${cfg.serverIcon} server-icon.png
+      '' + ''
 
         else
 
           # Declarative for the first time, backup stateful files
           ln -sb --suffix=.stateful ${whitelistFile} whitelist.json
           cp -b --suffix=.stateful ${serverPropertiesFile} server.properties
+      '' + lib.optionalString (cfg.serverIcon != null) ''
+          ln -sb --suffix=.stateful ${cfg.serverIcon} server-icon.png
+      '' + ''
 
           # server.properties must have write permissions, because every time
           # the server starts it first parses the file and then regenerates it..


### PR DESCRIPTION
###### Description of changes

Add an option to specify `server-icon.png`.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes (or backporting 23.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
