### PR TITLE
python310Packages.heudiconv: 0.12.2 -> 0.13.1

### DIFF
--- a/pkgs/development/python-modules/heudiconv/default.nix
+++ b/pkgs/development/python-modules/heudiconv/default.nix
@@ -1,9 +1,10 @@
 { lib
 , buildPythonPackage
 , fetchPypi
-, isPy27
-, pytest
-, mock
+, pythonOlder
+, pytestCheckHook
+, datalad
+, git
 , dcm2niix
 , nibabel
 , pydicom
@@ -14,35 +15,39 @@
 }:
 
 buildPythonPackage rec {
-  version = "0.12.2";
+  version = "0.13.1";
   pname = "heudiconv";
+  format = "pyproject";
 
-  disabled = isPy27;
+  disabled = pythonOlder "3.7";
 
   src = fetchPypi {
     inherit pname version;
-    #sha256 = "0gzqqa4pzhywdbvks2qjniwhr89sgipl5k7h9hcjs7cagmy9gb05";
-    sha256 = "sha256-cYr74mw7tXRJRr8rXlu1UMZuU3YXXfDzhuc+vaa+7PQ=";
+    sha256 = "sha256-UUBRC6RToj4XVbJnxG+EKdue4NVpTAW31RNm9ieF1lU=";
   };
 
-  postPatch = ''
-    # doesn't exist as a separate package with Python 3:
-    substituteInPlace heudiconv/info.py --replace "'pathlib'," ""
-  '';
-
   propagatedBuildInputs = [
-    dcm2niix nibabel pydicom nipype dcmstack etelemetry filelock
+    nibabel
+    pydicom
+    nipype
+    dcmstack
+    etelemetry
+    filelock
   ];
 
-  nativeCheckInputs = [ dcm2niix pytest mock ];
+  nativeCheckInputs = [
+    datalad
+    dcm2niix
+    pytestCheckHook
+    git
+  ];
 
-  # test_monitor and test_dlad require 'inotify' and 'datalad' respectively,
-  # and these aren't in Nixpkgs
-  checkPhase = "pytest -k 'not test_dlad and not test_monitor' heudiconv/tests";
+  preCheck = ''export HOME=$(mktemp -d)'';
 
   meta = with lib; {
     homepage = "https://heudiconv.readthedocs.io";
     description = "Flexible DICOM converter for organizing imaging data";
+    changelog = "https://github.com/nipy/heudiconv/releases/tag/v${version}";
     license = licenses.asl20;
     maintainers = with maintainers; [ bcdarwin ];
   };


### PR DESCRIPTION
###### Description of changes

Update and cleanup.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes (or backporting 23.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
