### PR TITLE
qt6.qtbase: fix plugin path discovery for Qt 6

### DIFF
--- a/pkgs/development/libraries/qt-6/default.nix
+++ b/pkgs/development/libraries/qt-6/default.nix
@@ -48,6 +48,7 @@ let
           ./patches/0005-qtbase-deal-with-a-font-face-at-index-0-as-Regular-f.patch
           ./patches/0006-qtbase-qt-cmake-always-use-cmake-from-path.patch
           ./patches/0007-qtbase-find-qt-tools-in-QTTOOLSPATH.patch
+          ./patches/0009-qtbase-qtpluginpath.patch
         ];
       };
       env = callPackage ./qt-env.nix { };

--- a/pkgs/development/libraries/qt-6/modules/qtbase.nix
+++ b/pkgs/development/libraries/qt-6/modules/qtbase.nix
@@ -250,6 +250,10 @@ stdenv.mkDerivation rec {
     fixQtBuiltinPaths "$out" '*.pr?'
   '';
 
+  preConfigure = ''
+    NIX_CFLAGS_COMPILE+=" -DNIXPKGS_QT_PLUGIN_PREFIX=\"$qtPluginPrefix\""
+  '';
+
   dontStrip = debugSymbols;
 
   setupHook = ../hooks/qtbase-setup-hook.sh;

--- a/pkgs/development/libraries/qt-6/patches/0009-qtbase-qtpluginpath.patch
+++ b/pkgs/development/libraries/qt-6/patches/0009-qtbase-qtpluginpath.patch
@@ -1,0 +1,33 @@
+From 9fc6efaf774a8716932c98c0b0ea6408ed2614c2 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Milan=20P=C3=A4ssler?= <me@pbb.lc>
+Date: Sun, 10 May 2020 12:47:28 +0200
+Subject: [PATCH 09/11] qtbase-qtpluginpath
+
+---
+ src/corelib/kernel/qcoreapplication.cpp | 10 ++++++++++
+ 1 file changed, 10 insertions(+)
+
+diff --git a/src/corelib/kernel/qcoreapplication.cpp b/src/corelib/kernel/qcoreapplication.cpp
+index 5fdcc9b914..1a126ef359 100644
+--- a/src/corelib/kernel/qcoreapplication.cpp
++++ b/src/corelib/kernel/qcoreapplication.cpp
+@@ -2691,6 +2691,16 @@ QStringList QCoreApplication::libraryPathsLocked()
+         QStringList *app_libpaths = new QStringList;
+         coreappdata()->app_libpaths.reset(app_libpaths);
+ 
++        // Add library paths derived from PATH
++        const QStringList paths = QFile::decodeName(qgetenv("PATH")).split(':');
++        const QString plugindir = QStringLiteral("../" NIXPKGS_QT_PLUGIN_PREFIX);
++        for (const QString &path: paths) {
++            if (!path.isEmpty()) {
++                app_libpaths->append(QDir::cleanPath(path + QDir::separator() + plugindir));
++            }
++        }
++
++
+         auto setPathsFromEnv = [&](QString libPathEnv) {
+             if (!libPathEnv.isEmpty()) {
+                 QStringList paths = libPathEnv.split(QDir::listSeparator(), Qt::SkipEmptyParts);
+-- 
+2.25.4
+


### PR DESCRIPTION
###### Description of changes

Qt 6 applications are unable to discover Qt plugins whose paths are not specified in QT_PLUGIN_PATH. This problem was already solved for Qt 5 and the patch for Qt 5 cleanly applies for Qt 6 as well.

###### Testing

I've run `nixpkgs-review rev --print-result HEAD` and—except for one—all built successfully.

<details>
  <summary>Expand to see output</summary>

```
       last 10 log lines:
       >
       >   https://ndi.tv/sdk/
       >
       > Once you have downloaded the file, please use the following command and
       > re-run the installation:
       >
       >   $ nix-prefetch-url file://$PWD/Install_NDI_SDK_v5_Linux.tar.gz
       >
       > ***
       >
       For full logs, run 'nix log /nix/store/x35rn6z0cfpy1a5xnjh5w2gkcxmbwv40-Install_NDI_SDK_v5_Linux.tar.gz.drv'.
error: 1 dependencies of derivation '/nix/store/w1ikbp5i40am1wr5yc0frqpsy04lsw0b-ndi-5.5.2.drv' failed to build
error: 1 dependencies of derivation '/nix/store/hbs3dn72pjcrhyg9sjvjksx5iiz5n5bs-obs-ndi-4.10.0.drv' failed to build
error: 1 dependencies of derivation '/nix/store/bqj5gdzgma35p3cmmcbljrwlcmzpjrrn-env.drv' failed to build
error: 1 dependencies of derivation '/nix/store/zn2gbh53g4kp04nz719wnk9f8ipdp5by-review-shell.drv' failed to build
1 package marked as broken and skipped:
obs-studio-plugins.obs-hyperion

1 package failed to build:
obs-studio-plugins.obs-ndi

214 packages built:
abracadabra activitywatch adwaita-qt6 adwaita-qt6.dev albert
alice-tools-qt6 anki anki.dist anki.doc anki.man aw-qt aw-qt.dist
bambootracker-qt6 beamerpresenter beamerpresenter-poppler calcmysky
calibre citra-canary citra-nightly copyq cudaPackages.nsight_compute
cutemaze dolphin-emu duckstation fcitx5-chinese-addons
fcitx5-configtool fcitx5-skk-qt fcitx5-unikey fcitx5-with-addons
gpxsee-qt6 gqrx gqrx-gr-audio gqrx-portaudio haka hydrus hydrus.doc
in-formant jami kemai khoj khoj.dist ladybird libremines
libsForQt5.fcitx5-qt maestral-gui maestral-gui.dist mediaelch-qt6
mnemosyne mnemosyne.dist mozillavpn nanovna-saver nanovna-saver.dist
obs-studio obs-studio-plugins.advanced-scene-switcher
obs-studio-plugins.droidcam-obs obs-studio-plugins.input-overlay
obs-studio-plugins.looking-glass-obs obs-studio-plugins.obs-3d-effect
obs-studio-plugins.obs-backgroundremoval
obs-studio-plugins.obs-command-source obs-studio-plugins.obs-gstreamer
obs-studio-plugins.obs-livesplit-one
obs-studio-plugins.obs-move-transition
obs-studio-plugins.obs-multi-rtmp obs-studio-plugins.obs-nvfbc
obs-studio-plugins.obs-pipewire-audio-capture
obs-studio-plugins.obs-shaderfilter
obs-studio-plugins.obs-source-clone
obs-studio-plugins.obs-source-record obs-studio-plugins.obs-teleport
obs-studio-plugins.obs-vaapi obs-studio-plugins.obs-vintage-filter
obs-studio-plugins.obs-vkcapture obs-studio-plugins.wlrobs
olive-editor ostinato path-of-building pgmodeler pineapple-pictures
pokefinder prismlauncher prismlauncher-unwrapped punes-qt6
python310Packages.pyqt6 python310Packages.pyqt6-charts
python310Packages.pyqt6-charts.dist python310Packages.pyqt6-webengine
python310Packages.pyqt6-webengine.dev
python310Packages.pyqt6-webengine.dist python310Packages.pyqt6.dev
python310Packages.pyqt6.dist python310Packages.pyside6
python310Packages.shiboken6 python311Packages.pyqt6
python311Packages.pyqt6-charts python311Packages.pyqt6-charts.dist
python311Packages.pyqt6-webengine
python311Packages.pyqt6-webengine.dev
python311Packages.pyqt6-webengine.dist python311Packages.pyqt6.dev
python311Packages.pyqt6.dist python311Packages.pyside6
python311Packages.shiboken6 qalculate-qt qgnomeplatform-qt6 qmmp
qownnotes qt6.full qt6.qmake qt6.qt3d qt6.qt3d.dev qt6.qt5compat
qt6.qt5compat.dev qt6.qtbase qt6.qtbase.dev qt6.qtcharts
qt6.qtcharts.dev qt6.qtconnectivity qt6.qtconnectivity.dev
qt6.qtdatavis3d qt6.qtdatavis3d.dev qt6.qtdeclarative
qt6.qtdeclarative.dev qt6.qtdoc qt6.qtgrpc qt6.qtgrpc.dev
qt6.qthttpserver qt6.qthttpserver.dev qt6.qtimageformats
qt6.qtimageformats.dev qt6.qtlanguageserver qt6.qtlanguageserver.dev
qt6.qtlocation qt6.qtlocation.dev qt6.qtlottie qt6.qtlottie.dev
qt6.qtmqtt qt6.qtmqtt.dev qt6.qtmultimedia qt6.qtmultimedia.dev
qt6.qtnetworkauth qt6.qtnetworkauth.dev qt6.qtpositioning
qt6.qtpositioning.dev qt6.qtquick3d qt6.qtquick3d.dev
qt6.qtquick3dphysics qt6.qtquick3dphysics.dev qt6.qtquickeffectmaker
qt6.qtquickeffectmaker.dev qt6.qtquicktimeline qt6.qtquicktimeline.dev
qt6.qtremoteobjects qt6.qtremoteobjects.dev qt6.qtscxml
qt6.qtscxml.dev qt6.qtsensors qt6.qtsensors.dev qt6.qtserialbus
qt6.qtserialbus.dev qt6.qtserialport qt6.qtserialport.dev
qt6.qtshadertools qt6.qtshadertools.dev qt6.qtspeech qt6.qtspeech.dev
qt6.qtsvg qt6.qtsvg.dev qt6.qttools qt6.qttools.dev qt6.qttranslations
qt6.qttranslations.dev qt6.qtvirtualkeyboard qt6.qtvirtualkeyboard.dev
qt6.qtwayland qt6.qtwayland.dev qt6.qtwebchannel qt6.qtwebchannel.dev
qt6.qtwebengine qt6.qtwebengine.dev qt6.qtwebsockets
qt6.qtwebsockets.dev qt6.qtwebview qt6.qtwebview.dev
qt6Packages.kcoreaddons qt6Packages.kcoreaddons.bin
qt6Packages.kcoreaddons.dev qt6Packages.poppler
qt6Packages.poppler.dev qt6Packages.qt6ct qt6Packages.qtkeychain
qt6Packages.qtpbfimageplugin qt6Packages.qtstyleplugin-kvantum
qt6Packages.quazip qt6Packages.quazip.dev qt6Packages.qxlsx
qtcreator-qt6 qtwirediff qucs-s qutebrowser-qt6 qutebrowser-qt6.dist
retext retext.dist stellarium syncplay telegram-desktop texworks
wireshark wireshark.dev yuzu-early-access yuzu-mainline zeal-qt6 zint
zint.dev
```

</details>

The build failure does not appear to be related to the changes in this PR so I think it is safe to ignore. I've attempted to resolve the unrelated build error by using `nix-prefetch-url` as the error output advised but to no avail. (I believe that package should be marked as broken as well but that discussion is out of the scope of this PR.)

Regarding the below "Tested, as applicable," I couldn't find any related tests but I could be mistaken. Any guidance would be much appreciated.

Regarding the below "Tested basic functionality of all binary files," I think because of the failing package above I don't have a `./results/bin`. That being said, I've tested that the patch works for my use case in Telegram Desktop so I've tentatively marked the step as complete.

###### This PR

This is my first contribution to nixpkgs so I apologize in advance if this PR is unfit for any reason. Any guidance is appreciated.

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes (or backporting 23.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).