### PR TITLE
nixos/top-level: change extraDependencies from packages to paths

### DIFF
--- a/lib/tests/modules.sh
+++ b/lib/tests/modules.sh
@@ -63,6 +63,16 @@ checkConfigOutput '^"one two"$' config.result ./shorthand-meta.nix
 
 checkConfigOutput '^true$' config.result ./test-mergeAttrDefinitionsWithPrio.nix
 
+# types.pathInStore
+checkConfigOutput '".*/store/5lz9p8xhf89kb1c1kk6jxrzskaiygnlh-bash-5.2-p15.drv"' config.pathInStore.ok1 ./types.nix
+checkConfigOutput '".*/store/xfb3ykw9r5hpayd05sr0cizwadzq1d8q-bash-5.2-p15"' config.pathInStore.ok2 ./types.nix
+checkConfigOutput '".*/store/xfb3ykw9r5hpayd05sr0cizwadzq1d8q-bash-5.2-p15/bin/bash"' config.pathInStore.ok3 ./types.nix
+checkConfigError 'A definition for option .* is not of type .path in the Nix store.. Definition values:\n\s*- In .*: ""' config.pathInStore.bad1 ./types.nix
+checkConfigError 'A definition for option .* is not of type .path in the Nix store.. Definition values:\n\s*- In .*: ".*/store"' config.pathInStore.bad2 ./types.nix
+checkConfigError 'A definition for option .* is not of type .path in the Nix store.. Definition values:\n\s*- In .*: ".*/store/"' config.pathInStore.bad3 ./types.nix
+checkConfigError 'A definition for option .* is not of type .path in the Nix store.. Definition values:\n\s*- In .*: ".*/store/.links"' config.pathInStore.bad4 ./types.nix
+checkConfigError 'A definition for option .* is not of type .path in the Nix store.. Definition values:\n\s*- In .*: "/foo/bar"' config.pathInStore.bad5 ./types.nix
+
 # Check boolean option.
 checkConfigOutput '^false$' config.enable ./declare-enable.nix
 checkConfigError 'The option .* does not exist. Definition values:\n\s*- In .*: true' config.enable ./define-enable.nix

--- a/lib/tests/modules/types.nix
+++ b/lib/tests/modules/types.nix
@@ -1,0 +1,24 @@
+{ lib, ... }:
+let
+  inherit (builtins)
+    storeDir;
+  inherit (lib)
+    types
+    mkOption
+    ;
+in
+{
+  options = {
+    pathInStore = mkOption { type = types.lazyAttrsOf types.pathInStore; };
+  };
+  config = {
+    pathInStore.ok1 = "${storeDir}/5lz9p8xhf89kb1c1kk6jxrzskaiygnlh-bash-5.2-p15.drv";
+    pathInStore.ok2 = "${storeDir}/xfb3ykw9r5hpayd05sr0cizwadzq1d8q-bash-5.2-p15";
+    pathInStore.ok3 = "${storeDir}/xfb3ykw9r5hpayd05sr0cizwadzq1d8q-bash-5.2-p15/bin/bash";
+    pathInStore.bad1 = "";
+    pathInStore.bad2 = "${storeDir}";
+    pathInStore.bad3 = "${storeDir}/";
+    pathInStore.bad4 = "${storeDir}/.links"; # technically true, but not reasonable
+    pathInStore.bad5 = "/foo/bar";
+  };
+}

--- a/lib/tests/release.nix
+++ b/lib/tests/release.nix
@@ -38,9 +38,6 @@ let
       export PAGER=cat
       cacheDir=$TEST_ROOT/binary-cache
 
-      mkdir -p $NIX_CONF_DIR
-      echo "experimental-features = nix-command" >> $NIX_CONF_DIR/nix.conf
-
       nix-store --init
 
       cp -r ${../.} lib

--- a/lib/types.nix
+++ b/lib/types.nix
@@ -461,6 +461,7 @@ rec {
     # - strings with context, e.g. "${pkgs.foo}" or (toString pkgs.foo)
     # - hardcoded store path literals (/nix/store/hash-foo) or strings without context
     #   ("/nix/store/hash-foo"). These get a context added to them using builtins.storePath.
+    # If you don't need a *top-level* store path, consider using pathInStore instead.
     package = mkOptionType {
       name = "package";
       descriptionClass = "noun";
@@ -488,6 +489,14 @@ rec {
       name = "path";
       descriptionClass = "noun";
       check = x: isStringLike x && builtins.substring 0 1 (toString x) == "/";
+      merge = mergeEqualOption;
+    };
+
+    pathInStore = mkOptionType {
+      name = "pathInStore";
+      description = "path in the Nix store";
+      descriptionClass = "noun";
+      check = x: isStringLike x && builtins.match "${builtins.storeDir}/[^.].*" (toString x) != null;
       merge = mergeEqualOption;
     };
 

--- a/nixos/doc/manual/development/option-types.section.md
+++ b/nixos/doc/manual/development/option-types.section.md
@@ -20,6 +20,11 @@ merging is handled.
     coerced to a string. Even if derivations can be considered as
     paths, the more specific `types.package` should be preferred.
 
+`types.pathInStore`
+
+:   A path that is contained in the Nix store. This can be a top-level store
+    path like `pkgs.hello` or a descendant like `"${pkgs.hello}/bin/hello"`.
+
 `types.package`
 
 :   A top-level store path. This can be an attribute set pointing

--- a/nixos/modules/system/activation/top-level.nix
+++ b/nixos/modules/system/activation/top-level.nix
@@ -260,10 +260,10 @@ in
     };
 
     system.extraDependencies = mkOption {
-      type = types.listOf types.package;
+      type = types.listOf types.pathInStore;
       default = [];
       description = lib.mdDoc ''
-        A list of packages that should be included in the system
+        A list of paths that should be included in the system
         closure but generally not visible to users.
 
         This option has also been used for build-time checks, but the


### PR DESCRIPTION
I was [once again](https://github.com/NixOS/nixpkgs/pull/163443) trying to work around https://github.com/NixOS/nix/issues/3995 by (recursively) adding my flake inputs to `system.extraDependencies`; this time `nixd`, which depends on `flake-parts`, which depends on the `lib` subdirectory of `nixpkgs`.

This fails because the subdirectory flake does not pass `types.package.check`: it's not a derivation, and it's not a store path either (it's a subdirectory of a store path).

Change the type to `path`, because there's no "store path or descendant" type. Honestly I'm not sure why anyone would ever use `types.package` at this point.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes (or backporting 23.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
