### PR TITLE
npm-check: init at 6.0.1

### DIFF
--- a/pkgs/development/tools/npm-check/default.nix
+++ b/pkgs/development/tools/npm-check/default.nix
@@ -9,7 +9,7 @@ buildNpmPackage rec {
 
   src = fetchFromGitHub {
     owner = "dylang";
-    repo = pname;
+    repo = "npm-check";
     rev = "v${version}"
     hash = "sha256-F7bMvGqOxJzoaw25VR6D90UNwT8HxZ4PZhhQEvQFDn4=";
   };

--- a/pkgs/development/tools/npm-check/default.nix
+++ b/pkgs/development/tools/npm-check/default.nix
@@ -1,0 +1,29 @@
+{ buildNpmPackage
+, fetchFromGitHub
+, lib
+}:
+
+buildNpmPackage rec {
+  pname = "npm-check";
+  version = "6.0.1";
+
+  src = fetchFromGitHub {
+    owner = "dylang";
+    repo = pname;
+    rev = "v" + (toString version);
+    hash = "sha256-F7bMvGqOxJzoaw25VR6D90UNwT8HxZ4PZhhQEvQFDn4=";
+  };
+
+  npmDepsHash = "sha256-KRLgLWikcCWMF8/cOxThom6DHE9ar6WO/9HtosJQnLE=";
+
+  npmFlags = [ "--legacy-peer-deps" ];
+
+  dontNpmBuild = true;
+
+  meta = with lib; {
+    description = "Check for outdated, incorrect, and unused dependencies.";
+    homepage = "https://github.com/dylang/npm-check";
+    license = licenses.mit;
+    maintainers = [ maintainers.thomasjm ];
+  };
+}

--- a/pkgs/development/tools/npm-check/default.nix
+++ b/pkgs/development/tools/npm-check/default.nix
@@ -10,7 +10,7 @@ buildNpmPackage rec {
   src = fetchFromGitHub {
     owner = "dylang";
     repo = pname;
-    rev = "v" + (toString version);
+    rev = "v${version}"
     hash = "sha256-F7bMvGqOxJzoaw25VR6D90UNwT8HxZ4PZhhQEvQFDn4=";
   };
 

--- a/pkgs/development/tools/npm-check/default.nix
+++ b/pkgs/development/tools/npm-check/default.nix
@@ -21,7 +21,7 @@ buildNpmPackage rec {
   dontNpmBuild = true;
 
   meta = with lib; {
-    description = "Check for outdated, incorrect, and unused dependencies.";
+    description = "Check for outdated, incorrect, and unused dependencies";
     homepage = "https://github.com/dylang/npm-check";
     changelog = "https://github.com/dylang/npm-check/releases/tag/v${version}";
     license = licenses.mit;

--- a/pkgs/development/tools/npm-check/default.nix
+++ b/pkgs/development/tools/npm-check/default.nix
@@ -10,7 +10,7 @@ buildNpmPackage rec {
   src = fetchFromGitHub {
     owner = "dylang";
     repo = "npm-check";
-    rev = "v${version}"
+    rev = "v${version}";
     hash = "sha256-F7bMvGqOxJzoaw25VR6D90UNwT8HxZ4PZhhQEvQFDn4=";
   };
 

--- a/pkgs/development/tools/npm-check/default.nix
+++ b/pkgs/development/tools/npm-check/default.nix
@@ -23,6 +23,7 @@ buildNpmPackage rec {
   meta = with lib; {
     description = "Check for outdated, incorrect, and unused dependencies.";
     homepage = "https://github.com/dylang/npm-check";
+    changelog = "https://github.com/dylang/npm-check/releases/tag/v${version}";
     license = licenses.mit;
     maintainers = [ maintainers.thomasjm ];
   };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10555,6 +10555,8 @@ with pkgs;
 
   notable = callPackage ../applications/misc/notable { };
 
+  npm-check = callPackage ../development/tools/npm-check { };
+
   nth = with python3Packages; toPythonApplication name-that-hash;
 
   ntlmrecon = callPackage ../tools/security/ntlmrecon { };


### PR DESCRIPTION
###### Description of changes

We already have `npm-check-updates` in `node-packages.json`. IMO `npm-check` is clearer and less of a blunt instrument to use, so it should be made available also.

###### Things done

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [X] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes (or backporting 23.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

