### PR TITLE
python310Packages.pylsp-mypy: 0.6.6 -> 0.6.7

### DIFF
--- a/pkgs/development/python-modules/pylsp-mypy/default.nix
+++ b/pkgs/development/python-modules/pylsp-mypy/default.nix
@@ -2,31 +2,46 @@
 , buildPythonPackage
 , fetchFromGitHub
 , fetchpatch
+, setuptools
 , mypy
 , pytestCheckHook
 , python-lsp-server
 , pythonOlder
-, toml
+, tomli
 }:
 
 buildPythonPackage rec {
   pname = "pylsp-mypy";
-  version = "0.6.6";
-  format = "setuptools";
+  version = "0.6.7";
+  format = "pyproject";
 
   disabled = pythonOlder "3.7";
 
   src = fetchFromGitHub {
-    owner = "Richardk2n";
+    owner = "python-lsp";
     repo = "pylsp-mypy";
     rev = "refs/tags/${version}";
-    hash = "sha256-9B+GSEoQEqd1W/g0oup4xULKWOF0TgSG5DfBtyWA3vs=";
+    hash = "sha256-ZsNIw0xjxnU9Ue0C7TlhzVOCOCKEbCa2CsiiqeMb14I=";
   };
+
+  patches = [
+    # https://github.com/python-lsp/pylsp-mypy/pull/64
+    (fetchpatch {
+      name = "fix-hanging-test.patch";
+      url = "https://github.com/python-lsp/pylsp-mypy/commit/90d28edb474135007804f1e041f88713a95736f9.patch";
+      hash = "sha256-3DVyUXVImRemXCuyoXlYbPJm6p8OnhBdEKmwjx88ets=";
+    })
+  ];
+
+  nativeBuildInputs = [
+    setuptools
+  ];
 
   propagatedBuildInputs = [
     mypy
     python-lsp-server
-    toml
+  ] ++ lib.optionals (pythonOlder "3.11") [
+    tomli
   ];
 
   nativeCheckInputs = [
@@ -44,7 +59,7 @@ buildPythonPackage rec {
 
   meta = with lib; {
     description = "Mypy plugin for the Python LSP Server";
-    homepage = "https://github.com/Richardk2n/pylsp-mypy";
+    homepage = "https://github.com/python-lsp/pylsp-mypy";
     license = licenses.mit;
     maintainers = with maintainers; [ cpcloud ];
   };


### PR DESCRIPTION
###### Description of changes

https://github.com/python-lsp/pylsp-mypy/compare/0.6.6...0.6.7

In addition:

1. Incorporate update to `tomli` done in https://github.com/python-lsp/pylsp-mypy/commit/77070a0f8fefd09856bf4dac4fb35b60612144f7.
2. Update the repository and homepage links to use the new GitHub owner name.
3. Fetch a patch to fix a hanging test.
4. Change the format to "pyproject", since the project has a pyproject.toml.

This will close https://github.com/NixOS/nixpkgs/issues/235603.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes (or backporting 23.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
