### PR TITLE
doc: apply manual normalization for markdown

### DIFF
--- a/doc/builders/special/darwin-builder.section.md
+++ b/doc/builders/special/darwin-builder.section.md
@@ -62,7 +62,7 @@ builders-use-substitutes = true
 $ sudo launchctl kickstart -k system/org.nixos.nix-daemon
 ```
 
-## Example flake usage
+## Example flake usage {#sec-darwin-builder-example-flake}
 
 ```
 {
@@ -120,7 +120,7 @@ $ sudo launchctl kickstart -k system/org.nixos.nix-daemon
 }
 ```
 
-## Reconfiguring the builder
+## Reconfiguring the builder {#sec-darwin-builder-reconfiguring}
 
 Initially you should not change the builder configuration else you will not be
 able to use the binary cache. However, after you have the builder running locally

--- a/doc/builders/special/makesetuphook.section.md
+++ b/doc/builders/special/makesetuphook.section.md
@@ -12,7 +12,7 @@ pkgs.makeSetupHook {
 } ./script.sh
 ```
 
-#### setup hook that depends on the hello package and runs hello and @shell@ is substituted with path to bash {#sec-pkgs.makeSetupHook-usage-example}
+### setup hook that depends on the hello package and runs hello and @shell@ is substituted with path to bash {#sec-pkgs.makeSetupHook-usage-example}
 
 ```nix
 pkgs.makeSetupHook {

--- a/doc/builders/special/vm-tools.section.md
+++ b/doc/builders/special/vm-tools.section.md
@@ -6,7 +6,7 @@ A set of VM related utilities, that help in building some packages in more advan
 
 A bash script fragment that produces a disk image at `destination`.
 
-### Attributes
+### Attributes {#vm-tools-createEmptyImage-attributes}
 
 * `size`. The disk size, in MiB.
 * `fullName`. Name that will be written to `${destination}/nix-support/full-name`.
@@ -20,14 +20,14 @@ Thus, any pure Nix derivation should run unmodified.
 
 If the build fails and Nix is run with the `-K/--keep-failed` option, a script `run-vm` will be left behind in the temporary build directory that allows you to boot into the VM and debug it interactively.
 
-### Attributes
+### Attributes {#vm-tools-runInLinuxVM-attributes}
 
 * `preVM` (optional). Shell command to be evaluated *before* the VM is started (i.e., on the host).
 * `memSize` (optional, default `512`). The memory size of the VM in MiB.
 * `diskImage` (optional). A file system image to be attached to `/dev/sda`.
   Note that currently we expect the image to contain a filesystem, not a full disk image with a partition table etc.
 
-### Examples
+### Examples {#vm-tools-runInLinuxVM-examples}
 
 Build the derivation hello inside a VM:
 ```nix
@@ -56,13 +56,13 @@ runInLinuxVM (hello.overrideAttrs (_: {
 
 Takes a file, such as an ISO, and extracts its contents into the store.
 
-### Attributes
+### Attributes {#vm-tools-extractFs-attributes}
 
 * `file`. Path to the file to be extracted.
   Note that currently we expect the image to contain a filesystem, not a full disk image with a partition table etc.
 * `fs` (optional). Filesystem of the contents of the file.
 
-### Examples
+### Examples {#vm-tools-extractFs-examples}
 
 Extract the contents of an ISO file:
 ```nix
@@ -82,7 +82,7 @@ Like [](#vm-tools-runInLinuxVM), but instead of using `stdenv` from the Nix stor
 
 Generate a script that can be used to run an interactive session in the given image.
 
-### Examples
+### Examples {#vm-tools-makeImageTestScript-examples}
 
 Create a script for running a Fedora 27 VM:
 ```nix
@@ -100,7 +100,7 @@ makeImageTestScript diskImages.ubuntu2004x86_64
 
 A set of functions that build a predefined set of minimal Linux distributions images.
 
-### Images
+### Images {#vm-tools-diskImageFuns-images}
 
 * Fedora
   * `fedora26x86_64`
@@ -126,12 +126,12 @@ A set of functions that build a predefined set of minimal Linux distributions im
   * `debian11i386`
   * `debian11x86_64`
 
-### Attributes
+### Attributes {#vm-tools-diskImageFuns-attributes}
 
 * `size` (optional, defaults to `4096`). The size of the image, in MiB.
 * `extraPackages` (optional). A list names of additional packages from the distribution that should be included in the image.
 
-### Examples
+### Examples {#vm-tools-diskImageFuns-examples}
 
 8GiB image containing Firefox in addition to the default packages:
 ```nix

--- a/doc/builders/testers.chapter.md
+++ b/doc/builders/testers.chapter.md
@@ -1,5 +1,5 @@
 # Testers {#chap-testers}
-This chapter describes several testing builders which are available in the <literal>testers</literal> namespace.
+This chapter describes several testing builders which are available in the `testers` namespace.
 
 ## `hasPkgConfigModule` {#tester-hasPkgConfigModule}
 

--- a/doc/hooks/autoconf.section.md
+++ b/doc/hooks/autoconf.section.md
@@ -1,4 +1,3 @@
-
-### Autoconf {#setup-hook-autoconf}
+# Autoconf {#setup-hook-autoconf}
 
 The `autoreconfHook` derivation adds `autoreconfPhase`, which runs autoreconf, libtoolize and automake, essentially preparing the configure script in autotools-based builds. Most autotools-based packages come with the configure script pre-generated, but this hook is necessary for a few packages and when you need to patch the package’s configure scripts.

--- a/doc/hooks/automake.section.md
+++ b/doc/hooks/automake.section.md
@@ -1,4 +1,3 @@
-
-### Automake {#setup-hook-automake}
+# Automake {#setup-hook-automake}
 
 Adds the `share/aclocal` subdirectory of each build input to the `ACLOCAL_PATH` environment variable.

--- a/doc/hooks/autopatchelf.section.md
+++ b/doc/hooks/autopatchelf.section.md
@@ -1,5 +1,4 @@
-
-### autoPatchelfHook {#setup-hook-autopatchelfhook}
+# autoPatchelfHook {#setup-hook-autopatchelfhook}
 
 This is a special setup hook which helps in packaging proprietary software in that it automatically tries to find missing shared library dependencies of ELF files based on the given `buildInputs` and `nativeBuildInputs`.
 

--- a/doc/hooks/breakpoint.section.md
+++ b/doc/hooks/breakpoint.section.md
@@ -1,5 +1,4 @@
-
-### breakpointHook {#breakpointhook}
+# breakpointHook {#breakpointhook}
 
 This hook will make a build pause instead of stopping when a failure happens. It prevents nix from cleaning up the build environment immediately and allows the user to attach to a build environment using the `cntr` command. Upon build error it will print instructions on how to use `cntr`, which can be used to enter the environment for debugging. Installing cntr and running the command will provide shell access to the build sandbox of failed build. At `/var/lib/cntr` the sandboxed filesystem is mounted. All commands and files of the system are still accessible within the shell. To execute commands from the sandbox use the cntr exec subcommand. `cntr` is only supported on Linux-based platforms. To use it first add `cntr` to your `environment.systemPackages` on NixOS or alternatively to the root user on non-NixOS systems. Then in the package that is supposed to be inspected, add `breakpointHook` to `nativeBuildInputs`.
 

--- a/doc/hooks/cmake.section.md
+++ b/doc/hooks/cmake.section.md
@@ -1,4 +1,3 @@
-
-### cmake {#cmake}
+# cmake {#cmake}
 
 Overrides the default configure phase to run the CMake command. By default, we use the Make generator of CMake. In addition, dependencies are added automatically to `CMAKE_PREFIX_PATH` so that packages are correctly detected by CMake. Some additional flags are passed in to give similar behavior to configure-based packages. You can disable this hook’s behavior by setting `configurePhase` to a custom value, or by setting `dontUseCmakeConfigure`. `cmakeFlags` controls flags passed only to CMake. By default, parallel building is enabled as CMake supports parallel building almost everywhere. When Ninja is also in use, CMake will detect that and use the ninja generator.

--- a/doc/hooks/gdk-pixbuf.section.md
+++ b/doc/hooks/gdk-pixbuf.section.md
@@ -1,4 +1,3 @@
-
-### gdk-pixbuf {#setup-hook-gdk-pixbuf}
+# gdk-pixbuf {#setup-hook-gdk-pixbuf}
 
 Exports `GDK_PIXBUF_MODULE_FILE` environment variable to the builder. Add librsvg package to `buildInputs` to get svg support. See also the [setup hook description in GNOME platform docs](#ssec-gnome-hooks-gdk-pixbuf).

--- a/doc/hooks/ghc.section.md
+++ b/doc/hooks/ghc.section.md
@@ -1,4 +1,3 @@
-
-### GHC {#ghc}
+# GHC {#ghc}
 
 Creates a temporary package database and registers every Haskell build input in it (TODO: how?).

--- a/doc/hooks/gnome.section.md
+++ b/doc/hooks/gnome.section.md
@@ -1,4 +1,3 @@
-
-### GNOME platform {#gnome-platform}
+# GNOME platform {#gnome-platform}
 
 Hooks related to GNOME platform and related libraries like GLib, GTK and GStreamer are described in [](#sec-language-gnome).

--- a/doc/hooks/installShellFiles.section.md
+++ b/doc/hooks/installShellFiles.section.md
@@ -1,5 +1,4 @@
-
-### `installShellFiles` {#installshellfiles}
+# `installShellFiles` {#installshellfiles}
 
 This hook helps with installing manpages and shell completion files. It exposes 2 shell functions `installManPage` and `installShellCompletion` that can be used from your `postInstall` hook.
 

--- a/doc/hooks/libiconv.section.md
+++ b/doc/hooks/libiconv.section.md
@@ -1,4 +1,3 @@
-
-### libiconv, libintl {#libiconv-libintl}
+# libiconv, libintl {#libiconv-libintl}
 
 A few libraries automatically add to `NIX_LDFLAGS` their library, making their symbols automatically available to the linker. This includes libiconv and libintl (gettext). This is done to provide compatibility between GNU Linux, where libiconv and libintl are bundled in, and other systems where that might not be the case. Sometimes, this behavior is not desired. To disable this behavior, set `dontAddExtraLibs`.

--- a/doc/hooks/libxml2.section.md
+++ b/doc/hooks/libxml2.section.md
@@ -1,4 +1,3 @@
-
-### libxml2 {#setup-hook-libxml2}
+# libxml2 {#setup-hook-libxml2}
 
 Adds every file named `catalog.xml` found under the `xml/dtd` and `xml/xsl` subdirectories of each build input to the `XML_CATALOG_FILES` environment variable.

--- a/doc/hooks/meson.section.md
+++ b/doc/hooks/meson.section.md
@@ -1,26 +1,25 @@
-
-### Meson {#meson}
+# Meson {#meson}
 
 Overrides the configure phase to run meson to generate Ninja files. To run these files, you should accompany Meson with ninja. By default, `enableParallelBuilding` is enabled as Meson supports parallel building almost everywhere.
 
-#### Variables controlling Meson {#variables-controlling-meson}
+## Variables controlling Meson {#variables-controlling-meson}
 
-##### `mesonFlags` {#mesonflags}
+### `mesonFlags` {#mesonflags}
 
 Controls the flags passed to meson.
 
-##### `mesonBuildType` {#mesonbuildtype}
+### `mesonBuildType` {#mesonbuildtype}
 
 Which [`--buildtype`](https://mesonbuild.com/Builtin-options.html#core-options) to pass to Meson. We default to `plain`.
 
-##### `mesonAutoFeatures` {#mesonautofeatures}
+### `mesonAutoFeatures` {#mesonautofeatures}
 
 What value to set [`-Dauto_features=`](https://mesonbuild.com/Builtin-options.html#core-options) to. We default to `enabled`.
 
-##### `mesonWrapMode` {#mesonwrapmode}
+### `mesonWrapMode` {#mesonwrapmode}
 
 What value to set [`-Dwrap_mode=`](https://mesonbuild.com/Builtin-options.html#core-options) to. We default to `nodownload` as we disallow network access.
 
-##### `dontUseMesonConfigure` {#dontusemesonconfigure}
+### `dontUseMesonConfigure` {#dontusemesonconfigure}
 
 Disables using Meson’s `configurePhase`.

--- a/doc/hooks/ninja.section.md
+++ b/doc/hooks/ninja.section.md
@@ -1,4 +1,3 @@
-
-### ninja {#ninja}
+# ninja {#ninja}
 
 Overrides the build, install, and check phase to run ninja instead of make. You can disable this behavior with the `dontUseNinjaBuild`, `dontUseNinjaInstall`, and `dontUseNinjaCheck`, respectively. Parallel building is enabled by default in Ninja.

--- a/doc/hooks/perl.section.md
+++ b/doc/hooks/perl.section.md
@@ -1,4 +1,3 @@
-
-### Perl {#setup-hook-perl}
+# Perl {#setup-hook-perl}
 
 Adds the `lib/site_perl` subdirectory of each build input to the `PERL5LIB` environment variable. For instance, if `buildInputs` contains Perl, then the `lib/site_perl` subdirectory of each input is added to the `PERL5LIB` environment variable.

--- a/doc/hooks/pkg-config.section.md
+++ b/doc/hooks/pkg-config.section.md
@@ -1,4 +1,3 @@
-
-### pkg-config {#setup-hook-pkg-config}
+# pkg-config {#setup-hook-pkg-config}
 
 Adds the `lib/pkgconfig` and `share/pkgconfig` subdirectories of each build input to the `PKG_CONFIG_PATH` environment variable.

--- a/doc/hooks/python.section.md
+++ b/doc/hooks/python.section.md
@@ -1,4 +1,3 @@
-
-### Python {#setup-hook-python}
+# Python {#setup-hook-python}
 
 Adds the `lib/${python.libPrefix}/site-packages` subdirectory of each build input to the `PYTHONPATH` environment variable.

--- a/doc/hooks/qt-4.section.md
+++ b/doc/hooks/qt-4.section.md
@@ -1,4 +1,3 @@
-
-### Qt 4 {#qt-4}
+# Qt 4 {#qt-4}
 
 Sets the `QTDIR` environment variable to Qt’s path.

--- a/doc/hooks/scons.section.md
+++ b/doc/hooks/scons.section.md
@@ -1,4 +1,3 @@
-
-### scons {#scons}
+# scons {#scons}
 
 Overrides the build, install, and check phases. This uses the scons build system as a replacement for make. scons does not provide a configure phase, so everything is managed at build and install time.

--- a/doc/hooks/tetex-tex-live.section.md
+++ b/doc/hooks/tetex-tex-live.section.md
@@ -1,4 +1,3 @@
-
-### teTeX / TeX Live {#tetex-tex-live}
+# teTeX / TeX Live {#tetex-tex-live}
 
 Adds the `share/texmf-nix` subdirectory of each build input to the `TEXINPUTS` environment variable.

--- a/doc/hooks/unzip.section.md
+++ b/doc/hooks/unzip.section.md
@@ -1,4 +1,3 @@
-
-### unzip {#unzip}
+# unzip {#unzip}
 
 This setup hook will allow you to unzip .zip files specified in `$src`. There are many similar packages like `unrar`, `undmg`, etc.

--- a/doc/hooks/validatePkgConfig.section.md
+++ b/doc/hooks/validatePkgConfig.section.md
@@ -1,4 +1,3 @@
-
-### validatePkgConfig {#validatepkgconfig}
+# validatePkgConfig {#validatepkgconfig}
 
 The `validatePkgConfig` hook validates all pkg-config (`.pc`) files in a package. This helps catching some common errors in pkg-config files, such as undefined variables.

--- a/doc/hooks/waf.section.md
+++ b/doc/hooks/waf.section.md
@@ -1,4 +1,3 @@
-
-### wafHook {#wafhook}
+# wafHook {#wafhook}
 
 Overrides the configure, build, and install phases. This will run the “waf” script used by many projects. If `wafPath` (default `./waf`) doesn’t exist, it will copy the version of waf available in Nixpkgs. `wafFlags` can be used to pass flags to the waf script.

--- a/doc/hooks/xcbuild.section.md
+++ b/doc/hooks/xcbuild.section.md
@@ -1,4 +1,3 @@
-
-### xcbuildHook {#xcbuildhook}
+# xcbuildHook {#xcbuildhook}
 
 Overrides the build and install phases to run the "xcbuild" command. This hook is needed when a project only comes with build files for the XCode build system. You can disable this behavior by setting buildPhase and configurePhase to a custom value. xcbuildFlags controls flags passed only to xcbuild.

--- a/doc/languages-frameworks/bower.section.md
+++ b/doc/languages-frameworks/bower.section.md
@@ -41,32 +41,18 @@ The function is implemented in [pkgs/development/bower-modules/generic/default.n
 
 ### Example buildBowerComponents {#ex-buildBowerComponents}
 
-```{=docbook}
-<programlisting language="nix">
+```nix
 bowerComponents = buildBowerComponents {
   name = "my-web-app";
-  generated = ./bower-packages.nix; <co xml:id="ex-buildBowerComponents-1" />
-  src = myWebApp; <co xml:id="ex-buildBowerComponents-2" />
+  generated = ./bower-packages.nix; # note 1
+  src = myWebApp; # note 2
 };
-</programlisting>
 ```
 
 In ["buildBowerComponents" example](#ex-buildBowerComponents) the following arguments are of special significance to the function:
 
-```{=docbook}
-<calloutlist>
-  <callout arearefs="ex-buildBowerComponents-1">
-    <para>
-      <varname>generated</varname> specifies the file which was created by <command>bower2nix</command>.
-    </para>
-    </callout>
-      <callout arearefs="ex-buildBowerComponents-2">
-    <para>
-      <varname>src</varname> is your project's sources. It needs to contain a <filename>bower.json</filename> file.
-    </para>
-  </callout>
-</calloutlist>
-```
+1. `generated` specifies the file which was created by {command}`bower2nix`.
+2. `src` is your project's sources. It needs to contain a {file}`bower.json` file.
 
 `buildBowerComponents` will run Bower to link together the output of `bower2nix`, resulting in a `bower_components` directory which can be used.
 
@@ -91,10 +77,9 @@ gulp.task('build', [], function () {
 
 ### Example Full example — default.nix {#ex-buildBowerComponentsDefaultNix}
 
-```{=docbook}
-<programlisting language="nix">
+```nix
 { myWebApp ? { outPath = ./.; name = "myWebApp"; }
-, pkgs ? import &lt;nixpkgs&gt; {}
+, pkgs ? import <nixpkgs> {}
 }:
 
 pkgs.stdenv.mkDerivation {
@@ -103,49 +88,29 @@ pkgs.stdenv.mkDerivation {
 
   buildInputs = [ pkgs.nodePackages.gulp ];
 
-  bowerComponents = pkgs.buildBowerComponents { <co xml:id="ex-buildBowerComponentsDefault-1" />
+  bowerComponents = pkgs.buildBowerComponents { # note 1
     name = "my-web-app";
     generated = ./bower-packages.nix;
     src = myWebApp;
   };
 
   buildPhase = ''
-    cp --reflink=auto --no-preserve=mode -R $bowerComponents/bower_components . <co xml:id="ex-buildBowerComponentsDefault-2" />
-    export HOME=$PWD <co xml:id="ex-buildBowerComponentsDefault-3" />
-    ${pkgs.nodePackages.gulp}/bin/gulp build <co xml:id="ex-buildBowerComponentsDefault-4" />
+    cp --reflink=auto --no-preserve=mode -R $bowerComponents/bower_components . # note 2
+    export HOME=$PWD # note 3
+    ${pkgs.nodePackages.gulp}/bin/gulp build # note 4
   '';
 
   installPhase = "mv gulpdist $out";
 }
-</programlisting>
 ```
 
 A few notes about [Full example — `default.nix`](#ex-buildBowerComponentsDefaultNix):
 
-```{=docbook}
-<calloutlist>
-  <callout arearefs="ex-buildBowerComponentsDefault-1">
-    <para>
-      The result of <varname>buildBowerComponents</varname> is an input to the frontend build.
-    </para>
-  </callout>
-  <callout arearefs="ex-buildBowerComponentsDefault-2">
-    <para>
-      Whether to symlink or copy the <filename>bower_components</filename> directory depends on the build tool in use. In this case a copy is used to avoid <command>gulp</command> silliness with permissions.
-    </para>
-  </callout>
-  <callout arearefs="ex-buildBowerComponentsDefault-3">
-    <para>
-      <command>gulp</command> requires <varname>HOME</varname> to refer to a writeable directory.
-    </para>
-  </callout>
-  <callout arearefs="ex-buildBowerComponentsDefault-4">
-    <para>
-      The actual build command. Other tools could be used.
-    </para>
-  </callout>
-</calloutlist>
-```
+1. The result of `buildBowerComponents` is an input to the frontend build.
+2. Whether to symlink or copy the {file}`bower_components` directory depends on the build tool in use.
+   In this case a copy is used to avoid {command}`gulp` silliness with permissions.
+3. {command}`gulp` requires `HOME` to refer to a writeable directory.
+4. The actual build command in this example is {command}`gulp`. Other tools could be used instead.
 
 ## Troubleshooting {#ssec-bower2nix-troubleshooting}
 

--- a/doc/languages-frameworks/gnome.section.md
+++ b/doc/languages-frameworks/gnome.section.md
@@ -137,15 +137,15 @@ Most GNOME package offer [`updateScript`](#var-passthru-updateScript), it is the
 
 ## Frequently encountered issues {#ssec-gnome-common-issues}
 
-#### `GLib-GIO-ERROR **: 06:04:50.903: No GSettings schemas are installed on the system` {#ssec-gnome-common-issues-no-schemas}
+### `GLib-GIO-ERROR **: 06:04:50.903: No GSettings schemas are installed on the system` {#ssec-gnome-common-issues-no-schemas}
 
 There are no schemas available in `XDG_DATA_DIRS`. Temporarily add a random package containing schemas like `gsettings-desktop-schemas` to `buildInputs`. [`glib`](#ssec-gnome-hooks-glib) and [`wrapGAppsHook`](#ssec-gnome-hooks-wrapgappshook) setup hooks will take care of making the schemas available to application and you will see the actual missing schemas with the [next error](#ssec-gnome-common-issues-missing-schema). Or you can try looking through the source code for the actual schemas used.
 
-#### `GLib-GIO-ERROR **: 06:04:50.903: Settings schema ‘org.gnome.foo’ is not installed` {#ssec-gnome-common-issues-missing-schema}
+### `GLib-GIO-ERROR **: 06:04:50.903: Settings schema ‘org.gnome.foo’ is not installed` {#ssec-gnome-common-issues-missing-schema}
 
 Package is missing some GSettings schemas. You can find out the package containing the schema with `nix-locate org.gnome.foo.gschema.xml` and let the hooks handle the wrapping as [above](#ssec-gnome-common-issues-no-schemas).
 
-#### When using `wrapGAppsHook` with special derivers you can end up with double wrapped binaries. {#ssec-gnome-common-issues-double-wrapped}
+### When using `wrapGAppsHook` with special derivers you can end up with double wrapped binaries. {#ssec-gnome-common-issues-double-wrapped}
 
 This is because derivers like `python.pkgs.buildPythonApplication` or `qt5.mkDerivation` have setup-hooks automatically added that produce wrappers with makeWrapper. The simplest way to workaround that is to disable the `wrapGAppsHook` automatic wrapping with `dontWrapGApps = true;` and pass the arguments it intended to pass to makeWrapper to another.
 
@@ -193,7 +193,7 @@ mkDerivation {
 }
 ```
 
-#### I am packaging a project that cannot be wrapped, like a library or GNOME Shell extension. {#ssec-gnome-common-issues-unwrappable-package}
+### I am packaging a project that cannot be wrapped, like a library or GNOME Shell extension. {#ssec-gnome-common-issues-unwrappable-package}
 
 You can rely on applications depending on the library setting the necessary environment variables but that is often easy to miss. Instead we recommend to patch the paths in the source code whenever possible. Here are some examples:
 
@@ -209,6 +209,6 @@ You can rely on applications depending on the library setting the necessary envi
 
   []{#ssec-gnome-common-issues-unwrappable-package-gsettings-c} [Hard-coding GSettings schema path in C library](https://github.com/NixOS/nixpkgs/blob/29c120c065d03b000224872251bed93932d42412/pkgs/development/libraries/glib-networking/default.nix#L31-L34) – nothing special other than using [Coccinelle patch](https://github.com/NixOS/nixpkgs/pull/67957#issuecomment-527717467) to generate the patch itself.
 
-#### I need to wrap a binary outside `bin` and `libexec` directories. {#ssec-gnome-common-issues-weird-location}
+### I need to wrap a binary outside `bin` and `libexec` directories. {#ssec-gnome-common-issues-weird-location}
 
 You can manually trigger the wrapping with `wrapGApp` in `preFixup` phase. It takes a path to a program as a first argument; the remaining arguments are passed directly to [`wrapProgram`](#fun-wrapProgram) function.

--- a/doc/languages-frameworks/qt.section.md
+++ b/doc/languages-frameworks/qt.section.md
@@ -10,36 +10,21 @@ pure and explicit at build-time, at the cost of introducing an extra indirection
 
 ## Nix expression for a Qt package (default.nix) {#qt-default-nix}
 
-```{=docbook}
-<programlisting>
-{ stdenv, lib, qtbase, wrapQtAppsHook }: <co xml:id='qt-default-nix-co-1' />
+```nix
+{ stdenv, lib, qtbase, wrapQtAppsHook }:
 
 stdenv.mkDerivation {
   pname = "myapp";
   version = "1.0";
 
   buildInputs = [ qtbase ];
-  nativeBuildInputs = [ wrapQtAppsHook ]; <co xml:id='qt-default-nix-co-2' />
+  nativeBuildInputs = [ wrapQtAppsHook ];
 }
-</programlisting>
-
- <calloutlist>
-  <callout arearefs='qt-default-nix-co-1'>
-   <para>
-    Import Qt modules directly, that is: <literal>qtbase</literal>, <literal>qtdeclarative</literal>, etc.
-    <emphasis>Do not</emphasis> import Qt package sets such as <literal>qt5</literal>
-    because the Qt versions of dependencies may not be coherent, causing build and runtime failures.
-   </para>
-  </callout>
-  <callout arearefs='qt-default-nix-co-2'>
-    <para>
-      All Qt packages must include <literal>wrapQtAppsHook</literal> in
-      <literal>nativeBuildInputs</literal>, or you must explicitly set
-      <literal>dontWrapQtApps</literal>.
-    </para>
-  </callout>
- </calloutlist>
 ```
+
+It is important to import Qt modules directly, that is: `qtbase`, `qtdeclarative`, etc. *Do not* import Qt package sets such as `qt5` because the Qt versions of dependencies may not be coherent, causing build and runtime failures.
+
+Additionally all Qt packages must include `wrapQtAppsHook` in `nativeBuildInputs`, or you must explicitly set `dontWrapQtApps`.
 
 ## Locating runtime dependencies {#qt-runtime-dependencies}
 

--- a/doc/stdenv/meta.chapter.md
+++ b/doc/stdenv/meta.chapter.md
@@ -128,7 +128,7 @@ Prefer `passthru.tests` for tests that are introduced in nixpkgs because:
 * we can run `passthru.tests` independently
 * `installCheckPhase` adds overhead to each build
 
-For more on how to write and run package tests, see <xref linkend="sec-package-tests"/>.
+For more on how to write and run package tests, see [](#sec-package-tests).
 
 #### NixOS tests {#var-meta-tests-nixos}
 

--- a/doc/stdenv/stdenv.chapter.md
+++ b/doc/stdenv/stdenv.chapter.md
@@ -971,7 +971,8 @@ to `~/.gdbinit`. GDB will then be able to find debug information installed via `
 
 The installCheck phase checks whether the package was installed correctly by running its test suite against the installed directories. The default `installCheck` calls `make installcheck`.
 
-It is often better to add tests that are not part of the source distribution to `passthru.tests` (see <xref linkend="var-meta-tests"/>). This avoids adding overhead to every build and enables us to run them independently.
+It is often better to add tests that are not part of the source distribution to `passthru.tests` (see
+[](#var-meta-tests)). This avoids adding overhead to every build and enables us to run them independently.
 
 #### Variables controlling the installCheck phase {#variables-controlling-the-installcheck-phase}
 
@@ -1234,7 +1235,7 @@ This runs the strip command on installed binaries and libraries. This removes un
 
 This setup hook patches installed scripts to add Nix store paths to their shebang interpreter as found in the build environment. The [shebang](https://en.wikipedia.org/wiki/Shebang_(Unix)) line tells a Unix-like operating system which interpreter to use to execute the script's contents.
 
-::: note
+::: {.note}
 The [generic builder][generic-builder] populates `PATH` from inputs of the derivation.
 :::
 
@@ -1272,7 +1273,7 @@ patchShebangs --build configure
 
 Interpreter paths that point to a valid Nix store location are not changed.
 
-::: note
+::: {.note}
 A script file must be marked as executable, otherwise it will not be
 considered.
 :::

--- a/pkgs/top-level/config.nix
+++ b/pkgs/top-level/config.nix
@@ -135,7 +135,7 @@ let
     checkMeta = mkOption {
       type = types.bool;
       default = false;
-      description = ''
+      description = lib.mdDoc ''
         Whether to check that the `meta` attribute of derivations are correct during evaluation time.
       '';
     };


### PR DESCRIPTION
###### Description of changes

if the nixpkgs manual is going to move to nixos-render-docs for rendering it'll have to drop a bunch of docbook-isms. this is that; apart from what is in this PR there seems to be not very much we still have to convert to markdown (except for nixdoc-generated function docs and the manual structuring mechanism).

there are still a few missing features in nixos-render-docs that have to be added before we can fully move over (most notably tables, footnotes and figures), but none of these should be too hard to add.

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes (or backporting 23.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).