### PR TITLE
kamilalisp: init at 0.2

### DIFF
--- a/pkgs/development/interpreters/kamilalisp/default.nix
+++ b/pkgs/development/interpreters/kamilalisp/default.nix
@@ -1,0 +1,38 @@
+{ lib
+, stdenv
+, fetchurl
+, jre
+, makeWrapper
+}:
+
+stdenv.mkDerivation rec {
+  name = "kamilalisp";
+  version = "0.2";
+
+  src = fetchurl {
+    url = "https://github.com/kspalaiologos/kamilalisp/releases/download/v${version}o/kamilalisp-${version}.jar";
+    hash = "sha256-NkRkLcJpar9iHEI+OmgpkYwkwVvU1J7izeBdytwIsdU=";
+  };
+
+  dontUnpack = true;
+
+  nativeBuildInputs = [ makeWrapper ];
+
+  installPhase = ''
+    mkdir -pv $out/share/java $out/bin
+    cp ${src} $out/share/java/${name}-${version}.jar
+    makeWrapper ${jre}/bin/java $out/bin/kamilalisp \
+      --add-flags "-jar $out/share/java/${name}-${version}.jar" \
+      --set _JAVA_OPTIONS '-Dawt.useSystemAAFontSettings=on' \
+      --set _JAVA_AWT_WM_NONREPARENTING 1
+  '';
+
+  meta = {
+    homepage = "https://github.com/kspalaiologos/kamilalisp";
+    description = "A functional, flexible, and concise Lisp";
+    license = lib.licenses.gpl3Plus;
+    inherit (jre.meta) platforms;
+    maintainers = with lib.maintainers; [ cafkafk ];
+    sourceProvenance = [ lib.sourceTypes.binaryBytecode ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -17084,6 +17084,8 @@ with pkgs;
 
   davmail = callPackage ../applications/networking/davmail { };
 
+  kamilalisp = callPackage ../development/interpreters/kamilalisp { };
+
   kanif = callPackage ../applications/networking/cluster/kanif { };
 
   kona = callPackage ../development/interpreters/kona { };


### PR DESCRIPTION
A functional, flexible and concise Lisp inspired by Haskell and APL, among others. A ground-up rewrite.

Release notes:
https://github.com/kspalaiologos/kamilalisp/releases/tag/v0.2o

###### Description of changes
Added the program via a jar wrapper, as advised by the program author.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes (or backporting 23.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
