### PR TITLE
docs: stub out epub manuals

### DIFF
--- a/doc/Makefile
+++ b/doc/Makefile
@@ -66,18 +66,13 @@ out/html/index.html: doc-support/result manual-full.xml style.css highlightjs
 	cp doc-support/result/xsl/docbook/images/callouts/*.svg out/html/images/callouts/
 	chmod u+w -R out/html/
 
-out/epub/manual.epub: manual-full.xml
+out/epub/manual.epub: epub.xml
 	mkdir -p out/epub/scratch
 	xsltproc --nonet \
 		--output out/epub/scratch/ \
 		doc-support/result/epub.xsl \
-		./manual-full.xml
+		./epub.xml
 
-	cp -r $(pandoc_media_dir) out/epub/scratch/OEBPS
-	cp ./overrides.css out/epub/scratch/OEBPS
-	cp ./style.css out/epub/scratch/OEBPS
-	mkdir -p out/epub/scratch/OEBPS/images/callouts/
-	cp doc-support/result/xsl/docbook/images/callouts/*.svg out/epub/scratch/OEBPS/images/callouts/
 	echo "application/epub+zip" > mimetype
 	zip -0Xq "out/epub/manual.epub" mimetype
 	rm mimetype

--- a/doc/default.nix
+++ b/doc/default.nix
@@ -20,7 +20,33 @@ in pkgs.stdenv.mkDerivation {
     ln -s ${doc-support} ./doc-support/result
   '';
 
+  epub = ''
+    <book xmlns="http://docbook.org/ns/docbook"
+          xmlns:xlink="http://www.w3.org/1999/xlink"
+          version="5.0"
+          xml:id="nixpkgs-manual">
+      <info>
+        <title>Nixpkgs Manual</title>
+        <subtitle>Version ${pkgs.lib.version}</subtitle>
+      </info>
+      <chapter>
+        <title>Temporarily unavailable</title>
+        <para>
+          The Nixpkgs manual is currently not available in EPUB format,
+          please use the <link xlink:href="https://nixos.org/nixpkgs/manual">HTML manual</link>
+          instead.
+        </para>
+        <para>
+          If you've used the EPUB manual in the past and it has been useful to you, please
+          <link xlink:href="https://github.com/NixOS/nixpkgs/issues/237234">let us know</link>.
+        </para>
+      </chapter>
+    </book>
+  '';
+  passAsFile = [ "epub" ];
+
   preBuild = ''
+    cp $epubPath epub.xml
     make -j$NIX_BUILD_CORES render-md
   '';
 

--- a/nixos/doc/manual/default.nix
+++ b/nixos/doc/manual/default.nix
@@ -267,19 +267,41 @@ in rec {
 
   manualEpub = runCommand "nixos-manual-epub"
     { nativeBuildInputs = [ buildPackages.libxml2.bin buildPackages.libxslt.bin buildPackages.zip ];
+      doc = ''
+        <book xmlns="http://docbook.org/ns/docbook"
+              xmlns:xlink="http://www.w3.org/1999/xlink"
+              version="5.0"
+              xml:id="book-nixos-manual">
+          <info>
+            <title>NixOS Manual</title>
+            <subtitle>Version ${lib.version}</subtitle>
+          </info>
+          <chapter>
+            <title>Temporarily unavailable</title>
+            <para>
+              The NixOS manual is currently not available in EPUB format,
+              please use the <link xlink:href="https://nixos.org/nixos/manual">HTML manual</link>
+              instead.
+            </para>
+            <para>
+              If you've used the EPUB manual in the past and it has been useful to you, please
+              <link xlink:href="https://github.com/NixOS/nixpkgs/issues/237234">let us know</link>.
+            </para>
+          </chapter>
+        </book>
+      '';
+      passAsFile = [ "doc" ];
     }
     ''
       # Generate the epub manual.
       dst=$out/share/doc/nixos
 
       xsltproc \
-        ${manualXsltprocOptions} \
+        --param chapter.autolabel 0 \
         --nonet --xinclude --output $dst/epub/ \
         ${docbook_xsl_ns}/xml/xsl/docbook/epub/docbook.xsl \
-        ${manual-combined}/manual-combined.xml
+        $docPath
 
-      mkdir -p $dst/epub/OEBPS/images/callouts
-      cp -r ${docbook_xsl_ns}/xml/xsl/docbook/images/callouts/*.svg $dst/epub/OEBPS/images/callouts # */
       echo "application/epub+zip" > mimetype
       manual="$dst/nixos-manual.epub"
       zip -0Xq "$manual" mimetype


### PR DESCRIPTION
###### Description of changes

these are holding up the transition to docbook, and so far we don't know that many people actually use them. the stub epubs links to a github issue (#237234) if someone finds the lack of epub disturbing. maybe we should drop epub as a first-class format altogether if we don't get any responses.

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes (or backporting 23.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
