### PR TITLE
python311Packages.py-multicodec: remove pytest-runner

### DIFF
--- a/pkgs/development/python-modules/py-multicodec/default.nix
+++ b/pkgs/development/python-modules/py-multicodec/default.nix
@@ -1,10 +1,9 @@
 { lib
 , buildPythonPackage
 , fetchFromGitHub
-, pytest-runner
+, morphys
 , pytestCheckHook
 , pythonOlder
-, morphys
 , six
 , varint
 }:
@@ -12,36 +11,39 @@
 buildPythonPackage rec {
   pname = "py-multicodec";
   version = "0.2.1";
-  disabled = pythonOlder "3.5";
+  format = "setuptools";
+
+  disabled = pythonOlder "3.7";
 
   src = fetchFromGitHub {
     owner = "multiformats";
     repo = pname;
-    rev = "v${version}";
+    rev = "refs/tags/v${version}";
     hash = "sha256-2aK+bfhqCMqSO+mtrHIfNQmQpQHpwd7yHseI/3O7Sp4=";
   };
 
   # Error when not substituting:
   # Failed: [pytest] section in setup.cfg files is no longer supported, change to [tool:pytest] instead.
   postPatch = ''
-    substituteInPlace setup.cfg --replace "[pytest]" "[tool:pytest]"
+    substituteInPlace setup.cfg \
+      --replace "[pytest]" "[tool:pytest]"
+    substituteInPlace setup.py \
+      --replace "'pytest-runner'," ""
   '';
 
-  nativeBuildInputs = [
-    pytest-runner
-  ];
-
   propagatedBuildInputs = [
-    varint
-    six
     morphys
+    six
+    varint
   ];
 
   nativeCheckInputs = [
     pytestCheckHook
   ];
 
-  pythonImportsCheck = [ "multicodec" ];
+  pythonImportsCheck = [
+    "multicodec"
+  ];
 
   meta = with lib; {
     description = "Compact self-describing codecs";


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes (or backporting 23.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
