### PR TITLE
rio: init at 0.0.6.1+2023-06-18

### DIFF
--- a/pkgs/applications/terminal-emulators/rio/default.nix
+++ b/pkgs/applications/terminal-emulators/rio/default.nix
@@ -1,0 +1,83 @@
+{ lib
+, fetchFromGitHub
+, rustPlatform
+, gitUpdater
+
+, autoPatchelfHook
+, pkg-config
+
+, gcc-unwrapped
+, fontconfig
+, libGL
+, vulkan-loader
+
+, withX11 ? true
+, libX11
+, libXcursor
+, libXi
+, libXrandr
+, libxcb
+
+, withWayland ? false
+, wayland
+}:
+let
+  rlinkLibs = [
+    (lib.getLib gcc-unwrapped)
+    fontconfig
+    libGL
+    vulkan-loader
+  ] ++ lib.optional withX11 [
+    libX11
+    libXcursor
+    libXi
+    libXrandr
+    libxcb
+  ] ++ lib.optional withWayland [
+    wayland
+  ];
+in
+rustPlatform.buildRustPackage rec {
+  pname = "rio";
+  version = "0.0.6.1-unstable-2023-06-18";
+
+  src = fetchFromGitHub {
+    owner = "raphamorim";
+    repo = "rio";
+    rev = "f3fbe7a020528d2f5ed8beaa3afd900a4c2e83a2";
+    hash = "sha256-emZqD/vvQHk43E8gTHVczCOni110sCRLMWp9igruYc8=";
+  };
+
+  cargoHash = "sha256-1ZQae5IHA+8HwyYGFBy1XPEYR8NAHHrU1JNOMT7T5zA=";
+
+  nativeBuildInputs = [
+    autoPatchelfHook
+    pkg-config
+  ];
+
+  runtimeDependencies = rlinkLibs;
+
+  buildInputs = rlinkLibs;
+
+  buildNoDefaultFeatures = true;
+  buildFeatures = [
+    (lib.optionalString withX11 "x11")
+    (lib.optionalString withWayland "wayland")
+  ];
+
+  passthru = {
+    updateScript = gitUpdater {
+      rev-prefix = "v";
+      ignoredVersions = ".(rc|beta).*";
+    };
+  };
+
+  meta = {
+    description = "A hardware-accelerated GPU terminal emulator powered by WebGPU";
+    homepage = "https://raphamorim.io/rio";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ otavio oluceps ];
+    platforms = lib.platforms.unix;
+    changelog = "https://github.com/raphamorim/rio/blob/v${version}/CHANGELOG.md";
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -11684,6 +11684,8 @@ with pkgs;
     inherit (darwin.apple_sdk_11_0.frameworks) Carbon Cocoa IOKit;
   };
 
+  rio = callPackage ../applications/terminal-emulators/rio { };
+
   rig = callPackage ../tools/misc/rig { };
 
   ripdrag = callPackage ../tools/misc/ripdrag { };


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes (or backporting 23.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
