### PR TITLE
etcher: 1.7.9 -> 1.18.4

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -7183,6 +7183,12 @@
     githubId = 3874017;
     name = "Jappie Klooster";
   };
+  jared-davis = {
+    email = "message@jared-pri.me";
+    github = "Jared-Prime";
+    githubId = 1060000;
+    name = "Jared Davis";
+  };
   jasoncarr = {
     email = "jcarr250@gmail.com";
     github = "jasoncarr0";

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7435,9 +7435,7 @@ with pkgs;
 
   esshader = callPackage ../tools/graphics/esshader { };
 
-  etcher = callPackage ../tools/misc/etcher {
-    electron = electron_12;
-  };
+  etcher = callPackage ../tools/misc/etcher { };
 
   ethercalc = callPackage ../servers/web-apps/ethercalc { };
 


### PR DESCRIPTION
###### Description of changes

This is my first PR to the nixpkgs project; happy to learn the ins-and-outs of contributing.

I noticed that [`etcher`](https://etcher.io/), a tool for flashing USB drives, would not build with the default nix package configuration due to an outdated [`electron`](https://electronjs.org/) dependency. My first pass is to get a passing build for the latest version of `etcher` targeting `x86_64-linux`. I'm focusing on an Ubuntu development environment at the moment. If all goes well, I'm happy to help contribute configurations for other platforms as well.

Changes made:

* Add jared-davis to maintainer list
* Create separate configuration for etcher 1.18

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes (or backporting 23.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
