### PR TITLE
stdenv: fix crossSystem localSystem comparison

### DIFF
--- a/pkgs/stdenv/custom/default.nix
+++ b/pkgs/stdenv/custom/default.nix
@@ -2,7 +2,7 @@
 , localSystem, crossSystem, config, overlays, crossOverlays ? []
 }:
 
-assert crossSystem == localSystem;
+assert lib.systems.equals crossSystem localSystem;
 
 let
   bootStages = import ../. {

--- a/pkgs/stdenv/darwin/default.nix
+++ b/pkgs/stdenv/darwin/default.nix
@@ -36,7 +36,7 @@
     }
 }:
 
-assert crossSystem == localSystem;
+assert lib.systems.equals crossSystem localSystem;
 
 let
   inherit (localSystem) system;

--- a/pkgs/stdenv/default.nix
+++ b/pkgs/stdenv/default.nix
@@ -36,7 +36,7 @@ let
 
   # Select the appropriate stages for the platform `system'.
 in
-  if crossSystem != localSystem || crossOverlays != [] then stagesCross
+  if !lib.systems.equals crossSystem localSystem || crossOverlays != [] then stagesCross
   else if config ? replaceStdenv then stagesCustom
   else if localSystem.isLinux then stagesLinux
   else if localSystem.isDarwin then stagesDarwin

--- a/pkgs/stdenv/freebsd/default.nix
+++ b/pkgs/stdenv/freebsd/default.nix
@@ -2,7 +2,7 @@
 , localSystem, crossSystem, config, overlays, crossOverlays ? []
 }:
 
-assert crossSystem == localSystem;
+assert lib.systems.equals crossSystem localSystem;
 let inherit (localSystem) system;
     fetchURL = import <nix/fetchurl.nix>;
     trivialBuilder = (import ./trivial-builder.nix);

--- a/pkgs/stdenv/linux/default.nix
+++ b/pkgs/stdenv/linux/default.nix
@@ -95,7 +95,7 @@
   in files
 }:
 
-assert crossSystem == localSystem;
+assert lib.systems.equals crossSystem localSystem;
 
 let
   inherit (localSystem) system;

--- a/pkgs/stdenv/native/default.nix
+++ b/pkgs/stdenv/native/default.nix
@@ -2,7 +2,7 @@
 , localSystem, crossSystem, config, overlays, crossOverlays ? []
 }:
 
-assert crossSystem == localSystem;
+assert lib.systems.equals crossSystem localSystem;
 
 let
   inherit (localSystem) system;

--- a/pkgs/stdenv/nix/default.nix
+++ b/pkgs/stdenv/nix/default.nix
@@ -4,7 +4,7 @@
 , ...
 }:
 
-assert crossSystem == localSystem;
+assert lib.systems.equals crossSystem localSystem;
 
 bootStages ++ [
   (prevStage: {


### PR DESCRIPTION
this appears to fix the following issue for some reason

```
nix-repl> (import ./. { localSystem.system = "x86_64-linux"; crossSystem.system = "x86_64-linux"; }).bash
«derivation /nix/store/5lz9p8xhf89kb1c1kk6jxrzskaiygnlh-bash-5.2-p15.drv»

nix-repl> (import ./. { localSystem.system = "x86_64-linux"; crossSystem = "x86_64-linux"; }).bash
«derivation /nix/store/1whiq03rsfrmch2ds3jhyqjaczfz97lb-bash-5.2-p15-x86_64-unknown-linux-gnu.drv»
```

fixed
```
nix-repl> (import ./. { localSystem.system = "x86_64-linux"; crossSystem = "x86_64-linux"; }).bash
«derivation /nix/store/5lz9p8xhf89kb1c1kk6jxrzskaiygnlh-bash-5.2-p15.drv»
```

issue reported by @spikespaz on matrix in the cross compilation channel 

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes (or backporting 23.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
