### PR TITLE
pam_rssh: init at unstable-2023-03-18

### DIFF
--- a/pkgs/os-specific/linux/pam_rssh/default.nix
+++ b/pkgs/os-specific/linux/pam_rssh/default.nix
@@ -1,0 +1,71 @@
+{ lib
+, rustPlatform
+, fetchFromGitHub
+, pkg-config
+, openssl
+, pam
+, openssh
+}:
+
+rustPlatform.buildRustPackage {
+  pname = "pam_rssh";
+  version = "unstable-2023-03-18";
+
+  src = fetchFromGitHub {
+    owner = "z4yx";
+    repo = "pam_rssh";
+    rev = "92c240bd079e9711c7afa8bacfcf01de48f42577";
+    hash = "sha256-mIQeItPh6RrF3cFbAth2Kmb2E/Xj+lOgatvjcLE4Yag=";
+    fetchSubmodules = true;
+  };
+
+  cargoHash = "sha256-/AQqjmAGgvnpVWyoK3ymZ1gNAhTSN30KQEiqv4G+zx8=";
+
+  nativeBuildInputs = [
+    pkg-config
+  ];
+
+  buildInputs = [
+    openssl
+    pam
+  ];
+
+  checkFlags = [
+    # Fails because it tries finding authorized_keys in /home/$USER.
+    "--skip=tests::parse_user_authorized_keys"
+  ];
+
+  nativeCheckInputs = [
+    openssh
+  ];
+
+  env.USER = "nixbld";
+
+  # Copied from https://github.com/z4yx/pam_rssh/blob/main/.github/workflows/rust.yml.
+  preCheck = ''
+    export HOME=$(mktemp -d)
+    mkdir $HOME/.ssh
+    ssh-keygen -q -N "" -t ecdsa -b 521 -f $HOME/.ssh/id_ecdsa521
+    ssh-keygen -q -N "" -t ecdsa -b 384 -f $HOME/.ssh/id_ecdsa384
+    ssh-keygen -q -N "" -t ecdsa -b 256 -f $HOME/.ssh/id_ecdsa256
+    ssh-keygen -q -N "" -t ed25519 -f $HOME/.ssh/id_ed25519
+    ssh-keygen -q -N "" -t rsa -f $HOME/.ssh/id_rsa
+    ssh-keygen -q -N "" -t dsa -f $HOME/.ssh/id_dsa
+    export SSH_AUTH_SOCK=$HOME/ssh-agent.sock
+    eval $(ssh-agent -a $SSH_AUTH_SOCK)
+    ssh-add $HOME/.ssh/id_ecdsa521
+    ssh-add $HOME/.ssh/id_ecdsa384
+    ssh-add $HOME/.ssh/id_ecdsa256
+    ssh-add $HOME/.ssh/id_ed25519
+    ssh-add $HOME/.ssh/id_rsa
+    ssh-add $HOME/.ssh/id_dsa
+  '';
+
+  meta = with lib; {
+    description = "PAM module for authenticating via ssh-agent, written in Rust";
+    homepage = "https://github.com/z4yx/pam_rssh";
+    license = licenses.mit;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ kranzes ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -27608,6 +27608,8 @@ with pkgs;
 
   pam_pgsql = callPackage ../os-specific/linux/pam_pgsql { };
 
+  pam_rssh = callPackage ../os-specific/linux/pam_rssh { };
+
   pam_ssh_agent_auth = callPackage ../os-specific/linux/pam_ssh_agent_auth { };
 
   pam_tmpdir = callPackage ../os-specific/linux/pam_tmpdir { };


### PR DESCRIPTION
###### Description of changes

Replaces #209962 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes (or backporting 23.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
