### PR TITLE
confluent-cli: 2.4.0 > 3.17.0

### DIFF
--- a/pkgs/development/tools/confluent-cli/default.nix
+++ b/pkgs/development/tools/confluent-cli/default.nix
@@ -2,16 +2,16 @@
 
 stdenv.mkDerivation rec {
   pname = "confluent-cli";
-  version = "2.4.0";
+  version = "3.17.0";
 
   # To get the latest version:
   # curl -L https://cnfl.io/cli | sh -s -- -l | grep -v latest | sort -V | tail -n1
   src = fetchurl (if stdenv.hostPlatform.isDarwin then {
-      url = "https://s3-us-west-2.amazonaws.com/confluent.cloud/confluent-cli/archives/${version}/confluent_v${version}_darwin_amd64.tar.gz";
-      sha256 = "1xkf7p9cn37k8j57cgbzxhqgnmchf86jyiza91bf6ddvm6jsm2gd";
+      url = "https://s3-us-west-2.amazonaws.com/confluent.cloud/confluent-cli/archives/${version}/confluent_${version}_darwin_amd64.tar.gz";
+      sha256 = "03104736f65591a5be9536424460d9b8c8fc8ac8b5eb646e832371397aaf7cef";
     } else {
-      url = "https://s3-us-west-2.amazonaws.com/confluent.cloud/confluent-cli/archives/${version}/confluent_v${version}_linux_amd64.tar.gz";
-      sha256 = "1wvy7x56cc7imycf0d83mxcqzdvv56cc0zbp913xgghjn9dl2z7a";
+      url = "https://s3-us-west-2.amazonaws.com/confluent.cloud/confluent-cli/archives/${version}/confluent_${version}_linux_amd64.tar.gz";
+      sha256 = "3243beca4fefd49cf067f9a4df4f5072a8ac5dac91638e9f10ef0b0544d30445";
     });
 
   nativeBuildInputs = lib.optionals stdenv.hostPlatform.isLinux [ autoPatchelfHook ];


### PR DESCRIPTION
###### Description of changes

Quite an extensive list of changes since the previous version can be found [on the upstream website](https://docs.confluent.io/confluent-cli/current/release-notes.html#confluent-cli-v3-17-0-release-notes)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes (or backporting 23.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

The package is a binary from upstream, which I tested by running the following basic commands:

```sh
./result/bin/confluent --version
./result/bin/confluent login
```
