### PR TITLE
upscayl: init at 2.5.5

### DIFF
--- a/pkgs/applications/graphics/upscayl/default.nix
+++ b/pkgs/applications/graphics/upscayl/default.nix
@@ -1,0 +1,42 @@
+{
+  appimageTools,
+  fetchurl,
+  lib,
+}: let
+  pname = "upscayl";
+  version = "2.5.5";
+
+  src = fetchurl {
+    url = "https://github.com/upscayl/upscayl/releases/download/v${version}/upscayl-${version}-linux.AppImage";
+    hash = "sha256-qpLxOGphR9iHvtb8AZZaMict/g8wLkL7Dhr4mt3LZdk=";
+  };
+
+  appimageContents = appimageTools.extractType2 {
+    inherit pname version src;
+  };
+in
+  appimageTools.wrapType2 {
+    inherit pname version src;
+
+    extraPkgs = pkgs: with pkgs; [vulkan-headers vulkan-loader];
+
+    extraInstallCommands = ''
+      mkdir -p $out/share/{applications,pixmaps}
+
+      cp ${appimageContents}/${pname}.desktop $out/share/applications/${pname}.desktop
+      cp ${appimageContents}/${pname}.png $out/share/pixmaps/${pname}.png
+
+      mv $out/bin/${pname}-${version} $out/bin/${pname}
+
+      substituteInPlace $out/share/applications/${pname}.desktop \
+        --replace 'Exec=AppRun --no-sandbox %U' 'Exec=${pname}'
+    '';
+
+    meta = with lib; {
+      description = "Free and Open Source AI Image Upscaler";
+      homepage = "https://upscayl.github.io/";
+      maintainers = with maintainers; [icy-thought];
+      license = licenses.agpl3Only;
+      platforms = platforms.linux;
+    };
+  }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -27984,6 +27984,8 @@ with pkgs;
 
   upower = callPackage ../os-specific/linux/upower { };
 
+  upscayl = callPackage ../applications/graphics/upscayl { };
+
   usbguard = callPackage ../os-specific/linux/usbguard { };
 
   usbguard-notifier = callPackage ../os-specific/linux/usbguard-notifier { };


### PR DESCRIPTION
###### Description of changes

Since the previous Upscayl (#192465) package has been neglected for quite some time I decided to create a new PR with the latest package update.

> **Note**
Package location has changed from `pkgs/applications/video` (original) -> ``pkgs/applications/graphics` because Upscayl does not support videos up-scaling. It is a`Free and Open Source AI Image Upscaler`.


Also, if you still want to remain as the package maintainers @TheZombie1999, then do create a PR and add yourself to the maintainers list! :)

###### Changelog:
- https://github.com/upscayl/upscayl/releases/tag/v2.5.5

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes (or backporting 23.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
