### PR TITLE
multipass: 1.11.1 -> 1.12.0

### DIFF
--- a/pkgs/tools/virtualization/multipass/cmake_no_fetch.patch
+++ b/pkgs/tools/virtualization/multipass/cmake_no_fetch.patch
@@ -1,0 +1,32 @@
+diff --git a/3rd-party/CMakeLists.txt b/3rd-party/CMakeLists.txt
+index 188ebfc6..4a34a922 100644
+--- a/3rd-party/CMakeLists.txt
++++ b/3rd-party/CMakeLists.txt
+@@ -2,12 +2,8 @@ include(FetchContent)
+ set(FETCHCONTENT_QUIET FALSE)
+ 
+ FetchContent_Declare(gRPC
+-  GIT_REPOSITORY https://github.com/CanonicalLtd/grpc.git
+-  GIT_TAG ba8e7f72
+-  GIT_SHALLOW TRUE
+-  GIT_SUBMODULES "third_party/abseil-cpp third_party/cares/cares third_party/protobuf third_party/re2 third_party/zlib"
+-  GIT_SUBMODULES_RECURSE false
+-  GIT_PROGRESS TRUE
++  DOWNLOAD_COMMAND true
++  SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/grpc
+ )
+ set(gRPC_SSL_PROVIDER "package" CACHE STRING "Provider of ssl library")
+ 
+diff --git a/tests/CMakeLists.txt b/tests/CMakeLists.txt
+index 52bd407f..a1100112 100644
+--- a/tests/CMakeLists.txt
++++ b/tests/CMakeLists.txt
+@@ -28,7 +28,7 @@ FetchContent_Declare(googletest
+ )
+ set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
+ set(INSTALL_GTEST OFF CACHE BOOL "")
+-FetchContent_MakeAvailable(googletest)
++# FetchContent_MakeAvailable(googletest)
+ 
+ add_executable(multipass_tests
+   blueprint_test_lambdas.cpp

--- a/pkgs/tools/virtualization/multipass/default.nix
+++ b/pkgs/tools/virtualization/multipass/default.nix
@@ -25,43 +25,51 @@
 
 let
   pname = "multipass";
-  version = "1.11.1";
+  version = "1.12.0";
+
+  # This is done here because a CMakeLists.txt from one of it's submodules tries
+  # to modify a file, so we grab the source for the submodule here, copy it into
+  # the source of the Multipass project which allows the modification to happen.
+  grpc_src = fetchFromGitHub {
+    owner = "CanonicalLtd";
+    repo = "grpc";
+    rev = "ba8e7f72a57b9e0b25783a4d3cea58c79379f194";
+    hash = "sha256-DS1UNLCUdbipn5w4p2aVa8LgHHhdJiAfzfEdIXNO69o=";
+    fetchSubmodules = true;
+  };
 in
-stdenv.mkDerivation {
+stdenv.mkDerivation
+{
   inherit pname version;
 
   src = fetchFromGitHub {
     owner = "canonical";
     repo = "multipass";
     rev = "refs/tags/v${version}";
-    sha256 = "sha256-AIZs+NRAn/r9EjTx9InDZzS4ycni4MZQXmC0A5rpaJk=";
+    sha256 = "sha256-CwyiLkpyTfn4734ESnHHWwiMdy3AP0BuQv6Uc1nTAuU=";
     fetchSubmodules = true;
   };
 
-  preConfigure = ''
+  patches = [
+    ./lxd_socket_path.patch
+    ./cmake_no_fetch.patch
+  ];
+
+  postPatch = ''
+    # Make sure the version is reported correctly in the compiled binary.
     substituteInPlace ./CMakeLists.txt \
       --replace "determine_version(MULTIPASS_VERSION)" "" \
       --replace 'set(MULTIPASS_VERSION ''${MULTIPASS_VERSION})' 'set(MULTIPASS_VERSION "v${version}")'
 
+    # Patch the patch of the OVMF binaries to use paths from the nix store.
     substituteInPlace ./src/platform/backends/qemu/linux/qemu_platform_detail_linux.cpp \
       --replace "OVMF.fd" "${OVMF.fd}/FV/OVMF.fd" \
       --replace "QEMU_EFI.fd" "${OVMF.fd}/FV/QEMU_EFI.fd"
-  '';
 
-  postPatch = ''
-    # Patch all of the places where Multipass expects the LXD socket to be provided by a snap
-    substituteInPlace ./src/network/network_access_manager.cpp \
-      --replace "/var/snap/lxd/common/lxd/unix.socket" "/var/lib/lxd/unix.socket"
+    # Copy the grpc submodule we fetched into the source code.
+    cp -r --no-preserve=mode ${grpc_src} 3rd-party/grpc
 
-    substituteInPlace ./src/platform/backends/lxd/lxd_virtual_machine.cpp \
-      --replace "/var/snap/lxd/common/lxd/unix.socket" "/var/lib/lxd/unix.socket"
-
-    substituteInPlace ./src/platform/backends/lxd/lxd_request.h \
-      --replace "/var/snap/lxd/common/lxd/unix.socket" "/var/lib/lxd/unix.socket"
-
-    substituteInPlace ./tests/CMakeLists.txt \
-      --replace "FetchContent_MakeAvailable(googletest)" ""
-
+    # Configure CMake to use gtest from the nix store since we disabled fetching from the internet.
     cat >> tests/CMakeLists.txt <<'EOF'
       add_library(gtest INTERFACE)
       target_include_directories(gtest INTERFACE ${gtest.dev}/include)

--- a/pkgs/tools/virtualization/multipass/lxd_socket_path.patch
+++ b/pkgs/tools/virtualization/multipass/lxd_socket_path.patch
@@ -1,0 +1,13 @@
+diff --git a/src/platform/backends/lxd/lxd_request.h b/src/platform/backends/lxd/lxd_request.h
+index 4b5e8840..5e673ad7 100644
+--- a/src/platform/backends/lxd/lxd_request.h
++++ b/src/platform/backends/lxd/lxd_request.h
+@@ -27,7 +27,7 @@
+ 
+ namespace multipass
+ {
+-const QUrl lxd_socket_url{"unix:///var/snap/lxd/common/lxd/unix.socket@1.0"};
++const QUrl lxd_socket_url{"unix:///var/lib/lxd/unix.socket@1.0"};
+ const QString lxd_project_name{"multipass"};
+ 
+ class NetworkAccessManager;


### PR DESCRIPTION
###### Description of changes

Update to the latest Multipass version and do some cleaning up along the way.

Multipass v1.12.0 introduced a behaviour where is used CMake FetchContent to grab a submodule, which I've overriden here in the derivation.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes (or backporting 23.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
