### PR TITLE
nixos/dynamic-hostname: init a dynamic hostname oneshot service

### DIFF
--- a/nixos/modules/services/networking/dynamic-hostname.nix
+++ b/nixos/modules/services/networking/dynamic-hostname.nix
@@ -1,0 +1,63 @@
+{ config, lib, pkgs, ... }:
+with lib;
+let
+  cfg = config.services.dynamichostnamed;
+in {
+  options.services.dynamichostnamed = {
+    enable = mkEnableOption "dynamichostnamed";
+    basename = mkOption {
+      description = "Base hostname.";
+      type = types.str;
+    };
+    uid_file = mkOption {
+      description = "File path of UID to append to hostname (optional).";
+      type = types.str;
+      default = "";
+    };
+    uid_raw = mkOption {
+      description = "Whether or not the UID file contents are raw bytes (default true).";
+      type = types.bool;
+      default = true;
+    };
+    uid_offset = mkOption {
+      description = "Character offset in UID to begin appending from (starting from 1).";
+      type = types.int;
+      default = 1;
+    };
+  };
+  config = mkIf cfg.enable {
+    networking.hostName = "";
+
+    systemd.services = {
+      dynamichostnamed = {
+        description = "Dynamic hostname changer.";
+        restartIfChanged = true;
+
+        # Use hostnamectl to change transient hostname, appending a UID
+        # to a base hostname.
+        script = ''
+          set -x
+          ${if cfg.uid_file == "" then ''
+            hostnamectl --transient hostname ${cfg.basename}
+          '' else ''
+            ${if cfg.uid_raw then ''
+              hostnamectl --transient hostname ${cfg.basename}-$(${pkgs.hexdump}/bin/hexdump -e '/1 "%02x"' ${cfg.uid_file} | cut -c${builtins.toString cfg.uid_offset}-)
+            '' else ''
+              hostnamectl --transient hostname ${cfg.basename}-$(cat ${cfg.uid_file} | cut -c${cfg.uid_offset}-)
+            ''}
+          ''}
+        '';
+
+        after = [ "systemd-hostnamed.service" ];
+        wants = [ "systemd-hostnamed.service" ];
+        wantedBy = [ "multi-user.target" ];
+
+        serviceConfig = {
+          Type = "oneshot";
+          User = "root";
+          Restart = "no";
+        };
+      };
+    };
+  };
+}


### PR DESCRIPTION
###### Description of changes

OEM's of devices will want the same nixos configuration flashed on all their devices but these devices may have programatically generated hostnames. Using `hostnamectl --transient` on boot will allow an OEM to define their own dynamic hostname scheme. This is particularly useful for IOT devices using NixOS.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes (or backporting 23.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
