### PR TITLE
treewide: "libary" -> "library"

### DIFF
--- a/pkgs/applications/networking/remote/rustdesk/default.nix
+++ b/pkgs/applications/networking/remote/rustdesk/default.nix
@@ -61,7 +61,7 @@ rustPlatform.buildRustPackage rec {
     ./cargo.patch
   ];
 
-  # Manually simulate a vcpkg installation so that it can link the libaries
+  # Manually simulate a vcpkg installation so that it can link the libraries
   # properly.
   postUnpack =
     let

--- a/pkgs/applications/window-managers/afterstep/default.nix
+++ b/pkgs/applications/window-managers/afterstep/default.nix
@@ -60,7 +60,7 @@ stdenv.mkDerivation rec {
     export NIX_CFLAGS_COMPILE="$NIX_CFLAGS_COMPILE $(pkg-config dbus-1 --cflags)"
   '';
 
-  # Parallel build fails due to missing dependencies between private libaries:
+  # Parallel build fails due to missing dependencies between private libraries:
   #   ld: cannot find ../libAfterConf/libAfterConf.a: No such file or directory
   # Let's disable parallel builds until it's fixed upstream:
   #   https://github.com/afterstep/afterstep/issues/8

--- a/pkgs/build-support/rust/build-rust-crate/default.nix
+++ b/pkgs/build-support/rust/build-rust-crate/default.nix
@@ -125,10 +125,10 @@ crate_: lib.makeOverridable
       #   hello = attrs: { buildInputs = [ openssl ]; };
       # }
     , crateOverrides
-      # Rust library dependencies, i.e. other libaries that were built
+      # Rust library dependencies, i.e. other libraries that were built
       # with buildRustCrate.
     , dependencies
-      # Rust build dependencies, i.e. other libaries that were built
+      # Rust build dependencies, i.e. other libraries that were built
       # with buildRustCrate and are used by a build script.
     , buildDependencies
       # Specify the "extern" name of a library if it differs from the library target.

--- a/pkgs/development/compilers/gcc/common/pre-configure.nix
+++ b/pkgs/development/compilers/gcc/common/pre-configure.nix
@@ -69,7 +69,7 @@ in lib.optionalString (hostPlatform.isSunOS && hostPlatform.is64bit) ''
 # This fix would not be necessary if ANY of the above were false:
 #  - If Nix used native headers for each different MacOS version, aligned_alloc
 #    would be in the headers on Catalina.
-#  - If Nix used the same libary binaries for each MacOS version, aligned_alloc
+#  - If Nix used the same library binaries for each MacOS version, aligned_alloc
 #    would not be in the library binaries.
 #  - If Catalina did not include aligned_alloc, this wouldn't be a problem.
 #  - If the configure scripts looked for header presence as well as

--- a/pkgs/development/libraries/libixp/default.nix
+++ b/pkgs/development/libraries/libixp/default.nix
@@ -25,7 +25,7 @@ stdenv.mkDerivation rec {
 
   meta = {
     homepage = "https://github.com/0intro/libixp";
-    description = "Portable, simple C-language 9P client and server libary";
+    description = "Portable, simple C-language 9P client and server library";
     maintainers = with lib.maintainers; [ kovirobi ];
     license = lib.licenses.mit;
     platforms = with lib.platforms; unix;

--- a/pkgs/development/python-modules/pilkit/default.nix
+++ b/pkgs/development/python-modules/pilkit/default.nix
@@ -40,7 +40,7 @@ buildPythonPackage rec {
   ];
 
   meta = with lib; {
-    description = "A collection of utilities and processors for the Python Imaging Libary";
+    description = "A collection of utilities and processors for the Python Imaging Library";
     homepage = "https://github.com/matthewwithanm/pilkit/";
     license = licenses.bsd0;
     maintainers = with maintainers; [ domenkozar ];

--- a/pkgs/development/tools/rust/bindgen/default.nix
+++ b/pkgs/development/tools/rust/bindgen/default.nix
@@ -10,7 +10,7 @@ let
       meta = rust-bindgen-unwrapped.meta // {
         longDescription = rust-bindgen-unwrapped.meta.longDescription + ''
           This version of bindgen is wrapped with the required compiler flags
-          required to find the c and c++ standard libary, as well as the libraries
+          required to find the c and c++ standard library, as well as the libraries
           specified in the buildInputs of your derivation.
         '';
       };

--- a/pkgs/development/tools/rust/cargo-c/default.nix
+++ b/pkgs/development/tools/rust/cargo-c/default.nix
@@ -41,7 +41,7 @@ rustPlatform.buildRustPackage rec {
   '';
 
   meta = with lib; {
-    description = "A cargo subcommand to build and install C-ABI compatibile dynamic and static libraries";
+    description = "A cargo subcommand to build and install C-ABI compatible dynamic and static libraries";
     longDescription = ''
       Cargo C-ABI helpers. A cargo applet that produces and installs a correct
       pkg-config file, a static library and a dynamic library, and a C header

--- a/pkgs/tools/graphics/leela/default.nix
+++ b/pkgs/tools/graphics/leela/default.nix
@@ -17,7 +17,7 @@ stdenv.mkDerivation {
   installFlags = [ "PREFIX=$(out)" "MANDIR=$(out)/share/man" ];
 
   meta = {
-    description = "CLI frontend to the poppler-glib libary of PDF tools";
+    description = "CLI frontend to the poppler-glib library of PDF tools";
     homepage = "https://github.com/TrilbyWhite/Leela";
     license = lib.licenses.gpl3;
     maintainers = [ lib.maintainers.puffnfresh ];

--- a/pkgs/tools/misc/usbimager/default.nix
+++ b/pkgs/tools/misc/usbimager/default.nix
@@ -20,7 +20,7 @@ stdenv.mkDerivation rec {
   buildInputs = lib.optionals withUdisks [ udisks glib ]
     ++ lib.optional (!withLibui) libX11
     ++ lib.optional withLibui gtk3;
-    # libui is bundled with the source of usbimager as a compiled static libary
+    # libui is bundled with the source of usbimager as a compiled static library
 
   postPatch = ''
     sed -i \


### PR DESCRIPTION
###### Description of changes



###### Things done

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes (or backporting 23.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).