### PR TITLE
litex: init at 2023.04

### DIFF
--- a/pkgs/development/python-modules/litespi/default.nix
+++ b/pkgs/development/python-modules/litespi/default.nix
@@ -1,0 +1,32 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, migen
+, litex
+}:
+
+buildPythonPackage rec {
+  pname = "litespi";
+  version = "2023.04";
+  format = "setuptools";
+
+  src = fetchFromGitHub {
+    owner = "litex-hub";
+    repo = "litespi";
+    rev = version;
+    hash = "sha256-q4I/ir7cQHAVcG+Qz3Zglk3iUwxzLQrCVZbCPTXugds=";
+  };
+
+  propagatedBuildInputs = [ migen litex ];
+
+  pythonImportsCheck = [ "litespi" ];
+
+  doCheck = false;
+
+  meta = with lib; {
+    description = "Small footprint and configurable SPI core";
+    homepage = "https://github.com/litex-hub/litespi";
+    license = licenses.bsd2;
+    maintainers = with maintainers; [ raitobezarius ];
+  };
+}

--- a/pkgs/development/python-modules/litex-boards/default.nix
+++ b/pkgs/development/python-modules/litex-boards/default.nix
@@ -1,0 +1,33 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, migen
+, litex
+}:
+
+buildPythonPackage rec {
+  pname = "litex-boards";
+  version = "2023.04";
+  format = "setuptools";
+
+  src = fetchFromGitHub {
+    owner = "litex-hub";
+    repo = "litex-boards";
+    rev = version;
+    hash = "sha256-4gG3vvqnVXNfB7FtOeI9EPD/E8biREM5WKuYnSSBELc=";
+  };
+
+  # VexRiscV CPU is needed.
+  nativeCheckInputs = [ migen litex ];
+
+  pythonImportsCheck = [ "litex_boards" ];
+
+  doCheck = false;
+
+  meta = with lib; {
+    description = "LiteX boards files";
+    homepage = "https://github.com/litex-hub/litex-boards";
+    license = licenses.bsd2;
+    maintainers = with maintainers; [ raitobezarius ];
+  };
+}

--- a/pkgs/development/python-modules/litex/default.nix
+++ b/pkgs/development/python-modules/litex/default.nix
@@ -1,0 +1,36 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, migen
+, packaging
+, requests
+, pyserial
+}:
+
+buildPythonPackage rec {
+  pname = "litex";
+  version = "2023.04";
+  format = "setuptools";
+
+  src = fetchFromGitHub {
+    owner = "enjoy-digital";
+    repo = "litex";
+    rev = version;
+    hash = "sha256-XXcYrCyFysglKT8AChyOT8rweG6IChEpueL+SFKc1Aw=";
+  };
+
+  propagatedBuildInputs = [ migen packaging requests pyserial ];
+
+  pythonImportsCheck = [ "litex" ];
+
+  # Tests are broken due to misimporting migen?
+  doCheck = false;
+
+  meta = with lib; {
+    description = "Build your hardware, easily";
+    homepage = "https://github.com/enjoy-digital/litex";
+    changelog = "https://github.com/enjoy-digital/litex/blob/${src.rev}/CHANGES.md";
+    license = with licenses; [ bsd2 ];
+    maintainers = with maintainers; [ raitobezarius ];
+  };
+}

--- a/pkgs/development/python-modules/pythondata-cpu-vexriscv/default.nix
+++ b/pkgs/development/python-modules/pythondata-cpu-vexriscv/default.nix
@@ -1,0 +1,30 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+}:
+
+buildPythonPackage rec {
+  pname = "pythondata-cpu-vexriscv";
+  version = "2020.04";
+  format = "setuptools";
+
+  src = fetchFromGitHub {
+    owner = "litex-hub";
+    repo = "pythondata-cpu-vexriscv";
+    rev = version;
+    hash = "sha256-6+cLGXhj16rlMRZ3p+qJ4FvIrRtvYUn+DKzqNT522NE=";
+    fetchSubmodules = true;
+  };
+
+  pythonImportsCheck = [ "pythondata_cpu_vexriscv" ];
+
+  # This is data.
+  doCheck = false;
+
+  meta = with lib; {
+    description = "Python module containing verilog files for vexriscv cpu (for use with LiteX";
+    homepage = "https://github.com/litex-hub/pythondata-cpu-vexriscv.git";
+    license = with licenses; [ mit ];
+    maintainers = with maintainers; [ raitobezarius ];
+  };
+}

--- a/pkgs/development/python-modules/pythondata-software-compiler_rt/default.nix
+++ b/pkgs/development/python-modules/pythondata-software-compiler_rt/default.nix
@@ -1,0 +1,28 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+}:
+
+buildPythonPackage rec {
+  pname = "pythondata-software-compiler-rt";
+  version = "2020.04";
+  format = "setuptools";
+
+  src = fetchFromGitHub {
+    owner = "litex-hub";
+    repo = "pythondata-software-compiler_rt";
+    rev = version;
+    hash = "sha256-nE0ZvdlHj4BfbKd1D+AqCHGpVXNMovOIGKMT32WqZ3A=";
+  };
+
+  pythonImportsCheck = [ "pythondata_software_compiler_rt" ];
+
+  doCheck = false;
+
+  meta = with lib; {
+    description = "Python module containing data files for compiler_rt software (for use with LiteX";
+    homepage = "https://github.com/litex-hub/pythondata-software-compiler_rt";
+    license = with licenses; [ ];
+    maintainers = with maintainers; [ raitobezarius ];
+  };
+}

--- a/pkgs/development/python-modules/pythondata-software-picolibc/default.nix
+++ b/pkgs/development/python-modules/pythondata-software-picolibc/default.nix
@@ -1,0 +1,29 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+}:
+
+buildPythonPackage rec {
+  pname = "pythondata-software-picolibc";
+  version = "2023.04";
+  format = "setuptools";
+
+  src = fetchFromGitHub {
+    owner = "litex-hub";
+    repo = "pythondata-software-picolibc";
+    rev = version;
+    hash = "sha256-0OpEdBGu/tkFFPUi1RLsTqF2tKwLSfYIi+vPqgfLMd8=";
+    fetchSubmodules = true;
+  };
+
+  pythonImportsCheck = [ "pythondata_software_picolibc" ];
+
+  doCheck = false;
+
+  meta = with lib; {
+    description = "Python module containing data files for picolibc software (for use with LiteX";
+    homepage = "https://github.com/litex-hub/pythondata-software-picolibc";
+    license = licenses.bsd3;
+    maintainers = with maintainers; [ raitobezarius ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -6242,6 +6242,7 @@ self: super: with self; {
   litex-boards = callPackage ../development/python-modules/litex-boards { };
 
   pythondata-software-picolibc = callPackage ../development/python-modules/pythondata-software-picolibc { };
+  pythondata-software-compiler_rt = callPackage ../development/python-modules/pythondata-software-compiler_rt { };
   mike = callPackage ../development/python-modules/mike { };
 
   milc = callPackage ../development/python-modules/milc { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -6241,6 +6241,7 @@ self: super: with self; {
 
   litex-boards = callPackage ../development/python-modules/litex-boards { };
 
+  pythondata-software-picolibc = callPackage ../development/python-modules/pythondata-software-picolibc { };
   mike = callPackage ../development/python-modules/mike { };
 
   milc = callPackage ../development/python-modules/milc { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -6237,6 +6237,8 @@ self: super: with self; {
 
   migen = callPackage ../development/python-modules/migen { };
 
+  litex = callPackage ../development/python-modules/litex { };
+
   mike = callPackage ../development/python-modules/mike { };
 
   milc = callPackage ../development/python-modules/milc { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -6239,6 +6239,8 @@ self: super: with self; {
 
   litex = callPackage ../development/python-modules/litex { };
 
+  litex-boards = callPackage ../development/python-modules/litex-boards { };
+
   mike = callPackage ../development/python-modules/mike { };
 
   milc = callPackage ../development/python-modules/milc { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -6243,8 +6243,10 @@ self: super: with self; {
 
   litespi = callPackage ../development/python-modules/litespi { };
 
+  pythondata-cpu-vexriscv = callPackage ../development/python-modules/pythondata-cpu-vexriscv { };
   pythondata-software-picolibc = callPackage ../development/python-modules/pythondata-software-picolibc { };
   pythondata-software-compiler_rt = callPackage ../development/python-modules/pythondata-software-compiler_rt { };
+
   mike = callPackage ../development/python-modules/mike { };
 
   milc = callPackage ../development/python-modules/milc { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -6241,6 +6241,8 @@ self: super: with self; {
 
   litex-boards = callPackage ../development/python-modules/litex-boards { };
 
+  litespi = callPackage ../development/python-modules/litespi { };
+
   pythondata-software-picolibc = callPackage ../development/python-modules/pythondata-software-picolibc { };
   pythondata-software-compiler_rt = callPackage ../development/python-modules/pythondata-software-compiler_rt { };
   mike = callPackage ../development/python-modules/mike { };


### PR DESCRIPTION
###### Description of changes

LiteX is a set of tools to work with FPGAs, I package the bare minimum to compile a VexRISCV for iCEBreaker iCE40 FPGA board.

This was tested with:
```
$ nix-shell -p 'python3.withPackages (ps: [ ps.litex-boards ps.litex ps.litespi ps.pythondata-cpu-vexriscv ps.pythondata-software-picolibc ps.pythondata-software-compiler_rt ])' 'pkgsCross.riscv32.buildPackages.gcc' 'meson' 'ninja' yosys nextpnr icestorm
$ python3 -m litex_boards.targets.icebreaker --cpu-type=vexriscv --cpu-variant=lite --build
```

producing a final Gateware for the iCEBreaker which was not tested on the hardware yet :).

**TODO** : I disabled tests everywhere because for some reason, it's complaining about migen not being there, etc. I am debugging this and this will be fixed or commented properly before merge.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes (or backporting 23.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
