### PR TITLE
pixelorama: 0.10.3 -> 0.11

### DIFF
--- a/pkgs/applications/editors/pixelorama/default.nix
+++ b/pkgs/applications/editors/pixelorama/default.nix
@@ -7,14 +7,14 @@ let
       else "Linux/X11 32-bit"
     else if stdenv.isDarwin then "Mac OSX"
     else throw "unsupported platform";
-in stdenv.mkDerivation rec {
+in stdenv.mkDerivation (finalAttrs: {
   pname = "pixelorama";
   version = "0.11";
 
   src = fetchFromGitHub {
     owner = "Orama-Interactive";
     repo = "Pixelorama";
-    rev = "v${version}";
+    rev = "v${finalAttrs.version}";
     sha256 = "sha256-r4iQJBxXzIbQ7n19Ah6szuIfALmuKlHKcvKsxEzOttk=";
   };
 
@@ -56,4 +56,4 @@ in stdenv.mkDerivation rec {
     platforms = [ "i686-linux" "x86_64-linux" ];
     maintainers = with maintainers; [ felschr ];
   };
-}
+})

--- a/pkgs/applications/editors/pixelorama/default.nix
+++ b/pkgs/applications/editors/pixelorama/default.nix
@@ -9,13 +9,13 @@ let
     else throw "unsupported platform";
 in stdenv.mkDerivation rec {
   pname = "pixelorama";
-  version = "0.10.3";
+  version = "0.11";
 
   src = fetchFromGitHub {
     owner = "Orama-Interactive";
     repo = "Pixelorama";
     rev = "v${version}";
-    sha256 = "sha256-RFE7K8NMl0COzFEhUqWhhYd5MGBsCDJf0T5daPu/4DI=";
+    sha256 = "sha256-r4iQJBxXzIbQ7n19Ah6szuIfALmuKlHKcvKsxEzOttk=";
   };
 
   nativeBuildInputs = [


### PR DESCRIPTION
###### Description of changes
[Changelog](https://github.com/Orama-Interactive/Pixelorama/releases/tag/v0.11)

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes (or backporting 23.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).