### PR TITLE
sway-unwrapped: rename wlroots_0_16 argument to wlroots

### DIFF
--- a/pkgs/applications/window-managers/sway/default.nix
+++ b/pkgs/applications/window-managers/sway/default.nix
@@ -11,21 +11,15 @@
 , trayEnabled ? systemdSupport
 }:
 
-# The "sd-bus-provider" meson option does not include a "none" option,
-# but it is silently ignored iff "-Dtray=disabled".  We use "basu"
-# (which is not in nixpkgs) instead of "none" to alert us if this
-# changes: https://github.com/swaywm/sway/issues/6843#issuecomment-1047288761
-assert trayEnabled -> systemdSupport;
-let sd-bus-provider = if systemdSupport then "libsystemd" else "basu"; in
-
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "sway-unwrapped";
   version = "1.8.1";
 
+  inherit enableXWayland isNixOS systemdSupport trayEnabled;
   src = fetchFromGitHub {
     owner = "swaywm";
     repo = "sway";
-    rev = version;
+    rev = finalAttrs.version;
     hash = "sha256-WxnT+le9vneQLFPz2KoBduOI+zfZPhn1fKlaqbPL6/g=";
   };
 
@@ -42,11 +36,11 @@ stdenv.mkDerivation rec {
       url = "https://github.com/swaywm/sway/commit/dee032d0a0ecd958c902b88302dc59703d703c7f.diff";
       hash = "sha256-dx+7MpEiAkxTBnJcsT3/1BO8rYRfNLecXmpAvhqGMD0=";
     })
-  ] ++ lib.optionals (!isNixOS) [
+  ] ++ lib.optionals (!finalAttrs.isNixOS) [
     # References to /nix/store/... will get GC'ed which causes problems when
     # copying the default configuration:
     ./sway-config-no-nix-store-references.patch
-  ] ++ lib.optionals isNixOS [
+  ] ++ lib.optionals finalAttrs.isNixOS [
     # Use /run/current-system/sw/share and /etc instead of /nix/store
     # references:
     ./sway-config-nixos-paths.patch
@@ -65,15 +59,23 @@ stdenv.mkDerivation rec {
     wayland libxkbcommon pcre2 json_c libevdev
     pango cairo libinput gdk-pixbuf librsvg
     wayland-protocols libdrm
-    (wlroots.override { inherit enableXWayland; })
-  ] ++ lib.optionals enableXWayland [
+    (wlroots.override { inherit (finalAttrs) enableXWayland; })
+  ] ++ lib.optionals finalAttrs.enableXWayland [
     xorg.xcbutilwm
   ];
 
-  mesonFlags =
+  mesonFlags = let
+    # The "sd-bus-provider" meson option does not include a "none" option,
+    # but it is silently ignored iff "-Dtray=disabled".  We use "basu"
+    # (which is not in nixpkgs) instead of "none" to alert us if this
+    # changes: https://github.com/swaywm/sway/issues/6843#issuecomment-1047288761
+    # assert trayEnabled -> systemdSupport && dbusSupport;
+
+    sd-bus-provider =  if systemdSupport then "libsystemd" else "basu";
+    in
     [ "-Dsd-bus-provider=${sd-bus-provider}" ]
-    ++ lib.optional (!enableXWayland) "-Dxwayland=disabled"
-    ++ lib.optional (!trayEnabled)    "-Dtray=disabled"
+    ++ lib.optional (!finalAttrs.enableXWayland) "-Dxwayland=disabled"
+    ++ lib.optional (!finalAttrs.trayEnabled)    "-Dtray=disabled"
   ;
 
   passthru.tests.basic = nixosTests.sway;
@@ -95,4 +97,4 @@ stdenv.mkDerivation rec {
     platforms   = platforms.linux;
     maintainers = with maintainers; [ primeos synthetica ];
   };
-}
+})

--- a/pkgs/applications/window-managers/sway/default.nix
+++ b/pkgs/applications/window-managers/sway/default.nix
@@ -2,7 +2,7 @@
 , meson, ninja, pkg-config, wayland-scanner, scdoc
 , wayland, libxkbcommon, pcre2, json_c, libevdev
 , pango, cairo, libinput, gdk-pixbuf, librsvg
-, wlroots_0_16, wayland-protocols, libdrm
+, wlroots, wayland-protocols, libdrm
 , nixosTests
 # Used by the NixOS module:
 , isNixOS ? false
@@ -65,7 +65,7 @@ stdenv.mkDerivation rec {
     wayland libxkbcommon pcre2 json_c libevdev
     pango cairo libinput gdk-pixbuf librsvg
     wayland-protocols libdrm
-    (wlroots_0_16.override { inherit enableXWayland; })
+    (wlroots.override { inherit enableXWayland; })
   ] ++ lib.optionals enableXWayland [
     xorg.xcbutilwm
   ];

--- a/pkgs/applications/window-managers/sway/wrapper.nix
+++ b/pkgs/applications/window-managers/sway/wrapper.nix
@@ -16,7 +16,7 @@ assert extraSessionCommands != "" -> withBaseWrapper;
 with lib;
 
 let
-  sway = sway-unwrapped.override { inherit isNixOS enableXWayland; };
+  sway = sway-unwrapped.overrideAttrs (oa: { inherit isNixOS enableXWayland; });
   baseWrapper = writeShellScriptBin "sway" ''
      set -o errexit
      if [ ! "$_SWAY_WRAPPER_ALREADY_EXECUTED" ]; then

--- a/pkgs/development/libraries/wlroots/default.nix
+++ b/pkgs/development/libraries/wlroots/default.nix
@@ -28,15 +28,17 @@
 
 let
   generic = { version, hash, extraBuildInputs ? [ ], extraNativeBuildInputs ? [ ], extraPatch ? "" }:
-    stdenv.mkDerivation rec {
+    stdenv.mkDerivation (finalAttrs: {
       pname = "wlroots";
       inherit version;
+
+      inherit enableXWayland;
 
       src = fetchFromGitLab {
         domain = "gitlab.freedesktop.org";
         owner = "wlroots";
         repo = "wlroots";
-        rev = version;
+        rev = finalAttrs.version;
         inherit hash;
       };
 
@@ -70,11 +72,11 @@ let
         xorg.xcbutilrenderutil
         xorg.xcbutilwm
       ]
-      ++ lib.optional enableXWayland xwayland
+      ++ lib.optional finalAttrs.enableXWayland xwayland
       ++ extraBuildInputs;
 
       mesonFlags =
-        lib.optional (!enableXWayland) "-Dxwayland=disabled"
+        lib.optional (!finalAttrs.enableXWayland) "-Dxwayland=disabled"
       ;
 
       postFixup = ''
@@ -98,13 +100,13 @@ let
           Pluggable, composable, unopinionated modules for building a Wayland
           compositor; or about 50,000 lines of code you were going to write anyway.
         '';
-        inherit (src.meta) homepage;
+        inherit (finalAttrs.src.meta) homepage;
         changelog = "https://gitlab.freedesktop.org/wlroots/wlroots/-/tags/${version}";
         license = licenses.mit;
         platforms = platforms.linux;
         maintainers = with maintainers; [ primeos synthetica ];
       };
-    };
+    });
 
 in
 rec {

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -31634,7 +31634,9 @@ with pkgs;
     wlroots_0_16
     wlroots;
 
-  sway-unwrapped = callPackage ../applications/window-managers/sway { };
+  sway-unwrapped = callPackage ../applications/window-managers/sway {
+    wlroots = wlroots_0_16;
+  };
   sway = callPackage ../applications/window-managers/sway/wrapper.nix { };
   swaybg = callPackage ../applications/window-managers/sway/bg.nix { };
   swayidle = callPackage ../applications/window-managers/sway/idle.nix { };


### PR DESCRIPTION
###### Description of changes

this makes the override of settings possible via overrideAttrs rather than override making the interface easier and also making this possible https://github.com/nix-community/home-manager/pull/4039 i.e., having home-manager configure swayfx in the same way it configures sway.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes (or backporting 23.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
