### PR TITLE
python3Packages.pylion: init at 0.5.2

### DIFF
--- a/pkgs/development/python-modules/pylion/default.nix
+++ b/pkgs/development/python-modules/pylion/default.nix
@@ -1,0 +1,55 @@
+{ lib
+, buildPythonPackage
+, fetchFromBitbucket
+, h5py
+, termcolor
+, pexpect
+, jinja2
+, sphinxHook
+, sphinx-rtd-theme
+}:
+
+buildPythonPackage {
+  pname = "pylion";
+  version = "0.5.2";
+  format = "setuptools";
+
+  src = fetchFromBitbucket {
+    owner = "dtrypogeorgos";
+    repo = "pylion";
+    # Version is set in setup.cfg, but not in a git tag / bitbucket release
+    rev = "8945a7b6f1912ae6b9c705f8a2bd521101f5ba59";
+    hash = "sha256-4AdJkoQ1hAssDUpgmARGmN+ihQqRPPOncWJ5ErQyWII=";
+  };
+
+  # Docs are not available online, besides the article:
+  # http://dx.doi.org/10.1016/j.cpc.2020.107187
+  nativeBuildInputs = [
+    sphinxHook
+    sphinx-rtd-theme
+  ];
+
+  propagatedBuildInputs = [
+    h5py
+    termcolor
+    pexpect
+    jinja2
+  ];
+
+  pythonImportsCheck = [ "pylion" ];
+
+  # Tests fail from some reason - some files seem to be missing from the repo.
+  doCheck = false;
+
+  postInstall = ''
+    mkdir -p $out/share/doc/$name
+    cp -r examples $out/share/doc/$name/examples
+  '';
+
+  meta = with lib; {
+    description = "A LAMMPS wrapper for molecular dynamics simulations of trapped ions";
+    homepage = "https://bitbucket.org/dtrypogeorgos/pylion";
+    license = licenses.mit;
+    maintainers = with maintainers; [ doronbehar ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -8811,6 +8811,8 @@ self: super: with self; {
 
   pylint-venv = callPackage ../development/python-modules/pylint-venv { };
 
+  pylion = callPackage ../development/python-modules/pylion { };
+
   pylitterbot = callPackage ../development/python-modules/pylitterbot { };
 
   py-libzfs = callPackage ../development/python-modules/py-libzfs { };


### PR DESCRIPTION
###### Motivation for this change


###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
