### PR TITLE
x2x: 1.27 -> unstable-2023-04-30

### DIFF
--- a/pkgs/tools/X11/x2x/default.nix
+++ b/pkgs/tools/X11/x2x/default.nix
@@ -1,25 +1,18 @@
-{ lib, stdenv, fetchurl, imake, libX11, libXtst, libXext, gccmakedep }:
+{ lib, stdenv, libX11, libXtst, libXext, fetchFromGitHub, autoreconfHook, pkg-config, libXi }:
 
 stdenv.mkDerivation rec {
   pname = "x2x";
-  version = "1.27";
+  version = "unstable-2023-04-30";
 
-  src = fetchurl {
-    url = "https://github.com/downloads/dottedmag/x2x/x2x-${version}.tar.gz";
-    sha256 = "0dha0kn1lbc4as0wixsvk6bn4innv49z9a0sm5wlx4q1v0vzqzyj";
+  src = fetchFromGitHub {
+    owner = "dottedmag";
+    repo = pname;
+    rev = "53692798fa0e991e0dd67cdf8e8126158d543d08";
+    hash = "sha256-FUl2z/Yz9uZlUu79LHdsXZ6hAwSlqwFV35N+GYDNvlQ=";
   };
 
-  nativeBuildInputs = [ imake gccmakedep ];
-  buildInputs = [ libX11 libXtst libXext ];
-
-  hardeningDisable = [ "format" ];
-
-  buildFlags = [ "x2x" ];
-
-  installPhase = ''
-    install -D x2x $out/bin/x2x
-    install -D x2x.1 $out/man/man1/x2x.1
-  '';
+  nativeBuildInputs = [ autoreconfHook pkg-config ];
+  buildInputs = [ libX11 libXtst libXext libXi ];
 
   meta = with lib; {
     description = "Allows the keyboard, mouse on one X display to be used to control another X display";


### PR DESCRIPTION
###### Description of changes
First nixpkgs bump since this was first packaged in 2010 (13 years ago!!)

I am typing this with the newly built derivation. It includes a more detailed manpage and some other things I haven't looked into.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux (**+qemu**)
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes (or backporting 23.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
