### PR TITLE
pythonPackages.polars: Fix build on darwin

### DIFF
--- a/pkgs/development/python-modules/polars/default.nix
+++ b/pkgs/development/python-modules/polars/default.nix
@@ -6,6 +6,7 @@
 , libiconv
 , fetchFromGitHub
 , typing-extensions
+, darwin
 }:
 let
   pname = "polars";
@@ -48,7 +49,10 @@ buildPythonPackage {
 
   nativeBuildInputs = with rustPlatform; [ cargoSetupHook maturinBuildHook ];
 
-  buildInputs = lib.optionals stdenv.isDarwin [ libiconv ];
+  buildInputs = lib.optionals stdenv.isDarwin [
+    libiconv
+    darwin.apple_sdk.frameworks.Security
+  ];
 
   pythonImportsCheck = [ "polars" ];
   # nativeCheckInputs = [
@@ -62,7 +66,7 @@ buildPythonPackage {
   # ];
 
   meta = with lib; {
-    broken = (stdenv.isLinux && stdenv.isAarch64) || stdenv.isDarwin;
+    broken = (stdenv.isLinux && stdenv.isAarch64);
     description = "Fast multi-threaded DataFrame library in Rust | Python | Node.js ";
     homepage = "https://github.com/pola-rs/polars";
     license = licenses.asl20;


### PR DESCRIPTION
The build had been failing with an error like

       Compiling py-polars v0.17.11 (/private/tmp/nix-build-python3.10-polars-0.17.11.drv-0/source/py-polars)
    error: linking with `/nix/store/0a46pjq0isnpbzf4wi6v1pdcvaj6i43m-clang-wrapper-11.1.0/bin/cc` failed: exit status: 1
      |
      = note: LC_ALL="C" PATH="/nix/store/9zglgb7pvcvv7lxwdxzvjqs1w4kfyfgv-rustc-1.69.0/lib/rustlib/aarch64-apple-darwin/bin:/nix/store/x1nk3q6shnsfqphmq2l27gf585wnpf1x-python3-3.10.11/bin:/nix/store/g9kv74wk0xyikshim0drwbgf67zcc3qh-python3.10-p>
      = note: ld: framework not found Security
              clang-11: error: linker command failed with exit code 1 (use -v to see invocation)

Adding the Security framework to buildInputs appears to have solved that.

Demonstration:

    $ read -r -d '' PYSRC <<EOF
    import platform
    print(platform.platform())

    import polars as pl

    s = pl.Series("a", [1, 2, 3, 4, 5])
    print(s)
    EOF
    $ nix shell --impure --expr \
    "with builtins.getFlake \"$PWD\"; with legacyPackages.aarch64-darwin; python3.withPackages (ps: with ps; [ polars ])" \
    --command python -c "$PYSRC"
    macOS-13.4-arm64-arm-64bit
    shape: (5,)
    Series: 'a' [i64]
    [
            1
            2
            3
            4
            5
    ]
