### PR TITLE
ironwail: init at 0.7.0

### DIFF
--- a/pkgs/games/ironwail/default.nix
+++ b/pkgs/games/ironwail/default.nix
@@ -1,0 +1,91 @@
+{ lib
+, stdenv
+, SDL2
+, fetchurl
+, gzip
+, libvorbis
+, libmad
+, flac
+, libopus
+, opusfile
+, libogg
+, curl
+, libxmp
+, vulkan-headers
+, vulkan-loader
+, copyDesktopItems
+, makeDesktopItem
+, pkg-config
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "ironwail";
+  version = "0.7.0";
+
+  src = fetchurl {
+    url = "https://github.com/andrei-drexler/ironwail/archive/refs/tags/v${finalAttrs.version}.tar.gz";
+    hash = "sha256-NBG0wwQWqyGWQYJmiLKfxGxpDJLw7Kwf4EnYd33dOpU=";
+  };
+
+  sourceRoot = "${finalAttrs.pname}-${finalAttrs.version}/Quake";
+
+  nativeBuildInputs = [
+    copyDesktopItems pkg-config vulkan-headers
+    gzip libvorbis libmad flac curl libopus
+    opusfile libogg libxmp vulkan-loader SDL2
+  ];
+
+  buildFlags = [
+    "DO_USERDIRS=1"
+    # Makefile defaults, set here to enforce consistency on Darwin build
+    "USE_CODEC_WAVE=1"
+    "USE_CODEC_MP3=1"
+    "USE_CODEC_VORBIS=1"
+    "USE_CODEC_FLAC=1"
+    "USE_CODEC_OPUS=1"
+    "USE_CODEC_MIKMOD=0"
+    "USE_CODEC_UMX=0"
+    "USE_CODEC_XMP=1"
+    "MP3LIB=mad"
+    "VORBISLIB=vorbis"
+    "SDL_CONFIG=sdl2-config"
+    "USE_SDL2=1"
+  ];
+
+  preInstall = ''
+    mkdir -p "$out/bin"
+    mkdir -p "$out/share/quake"
+    substituteInPlace Makefile --replace "cp ironwail.pak /usr/local/games/quake" "cp ironwail.pak $out/share/quake/ironwail.pak"
+    substituteInPlace Makefile --replace "/usr/local/games" "$out/bin"
+  '';
+
+  enableParallelBuilding = true;
+
+  desktopItems = [
+    (makeDesktopItem {
+      name = "ironwail";
+      exec = "quake";
+      desktopName = "Ironwail";
+      categories = [ "Game" ];
+    })
+  ];
+
+  meta = {
+    description = "A fork of the QuakeSpasm engine for iD software's Quake";
+    homepage = "https://github.com/andrei-drexler/ironwail";
+    longDescription = ''
+      Ironwail is a fork of QuakeSpasm with focus on high performance instead of
+      compatibility.
+      It features the ability to play the 2021 re-release content with no setup
+      required, a mods menu for quick access to installation of mods, and ease of
+      switching to installed mods.
+      It also include various visual features as well as improved limits for playing
+      larger levels with less performance impacts.
+    '';
+
+    license = lib.licenses.gpl2Plus;
+    platforms = lib.platforms.linux;
+    maintainers = [ lib.maintainers.necrophcodr ];
+    mainProgram = "quake";
+  };
+})

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -36795,6 +36795,8 @@ with pkgs;
   # used as base package for iortcw forks
   iortcw_sp = callPackage ../games/iortcw/sp.nix { };
 
+  ironwail = callPackage ../games/ironwail { };
+
   ivan = callPackage ../games/ivan { };
 
   ja2-stracciatella = callPackage ../games/ja2-stracciatella {


### PR DESCRIPTION
###### Description of changes

This adds the latest release of ironwail, a QuakeSpasm fork that is easier to use and has better support for larger levels, amongst other things.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes (or backporting 23.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
