### PR TITLE
adguardhome: 0.107.29 -> 0.107.31

### DIFF
--- a/pkgs/servers/adguardhome/bins.nix
+++ b/pkgs/servers/adguardhome/bins.nix
@@ -1,31 +1,31 @@
 { fetchurl, fetchzip }:
 {
 x86_64-darwin = fetchzip {
-  sha256 = "sha256-ygf5D8s1Yv9J1mVDAZrW9Q/4scQopQ547TfHG+fFwoU=";
-  url = "https://github.com/AdguardTeam/AdGuardHome/releases/download/v0.107.29/AdGuardHome_darwin_amd64.zip";
+  sha256 = "sha256-W2XSIXrRuNsFGEdiGXD/7aUEShSwYhGp1yvdTXDg7Xc=";
+  url = "https://github.com/AdguardTeam/AdGuardHome/releases/download/v0.107.31/AdGuardHome_darwin_amd64.zip";
 };
 aarch64-darwin = fetchzip {
-  sha256 = "sha256-s112LwCusgRcTaGmKWcRlUA2XnbdxJ7lVkWzG3QIUqQ=";
-  url = "https://github.com/AdguardTeam/AdGuardHome/releases/download/v0.107.29/AdGuardHome_darwin_arm64.zip";
+  sha256 = "sha256-hqjuITqHNNZCDX+9ox8WLxrSoXeFZdaaSd1/RXTm2fM=";
+  url = "https://github.com/AdguardTeam/AdGuardHome/releases/download/v0.107.31/AdGuardHome_darwin_arm64.zip";
 };
 i686-linux = fetchurl {
-  sha256 = "sha256-mBqxPT/qaER4nI1+pmmpUSTJuCb9eax9DMRIY+J92Lk=";
-  url = "https://github.com/AdguardTeam/AdGuardHome/releases/download/v0.107.29/AdGuardHome_linux_386.tar.gz";
+  sha256 = "sha256-rn8q3N4VT+xjss6OWYlW9DtAy+xfaQoriY0IuMIva6Y=";
+  url = "https://github.com/AdguardTeam/AdGuardHome/releases/download/v0.107.31/AdGuardHome_linux_386.tar.gz";
 };
 x86_64-linux = fetchurl {
-  sha256 = "sha256-M4VfjRnrqYxKc9neIJndJoa8D44RRIjN5ItE4Ec6VKY=";
-  url = "https://github.com/AdguardTeam/AdGuardHome/releases/download/v0.107.29/AdGuardHome_linux_amd64.tar.gz";
+  sha256 = "sha256-OdGccAnlo0gGQB0IWFQX9PKz03BeUjeKwKvTjYKS5kU=";
+  url = "https://github.com/AdguardTeam/AdGuardHome/releases/download/v0.107.31/AdGuardHome_linux_amd64.tar.gz";
 };
 aarch64-linux = fetchurl {
-  sha256 = "sha256-6zekpNnfss4r/Z+g/Te0O+oDpCskKu39NI8Q0e7bHOo=";
-  url = "https://github.com/AdguardTeam/AdGuardHome/releases/download/v0.107.29/AdGuardHome_linux_arm64.tar.gz";
+  sha256 = "sha256-EKWlhwgksmQv5OXme/4VHVFSREOsI2PGmWj9ArBukPw=";
+  url = "https://github.com/AdguardTeam/AdGuardHome/releases/download/v0.107.31/AdGuardHome_linux_arm64.tar.gz";
 };
 armv6l-linux = fetchurl {
-  sha256 = "sha256-j0n3lKyaxOXX7YHcpYlC1dpCz741q1tes2kgadHzivI=";
-  url = "https://github.com/AdguardTeam/AdGuardHome/releases/download/v0.107.29/AdGuardHome_linux_armv6.tar.gz";
+  sha256 = "sha256-eRdAyyNGTzn0oQ/cYcrZ0LAxUjih77yHx4O/1gm+YvY=";
+  url = "https://github.com/AdguardTeam/AdGuardHome/releases/download/v0.107.31/AdGuardHome_linux_armv6.tar.gz";
 };
 armv7l-linux = fetchurl {
-  sha256 = "sha256-LyD3arGmk5YWXB2FZBLPcMAukvBtlXfFPSQ/mZBJohA=";
-  url = "https://github.com/AdguardTeam/AdGuardHome/releases/download/v0.107.29/AdGuardHome_linux_armv7.tar.gz";
+  sha256 = "sha256-p5SHPpl33Q8JGmqRBEFJD84VcueFmSXwbp3RssRsJIg=";
+  url = "https://github.com/AdguardTeam/AdGuardHome/releases/download/v0.107.31/AdGuardHome_linux_armv7.tar.gz";
 };
 }

--- a/pkgs/servers/adguardhome/default.nix
+++ b/pkgs/servers/adguardhome/default.nix
@@ -7,7 +7,7 @@ in
 
 stdenv.mkDerivation rec {
   pname = "adguardhome";
-  version = "0.107.29";
+  version = "0.107.31";
   src = sources.${system} or (throw "Source for ${pname} is not available for ${system}");
 
   installPhase = ''


### PR DESCRIPTION
###### Things done

- Built on platform(s)
  - [ ] x86_64-linux
  - [X] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [X] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes (or backporting 23.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
