### PR TITLE
elf-dissector: unstable-2020-11-14 -> unstable-2023-06-06 & fix build

### DIFF
--- a/pkgs/applications/misc/elf-dissector/default.nix
+++ b/pkgs/applications/misc/elf-dissector/default.nix
@@ -1,17 +1,31 @@
-{ mkDerivation, fetchgit, lib, cmake, extra-cmake-modules, kitemmodels
-, libiberty, libelf, libdwarf, libopcodes }:
+{ lib
+, stdenv
+, fetchgit
+, cmake
+, extra-cmake-modules
+, wrapQtAppsHook
+, kitemmodels
+, libiberty
+, libelf
+, libdwarf
+, libopcodes
+}:
 
-mkDerivation rec {
+stdenv.mkDerivation rec {
   pname = "elf-dissector";
-  version = "unstable-2020-11-14";
+  version = "unstable-2023-06-06";
 
   src = fetchgit {
     url = "https://invent.kde.org/sdk/elf-dissector.git";
-    rev = "d1700e76e3f60aff0a2a9fb63bc001251d2be522";
-    sha256 = "1h1xr3ag1sbf005drcx8g8dc5mk7fb2ybs73swrld7clcawhxnk8";
+    rev = "de2e80438176b4b513150805238f3333f660718c";
+    hash = "sha256-2yHPVPu6cncXhFCJvrSodcRFVAxj4vn+e99WhtiZniM=";
   };
 
-  nativeBuildInputs = [ cmake extra-cmake-modules ];
+  patches = [
+    ./fix_build_for_src_lib_disassembler_disassembler.diff
+  ];
+
+  nativeBuildInputs = [ cmake extra-cmake-modules wrapQtAppsHook ];
 
   buildInputs = [ kitemmodels libiberty libelf libdwarf libopcodes ];
 

--- a/pkgs/applications/misc/elf-dissector/fix_build_for_src_lib_disassembler_disassembler.diff
+++ b/pkgs/applications/misc/elf-dissector/fix_build_for_src_lib_disassembler_disassembler.diff
@@ -1,0 +1,13 @@
+diff --git a/src/lib/disassmbler/disassembler.cpp b/src/lib/disassmbler/disassembler.cpp
+index 3277544..e77ffc4 100644
+--- a/src/lib/disassmbler/disassembler.cpp
++++ b/src/lib/disassmbler/disassembler.cpp
+@@ -127,7 +127,7 @@ QString Disassembler::disassembleBinutils(const unsigned char* data, uint64_t si
+     QString result;
+     disassembler_ftype disassemble_fn;
+     disassemble_info info;
+-    INIT_DISASSEMBLE_INFO(info, &result, qstring_printf);
++    INIT_DISASSEMBLE_INFO(info, &result, qstring_printf, qstring_printf);
+ 
+     info.application_data = this;
+     info.flavour = bfd_target_elf_flavour;


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes (or backporting 23.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
