### PR TITLE
vscode-extensions.vadimcn.vscode-lldb: 1.9.1 -> 1.9.2

### DIFF
--- a/pkgs/applications/editors/vscode/extensions/vadimcn.vscode-lldb/adapter-output-shared_object.patch
+++ b/pkgs/applications/editors/vscode/extensions/vadimcn.vscode-lldb/adapter-output-shared_object.patch
@@ -1,0 +1,22 @@
+From 4f64ad191ec79b9f40843f88e3ac5910720636da Mon Sep 17 00:00:00 2001
+From: Changsheng Wu <Congee@users.noreply.github.com>
+Date: Fri, 9 Jun 2023 15:41:53 -0400
+Subject: [PATCH] Update Cargo.toml
+
+---
+ adapter/Cargo.toml | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/adapter/Cargo.toml b/adapter/Cargo.toml
+index bc86723..f5f26ce 100644
+--- a/adapter/Cargo.toml
++++ b/adapter/Cargo.toml
+@@ -39,7 +39,7 @@ winapi = { version = "0.3.8", features = ["std", "wincon", "namedpipeapi"] }
+ winreg = "0.6.2"
+
+ [lib]
+-crate-type = ["staticlib"]
++crate-type = ["dylib", "rlib"]
+
+ [[bin]]
+ name = "codelldb"

--- a/pkgs/applications/editors/vscode/extensions/vadimcn.vscode-lldb/cmake-build-extension-only.patch
+++ b/pkgs/applications/editors/vscode/extensions/vadimcn.vscode-lldb/cmake-build-extension-only.patch
@@ -1,8 +1,7 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index 6ae4dfb..519f544 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -16,13 +16,6 @@ endif()
+@@ -16,13 +16,6 @@
  set(VERSION "${VERSION}${VERSION_SUFFIX}")
  message("Version ${VERSION}")
  
@@ -16,11 +15,11 @@ index 6ae4dfb..519f544 100644
  if (CMAKE_SYSROOT)
      set(CMAKE_C_FLAGS "--sysroot=${CMAKE_SYSROOT} ${CMAKE_C_FLAGS}")
      set(CMAKE_CXX_FLAGS "--sysroot=${CMAKE_SYSROOT} ${CMAKE_CXX_FLAGS}")
-@@ -93,16 +86,6 @@ configure_file(package.json ${CMAKE_CURRENT_BINARY_DIR}/package.json @ONLY)
+@@ -102,16 +95,6 @@
  configure_file(webpack.config.js ${CMAKE_CURRENT_BINARY_DIR}/webpack.config.js @ONLY)
  file(COPY ${CMAKE_CURRENT_SOURCE_DIR}/package-lock.json DESTINATION ${CMAKE_CURRENT_BINARY_DIR})
  
--# Run 'npm install'
+-# Install node_modules
 -execute_process(
 -    COMMAND ${NPM} ci # like install, but actually respects package-lock file.
 -    WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
@@ -30,10 +29,10 @@ index 6ae4dfb..519f544 100644
 -    message(FATAL_ERROR "npm intall failed: ${Result}")
 -endif()
 -
- # Copy it back, so we can commit the lock file.
- file(COPY ${CMAKE_CURRENT_BINARY_DIR}/package-lock.json DESTINATION ${CMAKE_CURRENT_SOURCE_DIR})
- 
-@@ -154,6 +137,7 @@ add_custom_target(tests
+ # Resolve $refs
+ execute_process(
+     COMMAND ${WithEnv} NODE_PATH=${CMAKE_CURRENT_BINARY_DIR}/node_modules node ${CMAKE_CURRENT_SOURCE_DIR}/tools/prep-package.js ${CMAKE_CURRENT_BINARY_DIR}/package.json ${CMAKE_CURRENT_BINARY_DIR}/package.json
+@@ -169,6 +152,7 @@
  
  add_copy_file(PackageFiles ${CMAKE_CURRENT_SOURCE_DIR}/README.md ${CMAKE_CURRENT_BINARY_DIR}/README.md)
  add_copy_file(PackageFiles ${CMAKE_CURRENT_SOURCE_DIR}/CHANGELOG.md ${CMAKE_CURRENT_BINARY_DIR}/CHANGELOG.md)
@@ -41,7 +40,7 @@ index 6ae4dfb..519f544 100644
  add_copy_file(PackageFiles ${CMAKE_CURRENT_SOURCE_DIR}/images/lldb.png ${CMAKE_CURRENT_BINARY_DIR}/images/lldb.png)
  add_copy_file(PackageFiles ${CMAKE_CURRENT_SOURCE_DIR}/images/user.svg ${CMAKE_CURRENT_BINARY_DIR}/images/user.svg)
  add_copy_file(PackageFiles ${CMAKE_CURRENT_SOURCE_DIR}/images/users.svg ${CMAKE_CURRENT_BINARY_DIR}/images/users.svg)
-@@ -170,6 +154,7 @@ add_custom_target(dev_debugging
+@@ -185,6 +169,7 @@
  set(PackagedFilesBootstrap
      README.md
      CHANGELOG.md
@@ -49,4 +48,3 @@ index 6ae4dfb..519f544 100644
      extension.js
      images/*
      syntaxes/*
-

--- a/pkgs/applications/editors/vscode/extensions/vadimcn.vscode-lldb/default.nix
+++ b/pkgs/applications/editors/vscode/extensions/vadimcn.vscode-lldb/default.nix
@@ -15,7 +15,7 @@ let
     owner = "vadimcn";
     repo = "vscode-lldb";
     rev = "v${version}";
-    sha256 = "6QmYRlSv8jY3OE3RcYuZt+c3z6GhFc8ESETVfCfF5RI=";
+    hash = "sha256-6QmYRlSv8jY3OE3RcYuZt+c3z6GhFc8ESETVfCfF5RI=";
   };
 
   # need to build a custom version of lldb and llvm for enhanced rust support

--- a/pkgs/applications/editors/vscode/extensions/vadimcn.vscode-lldb/default.nix
+++ b/pkgs/applications/editors/vscode/extensions/vadimcn.vscode-lldb/default.nix
@@ -25,7 +25,7 @@ let
     pname = "${pname}-adapter";
     inherit version src;
 
-    cargoSha256 = "sha256-Qq2igtH1XIB+NAEES6hdNZcMbEmaFN69qIJ+gTYupvQ=";
+    cargoHash = "sha256-Qq2igtH1XIB+NAEES6hdNZcMbEmaFN69qIJ+gTYupvQ=";
 
     nativeBuildInputs = [ makeWrapper ];
 

--- a/pkgs/applications/editors/vscode/extensions/vadimcn.vscode-lldb/default.nix
+++ b/pkgs/applications/editors/vscode/extensions/vadimcn.vscode-lldb/default.nix
@@ -5,7 +5,7 @@ assert lib.versionAtLeast python3.version "3.5";
 let
   publisher = "vadimcn";
   pname = "vscode-lldb";
-  version = "1.9.1";
+  version = "1.9.2";
 
   vscodeExtUniqueId = "${publisher}.${pname}";
   vscodeExtPublisher = publisher;
@@ -15,7 +15,7 @@ let
     owner = "vadimcn";
     repo = "vscode-lldb";
     rev = "v${version}";
-    sha256 = "sha256-DqxdZtSW8TZaOFGXOZQ7a4tmgRj6iAWDppCNomdfVxY=";
+    sha256 = "6QmYRlSv8jY3OE3RcYuZt+c3z6GhFc8ESETVfCfF5RI=";
   };
 
   # need to build a custom version of lldb and llvm for enhanced rust support
@@ -25,7 +25,7 @@ let
     pname = "${pname}-adapter";
     inherit version src;
 
-    cargoSha256 = "sha256-+hfNkr9cZbOcWdWKUWUqDj9a0PKjKeApFXYZzS1XokE=";
+    cargoSha256 = "sha256-Qq2igtH1XIB+NAEES6hdNZcMbEmaFN69qIJ+gTYupvQ=";
 
     nativeBuildInputs = [ makeWrapper ];
 
@@ -38,6 +38,8 @@ let
       "--bin=codelldb"
     ];
 
+    patches = [ ./adapter-output-shared_object.patch ];
+
     # Tests are linked to liblldb but it is not available here.
     doCheck = false;
   };
@@ -46,7 +48,7 @@ let
     pname = "${pname}-node-deps";
     inherit version src;
 
-    npmDepsHash = "sha256-Cdlq1jxHSCfPjXhasClc6XzEUp3vlLgkStbhYtCyc7E=";
+    npmDepsHash = "sha256-fMKGi+AJTMlWl7SQtZ21hUwOLgqlFYDhwLvEergQLfI=";
 
     nativeBuildInputs = [
       python3
@@ -81,12 +83,6 @@ in stdenv.mkDerivation {
   nativeBuildInputs = [ cmake nodejs unzip makeWrapper ];
 
   patches = [ ./cmake-build-extension-only.patch ];
-
-  postPatch = ''
-    # temporary patch for forgotten version updates
-    substituteInPlace CMakeLists.txt \
-      --replace "1.9.0" ${version}
-  '';
 
   postConfigure = ''
     cp -r ${nodeDeps}/lib/node_modules .


### PR DESCRIPTION
The patched adapter now produces a dynamic library instead of a static archive

fixes #234908
fixes #160874

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes (or backporting 23.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
