### PR TITLE
nixos/duosec: Split `mkdir` mode into `chmod` command for clarity

### DIFF
--- a/nixos/modules/security/duosec.nix
+++ b/nixos/modules/security/duosec.nix
@@ -196,7 +196,8 @@ in
     system.activationScripts = {
       login_duo = mkIf cfg.ssh.enable ''
         if test -f "${cfg.secretKeyFile}"; then
-          mkdir -m 0755 -p /etc/duo
+          mkdir -p /etc/duo
+          chmod 0755 /etc/duo
 
           umask 0077
           conf="$(mktemp)"
@@ -211,7 +212,8 @@ in
       '';
       pam_duo = mkIf cfg.pam.enable ''
         if test -f "${cfg.secretKeyFile}"; then
-          mkdir -m 0755 -p /etc/duo
+          mkdir -p /etc/duo
+          chmod 0755 /etc/duo
 
           umask 0077
           conf="$(mktemp)"


### PR DESCRIPTION
###### Description of changes

As recommended by ShellCheck
<https://github.com/koalaman/shellcheck/wiki/SC2174>.

Motivation: https://github.com/NixOS/nixpkgs/issues/133088.

###### Things done

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes (or backporting 23.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).