### PR TITLE
`lib.systems.equals`

### DIFF
--- a/lib/systems/default.nix
+++ b/lib/systems/default.nix
@@ -24,8 +24,8 @@ rec {
     both arguments have been `elaborate`-d.
   */
   equals =
-    let uncomparable = { canExecute = null; emulator = null; emulatorAvailable = null; isCompatible = null; };
-    in a: b: a // uncomparable == b // uncomparable;
+    let removeFunctions = a: lib.filterAttrs (_: v: !builtins.isFunction v) a;
+    in a: b: removeFunctions a == removeFunctions b;
 
   /*
     Try to convert an elaborated system back to a simple string. If not possible,

--- a/lib/tests/release.nix
+++ b/lib/tests/release.nix
@@ -53,6 +53,9 @@ let
       echo "Running lib/tests/sources.sh"
       TEST_LIB=$PWD/lib bash lib/tests/sources.sh
 
+      echo "Running lib/tests/systems.nix"
+      [[ $(nix-instantiate --eval --strict lib/tests/systems.nix | tee /dev/stderr) == '[ ]' ]];
+
       mkdir $out
       echo success > $out/${nix.version}
     '';

--- a/lib/tests/systems.nix
+++ b/lib/tests/systems.nix
@@ -69,7 +69,7 @@ lib.runTests (
     let modified =
           assert origValue != arbitraryValue;
           lib.systems.elaborate "x86_64-linux" // { ${platformAttrName} = arbitraryValue; };
-        arbitraryValue = "<<modified>>";
+        arbitraryValue = x: "<<modified>>";
     in {
       expr = lib.systems.equals (lib.systems.elaborate "x86_64-linux") modified;
       expected = {

--- a/lib/tests/systems.nix
+++ b/lib/tests/systems.nix
@@ -1,6 +1,8 @@
 # Run:
 # [nixpkgs]$ nix-instantiate --eval --strict lib/tests/systems.nix
 # Expected output: [], or the failed cases
+#
+# OfBorg runs (approximately) nix-build lib/tests/release.nix
 let
   lib = import ../default.nix;
   mseteq = x: y: {


### PR DESCRIPTION
###### Description of changes

Helps #237427
Cherry-picked from https://github.com/NixOS/nixpkgs/pull/231940

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes (or backporting 23.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
