### PR TITLE
kdeconnect-kde: add kirigami-addons to buildInputs

### DIFF
--- a/pkgs/applications/kde/kdeconnect-kde.nix
+++ b/pkgs/applications/kde/kdeconnect-kde.nix
@@ -8,6 +8,7 @@
 , kiconthemes
 , kio
 , kirigami2
+, kirigami-addons
 , knotifications
 , kpeople
 , kpeoplevcard
@@ -43,6 +44,7 @@ mkDerivation {
     kiconthemes
     kio
     kirigami2
+    kirigami-addons
     knotifications
     kpeople
     kpeoplevcard

--- a/pkgs/applications/kde/kdeconnect-kde.nix
+++ b/pkgs/applications/kde/kdeconnect-kde.nix
@@ -78,5 +78,6 @@ mkDerivation {
     homepage = "https://community.kde.org/KDEConnect";
     license = with licenses; [ gpl2 ];
     maintainers = with maintainers; [ fridh ];
+    mainProgram = "kdeconnect-app";
   };
 }


### PR DESCRIPTION
###### Description of changes

Adds `kirigami-addons` to `buildInputs`. Otherwise, the settings window becomes blank due to the following error:

```
file:///nix/store/9rfh9zafpaz7nb8ac9yxb6lr8cdda7dd-kirigami2-5.106.0/lib/qt-5.15.9/qml/org/kde/kirigami.2/PageRow.qml:914: Error: Error while loading page: qrc:/qml/Settings.qml:8 module "org.kde.kirigamiaddons.labs.mobileform" is not installed
```

Also sets `meta.mainProgram` to `"kdeconnect-app"`. Although there's also `kdeconnect-cli`, most users would want a gui instead. 

![image](https://github.com/NixOS/nixpkgs/assets/49368953/8fd70fe3-da4e-498c-9ae0-4377e5381aff)

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes (or backporting 23.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).