### PR TITLE
byobu: add `gettext` to nativeBuildInputs

### DIFF
--- a/pkgs/tools/misc/byobu/default.nix
+++ b/pkgs/tools/misc/byobu/default.nix
@@ -16,8 +16,9 @@ stdenv.mkDerivation rec {
 
   doCheck = true;
 
-  nativeBuildInputs = [ makeWrapper ];
-  buildInputs = [ perl gettext ];
+  strictdeps = true;
+  nativeBuildInputs = [ makeWrapper gettext ];
+  buildInputs = [ perl ]; # perl is needed for `lib/byobu/include/*` scripts
   propagatedBuildInputs = [ textual-window-manager screen ];
 
   postPatch = ''


### PR DESCRIPTION
###### Description of changes

This PR fixes crosscompile issues with byobu.

to reproduce:
```
nix build nixpkgs#pkgsCross.aarch64-multiplatform.pkgs.byobu
error: builder for '/nix/store/a2vr8a9bx385pcbxvi6bvnfjq20kyzlp-byobu-aarch64-unknown-linux-gnu-5.133.drv' failed with exit code 127;
       last 10 log lines:
       > make[2]: Leaving directory '/build/byobu-5.133/usr/bin'
       > make[1]: Leaving directory '/build/byobu-5.133/usr/bin'
       > make[1]: Entering directory '/build/byobu-5.133'
       > make[2]: Entering directory '/build/byobu-5.133'
       > make[2]: Nothing to be done for 'install-exec-am'.
       > make[2]: Nothing to be done for 'install-data-am'.
       > make[2]: Leaving directory '/build/byobu-5.133'
       > make[1]: Leaving directory '/build/byobu-5.133'
       > /nix/store/pi4nks092wm676by0xqh72rfcrfwf3bp-stdenv-linux/setup: line 133: msgfmt: command not found
       > /nix/store/pi4nks092wm676by0xqh72rfcrfwf3bp-stdenv-linux/setup: line 144: pop_var_context: head of shell_variables not a function context
       For full logs, run 'nix log /nix/store/a2vr8a9bx385pcbxvi6bvnfjq20kyzlp-byobu-aarch64-unknown-linux-gnu-5.133.drv'.
```

###### Things done

The following command does now compile:
`nix build .#pkgsCross.aarch64-multiplatform.pkgs.byobu`


- Built on platform(s)
  - [ ] x86_64-linux
  - [x] x86_64-linux -> aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes (or backporting 23.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).


My First Pull request here, if something is missing please tell me.