### PR TITLE
python310Packages.monai: 1.1.0 -> 1.2.0

### DIFF
--- a/pkgs/development/python-modules/monai/default.nix
+++ b/pkgs/development/python-modules/monai/default.nix
@@ -12,14 +12,14 @@
 
 buildPythonPackage rec {
   pname = "monai";
-  version = "1.1.0";
-  disabled = pythonOlder "3.7";
+  version = "1.2.0";
+  disabled = pythonOlder "3.8";
 
   src = fetchFromGitHub {
     owner = "Project-MONAI";
     repo = "MONAI";
     rev = "refs/tags/${version}";
-    hash = "sha256-XTjZhynIiFtFjJSW6rRAnpErZvf6QHkuK4e2L6l3naM=";
+    hash = "sha256-nMxROOBkLPmw1GRKiZq6WGJq93LOpSg/7zIVOg+WzC8=";
   };
 
   # Ninja is not detected by setuptools for some reason even though it's present:
@@ -37,7 +37,7 @@ buildPythonPackage rec {
 
   BUILD_MONAI = 1;
 
-  doCheck = false;  # takes too long; numerous dependencies, some not in Nixpkgs
+  doCheck = false;  # takes too long; tries to download data
 
   pythonImportsCheck = [
     "monai"
@@ -58,6 +58,7 @@ buildPythonPackage rec {
   meta = with lib; {
     description = "Pytorch framework (based on Ignite) for deep learning in medical imaging";
     homepage = "https://github.com/Project-MONAI/MONAI";
+    changelog = "https://github.com/Project-MONAI/MONAI/releases/tag/${version}";
     license = licenses.asl20;
     maintainers = [ maintainers.bcdarwin ];
   };


### PR DESCRIPTION
###### Description of changes

Routine update.

###### Things done


- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes (or backporting 23.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).