### PR TITLE
pynitrokey: 0.4.37 -> 0.4.38, python3Packages.click-aliases: init at 1.0.1

### DIFF
--- a/pkgs/development/python-modules/click-aliases/0001-Fix-quotes-in-test.patch
+++ b/pkgs/development/python-modules/click-aliases/0001-Fix-quotes-in-test.patch
@@ -1,0 +1,39 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Nicolas Benes <nbenes.gh@xandea.de>
+Date: Mon, 12 Jun 2023 11:29:32 +0200
+Subject: [PATCH] Fix quotes in test
+
+
+diff --git a/tests/test_basic.py b/tests/test_basic.py
+index 077e6c0..90bbdc3 100644
+--- a/tests/test_basic.py
++++ b/tests/test_basic.py
+@@ -43,8 +43,8 @@ def test_foobar(runner):
+ 
+ TEST_INVALID = """Usage: cli [OPTIONS] COMMAND [ARGS]...
+ {}
+-Error: No such command "bar".
+-""".format('Try "cli --help" for help.\n' if _click7 else '')
++Error: No such command 'bar'.
++""".format("Try 'cli --help' for help.\n" if _click7 else '')
+ 
+ 
+ def test_invalid(runner):
+diff --git a/tests/test_foobar.py b/tests/test_foobar.py
+index fd6c4e6..ab0ad5d 100644
+--- a/tests/test_foobar.py
++++ b/tests/test_foobar.py
+@@ -44,8 +44,8 @@ def test_foobar(runner):
+ 
+ TEST_INVALID = """Usage: cli [OPTIONS] COMMAND [ARGS]...
+ {}
+-Error: No such command "baz".
+-""".format('Try "cli --help" for help.\n' if _click7 else '')
++Error: No such command 'baz'.
++""".format("Try 'cli --help' for help.\n" if _click7 else '')
+ 
+ 
+ def test_invalid(runner):
+-- 
+2.40.1
+

--- a/pkgs/development/python-modules/click-aliases/default.nix
+++ b/pkgs/development/python-modules/click-aliases/default.nix
@@ -1,0 +1,39 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, click
+, pytestCheckHook
+}:
+
+buildPythonPackage rec {
+  pname = "click-aliases";
+  version = "1.0.1";
+
+  src = fetchFromGitHub {
+    owner = "click-contrib";
+    repo = "click-aliases";
+    rev = "v${version}";
+    hash = "sha256-vzWlCb4m9TdRaVz4DrlRRZ60+9gj60NoiALgvaIG0gA=";
+  };
+
+  patches = [
+    ./0001-Fix-quotes-in-test.patch
+  ];
+
+  propagatedBuildInputs = [
+    click
+  ];
+
+  nativeCheckInputs = [
+    pytestCheckHook
+  ];
+
+  pythonImportsCheck = [ "click_aliases" ];
+
+  meta = with lib; {
+    homepage = "https://github.com/click-contrib/click-aliases";
+    description = "Enable aliases for click";
+    license = licenses.mit;
+    maintainers = with maintainers; [ panicgh ];
+  };
+}

--- a/pkgs/tools/security/pynitrokey/default.nix
+++ b/pkgs/tools/security/pynitrokey/default.nix
@@ -1,4 +1,10 @@
-{ lib, python3Packages, fetchPypi, nrfutil, libnitrokey }:
+{ lib
+, python3Packages
+, fetchPypi
+, nrfutil
+, libnitrokey
+, nix-update-script
+}:
 
 with python3Packages;
 
@@ -45,7 +51,7 @@ buildPythonApplication rec {
     "typing_extensions"
   ];
 
-  # libnitrokey is not propagated to users of pynitrokey
+  # libnitrokey is not propagated to users of the pynitrokey Python package.
   # It is only usable from the wrapped bin/nitropy
   makeWrapperArgs = [
     "--set LIBNK_PATH ${lib.makeLibraryPath [ libnitrokey ]}"
@@ -55,6 +61,8 @@ buildPythonApplication rec {
   doCheck = false;
 
   pythonImportsCheck = [ "pynitrokey" ];
+
+  passthru.updateScript = nix-update-script { };
 
   meta = with lib; {
     description = "Python client for Nitrokey devices";

--- a/pkgs/tools/security/pynitrokey/default.nix
+++ b/pkgs/tools/security/pynitrokey/default.nix
@@ -10,18 +10,19 @@ with python3Packages;
 
 buildPythonApplication rec {
   pname = "pynitrokey";
-  version = "0.4.37";
+  version = "0.4.38";
   format = "flit";
 
   src = fetchPypi {
     inherit pname version;
-    hash = "sha256-KoZym1b+E0P3kRt0PTm9wCX4nO31isDIwEq38xMgDDU=";
+    hash = "sha256-8TMDbkRyTkzULrBeO0SL/WXB240LD/iZLigE/zPum2A=";
   };
 
   propagatedBuildInputs = [
     certifi
     cffi
     click
+    click-aliases
     cryptography
     ecdsa
     frozendict
@@ -32,6 +33,7 @@ buildPythonApplication rec {
     python-dateutil
     pyusb
     requests
+    semver
     spsdk
     tqdm
     urllib3

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1877,6 +1877,8 @@ self: super: with self; {
 
   clickclick = callPackage ../development/python-modules/clickclick { };
 
+  click-aliases = callPackage ../development/python-modules/click-aliases { };
+
   click-command-tree = callPackage ../development/python-modules/click-command-tree { };
 
   click-completion = callPackage ../development/python-modules/click-completion { };


### PR DESCRIPTION
###### Description of changes

Upstream release summary: https://github.com/Nitrokey/pynitrokey/releases/tag/v0.4.38

In particular it fixes a firmware update issue and updates the "Secrets" app (for OTP, challenge-response etc).

I also had to add an otherwise missing Python dependency "click-aliases".

Ping maintainer: @frogamic 

###### Things done

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [X] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes (or backporting 23.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

----

Tested with a Nitrokey 3.

Result of `nixpkgs-review` run on x86_64-linux [1](https://github.com/Mic92/nixpkgs-review)
<details>
  <summary>6 packages built:</summary>
  <ul>
    <li>pynitrokey</li>
    <li>pynitrokey.dist</li>
    <li>python310Packages.click-aliases</li>
    <li>python310Packages.click-aliases.dist</li>
    <li>python311Packages.click-aliases</li>
    <li>python311Packages.click-aliases.dist</li>
  </ul>
</details>