### PR TITLE
python3Packages.dagger-io: init at 0.6.1

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -13328,6 +13328,12 @@
     githubId = 145816;
     name = "David McKay";
   };
+  rayanpiro = {
+    email = "red_ink@hotmail.es";
+    github = "rayanpiro";
+    githubId = 46218596;
+    name = "rayanpiro";
+  };
   razvan = {
     email = "razvan.panda@gmail.com";
     github = "razvan-flavius-panda";

--- a/pkgs/development/python-modules/dagger-io/default.nix
+++ b/pkgs/development/python-modules/dagger-io/default.nix
@@ -1,28 +1,23 @@
-# pkgs = import (fetchTarball {
-# 	url = "https://github.com/NixOS/nixpkgs/archive/nixpkgs-unstable.tar.gz";
-# 	sha256 = "sha256:0s4hvb6zgbi3nqnh2r4q129q4672fv65cy02mxchddz7p5hg5sma";
-# }) {};
-
-{
-buildPythonPackage,
-fetchFromGitHub,
-pythonOlder,
-poetry-core,
-anyio,
-attrs,
-cattrs,
-graphql-core,
-gql,
-httpx,
-beartype,
-platformdirs,
-typing-extensions,
-rich,
-typer,
-strawberry-graphql,
-shellingham,
-colorama,
-} :
+{ lib
+, anyio
+, attrs
+, beartype
+, buildPythonPackage
+, cattrs
+, colorama
+, fetchFromGitHub
+, gql
+, graphql-core
+, httpx
+, platformdirs
+, poetry-core
+, pythonOlder
+, rich
+, shellingham
+, strawberry-graphql
+, typer
+, typing-extensions
+}:
 
 buildPythonPackage rec {
   pname = "dagger-io";
@@ -30,31 +25,37 @@ buildPythonPackage rec {
   format = "pyproject";
 
   disabled = pythonOlder "3.10";
-  
-  src = fetchFromGitHub
-    {
+
+  src = fetchFromGitHub {
       owner = "dagger";
       repo = "dagger";
       rev = version;
       sha256 = "sha256-9QQ6aDCkTWNq5KOSGF6FH6UQrOYa51ctW3CMcGrCJAQ=";
-    } + "/sdk/python";
-  doCheck = false;
+  } + "/sdk/python";
 
   propagatedBuildInputs = [
-    poetry-core
     anyio
     attrs
-    cattrs
-    graphql-core
-    gql
-    httpx
     beartype
-    platformdirs
-    typing-extensions
-    rich
-    typer
-    strawberry-graphql
-    shellingham
+    cattrs
     colorama
+    gql
+    graphql-core
+    httpx
+    platformdirs
+    poetry-core
+    rich
+    shellingham
+    strawberry-graphql
+    typer
+    typing-extensions
   ];
+  meta = with lib; {
+    description = "Dagger is a programmable CI/CD engine that runs your pipelines in containers.";
+    homepage = "https://github.com/dagger/dagger";
+    changelog = "https://github.com/dagger/dagger/releases/tag/${version}";
+    license = licenses.asl20 ;
+    # Just commented until I got into maintainers-list.
+    # maintainers = with maintainers; [ rayanpiro ];
+  };
 }

--- a/pkgs/development/python-modules/dagger-io/default.nix
+++ b/pkgs/development/python-modules/dagger-io/default.nix
@@ -55,7 +55,6 @@ buildPythonPackage rec {
     homepage = "https://github.com/dagger/dagger";
     changelog = "https://github.com/dagger/dagger/releases/tag/v${version}";
     license = licenses.asl20 ;
-    # Just commented until I got into maintainers-list.
-    # maintainers = with maintainers; [ rayanpiro ];
+    maintainers = with maintainers; [ rayanpiro ];
   };
 }

--- a/pkgs/development/python-modules/dagger-io/default.nix
+++ b/pkgs/development/python-modules/dagger-io/default.nix
@@ -27,10 +27,10 @@ buildPythonPackage rec {
   disabled = pythonOlder "3.10";
 
   src = fetchFromGitHub {
-      owner = "dagger";
-      repo = "dagger";
-      rev = "v${version}";
-      sha256 = "sha256-9QQ6aDCkTWNq5KOSGF6FH6UQrOYa51ctW3CMcGrCJAQ=";
+    owner = "dagger";
+    repo = "dagger";
+    rev = "v${version}";
+    hash = "sha256-9QQ6aDCkTWNq5KOSGF6FH6UQrOYa51ctW3CMcGrCJAQ=";
   } + "/sdk/python";
 
   propagatedBuildInputs = [

--- a/pkgs/development/python-modules/dagger-io/default.nix
+++ b/pkgs/development/python-modules/dagger-io/default.nix
@@ -38,7 +38,6 @@ buildPythonPackage rec {
     attrs
     beartype
     cattrs
-    colorama
     gql
     graphql-core
     httpx

--- a/pkgs/development/python-modules/dagger-io/default.nix
+++ b/pkgs/development/python-modules/dagger-io/default.nix
@@ -51,7 +51,7 @@ buildPythonPackage rec {
     typing-extensions
   ];
   meta = with lib; {
-    description = "Dagger is a programmable CI/CD engine that runs your pipelines in containers.";
+    description = "Dagger is a programmable CI/CD engine that runs your pipelines in containers";
     homepage = "https://github.com/dagger/dagger";
     changelog = "https://github.com/dagger/dagger/releases/tag/v${version}";
     license = licenses.asl20 ;

--- a/pkgs/development/python-modules/dagger-io/default.nix
+++ b/pkgs/development/python-modules/dagger-io/default.nix
@@ -45,7 +45,6 @@ buildPythonPackage rec {
     platformdirs
     poetry-core
     rich
-    shellingham
     strawberry-graphql
     typer
     typing-extensions

--- a/pkgs/development/python-modules/dagger-io/default.nix
+++ b/pkgs/development/python-modules/dagger-io/default.nix
@@ -1,0 +1,60 @@
+# pkgs = import (fetchTarball {
+# 	url = "https://github.com/NixOS/nixpkgs/archive/nixpkgs-unstable.tar.gz";
+# 	sha256 = "sha256:0s4hvb6zgbi3nqnh2r4q129q4672fv65cy02mxchddz7p5hg5sma";
+# }) {};
+
+{
+buildPythonPackage,
+fetchFromGitHub,
+pythonOlder,
+poetry-core,
+anyio,
+attrs,
+cattrs,
+graphql-core,
+gql,
+httpx,
+beartype,
+platformdirs,
+typing-extensions,
+rich,
+typer,
+strawberry-graphql,
+shellingham,
+colorama,
+} :
+
+buildPythonPackage rec {
+  pname = "dagger-io";
+  version = "v0.6.1";
+  format = "pyproject";
+
+  disabled = pythonOlder "3.10";
+  
+  src = fetchFromGitHub
+    {
+      owner = "dagger";
+      repo = "dagger";
+      rev = version;
+      sha256 = "sha256-9QQ6aDCkTWNq5KOSGF6FH6UQrOYa51ctW3CMcGrCJAQ=";
+    } + "/sdk/python";
+  doCheck = false;
+
+  propagatedBuildInputs = [
+    poetry-core
+    anyio
+    attrs
+    cattrs
+    graphql-core
+    gql
+    httpx
+    beartype
+    platformdirs
+    typing-extensions
+    rich
+    typer
+    strawberry-graphql
+    shellingham
+    colorama
+  ];
+}

--- a/pkgs/development/python-modules/dagger-io/default.nix
+++ b/pkgs/development/python-modules/dagger-io/default.nix
@@ -21,7 +21,7 @@
 
 buildPythonPackage rec {
   pname = "dagger-io";
-  version = "v0.6.1";
+  version = "0.6.1";
   format = "pyproject";
 
   disabled = pythonOlder "3.10";
@@ -29,7 +29,7 @@ buildPythonPackage rec {
   src = fetchFromGitHub {
       owner = "dagger";
       repo = "dagger";
-      rev = version;
+      rev = "v${version}";
       sha256 = "sha256-9QQ6aDCkTWNq5KOSGF6FH6UQrOYa51ctW3CMcGrCJAQ=";
   } + "/sdk/python";
 
@@ -53,7 +53,7 @@ buildPythonPackage rec {
   meta = with lib; {
     description = "Dagger is a programmable CI/CD engine that runs your pipelines in containers.";
     homepage = "https://github.com/dagger/dagger";
-    changelog = "https://github.com/dagger/dagger/releases/tag/${version}";
+    changelog = "https://github.com/dagger/dagger/releases/tag/v${version}";
     license = licenses.asl20 ;
     # Just commented until I got into maintainers-list.
     # maintainers = with maintainers; [ rayanpiro ];

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2285,6 +2285,8 @@ self: super: with self; {
 
   daemonocle = callPackage ../development/python-modules/daemonocle { };
 
+  dagger-io = callPackage ../development/python-modules/dagger-io { };
+
   daiquiri = callPackage ../development/python-modules/daiquiri { };
 
   dalle-mini = callPackage ../development/python-modules/dalle-mini { };


### PR DESCRIPTION
###### Description of changes

New python module include.
Name: [dagger-io](https://dagger.io/)

###### Things done

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes (or backporting 23.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
