### PR TITLE
gitea: Fix postPatch command; add coreutils to PATH

### DIFF
--- a/pkgs/applications/version-management/gitea/default.nix
+++ b/pkgs/applications/version-management/gitea/default.nix
@@ -5,6 +5,7 @@
 , makeWrapper
 , git
 , bash
+, coreutils
 , gitea
 , gzip
 , openssh
@@ -62,7 +63,7 @@ buildGoModule rec {
     cp -R ./options/locale $out/locale
 
     wrapProgram $out/bin/gitea \
-      --prefix PATH : ${lib.makeBinPath [ bash git gzip openssh ]}
+      --prefix PATH : ${lib.makeBinPath [ bash coreutils git gzip openssh ]}
   '';
 
   passthru = {

--- a/pkgs/applications/version-management/gitea/default.nix
+++ b/pkgs/applications/version-management/gitea/default.nix
@@ -34,7 +34,7 @@ buildGoModule rec {
   ];
 
   postPatch = ''
-    substituteInPlace modules/setting/setting.go --subst-var data
+    substituteInPlace modules/setting/server.go --subst-var data
   '';
 
   subPackages = [ "." ];


### PR DESCRIPTION
###### Description of changes

- Fixed substitution of wrong file in `postPatch` phase. This command is needed to substitute `@data@` which is added by `static-root-path.patch`. When that patch was rebased for 1.19.0 in 5c5f710388f0d94a222c91c79c0c812d2b65fdde, the file name changed from `setting.go` to `server.go`, but the command was not updated. So I was not able to start gitea without setting `STATIC_ROOT_PATH` in my config file explicitly.

- Added coreutils to `PATH` explicitly. Coreutils is used in git hooks generated by gitea, e.g. [here](https://github.com/go-gitea/gitea/blob/v1.19.3/modules/repository/hooks.go#L23-L25), and if you omit coreutils and it's not present in default `PATH`, you get these errors when doing `git push`:
  ```
  remote: hooks/pre-receive: line 3: cat: command not found
  remote: hooks/pre-receive: line 5: basename: command not found
  remote: hooks/update: line 4: basename: command not found
  remote: hooks/post-receive: line 3: cat: command not found
  remote: hooks/post-receive: line 5: basename: command not found
  ```

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes (or backporting 23.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).