### PR TITLE
process-compose: wrap in `pkgs.bash`

### DIFF
--- a/pkgs/applications/misc/process-compose/default.nix
+++ b/pkgs/applications/misc/process-compose/default.nix
@@ -1,7 +1,10 @@
 { lib
+, bash
+, coreutils
 , buildGoModule
 , fetchFromGitHub
 , installShellFiles
+, makeWrapper
 }:
 
 let config-module = "github.com/f1bonacc1/process-compose/src/config";
@@ -41,6 +44,7 @@ buildGoModule rec {
 
   nativeBuildInputs = [
     installShellFiles
+    makeWrapper
   ];
 
   vendorHash = "sha256-9RvVBup07FHCjfV/Q6ryU28inqydL/pMGVUfbo2OG5s=";
@@ -54,6 +58,10 @@ buildGoModule rec {
       --bash <($out/bin/process-compose completion bash) \
       --zsh <($out/bin/process-compose completion zsh) \
       --fish <($out/bin/process-compose completion fish)
+
+    # process-compose looks up bash at runtime.
+    # Also add coreutils because most programs need it.
+    wrapProgram $out/bin/process-compose --set PATH "${lib.makeBinPath [ bash coreutils ]}"
   '';
 
   meta = with lib; {


### PR DESCRIPTION


###### Description of changes

Otherwise, process-compose when run a bare system (eg: nixosTest) without bash on PATH will fail. cf. https://github.com/Platonic-Systems/process-compose-flake/issues/19

cc @thenonameguy

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes (or backporting 23.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
