### PR TITLE
SANE improvements

### DIFF
--- a/nixos/modules/services/hardware/sane.nix
+++ b/nixos/modules/services/hardware/sane.nix
@@ -23,7 +23,7 @@ let
     destination = "/etc/sane.d/net.conf";
     text = ''
       ${lib.optionalString config.services.saned.enable "localhost"}
-      ${config.hardware.sane.netConf}
+      ${lib.strings.concatStringsSep "\n" config.hardware.sane.remoteHosts}
     '';
   };
 
@@ -54,6 +54,13 @@ let
 in
 
 {
+
+  imports = [
+    (mkRemovedOptionModule ["hardware" "sane" "netConf"] ''
+      The configuration for SANE remote hosts has been moved to the `remoteHosts` option,
+      which accepts now a list of IP addresses or hostnames as input.
+    '')
+  ];
 
   ###### interface
 
@@ -127,12 +134,12 @@ in
       description = lib.mdDoc "The value of SANE_CONFIG_DIR.";
     };
 
-    hardware.sane.netConf = mkOption {
-      type = types.lines;
-      default = "";
-      example = "192.168.0.16";
+    hardware.sane.remoteHosts = mkOption {
+      type = types.listOf types.str;
+      default = [];
+      example = ["192.168.0.16" "192.168.0.38"];
       description = lib.mdDoc ''
-        Network hosts that should be probed for remote scanners.
+        Network hosts providing scanners via a `saned`.
       '';
     };
 

--- a/nixos/modules/services/hardware/sane.nix
+++ b/nixos/modules/services/hardware/sane.nix
@@ -184,6 +184,15 @@ in
       '';
     };
 
+    services.saned.openFirewall = mkOption {
+      type = types.bool;
+      default = false;
+      description = lib.mdDoc ''
+        Open incoming ports needed so that other SANE clients using
+        the `net` backend can connect to this `saned` instance.
+      '';
+    };
+
     services.saned.extraGroups = mkOption {
       type = types.listOf types.string;
       default = [];
@@ -250,6 +259,7 @@ in
     })
 
     (mkIf config.services.saned.enable {
+      networking.firewall.allowedTCPPorts = mkIf config.services.saned.openFirewall [ config.services.saned.listenPort ];
       networking.firewall.connectionTrackingModules = [ "sane" ];
 
       systemd.services."saned@" = {

--- a/nixos/modules/services/hardware/sane.nix
+++ b/nixos/modules/services/hardware/sane.nix
@@ -33,7 +33,7 @@ let
   };
 
   backends = [ pkg netConf ] ++ optional config.services.saned.enable sanedConf ++ config.hardware.sane.extraBackends;
-  saneConfig = pkgs.mkSaneConfig { paths = backends; inherit (config.hardware.sane) disabledDefaultBackends; };
+  saneConfig = pkgs.mkSaneConfig { paths = backends; inherit (config.hardware.sane) disabledDefaultBackends enabledDefaultBackends; };
 
   enabled = config.hardware.sane.enable || config.services.saned.enable;
 
@@ -84,6 +84,16 @@ in
       example = [ "v4l" ];
       description = lib.mdDoc ''
         Names of backends which are enabled by default but should be disabled.
+        See `$SANE_CONFIG_DIR/dll.conf` for the list of possible names.
+      '';
+    };
+
+    hardware.sane.enabledDefaultBackends = mkOption {
+      type = types.listOf types.str;
+      default = [];
+      example = [ "plustek_pp" ];
+      description = lib.mdDoc ''
+        Names of backends which are disabled by default but should be enabled.
         See `$SANE_CONFIG_DIR/dll.conf` for the list of possible names.
       '';
     };

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -664,6 +664,7 @@ in {
   sabnzbd = handleTest ./sabnzbd.nix {};
   samba = handleTest ./samba.nix {};
   samba-wsdd = handleTest ./samba-wsdd.nix {};
+  sane = handleTest ./saned-sane-net.nix {};
   sanoid = handleTest ./sanoid.nix {};
   schleuder = handleTest ./schleuder.nix {};
   sddm = handleTest ./sddm.nix {};

--- a/nixos/tests/saned-sane-net.nix
+++ b/nixos/tests/saned-sane-net.nix
@@ -1,0 +1,62 @@
+# integration tests for saned/sane-net functionality
+# saned is a daemon which provides remote-access to scanners
+# sane-net is a sane backend, which connects to remote saned instances
+let
+  serverAddress = "192.168.1.1";
+  clientAddress = "192.168.1.2";
+in
+import ./make-test-python.nix ({ pkgs, ...} : {
+  name = "saned-sane-net";
+  meta = with pkgs.lib.maintainers; {
+    maintainers = [ eliasp ];
+  };
+
+  nodes.server = { pkgs, lib, ... }:
+    {
+      networking.interfaces.eth1.ipv4.addresses = lib.mkForce [{
+        address = serverAddress;
+        prefixLength = 24;
+      }];
+      hardware.sane = {
+        enable = true;
+        enabledDefaultBackends = ["test"];
+      };
+      services.saned = {
+        enable = true;
+        openFirewall = true;
+      };
+    };
+  nodes.client = { pkgs, lib, ... }:
+    {
+      networking.interfaces.eth1.ipv4.addresses = lib.mkForce [{
+        address = clientAddress;
+        prefixLength = 24;
+      }];
+      hardware.sane = {
+        enable = true;
+        enabledDefaultBackends = ["test" "net"];
+        remoteHosts = [serverAddress];
+      };
+    };
+
+  testScript = ''
+    start_all()
+    server.wait_for_unit("saned.socket")
+    client.wait_for_unit("network.target")
+    # scanimage lists two test scanners
+    deviceList = client.succeed('scanimage -p -L')
+    assert "device `test:0' is a Noname frontend-tester virtual device" in deviceList
+    assert "device `test:1' is a Noname frontend-tester virtual device" in deviceList
+
+    # scanimage lists two remote test scanners
+    assert "device `net:${serverAddress}:test:0' is a Noname frontend-tester virtual device" in deviceList
+    assert "device `net:${serverAddress}:test:1' is a Noname frontend-tester virtual device" in deviceList
+
+    server.block()
+    deviceList = client.succeed('scanimage -p -L')
+
+    # scanimage doesn't list two remote test scanners
+    assert "device `net:${serverAddress}:test:0' is a Noname frontend-tester virtual device" not in deviceList
+    assert "device `net:${serverAddress}:test:1' is a Noname frontend-tester virtual device" not in deviceList
+  '';
+})


### PR DESCRIPTION
###### Description of changes
This improves and extends the configurability of SANE.
Right now, it's still in "Draft" state, but I hope to finish it within the next few days.

Changes:
- [x] 7cd54c285f10 - nixos/sane: don't disable partially matching backends
- [x] 7972d8fdc67a - nixos/sane: allow to enable backends, which are disabled by default
- [x] 4d8b134d33d - nixos/sane: use dedicated dynamic user for `saned`
- [x] 2f7a970c1281 - nixos/sane: make listen addresses of `saned` configurable
- [x] 12f87f0ce487 - nixos/sane: add option to enable/disable airscan support
- [x] ensure `pkgs.sane-airscan` is removed from `hardware.sane.extraBackends` when `hardware.sane.airscane.enable = false` (explicitly configured) and a corresponding warning is emitted (now part of 12f87f0ce487)
- [x] 46dd54521e9c - nixos/sane: rename `netConf` option to `remoteHosts` (Also change its type from a string to a list of strings (remote hosts/IP addresses).)
- [x]  2ee0465af44c - add `services.saned.openFirewall` to allow remote clients to connect to a local `saned` instance
- [x] 37e3fc28dd0e - nixos/sane: add tests for sane/sane-net/saned
- [ ] update descriptions/examples of all sane config options to improve partially confusing explanations (**WIP**)
- [ ] handle Avahi/systemd-resolved (mDNS) configuration when `hardware.sane.airscane.enable = true`
- [ ] further lockdown of `saned@.service` to reduce potential outfall of vulnerabilities
- [ ] write release notes

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes (or backporting 23.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).