### PR TITLE
nixos/ci: Split `mkdir` mode into `chmod` command for clarity

### DIFF
--- a/nixos/modules/services/continuous-integration/buildkite-agents.nix
+++ b/nixos/modules/services/continuous-integration/buildkite-agents.nix
@@ -238,7 +238,8 @@ in
           tagsStr = lib.concatStringsSep "," (lib.mapAttrsToList tagStr cfg.tags);
         in
           optionalString (cfg.privateSshKeyPath != null) ''
-            mkdir -m 0700 -p "${sshDir}"
+            mkdir -p "${sshDir}"
+            chmod 0700 "${sshDir}"
             install -m600 "${toString cfg.privateSshKeyPath}" "${sshDir}/id_rsa"
           '' + ''
             cat > "${cfg.dataDir}/buildkite-agent.cfg" <<EOF

--- a/nixos/modules/services/continuous-integration/gitlab-runner.nix
+++ b/nixos/modules/services/continuous-integration/gitlab-runner.nix
@@ -229,15 +229,24 @@ in {
             ];
             dockerDisableCache = true;
             preBuildScript = pkgs.writeScript "setup-container" '''
-              mkdir -p -m 0755 /nix/var/log/nix/drvs
-              mkdir -p -m 0755 /nix/var/nix/gcroots
-              mkdir -p -m 0755 /nix/var/nix/profiles
-              mkdir -p -m 0755 /nix/var/nix/temproots
-              mkdir -p -m 0755 /nix/var/nix/userpool
-              mkdir -p -m 1777 /nix/var/nix/gcroots/per-user
-              mkdir -p -m 1777 /nix/var/nix/profiles/per-user
-              mkdir -p -m 0755 /nix/var/nix/profiles/per-user/root
-              mkdir -p -m 0700 "$HOME/.nix-defexpr"
+              mkdir -p /nix/var/log/nix/drvs
+              chmod 0755 /nix/var/log/nix/drvs
+              mkdir -p /nix/var/nix/gcroots
+              chmod 0755 /nix/var/nix/gcroots
+              mkdir -p /nix/var/nix/profiles
+              chmod 0755 /nix/var/nix/profiles
+              mkdir -p /nix/var/nix/temproots
+              chmod 0755 /nix/var/nix/temproots
+              mkdir -p /nix/var/nix/userpool
+              chmod 0755 /nix/var/nix/userpool
+              mkdir -p /nix/var/nix/gcroots/per-user
+              chmod 1777 /nix/var/nix/gcroots/per-user
+              mkdir -p /nix/var/nix/profiles/per-user
+              chmod 1777 /nix/var/nix/profiles/per-user
+              mkdir -p /nix/var/nix/profiles/per-user/root
+              chmod 0755 /nix/var/nix/profiles/per-user/root
+              mkdir -p "$HOME/.nix-defexpr"
+              chmod 0700 "$HOME/.nix-defexpr"
 
               . ''${pkgs.nix}/etc/profile.d/nix.sh
 

--- a/nixos/modules/services/continuous-integration/hydra/default.nix
+++ b/nixos/modules/services/continuous-integration/hydra/default.nix
@@ -306,12 +306,16 @@ in
 
           ln -sf ${hydraConf} ${baseDir}/hydra.conf
 
-          mkdir -m 0700 -p ${baseDir}/www
+          mkdir -p ${baseDir}/www
+          chmod 0700 ${baseDir}/www
           chown hydra-www:hydra ${baseDir}/www
 
-          mkdir -m 0700 -p ${baseDir}/queue-runner
-          mkdir -m 0750 -p ${baseDir}/build-logs
-          mkdir -m 0750 -p ${baseDir}/runcommand-logs
+          mkdir -p ${baseDir}/queue-runner
+          chmod 0700 ${baseDir}/queue-runner
+          mkdir -p ${baseDir}/build-logs
+          chmod 0750 ${baseDir}/build-logs
+          mkdir -p ${baseDir}/runcommand-logs
+          chmod 0750 ${baseDir}/runcommand-logs
           chown hydra-queue-runner.hydra \
             ${baseDir}/queue-runner \
             ${baseDir}/build-logs \


### PR DESCRIPTION
###### Description of changes

As recommended by ShellCheck
<https://github.com/koalaman/shellcheck/wiki/SC2174>.

Motivation: https://github.com/NixOS/nixpkgs/issues/133088.

###### Things done

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes (or backporting 23.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).