### PR TITLE
fuse-ext2: init at unstable-2020-07-12

### DIFF
--- a/pkgs/tools/filesystems/fuse-ext2/darwin-no-installer.patch
+++ b/pkgs/tools/filesystems/fuse-ext2/darwin-no-installer.patch
@@ -1,0 +1,31 @@
+diff --git a/fuse-ext2/Makefile.am b/fuse-ext2/Makefile.am
+index 9d3a065..c73f337 100644
+--- a/fuse-ext2/Makefile.am
++++ b/fuse-ext2/Makefile.am
+@@ -113,7 +113,7 @@ fuse_ext2_CFLAGS = \
+ 	-DHAVE_CONFIG_H \
+ 	-I/usr/local/include
+ 
+-if DARWIN
++if FALSE
+ bin_PROGRAMS += \
+ 	fuse-ext2.wait \
+ 	fuse-ext2.install \
+@@ -151,9 +151,6 @@ endif
+ if DARWIN
+ install-exec-local:
+ 	$(INSTALL) -d "$(DESTDIR)/$(sbindir)"
+-	$(LN_S) -f "/Library/Filesystems/fuse-ext2.fs/Contents/Resources/mount_fuse-ext2" "$(DESTDIR)/$(sbindir)/mount_fuse-ext2"
+-	$(LN_S) -f "/usr/local/opt/e2fsprogs/sbin/e2label" "$(DESTDIR)/$(sbindir)/e2label"
+-	$(LN_S) -f "/usr/local/opt/e2fsprogs/sbin/mke2fs" "$(DESTDIR)/$(sbindir)/mke2fs"
+ endif
+ if LINUX
+ install-data-hook:
+diff --git a/tools/Makefile.am b/tools/Makefile.am
+index 52f81e1..78c418f 100644
+--- a/tools/Makefile.am
++++ b/tools/Makefile.am
+@@ -1,2 +1,2 @@
+ 
+-SUBDIRS = macosx
++SUBDIRS =

--- a/pkgs/tools/filesystems/fuse-ext2/default.nix
+++ b/pkgs/tools/filesystems/fuse-ext2/default.nix
@@ -1,0 +1,46 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, autoreconfHook
+, e2fsprogs
+, fuse
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "fuse-ext2";
+  version = "unstable-2020-07-12";
+
+  src = fetchFromGitHub {
+    owner = "alperakcan";
+    repo = "fuse-ext2";
+    rev = "899f17c982dadcea13aa447c3a83c53b9431435a";
+    sha256 = "AE7Z+HePAy/h2TCNI9tsz6GVLdnE2AIOM3GnQzerKn8=";
+  };
+
+  patches = [
+    # Remove references to paths outside the nix store
+    ./remove-impure-paths.patch
+    # Don't build macOS desktop installer
+    ./darwin-no-installer.patch
+  ];
+
+  nativeBuildInputs = [
+    autoreconfHook
+  ];
+
+  buildInputs = [
+    e2fsprogs
+    fuse
+  ];
+
+  env.NIX_CFLAGS_COMPILE = lib.optionalString stdenv.cc.isClang "-Wno-error=incompatible-function-pointer-types";
+
+  meta = with lib; {
+    description = "FUSE module to mount ext2, ext3 and ext4 with read write support";
+    homepage = "https://github.com/alperakcan/fuse-ext2";
+    license = licenses.gpl2Plus;
+    maintainers = with maintainers; [ emilytrau ];
+    platforms = platforms.unix;
+    mainProgram = "fuse-ext2";
+  };
+})

--- a/pkgs/tools/filesystems/fuse-ext2/remove-impure-paths.patch
+++ b/pkgs/tools/filesystems/fuse-ext2/remove-impure-paths.patch
@@ -1,0 +1,35 @@
+diff --git a/fuse-ext2/Makefile.am b/fuse-ext2/Makefile.am
+index 9d3a065..0bb4341 100644
+--- a/fuse-ext2/Makefile.am
++++ b/fuse-ext2/Makefile.am
+@@ -17,8 +17,7 @@ fuse_ext2_probe_SOURCES = \
+ 
+ fuse_ext2_probe_CFLAGS = \
+ 	-Wall \
+-	-DHAVE_CONFIG_H \
+-	-I/usr/local/include
++	-DHAVE_CONFIG_H
+ 
+ fuse_ext2_SOURCES =	\
+ 	fuse-ext2.h \
+@@ -98,9 +97,7 @@ umfuseext2_la_CFLAGS = \
+ 	-Wall \
+ 	-DHAVE_CONFIG_H \
+ 	-D_GNU_SOURCE \
+-	$(DEVELFLAGS) \
+-	-I$(includedir)/umview \
+-	-I/usr/local/include
++	$(DEVELFLAGS)
+ 
+ umfuseext2_la_LDFLAGS = \
+ 	-module \
+@@ -110,8 +107,7 @@ umfuseext2_la_LDFLAGS = \
+ 
+ fuse_ext2_CFLAGS = \
+ 	-Wall \
+-	-DHAVE_CONFIG_H \
+-	-I/usr/local/include
++	-DHAVE_CONFIG_H
+ 
+ if DARWIN
+ bin_PROGRAMS += \

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8410,6 +8410,8 @@ with pkgs;
 
   fuse-archive = callPackage ../tools/filesystems/fuse-archive { };
 
+  fuse-ext2 = darwin.apple_sdk_11_0.callPackage ../tools/filesystems/fuse-ext2 { };
+
   fuse-overlayfs = callPackage ../tools/filesystems/fuse-overlayfs { };
 
   fusee-interfacee-tk = callPackage ../applications/misc/fusee-interfacee-tk { };


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
https://github.com/alperakcan/fuse-ext2

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes (or backporting 23.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
