### PR TITLE
dbus-broker: v32 -> v33

### DIFF
--- a/pkgs/os-specific/linux/dbus-broker/default.nix
+++ b/pkgs/os-specific/linux/dbus-broker/default.nix
@@ -11,6 +11,7 @@
 }:
 
 let
+
   dep = { pname, version, hash, rev ? "v${version}", buildInputs ? [ ] }:
     stdenv.mkDerivation {
       inherit pname version;
@@ -30,22 +31,22 @@ let
   c-dvar = dep { pname = "c-dvar"; version = "1.0.0"; hash = "sha256-P7y7gUHXQn2eyS6IcV7m7yGy4VGtQ2orgBkS7Y729ZY="; buildInputs = [ c-stdaux c-utf8 ]; };
   c-ini = dep { pname = "c-ini"; version = "1.0.0"; hash = "sha256-VKxoGexMcquakMmiH5IJt0382TjkV1FLncTSyEqf4X0="; buildInputs = [ c-list c-rbtree c-stdaux c-utf8 ]; };
   c-list = dep { pname = "c-list"; version = "3.1.0"; hash = "sha256-fp3EAqcbFCLaT2EstLSzwP2X13pi2EFpFAullhoCtpw="; };
-  # TODO: Fetch c-rbtree from a tag after its next release
-  c-rbtree = dep { pname = "c-rbtree"; version = "unstable-2022-07-07"; rev = "431a4746705223673e43940ca1ad9b5f52473a4b"; hash = "sha256-ExSPgNqhTjSwRgYfZOAyoaehOpFNHKFqPYkcCfptkrs="; buildInputs = [ c-stdaux ]; };
+  c-rbtree = dep { pname = "c-rbtree"; version = "3.1.0"; hash = "sha256-ozVzL6FllAn8eHbso0RZc/+PGWwEp6r/R1MR+r4Bi/4="; buildInputs = [ c-stdaux ]; };
   c-shquote = dep { pname = "c-shquote"; version = "1.0.0"; hash = "sha256-Ze1enX0VJ6Xi5e4EhWzaiHc7PnuaifrUP+JuJnauv5c="; buildInputs = [ c-stdaux ]; };
-  c-stdaux = dep { pname = "c-stdaux"; version = "1.2.0"; hash = "sha256-/D+IFdqn1XHDfdOsDnLMO5IHQ5B4P4ELyMpRcPBg/4s="; };
+  c-stdaux = dep { pname = "c-stdaux"; version = "1.4.0"; hash = "sha256-gEqXVBAUE0dHD03ina9QbEP26NU12cHKRpuD7GoPmDs="; };
   c-utf8 = dep { pname = "c-utf8"; version = "1.0.0"; hash = "sha256-QEnjmfQ6kxJdsHfyRgXAlP+oGrKLYQ0m9r+D2L+pizI="; buildInputs = [ c-stdaux ]; };
 
 in
-stdenv.mkDerivation rec {
+
+stdenv.mkDerivation ( finalAttrs: {
   pname = "dbus-broker";
-  version = "32";
+  version = "33";
 
   src = fetchFromGitHub {
     owner = "bus1";
     repo = "dbus-broker";
-    rev = "v${version}";
-    hash = "sha256-PVdRyg/t6D3HjSHeap5L8AiEm39iSO5qXohLw2UAUYY=";
+    rev = "v${finalAttrs.version}";
+    hash = "sha256-c5kEUB2k9CCuno9d4QOUUp1wbQfsvraGDLN6Yaa7T2w=";
   };
 
   patches = [ ./paths.patch ];
@@ -92,4 +93,4 @@ stdenv.mkDerivation rec {
     maintainers = with maintainers; [ peterhoeg ];
     platforms = platforms.linux;
   };
-}
+} )


### PR DESCRIPTION
###### Description of changes

Release: https://github.com/bus1/dbus-broker/releases/tag/v33
Diff: https://github.com/bus1/dbus-broker/compare/v32...v33

Updated dbus-broker from v32 to v33, also updated 2 dependencies and removed 1 TODO. 

Running v33 on my laptop for a whole day, and everything stays in the right shape :)

Closes https://github.com/NixOS/nixpkgs/issues/236837

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes (or backporting 23.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
