### PR TITLE
python3Packages.schemdraw: 0.16 -> 0.17, python3Packages.ziamath: 0.7 -> 0.8.1

### DIFF
--- a/pkgs/development/python-modules/schemdraw/default.nix
+++ b/pkgs/development/python-modules/schemdraw/default.nix
@@ -13,7 +13,7 @@
 
 buildPythonPackage rec {
   pname = "schemdraw";
-  version = "0.16";
+  version = "0.17";
   format = "pyproject";
 
   disabled = pythonOlder "3.8";
@@ -22,7 +22,7 @@ buildPythonPackage rec {
     owner = "cdelker";
     repo = pname;
     rev = version;
-    hash = "sha256-W9sXtYI8gEwQPRo50taEGT6AQG1tdAbeCtX49eHVvFQ=";
+    hash = "sha256-wa/IeNGZynU/xKwyFwebXcFaruhBFqGWsrZYaIEVa8Q=";
   };
 
   propagatedBuildInputs = [

--- a/pkgs/development/python-modules/ziamath/default.nix
+++ b/pkgs/development/python-modules/ziamath/default.nix
@@ -10,7 +10,8 @@
 
 buildPythonPackage rec {
   pname = "ziamath";
-  version = "0.7";
+  version = "0.8.1";
+  format = "pyproject";
 
   disabled = pythonOlder "3.8";
 
@@ -18,7 +19,7 @@ buildPythonPackage rec {
     owner = "cdelker";
     repo = pname;
     rev = version;
-    hash = "sha256-JuuCDww0EZEHZLxB5oQrWEJpv0szjwe4iXCRGl7OYTA=";
+    hash = "sha256-Bbwq4Ods3P/724KO94jSmMLD1ubfaMHP/gTlOL/2pnE=";
   };
 
   propagatedBuildInputs = [
@@ -32,6 +33,13 @@ buildPythonPackage rec {
   ];
 
   pytestFlagsArray = [ "--nbval-lax" ];
+
+  # Prevent the test suite from attempting to download fonts
+  postPatch = ''
+    substituteInPlace test/styles.ipynb \
+      --replace '"def testfont(exprs, fonturl):\n",' '"def testfont(exprs, fonturl):\n", "    return\n",' \
+      --replace "mathfont='FiraMath-Regular.otf', " ""
+  '';
 
   pythonImportsCheck = [ "ziamath" ];
 


### PR DESCRIPTION
###### Description of changes

https://github.com/cdelker/schemdraw/compare/0.16...0.17

Also needs a new ziamath: https://github.com/cdelker/ziamath/compare/0.7...0.8.1

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes (or backporting 23.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
