### PR TITLE
ocamlPackages: fixes for OCaml ≥ 5.0

### DIFF
--- a/pkgs/development/ocaml-modules/ansiterminal/default.nix
+++ b/pkgs/development/ocaml-modules/ansiterminal/default.nix
@@ -9,6 +9,10 @@ buildDunePackage rec {
     hash = "sha256-q3OyGLajAmfSu8QzEtzzE5gbiwvsVV2SsGuHZkst0w4=";
   };
 
+  postPatch = ''
+    substituteInPlace src/dune --replace 'libraries unix bytes' 'libraries unix'
+  '';
+
   doCheck = true;
 
   meta = with lib; {

--- a/pkgs/development/ocaml-modules/bz2/default.nix
+++ b/pkgs/development/ocaml-modules/bz2/default.nix
@@ -1,6 +1,7 @@
 { lib, stdenv, fetchFromGitLab, ocaml, findlib, bzip2, autoreconfHook }:
 
 if lib.versionOlder ocaml.version "4.02"
+|| lib.versionAtLeast ocaml.version "5.0"
 then throw "bz2 is not available for OCaml ${ocaml.version}"
 else
 

--- a/pkgs/development/ocaml-modules/mariadb/default.nix
+++ b/pkgs/development/ocaml-modules/mariadb/default.nix
@@ -1,5 +1,6 @@
 { lib, fetchurl, stdenv
-, ocaml, findlib, ocamlbuild
+, fetchpatch
+, ocaml, findlib, ocamlbuild, camlp-streams
 , ctypes, mariadb, libmysqlclient }:
 
 lib.throwIfNot (lib.versionAtLeast ocaml.version "4.07")
@@ -14,8 +15,18 @@ stdenv.mkDerivation rec {
     sha256 = "sha256-3/C1Gz6luUzS7oaudLlDHMT6JB2v5OdbLVzJhtayHGM=";
   };
 
+  patches = fetchpatch {
+    url = "https://github.com/andrenth/ocaml-mariadb/commit/9db2e4d8dec7c584213d0e0f03d079a36a35d9d5.patch";
+    hash = "sha256-heROtU02cYBJ5edIHMdYP1xNXcLv8h79GYGBuudJhgE=";
+  };
+
+  postPatch = ''
+    substituteInPlace setup.ml --replace '#use "topfind"' \
+      '#directory "${findlib}/lib/ocaml/${ocaml.version}/site-lib/";; #use "topfind"'
+  '';
+
   nativeBuildInputs = [ ocaml findlib ocamlbuild ];
-  buildInputs = [ mariadb libmysqlclient ];
+  buildInputs = [ mariadb libmysqlclient camlp-streams ocamlbuild ];
   propagatedBuildInputs = [ ctypes ];
 
   strictDeps = true;


### PR DESCRIPTION
###### Description of changes

Small patches, waiting for upstream releases.

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes (or backporting 23.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
