### PR TITLE
sgx-sdk, sgx-psw: 2.16 -> 2.19

### DIFF
--- a/pkgs/os-specific/linux/sgx/psw/default.nix
+++ b/pkgs/os-specific/linux/sgx/psw/default.nix
@@ -25,14 +25,14 @@ stdenv.mkDerivation rec {
     let
       ae.prebuilt = fetchurl {
         url = "https://download.01.org/intel-sgx/sgx-linux/${versionTag}/prebuilt_ae_${versionTag}.tar.gz";
-        hash = "sha256-JriA9UGYFkAPuCtRizk8RMM1YOYGR/eO9ILnx47A40s=";
+        hash = "sha256-IckW4p1XWkWCDCErXyTtnKYKeAUaCrp5iAMsRBMjLX0=";
       };
       dcap = rec {
-        version = "1.13";
+        version = "1.16";
         filename = "prebuilt_dcap_${version}.tar.gz";
         prebuilt = fetchurl {
           url = "https://download.01.org/intel-sgx/sgx-dcap/${version}/linux/${filename}";
-          hash = "sha256-0kD6hxN8qZ/7/H99aboQx7Qg7ewmYPEexoU6nqczAik=";
+          hash = "sha256-LBOglLkn/IX6J4bOUJl9ipKjgENjpy5n8Zhc60CTLFA=";
         };
       };
     in

--- a/pkgs/os-specific/linux/sgx/samples/default.nix
+++ b/pkgs/os-specific/linux/sgx/samples/default.nix
@@ -1,6 +1,7 @@
 { stdenv
 , lib
 , makeWrapper
+, openssl
 , sgx-sdk
 , sgx-psw
 , which
@@ -23,6 +24,7 @@ let
 
     buildInputs = [
       sgx-sdk
+      openssl
     ];
 
     # The samples don't have proper support for parallel building

--- a/pkgs/os-specific/linux/sgx/sdk/default.nix
+++ b/pkgs/os-specific/linux/sgx/sdk/default.nix
@@ -29,15 +29,15 @@
 stdenv.mkDerivation rec {
   pname = "sgx-sdk";
   # Version as given in se_version.h
-  version = "2.16.100.4";
+  version = "2.19.100.3";
   # Version as used in the Git tag
-  versionTag = "2.16";
+  versionTag = "2.19";
 
   src = fetchFromGitHub {
     owner = "intel";
     repo = "linux-sgx";
     rev = "sgx_${versionTag}";
-    hash = "sha256-qgXuJJWiqmcU11umCsE3DnlK4VryuTDAsNf53YPw6UY=";
+    hash = "sha256-6UGcY3evRIDtkjYB1kJWs5HaLFksBw0m+8vyC/nPttc=";
     fetchSubmodules = true;
   };
 
@@ -128,6 +128,8 @@ stdenv.mkDerivation rec {
       install -D ${ipp-crypto-no_mitigation.src}/LICENSE license/LICENSE
 
       popd
+
+      sh external/sgx-emm/create_symlink.sh
     '';
 
   buildFlags = [
@@ -164,6 +166,7 @@ stdenv.mkDerivation rec {
 
     # Move `lib64` to `lib` and symlink `lib64`
     mv $installDir/lib64 lib
+    ln -sf $out/lib/libsgx_urts.so lib/libsgx_urts.so.2
     ln -s lib/ lib64
 
     mv $installDir/include/ .
@@ -216,6 +219,8 @@ stdenv.mkDerivation rec {
 
     echo "Fixing SGX_SDK default in samples"
     substituteInPlace $out/share/SampleCode/LocalAttestation/buildenv.mk \
+      --replace '/opt/intel/sgxsdk' "$out"
+    substituteInPlace $out/share/SampleCode/SampleAttestedTLS/sgxenv.mk \
       --replace '/opt/intel/sgxsdk' "$out"
     for file in $out/share/SampleCode/*/Makefile; do
       substituteInPlace $file \


### PR DESCRIPTION
###### Description of changes
Update to [v2.19](https://github.com/intel/linux-sgx/releases/tag/sgx_2.19)

Besides updating the version numbers and hashes, the following small necessary changes were made.

* Symlink header files of new dependency `sgx-emm`. The `Makefile` creates the symlink via the `preparation` target, but we don't run this target -- (it initializes git submodules, downloads prebuilt binaries and applies patches).
* Repair broken symlink in installation phase when moving `$TMPDIR/sgxsdk/lib64` to `$out/lib`.
* Add missing substitution for the `SGX_SDK` variable in `SampleAttestedTLS`.
* Add `openssl`, a required dependency to build the samples (it is used to create dummy signing keys).


<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes (or backporting 23.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
