### PR TITLE
python3Packages.moto: 4.1.3 -> 4.1.11

### DIFF
--- a/pkgs/development/python-modules/moto/default.nix
+++ b/pkgs/development/python-modules/moto/default.nix
@@ -25,6 +25,7 @@
 , python-dateutil
 , python-jose
 , pyyaml
+, py-partiql-parser
 , requests
 , responses
 , sshpubkeys
@@ -40,14 +41,16 @@
 
 buildPythonPackage rec {
   pname = "moto";
-  version = "4.1.3";
+  version = "4.1.11";
   format = "pyproject";
 
-  disabled = pythonOlder "3.6";
+  __darwinAllowLocalNetworking = true;
+
+  disabled = pythonOlder "3.7";
 
   src = fetchPypi {
     inherit pname version;
-    hash = "sha256-yCAMyqlEDC6dqgvV4L12inGdtaLILqjXgvDj+gmjxeI=";
+    hash = "sha256-8+lmuhRgdR4Z6rU1ZUWBOynAVHi0frDaRF1oiUkzm+I=";
   };
 
   nativeBuildInputs = [
@@ -72,6 +75,7 @@ buildPythonPackage rec {
     python-dateutil
     python-jose
     pyyaml
+    py-partiql-parser
     requests
     responses
     sshpubkeys
@@ -107,6 +111,7 @@ buildPythonPackage rec {
     "--deselect=tests/test_s3/test_multiple_accounts_server.py::TestAccountIdResolution::test_with_custom_request_header"
 
     # Disable tests that require docker daemon
+    "--deselect=tests/test_core/test_docker.py::test_docker_is_running_and_available"
     "--deselect=tests/test_events/test_events_lambdatriggers_integration.py::test_creating_bucket__invokes_lambda"
     "--deselect=tests/test_s3/test_s3_lambda_integration.py::test_objectcreated_put__invokes_lambda"
 
@@ -122,7 +127,7 @@ buildPythonPackage rec {
 
     # Blocks test execution
     "--deselect=tests/test_utilities/test_threaded_server.py::TestThreadedMotoServer::test_load_data_from_inmemory_client"
-  ] ++ lib.optionals (stdenv.isDarwin && stdenv.isAarch64) [
+  ] ++ lib.optionals stdenv.isDarwin [
     "--deselect=tests/test_utilities/test_threaded_server.py::test_threaded_moto_server__different_port"
     "--deselect=tests/test_utilities/test_threaded_server.py::TestThreadedMotoServer::test_server_can_handle_multiple_services"
     "--deselect=tests/test_utilities/test_threaded_server.py::TestThreadedMotoServer::test_server_is_reachable"
@@ -141,8 +146,11 @@ buildPythonPackage rec {
     "tests/test_awslambda/test_lambda_eventsourcemapping.py"
     "tests/test_awslambda/test_lambda_invoke.py"
     "tests/test_batch/test_batch_jobs.py"
+    "tests/test_dynamodb/test_dynamodb_statements.py"
     "tests/test_kinesis/test_kinesis.py"
     "tests/test_kinesis/test_kinesis_stream_consumers.py"
+    "tests/test_s3/test_s3_select.py"
+    "tests/test_sqs/test_sqs_integration.py"
   ];
 
   disabledTests = [


### PR DESCRIPTION
###### Description of changes

[Change log](https://github.com/getmoto/moto/blob/master/CHANGELOG.md).

###### Things done

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes (or backporting 23.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).