### PR TITLE
aiac: 2.4.0 -> 2.5.0

### DIFF
--- a/pkgs/applications/networking/cluster/aiac/default.nix
+++ b/pkgs/applications/networking/cluster/aiac/default.nix
@@ -2,14 +2,14 @@
 
 buildGoModule rec {
   pname = "aiac";
-  version = "2.4.0";
+  version = "2.5.0";
   excludedPackages = [".ci"];
 
   src = fetchFromGitHub {
     owner = "gofireflyio";
     repo = pname;
     rev = "v${version}";
-    hash = "sha256-C9eQdN8S8Qe0x+Uly69nbYNXDKpi1uZ6qNBetn2P4Gk=";
+    hash = "sha256-BCcoMftnvfAqmabnSz/oRAlJg95KJ236mduxV2DfRG4=";
   };
 
   vendorHash = "sha256-Uqr9wH7hCLdZEu6DXddgB7NuLtqcjUbOPJ2YX+9ehKM=";


### PR DESCRIPTION
###### Description of changes

https://github.com/gofireflyio/aiac/commit/75a0ab392180a93d098f0bbb896ca807b3e65af1 Add support for azure open ai api adaptations (https://github.com/gofireflyio/aiac/pull/59)
    https://github.com/gofireflyio/aiac/commit/43a6574d5ec72a5f0b1cf3afa32e0ebbb66a0746 Change clipboard package (https://github.com/gofireflyio/aiac/pull/54)
    https://github.com/gofireflyio/aiac/commit/209a69f74788f2f8211aba0dc4c4378f2f86409c Update goreleaser.yml (https://github.com/gofireflyio/aiac/pull/52)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes (or backporting 23.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
