### PR TITLE
pdfstudio2023: init at 2023.0.3, pdfstudio2022: 2022.2.4 -> 2022.2.5, pdfstudio2021: 2021.2.1 -> 2022.2.2, pdfstudioviewer: 2022.2.4->2023.0.3

### DIFF
--- a/pkgs/applications/misc/pdfstudio/default.nix
+++ b/pkgs/applications/misc/pdfstudio/default.nix
@@ -31,23 +31,23 @@ in
 {
   pdfstudioviewer = callPackage ./common.nix rec {
     inherit desktopName pname program year;
-    version = "${year}.0.1";
+    version = "${year}.0.3";
     longDescription = ''
       PDF Studio Viewer is an easy to use, full-featured PDF editing software. This is the free edition. For the standard/pro edition, see the package pdfstudio.
     '';
     src = fetchurl {
       url = "https://download.qoppa.com/pdfstudioviewer/PDFStudioViewer_linux64.deb";
-      sha256 = "sha256-afRhx9VCVRFUJoUnqs1bzF0yXpz3yEgLiFjMRB9xvsk=";
+      sha256 = "sha256-JQx5yJLjwW4VRXLM+/VNDXFN8ZcHJxlxyKDIzc++hEs=";
     };
     jdk = jdk17;
   };
 
   pdfstudio2021 = callPackage ./common.nix rec {
     inherit desktopName longDescription pname program year;
-    version = "${year}.2.1";
+    version = "${year}.2.2";
     src = fetchurl {
       url = "https://download.qoppa.com/pdfstudio/v${year}/PDFStudio_v${dot2dash version}_linux64.deb";
-      sha256 = "sha256-yELpza2C3HJJIP+ZQP7x3Tfez0Nl6ctCbHCmTmpX3jo=";
+      sha256 = "sha256-HdkwRMqwquAaW6l3AukGReFtw2f5n36tZ8vXo6QiPvU=";
     };
     extraBuildInputs = [
       (lib.getLib stdenv.cc.cc)  # for libstdc++.so.6 and libgomp.so.1
@@ -57,10 +57,10 @@ in
 
   pdfstudio2022 = callPackage ./common.nix rec {
     inherit desktopName longDescription pname program year;
-    version = "${year}.2.4";
+    version = "${year}.2.5";
     src = fetchurl {
       url = "https://download.qoppa.com/pdfstudio/v${year}/PDFStudio_v${dot2dash version}_linux64.deb";
-      sha256 = "sha256-bti+WI8JdOmUsHq8ijfxGC4ZsWXwbwwM26kuBgPDUMQ=";
+      sha256 = "sha256-3faZyWUnFe//S+gOskWhsZ6jzHw67FRsv/xP77R1jj4=";
     };
     extraBuildInputs = [
       (lib.getLib stdenv.cc.cc)  # for libstdc++.so.6 and libgomp.so.1
@@ -70,10 +70,10 @@ in
 
   pdfstudio2023 = callPackage ./common.nix rec {
     inherit desktopName longDescription pname program year;
-    version = "${year}.0.1";
+    version = "${year}.0.3";
     src = fetchurl {
       url = "https://download.qoppa.com/pdfstudio/v${year}/PDFStudio_v${dot2dash version}_linux64.deb";
-      sha256 = "sha256-WGl9D4JQNPs73jlpmITYFuupUFl0/4Po524M/8EaABk=";
+      sha256 = "sha256-Po7BMmEWoC46rP7tUwZT9Ji/Wi8lKc6WN8x47fx2DXg=";
     };
     jdk = jdk17;
   };

--- a/pkgs/applications/misc/pdfstudio/default.nix
+++ b/pkgs/applications/misc/pdfstudio/default.nix
@@ -11,7 +11,7 @@
 { lib
 , stdenv
 , program ? "pdfstudio"
-, year ? "2022"
+, year ? "2023"
 , fetchurl
 , callPackage
 , jdk11
@@ -31,13 +31,13 @@ in
 {
   pdfstudioviewer = callPackage ./common.nix rec {
     inherit desktopName pname program year;
-    version = "${year}.2.4";
+    version = "${year}.0.1";
     longDescription = ''
       PDF Studio Viewer is an easy to use, full-featured PDF editing software. This is the free edition. For the standard/pro edition, see the package pdfstudio.
     '';
     src = fetchurl {
       url = "https://download.qoppa.com/pdfstudioviewer/PDFStudioViewer_linux64.deb";
-      sha256 = "sha256-QXNsH1T+ItV3s9r8CnwgRUo1mhVbe8LkEun9gUmlVQg=";
+      sha256 = "sha256-afRhx9VCVRFUJoUnqs1bzF0yXpz3yEgLiFjMRB9xvsk=";
     };
     jdk = jdk17;
   };
@@ -65,6 +65,16 @@ in
     extraBuildInputs = [
       (lib.getLib stdenv.cc.cc)  # for libstdc++.so.6 and libgomp.so.1
     ];
+    jdk = jdk17;
+  };
+
+  pdfstudio2023 = callPackage ./common.nix rec {
+    inherit desktopName longDescription pname program year;
+    version = "${year}.0.1";
+    src = fetchurl {
+      url = "https://download.qoppa.com/pdfstudio/v${year}/PDFStudio_v${dot2dash version}_linux64.deb";
+      sha256 = "sha256-WGl9D4JQNPs73jlpmITYFuupUFl0/4Po524M/8EaABk=";
+    };
     jdk = jdk17;
   };
 }.${pname}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -29326,6 +29326,10 @@ with pkgs;
     year = "2022";
   };
 
+  pdfstudio2023 = callPackage ../applications/misc/pdfstudio {
+    year = "2023";
+  };
+
   pdfstudioviewer = callPackage ../applications/misc/pdfstudio {
     program = "pdfstudioviewer";
   };


### PR DESCRIPTION
###### Description of changes
Adds package pdfstudio2023 at 2023.0.3 (latest commercial version), and updates the following:
pdfstudio2022: 2022.2.4 -> 2022.2.5
pdfstudio2021: 2021.2.1 -> 2022.2.2
pdfstudioviewer: 2022.2.4 -> 2023.0.3

Fixes https://github.com/NixOS/nixpkgs/pull/241972

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes (or backporting 23.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
