### PR TITLE
djgpp: init at 12.2.0

### DIFF
--- a/pkgs/development/compilers/djgpp/default.nix
+++ b/pkgs/development/compilers/djgpp/default.nix
@@ -1,0 +1,94 @@
+{ bison
+, buildPackages
+, curl
+, fetchFromGitHub
+, fetchurl
+, file
+, flex
+, targetArchitecture ? "i586"
+, lib
+, makeWrapper
+, perl
+, stdenv
+, texinfo
+, unzip
+, which }:
+
+let
+  s = import ./sources.nix { inherit fetchurl fetchFromGitHub; };
+in
+assert lib.elem targetArchitecture [ "i586" "i686" ];
+stdenv.mkDerivation rec {
+  pname = "djgpp";
+  version = s.gccVersion;
+  src = s.src;
+
+  patchPhase = ''
+    runHook prePatch
+    for f in "build-djgpp.sh" "script/${version}" "setenv/copyfile.sh"; do
+      substituteInPlace "$f" --replace '/usr/bin/env' '${buildPackages.coreutils}/bin/env'
+    done
+  ''
+  # i686 patches from https://github.com/andrewwutw/build-djgpp/issues/45#issuecomment-1484010755
+  # The build script unpacks some files so we can't patch ahead of time, instead patch the script
+  # to patch after it extracts
+
+  + lib.optionalString (targetArchitecture == "i686") ''
+    sed -i 's/i586/i686/g' setenv/setenv script/${version}
+    sed -i '/Building DXE tools./a sed -i "s/i586/i686/g" src/makefile.def src/dxe/makefile.dxe' script/${version}
+  ''
+  + ''
+    runHook postPatch
+  '';
+
+  buildInputs = [
+    bison
+    curl
+    file
+    flex
+    makeWrapper
+    perl
+    texinfo
+    unzip
+    which
+  ];
+
+  hardeningDisable = [ "format" ];
+
+  buildPhase = ''
+    runHook preBuild
+    mkdir download; pushd download
+    ln -s "${s.autoconf}"   "${s.autoconf.name}"
+    ln -s "${s.automake}"   "${s.automake.name}"
+    ln -s "${s.binutils}"   "${s.binutils.name}"
+    ln -s "${s.djcrossgcc}" "${s.djcrossgcc.name}"
+    ln -s "${s.djcrx}"      "${s.djcrx.name}"
+    ln -s "${s.djdev}"      "${s.djdev.name}"
+    ln -s "${s.djlsr}"      "${s.djlsr.name}"
+    ln -s "${s.gcc}"        "${s.gcc.name}"
+    ln -s "${s.gmp}"        "${s.gmp.name}"
+    ln -s "${s.mpc}"        "${s.mpc.name}"
+    ln -s "${s.mpfr}"       "${s.mpfr.name}"
+    popd
+    DJGPP_PREFIX=$out ./build-djgpp.sh ${version}
+    runHook postBuild
+  '';
+
+  postInstall = ''
+    for f in dxegen dxe3gen dxe3res exe2coff stubify; do
+      cp -v "$out/${targetArchitecture}-pc-msdosdjgpp/bin/$f" "$out/bin"
+    done
+
+    for f in dxegen dxe3gen; do
+      wrapProgram $out/bin/$f --set DJDIR $out
+    done
+  '';
+
+  meta = {
+    description = "A complete 32-bit GNU-based development system for Intel x86 PCs running DOS";
+    homepage = "https://www.delorie.com/djgpp/";
+    license = lib.licenses.gpl2Plus;
+    maintainers = with lib.maintainers; [ hughobrien ];
+    platforms = lib.platforms.linux;
+  };
+}

--- a/pkgs/development/compilers/djgpp/sources.nix
+++ b/pkgs/development/compilers/djgpp/sources.nix
@@ -1,0 +1,81 @@
+let
+  # adapted from https://github.com/andrewwutw/build-djgpp/blob/master/script/12.1.0
+  gccVersion = "12.2.0";
+  binutilsVersion = "230";
+  djcrxVersion = "205";
+  djlsrVersion = "205";
+  djdevVersion = "205";
+  gmpVersion = "6.2.1";
+  mpfrVersion = "4.1.0";
+  mpcVersion = "1.2.1";
+  autoconfVersion = "2.69";
+  automakeVersion = "1.15.1";
+  djgppFtpMirror = "https://www.mirrorservice.org/sites/ftp.delorie.com/pub";
+  gnuFtpMirror = "https://www.mirrorservice.org/sites/ftp.gnu.org/gnu";
+in
+{ fetchFromGitHub, fetchurl }: {
+  inherit gccVersion;
+
+  src = fetchFromGitHub {
+    owner = "andrewwutw";
+    repo = "build-djgpp";
+    rev = "0dc28365825f853c3cc6ad0d8f10f8570bed5828";
+    hash = "sha256-L7ROTbnd/Ry/E9cP0N+l0y0cUzkkbC5B2aU9/r3rLQg=";
+  };
+
+  autoconf = fetchurl {
+    url = "${gnuFtpMirror}/autoconf/autoconf-${autoconfVersion}.tar.xz";
+    hash = "sha256-ZOvOyfisWySHElqGp3YNJZGsnh09vVlIljP53mKldoQ=";
+  };
+
+  automake = fetchurl {
+    url = "${gnuFtpMirror}/Automake/automake-${automakeVersion}.tar.xz";
+    hash = "sha256-r2ujkUIiBofFAPebSqLxgdmyTk+NjsSXzqS6JsZL7a8=";
+  };
+
+  binutils = fetchurl {
+    url = "${djgppFtpMirror}/djgpp/deleted/v2gnu/bnu${binutilsVersion}s.zip";
+    hash = "sha256-DSFQyFvswmP5/qYXbesFmUJ9tqEFJpILb0mGclfpXX0=";
+  };
+
+  djcrossgcc = fetchurl {
+    url = "${djgppFtpMirror}/djgpp/rpms/djcross-gcc-${gccVersion}/djcross-gcc-${gccVersion}.tar.bz2";
+    hash = "sha256-UL+wkeNv3LCQog0JigShIyBM7qJRqvN58Zitmti/BZM=";
+  };
+
+  djcrx = fetchurl {
+    url = "${djgppFtpMirror}/djgpp/current/v2/djcrx${djcrxVersion}.zip";
+    hash = "sha256-IidO2NXuV898zxYfXhaE/RwBkgaHJKfTThveFoBBymA=";
+  };
+
+  djdev = fetchurl {
+    url = "${djgppFtpMirror}/djgpp/current/v2/djdev${djdevVersion}.zip";
+    hash = "sha256-RVfftsFh0yZoCuX6cfAJisSUJaGxG5CgILgxYutwXdo=";
+  };
+
+  djlsr = fetchurl {
+    url = "${djgppFtpMirror}/djgpp/current/v2/djlsr${djlsrVersion}.zip";
+    hash = "sha256-gGkLbkT/i8bGCB/KH0+uuhWRxEkLdu8OyLNYR7ql3uo=";
+  };
+
+  gcc = fetchurl {
+    url = "${gnuFtpMirror}/gcc/gcc-${gccVersion}/gcc-${gccVersion}.tar.xz";
+    hash = "sha256-5UnPnPNZSgDie2WJ1DItcOByDN0hPzm+tBgeBpJiMP8=";
+  };
+
+  gmp = fetchurl {
+    url = "${gnuFtpMirror}/gmp/gmp-${gmpVersion}.tar.xz";
+    hash = "sha256-/UgpkSzd0S+EGBw0Ucx1K+IkZD6H+sSXtp7d2txJtPI=";
+  };
+
+  mpc = fetchurl {
+    url = "${gnuFtpMirror}/mpc/mpc-${mpcVersion}.tar.gz";
+    hash = "sha256-F1A9LDld/PEGtiLcFCaDwRmUMdCVNnxqrLpu7DA0BFk=";
+  };
+
+  mpfr = fetchurl {
+    url = "${gnuFtpMirror}/mpfr/mpfr-${mpfrVersion}.tar.xz";
+    hash = "sha256-DJij8XMv9spOppBVIHnanFl4ctMOluwoQU7iPJVVin8=";
+  };
+
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -533,6 +533,10 @@ with pkgs;
 
   dinghy = with python3Packages; toPythonApplication dinghy;
 
+  djgpp = djgpp_i586;
+  djgpp_i586 = callPackage ../development/compilers/djgpp { targetArchitecture = "i586"; };
+  djgpp_i686 = lowPrio (callPackage ../development/compilers/djgpp { targetArchitecture = "i686"; });
+
   djhtml = python3Packages.callPackage ../development/tools/djhtml { };
 
   deadcode = callPackage ../development/tools/deadcode { };


### PR DESCRIPTION
###### Description of changes

Introduce [DJGPP](https://en.wikipedia.org/wiki/DJGPP), a port of GCC for DOS systems. Note that [watcom tools](https://search.nixos.org/packages?channel=unstable&from=0&size=50&sort=relevance&type=packages&query=watcom) which provide similar functionality from a (previously) commercial compiler are already in nixpkgs.

This derivation is based on [this](https://github.com/andrewwutw/build-djgpp) build script which automates much of the process, including applying the various packages necessary to support this ~1989 software. The [DJGPP homepage](https://www.delorie.com/djgpp/) has the full details.

i686 patch is based on an [issue](https://github.com/andrewwutw/build-djgpp/issues/45#issuecomment-1484010755) on the same project.

This is based on GCC 12, which is naively compiled from the GNU sources. Nixpkgs' own GCC builds contain various patches which are not present here, because frankly I don't understand them. I welcome some expert review here.

Note that the compilation can take 20+ minutes.

Fun fact, DJGPP was used to build the [DOS version of Quake](https://github.com/search?q=repo%3Aid-Software%2FQuake+djgpp&type=code)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes (or backporting 23.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
