### PR TITLE
Remove roy mirror

### DIFF
--- a/pkgs/build-support/fetchurl/mirrors.nix
+++ b/pkgs/build-support/fetchurl/mirrors.nix
@@ -175,12 +175,6 @@
     "https://download.qt.io/"
   ];
 
-  # Roy marples mirrors
-  roy = [
-    "https://roy.marples.name/downloads/"
-    "https://cflags.cc/roy/"
-  ];
-
   # Sage mirrors (https://www.sagemath.org/mirrors.html)
   sageupstream = [
     # Africa (HTTPS)

--- a/pkgs/tools/networking/dhcpcd/default.nix
+++ b/pkgs/tools/networking/dhcpcd/default.nix
@@ -1,6 +1,6 @@
 { lib
 , stdenv
-, fetchurl
+, fetchFromGitHub
 , fetchpatch
 , pkg-config
 , udev
@@ -14,9 +14,11 @@ stdenv.mkDerivation rec {
   pname = "dhcpcd";
   version = "9.4.1";
 
-  src = fetchurl {
-    url = "mirror://roy/${pname}/${pname}-${version}.tar.xz";
-    sha256 = "sha256-gZNXY07+0epc9E7AGyTT0/iFL+yLQkmSXcxWZ8VON2w=";
+  src = fetchFromGitHub {
+    owner = "NetworkConfiguration";
+    repo = "dhcpcd";
+    rev = "v${version}";
+    sha256 = "sha256-qyxON+TsAKMwAI19b5P+dT/sgxpW6m1giGcf/boFpHc=";
   };
 
   patches = [

--- a/pkgs/tools/networking/openresolv/default.nix
+++ b/pkgs/tools/networking/openresolv/default.nix
@@ -1,12 +1,14 @@
-{ lib, stdenv, fetchurl, makeWrapper, coreutils }:
+{ lib, stdenv, fetchFromGitHub, makeWrapper, coreutils }:
 
 stdenv.mkDerivation rec {
   pname = "openresolv";
   version = "3.12.0";
 
-  src = fetchurl {
-    url = "mirror://roy/openresolv/${pname}-${version}.tar.xz";
-    sha256 = "sha256-QrMFCOhXoihTXGMeqsk2hi2G7KaMFLXAvzh7oXa5G5c=";
+  src = fetchFromGitHub {
+    owner = "NetworkConfiguration";
+    repo = "openresolv";
+    rev = "v${version}";
+    sha256 = "sha256-lEyqOf2NGWnH44pDVNVSWZeuhXx7z0ru4KuXu2RuyIg=";
   };
 
   nativeBuildInputs = [ makeWrapper ];


### PR DESCRIPTION
###### Description of changes

Roy Marples started releasing his stuff via GitHub, instead of hosting tarballs on his website. Replace uses of `mirror://roy` with `fetchFromGitHub` and remove the mirror.

Fixes #231217.

###### Things done

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes (or backporting 23.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).