### PR TITLE
python311Packages.flask-limiter: 3.1.0 -> 3.3.1

### DIFF
--- a/pkgs/development/python-modules/flask-limiter/default.nix
+++ b/pkgs/development/python-modules/flask-limiter/default.nix
@@ -1,26 +1,27 @@
 { lib
+, asgiref
 , buildPythonPackage
 , fetchFromGitHub
-
 , flask
+, hiro
 , limits
 , ordered-set
-, rich
-, typing-extensions
-
-, asgiref
-, hiro
 , pymemcache
+, pymongo
 , pytest-mock
 , pytestCheckHook
+, pythonOlder
 , redis
-, pymongo
+, rich
+, typing-extensions
 }:
 
 buildPythonPackage rec {
   pname = "flask-limiter";
   version = "3.3.1";
   format = "setuptools";
+
+  disabled = pythonOlder "3.7";
 
   src = fetchFromGitHub {
     owner = "alisaifee";
@@ -30,9 +31,6 @@ buildPythonPackage rec {
   };
 
   postPatch = ''
-    substituteInPlace requirements/main.txt \
-      --replace "rich>=12,<13" "rich"
-
     sed -i "/--cov/d" pytest.ini
 
     # flask-restful is unmaintained and breaks regularly, don't depend on it
@@ -82,11 +80,14 @@ buildPythonPackage rec {
     "tests/test_storage.py"
   ];
 
-  pythonImportsCheck = [ "flask_limiter" ];
+  pythonImportsCheck = [
+    "flask_limiter"
+  ];
 
   meta = with lib; {
     description = "Rate limiting for flask applications";
     homepage = "https://flask-limiter.readthedocs.org/";
+    changelog = "https://github.com/alisaifee/flask-limiter/blob/${version}/HISTORY.rst";
     license = licenses.mit;
     maintainers = with maintainers; [ ];
   };

--- a/pkgs/development/python-modules/flask-limiter/default.nix
+++ b/pkgs/development/python-modules/flask-limiter/default.nix
@@ -19,14 +19,14 @@
 
 buildPythonPackage rec {
   pname = "flask-limiter";
-  version = "3.1.0";
+  version = "3.3.1";
   format = "setuptools";
 
   src = fetchFromGitHub {
     owner = "alisaifee";
     repo = "flask-limiter";
     rev = "refs/tags/${version}";
-    hash = "sha256-eAJRqyAH1j1NHYfagRZM2fPE6hm9+tJHD8FMqvgvMBI=";
+    hash = "sha256-YDVZ/dD+TRJEnJRTRmGEB6EIkK5eQ5MdXh8FideoVDQ=";
   };
 
   postPatch = ''


### PR DESCRIPTION
Diff: https://github.com/alisaifee/flask-limiter/compare/refs/tags/3.1.0...3.3.1

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes (or backporting 23.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
