### PR TITLE
sway: remove unused build inputs

### DIFF
--- a/pkgs/applications/window-managers/sway/default.nix
+++ b/pkgs/applications/window-managers/sway/default.nix
@@ -1,7 +1,6 @@
 { lib, stdenv, fetchFromGitHub, fetchpatch, substituteAll, swaybg
 , meson, ninja, pkg-config, wayland-scanner, scdoc
 , wayland, libxkbcommon, pcre2, json_c, libevdev
-
 , pango, cairo, libinput, gdk-pixbuf, librsvg
 , wlroots_0_16, wayland-protocols, libdrm
 , nixosTests

--- a/pkgs/applications/window-managers/sway/default.nix
+++ b/pkgs/applications/window-managers/sway/default.nix
@@ -1,23 +1,22 @@
 { lib, stdenv, fetchFromGitHub, fetchpatch, substituteAll, swaybg
 , meson, ninja, pkg-config, wayland-scanner, scdoc
 , wayland, libxkbcommon, pcre2, json_c, libevdev
-, pango, cairo, libinput, libcap, pam, gdk-pixbuf, librsvg
+
+, pango, cairo, libinput, gdk-pixbuf, librsvg
 , wlroots_0_16, wayland-protocols, libdrm
 , nixosTests
 # Used by the NixOS module:
 , isNixOS ? false
 , enableXWayland ? true, xorg
 , systemdSupport ? lib.meta.availableOn stdenv.hostPlatform systemd, systemd
-, dbusSupport ? true
-, dbus
-, trayEnabled ? systemdSupport && dbusSupport
+, trayEnabled ? systemdSupport
 }:
 
 # The "sd-bus-provider" meson option does not include a "none" option,
 # but it is silently ignored iff "-Dtray=disabled".  We use "basu"
 # (which is not in nixpkgs) instead of "none" to alert us if this
 # changes: https://github.com/swaywm/sway/issues/6843#issuecomment-1047288761
-assert trayEnabled -> systemdSupport && dbusSupport;
+assert trayEnabled -> systemdSupport;
 let sd-bus-provider = if systemdSupport then "libsystemd" else "basu"; in
 
 stdenv.mkDerivation rec {
@@ -65,11 +64,9 @@ stdenv.mkDerivation rec {
 
   buildInputs = [
     wayland libxkbcommon pcre2 json_c libevdev
-    pango cairo libinput libcap pam gdk-pixbuf librsvg
+    pango cairo libinput gdk-pixbuf librsvg
     wayland-protocols libdrm
     (wlroots_0_16.override { inherit enableXWayland; })
-  ] ++ lib.optionals dbusSupport [
-    dbus
   ] ++ lib.optionals enableXWayland [
     xorg.xcbutilwm
   ];


### PR DESCRIPTION
None of these have been used since before Sway 1.0.

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes (or backporting 23.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
