### PR TITLE
gst_all_1.gst-plugins-rs: 0.10.7 -> 0.10.8

### DIFF
--- a/pkgs/development/libraries/gstreamer/rs/Cargo.lock
+++ b/pkgs/development/libraries/gstreamer/rs/Cargo.lock
@@ -49,10 +49,16 @@ dependencies = [ "getrandom", "once_cell", "version_check",]
 
 [[package]]
 name = "aho-corasick"
-version = "1.0.1"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67fc08ce920c31afb70f013dcce1bfc3a3195de6a228474e45e1f145b36f8d04"
+checksum = "43f6cb1bf222025340178f382c426f13757b2960e89779dfcb319c32542a5a41"
 dependencies = [ "memchr",]
+
+[[package]]
+name = "android-tzdata"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e999941b234f3131b00bc13c22d06e8c5ff726d1b6318ac7eb276997bbb4fef0"
 
 [[package]]
 name = "android_system_properties"
@@ -123,9 +129,9 @@ dependencies = [ "serde",]
 
 [[package]]
 name = "async-compression"
-version = "0.3.15"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "942c7cd7ae39e91bde4820d74132e9862e62c2f386c3aa90ccf55949f5bad63a"
+checksum = "5b0122885821398cc923ece939e24d1056a2384ee719432397fa9db87230ff11"
 dependencies = [ "flate2", "futures-core", "memchr", "pin-project-lite", "tokio",]
 
 [[package]]
@@ -133,7 +139,7 @@ name = "async-recursion"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0e97ce7de6cf12de5d7226c73f5ba9811622f4db3a5b91b55c53e987e5f91cba"
-dependencies = [ "proc-macro2", "quote", "syn 2.0.15",]
+dependencies = [ "proc-macro2", "quote", "syn 2.0.18",]
 
 [[package]]
 name = "async-task"
@@ -146,13 +152,13 @@ name = "async-trait"
 version = "0.1.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9ccdd8f2a161be9bd5c023df56f1b2a0bd1d83872ae53b71a84a12c9bf6e842"
-dependencies = [ "proc-macro2", "quote", "syn 2.0.15",]
+dependencies = [ "proc-macro2", "quote", "syn 2.0.18",]
 
 [[package]]
 name = "async-tungstenite"
-version = "0.22.1"
+version = "0.22.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a48bf42ab2178374a79853bceef600e279258c75049b20481b022d73c908882"
+checksum = "ce01ac37fdc85f10a43c43bc582cbd566720357011578a935761075f898baf58"
 dependencies = [ "futures-io", "futures-util", "log", "native-tls", "pin-project-lite", "tokio", "tokio-native-tls", "tungstenite",]
 
 [[package]]
@@ -183,149 +189,149 @@ dependencies = [ "anyhow", "arrayvec", "itertools", "log", "nom", "num-rational"
 
 [[package]]
 name = "aws-config"
-version = "0.55.2"
+version = "0.55.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc00553f5f3c06ffd4510a9d576f92143618706c45ea6ff81e84ad9be9588abd"
+checksum = "bcdcf0d683fe9c23d32cf5b53c9918ea0a500375a9fb20109802552658e576c9"
 dependencies = [ "aws-credential-types", "aws-http", "aws-sdk-sso", "aws-sdk-sts", "aws-smithy-async", "aws-smithy-client", "aws-smithy-http", "aws-smithy-http-tower", "aws-smithy-json", "aws-smithy-types", "aws-types", "bytes", "fastrand", "hex", "http", "hyper", "ring", "time 0.3.20", "tokio", "tower", "tracing", "zeroize",]
 
 [[package]]
 name = "aws-credential-types"
-version = "0.55.2"
+version = "0.55.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4cb57ac6088805821f78d282c0ba8aec809f11cbee10dda19a97b03ab040ccc2"
+checksum = "1fcdb2f7acbc076ff5ad05e7864bdb191ca70a6fd07668dc3a1a8bcd051de5ae"
 dependencies = [ "aws-smithy-async", "aws-smithy-types", "fastrand", "tokio", "tracing", "zeroize",]
 
 [[package]]
 name = "aws-endpoint"
-version = "0.55.2"
+version = "0.55.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c5f6f84a4f46f95a9bb71d9300b73cd67eb868bc43ae84f66ad34752299f4ac"
+checksum = "8cce1c41a6cfaa726adee9ebb9a56fcd2bbfd8be49fd8a04c5e20fd968330b04"
 dependencies = [ "aws-smithy-http", "aws-smithy-types", "aws-types", "http", "regex", "tracing",]
 
 [[package]]
 name = "aws-http"
-version = "0.55.2"
+version = "0.55.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a754683c322f7dc5167484266489fdebdcd04d26e53c162cad1f3f949f2c5671"
+checksum = "aadbc44e7a8f3e71c8b374e03ecd972869eb91dd2bc89ed018954a52ba84bc44"
 dependencies = [ "aws-credential-types", "aws-smithy-http", "aws-smithy-types", "aws-types", "bytes", "http", "http-body", "lazy_static", "percent-encoding", "pin-project-lite", "tracing",]
 
 [[package]]
 name = "aws-sdk-s3"
-version = "0.27.0"
+version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37c77060408d653d3efa6ea7b66c1389bc35a0342352984c8bf8bcb814a8fc27"
+checksum = "fba197193cbb4bcb6aad8d99796b2291f36fa89562ded5d4501363055b0de89f"
 dependencies = [ "aws-credential-types", "aws-endpoint", "aws-http", "aws-sig-auth", "aws-sigv4", "aws-smithy-async", "aws-smithy-checksums", "aws-smithy-client", "aws-smithy-eventstream", "aws-smithy-http", "aws-smithy-http-tower", "aws-smithy-json", "aws-smithy-types", "aws-smithy-xml", "aws-types", "bytes", "http", "http-body", "once_cell", "percent-encoding", "regex", "tokio-stream", "tower", "tracing", "url",]
 
 [[package]]
 name = "aws-sdk-sso"
-version = "0.27.0"
+version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "babfd626348836a31785775e3c08a4c345a5ab4c6e06dfd9167f2bee0e6295d6"
+checksum = "c8b812340d86d4a766b2ca73f740dfd47a97c2dff0c06c8517a16d88241957e4"
 dependencies = [ "aws-credential-types", "aws-endpoint", "aws-http", "aws-sig-auth", "aws-smithy-async", "aws-smithy-client", "aws-smithy-http", "aws-smithy-http-tower", "aws-smithy-json", "aws-smithy-types", "aws-types", "bytes", "http", "regex", "tokio-stream", "tower", "tracing",]
 
 [[package]]
 name = "aws-sdk-sts"
-version = "0.27.0"
+version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d0fbe3c2c342bc8dfea4bb43937405a8ec06f99140a0dcb9c7b59e54dfa93a1"
+checksum = "265fac131fbfc188e5c3d96652ea90ecc676a934e3174eaaee523c6cec040b3b"
 dependencies = [ "aws-credential-types", "aws-endpoint", "aws-http", "aws-sig-auth", "aws-smithy-async", "aws-smithy-client", "aws-smithy-http", "aws-smithy-http-tower", "aws-smithy-json", "aws-smithy-query", "aws-smithy-types", "aws-smithy-xml", "aws-types", "bytes", "http", "regex", "tower", "tracing",]
 
 [[package]]
 name = "aws-sdk-transcribe"
-version = "0.27.0"
+version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9793902457988cb3915eb9e57b509c8da10aa3a89a8949eabe4ebbb5f6625a40"
+checksum = "f6b561d56e7989062837c92f3cee6802f1b9cdb81b248bcc47790e38de1b96ab"
 dependencies = [ "aws-credential-types", "aws-endpoint", "aws-http", "aws-sig-auth", "aws-smithy-async", "aws-smithy-client", "aws-smithy-http", "aws-smithy-http-tower", "aws-smithy-json", "aws-smithy-types", "aws-types", "bytes", "http", "regex", "tokio-stream", "tower", "tracing",]
 
 [[package]]
 name = "aws-sig-auth"
-version = "0.55.2"
+version = "0.55.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84dc92a63ede3c2cbe43529cb87ffa58763520c96c6a46ca1ced80417afba845"
+checksum = "3b94acb10af0c879ecd5c7bdf51cda6679a0a4f4643ce630905a77673bfa3c61"
 dependencies = [ "aws-credential-types", "aws-sigv4", "aws-smithy-eventstream", "aws-smithy-http", "aws-types", "http", "tracing",]
 
 [[package]]
 name = "aws-sigv4"
-version = "0.55.2"
+version = "0.55.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "392fefab9d6fcbd76d518eb3b1c040b84728ab50f58df0c3c53ada4bea9d327e"
+checksum = "9d2ce6f507be68e968a33485ced670111d1cbad161ddbbab1e313c03d37d8f4c"
 dependencies = [ "aws-smithy-eventstream", "aws-smithy-http", "bytes", "form_urlencoded", "hex", "hmac 0.12.1", "http", "once_cell", "percent-encoding", "regex", "sha2", "time 0.3.20", "tracing",]
 
 [[package]]
 name = "aws-smithy-async"
-version = "0.55.2"
+version = "0.55.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae23b9fe7a07d0919000116c4c5c0578303fbce6fc8d32efca1f7759d4c20faf"
+checksum = "13bda3996044c202d75b91afeb11a9afae9db9a721c6a7a427410018e286b880"
 dependencies = [ "futures-util", "pin-project-lite", "tokio", "tokio-stream",]
 
 [[package]]
 name = "aws-smithy-checksums"
-version = "0.55.2"
+version = "0.55.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6367acbd6849b8c7c659e166955531274ae147bf83ab4312885991f6b6706cb"
+checksum = "07ed8b96d95402f3f6b8b57eb4e0e45ee365f78b1a924faf20ff6e97abf1eae6"
 dependencies = [ "aws-smithy-http", "aws-smithy-types", "bytes", "crc32c", "crc32fast", "hex", "http", "http-body", "md-5", "pin-project-lite", "sha1", "sha2", "tracing",]
 
 [[package]]
 name = "aws-smithy-client"
-version = "0.55.2"
+version = "0.55.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5230d25d244a51339273b8870f0f77874cd4449fb4f8f629b21188ae10cfc0ba"
+checksum = "0a86aa6e21e86c4252ad6a0e3e74da9617295d8d6e374d552be7d3059c41cedd"
 dependencies = [ "aws-smithy-async", "aws-smithy-http", "aws-smithy-http-tower", "aws-smithy-types", "bytes", "fastrand", "http", "http-body", "hyper", "hyper-rustls", "lazy_static", "pin-project-lite", "rustls", "tokio", "tower", "tracing",]
 
 [[package]]
 name = "aws-smithy-eventstream"
-version = "0.55.2"
+version = "0.55.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22d2a2bcc16e5c4d949ffd2b851da852b9bbed4bb364ed4ae371b42137ca06d9"
+checksum = "460c8da5110835e3d9a717c61f5556b20d03c32a1dec57f8fc559b360f733bb8"
 dependencies = [ "aws-smithy-types", "bytes", "crc32fast",]
 
 [[package]]
 name = "aws-smithy-http"
-version = "0.55.2"
+version = "0.55.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b60e2133beb9fe6ffe0b70deca57aaeff0a35ad24a9c6fab2fd3b4f45b99fdb5"
+checksum = "2b3b693869133551f135e1f2c77cb0b8277d9e3e17feaf2213f735857c4f0d28"
 dependencies = [ "aws-smithy-eventstream", "aws-smithy-types", "bytes", "bytes-utils", "futures-core", "http", "http-body", "hyper", "once_cell", "percent-encoding", "pin-project-lite", "pin-utils", "tokio", "tokio-util", "tracing",]
 
 [[package]]
 name = "aws-smithy-http-tower"
-version = "0.55.2"
+version = "0.55.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a4d94f556c86a0dd916a5d7c39747157ea8cb909ca469703e20fee33e448b67"
+checksum = "3ae4f6c5798a247fac98a867698197d9ac22643596dc3777f0c76b91917616b9"
 dependencies = [ "aws-smithy-http", "aws-smithy-types", "bytes", "http", "http-body", "pin-project-lite", "tower", "tracing",]
 
 [[package]]
 name = "aws-smithy-json"
-version = "0.55.2"
+version = "0.55.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ce3d6e6ebb00b2cce379f079ad5ec508f9bcc3a9510d9b9c1840ed1d6f8af39"
+checksum = "23f9f42fbfa96d095194a632fbac19f60077748eba536eb0b9fecc28659807f8"
 dependencies = [ "aws-smithy-types",]
 
 [[package]]
 name = "aws-smithy-query"
-version = "0.55.2"
+version = "0.55.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d58edfca32ef9bfbc1ca394599e17ea329cb52d6a07359827be74235b64b3298"
+checksum = "98819eb0b04020a1c791903533b638534ae6c12e2aceda3e6e6fba015608d51d"
 dependencies = [ "aws-smithy-types", "urlencoding",]
 
 [[package]]
 name = "aws-smithy-types"
-version = "0.55.2"
+version = "0.55.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "58db46fc1f4f26be01ebdb821751b4e2482cd43aa2b64a0348fb89762defaffa"
+checksum = "16a3d0bf4f324f4ef9793b86a1701d9700fbcdbd12a846da45eed104c634c6e8"
 dependencies = [ "base64-simd", "itoa", "num-integer", "ryu", "time 0.3.20",]
 
 [[package]]
 name = "aws-smithy-xml"
-version = "0.55.2"
+version = "0.55.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb557fe4995bd9ec87fb244bbb254666a971dc902a783e9da8b7711610e9664c"
+checksum = "b1b9d12875731bd07e767be7baad95700c3137b56730ec9ddeedb52a5e5ca63b"
 dependencies = [ "xmlparser",]
 
 [[package]]
 name = "aws-types"
-version = "0.55.2"
+version = "0.55.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de0869598bfe46ec44ffe17e063ed33336e59df90356ca8ff0e8da6f7c1d994b"
+checksum = "6dd209616cc8d7bfb82f87811a5c655dc97537f592689b18743bddf5dc5c4829"
 dependencies = [ "aws-credential-types", "aws-smithy-async", "aws-smithy-client", "aws-smithy-http", "aws-smithy-types", "http", "rustc_version", "tracing",]
 
 [[package]]
@@ -356,9 +362,9 @@ checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
 
 [[package]]
 name = "base64"
-version = "0.21.0"
+version = "0.21.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4a4ddaa51a5bc52a6948f74c06d20aaaddb71924eab79b8c97a8c556e942d6a"
+checksum = "604178f6c5c21f02dc555784810edfb88d34ac2c73b2eae109655649ee73ce3d"
 
 [[package]]
 name = "base64-simd"
@@ -421,9 +427,9 @@ dependencies = [ "cargo-lock",]
 
 [[package]]
 name = "bumpalo"
-version = "3.12.1"
+version = "3.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b1ce199063694f33ffb7dd4e0ee620741495c32833cde5aa08f02a0bf96f0c8"
+checksum = "a3e2c3daef883ecc1b5d58c15adae93470a91d425f3532ba1695849656af3fc1"
 
 [[package]]
 name = "byte-slice-cast"
@@ -458,14 +464,14 @@ dependencies = [ "bytes", "either",]
 
 [[package]]
 name = "cairo-rs"
-version = "0.17.9"
-source = "git+https://github.com/gtk-rs/gtk-rs-core?branch=0.17#3ad562c758bf7b2452827c2e6d35e4effce23f71"
+version = "0.17.10"
+source = "git+https://github.com/gtk-rs/gtk-rs-core?branch=0.17#6b109fb807237b5d07aff9a541ca68e9c2191abd"
 dependencies = [ "bitflags", "cairo-sys-rs", "glib", "libc", "once_cell", "thiserror",]
 
 [[package]]
 name = "cairo-sys-rs"
-version = "0.17.9"
-source = "git+https://github.com/gtk-rs/gtk-rs-core?branch=0.17#3ad562c758bf7b2452827c2e6d35e4effce23f71"
+version = "0.17.10"
+source = "git+https://github.com/gtk-rs/gtk-rs-core?branch=0.17#6b109fb807237b5d07aff9a541ca68e9c2191abd"
 dependencies = [ "glib-sys", "libc", "system-deps",]
 
 [[package]]
@@ -497,9 +503,9 @@ dependencies = [ "cdg", "image",]
 
 [[package]]
 name = "cfg-expr"
-version = "0.15.1"
+version = "0.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8790cf1286da485c72cf5fc7aeba308438800036ec67d89425924c4807268c9"
+checksum = "e70d3ad08698a0568b0562f22710fe6bfc1f4a61a367c77d0398c562eadd453a"
 dependencies = [ "smallvec", "target-lexicon",]
 
 [[package]]
@@ -510,10 +516,10 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "chrono"
-version = "0.4.24"
+version = "0.4.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e3c5919066adf22df73762e50cffcde3a758f2a848b113b586d1f86728b673b"
-dependencies = [ "iana-time-zone", "js-sys", "num-integer", "num-traits", "time 0.1.45", "wasm-bindgen", "winapi",]
+checksum = "ec837a71355b28f6556dbd569b37b3f363091c0bd4b2e735674521b4c5fd9bc5"
+dependencies = [ "android-tzdata", "iana-time-zone", "js-sys", "num-traits", "time 0.1.45", "wasm-bindgen", "winapi",]
 
 [[package]]
 name = "cipher"
@@ -524,43 +530,36 @@ dependencies = [ "generic-array",]
 
 [[package]]
 name = "clap"
-version = "4.2.7"
+version = "4.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34d21f9bf1b425d2968943631ec91202fe5e837264063503708b83013f8fc938"
+checksum = "401a4694d2bf92537b6867d94de48c4842089645fdcdf6c71865b175d836e9c2"
 dependencies = [ "clap_builder", "clap_derive", "once_cell",]
 
 [[package]]
 name = "clap_builder"
-version = "4.2.7"
+version = "4.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "914c8c79fb560f238ef6429439a30023c862f7a28e688c58f7203f12b29970bd"
+checksum = "72394f3339a76daf211e57d4bcb374410f3965dcc606dd0e03738c7888766980"
 dependencies = [ "anstream", "anstyle", "bitflags", "clap_lex", "strsim",]
 
 [[package]]
 name = "clap_derive"
-version = "4.2.0"
+version = "4.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f9644cd56d6b87dbe899ef8b053e331c0637664e9e21a33dfcdc36093f5c5c4"
-dependencies = [ "heck", "proc-macro2", "quote", "syn 2.0.15",]
+checksum = "b8cd2b2a819ad6eec39e8f1d6b53001af1e5469f8c177579cdaeb313115b825f"
+dependencies = [ "heck", "proc-macro2", "quote", "syn 2.0.18",]
 
 [[package]]
 name = "clap_lex"
-version = "0.4.1"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a2dd5a6fe8c6e3502f568a6353e5273bbb15193ad9a89e457b9970798efbea1"
+checksum = "2da6da31387c7e4ef160ffab6d5e7f00c42626fe39aea70a7b0f1773f7dd6c1b"
 
 [[package]]
 name = "claxon"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4bfbf56724aa9eca8afa4fcfadeb479e722935bb2a0900c2d37e0cc477af0688"
-
-[[package]]
-name = "codespan-reporting"
-version = "0.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3538270d33cc669650c4b093848450d380def10c331d38c768e34cac80576e6e"
-dependencies = [ "termcolor", "unicode-width",]
 
 [[package]]
 name = "color-name"
@@ -738,33 +737,6 @@ checksum = "fb4a30d54f7443bf3d6191dcd486aca19e67cb3c49fa7a06a319966346707e7f"
 dependencies = [ "cipher",]
 
 [[package]]
-name = "cxx"
-version = "1.0.94"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f61f1b6389c3fe1c316bf8a4dccc90a38208354b330925bce1f74a6c4756eb93"
-dependencies = [ "cc", "cxxbridge-flags", "cxxbridge-macro", "link-cplusplus",]
-
-[[package]]
-name = "cxx-build"
-version = "1.0.94"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12cee708e8962df2aeb38f594aae5d827c022b6460ac71a7a3e2c3c2aae5a07b"
-dependencies = [ "cc", "codespan-reporting", "once_cell", "proc-macro2", "quote", "scratch", "syn 2.0.15",]
-
-[[package]]
-name = "cxxbridge-flags"
-version = "1.0.94"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7944172ae7e4068c533afbb984114a56c46e9ccddda550499caa222902c7f7bb"
-
-[[package]]
-name = "cxxbridge-macro"
-version = "1.0.94"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2345488264226bf682893e25de0769f3360aac9957980ec49361b083ddaa5bc5"
-dependencies = [ "proc-macro2", "quote", "syn 2.0.15",]
-
-[[package]]
 name = "dasp_frame"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -779,9 +751,9 @@ checksum = "0c87e182de0887fd5361989c677c4e8f5000cd9491d6d563161a8f3a5519fc7f"
 
 [[package]]
 name = "data-encoding"
-version = "2.3.3"
+version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23d8666cb01533c39dde32bcbab8e227b4ed6679b2c925eba05feabea39508fb"
+checksum = "c2e66c9d817f1720209181c316d28635c050fa304f9c79e47a520882661b7308"
 
 [[package]]
 name = "dav1d"
@@ -812,9 +784,9 @@ dependencies = [ "generic-array",]
 
 [[package]]
 name = "digest"
-version = "0.10.6"
+version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8168378f4e5023e7218c89c891c0fd8ecdb5e5e4f18cb78f38cf245dd021e76f"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [ "block-buffer 0.10.4", "crypto-common", "subtle",]
 
 [[package]]
@@ -881,10 +853,10 @@ dependencies = [ "cc", "libc",]
 
 [[package]]
 name = "exr"
-version = "1.6.3"
+version = "1.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bdd2162b720141a91a054640662d3edce3d50a944a50ffca5313cd951abb35b4"
-dependencies = [ "bit_field", "flume", "half", "lebe", "miniz_oxide 0.6.2", "rayon-core", "smallvec", "zune-inflate",]
+checksum = "279d3efcc55e19917fff7ab3ddd6c14afb6a90881a0078465196fe2f99d08c56"
+dependencies = [ "bit_field", "flume", "half", "lebe", "miniz_oxide 0.7.1", "rayon-core", "smallvec", "zune-inflate",]
 
 [[package]]
 name = "fastrand"
@@ -908,10 +880,10 @@ dependencies = [ "crc 1.8.1", "num-traits", "thiserror",]
 
 [[package]]
 name = "field-offset"
-version = "0.3.5"
+version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3cf3a800ff6e860c863ca6d4b16fd999db8b752819c1606884047b73e468535"
-dependencies = [ "memoffset 0.8.0", "rustc_version",]
+checksum = "38e2275cc4e4fc009b0669731a1e5ab7ebf11f469eaede2bab9309a5b4d6057f"
+dependencies = [ "memoffset 0.9.0", "rustc_version",]
 
 [[package]]
 name = "fixedbitset"
@@ -960,9 +932,9 @@ checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
 name = "form_urlencoded"
-version = "1.1.0"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9c384f161156f5260c24a097c56119f9be8c798586aecc13afbcbe7b7e26bf8"
+checksum = "a62bc1cf6f830c2ec14a513a9fb124d0a213a629668a4186f329db21fe045652"
 dependencies = [ "percent-encoding",]
 
 [[package]]
@@ -1009,7 +981,7 @@ name = "futures-macro"
 version = "0.3.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "89ca545a94061b6365f2c7355b4b32bd20df3ff95f02da9329b34ccc3bd6ee72"
-dependencies = [ "proc-macro2", "quote", "syn 2.0.15",]
+dependencies = [ "proc-macro2", "quote", "syn 2.0.18",]
 
 [[package]]
 name = "futures-sink"
@@ -1032,14 +1004,14 @@ dependencies = [ "futures-channel", "futures-core", "futures-io", "futures-macro
 
 [[package]]
 name = "gdk-pixbuf"
-version = "0.17.9"
-source = "git+https://github.com/gtk-rs/gtk-rs-core?branch=0.17#3ad562c758bf7b2452827c2e6d35e4effce23f71"
+version = "0.17.10"
+source = "git+https://github.com/gtk-rs/gtk-rs-core?branch=0.17#6b109fb807237b5d07aff9a541ca68e9c2191abd"
 dependencies = [ "bitflags", "gdk-pixbuf-sys", "gio", "glib", "libc", "once_cell",]
 
 [[package]]
 name = "gdk-pixbuf-sys"
-version = "0.17.9"
-source = "git+https://github.com/gtk-rs/gtk-rs-core?branch=0.17#3ad562c758bf7b2452827c2e6d35e4effce23f71"
+version = "0.17.10"
+source = "git+https://github.com/gtk-rs/gtk-rs-core?branch=0.17#6b109fb807237b5d07aff9a541ca68e9c2191abd"
 dependencies = [ "gio-sys", "glib-sys", "gobject-sys", "libc", "system-deps",]
 
 [[package]]
@@ -1094,9 +1066,9 @@ dependencies = [ "unicode-width",]
 
 [[package]]
 name = "getrandom"
-version = "0.2.9"
+version = "0.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c85e1d9ab2eadba7e5040d4e09cbd6d072b76a557ad64e797c2cb9d4da21d7e4"
+checksum = "be4136b2a15dd319360be1c07d9933517ccf0be8f16bf62a3bee4f0d618df427"
 dependencies = [ "cfg-if", "js-sys", "libc", "wasi 0.11.0+wasi-snapshot-preview1", "wasm-bindgen",]
 
 [[package]]
@@ -1114,32 +1086,32 @@ checksum = "ad0a93d233ebf96623465aad4046a8d3aa4da22d4f4beba5388838c8a434bbb4"
 
 [[package]]
 name = "gio"
-version = "0.17.9"
-source = "git+https://github.com/gtk-rs/gtk-rs-core?branch=0.17#3ad562c758bf7b2452827c2e6d35e4effce23f71"
+version = "0.17.10"
+source = "git+https://github.com/gtk-rs/gtk-rs-core?branch=0.17#6b109fb807237b5d07aff9a541ca68e9c2191abd"
 dependencies = [ "bitflags", "futures-channel", "futures-core", "futures-io", "futures-util", "gio-sys", "glib", "libc", "once_cell", "pin-project-lite", "smallvec", "thiserror",]
 
 [[package]]
 name = "gio-sys"
-version = "0.17.9"
-source = "git+https://github.com/gtk-rs/gtk-rs-core?branch=0.17#3ad562c758bf7b2452827c2e6d35e4effce23f71"
+version = "0.17.10"
+source = "git+https://github.com/gtk-rs/gtk-rs-core?branch=0.17#6b109fb807237b5d07aff9a541ca68e9c2191abd"
 dependencies = [ "glib-sys", "gobject-sys", "libc", "system-deps", "winapi",]
 
 [[package]]
 name = "glib"
-version = "0.17.9"
-source = "git+https://github.com/gtk-rs/gtk-rs-core?branch=0.17#3ad562c758bf7b2452827c2e6d35e4effce23f71"
+version = "0.17.10"
+source = "git+https://github.com/gtk-rs/gtk-rs-core?branch=0.17#6b109fb807237b5d07aff9a541ca68e9c2191abd"
 dependencies = [ "bitflags", "futures-channel", "futures-core", "futures-executor", "futures-task", "futures-util", "gio-sys", "glib-macros", "glib-sys", "gobject-sys", "libc", "memchr", "once_cell", "smallvec", "thiserror",]
 
 [[package]]
 name = "glib-macros"
-version = "0.17.9"
-source = "git+https://github.com/gtk-rs/gtk-rs-core?branch=0.17#3ad562c758bf7b2452827c2e6d35e4effce23f71"
+version = "0.17.10"
+source = "git+https://github.com/gtk-rs/gtk-rs-core?branch=0.17#6b109fb807237b5d07aff9a541ca68e9c2191abd"
 dependencies = [ "anyhow", "heck", "proc-macro-crate", "proc-macro-error", "proc-macro2", "quote", "syn 1.0.109",]
 
 [[package]]
 name = "glib-sys"
-version = "0.17.9"
-source = "git+https://github.com/gtk-rs/gtk-rs-core?branch=0.17#3ad562c758bf7b2452827c2e6d35e4effce23f71"
+version = "0.17.10"
+source = "git+https://github.com/gtk-rs/gtk-rs-core?branch=0.17#6b109fb807237b5d07aff9a541ca68e9c2191abd"
 dependencies = [ "libc", "system-deps",]
 
 [[package]]
@@ -1150,20 +1122,20 @@ checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
 
 [[package]]
 name = "gobject-sys"
-version = "0.17.9"
-source = "git+https://github.com/gtk-rs/gtk-rs-core?branch=0.17#3ad562c758bf7b2452827c2e6d35e4effce23f71"
+version = "0.17.10"
+source = "git+https://github.com/gtk-rs/gtk-rs-core?branch=0.17#6b109fb807237b5d07aff9a541ca68e9c2191abd"
 dependencies = [ "glib-sys", "libc", "system-deps",]
 
 [[package]]
 name = "graphene-rs"
-version = "0.17.9"
-source = "git+https://github.com/gtk-rs/gtk-rs-core?branch=0.17#3ad562c758bf7b2452827c2e6d35e4effce23f71"
+version = "0.17.10"
+source = "git+https://github.com/gtk-rs/gtk-rs-core?branch=0.17#6b109fb807237b5d07aff9a541ca68e9c2191abd"
 dependencies = [ "glib", "graphene-sys", "libc",]
 
 [[package]]
 name = "graphene-sys"
-version = "0.17.9"
-source = "git+https://github.com/gtk-rs/gtk-rs-core?branch=0.17#3ad562c758bf7b2452827c2e6d35e4effce23f71"
+version = "0.17.10"
+source = "git+https://github.com/gtk-rs/gtk-rs-core?branch=0.17#6b109fb807237b5d07aff9a541ca68e9c2191abd"
 dependencies = [ "glib-sys", "libc", "pkg-config", "system-deps",]
 
 [[package]]
@@ -1180,188 +1152,188 @@ dependencies = [ "cairo-sys-rs", "gdk4-sys", "glib-sys", "gobject-sys", "graphen
 
 [[package]]
 name = "gst-plugin-audiofx"
-version = "0.10.7"
+version = "0.10.8"
 dependencies = [ "anyhow", "atomic_refcell", "byte-slice-cast", "ebur128", "gst-plugin-version-helper", "gstreamer", "gstreamer-app", "gstreamer-audio", "gstreamer-base", "gstreamer-check", "hrtf", "nnnoiseless", "num-traits", "once_cell", "rayon", "smallvec",]
 
 [[package]]
 name = "gst-plugin-aws"
-version = "0.10.7"
+version = "0.10.8"
 dependencies = [ "async-tungstenite", "atomic_refcell", "aws-config", "aws-credential-types", "aws-sdk-s3", "aws-sdk-transcribe", "aws-sig-auth", "aws-smithy-http", "aws-smithy-types", "aws-types", "backoff", "base32", "byteorder", "bytes", "chrono", "crc 3.0.1", "env_logger 0.10.0", "futures", "gio", "gst-plugin-version-helper", "gstreamer", "gstreamer-audio", "gstreamer-base", "gstreamer-check", "http", "nom", "once_cell", "percent-encoding", "rand", "serde", "serde_derive", "serde_json", "test-with", "tokio", "url",]
 
 [[package]]
 name = "gst-plugin-cdg"
-version = "0.10.7"
+version = "0.10.8"
 dependencies = [ "cdg", "cdg_renderer", "gst-plugin-version-helper", "gstreamer", "gstreamer-app", "gstreamer-base", "gstreamer-video", "image", "muldiv", "once_cell",]
 
 [[package]]
 name = "gst-plugin-claxon"
-version = "0.10.7"
+version = "0.10.8"
 dependencies = [ "atomic_refcell", "byte-slice-cast", "claxon", "gst-plugin-version-helper", "gstreamer", "gstreamer-audio", "gstreamer-check", "once_cell",]
 
 [[package]]
 name = "gst-plugin-closedcaption"
-version = "0.10.7"
+version = "0.10.8"
 dependencies = [ "anyhow", "atomic_refcell", "byteorder", "cairo-rs", "cc", "chrono", "either", "gst-plugin-version-helper", "gstreamer", "gstreamer-base", "gstreamer-check", "gstreamer-video", "nom", "once_cell", "pango", "pangocairo", "pretty_assertions", "rand", "serde", "serde_json", "uuid",]
 
 [[package]]
 name = "gst-plugin-csound"
-version = "0.10.7"
+version = "0.10.8"
 dependencies = [ "byte-slice-cast", "csound", "gst-plugin-version-helper", "gstreamer", "gstreamer-audio", "gstreamer-base", "gstreamer-check", "once_cell",]
 
 [[package]]
 name = "gst-plugin-dav1d"
-version = "0.10.7"
+version = "0.10.8"
 dependencies = [ "dav1d", "gst-plugin-version-helper", "gstreamer", "gstreamer-base", "gstreamer-video", "num_cpus", "once_cell",]
 
 [[package]]
 name = "gst-plugin-fallbackswitch"
-version = "0.10.7"
+version = "0.10.8"
 dependencies = [ "gio", "gst-plugin-gtk4", "gst-plugin-version-helper", "gstreamer", "gstreamer-app", "gstreamer-audio", "gstreamer-base", "gstreamer-check", "gstreamer-video", "gtk4", "once_cell", "parking_lot",]
 
 [[package]]
 name = "gst-plugin-ffv1"
-version = "0.10.7"
+version = "0.10.8"
 dependencies = [ "byte-slice-cast", "ffv1", "gst-plugin-version-helper", "gstreamer", "gstreamer-check", "gstreamer-video", "once_cell",]
 
 [[package]]
 name = "gst-plugin-file"
-version = "0.10.7"
+version = "0.10.8"
 dependencies = [ "gst-plugin-version-helper", "gstreamer", "gstreamer-base", "once_cell", "url",]
 
 [[package]]
 name = "gst-plugin-flavors"
-version = "0.10.7"
+version = "0.10.8"
 dependencies = [ "byteorder", "flavors", "gst-plugin-version-helper", "gstreamer", "gstreamer-audio", "gstreamer-base", "muldiv", "nom", "num-rational", "once_cell", "smallvec",]
 
 [[package]]
 name = "gst-plugin-fmp4"
-version = "0.10.7"
+version = "0.10.8"
 dependencies = [ "anyhow", "chrono", "gst-plugin-version-helper", "gstreamer", "gstreamer-app", "gstreamer-audio", "gstreamer-base", "gstreamer-check", "gstreamer-pbutils", "gstreamer-video", "m3u8-rs", "once_cell",]
 
 [[package]]
 name = "gst-plugin-gif"
-version = "0.10.7"
+version = "0.10.8"
 dependencies = [ "atomic_refcell", "gif", "gst-plugin-version-helper", "gstreamer", "gstreamer-check", "gstreamer-video", "once_cell",]
 
 [[package]]
 name = "gst-plugin-gtk4"
-version = "0.10.7"
+version = "0.10.8"
 dependencies = [ "gdk4-wayland", "gdk4-x11", "gst-plugin-version-helper", "gstreamer", "gstreamer-base", "gstreamer-gl", "gstreamer-gl-egl", "gstreamer-gl-wayland", "gstreamer-gl-x11", "gstreamer-video", "gtk4", "once_cell",]
 
 [[package]]
 name = "gst-plugin-hlssink3"
-version = "0.10.7"
+version = "0.10.8"
 dependencies = [ "gio", "glib", "gst-plugin-version-helper", "gstreamer", "gstreamer-audio", "gstreamer-base", "gstreamer-check", "m3u8-rs", "once_cell", "regex",]
 
 [[package]]
 name = "gst-plugin-hsv"
-version = "0.10.7"
+version = "0.10.8"
 dependencies = [ "byte-slice-cast", "gst-plugin-version-helper", "gstreamer", "gstreamer-audio", "gstreamer-base", "gstreamer-check", "gstreamer-video", "num-traits", "once_cell",]
 
 [[package]]
 name = "gst-plugin-json"
-version = "0.10.7"
+version = "0.10.8"
 dependencies = [ "gst-plugin-version-helper", "gstreamer", "gstreamer-check", "once_cell", "serde", "serde_json",]
 
 [[package]]
 name = "gst-plugin-lewton"
-version = "0.10.7"
+version = "0.10.8"
 dependencies = [ "atomic_refcell", "byte-slice-cast", "gst-plugin-version-helper", "gstreamer", "gstreamer-audio", "gstreamer-check", "lewton", "once_cell",]
 
 [[package]]
 name = "gst-plugin-livesync"
-version = "0.10.7"
+version = "0.10.8"
 dependencies = [ "gio", "gst-plugin-gtk4", "gst-plugin-version-helper", "gstreamer", "gstreamer-audio", "gstreamer-check", "gtk4", "muldiv", "num-rational", "once_cell", "parking_lot",]
 
 [[package]]
 name = "gst-plugin-mp4"
-version = "0.10.7"
+version = "0.10.8"
 dependencies = [ "anyhow", "gst-plugin-version-helper", "gstreamer", "gstreamer-audio", "gstreamer-base", "gstreamer-pbutils", "gstreamer-video", "once_cell", "tempfile", "url",]
 
 [[package]]
 name = "gst-plugin-ndi"
-version = "0.10.7"
+version = "0.10.8"
 dependencies = [ "atomic_refcell", "byte-slice-cast", "byteorder", "glib", "gst-plugin-version-helper", "gstreamer", "gstreamer-audio", "gstreamer-base", "gstreamer-video", "libloading", "once_cell",]
 
 [[package]]
 name = "gst-plugin-onvif"
-version = "0.10.7"
+version = "0.10.8"
 dependencies = [ "cairo-rs", "chrono", "gst-plugin-version-helper", "gstreamer", "gstreamer-base", "gstreamer-rtp", "gstreamer-video", "once_cell", "pango", "pangocairo", "xmlparser", "xmltree",]
 
 [[package]]
 name = "gst-plugin-png"
-version = "0.10.7"
+version = "0.10.8"
 dependencies = [ "gst-plugin-version-helper", "gstreamer", "gstreamer-check", "gstreamer-video", "once_cell", "parking_lot", "png",]
 
 [[package]]
 name = "gst-plugin-raptorq"
-version = "0.10.7"
+version = "0.10.8"
 dependencies = [ "gst-plugin-version-helper", "gstreamer", "gstreamer-base", "gstreamer-check", "gstreamer-rtp", "once_cell", "rand", "raptorq",]
 
 [[package]]
 name = "gst-plugin-rav1e"
-version = "0.10.7"
+version = "0.10.8"
 dependencies = [ "atomic_refcell", "gst-plugin-version-helper", "gstreamer", "gstreamer-check", "gstreamer-video", "once_cell", "rav1e",]
 
 [[package]]
 name = "gst-plugin-regex"
-version = "0.10.7"
+version = "0.10.8"
 dependencies = [ "gst-plugin-version-helper", "gstreamer", "gstreamer-check", "once_cell", "regex",]
 
 [[package]]
 name = "gst-plugin-reqwest"
-version = "0.10.7"
+version = "0.10.8"
 dependencies = [ "futures", "gst-plugin-version-helper", "gstreamer", "gstreamer-base", "headers", "hyper", "mime", "once_cell", "reqwest", "tokio", "url",]
 
 [[package]]
 name = "gst-plugin-rtp"
-version = "0.10.7"
+version = "0.10.8"
 dependencies = [ "bitstream-io", "chrono", "gst-plugin-version-helper", "gstreamer", "gstreamer-check", "gstreamer-rtp", "once_cell",]
 
 [[package]]
 name = "gst-plugin-sodium"
-version = "0.10.7"
+version = "0.10.8"
 dependencies = [ "clap", "gst-plugin-version-helper", "gstreamer", "gstreamer-app", "gstreamer-base", "gstreamer-check", "hex", "once_cell", "pretty_assertions", "rand", "serde", "serde_json", "smallvec", "sodiumoxide",]
 
 [[package]]
 name = "gst-plugin-spotify"
-version = "0.10.7"
+version = "0.10.8"
 dependencies = [ "anyhow", "futures", "gst-plugin-version-helper", "gstreamer", "gstreamer-base", "librespot", "once_cell", "tokio", "url",]
 
 [[package]]
 name = "gst-plugin-textahead"
-version = "0.10.7"
+version = "0.10.8"
 dependencies = [ "gst-plugin-version-helper", "gstreamer", "once_cell",]
 
 [[package]]
 name = "gst-plugin-textwrap"
-version = "0.10.7"
+version = "0.10.8"
 dependencies = [ "gst-plugin-version-helper", "gstreamer", "gstreamer-check", "hyphenation", "once_cell", "textwrap",]
 
 [[package]]
 name = "gst-plugin-threadshare"
-version = "0.10.7"
-dependencies = [ "async-task", "cc", "clap", "concurrent-queue", "flume", "futures", "gio", "gst-plugin-version-helper", "gstreamer", "gstreamer-app", "gstreamer-audio", "gstreamer-check", "gstreamer-net", "gstreamer-rtp", "libc", "once_cell", "pin-project-lite", "pkg-config", "polling", "rand", "slab", "socket2 0.5.2", "waker-fn", "winapi",]
+version = "0.10.8"
+dependencies = [ "async-task", "cc", "clap", "concurrent-queue", "flume", "futures", "gio", "gst-plugin-version-helper", "gstreamer", "gstreamer-app", "gstreamer-audio", "gstreamer-check", "gstreamer-net", "gstreamer-rtp", "libc", "once_cell", "pin-project-lite", "pkg-config", "polling", "rand", "slab", "socket2 0.5.3", "waker-fn", "winapi",]
 
 [[package]]
 name = "gst-plugin-togglerecord"
-version = "0.10.7"
+version = "0.10.8"
 dependencies = [ "either", "gio", "gst-plugin-gtk4", "gst-plugin-version-helper", "gstreamer", "gstreamer-audio", "gstreamer-video", "gtk4", "once_cell", "parking_lot",]
 
 [[package]]
 name = "gst-plugin-tracers"
-version = "0.10.7"
+version = "0.10.8"
 dependencies = [ "anyhow", "gst-plugin-version-helper", "gstreamer", "once_cell", "regex", "signal-hook",]
 
 [[package]]
 name = "gst-plugin-tutorial"
-version = "0.10.7"
+version = "0.10.8"
 dependencies = [ "byte-slice-cast", "gst-plugin-version-helper", "gstreamer", "gstreamer-audio", "gstreamer-base", "gstreamer-video", "num-traits", "once_cell",]
 
 [[package]]
 name = "gst-plugin-uriplaylistbin"
-version = "0.10.7"
-dependencies = [ "anyhow", "clap", "gst-plugin-version-helper", "gstreamer", "gstreamer-app", "more-asserts", "once_cell", "url",]
+version = "0.10.8"
+dependencies = [ "anyhow", "clap", "gst-plugin-version-helper", "gstreamer", "gstreamer-app", "more-asserts", "once_cell", "thiserror", "url",]
 
 [[package]]
 name = "gst-plugin-version-helper"
@@ -1370,218 +1342,218 @@ dependencies = [ "chrono",]
 
 [[package]]
 name = "gst-plugin-videofx"
-version = "0.10.7"
+version = "0.10.8"
 dependencies = [ "atomic_refcell", "cairo-rs", "color-name", "color-thief", "dssim-core", "gst-plugin-version-helper", "gstreamer", "gstreamer-base", "gstreamer-check", "gstreamer-video", "image", "image_hasher", "once_cell", "rgb",]
 
 [[package]]
 name = "gst-plugin-webp"
-version = "0.10.7"
+version = "0.10.8"
 dependencies = [ "gst-plugin-version-helper", "gstreamer", "gstreamer-check", "gstreamer-video", "libwebp-sys2", "once_cell", "pretty_assertions",]
 
 [[package]]
 name = "gst-plugin-webrtc"
-version = "0.10.7"
+version = "0.10.8"
 dependencies = [ "anyhow", "async-tungstenite", "clap", "fastrand", "futures", "gst-plugin-version-helper", "gst-plugin-webrtc-signalling-protocol", "gstreamer", "gstreamer-app", "gstreamer-base", "gstreamer-rtp", "gstreamer-sdp", "gstreamer-utils", "gstreamer-video", "gstreamer-webrtc", "human_bytes", "once_cell", "serde", "serde_json", "thiserror", "tokio", "tokio-native-tls", "tokio-stream", "tracing", "tracing-log", "tracing-subscriber", "url", "uuid",]
 
 [[package]]
 name = "gst-plugin-webrtc-signalling"
-version = "0.10.7"
+version = "0.10.8"
 dependencies = [ "anyhow", "async-tungstenite", "clap", "futures", "gst-plugin-webrtc-signalling-protocol", "once_cell", "pin-project-lite", "serde", "serde_json", "test-log", "thiserror", "tokio", "tokio-native-tls", "tracing", "tracing-log", "tracing-subscriber", "uuid",]
 
 [[package]]
 name = "gst-plugin-webrtc-signalling-protocol"
-version = "0.10.7"
+version = "0.10.8"
 dependencies = [ "serde", "serde_json",]
 
 [[package]]
 name = "gst-plugin-webrtchttp"
-version = "0.10.7"
+version = "0.10.8"
 dependencies = [ "async-recursion", "bytes", "futures", "gst-plugin-version-helper", "gstreamer", "gstreamer-sdp", "gstreamer-webrtc", "once_cell", "parse_link_header", "reqwest", "tokio",]
 
 [[package]]
 name = "gstreamer"
-version = "0.20.5"
-source = "git+https://gitlab.freedesktop.org/gstreamer/gstreamer-rs?branch=0.20#50ec1922855441994c1cbe3e85a584cd91e72ddd"
+version = "0.20.6"
+source = "git+https://gitlab.freedesktop.org/gstreamer/gstreamer-rs?branch=0.20#f17ef98d4a73df014ae0eed2fe1fbc56ddd3facc"
 dependencies = [ "bitflags", "cfg-if", "futures-channel", "futures-core", "futures-util", "glib", "gstreamer-sys", "libc", "muldiv", "num-integer", "num-rational", "once_cell", "option-operations", "paste", "pretty-hex", "serde", "serde_bytes", "smallvec", "thiserror",]
 
 [[package]]
 name = "gstreamer-app"
-version = "0.20.5"
-source = "git+https://gitlab.freedesktop.org/gstreamer/gstreamer-rs?branch=0.20#50ec1922855441994c1cbe3e85a584cd91e72ddd"
+version = "0.20.6"
+source = "git+https://gitlab.freedesktop.org/gstreamer/gstreamer-rs?branch=0.20#f17ef98d4a73df014ae0eed2fe1fbc56ddd3facc"
 dependencies = [ "bitflags", "futures-core", "futures-sink", "glib", "gstreamer", "gstreamer-app-sys", "gstreamer-base", "libc", "once_cell",]
 
 [[package]]
 name = "gstreamer-app-sys"
-version = "0.20.5"
-source = "git+https://gitlab.freedesktop.org/gstreamer/gstreamer-rs?branch=0.20#50ec1922855441994c1cbe3e85a584cd91e72ddd"
+version = "0.20.6"
+source = "git+https://gitlab.freedesktop.org/gstreamer/gstreamer-rs?branch=0.20#f17ef98d4a73df014ae0eed2fe1fbc56ddd3facc"
 dependencies = [ "glib-sys", "gstreamer-base-sys", "gstreamer-sys", "libc", "system-deps",]
 
 [[package]]
 name = "gstreamer-audio"
-version = "0.20.5"
-source = "git+https://gitlab.freedesktop.org/gstreamer/gstreamer-rs?branch=0.20#50ec1922855441994c1cbe3e85a584cd91e72ddd"
+version = "0.20.6"
+source = "git+https://gitlab.freedesktop.org/gstreamer/gstreamer-rs?branch=0.20#f17ef98d4a73df014ae0eed2fe1fbc56ddd3facc"
 dependencies = [ "bitflags", "cfg-if", "glib", "gstreamer", "gstreamer-audio-sys", "gstreamer-base", "libc", "once_cell",]
 
 [[package]]
 name = "gstreamer-audio-sys"
-version = "0.20.5"
-source = "git+https://gitlab.freedesktop.org/gstreamer/gstreamer-rs?branch=0.20#50ec1922855441994c1cbe3e85a584cd91e72ddd"
+version = "0.20.6"
+source = "git+https://gitlab.freedesktop.org/gstreamer/gstreamer-rs?branch=0.20#f17ef98d4a73df014ae0eed2fe1fbc56ddd3facc"
 dependencies = [ "glib-sys", "gobject-sys", "gstreamer-base-sys", "gstreamer-sys", "libc", "system-deps",]
 
 [[package]]
 name = "gstreamer-base"
-version = "0.20.5"
-source = "git+https://gitlab.freedesktop.org/gstreamer/gstreamer-rs?branch=0.20#50ec1922855441994c1cbe3e85a584cd91e72ddd"
+version = "0.20.6"
+source = "git+https://gitlab.freedesktop.org/gstreamer/gstreamer-rs?branch=0.20#f17ef98d4a73df014ae0eed2fe1fbc56ddd3facc"
 dependencies = [ "atomic_refcell", "bitflags", "cfg-if", "glib", "gstreamer", "gstreamer-base-sys", "libc",]
 
 [[package]]
 name = "gstreamer-base-sys"
-version = "0.20.5"
-source = "git+https://gitlab.freedesktop.org/gstreamer/gstreamer-rs?branch=0.20#50ec1922855441994c1cbe3e85a584cd91e72ddd"
+version = "0.20.6"
+source = "git+https://gitlab.freedesktop.org/gstreamer/gstreamer-rs?branch=0.20#f17ef98d4a73df014ae0eed2fe1fbc56ddd3facc"
 dependencies = [ "glib-sys", "gobject-sys", "gstreamer-sys", "libc", "system-deps",]
 
 [[package]]
 name = "gstreamer-check"
-version = "0.20.5"
-source = "git+https://gitlab.freedesktop.org/gstreamer/gstreamer-rs?branch=0.20#50ec1922855441994c1cbe3e85a584cd91e72ddd"
+version = "0.20.6"
+source = "git+https://gitlab.freedesktop.org/gstreamer/gstreamer-rs?branch=0.20#f17ef98d4a73df014ae0eed2fe1fbc56ddd3facc"
 dependencies = [ "bitflags", "glib", "gstreamer", "gstreamer-check-sys",]
 
 [[package]]
 name = "gstreamer-check-sys"
-version = "0.20.5"
-source = "git+https://gitlab.freedesktop.org/gstreamer/gstreamer-rs?branch=0.20#50ec1922855441994c1cbe3e85a584cd91e72ddd"
+version = "0.20.6"
+source = "git+https://gitlab.freedesktop.org/gstreamer/gstreamer-rs?branch=0.20#f17ef98d4a73df014ae0eed2fe1fbc56ddd3facc"
 dependencies = [ "glib-sys", "gobject-sys", "gstreamer-sys", "libc", "system-deps",]
 
 [[package]]
 name = "gstreamer-gl"
-version = "0.20.5"
-source = "git+https://gitlab.freedesktop.org/gstreamer/gstreamer-rs?branch=0.20#50ec1922855441994c1cbe3e85a584cd91e72ddd"
+version = "0.20.6"
+source = "git+https://gitlab.freedesktop.org/gstreamer/gstreamer-rs?branch=0.20#f17ef98d4a73df014ae0eed2fe1fbc56ddd3facc"
 dependencies = [ "bitflags", "glib", "gstreamer", "gstreamer-base", "gstreamer-gl-sys", "gstreamer-video", "libc", "once_cell",]
 
 [[package]]
 name = "gstreamer-gl-egl"
-version = "0.20.5"
-source = "git+https://gitlab.freedesktop.org/gstreamer/gstreamer-rs?branch=0.20#50ec1922855441994c1cbe3e85a584cd91e72ddd"
+version = "0.20.6"
+source = "git+https://gitlab.freedesktop.org/gstreamer/gstreamer-rs?branch=0.20#f17ef98d4a73df014ae0eed2fe1fbc56ddd3facc"
 dependencies = [ "glib", "gstreamer", "gstreamer-gl", "gstreamer-gl-egl-sys", "libc",]
 
 [[package]]
 name = "gstreamer-gl-egl-sys"
-version = "0.20.5"
-source = "git+https://gitlab.freedesktop.org/gstreamer/gstreamer-rs?branch=0.20#50ec1922855441994c1cbe3e85a584cd91e72ddd"
+version = "0.20.6"
+source = "git+https://gitlab.freedesktop.org/gstreamer/gstreamer-rs?branch=0.20#f17ef98d4a73df014ae0eed2fe1fbc56ddd3facc"
 dependencies = [ "glib-sys", "gstreamer-gl-sys", "libc", "system-deps",]
 
 [[package]]
 name = "gstreamer-gl-sys"
-version = "0.20.5"
-source = "git+https://gitlab.freedesktop.org/gstreamer/gstreamer-rs?branch=0.20#50ec1922855441994c1cbe3e85a584cd91e72ddd"
+version = "0.20.6"
+source = "git+https://gitlab.freedesktop.org/gstreamer/gstreamer-rs?branch=0.20#f17ef98d4a73df014ae0eed2fe1fbc56ddd3facc"
 dependencies = [ "glib-sys", "gobject-sys", "gstreamer-base-sys", "gstreamer-sys", "gstreamer-video-sys", "libc", "system-deps",]
 
 [[package]]
 name = "gstreamer-gl-wayland"
-version = "0.20.5"
-source = "git+https://gitlab.freedesktop.org/gstreamer/gstreamer-rs?branch=0.20#50ec1922855441994c1cbe3e85a584cd91e72ddd"
+version = "0.20.6"
+source = "git+https://gitlab.freedesktop.org/gstreamer/gstreamer-rs?branch=0.20#f17ef98d4a73df014ae0eed2fe1fbc56ddd3facc"
 dependencies = [ "glib", "gstreamer", "gstreamer-gl", "gstreamer-gl-wayland-sys", "libc",]
 
 [[package]]
 name = "gstreamer-gl-wayland-sys"
-version = "0.20.5"
-source = "git+https://gitlab.freedesktop.org/gstreamer/gstreamer-rs?branch=0.20#50ec1922855441994c1cbe3e85a584cd91e72ddd"
+version = "0.20.6"
+source = "git+https://gitlab.freedesktop.org/gstreamer/gstreamer-rs?branch=0.20#f17ef98d4a73df014ae0eed2fe1fbc56ddd3facc"
 dependencies = [ "glib-sys", "gstreamer-gl-sys", "libc", "system-deps",]
 
 [[package]]
 name = "gstreamer-gl-x11"
-version = "0.20.5"
-source = "git+https://gitlab.freedesktop.org/gstreamer/gstreamer-rs?branch=0.20#50ec1922855441994c1cbe3e85a584cd91e72ddd"
+version = "0.20.6"
+source = "git+https://gitlab.freedesktop.org/gstreamer/gstreamer-rs?branch=0.20#f17ef98d4a73df014ae0eed2fe1fbc56ddd3facc"
 dependencies = [ "glib", "gstreamer", "gstreamer-gl", "gstreamer-gl-x11-sys", "libc",]
 
 [[package]]
 name = "gstreamer-gl-x11-sys"
-version = "0.20.5"
-source = "git+https://gitlab.freedesktop.org/gstreamer/gstreamer-rs?branch=0.20#50ec1922855441994c1cbe3e85a584cd91e72ddd"
+version = "0.20.6"
+source = "git+https://gitlab.freedesktop.org/gstreamer/gstreamer-rs?branch=0.20#f17ef98d4a73df014ae0eed2fe1fbc56ddd3facc"
 dependencies = [ "glib-sys", "gstreamer-gl-sys", "libc", "system-deps",]
 
 [[package]]
 name = "gstreamer-net"
-version = "0.20.5"
-source = "git+https://gitlab.freedesktop.org/gstreamer/gstreamer-rs?branch=0.20#50ec1922855441994c1cbe3e85a584cd91e72ddd"
+version = "0.20.6"
+source = "git+https://gitlab.freedesktop.org/gstreamer/gstreamer-rs?branch=0.20#f17ef98d4a73df014ae0eed2fe1fbc56ddd3facc"
 dependencies = [ "gio", "glib", "gstreamer", "gstreamer-net-sys",]
 
 [[package]]
 name = "gstreamer-net-sys"
-version = "0.20.5"
-source = "git+https://gitlab.freedesktop.org/gstreamer/gstreamer-rs?branch=0.20#50ec1922855441994c1cbe3e85a584cd91e72ddd"
+version = "0.20.6"
+source = "git+https://gitlab.freedesktop.org/gstreamer/gstreamer-rs?branch=0.20#f17ef98d4a73df014ae0eed2fe1fbc56ddd3facc"
 dependencies = [ "gio-sys", "glib-sys", "gstreamer-sys", "libc", "system-deps",]
 
 [[package]]
 name = "gstreamer-pbutils"
-version = "0.20.5"
-source = "git+https://gitlab.freedesktop.org/gstreamer/gstreamer-rs?branch=0.20#50ec1922855441994c1cbe3e85a584cd91e72ddd"
+version = "0.20.6"
+source = "git+https://gitlab.freedesktop.org/gstreamer/gstreamer-rs?branch=0.20#f17ef98d4a73df014ae0eed2fe1fbc56ddd3facc"
 dependencies = [ "bitflags", "glib", "gstreamer", "gstreamer-audio", "gstreamer-pbutils-sys", "gstreamer-video", "libc", "thiserror",]
 
 [[package]]
 name = "gstreamer-pbutils-sys"
-version = "0.20.5"
-source = "git+https://gitlab.freedesktop.org/gstreamer/gstreamer-rs?branch=0.20#50ec1922855441994c1cbe3e85a584cd91e72ddd"
+version = "0.20.6"
+source = "git+https://gitlab.freedesktop.org/gstreamer/gstreamer-rs?branch=0.20#f17ef98d4a73df014ae0eed2fe1fbc56ddd3facc"
 dependencies = [ "glib-sys", "gobject-sys", "gstreamer-audio-sys", "gstreamer-sys", "gstreamer-video-sys", "libc", "system-deps",]
 
 [[package]]
 name = "gstreamer-rtp"
-version = "0.20.5"
-source = "git+https://gitlab.freedesktop.org/gstreamer/gstreamer-rs?branch=0.20#50ec1922855441994c1cbe3e85a584cd91e72ddd"
+version = "0.20.6"
+source = "git+https://gitlab.freedesktop.org/gstreamer/gstreamer-rs?branch=0.20#f17ef98d4a73df014ae0eed2fe1fbc56ddd3facc"
 dependencies = [ "bitflags", "glib", "gstreamer", "gstreamer-rtp-sys", "libc", "once_cell",]
 
 [[package]]
 name = "gstreamer-rtp-sys"
-version = "0.20.5"
-source = "git+https://gitlab.freedesktop.org/gstreamer/gstreamer-rs?branch=0.20#50ec1922855441994c1cbe3e85a584cd91e72ddd"
+version = "0.20.6"
+source = "git+https://gitlab.freedesktop.org/gstreamer/gstreamer-rs?branch=0.20#f17ef98d4a73df014ae0eed2fe1fbc56ddd3facc"
 dependencies = [ "glib-sys", "gstreamer-base-sys", "gstreamer-sys", "libc", "system-deps",]
 
 [[package]]
 name = "gstreamer-sdp"
-version = "0.20.5"
-source = "git+https://gitlab.freedesktop.org/gstreamer/gstreamer-rs?branch=0.20#50ec1922855441994c1cbe3e85a584cd91e72ddd"
+version = "0.20.6"
+source = "git+https://gitlab.freedesktop.org/gstreamer/gstreamer-rs?branch=0.20#f17ef98d4a73df014ae0eed2fe1fbc56ddd3facc"
 dependencies = [ "glib", "gstreamer", "gstreamer-sdp-sys",]
 
 [[package]]
 name = "gstreamer-sdp-sys"
-version = "0.20.5"
-source = "git+https://gitlab.freedesktop.org/gstreamer/gstreamer-rs?branch=0.20#50ec1922855441994c1cbe3e85a584cd91e72ddd"
+version = "0.20.6"
+source = "git+https://gitlab.freedesktop.org/gstreamer/gstreamer-rs?branch=0.20#f17ef98d4a73df014ae0eed2fe1fbc56ddd3facc"
 dependencies = [ "glib-sys", "gstreamer-sys", "libc", "system-deps",]
 
 [[package]]
 name = "gstreamer-sys"
-version = "0.20.5"
-source = "git+https://gitlab.freedesktop.org/gstreamer/gstreamer-rs?branch=0.20#50ec1922855441994c1cbe3e85a584cd91e72ddd"
+version = "0.20.6"
+source = "git+https://gitlab.freedesktop.org/gstreamer/gstreamer-rs?branch=0.20#f17ef98d4a73df014ae0eed2fe1fbc56ddd3facc"
 dependencies = [ "glib-sys", "gobject-sys", "libc", "system-deps",]
 
 [[package]]
 name = "gstreamer-utils"
-version = "0.20.5"
-source = "git+https://gitlab.freedesktop.org/gstreamer/gstreamer-rs?branch=0.20#50ec1922855441994c1cbe3e85a584cd91e72ddd"
+version = "0.20.6"
+source = "git+https://gitlab.freedesktop.org/gstreamer/gstreamer-rs?branch=0.20#f17ef98d4a73df014ae0eed2fe1fbc56ddd3facc"
 dependencies = [ "gstreamer", "gstreamer-app", "gstreamer-video", "once_cell", "thiserror",]
 
 [[package]]
 name = "gstreamer-video"
-version = "0.20.5"
-source = "git+https://gitlab.freedesktop.org/gstreamer/gstreamer-rs?branch=0.20#50ec1922855441994c1cbe3e85a584cd91e72ddd"
+version = "0.20.6"
+source = "git+https://gitlab.freedesktop.org/gstreamer/gstreamer-rs?branch=0.20#f17ef98d4a73df014ae0eed2fe1fbc56ddd3facc"
 dependencies = [ "bitflags", "cfg-if", "futures-channel", "glib", "gstreamer", "gstreamer-base", "gstreamer-video-sys", "libc", "once_cell", "serde",]
 
 [[package]]
 name = "gstreamer-video-sys"
-version = "0.20.5"
-source = "git+https://gitlab.freedesktop.org/gstreamer/gstreamer-rs?branch=0.20#50ec1922855441994c1cbe3e85a584cd91e72ddd"
+version = "0.20.6"
+source = "git+https://gitlab.freedesktop.org/gstreamer/gstreamer-rs?branch=0.20#f17ef98d4a73df014ae0eed2fe1fbc56ddd3facc"
 dependencies = [ "glib-sys", "gobject-sys", "gstreamer-base-sys", "gstreamer-sys", "libc", "system-deps",]
 
 [[package]]
 name = "gstreamer-webrtc"
-version = "0.20.5"
-source = "git+https://gitlab.freedesktop.org/gstreamer/gstreamer-rs?branch=0.20#50ec1922855441994c1cbe3e85a584cd91e72ddd"
+version = "0.20.6"
+source = "git+https://gitlab.freedesktop.org/gstreamer/gstreamer-rs?branch=0.20#f17ef98d4a73df014ae0eed2fe1fbc56ddd3facc"
 dependencies = [ "glib", "gstreamer", "gstreamer-sdp", "gstreamer-webrtc-sys", "libc",]
 
 [[package]]
 name = "gstreamer-webrtc-sys"
-version = "0.20.5"
-source = "git+https://gitlab.freedesktop.org/gstreamer/gstreamer-rs?branch=0.20#50ec1922855441994c1cbe3e85a584cd91e72ddd"
+version = "0.20.6"
+source = "git+https://gitlab.freedesktop.org/gstreamer/gstreamer-rs?branch=0.20#f17ef98d4a73df014ae0eed2fe1fbc56ddd3facc"
 dependencies = [ "glib-sys", "gstreamer-sdp-sys", "gstreamer-sys", "libc", "system-deps",]
 
 [[package]]
@@ -1604,9 +1576,9 @@ dependencies = [ "cairo-sys-rs", "gdk-pixbuf-sys", "gdk4-sys", "gio-sys", "glib-
 
 [[package]]
 name = "h2"
-version = "0.3.18"
+version = "0.3.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17f8a914c2987b688368b5138aa05321db91f4090cf26118185672ad588bce21"
+checksum = "d357c7ae988e7d2182f7d7871d0b963962420b0678b0997ce7de72001aeab782"
 dependencies = [ "bytes", "fnv", "futures-core", "futures-sink", "futures-util", "http", "indexmap", "slab", "tokio", "tokio-util", "tracing",]
 
 [[package]]
@@ -1681,7 +1653,7 @@ name = "hmac"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
-dependencies = [ "digest 0.10.6",]
+dependencies = [ "digest 0.10.7",]
 
 [[package]]
 name = "hostname"
@@ -1786,10 +1758,10 @@ dependencies = [ "android_system_properties", "core-foundation-sys", "iana-time-
 
 [[package]]
 name = "iana-time-zone-haiku"
-version = "0.1.1"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0703ae284fc167426161c2e3f1da3ea71d94b21bedbcc9494e92b28e334e3dca"
-dependencies = [ "cxx", "cxx-build",]
+checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
+dependencies = [ "cc",]
 
 [[package]]
 name = "idna"
@@ -1803,6 +1775,13 @@ name = "idna"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e14ddfc70884202db2244c223200c204c2bda1bc6e0998d11b5e024d657209e6"
+dependencies = [ "unicode-bidi", "unicode-normalization",]
+
+[[package]]
+name = "idna"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d20d6b07bfbc108882d88ed8e37d39636dcc260e15e30c45e6ba089610b917c"
 dependencies = [ "unicode-bidi", "unicode-normalization",]
 
 [[package]]
@@ -1821,10 +1800,10 @@ dependencies = [ "bytemuck", "byteorder", "color_quant", "exr", "gif", "jpeg-dec
 
 [[package]]
 name = "image_hasher"
-version = "1.1.2"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a465709ca502270eba7ae8129c6a680f5668748d7edafa85da0f8ceae596bb2b"
-dependencies = [ "base64 0.13.1", "image", "rustdct", "serde", "transpose",]
+checksum = "8f9e64a8c472ea9f81ac448e3b488fd82dcdfce6434cf880882bf36bfb5c268a"
+dependencies = [ "base64 0.21.2", "image", "rustdct", "serde", "transpose",]
 
 [[package]]
 name = "imgref"
@@ -1855,9 +1834,9 @@ dependencies = [ "proc-macro2", "quote", "syn 1.0.109",]
 
 [[package]]
 name = "io-lifetimes"
-version = "1.0.10"
+version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c66c74d2ae7e79a5a8f7ac924adbe38ee42a859c6539ad869eb51f0b52dc220"
+checksum = "eae7b9aee968036d54dce06cebaefd919e4472e753296daccd6d344e3e2df0c2"
 dependencies = [ "hermit-abi 0.3.1", "libc", "windows-sys 0.48.0",]
 
 [[package]]
@@ -1902,9 +1881,9 @@ dependencies = [ "rayon",]
 
 [[package]]
 name = "js-sys"
-version = "0.3.61"
+version = "0.3.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "445dde2150c55e483f3d8416706b97ec8e8237c307e5b7b4b8dd15e6af2a0730"
+checksum = "2f37a4a5928311ac501dee68b3c7613a1037d0edb30c8e5427bd832d55d1b790"
 dependencies = [ "wasm-bindgen",]
 
 [[package]]
@@ -1928,9 +1907,9 @@ dependencies = [ "byteorder", "ogg", "tinyvec",]
 
 [[package]]
 name = "libc"
-version = "0.2.144"
+version = "0.2.146"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b00cc1c228a6782d0f076e7b232802e0c5689d41bb5df366f2a6b6621cfdfe1"
+checksum = "f92be4933c13fd498862a9e02a3055f8a8d9c039ce33db97306fd5a6caa7f29b"
 
 [[package]]
 name = "libfuzzer-sys"
@@ -1948,9 +1927,9 @@ dependencies = [ "cfg-if", "windows-sys 0.48.0",]
 
 [[package]]
 name = "libm"
-version = "0.2.6"
+version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "348108ab3fba42ec82ff6e9564fc4ca0247bdccdc68dd8af9764bbc79c3c8ffb"
+checksum = "f7012b1bbb0719e1097c47611d3898568c546d597c2e74d66f6087edd5233ff4"
 
 [[package]]
 name = "libmdns"
@@ -2030,31 +2009,23 @@ checksum = "74f9c6964201c51319f16a796dc947a73961646eba49f584187b12de9970d077"
 dependencies = [ "cc", "cfg-if", "libc", "pkg-config", "vcpkg",]
 
 [[package]]
-name = "link-cplusplus"
-version = "1.0.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ecd207c9c713c34f95a097a5b029ac2ce6010530c7b49d7fea24d977dede04f5"
-dependencies = [ "cc",]
-
-[[package]]
 name = "linux-raw-sys"
-version = "0.3.7"
+version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ece97ea872ece730aed82664c424eb4c8291e1ff2480247ccf7409044bc6479f"
+checksum = "ef53942eb7bf7ff43a617b3e2c1c4a5ecf5944a7c1bc12d7ee39bbb15e5c1519"
 
 [[package]]
 name = "lock_api"
-version = "0.4.9"
+version = "0.4.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "435011366fe56583b16cf956f9df0095b405b82d76425bc8981c0e22e60ec4df"
+checksum = "c1cc9717a20b1bb222f333e6a92fd32f7d8a18ddc5a3191a11af45dcbf4dcd16"
 dependencies = [ "autocfg", "scopeguard",]
 
 [[package]]
 name = "log"
-version = "0.4.17"
+version = "0.4.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "abb12e687cfb44aa40f41fc3978ef76448f9b6038cad6aef4259d3c095a2382e"
-dependencies = [ "cfg-if",]
+checksum = "518ef76f2f87365916b142844c16d8fefd85039bc5699050210a7778ee1cd1de"
 
 [[package]]
 name = "m3u8-rs"
@@ -2094,7 +2065,7 @@ name = "md-5"
 version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6365506850d44bff6e2fbcb5176cf63650e48bd45ef2fe2665ae1570e0f4b9ca"
-dependencies = [ "digest 0.10.6",]
+dependencies = [ "digest 0.10.7",]
 
 [[package]]
 name = "memchr"
@@ -2114,6 +2085,13 @@ name = "memoffset"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d61c719bcfbcf5d62b3a09efa6088de8c54bc0bfcd3ea7ae39fcc186108b8de1"
+dependencies = [ "autocfg",]
+
+[[package]]
+name = "memoffset"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a634b1c61a95585bd15607c6ab0c4e5b226e695ff2800ba0cdccddf208c406c"
 dependencies = [ "autocfg",]
 
 [[package]]
@@ -2144,10 +2122,10 @@ dependencies = [ "adler", "simd-adler32",]
 
 [[package]]
 name = "mio"
-version = "0.8.6"
+version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b9d9a46eff5b4ff64b45a9e316a6d1e0bc719ef429cbec4dc630684212bfdf9"
-dependencies = [ "libc", "log", "wasi 0.11.0+wasi-snapshot-preview1", "windows-sys 0.45.0",]
+checksum = "927a765cd3fc26206e66b296465fa9d3e5ab003e651c1b3c060e7956d96b19d2"
+dependencies = [ "libc", "wasi 0.11.0+wasi-snapshot-preview1", "windows-sys 0.48.0",]
 
 [[package]]
 name = "more-asserts"
@@ -2280,9 +2258,9 @@ dependencies = [ "hermit-abi 0.2.6", "libc",]
 
 [[package]]
 name = "object"
-version = "0.30.3"
+version = "0.30.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea86265d3d3dcb6a27fc51bd29a4bf387fae9d2986b823079d4986af253eb439"
+checksum = "03b4680b86d9cfafba8fc491dc9b6df26b68cf40e9e6cd73909194759a63c385"
 dependencies = [ "memchr",]
 
 [[package]]
@@ -2294,9 +2272,9 @@ dependencies = [ "byteorder",]
 
 [[package]]
 name = "once_cell"
-version = "1.17.1"
+version = "1.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7e5500299e16ebb147ae15a00a942af264cf3688f47923b8fc2cd5858f23ad3"
+checksum = "dd8b5dd2ae5ed71462c540258bedcb51965123ad7e7ccf4b9a8cafaa4a63576d"
 
 [[package]]
 name = "opaque-debug"
@@ -2306,9 +2284,9 @@ checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 
 [[package]]
 name = "openssl"
-version = "0.10.52"
+version = "0.10.54"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01b8574602df80f7b85fdfc5392fa884a4e3b3f4f35402c070ab34c3d3f78d56"
+checksum = "69b3f656a17a6cbc115b5c7a40c616947d213ba182135b014d6051b73ab6f019"
 dependencies = [ "bitflags", "cfg-if", "foreign-types", "libc", "once_cell", "openssl-macros", "openssl-sys",]
 
 [[package]]
@@ -2316,7 +2294,7 @@ name = "openssl-macros"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
-dependencies = [ "proc-macro2", "quote", "syn 2.0.15",]
+dependencies = [ "proc-macro2", "quote", "syn 2.0.18",]
 
 [[package]]
 name = "openssl-probe"
@@ -2326,9 +2304,9 @@ checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.87"
+version = "0.9.88"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e17f59264b2809d77ae94f0e1ebabc434773f370d6ca667bd223ea10e06cc7e"
+checksum = "c2ce0f250f34a308dcfdbb351f511359857d4ed2134ba715a4eadd46e1ffd617"
 dependencies = [ "cc", "libc", "pkg-config", "vcpkg",]
 
 [[package]]
@@ -2359,26 +2337,26 @@ checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 
 [[package]]
 name = "pango"
-version = "0.17.9"
-source = "git+https://github.com/gtk-rs/gtk-rs-core?branch=0.17#3ad562c758bf7b2452827c2e6d35e4effce23f71"
+version = "0.17.10"
+source = "git+https://github.com/gtk-rs/gtk-rs-core?branch=0.17#6b109fb807237b5d07aff9a541ca68e9c2191abd"
 dependencies = [ "bitflags", "gio", "glib", "libc", "once_cell", "pango-sys",]
 
 [[package]]
 name = "pango-sys"
-version = "0.17.9"
-source = "git+https://github.com/gtk-rs/gtk-rs-core?branch=0.17#3ad562c758bf7b2452827c2e6d35e4effce23f71"
+version = "0.17.10"
+source = "git+https://github.com/gtk-rs/gtk-rs-core?branch=0.17#6b109fb807237b5d07aff9a541ca68e9c2191abd"
 dependencies = [ "glib-sys", "gobject-sys", "libc", "system-deps",]
 
 [[package]]
 name = "pangocairo"
-version = "0.17.9"
-source = "git+https://github.com/gtk-rs/gtk-rs-core?branch=0.17#3ad562c758bf7b2452827c2e6d35e4effce23f71"
+version = "0.17.10"
+source = "git+https://github.com/gtk-rs/gtk-rs-core?branch=0.17#6b109fb807237b5d07aff9a541ca68e9c2191abd"
 dependencies = [ "bitflags", "cairo-rs", "glib", "libc", "pango", "pangocairo-sys",]
 
 [[package]]
 name = "pangocairo-sys"
-version = "0.17.9"
-source = "git+https://github.com/gtk-rs/gtk-rs-core?branch=0.17#3ad562c758bf7b2452827c2e6d35e4effce23f71"
+version = "0.17.10"
+source = "git+https://github.com/gtk-rs/gtk-rs-core?branch=0.17#6b109fb807237b5d07aff9a541ca68e9c2191abd"
 dependencies = [ "cairo-sys-rs", "glib-sys", "libc", "pango-sys", "system-deps",]
 
 [[package]]
@@ -2390,10 +2368,10 @@ dependencies = [ "lock_api", "parking_lot_core",]
 
 [[package]]
 name = "parking_lot_core"
-version = "0.9.7"
+version = "0.9.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9069cbb9f99e3a5083476ccb29ceb1de18b9118cafa53e90c9551235de2b9521"
-dependencies = [ "backtrace", "cfg-if", "libc", "petgraph", "redox_syscall 0.2.16", "smallvec", "thread-id", "windows-sys 0.45.0",]
+checksum = "93f00c865fe7cabf650081affecd3871070f26767e7b2070a3ffae14c654b447"
+dependencies = [ "backtrace", "cfg-if", "libc", "petgraph", "redox_syscall 0.3.5", "smallvec", "thread-id", "windows-targets",]
 
 [[package]]
 name = "parse_link_header"
@@ -2417,9 +2395,9 @@ dependencies = [ "crypto-mac", "hmac 0.11.0",]
 
 [[package]]
 name = "percent-encoding"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "478c572c3d73181ff3c2539045f6eb99e5491218eae919370993b890cdbdd98e"
+checksum = "9b2a4787296e9989611394c33f193f676704af1686e70b8f8033ab5ba9a35a94"
 
 [[package]]
 name = "petgraph"
@@ -2430,17 +2408,17 @@ dependencies = [ "fixedbitset", "indexmap",]
 
 [[package]]
 name = "pin-project"
-version = "1.0.12"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad29a609b6bcd67fee905812e544992d216af9d755757c05ed2d0e15a74c6ecc"
+checksum = "c95a7476719eab1e366eaf73d0260af3021184f18177925b07f54b30089ceead"
 dependencies = [ "pin-project-internal",]
 
 [[package]]
 name = "pin-project-internal"
-version = "1.0.12"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "069bdb1e05adc7a8990dce9cc75370895fbe4e3d58b9b73bf1aee56359344a55"
-dependencies = [ "proc-macro2", "quote", "syn 1.0.109",]
+checksum = "39407670928234ebc5e6e580247dd567ad73a3578460c5990f9503df207e8f07"
+dependencies = [ "proc-macro2", "quote", "syn 2.0.18",]
 
 [[package]]
 name = "pin-project-lite"
@@ -2536,9 +2514,9 @@ dependencies = [ "proc-macro2", "quote", "version_check",]
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.56"
+version = "1.0.59"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b63bdb0cd06f1f4dedf69b254734f9b45af66e4a031e42a7480257d9898b435"
+checksum = "6aeca18b86b413c660b781aa319e4e2648a3e6f9eadc9b47e9038e6fe9f3451b"
 dependencies = [ "unicode-ident",]
 
 [[package]]
@@ -2583,9 +2561,9 @@ dependencies = [ "bytemuck",]
 
 [[package]]
 name = "quote"
-version = "1.0.27"
+version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f4f29d145265ec1c483c7c654450edde0bfe043d3938d6972630663356d9500"
+checksum = "1b9ab9c7eadfd8df19006f1cf1a4aed13540ed5cbc047010ece5826e10825488"
 dependencies = [ "proc-macro2",]
 
 [[package]]
@@ -2624,9 +2602,9 @@ checksum = "655b020bbf5c89791160a30f0d4706d8ec7aa5718d6a198f6df19c400e4f4470"
 
 [[package]]
 name = "rav1e"
-version = "0.6.5"
+version = "0.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1958c98fa048e4a52218524b3688474943507e25caf29d333ad85aa8a43575de"
+checksum = "16c383692a5e7abd9f6d1eddb1a5e0269f859392387883361bb09e5555852ec1"
 dependencies = [ "arbitrary", "arg_enum_proc_macro", "arrayvec", "av1-grain", "bitstream-io", "built", "cc", "cfg-if", "interpolate_name", "itertools", "libc", "libfuzzer-sys", "log", "maybe-rayon", "nasm-rs", "new_debug_unreachable", "noop_proc_macro", "num-derive", "num-traits", "once_cell", "paste", "rand", "rand_chacha", "rust_hawktracer", "rustc_version", "simd_helpers", "system-deps", "thiserror", "v_frame",]
 
 [[package]]
@@ -2666,10 +2644,10 @@ dependencies = [ "bitflags",]
 
 [[package]]
 name = "regex"
-version = "1.8.1"
+version = "1.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af83e617f331cc6ae2da5443c602dfa5af81e517212d9d611a5b3ba1777b5370"
-dependencies = [ "aho-corasick", "memchr", "regex-syntax 0.7.1",]
+checksum = "d0ab3ca65655bb1e41f2a8c8cd662eb4fb035e67c3f78da1d61dffe89d07300f"
+dependencies = [ "aho-corasick", "memchr", "regex-syntax 0.7.2",]
 
 [[package]]
 name = "regex-automata"
@@ -2686,16 +2664,16 @@ checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
 
 [[package]]
 name = "regex-syntax"
-version = "0.7.1"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5996294f19bd3aae0453a862ad728f60e6600695733dd5df01da90c54363a3c"
+checksum = "436b050e76ed2903236f032a59761c1eb99e1b0aead2c257922771dab1fc8c78"
 
 [[package]]
 name = "reqwest"
-version = "0.11.17"
+version = "0.11.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13293b639a097af28fc8a90f22add145a9c954e49d77da06263d58cf44d5fb91"
-dependencies = [ "async-compression", "base64 0.21.0", "bytes", "cookie", "cookie_store", "encoding_rs", "futures-core", "futures-util", "h2", "http", "http-body", "hyper", "hyper-tls", "ipnet", "js-sys", "log", "mime", "native-tls", "once_cell", "percent-encoding", "pin-project-lite", "serde", "serde_json", "serde_urlencoded", "tokio", "tokio-native-tls", "tokio-util", "tower-service", "url", "wasm-bindgen", "wasm-bindgen-futures", "web-sys", "winreg",]
+checksum = "cde824a14b7c14f85caff81225f411faacc04a2013f41670f41443742b1c1c55"
+dependencies = [ "async-compression", "base64 0.21.2", "bytes", "cookie", "cookie_store", "encoding_rs", "futures-core", "futures-util", "h2", "http", "http-body", "hyper", "hyper-tls", "ipnet", "js-sys", "log", "mime", "native-tls", "once_cell", "percent-encoding", "pin-project-lite", "serde", "serde_json", "serde_urlencoded", "tokio", "tokio-native-tls", "tokio-util", "tower-service", "url", "wasm-bindgen", "wasm-bindgen-futures", "web-sys", "winreg",]
 
 [[package]]
 name = "rgb"
@@ -2797,7 +2775,7 @@ name = "rustls-pemfile"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d194b56d58803a43635bdc398cd17e383d6f71f9182b9a192c127ca42494a59b"
-dependencies = [ "base64 0.21.0",]
+dependencies = [ "base64 0.21.2",]
 
 [[package]]
 name = "ryu"
@@ -2826,12 +2804,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
 
 [[package]]
-name = "scratch"
-version = "1.0.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1792db035ce95be60c3f8853017b3999209281c24e2ba5bc8e59bf97a0c590c1"
-
-[[package]]
 name = "sct"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2840,16 +2812,16 @@ dependencies = [ "ring", "untrusted",]
 
 [[package]]
 name = "security-framework"
-version = "2.8.2"
+version = "2.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a332be01508d814fed64bf28f798a146d73792121129962fdf335bb3c49a4254"
+checksum = "1fc758eb7bffce5b308734e9b0c1468893cae9ff70ebf13e7090be8dcbcc83a8"
 dependencies = [ "bitflags", "core-foundation", "core-foundation-sys", "libc", "security-framework-sys",]
 
 [[package]]
 name = "security-framework-sys"
-version = "2.8.0"
+version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "31c9bb296072e961fcbd8853511dd39c2d8be2deb1e17c6860b1d30732b323b4"
+checksum = "f51d0c0d83bec45f16480d0ce0058397a69e48fcdc52d1dc8855fb68acbd31a7"
 dependencies = [ "core-foundation-sys", "libc",]
 
 [[package]]
@@ -2861,9 +2833,9 @@ dependencies = [ "serde",]
 
 [[package]]
 name = "serde"
-version = "1.0.162"
+version = "1.0.163"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71b2f6e1ab5c2b98c05f0f35b236b22e8df7ead6ffbf51d7808da7f8817e7ab6"
+checksum = "2113ab51b87a539ae008b5c6c02dc020ffa39afd2d83cffcb3f4eb2722cebec2"
 dependencies = [ "serde_derive",]
 
 [[package]]
@@ -2875,10 +2847,10 @@ dependencies = [ "serde",]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.162"
+version = "1.0.163"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2a0814352fd64b58489904a44ea8d90cb1a91dcb6b4f5ebabc32c8318e93cb6"
-dependencies = [ "proc-macro2", "quote", "syn 2.0.15",]
+checksum = "8c805777e3930c8883389c602315a24224bcc738b63905ef87cd1420353ea93e"
+dependencies = [ "proc-macro2", "quote", "syn 2.0.18",]
 
 [[package]]
 name = "serde_json"
@@ -2889,9 +2861,9 @@ dependencies = [ "itoa", "ryu", "serde",]
 
 [[package]]
 name = "serde_spanned"
-version = "0.6.1"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0efd8caf556a6cebd3b285caf480045fcc1ac04f6bd786b09a6f11af30c4fcf4"
+checksum = "93107647184f6027e3b7dcb2e11034cf95ffa1e3a682c67951963ac69c1c007d"
 dependencies = [ "serde",]
 
 [[package]]
@@ -2913,14 +2885,14 @@ name = "sha1"
 version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f04293dc80c3993519f2d7f6f511707ee7094fe0c6d3406feb330cdb3540eba3"
-dependencies = [ "cfg-if", "cpufeatures", "digest 0.10.6",]
+dependencies = [ "cfg-if", "cpufeatures", "digest 0.10.7",]
 
 [[package]]
 name = "sha2"
 version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "82e6b795fe2e3b1e845bafcb27aa35405c4d47cdfc92af5fc8d3002f76cebdc0"
-dependencies = [ "cfg-if", "cpufeatures", "digest 0.10.6",]
+dependencies = [ "cfg-if", "cpufeatures", "digest 0.10.7",]
 
 [[package]]
 name = "shannon"
@@ -3003,9 +2975,9 @@ dependencies = [ "libc", "winapi",]
 
 [[package]]
 name = "socket2"
-version = "0.5.2"
+version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d283f86695ae989d1e18440a943880967156325ba025f05049946bff47bcc2b"
+checksum = "2538b18701741680e0322a2302176d3253a35388e2e62f172f64f4f16605f877"
 dependencies = [ "libc", "windows-sys 0.48.0",]
 
 [[package]]
@@ -3055,9 +3027,9 @@ dependencies = [ "proc-macro2", "quote", "unicode-ident",]
 
 [[package]]
 name = "syn"
-version = "2.0.15"
+version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a34fcf3e8b60f57e6a14301a2e916d323af98b0ea63c599441eec8558660c822"
+checksum = "32d41677bcbe24c20c52e7c70b0d8db04134c5d1066bf98662e2871ad200ea3e"
 dependencies = [ "proc-macro2", "quote", "unicode-ident",]
 
 [[package]]
@@ -3065,7 +3037,7 @@ name = "system-deps"
 version = "6.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5fa6fb9ee296c0dc2df41a656ca7948546d061958115ddb0bcaae43ad0d17d2"
-dependencies = [ "cfg-expr", "heck", "pkg-config", "toml 0.7.3", "version-compare",]
+dependencies = [ "cfg-expr", "heck", "pkg-config", "toml 0.7.4", "version-compare",]
 
 [[package]]
 name = "target-lexicon"
@@ -3075,10 +3047,10 @@ checksum = "fd1ba337640d60c3e96bc6f0638a939b9c9a7f2c316a1598c279828b3d1dc8c5"
 
 [[package]]
 name = "tempfile"
-version = "3.5.0"
+version = "3.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9fbec84f381d5795b08656e4912bec604d162bff9291d6189a78f4c8ab87998"
-dependencies = [ "cfg-if", "fastrand", "redox_syscall 0.3.5", "rustix", "windows-sys 0.45.0",]
+checksum = "31c0432476357e58790aaa47a8efb0c5138f137343f3b5f23bd36a27e3b0a6d6"
+dependencies = [ "autocfg", "cfg-if", "fastrand", "redox_syscall 0.3.5", "rustix", "windows-sys 0.48.0",]
 
 [[package]]
 name = "termcolor"
@@ -3099,7 +3071,7 @@ name = "test-with"
 version = "0.9.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ca3e3e1275a1442b99772321d4a35e0622f7abc04f6af49bd801c7119645bc9e"
-dependencies = [ "proc-macro-error", "proc-macro2", "quote", "regex", "syn 2.0.15",]
+dependencies = [ "proc-macro-error", "proc-macro2", "quote", "regex", "syn 2.0.18",]
 
 [[package]]
 name = "textwrap"
@@ -3120,13 +3092,13 @@ name = "thiserror-impl"
 version = "1.0.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f9456a42c5b0d803c8cd86e73dd7cc9edd429499f37a3550d286d5e86720569f"
-dependencies = [ "proc-macro2", "quote", "syn 2.0.15",]
+dependencies = [ "proc-macro2", "quote", "syn 2.0.18",]
 
 [[package]]
 name = "thread-id"
-version = "4.0.0"
+version = "4.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fdfe0627923f7411a43ec9ec9c39c3a9b4151be313e0922042581fb6c9b717f"
+checksum = "3ee93aa2b8331c0fec9091548843f2c90019571814057da3b783f9de09349d73"
 dependencies = [ "libc", "redox_syscall 0.2.16", "winapi",]
 
 [[package]]
@@ -3185,9 +3157,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.28.0"
+version = "1.28.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3c786bf8134e5a3a166db9b29ab8f48134739014a3eca7bc6bfa95d673b136f"
+checksum = "94d7b1cfd2aa4011f2de74c2c4c63665e27a71006b0a192dcd2710272e73dfa2"
 dependencies = [ "autocfg", "bytes", "libc", "mio", "num_cpus", "parking_lot", "pin-project-lite", "signal-hook-registry", "socket2 0.4.9", "tokio-macros", "windows-sys 0.48.0",]
 
 [[package]]
@@ -3195,7 +3167,7 @@ name = "tokio-macros"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "630bdcf245f78637c13ec01ffae6187cca34625e8c63150d424b59e55af2675e"
-dependencies = [ "proc-macro2", "quote", "syn 2.0.15",]
+dependencies = [ "proc-macro2", "quote", "syn 2.0.18",]
 
 [[package]]
 name = "tokio-native-tls"
@@ -3234,23 +3206,23 @@ dependencies = [ "serde",]
 
 [[package]]
 name = "toml"
-version = "0.7.3"
+version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b403acf6f2bb0859c93c7f0d967cb4a75a7ac552100f9322faf64dc047669b21"
+checksum = "d6135d499e69981f9ff0ef2167955a5333c35e36f6937d382974566b3d5b94ec"
 dependencies = [ "serde", "serde_spanned", "toml_datetime", "toml_edit",]
 
 [[package]]
 name = "toml_datetime"
-version = "0.6.1"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ab8ed2edee10b50132aed5f331333428b011c99402b5a534154ed15746f9622"
+checksum = "5a76a9312f5ba4c2dec6b9161fdf25d87ad8a09256ccea5a556fef03c706a10f"
 dependencies = [ "serde",]
 
 [[package]]
 name = "toml_edit"
-version = "0.19.8"
+version = "0.19.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "239410c8609e8125456927e6707163a3b1fdb40561e4b803bc041f466ccfdc13"
+checksum = "2380d56e8670370eee6566b0bfd4265f65b3f432e8c6d85623f728d4fa31f739"
 dependencies = [ "indexmap", "serde", "serde_spanned", "toml_datetime", "winnow",]
 
 [[package]]
@@ -3284,13 +3256,13 @@ name = "tracing-attributes"
 version = "0.1.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0f57e3ca2a01450b1a921183a9c9cbfda207fd822cef4ccb00a65402cbba7a74"
-dependencies = [ "proc-macro2", "quote", "syn 2.0.15",]
+dependencies = [ "proc-macro2", "quote", "syn 2.0.18",]
 
 [[package]]
 name = "tracing-core"
-version = "0.1.30"
+version = "0.1.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24eb03ba0eab1fd845050058ce5e616558e8f8d8fca633e6b163fe25c797213a"
+checksum = "0955b8137a1df6f1a2e9a37d8a6656291ff0297c1a97c24e0d8425fe2312f79a"
 dependencies = [ "once_cell", "valuable",]
 
 [[package]]
@@ -3341,9 +3313,9 @@ checksum = "92888ba5573ff080736b3648696b70cafad7d250551175acbaa4e0385b3e1460"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.8"
+version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5464a87b239f13a63a501f2701565754bae92d243d4bb7eb12f6d57d2269bf4"
+checksum = "b15811caf2415fb889178633e7724bad2509101cde276048e013b9def5e51fa0"
 
 [[package]]
 name = "unicode-linebreak"
@@ -3373,10 +3345,10 @@ checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
 
 [[package]]
 name = "url"
-version = "2.3.1"
+version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d68c799ae75762b8c3fe375feb6600ef5602c883c5d21eb51c09f22b83c4643"
-dependencies = [ "form_urlencoded", "idna 0.3.0", "percent-encoding",]
+checksum = "50bff7831e19200a85b17131d085c25d7811bc4e186efdaf54bbd132994a88cb"
+dependencies = [ "form_urlencoded", "idna 0.4.0", "percent-encoding",]
 
 [[package]]
 name = "urlencoding"
@@ -3398,9 +3370,9 @@ checksum = "711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a"
 
 [[package]]
 name = "uuid"
-version = "1.3.2"
+version = "1.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4dad5567ad0cf5b760e5665964bec1b47dfd077ba8a2544b513f3556d3d239a2"
+checksum = "345444e32442451b267fc254ae85a209c64be56d2890e601a0c37ff0c3c5ecd2"
 dependencies = [ "getrandom",]
 
 [[package]]
@@ -3487,50 +3459,50 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.84"
+version = "0.2.86"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "31f8dcbc21f30d9b8f2ea926ecb58f6b91192c17e9d33594b3df58b2007ca53b"
+checksum = "5bba0e8cb82ba49ff4e229459ff22a191bbe9a1cb3a341610c9c33efc27ddf73"
 dependencies = [ "cfg-if", "wasm-bindgen-macro",]
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.84"
+version = "0.2.86"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95ce90fd5bcc06af55a641a86428ee4229e44e07033963a2290a8e241607ccb9"
-dependencies = [ "bumpalo", "log", "once_cell", "proc-macro2", "quote", "syn 1.0.109", "wasm-bindgen-shared",]
+checksum = "19b04bc93f9d6bdee709f6bd2118f57dd6679cf1176a1af464fca3ab0d66d8fb"
+dependencies = [ "bumpalo", "log", "once_cell", "proc-macro2", "quote", "syn 2.0.18", "wasm-bindgen-shared",]
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.34"
+version = "0.4.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f219e0d211ba40266969f6dbdd90636da12f75bee4fc9d6c23d1260dadb51454"
+checksum = "2d1985d03709c53167ce907ff394f5316aa22cb4e12761295c5dc57dacb6297e"
 dependencies = [ "cfg-if", "js-sys", "wasm-bindgen", "web-sys",]
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.84"
+version = "0.2.86"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c21f77c0bedc37fd5dc21f897894a5ca01e7bb159884559461862ae90c0b4c5"
+checksum = "14d6b024f1a526bb0234f52840389927257beb670610081360e5a03c5df9c258"
 dependencies = [ "quote", "wasm-bindgen-macro-support",]
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.84"
+version = "0.2.86"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2aff81306fcac3c7515ad4e177f521b5c9a15f2b08f4e32d823066102f35a5f6"
-dependencies = [ "proc-macro2", "quote", "syn 1.0.109", "wasm-bindgen-backend", "wasm-bindgen-shared",]
+checksum = "e128beba882dd1eb6200e1dc92ae6c5dbaa4311aa7bb211ca035779e5efc39f8"
+dependencies = [ "proc-macro2", "quote", "syn 2.0.18", "wasm-bindgen-backend", "wasm-bindgen-shared",]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.84"
+version = "0.2.86"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0046fef7e28c3804e5e38bfa31ea2a0f73905319b677e57ebe37e49358989b5d"
+checksum = "ed9d5b4305409d1fc9482fee2d7f9bcbf24b3972bf59817ef757e23982242a93"
 
 [[package]]
 name = "web-sys"
-version = "0.3.61"
+version = "0.3.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e33b99f4b23ba3eec1a53ac264e35a755f00e966e0065077d6027c0f575b0b97"
+checksum = "3bdd9ef4e984da1187bf8110c5cf5b845fbc87a23602cdf912386a76fcd3a7c2"
 dependencies = [ "js-sys", "wasm-bindgen",]
 
 [[package]]
@@ -3577,7 +3549,7 @@ name = "windows"
 version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e686886bc078bc1b0b600cac0147aadb815089b6e4da64016cbd754b6342700f"
-dependencies = [ "windows-targets 0.48.0",]
+dependencies = [ "windows-targets",]
 
 [[package]]
 name = "windows-sys"
@@ -3588,24 +3560,10 @@ dependencies = [ "windows_aarch64_gnullvm 0.42.2", "windows_aarch64_msvc 0.42.2"
 
 [[package]]
 name = "windows-sys"
-version = "0.45.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
-dependencies = [ "windows-targets 0.42.2",]
-
-[[package]]
-name = "windows-sys"
 version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
-dependencies = [ "windows-targets 0.48.0",]
-
-[[package]]
-name = "windows-targets"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e5180c00cd44c9b1c88adb3693291f1cd93605ded80c250a75d472756b4d071"
-dependencies = [ "windows_aarch64_gnullvm 0.42.2", "windows_aarch64_msvc 0.42.2", "windows_i686_gnu 0.42.2", "windows_i686_msvc 0.42.2", "windows_x86_64_gnu 0.42.2", "windows_x86_64_gnullvm 0.42.2", "windows_x86_64_msvc 0.42.2",]
+dependencies = [ "windows-targets",]
 
 [[package]]
 name = "windows-targets"
@@ -3714,9 +3672,9 @@ dependencies = [ "winapi",]
 
 [[package]]
 name = "xml-rs"
-version = "0.8.8"
+version = "0.8.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f20f14e2bd1fef6ec891d50dbb37c7290a0568a6bbd9020bf62010d02b6f80e"
+checksum = "52839dc911083a8ef63efa4d039d1f58b5e409f923e44c80828f206f66e5541c"
 
 [[package]]
 name = "xmlparser"

--- a/pkgs/development/libraries/gstreamer/rs/default.nix
+++ b/pkgs/development/libraries/gstreamer/rs/default.nix
@@ -118,7 +118,7 @@ in
 
 stdenv.mkDerivation rec {
   pname = "gst-plugins-rs";
-  version = "0.10.7";
+  version = "0.10.8";
 
   outputs = [ "out" "dev" ];
 
@@ -127,7 +127,7 @@ stdenv.mkDerivation rec {
     owner = "gstreamer";
     repo = "gst-plugins-rs";
     rev = version;
-    hash = "sha256-b+j7nAMK66+msRnIaj1S1DSvES5Gid3QazXgqO1II/Q=";
+    hash = "sha256-UxmfyqbQwkQjwHiARRpFJiGsrsNjv6V129lIHPk7gRk=";
     # TODO: temporary workaround for case-insensitivity problems with color-name crate - https://github.com/annymosse/color-name/pull/2
     nativeBuildInputs = [ yq moreutils ];
     postFetch = ''
@@ -141,12 +141,12 @@ stdenv.mkDerivation rec {
   cargoDeps = rustPlatform.importCargoLock {
     lockFile = ./Cargo.lock;
     outputHashes = {
-      "cairo-rs-0.17.9" = "sha256-LiIb6y/Ks/o+rZhU8RpXN7jSo7JzBGmcNumxyx/lZs0=";
+      "cairo-rs-0.17.10" = "sha256-5lWlDHlMco380tRaxyApdNv5DDKJL9QrKI2DvHM3868=";
       "color-name-1.1.0" = "sha256-RfMStbe2wX5qjPARHIFHlSDKjzx8DwJ+RjzyltM5K7A=";
       "ffv1-0.0.0" = "sha256-af2VD00tMf/hkfvrtGrHTjVJqbl+VVpLaR0Ry+2niJE=";
       "flavors-0.2.0" = "sha256-zBa0X75lXnASDBam9Kk6w7K7xuH9fP6rmjWZBUB5hxk=";
       "gdk4-0.6.6" = "sha256-TI4F9MjIpxFEZItoewP/Zem1vM4MsKNJTzfgah1vjmI=";
-      "gstreamer-0.20.5" = "sha256-IQ56Upe73egId1IJRfzvqrJIzTc1x5FgAEbva9kuqPE=";
+      "gstreamer-0.20.6" = "sha256-IyzqCQ5oQt5QgFp6liGyDaFhteCceR1KPzJCE4R6zus=";
     };
   };
 


### PR DESCRIPTION
###### Description of changes

This release is mostly minor fixes

Release notes: https://gitlab.freedesktop.org/gstreamer/gst-plugins-rs/-/blob/0.10.8/CHANGELOG.md#0108-2023-06-07

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes (or backporting 23.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).