### PR TITLE
sirikali: init at 1.5.1

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -9849,6 +9849,13 @@
     githubId = 725613;
     name = "Linus Arver";
   };
+  linuxissuper = {
+    email = "m+nix@linuxistcool.de";
+    matrix = "@m:linuxistcool.de";
+    github = "linuxissuper";
+    githubId = 74221543;
+    name = "Moritz Goltdammer";
+  };
   lionello = {
     email = "lio@lunesu.com";
     github = "lionello";

--- a/pkgs/tools/security/sirikali/default.nix
+++ b/pkgs/tools/security/sirikali/default.nix
@@ -1,0 +1,88 @@
+{ lib
+, stdenv
+, qtbase
+, libpwquality
+, hicolor-icon-theme
+, fetchFromGitHub
+, wrapQtAppsHook
+, cmake
+, pkg-config
+, libgcrypt
+, cryfs
+, encfs
+, fscrypt-experimental
+, gocryptfs
+, securefs
+, sshfs
+, libsecret
+, kwallet
+, withKWallet ? true
+, withLibsecret ? true
+}:
+
+stdenv.mkDerivation rec {
+  pname = "sirikali";
+  version = "1.5.1";
+
+  src = fetchFromGitHub {
+    owner = "mhogomchungu";
+    repo = "sirikali";
+    rev = version;
+    hash = "sha256-1bY8cCMMK4Jie4+9c7eUEBrPEYDaOqFHZ5252TPSotA=";
+  };
+
+  buildInputs = [
+    qtbase
+    libpwquality
+    hicolor-icon-theme
+    libgcrypt
+    cryfs
+    encfs
+    fscrypt-experimental
+    gocryptfs
+    securefs
+    sshfs
+  ]
+  ++ lib.optionals withKWallet [ libsecret ]
+  ++ lib.optionals withLibsecret [ kwallet ]
+  ;
+
+  nativeBuildInputs = [
+    wrapQtAppsHook
+    cmake
+    pkg-config
+  ];
+
+  qtWrapperArgs = [
+    ''--prefix PATH : ${lib.makeBinPath [
+      cryfs
+      encfs
+      fscrypt-experimental
+      gocryptfs
+      securefs
+      sshfs
+    ]}''
+  ];
+
+  postPatch = ''
+    substituteInPlace "src/engines.cpp" --replace "/sbin/" "/run/wrappers/bin/"
+  '';
+
+  doCheck = true;
+
+  cmakeFlags = [
+    "-DCMAKE_BUILD_TYPE=RELEASE"
+    "-DINTERNAL_LXQT_WALLET=false"
+    "-DNOKDESUPPORT=${if withKWallet then "false" else "true"}"
+    "-DNOSECRETSUPPORT=${if withLibsecret then "false" else "true"}"
+    "-DQT5=true"
+  ];
+
+  meta = with lib; {
+    description = "A Qt/C++ GUI front end to sshfs, ecryptfs-simple, cryfs, gocryptfs, securefs, fscrypt and encfs";
+    homepage = "https://github.com/mhogomchungu/sirikali";
+    changelog = "https://github.com/mhogomchungu/sirikali/blob/${src.rev}/changelog";
+    license = licenses.gpl3Only;
+    maintainers = with maintainers; [ linuxissuper ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -42294,6 +42294,8 @@ with pkgs;
 
   dict-cc-py = callPackage ../applications/misc/dict-cc-py { };
 
+  sirikali = libsForQt5.callPackage ../tools/security/sirikali { };
+
   wttrbar = callPackage ../applications/misc/wttrbar { };
 
   wpm = callPackage ../applications/misc/wpm { };


### PR DESCRIPTION
###### Description of changes

A Qt/C++ GUI front end to sshfs, ecryptfs-simple, cryfs, gocryptfs, securefs, fscrypt and encfs   
from https://github.com/mhogomchungu/sirikali

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes (or backporting 23.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
