### PR TITLE
kaniko: 1.10.0 -> 1.11.0

### DIFF
--- a/pkgs/applications/networking/cluster/kaniko/default.nix
+++ b/pkgs/applications/networking/cluster/kaniko/default.nix
@@ -9,13 +9,13 @@
 
 buildGoModule rec {
   pname = "kaniko";
-  version = "1.10.0";
+  version = "1.11.0";
 
   src = fetchFromGitHub {
     owner = "GoogleContainerTools";
     repo = "kaniko";
     rev = "v${version}";
-    hash = "sha256-SPHayFfYFpg1AOoe003xh7NGQLpvhd1C2k4IilgMqSw=";
+    hash = "sha256-p/mGobQyn5e7TpqjarVT7qBgYDWtX1VgXq814O8mTmI=";
   };
 
   vendorHash = null;
@@ -47,7 +47,7 @@ buildGoModule rec {
     homepage = "https://github.com/GoogleContainerTools/kaniko";
     license = lib.licenses.asl20;
     platforms = lib.platforms.linux;
-    maintainers = with lib.maintainers; [ jk ];
+    maintainers = with lib.maintainers; [ jk qjoly ];
     mainProgram = "executor";
   };
 }


### PR DESCRIPTION
###### Description of changes

Highlights:

    fix: Deduplicate paths while saving files for later use https://github.com/GoogleContainerTools/kaniko/pull/2504
        Fixes issues with dupe paths which caused breakage previously with some symlink+multi-stage usage, more info here - https://github.com/GoogleContainerTools/kaniko/issues/2381
    fix: Download docker-credential-gcr from release artifacts https://github.com/GoogleContainerTools/kaniko/pull/2540
        Previously docker-credential-gcr version in Dockerfile not actually respected due a proxy issue w/ the docker-credential-gcr repo. Fixed via pulling from commit vs tag.
    docs: Add guide on creating multi-arch manifests https://github.com/GoogleContainerTools/kaniko/pull/2306
    chore(deps): bump github.com/google/go-containerregistry from 0.15.1 to 0.15.2 https://github.com/GoogleContainerTools/kaniko/pull/2546
        Fixes issues where trying to build an image with the --reproducible flag causes a panic in v1.10 https://github.com/GoogleContainerTools/kaniko/issues/2537
    chore(deps): update docker-credential-* binaries in kaniko images https://github.com/GoogleContainerTools/kaniko/pull/2531
        Fixes some issues related to GCR usage (ex: https://github.com/GoogleContainerTools/kaniko/issues/2251)
    chore(deps): use aws-sdk-go-v2 https://github.com/GoogleContainerTools/kaniko/pull/2550
        Shrinks binary size ~10% tada
    chore(deps): updated numerous dependencies (see full changelog for more info)

Fixes:

    fix: Deduplicate paths while saving files for later use https://github.com/GoogleContainerTools/kaniko/pull/2504
    fix: Download docker-credential-gcr from release artifacts https://github.com/GoogleContainerTools/kaniko/pull/2540

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes (or backporting 23.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->


1 package updated:
kaniko (1.10.0 → 1.11.0)

1 package built:
kaniko
