### PR TITLE
ocamlPackages.parmap: 1.2.4 → 1.2.5; cudf: 0.9 → 0.10

### DIFF
--- a/pkgs/development/ocaml-modules/cudf/default.nix
+++ b/pkgs/development/ocaml-modules/cudf/default.nix
@@ -1,45 +1,26 @@
-{ lib, fetchurl, stdenv, ocaml, ocamlbuild, findlib, extlib, glib, perl, pkg-config, stdlib-shims, ounit }:
+{ lib, buildDunePackage, ocaml, fetchFromGitLab, extlib, ounit2 }:
 
-stdenv.mkDerivation rec {
-  pname = "ocaml${ocaml.version}-cudf";
-  version = "0.9";
+buildDunePackage rec {
+  pname = "cudf";
+  version = "0.10";
 
-  src = fetchurl {
-    url = "https://gforge.inria.fr/frs/download.php/36602/cudf-0.9.tar.gz";
-    sha256 = "sha256-mTLk2V3OI1sUNIYv84nM3reiirf0AuozG5ZzLCmn4Rw=";
+  minimalOCamlVersion = "4.07";
+
+  src = fetchFromGitLab {
+    owner = "irill";
+    repo = pname;
+    rev = "v${version}";
+    hash = "sha256-E4KXKnso/Q3ZwcYpKPgvswNR9qd/lafKljPMxfStedM=";
   };
 
-  buildFlags = [
-    "all"
-    "opt"
-  ];
-
-  nativeBuildInputs = [
-    findlib
-    ocaml
-    ocamlbuild
-    pkg-config
-    perl
-  ];
-  buildInputs = [
-    glib
-    stdlib-shims
-  ];
   propagatedBuildInputs = [
     extlib
   ];
 
-  checkTarget = [
-    "all"
-    "test"
-  ];
   checkInputs = [
-    ounit
+    ounit2
   ];
   doCheck = lib.versionAtLeast ocaml.version "4.08";
-
-  preInstall = "mkdir -p $OCAMLFIND_DESTDIR";
-  installFlags = [ "BINDIR=$(out)/bin" ];
 
   meta = with lib; {
     description = "A library for CUDF format";

--- a/pkgs/development/ocaml-modules/dose3/default.nix
+++ b/pkgs/development/ocaml-modules/dose3/default.nix
@@ -1,7 +1,7 @@
 { lib, buildDunePackage, fetchFromGitLab
-, camlzip, ocamlgraph, parmap, re, stdlib-shims
-, base64, bz2, extlib, cudf
-, dpkg, git, ocaml, ounit, python39, python39Packages
+, ocamlgraph, parmap, re, stdlib-shims
+, base64, extlib, cudf
+, ocaml, ounit
 }:
 
 buildDunePackage rec {
@@ -15,8 +15,7 @@ buildDunePackage rec {
     sha256 = "sha256-K0fYSAWV48Rers/foDrEIqieyJ0PvpXkuYrFrZGBkkE=";
   };
 
-  minimalOCamlVersion = "4.03";
-  useDune2 = true;
+  minimalOCamlVersion = "4.07";
 
   buildInputs = [
     parmap
@@ -24,8 +23,6 @@ buildDunePackage rec {
 
   propagatedBuildInputs = [
     base64
-    bz2
-    camlzip
     cudf
     extlib
     ocamlgraph
@@ -33,17 +30,10 @@ buildDunePackage rec {
     stdlib-shims
   ];
 
-  nativeCheckInputs = [
-    python39                  # Replaces: conf-python-3
-    python39Packages.pyyaml   # Replaces: conf-python3-yaml
-    git
-  ];
   checkInputs = [
-    dpkg                      # Replaces: conf-dpkg
     ounit
   ];
-  doCheck = false; # Tests are failing.
-                   # To enable tests use: lib.versionAtLeast ocaml.version "4.04";
+  doCheck = lib.versionAtLeast ocaml.version "4.08";
 
   meta = with lib; {
     description = "Dose library (part of Mancoosi tools)";

--- a/pkgs/development/ocaml-modules/parmap/default.nix
+++ b/pkgs/development/ocaml-modules/parmap/default.nix
@@ -1,12 +1,14 @@
-{ lib, fetchurl, buildDunePackage, dune-configurator }:
+{ lib, fetchFromGitHub, buildDunePackage, dune-configurator }:
 
 buildDunePackage rec {
   pname = "parmap";
-  version = "1.2.4";
+  version = "1.2.5";
 
-  src = fetchurl {
-    url = "https://github.com/rdicosmo/${pname}/releases/download/${version}/${pname}-${version}.tbz";
-    sha256 = "sha256-BTkSEjIK3CVNloJACFo6eQ6Ob9o/cdrA9xuv87NKas4=";
+  src = fetchFromGitHub {
+    owner = "rdicosmo";
+    repo = pname;
+    rev = version;
+    hash = "sha256-tBu7TGtDOe5FbxLZuz6nl+65aN9FHIngq/O4dJWzr3Q=";
   };
 
   minimalOCamlVersion = "4.03";


### PR DESCRIPTION
###### Description of changes

Support for OCaml ≥ 5.0:
  - https://github.com/rdicosmo/parmap/releases/tag/1.2.5
  - https://gitlab.com/irill/cudf/-/blob/v0.10/ChangeLog

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes (or backporting 23.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
