### PR TITLE
libdatachannel: init at 0.18.5

### DIFF
--- a/pkgs/development/libraries/libdatachannel/default.nix
+++ b/pkgs/development/libraries/libdatachannel/default.nix
@@ -1,0 +1,80 @@
+{ stdenv
+, lib
+, fetchFromGitHub
+, srcOnly
+, cmake
+, ninja
+, pkg-config
+, libnice
+, openssl
+, plog
+, srtp
+, usrsctp
+}:
+
+let
+  # Use usrsctp version specified at https://github.com/paullouisageneau/libdatachannel/tree/master/deps
+  # Older or newer usrsctp might break libdatachannel, please keep it synced with upstream.
+  customUsrsctp = usrsctp.overrideAttrs (finalAttrs: previousAttrs: {
+    version = "unstable-2021-10-08";
+    src = fetchFromGitHub {
+      owner = "sctplab";
+      repo = "usrsctp";
+      rev = "7c31bd35c79ba67084ce029511193a19ceb97447";
+      hash = "sha256-KeOR/0WDtG1rjUndwTUOhE21PoS+ETs1Vk7jQYy/vNs=";
+    };
+  });
+in
+stdenv.mkDerivation rec {
+  pname = "libdatachannel";
+  version = "0.18.5";
+
+  src = fetchFromGitHub {
+    owner = "paullouisageneau";
+    repo = pname;
+    rev = "v${version}";
+    hash = "sha256-ognjEDw68DpdQ/4JqcTejP5f9K0zLZGnpr99P/dvHK4=";
+  };
+
+  outputs = [ "out" "dev" ];
+
+  strictDeps = true;
+  nativeBuildInputs = [
+    cmake
+    ninja
+    pkg-config
+  ];
+  buildInputs = [
+    libnice
+    openssl
+    srtp
+  ];
+
+  cmakeFlags = [
+    "-DUSE_NICE=ON"
+    "-DUSE_SYSTEM_SRTP=ON"
+    "-DNO_EXAMPLES=ON"
+  ];
+
+  postPatch = ''
+    # TODO: Remove when updating to 0.19.x, and add
+    # -DUSE_SYSTEM_USRSCTP=ON and -DUSE_SYSTEM_PLOG=ON to cmakeFlags instead
+    mkdir -p deps/{usrsctp,plog}
+    cp -r --no-preserve=mode ${srcOnly customUsrsctp}/. deps/usrsctp
+    cp -r --no-preserve=mode ${srcOnly plog}/. deps/plog
+  '';
+
+  postFixup = ''
+    # Fix shared library path that will be incorrect on move to "dev" output
+    substituteInPlace "$dev/lib/cmake/LibDataChannel/LibDataChannelTargets-release.cmake" \
+      --replace "\''${_IMPORT_PREFIX}/lib" "$out/lib"
+  '';
+
+  meta = with lib; {
+    description = "C/C++ WebRTC network library featuring Data Channels, Media Transport, and WebSockets";
+    homepage = "https://libdatachannel.org/";
+    license = with licenses; [ mpl20 ];
+    maintainers = with maintainers; [ erdnaxe ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -27238,6 +27238,8 @@ with pkgs;
 
   libcgroup = callPackage ../os-specific/linux/libcgroup { };
 
+  libdatachannel = callPackage ../development/libraries/libdatachannel { };
+
   libkrun = callPackage ../development/libraries/libkrun {
     inherit (darwin.apple_sdk.frameworks) Hypervisor;
   };


### PR DESCRIPTION
###### Description of changes

Motivation: Next major version of OBS Studio will depend on libdatachannel for WHIP (WebRTC) support.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [X] Tested, as applicable:
  - Built OBS Studio master with it, and successfully streamed using WHIP.
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes (or backporting 23.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
