### PR TITLE
nixos/boot: Fix some ShellCheck lints

### DIFF
--- a/nixos/modules/system/boot/stage-1-init.sh
+++ b/nixos/modules/system/boot/stage-1-init.sh
@@ -10,7 +10,6 @@ info() {
     fi
 }
 
-extraUtils="@extraUtils@"
 export LD_LIBRARY_PATH=@extraUtils@/lib
 export PATH=@extraUtils@/bin
 ln -s @extraUtils@/bin /bin

--- a/nixos/modules/system/boot/stage-1-init.sh
+++ b/nixos/modules/system/boot/stage-1-init.sh
@@ -12,14 +12,14 @@ info() {
 
 export LD_LIBRARY_PATH=@extraUtils@/lib
 export PATH=@extraUtils@/bin
-ln -s @extraUtils@/bin /bin
+ln -s "@extraUtils@/bin" /bin
 # hardcoded in util-linux's mount helper search path `/run/wrappers/bin:/run/current-system/sw/bin:/sbin`
-ln -s @extraUtils@/bin /sbin
+ln -s "@extraUtils@/bin" /sbin
 
 # Copy the secrets to their needed location
 if [ -d "@extraUtils@/secrets" ]; then
     for secret in $(cd "@extraUtils@/secrets"; find . -type f); do
-        mkdir -p $(dirname "/$secret")
+        mkdir -p "$(dirname "/$secret")"
         ln -s "@extraUtils@/secrets/$secret" "$secret"
     done
 fi
@@ -146,7 +146,7 @@ specialMount() {
   chmod 0755 "$mountPoint"
   mount -n -t "$fsType" -o "$options" "$device" "$mountPoint"
 }
-source @earlyMountScript@
+source "@earlyMountScript@"
 
 # Copy initrd secrets from /.initrd-secrets to their actual destinations
 if [ -d "/.initrd-secrets" ]; then
@@ -155,7 +155,7 @@ if [ -d "/.initrd-secrets" ]; then
     # under /.initrd-secrets/
     #
     for secret in $(cd "/.initrd-secrets"; find . -type f); do
-        mkdir -p $(dirname "/$secret")
+        mkdir -p "$(dirname "/$secret")"
         cp "/.initrd-secrets/$secret" "$secret"
     done
 fi
@@ -253,10 +253,10 @@ done
 @setHostId@
 
 # Load the required kernel modules.
-echo @extraUtils@/bin/modprobe > /proc/sys/kernel/modprobe
+echo "@extraUtils@/bin/modprobe" > /proc/sys/kernel/modprobe
 for i in @kernelModules@; do
     info "loading module $(basename $i)..."
-    modprobe $i
+    modprobe "$i"
 done
 
 
@@ -268,9 +268,9 @@ ln -sfn /proc/self/fd/0 /dev/stdin
 ln -sfn /proc/self/fd/1 /dev/stdout
 ln -sfn /proc/self/fd/2 /dev/stderr
 mkdir -p /etc/systemd
-ln -sfn @linkUnits@ /etc/systemd/network
+ln -sfn "@linkUnits@" /etc/systemd/network
 mkdir -p /etc/udev
-ln -sfn @udevRules@ /etc/udev/rules.d
+ln -sfn "@udevRules@" /etc/udev/rules.d
 mkdir -p /dev/.mdadm
 systemd-udevd --daemon
 udevadm trigger --action=add
@@ -526,7 +526,7 @@ fi
 # Try to find and mount the root device.
 mkdir -p $targetRoot
 
-exec 3< @fsInfo@
+exec 3< "@fsInfo@"
 
 while read -u 3 mountPoint; do
     read -u 3 device
@@ -619,7 +619,7 @@ udevadm control --exit
 
 # Reset the logging file descriptors.
 # Do this just before pkill, which will kill the tee process.
-exec 1>&$logOutFd 2>&$logErrFd
+exec 1>&"$logOutFd" 2>&"$logErrFd"
 eval "exec $logOutFd>&- $logErrFd>&-"
 
 # Kill any remaining processes, just to be sure we're not taking any
@@ -656,13 +656,13 @@ if [ ! -e "$targetRoot/$stage2Init" ]; then
     fi
 fi
 
-mkdir -p $targetRoot/proc $targetRoot/sys $targetRoot/dev $targetRoot/run
-chmod 0755 $targetRoot/proc $targetRoot/sys $targetRoot/dev $targetRoot/run
+mkdir -p "$targetRoot/proc" "$targetRoot/sys" "$targetRoot/dev" "$targetRoot/run"
+chmod 0755 "$targetRoot/proc" "$targetRoot/sys" "$targetRoot/dev" "$targetRoot/run"
 
-mount --move /proc $targetRoot/proc
-mount --move /sys $targetRoot/sys
-mount --move /dev $targetRoot/dev
-mount --move /run $targetRoot/run
+mount --move /proc "$targetRoot/proc"
+mount --move /sys "$targetRoot/sys"
+mount --move /dev "$targetRoot/dev"
+mount --move /run "$targetRoot/run"
 
 exec env -i $(type -P switch_root) "$targetRoot" "$stage2Init"
 

--- a/nixos/modules/system/boot/stage-1-init.sh
+++ b/nixos/modules/system/boot/stage-1-init.sh
@@ -184,21 +184,21 @@ export stage2Init=/init
 for o in $(cat /proc/cmdline); do
     case $o in
         console=*)
-            set -- $(IFS==; echo $o)
+            set -- $(IFS='='; echo $o)
             params=$2
-            set -- $(IFS=,; echo $params)
+            set -- $(IFS=','; echo $params)
             console=$1
             ;;
         init=*)
-            set -- $(IFS==; echo $o)
+            set -- $(IFS='='; echo $o)
             stage2Init=$2
             ;;
         boot.persistence=*)
-            set -- $(IFS==; echo $o)
+            set -- $(IFS='='; echo $o)
             persistence=$2
             ;;
         boot.persistence.opt=*)
-            set -- $(IFS==; echo $o)
+            set -- $(IFS='='; echo $o)
             persistence_opt=$2
             ;;
         boot.trace|debugtrace)
@@ -227,7 +227,7 @@ for o in $(cat /proc/cmdline); do
             # If a root device is specified on the kernel command
             # line, make it available through the symlink /dev/root.
             # Recognise LABEL= and UUID= to support UNetbootin.
-            set -- $(IFS==; echo $o)
+            set -- $(IFS='='; echo $o)
             if [ $2 = "LABEL" ]; then
                 root="/dev/disk/by-label/$3"
             elif [ $2 = "UUID" ]; then
@@ -243,7 +243,7 @@ for o in $(cat /proc/cmdline); do
         findiso=*)
             # if an iso name is supplied, try to find the device where
             # the iso resides on
-            set -- $(IFS==; echo $o)
+            set -- $(IFS='='; echo $o)
             isoPath=$2
             ;;
     esac
@@ -386,7 +386,7 @@ mountFS() {
     fi
 
     # Filter out x- options, which busybox doesn't do yet.
-    local optionsFiltered="$(IFS=,; for i in $options; do if [ "${i:0:2}" != "x-" ]; then echo -n $i,; fi; done)"
+    local optionsFiltered="$(IFS=','; for i in $options; do if [ "${i:0:2}" != "x-" ]; then echo -n $i,; fi; done)"
     # Prefix (lower|upper|work)dir with /mnt-root (overlayfs)
     local optionsPrefixed="$( echo "$optionsFiltered" | sed -E 's#\<(lowerdir|upperdir|workdir)=#\1=/mnt-root#g' )"
 

--- a/nixos/modules/system/boot/stage-1-init.sh
+++ b/nixos/modules/system/boot/stage-1-init.sh
@@ -143,7 +143,8 @@ specialMount() {
   local options="$3"
   local fsType="$4"
 
-  mkdir -m 0755 -p "$mountPoint"
+  mkdir -p "$mountPoint"
+  chmod 0755 "$mountPoint"
   mount -n -t "$fsType" -o "$options" "$device" "$mountPoint"
 }
 source @earlyMountScript@
@@ -397,7 +398,8 @@ mountFS() {
     if [ "$fsType" = overlay ]; then
         for i in upper work; do
              dir="$( echo "$optionsPrefixed" | grep -o "${i}dir=[^,]*" )"
-             mkdir -m 0700 -p "${dir##*=}"
+             mkdir -p "${dir##*=}"
+             chmod 0700 "${dir##*=}"
         done
     fi
 
@@ -435,7 +437,8 @@ lustrateRoot () {
     echo -e "\e[1;33m<<< @distroName@ is now lustrating the root filesystem (cruft goes to /old-root) >>>\e[0m"
     echo
 
-    mkdir -m 0755 -p "$root/old-root.tmp"
+    mkdir -p "$root/old-root.tmp"
+    chmod 0755 "$root/old-root.tmp"
 
     echo
     echo "Moving impurities out of the way:"
@@ -451,7 +454,8 @@ lustrateRoot () {
     # Use .tmp to make sure subsequent invocations don't clash
     mv -v "$root/old-root.tmp" "$root/old-root"
 
-    mkdir -m 0755 -p "$root/etc"
+    mkdir -p "$root/etc"
+    chmod 0755 "$root/etc"
     touch "$root/etc/NIXOS"
 
     exec 4< "$root/old-root/etc/NIXOS_LUSTRATE"
@@ -460,7 +464,8 @@ lustrateRoot () {
     echo "Restoring selected impurities:"
     while read -u 4 keeper; do
         dirname="$(dirname "$keeper")"
-        mkdir -m 0755 -p "$root/$dirname"
+        mkdir -p "$root/$dirname"
+        chmod 0755 "$root/$dirname"
         cp -av "$root/old-root/$keeper" "$root/$keeper"
     done
 
@@ -652,7 +657,8 @@ if [ ! -e "$targetRoot/$stage2Init" ]; then
     fi
 fi
 
-mkdir -m 0755 -p $targetRoot/proc $targetRoot/sys $targetRoot/dev $targetRoot/run
+mkdir -p $targetRoot/proc $targetRoot/sys $targetRoot/dev $targetRoot/run
+chmod 0755 $targetRoot/proc $targetRoot/sys $targetRoot/dev $targetRoot/run
 
 mount --move /proc $targetRoot/proc
 mount --move /sys $targetRoot/sys

--- a/nixos/modules/system/boot/stage-2-init.sh
+++ b/nixos/modules/system/boot/stage-2-init.sh
@@ -137,7 +137,7 @@ ln -sfn "$systemConfig" /run/booted-system
 # especially no need to start systemd
 if [ "${IN_NIXOS_SYSTEMD_STAGE1:-}" != true ]; then
     # Reset the logging file descriptors.
-    exec 1>&$logOutFd 2>&$logErrFd
+    exec 1>&"$logOutFd" 2>&"$logErrFd"
     exec {logOutFd}>&- {logErrFd}>&-
 
 


### PR DESCRIPTION
###### Description of changes

Motivation: https://github.com/NixOS/nixpkgs/issues/133088.

Please see the individual commit messages for details. This does not fix *every* ShellCheck issue in these files, because that would make the code review much harder.

###### Things done

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes (or backporting 23.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).