### PR TITLE
libgdiplus: 6.0.5 -> 6.1

### DIFF
--- a/pkgs/development/libraries/libgdiplus/configure-pkg-config.patch
+++ b/pkgs/development/libraries/libgdiplus/configure-pkg-config.patch
@@ -1,0 +1,17 @@
+diff --git a/configure.ac b/configure.ac
+index e47a3f1..f529e69 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -16,10 +16,8 @@ m4_ifdef([AM_SILENT_RULES], [AM_SILENT_RULES([yes])])
+ 
+ AC_C_BIGENDIAN
+ 
+-AC_PATH_PROG(PKG_CONFIG, pkg-config, no)
+-if test "x$PKG_CONFIG" = "xno"; then
+-	AC_MSG_ERROR([You need to install pkg-config])
+-fi
++PKG_PROG_PKG_CONFIG
++
+ GLIB_REQUIRED_VERSION="2.2.3"
+ PKG_CHECK_MODULES(BASE_DEPENDENCIES, glib-2.0 >= $GLIB_REQUIRED_VERSION)
+ 

--- a/pkgs/development/libraries/libgdiplus/default.nix
+++ b/pkgs/development/libraries/libgdiplus/default.nix
@@ -1,17 +1,22 @@
-{ lib, stdenv, fetchFromGitHub, pkg-config, glib, cairo, Carbon, fontconfig
+{ lib, stdenv, fetchzip, pkg-config, glib, cairo, Carbon, fontconfig
 , libtiff, giflib, libjpeg, libpng
 , libXrender, libexif, autoreconfHook, fetchpatch }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "libgdiplus";
-  version = "6.0.5";
+  version = "6.1";
 
-  src = fetchFromGitHub {
-    owner = "mono";
-    repo = "libgdiplus";
-    rev = version;
-    sha256 = "1387lgph5r17viv3rkf5hbksdn435njzmra7s17q0nzk2mkkm68c";
+  # Using source archive to avoid fetching Git submodules.
+  # Git repo: https://github.com/mono/libgdiplus
+  src = fetchzip {
+    url = "https://download.mono-project.com/sources/libgdiplus/libgdiplus-${finalAttrs.version}.tar.gz";
+    hash = "sha256-+lP9ETlw3s0RUliQT1uBWZ2j6o3V9EECBQSppOYFq4Q=";
   };
+
+  patches = [
+    # Fix pkg-config lookup when cross-compiling.
+    ./configure-pkg-config.patch
+  ];
 
   NIX_LDFLAGS = "-lgif";
 
@@ -45,4 +50,4 @@ stdenv.mkDerivation rec {
     platforms = platforms.unix;
     license = licenses.mit;
   };
-}
+})


### PR DESCRIPTION
###### Description of changes

This change updates `libgdiplus` from `6.0.5` to `6.1` and fixes `pkg-config` lookup in `configure.ac` when cross-compiling.

https://github.com/mono/libgdiplus/compare/6.0.5...6.1

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes (or backporting 23.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
