### PR TITLE
oregano: init at 0.84.43

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -199,6 +199,13 @@
     github = "2hexed";
     githubId = 54501296;
   };
+  _3442 = {
+    name = "Alejandro Soto";
+    email = "alejandro@34project.org";
+    github = "3442";
+    githubId = 31359863;
+    keys = [ { fingerprint = "E142 1858 9D0D 90B5 2B1A  5368 F264 360B 2C09 05A6"; } ];
+  };
   _360ied = {
     name = "Brian Zhu";
     email = "therealbarryplayer@gmail.com";

--- a/pkgs/by-name/or/oregano/check-cfg-gio-unix.patch
+++ b/pkgs/by-name/or/oregano/check-cfg-gio-unix.patch
@@ -1,0 +1,12 @@
+diff --git a/wscript b/wscript
+index 03de4b3..f64ccc4 100644
+--- a/wscript
++++ b/wscript
+@@ -68,6 +68,7 @@ def configure(conf):
+ 
+ 	conf.check_cfg(atleast_pkgconfig_version='0.26')
+ 	conf.check_cfg(package='glib-2.0', uselib_store='GLIB', args=['glib-2.0 >= 2.44', '--cflags', '--libs'], mandatory=True)
++	conf.check_cfg(package='gio-unix-2.0', uselib_store='GLIB', args=['--cflags', '--libs'], mandatory=True)
+ 	conf.check_cfg(package='gobject-2.0', uselib_store='GOBJECT', args=['--cflags', '--libs'], mandatory=True)
+ 	conf.check_cfg(package='gtk+-3.0', uselib_store='GTK3', args=['gtk+-3.0 >= 3.12', '--cflags', '--libs'], mandatory=True)
+ 	conf.check_cfg(package='libxml-2.0', uselib_store='XML', args=['--cflags', '--libs'], mandatory=True)

--- a/pkgs/by-name/or/oregano/fix-selection_changed-type-mismatch.patch
+++ b/pkgs/by-name/or/oregano/fix-selection_changed-type-mismatch.patch
@@ -1,0 +1,14 @@
+diff --git a/src/sheet/wire-item.c b/src/sheet/wire-item.c
+index 208710c..c97d13e 100644
+--- a/src/sheet/wire-item.c
++++ b/src/sheet/wire-item.c
+@@ -114,7 +114,7 @@ static void wire_item_class_init (WireItemClass *wire_item_class)
+ 	sheet_item_class->moved = wire_item_moved;
+ 	sheet_item_class->paste = wire_item_paste;
+ 	sheet_item_class->is_in_area = is_in_area;
+-	sheet_item_class->selection_changed = selection_changed;
++	sheet_item_class->selection_changed = (void (*)(SheetItem *item)) selection_changed;
+ 	sheet_item_class->place = wire_item_place;
+ 	sheet_item_class->place_ghost = wire_item_place_ghost;
+ }
+-- 

--- a/pkgs/by-name/or/oregano/package.nix
+++ b/pkgs/by-name/or/oregano/package.nix
@@ -1,0 +1,83 @@
+{
+  fetchFromGitHub,
+  glib,
+  goocanvas2,
+  gnucap,
+  groff,
+  gtk3,
+  gtksourceview3,
+  intltool,
+  libxml2,
+  lib,
+  makeWrapper,
+  ngspice,
+  perl,
+  pkg-config,
+  python3,
+  stdenv,
+  wafHook,
+  wrapGAppsHook,
+  useNgspice ? false,
+}:
+let
+  version = "0.84.43";
+in
+stdenv.mkDerivation {
+  pname = "oregano";
+  inherit version;
+
+  src = fetchFromGitHub {
+    owner = "drahnr";
+    repo = "oregano";
+    tag = "v${version}";
+    hash = "sha256-1GsL0N3O0clqdgkXoPKMhvW+y4Rzg4QSeOA54nH4kz4=";
+  };
+
+  patches = [
+    ./check-cfg-gio-unix.patch
+    ./fix-selection_changed-type-mismatch.patch
+  ];
+
+  buildInputs = [
+    glib
+    goocanvas2
+    gtk3
+    gtksourceview3
+    libxml2
+  ];
+
+  nativeBuildInputs = [
+    groff
+    intltool
+    makeWrapper
+    wafHook
+    perl
+    pkg-config
+    python3
+    wrapGAppsHook
+  ];
+
+  # Force nixpkgs version of waf
+  postPatch = ''
+    rm waf
+  '';
+
+  postFixup = ''
+    wrapProgram $out/bin/oregano \
+      --suffix PATH : ${lib.makeBinPath [ (if useNgspice then ngspice else gnucap) ]}
+  '';
+
+  meta = {
+    description = "Schematic capture and circuit simulator";
+    longDescription = ''
+      Oregano is an application for schematic capture and simulation of
+      electronic circuits. The actual simulation is performed by Berkeley
+      Spice, GNUcap or the new generation ngspice.
+    '';
+
+    homepage = "https://github.com/drahnr/oregano/";
+    license = lib.licenses.gpl2;
+    platforms = lib.platforms.linux;
+    maintainers = with lib.maintainers; [ _3442 ];
+  };
+}


### PR DESCRIPTION
###### Description of changes

Oregano is an application for schematic capture and simulation of electronic circuits. The actual simulation is performed by Berkeley Spice, GNUcap or the new generation ngspice.

[https://github.com/drahnr/oregano](https://github.com/drahnr/oregano)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes (or backporting 23.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
