### PR TITLE
whalebird: 4.7.4 -> 5.0.7

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -17054,6 +17054,16 @@
     github = "wdavidw";
     githubId = 46896;
   };
+  weathercold = {
+    name = "Weathercold";
+    email = "weathercold.scr@gmail.com";
+    matrix = "@weathercold:matrix.org";
+    github = "Weathercold";
+    githubId = 49368953;
+    keys = [{
+      fingerprint = "D20F C904 A145 8B28 53D8  FBA0 0422 0096 01E4 87FC";
+    }];
+  };
   wegank = {
     name = "Weijia Wang";
     email = "contact@weijia.wang";

--- a/pkgs/applications/misc/whalebird/default.nix
+++ b/pkgs/applications/misc/whalebird/default.nix
@@ -1,22 +1,24 @@
-{ lib, stdenv, fetchurl, autoPatchelfHook, makeDesktopItem, copyDesktopItems, makeWrapper, electron
-, nodePackages, alsa-lib, gtk3, libdbusmenu, libxshmfence, mesa, nss }:
+{ lib, stdenv, fetchurl
+, autoPatchelfHook, makeDesktopItem, copyDesktopItems, makeWrapper, gnugrep, nodePackages
+, electron, python3, alsa-lib, gtk3, libdbusmenu, libxshmfence, mesa, nss
+}:
 
 stdenv.mkDerivation rec {
   pname = "whalebird";
-  version = "4.7.4";
+  version = "5.0.7";
 
   src = let
-    downloads = "https://github.com/h3poteto/whalebird-desktop/releases/download/${version}";
+    downloads = "https://github.com/h3poteto/whalebird-desktop/releases/download/v${version}";
   in
     if stdenv.system == "x86_64-linux" then
       fetchurl {
         url = downloads + "/Whalebird-${version}-linux-x64.tar.bz2";
-        sha256 = "sha256-jRtlnKlrh6If9wy3FqVBtctQO3rZJRwceUWAPmieT4A=";
+        hash = "sha256-eufP038REwF2VwAxxI8R0S3fE8oJ+SX/CES5ozuut2w=";
       }
     else if stdenv.system == "aarch64-linux" then
       fetchurl {
         url = downloads + "/Whalebird-${version}-linux-arm64.tar.bz2";
-        sha256 = "sha256-gWCBH2zfhJdJ3XUAxvZ0+gBHye5uYCUgX1BDEoaruxY=";
+        hash = "sha256-U0xVTUUm6wsRxYc1w4vfNtVE6o8dNzXTSi+IX4mgDEE=";
       }
     else
       throw "Whalebird is not supported for ${stdenv.system}";
@@ -25,6 +27,7 @@ stdenv.mkDerivation rec {
     autoPatchelfHook
     makeWrapper
     copyDesktopItems
+    gnugrep
     nodePackages.asar
   ];
 
@@ -52,9 +55,16 @@ stdenv.mkDerivation rec {
     runHook preBuild
 
     # Necessary steps to find the tray icon
+    # For aarch64-linux, we need to overwrite this symlink first as it points to
+    # /usr/bin/python3
+    if [ "${stdenv.system}" = "aarch64-linux" ]
+    then ln -sf ${python3}/bin/python3 \
+      opt/Whalebird/resources/app.asar.unpacked/node_modules/better-sqlite3/build/node_gyp_bins/python3
+    fi
     asar extract opt/Whalebird/resources/app.asar "$TMP/work"
-    substituteInPlace $TMP/work/dist/electron/main.js \
-      --replace "qt,\"tray_icon.png\"" "\"$out/opt/Whalebird/resources/build/icons/tray_icon.png\""
+    substituteInPlace "$TMP/work/dist/electron/main.js" \
+      --replace "$(grep -oE '.{2},"tray_icon.png"' "$TMP/work/dist/electron/main.js")" \
+        "\"$out/opt/Whalebird/resources/build/icons/tray_icon.png\""
     asar pack --unpack='{*.node,*.ftz,rect-overlay}' "$TMP/work" opt/Whalebird/resources/app.asar
 
     runHook postBuild
@@ -83,8 +93,8 @@ stdenv.mkDerivation rec {
     description = "Electron based Mastodon, Pleroma and Misskey client for Windows, Mac and Linux";
     homepage = "https://whalebird.social";
     sourceProvenance = with sourceTypes; [ binaryNativeCode ];
-    license = licenses.mit;
-    maintainers = with maintainers; [ wolfangaukang colinsane ];
+    license = licenses.gpl3Only;
+    maintainers = with maintainers; [ wolfangaukang colinsane weathercold ];
     platforms = [ "x86_64-linux" "aarch64-linux" ];
   };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -35360,7 +35360,7 @@ with pkgs;
   wgnord = callPackage ../applications/networking/wgnord/default.nix { };
 
   whalebird = callPackage ../applications/misc/whalebird {
-    electron = electron_19;
+    electron = electron_21;
   };
 
   windowlab = callPackage ../applications/window-managers/windowlab { };


### PR DESCRIPTION
###### Description of changes

changelog: <https://github.com/h3poteto/whalebird-desktop/releases>

notable changes:
- Add hide-to-tray on start option (3942)
- Re-implement layout and sidebar (4037)
- Show reply target message on compose (4098)
- Show character limit in compose (4099)
- Show quote target message on compose (4100)
- Add validation for compose (4121)
- Auto-complete in compose (4139)
- Add shortcut key for post (4269)
- **Update electron version to 21.4.4** (4304)
- **Change license to GPL** (4363)
- Add scroll bar if there are many hashtags or lists (4421)
- Add shortuct for reloading with CMD+R (4422)
- Tons of dependency bumps and fixes

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes (or backporting 23.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).