### PR TITLE
treewide: make many outputs that contain zip files reproducible

### DIFF
--- a/pkgs/applications/blockchains/bisq-desktop/default.nix
+++ b/pkgs/applications/blockchains/bisq-desktop/default.nix
@@ -41,7 +41,14 @@ stdenv.mkDerivation rec {
     sha256 = "0jisxzajsc4wfvxabvfzd0x9y1fxzg39fkhap1781q7wyi4ry9kd";
   };
 
-  nativeBuildInputs = [ makeWrapper copyDesktopItems imagemagick dpkg zip xz ];
+  nativeBuildInputs = [
+    copyDesktopItems
+    dpkg
+    imagemagick
+    makeWrapper
+    xz
+    zip
+  ];
 
   desktopItems = [
     (makeDesktopItem {

--- a/pkgs/applications/blockchains/bisq-desktop/default.nix
+++ b/pkgs/applications/blockchains/bisq-desktop/default.nix
@@ -9,6 +9,7 @@
 , dpkg
 , writeScript
 , bash
+, strip-nondeterminism
 , tor
 , zip
 , xz
@@ -46,6 +47,7 @@ stdenv.mkDerivation rec {
     dpkg
     imagemagick
     makeWrapper
+    strip-nondeterminism
     xz
     zip
   ];
@@ -71,8 +73,9 @@ stdenv.mkDerivation rec {
 
     mkdir -p native/linux/x64/
     cp ${bisq-tor} ./tor
-    tar -cJf native/linux/x64/tor.tar.xz tor
+    tar --sort=name --mtime="@$SOURCE_DATE_EPOCH" -cJf native/linux/x64/tor.tar.xz tor
     zip -r opt/bisq/lib/app/desktop-${version}-all.jar native
+    strip-nondeterminism opt/bisq/lib/app/desktop-${version}-all.jar
   '';
 
   installPhase = ''

--- a/pkgs/applications/emulators/pcsx2/default.nix
+++ b/pkgs/applications/emulators/pcsx2/default.nix
@@ -23,6 +23,7 @@
 , rapidyaml
 , SDL2
 , soundtouch
+, strip-nondeterminism
 , vulkan-headers
 , vulkan-loader
 , wayland
@@ -61,6 +62,7 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [
     cmake
     pkg-config
+    strip-nondeterminism
     wrapQtAppsHook
     zip
   ];
@@ -100,6 +102,7 @@ stdenv.mkDerivation rec {
     install -Dm644 $src/.github/workflows/scripts/linux/pcsx2-qt.desktop $out/share/applications/PCSX2.desktop
 
     zip -jq $out/bin/resources/patches.zip ${pcsx2_patches}/patches/*
+    strip-nondeterminism $out/bin/resources/patches.zip
   '';
 
   qtWrapperArgs = [

--- a/pkgs/applications/emulators/pcsx2/default.nix
+++ b/pkgs/applications/emulators/pcsx2/default.nix
@@ -58,7 +58,12 @@ stdenv.mkDerivation rec {
     "-DDISABLE_BUILD_DATE=TRUE"
   ];
 
-  nativeBuildInputs = [ cmake pkg-config wrapQtAppsHook zip ];
+  nativeBuildInputs = [
+    cmake
+    pkg-config
+    wrapQtAppsHook
+    zip
+  ];
 
   buildInputs = [
     curl

--- a/pkgs/build-support/fetchfirefoxaddon/default.nix
+++ b/pkgs/build-support/fetchfirefoxaddon/default.nix
@@ -1,7 +1,12 @@
-{stdenv, unzip, jq, zip, fetchurl,writeScript,  ...}:
+{ stdenv
+, fetchurl
+, jq
+, unzip
+, writeScript
+, zip
+}:
 
-{
-  name
+{ name
 , url ? null
 , md5 ? ""
 , sha1 ? ""
@@ -14,7 +19,8 @@
 
 let
   extid = if fixedExtid == null then "nixos@${name}" else fixedExtid;
-  source = if url == null then src else fetchurl {
+  source = if url == null then src else
+  fetchurl {
     url = url;
     inherit md5 sha1 sha256 sha512 hash;
   };
@@ -40,5 +46,10 @@ stdenv.mkDerivation {
     zip -r -q -FS "$out/$UUID.xpi" *
     rm -r "$out/$UUID"
   '';
-  nativeBuildInputs = [ unzip zip jq  ];
+
+  nativeBuildInputs = [
+    jq
+    unzip
+    zip
+  ];
 }

--- a/pkgs/build-support/fetchfirefoxaddon/default.nix
+++ b/pkgs/build-support/fetchfirefoxaddon/default.nix
@@ -1,6 +1,7 @@
 { stdenv
 , fetchurl
 , jq
+, strip-nondeterminism
 , unzip
 , writeScript
 , zip
@@ -44,11 +45,13 @@ stdenv.mkDerivation {
     echo "$NEW_MANIFEST" > "$out/$UUID/manifest.json"
     cd "$out/$UUID"
     zip -r -q -FS "$out/$UUID.xpi" *
+    strip-nondeterminism "$out/$UUID.xpi"
     rm -r "$out/$UUID"
   '';
 
   nativeBuildInputs = [
     jq
+    strip-nondeterminism
     unzip
     zip
   ];

--- a/pkgs/development/tools/slimerjs/default.nix
+++ b/pkgs/development/tools/slimerjs/default.nix
@@ -2,6 +2,7 @@
 , bash
 , fetchFromGitHub
 , firefox
+, strip-nondeterminism
 , stdenv
 , unzip
 , zip
@@ -19,7 +20,10 @@ stdenv.mkDerivation rec {
   };
 
   buildInputs = [ zip ];
-  nativeBuildInputs = [ unzip ];
+  nativeBuildInputs = [
+    strip-nondeterminism
+    unzip
+  ];
 
   preConfigure = ''
     test -d src && cd src
@@ -27,6 +31,7 @@ stdenv.mkDerivation rec {
   '';
 
   installPhase = ''
+    strip-nondeterminism --type zip omni.ja
     mkdir -p "$out"/{bin,share/doc/slimerjs,lib/slimerjs}
     cp LICENSE README* "$out/share/doc/slimerjs"
     cp -r * "$out/lib/slimerjs"

--- a/pkgs/development/tools/slimerjs/default.nix
+++ b/pkgs/development/tools/slimerjs/default.nix
@@ -1,4 +1,11 @@
-{ lib, stdenv, fetchFromGitHub, zip, unzip, firefox, bash }:
+{ lib
+, bash
+, fetchFromGitHub
+, firefox
+, stdenv
+, unzip
+, zip
+}:
 
 stdenv.mkDerivation rec {
   pname = "slimerjs";

--- a/pkgs/games/mari0/default.nix
+++ b/pkgs/games/mari0/default.nix
@@ -5,6 +5,7 @@
 , makeDesktopItem
 , makeWrapper
 , stdenv
+, strip-nondeterminism
 , zip
 }:
 
@@ -22,6 +23,7 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [
     copyDesktopItems
     makeWrapper
+    strip-nondeterminism
     zip
   ];
 
@@ -39,6 +41,7 @@ stdenv.mkDerivation rec {
   installPhase = ''
     runHook preInstall
     zip -9 -r mari0.love ./*
+    strip-nondeterminism --type zip mari0.love
     install -Dm444 -t $out/share/games/lovegames/ mari0.love
     makeWrapper ${love}/bin/love $out/bin/mari0 \
       --add-flags $out/share/games/lovegames/mari0.love

--- a/pkgs/games/mari0/default.nix
+++ b/pkgs/games/mari0/default.nix
@@ -1,5 +1,12 @@
-{ lib, stdenv, fetchFromGitHub, zip, love, makeWrapper, makeDesktopItem
-, copyDesktopItems }:
+{ lib
+, copyDesktopItems
+, fetchFromGitHub
+, love
+, makeDesktopItem
+, makeWrapper
+, stdenv
+, zip
+}:
 
 stdenv.mkDerivation rec {
   pname = "mari0";
@@ -12,7 +19,11 @@ stdenv.mkDerivation rec {
     sha256 = "1zqaq4w599scsjvy1rsb21fd2r8j3srx9vym4ir9bh666dp36gxa";
   };
 
-  nativeBuildInputs = [ makeWrapper copyDesktopItems zip ];
+  nativeBuildInputs = [
+    copyDesktopItems
+    makeWrapper
+    zip
+  ];
 
   desktopItems = [
     (makeDesktopItem {

--- a/pkgs/games/orthorobot/default.nix
+++ b/pkgs/games/orthorobot/default.nix
@@ -7,6 +7,7 @@
 , makeDesktopItem
 , makeWrapper
 , stdenv
+, strip-nondeterminism
 , zip
 }:
 
@@ -41,6 +42,7 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [
     copyDesktopItems
     makeWrapper
+    strip-nondeterminism
     zip
   ];
 
@@ -55,6 +57,7 @@ stdenv.mkDerivation rec {
   installPhase = ''
     runHook preInstall
     zip -9 -r orthorobot.love ./*
+    strip-nondeterminism --type zip orthorobot.love
     install -Dm444 -t $out/share/games/lovegames/ orthorobot.love
     makeWrapper ${love}/bin/love $out/bin/orthorobot \
                 --add-flags $out/share/games/lovegames/orthorobot.love

--- a/pkgs/games/orthorobot/default.nix
+++ b/pkgs/games/orthorobot/default.nix
@@ -1,5 +1,14 @@
-{ lib, stdenv, fetchurl, fetchFromGitHub, love, zip, fetchpatch, makeWrapper
-, makeDesktopItem, copyDesktopItems }:
+{ lib
+, copyDesktopItems
+, fetchFromGitHub
+, fetchpatch
+, fetchurl
+, love
+, makeDesktopItem
+, makeWrapper
+, stdenv
+, zip
+}:
 
 stdenv.mkDerivation rec {
   pname = "orthorobot";
@@ -29,7 +38,11 @@ stdenv.mkDerivation rec {
     })
   ];
 
-  nativeBuildInputs = [ makeWrapper zip copyDesktopItems ];
+  nativeBuildInputs = [
+    copyDesktopItems
+    makeWrapper
+    zip
+  ];
 
   patches = [
     # support for love11

--- a/pkgs/games/wireworld/default.nix
+++ b/pkgs/games/wireworld/default.nix
@@ -6,6 +6,7 @@
 , makeWrapper
 , makeDesktopItem
 , copyDesktopItems
+, strip-nondeterminism
 }:
 
 stdenv.mkDerivation rec {
@@ -22,6 +23,7 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [
     copyDesktopItems
     makeWrapper
+    strip-nondeterminism
     zip
   ];
 
@@ -39,6 +41,7 @@ stdenv.mkDerivation rec {
   installPhase = ''
     runHook preInstall
     zip -9 -r Wireworld.love ./*
+    strip-nondeterminism --type zip Wireworld.love
     install -Dm444 -t $out/share/games/lovegames/ Wireworld.love
     makeWrapper ${love}/bin/love $out/bin/Wireworld \
       --add-flags $out/share/games/lovegames/Wireworld.love

--- a/pkgs/games/wireworld/default.nix
+++ b/pkgs/games/wireworld/default.nix
@@ -19,7 +19,11 @@ stdenv.mkDerivation rec {
     hash = "sha256-8BshnGLuA8lmG9g7FU349DWKP/fZvlvjrQBau/LSJ4E=";
   };
 
-  nativeBuildInputs = [ makeWrapper copyDesktopItems zip ];
+  nativeBuildInputs = [
+    copyDesktopItems
+    makeWrapper
+    zip
+  ];
 
   desktopItems = [
     (makeDesktopItem {

--- a/pkgs/tools/misc/pridefetch/default.nix
+++ b/pkgs/tools/misc/pridefetch/default.nix
@@ -1,4 +1,11 @@
-{ lib, stdenv, fetchFromGitHub, python3, zip }: let
+{ lib
+, fetchFromGitHub
+, python3
+, stdenv
+, zip
+}:
+
+let
   version = "1.1.0";
   sha256 = "sha256-563xOz63vto19yuaHtReV1dSw6BgNf+CLtS3lrPnaoc=";
 
@@ -9,16 +16,21 @@
     rev = "v" + version;
     inherit sha256;
   };
-in stdenv.mkDerivation {
+in
+
+stdenv.mkDerivation {
   inherit pname version src;
+
   nativeBuildInputs = [
     zip
   ];
+
   buildInputs = [
     (python3.withPackages (pythonPackages: with pythonPackages; [
       distro
     ]))
   ];
+
   buildPhase = ''
     runHook preBuild
     pushd src
@@ -28,6 +40,7 @@ in stdenv.mkDerivation {
     rm pridefetch.zip
     runHook postBuild
   '';
+
   installPhase = ''
     runHook preInstall
     mkdir -p $out/bin
@@ -35,6 +48,7 @@ in stdenv.mkDerivation {
     chmod +x $out/bin/pridefetch
     runHook postInstall
   '';
+
   meta = with lib; {
     description = "Print out system statistics with pride flags";
     longDescription = ''

--- a/pkgs/tools/misc/pridefetch/default.nix
+++ b/pkgs/tools/misc/pridefetch/default.nix
@@ -2,6 +2,7 @@
 , fetchFromGitHub
 , python3
 , stdenv
+, strip-nondeterminism
 , zip
 }:
 
@@ -22,6 +23,7 @@ stdenv.mkDerivation {
   inherit pname version src;
 
   nativeBuildInputs = [
+    strip-nondeterminism
     zip
   ];
 
@@ -35,6 +37,7 @@ stdenv.mkDerivation {
     runHook preBuild
     pushd src
     zip -r ../pridefetch.zip ./*
+    strip-nondeterminism ../pridefetch.zip
     popd
     echo '#!/usr/bin/env python' | cat - pridefetch.zip > pridefetch
     rm pridefetch.zip


### PR DESCRIPTION
###### Description of changes

I simply grepped for ` zip ` and then only bothered with pkgs that were using `zip` directly in the drv build scripts. Each pkg was red-greened to verify it was already non-deterministic, ones that were deterministic were skipped. If there were other non-trivial reproducibility problems beyond the zip file (I think only `manualEpub` had other issues), I skipped it. Likely there are more pkgs that could benefit from this treatment that generate zip files internally in their build processes, but this was low-hanging fruit.

For `fetchFirefoxAddon`, I used an existing example addon drv I had to validate.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes (or backporting 23.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
