### PR TITLE
python311Packages.filedepot: init at 0.9.0

### DIFF
--- a/pkgs/development/python-modules/filedepot/default.nix
+++ b/pkgs/development/python-modules/filedepot/default.nix
@@ -1,0 +1,64 @@
+{ lib
+, anyascii
+, buildPythonPackage
+, fetchFromGitHub
+, flaky
+, mock
+, paste
+, pillow
+, pymongo
+, pytestCheckHook
+, pythonOlder
+, requests
+, sqlalchemy
+}:
+
+buildPythonPackage rec {
+  pname = "filedepot";
+  version = "0.9.0";
+  format = "setuptools";
+
+  disabled = pythonOlder "3.7";
+
+  src = fetchFromGitHub {
+    owner = "amol-";
+    repo = "depot";
+    rev = "refs/tags/${version}";
+    hash = "sha256-OJc4Qwar3sKhKKF1WldwaueRG7FCboWT2wXYldHJbPU=";
+  };
+
+  propagatedBuildInputs = [
+    anyascii
+  ];
+
+  nativeCheckInputs = [
+    flaky
+    mock
+    paste
+    pillow
+    pymongo
+    pytestCheckHook
+    requests
+    sqlalchemy
+  ];
+
+  disabledTestPaths = [
+    # The examples have tests
+    "examples"
+    # Missing dependencies (TurboGears2 and ming)
+    "tests/test_fields_ming.py"
+    "tests/test_wsgi_middleware.py"
+  ];
+
+  pythonImportsCheck = [
+    "depot"
+  ];
+
+  meta = with lib; {
+    description = "Toolkit for storing files and attachments in web applications";
+    homepage = "https://github.com/amol-/depot";
+    changelog = "https://github.com/amol-/depot/releases/tag/${version}";
+    license = licenses.mit;
+    maintainers = with maintainers; [ fab ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -3554,6 +3554,8 @@ self: super: with self; {
 
   filecheck = callPackage ../development/python-modules/filecheck { };
 
+  filedepot = callPackage ../development/python-modules/filedepot { };
+
   filelock = callPackage ../development/python-modules/filelock { };
 
   filetype = callPackage ../development/python-modules/filetype { };


### PR DESCRIPTION
###### Description of changes
Toolkit for storing files and attachments in web applications

https://github.com/amol-/depot

Related to #81418
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes (or backporting 23.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
