### PR TITLE
[backport release-23.05] tor-browser-bundle-bin: 12.0.6 -> 12.0.7, update maintainers

### DIFF
--- a/pkgs/applications/networking/browsers/tor-browser-bundle-bin/default.nix
+++ b/pkgs/applications/networking/browsers/tor-browser-bundle-bin/default.nix
@@ -2,6 +2,7 @@
 , fetchurl
 , makeDesktopItem
 , writeText
+, callPackage
 
 # Common run-time dependencies
 , zlib
@@ -92,7 +93,7 @@ let
 
   lang = "ALL";
 
-  srcs = {
+  sources = {
     x86_64-linux = fetchurl {
       urls = [
         "https://dist.torproject.org/torbrowser/${version}/tor-browser-linux64-${version}_${lang}.tar.xz"
@@ -131,7 +132,7 @@ stdenv.mkDerivation rec {
   pname = "tor-browser-bundle-bin";
   inherit version;
 
-  src = srcs.${stdenv.hostPlatform.system} or (throw "unsupported system: ${stdenv.hostPlatform.system}");
+  src = sources.${stdenv.hostPlatform.system} or (throw "unsupported system: ${stdenv.hostPlatform.system}");
 
   preferLocalBuild = true;
   allowSubstitutes = false;
@@ -447,6 +448,13 @@ stdenv.mkDerivation rec {
     runHook postInstall
   '';
 
+  passthru = {
+    inherit sources;
+    updateScript = callPackage ./update.nix {
+      inherit pname version meta;
+    };
+  };
+
   meta = with lib; {
     description = "Tor Browser Bundle built by torproject.org";
     longDescription = ''
@@ -460,7 +468,7 @@ stdenv.mkDerivation rec {
     '';
     homepage = "https://www.torproject.org/";
     changelog = "https://gitweb.torproject.org/builders/tor-browser-build.git/plain/projects/tor-browser/Bundle-Data/Docs/ChangeLog.txt?h=maint-${version}";
-    platforms = attrNames srcs;
+    platforms = attrNames sources;
     maintainers = with maintainers; [ offline matejc thoughtpolice joachifm hax404 KarlJoad ];
     mainProgram = "tor-browser";
     # MPL2.0+, GPL+, &c.  While it's not entirely clear whether

--- a/pkgs/applications/networking/browsers/tor-browser-bundle-bin/default.nix
+++ b/pkgs/applications/networking/browsers/tor-browser-bundle-bin/default.nix
@@ -469,7 +469,7 @@ stdenv.mkDerivation rec {
     homepage = "https://www.torproject.org/";
     changelog = "https://gitweb.torproject.org/builders/tor-browser-build.git/plain/projects/tor-browser/Bundle-Data/Docs/ChangeLog.txt?h=maint-${version}";
     platforms = attrNames sources;
-    maintainers = with maintainers; [ offline matejc thoughtpolice joachifm hax404 KarlJoad ];
+    maintainers = with maintainers; [ joachifm hax404 ];
     mainProgram = "tor-browser";
     # MPL2.0+, GPL+, &c.  While it's not entirely clear whether
     # the compound is "libre" in a strict sense (some components place certain

--- a/pkgs/applications/networking/browsers/tor-browser-bundle-bin/default.nix
+++ b/pkgs/applications/networking/browsers/tor-browser-bundle-bin/default.nix
@@ -89,7 +89,7 @@ let
   fteLibPath = lib.makeLibraryPath [ stdenv.cc.cc gmp ];
 
   # Upstream source
-  version = "12.0.6";
+  version = "12.0.7";
 
   lang = "ALL";
 
@@ -101,7 +101,7 @@ let
         "https://tor.eff.org/dist/torbrowser/${version}/tor-browser-linux64-${version}_${lang}.tar.xz"
         "https://tor.calyxinstitute.org/dist/torbrowser/${version}/tor-browser-linux64-${version}_${lang}.tar.xz"
       ];
-      hash = "sha256-MLy/T8A+udasITWYSzaqXSFhA3PJsG7DnKJG0b9UYvA=";
+      hash = "sha256-lo+Iy6I7S1NV1E9CBPqJjRFzuEXGC80NRUUlpZfG5wU=";
     };
 
     i686-linux = fetchurl {
@@ -111,7 +111,7 @@ let
         "https://tor.eff.org/dist/torbrowser/${version}/tor-browser-linux32-${version}_${lang}.tar.xz"
         "https://tor.calyxinstitute.org/dist/torbrowser/${version}/tor-browser-linux32-${version}_${lang}.tar.xz"
       ];
-      hash = "sha256-njJB5k7rQxRyL7foU8fLCQxy43dJvV26oKvQ+fw6U0o=";
+      hash = "sha256-aLHZUFDZZ4i7BXoM5YxPrznYw812/OGmhG97t9okOvs=";
     };
   };
 

--- a/pkgs/applications/networking/browsers/tor-browser-bundle-bin/default.nix
+++ b/pkgs/applications/networking/browsers/tor-browser-bundle-bin/default.nix
@@ -469,7 +469,7 @@ stdenv.mkDerivation rec {
     homepage = "https://www.torproject.org/";
     changelog = "https://gitweb.torproject.org/builders/tor-browser-build.git/plain/projects/tor-browser/Bundle-Data/Docs/ChangeLog.txt?h=maint-${version}";
     platforms = attrNames sources;
-    maintainers = with maintainers; [ joachifm hax404 ];
+    maintainers = with maintainers; [ felschr panicgh joachifm hax404 ];
     mainProgram = "tor-browser";
     # MPL2.0+, GPL+, &c.  While it's not entirely clear whether
     # the compound is "libre" in a strict sense (some components place certain

--- a/pkgs/applications/networking/browsers/tor-browser-bundle-bin/update.nix
+++ b/pkgs/applications/networking/browsers/tor-browser-bundle-bin/update.nix
@@ -1,0 +1,62 @@
+{ lib
+, writeShellScript
+, coreutils
+, gnused
+, gnugrep
+, curl
+, gnupg
+, nix
+, common-updater-scripts
+
+# options
+, pname
+, version
+, meta
+, baseUrl ? "https://dist.torproject.org/torbrowser/"
+# prefix used to match published archive
+, prefix ? "tor-browser-"
+# suffix used to match published archive
+, suffix ? "_ALL.tar.xz"
+}:
+
+writeShellScript "update-${pname}" ''
+  PATH="${lib.makeBinPath [ coreutils curl gnugrep gnused gnupg nix common-updater-scripts ]}"
+  set -euo pipefail
+
+  trap
+
+  url=${baseUrl}
+  version=$(curl -s $url \
+            | sed -rne 's,^.*href="([0-9]+(\.[0-9]+)*)/".*,\1,p' \
+            | sort --version-sort | tail -1)
+
+  if [[ "${version}" = "$version" ]]; then
+      echo "The new version same as the old version."
+      exit 0
+  fi
+
+  HOME=$(mktemp -d)
+  export GNUPGHOME=$(mktemp -d)
+  trap 'rm -rf "$HOME" "$GNUPGHOME"' EXIT
+
+  gpg --auto-key-locate nodefault,wkd --locate-keys torbrowser@torproject.org
+  gpg --output $HOME/tor.keyring --export 0xEF6E286DDA85EA2A4BA7DE684E2C6E8793298290
+
+  curl --silent --show-error --fail -o $HOME/shasums "$url$version/sha256sums-signed-build.txt"
+  curl --silent --show-error --fail -o $HOME/shasums.asc "$url$version/sha256sums-signed-build.txt.asc"
+  gpgv --keyring=$HOME/tor.keyring $HOME/shasums.asc $HOME/shasums
+
+  declare -A platforms=(
+    ['x86_64-linux']='linux64'
+    ['i686-linux']='linux32'
+  )
+
+  for platform in ${lib.escapeShellArgs meta.platforms}; do
+    arch="''${platforms[$platform]}"
+    sha256=$(cat "$HOME/shasums" | grep "${prefix}""$arch-$version""${suffix}" | cut -d" " -f1)
+    hash=$(nix hash to-sri --type sha256 "$sha256")
+
+    update-source-version "${pname}" "0" "sha256-${lib.fakeSha256}" --source-key="sources.$platform"
+    update-source-version "${pname}" "$version" "$hash" --source-key="sources.$platform"
+  done
+''


### PR DESCRIPTION
###### Description of changes
Backport of https://github.com/NixOS/nixpkgs/pull/236709 & https://github.com/NixOS/nixpkgs/commit/e9d18d3644097041e634fdca7e4e956e684cb5aa (to resolve conflicts).
Supersedes #236798.

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes (or backporting 23.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).