### PR TITLE
nixos/ddclient: remove obsolete ipv6 option

### DIFF
--- a/nixos/modules/services/networking/ddclient.nix
+++ b/nixos/modules/services/networking/ddclient.nix
@@ -20,7 +20,6 @@ let
     ${lib.optionalString (cfg.zone != "")   "zone=${cfg.zone}"}
     ssl=${boolToStr cfg.ssl}
     wildcard=YES
-    ipv6=${boolToStr cfg.ipv6}
     quiet=${boolToStr cfg.quiet}
     verbose=${boolToStr cfg.verbose}
     ${cfg.extraConfig}
@@ -52,6 +51,7 @@ with lib;
         in if value != "" then [ value ] else []))
     (mkRemovedOptionModule [ "services" "ddclient" "homeDir" ] "")
     (mkRemovedOptionModule [ "services" "ddclient" "password" ] "Use services.ddclient.passwordFile instead.")
+    (mkRemovedOptionModule [ "services" "ddclient" "ipv6" ] "")
   ];
 
   ###### interface
@@ -145,15 +145,6 @@ with lib;
           Whether to use SSL/TLS to connect to dynamic DNS provider.
         '';
       };
-
-      ipv6 = mkOption {
-        default = false;
-        type = bool;
-        description = lib.mdDoc ''
-          Whether to use IPv6.
-        '';
-      };
-
 
       quiet = mkOption {
         default = false;


### PR DESCRIPTION
Since ddclient@24ba945 (v3.10.0), the type and meaning of the "ipv6"
option has changed. This resulted in the following warning when
starting the service:

    WARNING:  file /run/ddclient/ddclient.conf, line 13:
    Invalid Value for keyword 'ipv6' = 'no'

This therefore removes the matching boolean option.
More advanced configurations can use the "extraConfig" option instead.
