### PR TITLE
em100: init at unstable-2023-06-12

### DIFF
--- a/pkgs/tools/misc/em100/default.nix
+++ b/pkgs/tools/misc/em100/default.nix
@@ -1,0 +1,46 @@
+{ curl
+, fetchgit
+, lib
+, libusb1
+, pkg-config
+, stdenv
+}:
+
+stdenv.mkDerivation rec {
+  pname = "em100";
+  version = "unstable-2023-06-12";
+
+  src = fetchgit {
+    url = "https://review.coreboot.org/em100";
+    rev = "a1d938f8b4253c76fb31e69de33266cb71bda141";
+    hash = "sha256-jkgdUKAQlg04fwVGw94JorwAKiJcgDbYtcQvAI2BepI=";
+  };
+
+  nativeBuildInputs = [ pkg-config ];
+
+  buildInputs = [
+    curl
+    libusb1
+  ];
+
+  buildPhase = ''
+    runHook preBuild
+    make em100
+    runHook postBuild
+  '';
+
+  installPhase = ''
+    runHook preInstall
+    install -Dm755 em100 $out/bin/em100
+    install -Dm644 60-dediprog-em100pro.rules $out/lib/udev/rules.d/dediprog_em100.rules
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    homepage = "https://www.coreboot.org";
+    description = "Open source tool for the EM100 SPI flash emulator";
+    license = licenses.gpl2;
+    maintainers = with maintainers; [ felixsinger ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7641,6 +7641,8 @@ with pkgs;
 
   flamerobin = callPackage ../applications/misc/flamerobin { };
 
+  em100 = callPackage ../tools/misc/em100 { };
+
   flashrom = callPackage ../tools/misc/flashrom { };
 
   flashrom-stable = callPackage ../tools/misc/flashrom-stable { };


### PR DESCRIPTION
###### Description of changes



###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes (or backporting 23.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
