### PR TITLE
starlark-rust: init at 0.9.0

### DIFF
--- a/pkgs/development/interpreters/starlark-rust/default.nix
+++ b/pkgs/development/interpreters/starlark-rust/default.nix
@@ -1,0 +1,38 @@
+{ lib
+, rustPlatform
+, fetchCrate
+, fetchpatch
+, stdenv
+}:
+
+rustPlatform.buildRustPackage rec {
+  pname = "starlark";
+  version = "0.9.0";
+
+  src = fetchCrate {
+    inherit pname version;
+    hash = "sha256-h8TBWWw94Ka9C0W0i0aHACq6jO0QOLnLW+wTRzorHcc=";
+  };
+
+  cargoHash = "sha256-OLzotKyiG0JmtjH0ckRImHMPPxfQZ+8IHZtXlo1f8+Y=";
+
+  patches = [
+    # fix test broken due to using `fetchCrate`
+    # https://github.com/facebookexperimental/starlark-rust/pull/78
+    (fetchpatch {
+      name = "fix-test-rust-loc-when-tested-from-the-crate.patch";
+      url = "https://github.com/facebookexperimental/starlark-rust/commit/0e4f90c77868e506268fcb6c9d37368e5b2b8cf5.patch";
+      hash = "sha256-c8irAyS2IQ5C6s+0t4+hbW8aFptkwvCu9JHLyZqZsW4=";
+      stripLen = 1;
+    })
+  ];
+
+  meta = with lib; {
+    description = "A Rust implementation of the Starlark language";
+    homepage = "https://github.com/facebookexperimental/starlark-rust";
+    changelog = "https://github.com/facebookexperimental/starlark-rust/blob/v${version}/CHANGELOG.md";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ figsoda ];
+    broken = stdenv.isAarch64 || stdenv.isDarwin;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -17480,6 +17480,8 @@ with pkgs;
 
   starlark = callPackage ../development/interpreters/starlark { };
 
+  starlark-rust = callPackage ../development/interpreters/starlark-rust { };
+
   supercollider = libsForQt5.callPackage ../development/interpreters/supercollider {
     fftw = fftwSinglePrec;
   };


### PR DESCRIPTION
https://github.com/facebookexperimental/starlark-rust

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes (or backporting 23.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
