### PR TITLE
unscii: 1.1 -> 2.1

### DIFF
--- a/pkgs/data/fonts/unscii/default.nix
+++ b/pkgs/data/fonts/unscii/default.nix
@@ -9,11 +9,11 @@ let
 in
 stdenv.mkDerivation rec {
   pname = "unscii";
-  version = "1.1";
+  version = "2.1";
 
   src = fetchurl {
-    url = "http://pelulamu.net/${pname}/${pname}-${version}-src.tar.gz";
-    sha256 = "0qcxcnqz2nlwfzlrn115kkp3n8dd7593h762vxs6vfqm13i39lq1";
+    url = "http://viznut.fi/${pname}/${pname}-${version}-src.tar.gz";
+    sha256 = "0msvqrq7x36p76a2n5bzkadh95z954ayqa08wxd017g4jpa1a4jd";
   };
 
   nativeBuildInputs =
@@ -66,6 +66,6 @@ stdenv.mkDerivation rec {
     # version. The reduced version is public domain.
     license = "http://unifoundry.com/LICENSE.txt";
     maintainers = [ lib.maintainers.raskin ];
-    homepage = "http://pelulamu.net/unscii/";
+    homepage = "http://viznut.fi/unscii/";
   };
 }


### PR DESCRIPTION
Old domain appears to be parked, update URLs to new domain that is also linked from GitHub.

###### Description of changes

> In 2020-03-10, the new [Unicode version 13.0](http://www.unicode.org/versions/Unicode13.0.0/) added 214 graphics characters for "legacy computing" (including, among all, the missing PETSCII characters, and a majority of missing Teletext/Videotex characters). Most of these were already included in Unscii 1.x, but now I have been able to give them proper Unicode mappings as well. This is the main reason for the Unscii 2.0 release.
>
> Additionally, Unscii 2.0 fixes errors in some characters, legibility in some others and adds a bunch of new ones.

-- [Unscii website](http://viznut.fi/unscii/). No changelog for 2.1 :(
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes (or backporting 23.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
