### PR TITLE
python310Packages.django-rapyd-modernauth: init at 0.0.4

### DIFF
--- a/pkgs/development/python-modules/django-rapyd-modernauth/default.nix
+++ b/pkgs/development/python-modules/django-rapyd-modernauth/default.nix
@@ -1,0 +1,55 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, asgiref
+, django
+, python
+, python-dotenv
+, pytz
+, setuptools
+, sqlparse
+, zipp
+}:
+
+buildPythonPackage rec {
+  pname = "django-rapyd-modernauth";
+  version = "0.0.4";
+
+  src = fetchFromGitHub {
+    owner = "karthicraghupathi";
+    repo = "django_rapyd_modernauth";
+    rev = "v${version}";
+    hash = "sha256-9IIW6Xsaj2+/SR2CIX4fnUHlAehmLulpBAC7YB3ZrZE=";
+  };
+
+  checkPhase = ''
+    runHook preCheck
+
+    echo 'LOG_LEVEL="INFO"' > .env
+    echo DJANGO_SECRET_KEY="$(base64 /dev/urandom | head -c50)" >> .env
+    ${python.interpreter} ./testrunner.py
+
+    runHook postCheck
+  '';
+
+  propagatedBuildInputs = [
+    asgiref
+    django
+    python-dotenv
+    pytz
+    setuptools
+    sqlparse
+    zipp
+  ];
+
+  pythonImportsCheck = [
+    "modernauth"
+  ];
+
+  meta = with lib; {
+    description = "A Django application that provides a custom User model where the username is the email address.";
+    homepage = "https://github.com/karthicraghupathi/django_rapyd_modernauth";
+    license = licenses.afl20;
+    maintainers = [ maintainers.greg ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2958,6 +2958,8 @@ self: super: with self; {
 
   django-ranged-response = callPackage ../development/python-modules/django-ranged-response { };
 
+  django-rapyd-modernauth = callPackage ../development/python-modules/django-rapyd-modernauth { };
+
   django-raster = callPackage ../development/python-modules/django-raster { };
 
   django-redis = callPackage ../development/python-modules/django-redis { };


### PR DESCRIPTION
###### Description of changes

The package is a plugin for Django providing a modern authorization platform.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes (or backporting 23.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).