### PR TITLE
fedifetcher: init at 5.0.1

### DIFF
--- a/pkgs/tools/misc/fedifetcher/default.nix
+++ b/pkgs/tools/misc/fedifetcher/default.nix
@@ -1,0 +1,39 @@
+{ lib, fetchFromGitHub, python3 }:
+
+python3.pkgs.buildPythonApplication rec {
+  pname = "fedifetcher";
+  version = "5.0.1";
+  format = "other";
+
+  src = fetchFromGitHub {
+    owner = "nanos";
+    repo = "FediFetcher";
+    rev = "v${version}";
+    hash = "sha256-O7YDxNQel1XFSjGrzdBI4PsejmzPVLvYLNF/vZgdh4w=";
+  };
+
+  propagatedBuildInputs = with python3.pkgs; [
+    python-dateutil
+    requests
+  ];
+
+  installPhase = ''
+    runHook preInstall
+
+    install -vD find_posts.py $out/bin/fedifetcher
+
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    description = "A tool for Mastodon that automatically fetches missing replies and posts from other fediverse instances";
+    longDescription = ''
+      FediFetcher is a tool for Mastodon that automatically fetches missing
+      replies and posts from other fediverse instances, and adds them to your
+      own Mastodon instance.
+    '';
+    homepage = "https://blog.thms.uk/fedifetcher";
+    license = licenses.mit;
+    maintainers = with maintainers; [ delroth ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3470,6 +3470,8 @@ with pkgs;
     inherit (darwin.apple_sdk.frameworks) Security;
   };
 
+  fedifetcher = callPackage ../tools/misc/fedifetcher { };
+
   fitnesstrax = callPackage ../applications/misc/fitnesstrax { };
 
   flavours = callPackage ../applications/misc/flavours { };


### PR DESCRIPTION
###### Description of changes

FediFetcher is a tool for Mastodon that automatically fetches missing replies and posts from other fediverse instances, and adds them to your own Mastodon instance.

No NixOS module for now, but I've successfully used it directly by CLI invocation and confirmed it's working properly.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes (or backporting 23.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
