### PR TITLE
koodousfinder: init at 0.1.0

### DIFF
--- a/pkgs/by-name/ko/koodousfinder/package.nix
+++ b/pkgs/by-name/ko/koodousfinder/package.nix
@@ -1,0 +1,42 @@
+{ lib
+, python3
+, fetchFromGitHub
+}:
+
+python3.pkgs.buildPythonApplication rec {
+  pname = "koodousfinder";
+  version = "0.1.0";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "teixeira0xfffff";
+    repo = "KoodousFinder";
+    # Not properly tagged, https://github.com/teixeira0xfffff/KoodousFinder/issues/7
+    #rev = "refs/tags/v${version}";
+    rev = "d9dab5572f44e5cd45c04e6fcda38956897855d1";
+    hash = "sha256-skCbt2lDKgSyZdHY3WImbr6CF0icrDPTIXNV1736gKk=";
+  };
+
+  nativeBuildInputs = with python3.pkgs; [
+    poetry-core
+  ];
+
+  propagatedBuildInputs = with python3.pkgs; [
+    keyring
+    requests
+  ];
+
+  # Project has no tests, re-check with next release
+  doCheck = false;
+
+  pythonImportsCheck = [
+    "koodousfinder"
+  ];
+
+  meta = with lib; {
+    description = "Tool to allows users to search for and analyze Android apps";
+    homepage = "https://github.com/teixeira0xfffff/KoodousFinder";
+    license = with licenses; [ mit ];
+    maintainers = with maintainers; [ fab ];
+  };
+}


### PR DESCRIPTION
###### Description of changes
Tool to allows users to search for and analyze Android apps

https://github.com/teixeira0xfffff/KoodousFinder

Currently `unfree`: https://github.com/teixeira0xfffff/KoodousFinder/issues/5

Related to https://github.com/NixOS/nixpkgs/issues/81418
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes (or backporting 23.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
