### PR TITLE
firefox: support unsigned extensions in wrapper

### DIFF
--- a/pkgs/applications/networking/browsers/firefox/common.nix
+++ b/pkgs/applications/networking/browsers/firefox/common.nix
@@ -364,6 +364,7 @@ buildStdenv.mkDerivation ({
   configurePlatforms = [ ];
 
   configureFlags = [
+    "--allow-addon-sideload"
     "--disable-tests"
     "--disable-updater"
     "--enable-application=${application}"
@@ -381,6 +382,7 @@ buildStdenv.mkDerivation ({
     "--with-system-png" # needs APNG support
     "--with-system-webp"
     "--with-system-zlib"
+    "--with-unsigned-addon-scopes=app"
     "--with-wasi-sysroot=${wasiSysRoot}"
     # for firefox, host is buildPlatform, target is hostPlatform
     "--host=${buildStdenv.buildPlatform.config}"

--- a/pkgs/applications/networking/browsers/firefox/wrapper.nix
+++ b/pkgs/applications/networking/browsers/firefox/wrapper.nix
@@ -381,8 +381,6 @@ let
         ${extraPrefs}
         EOF
 
-        mkdir -p $out/lib/${libName}/distribution/extensions
-
         #############################
         #                           #
         #   END EXTRA PREF CHANGES  #

--- a/pkgs/applications/networking/browsers/firefox/wrapper.nix
+++ b/pkgs/applications/networking/browsers/firefox/wrapper.nix
@@ -133,15 +133,10 @@ let
             ret // {
               "${e.extid}" = {
                 installation_mode = "allowed";
+                install_url = "file://${e.outPath}/${e.extid}.xpi";
               };
             }
           ) {} extensions;
-
-          Extensions = {
-            Install = lib.foldr (e: ret:
-              ret ++ [ "${e.outPath}/${e.extid}.xpi" ]
-            ) [] extensions;
-          };
         } // lib.optionalAttrs smartcardSupport {
           SecurityDevices = {
             "OpenSC PKCS#11 Module" = "opensc-pkcs11.so";


### PR DESCRIPTION
**Currently draft** as I work out some quirks in the interaction between FF Policies, autoDisableScopes, and signing exclusion paths, but the overall approach is unlikely to change *too* much (hopefully).

###### Description of changes

A similar technique is done by [Arch][1], [Debian][2], [Fedora][3],
[Gentoo][4], and probably others.

Since we are only using the `app` scope, not the `system` one, don’t use
it to minimize the expansion of allowed unsigned extension paths.

`autoDisableScopes` defaults to 15 upstream, and SCOPE_APPLICATION=4, so
15 xor 4 = 11. This allows the extensions we bundle in the wrapper to be
auto-installed.

Since we can now have unsigned addons in `nixExtensions` with Firefox
release builds, remove various assertions around scenarios where they
would previously not work.

Discovering the required path by code-diving was…less than successful as
there is a lot of indirection in the handling in FF source. Instead, the
browser toolbox was used to inspect the value of
`lazy.XPIInternal.XPIStates.locations()`.

[1]: https://gitlab.archlinux.org/archlinux/packaging/packages/firefox/-/blob/29ab50162f4a89d281b9f0a0fb9e2ebce496e4ac/PKGBUILD#L120
[2]: https://salsa.debian.org/mozilla-team/firefox/-/blob/90a0107053660c575fa432615830dedf8c9b7e13/debian/browser.mozconfig.in#L30
[3]: https://src.fedoraproject.org/rpms/firefox/blob/e9c16e2628afd9e0d7f0962228bec7b0f56172d4/f/firefox-mozconfig#_16
[4]: https://gitweb.gentoo.org/repo/gentoo.git/tree/www-client/firefox/firefox-114.0.ebuild?id=0faf645c97c0d979fb10cb92e0d7e5980ffb1ea6#n815

###### Things done

I have tested, with fresh profile and *only* the regular `pkgs.firefox`:

- unsigned extension built from source
- signed extensions downloaded from addons.mozilla.org
- removing extensions from `nixExtensions` removes them
- **not** tested is transitioning from existing profile with `nixExtensions` set before this change

Note all testing was done with `pgoEnabled = false` to reduce build times.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes (or backporting 23.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
