### PR TITLE
nixos-render-docs: De-lint using `ruff --fix`

### DIFF
--- a/pkgs/tools/nix/nixos-render-docs/src/nixos_render_docs/__init__.py
+++ b/pkgs/tools/nix/nixos-render-docs/src/nixos_render_docs/__init__.py
@@ -1,13 +1,10 @@
 import argparse
-import os
 import sys
 import textwrap
 import traceback
 from io import StringIO
 from pprint import pprint
-from typing import Any, Dict
 
-from .md import Converter
 from . import manual
 from . import options
 from . import parallel
@@ -26,7 +23,7 @@ def pretty_print_exc(e: BaseException, *, _desc_text: str = "error") -> None:
         for arg in args:
             pprint(arg, stream=buf)
         if extra_info := buf.getvalue():
-            print(f"\x1b[1;34mextra info:\x1b[0m", file=sys.stderr)
+            print("\x1b[1;34mextra info:\x1b[0m", file=sys.stderr)
             print(textwrap.indent(extra_info, "\t"), file=sys.stderr, end="")
     else:
         print(e)

--- a/pkgs/tools/nix/nixos-render-docs/src/nixos_render_docs/asciidoc.py
+++ b/pkgs/tools/nix/nixos-render-docs/src/nixos_render_docs/asciidoc.py
@@ -1,6 +1,6 @@
 from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
-from typing import Any, cast, Optional
+from typing import cast
 from urllib.parse import quote
 
 from .md import Renderer
@@ -104,7 +104,7 @@ class AsciiDocRenderer(Renderer):
     def hardbreak(self, token: Token, tokens: Sequence[Token], i: int) -> str:
         return " +\n"
     def softbreak(self, token: Token, tokens: Sequence[Token], i: int) -> str:
-        return f" "
+        return " "
     def code_inline(self, token: Token, tokens: Sequence[Token], i: int) -> str:
         self._parstack[-1].continuing = True
         return f"``{asciidoc_escape(token.content)}``"

--- a/pkgs/tools/nix/nixos-render-docs/src/nixos_render_docs/commonmark.py
+++ b/pkgs/tools/nix/nixos-render-docs/src/nixos_render_docs/commonmark.py
@@ -1,6 +1,6 @@
 from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
-from typing import Any, cast, Optional
+from typing import cast, Optional
 
 from .md import md_escape, md_make_code, Renderer
 

--- a/pkgs/tools/nix/nixos-render-docs/src/nixos_render_docs/docbook.py
+++ b/pkgs/tools/nix/nixos-render-docs/src/nixos_render_docs/docbook.py
@@ -1,7 +1,6 @@
 from collections.abc import Mapping, Sequence
-from typing import Any, cast, Optional, NamedTuple
+from typing import cast, Optional, NamedTuple
 
-import markdown_it
 from markdown_it.token import Token
 from xml.sax.saxutils import escape, quoteattr
 
@@ -197,7 +196,7 @@ class DocBookRenderer(Renderer):
         spacing = ' spacing="compact"' if token.meta.get('compact', False) else ''
         return f"<orderedlist{start}{spacing}>"
     def ordered_list_close(self, token: Token, tokens: Sequence[Token], i: int) -> str:
-        return f"</orderedlist>"
+        return "</orderedlist>"
     def heading_open(self, token: Token, tokens: Sequence[Token], i: int) -> str:
         hlevel = int(token.tag[1:])
         result = self._close_headings(hlevel)

--- a/pkgs/tools/nix/nixos-render-docs/src/nixos_render_docs/html.py
+++ b/pkgs/tools/nix/nixos-render-docs/src/nixos_render_docs/html.py
@@ -211,7 +211,7 @@ class HTMLRenderer(Renderer):
         self._ordered_list_nesting += 1
         return f'<div class="orderedlist"><ol class="orderedlist {extra}" {start} type="{style}">'
     def ordered_list_close(self, token: Token, tokens: Sequence[Token], i: int) -> str:
-        self._ordered_list_nesting -= 1;
+        self._ordered_list_nesting -= 1
         return "</ol></div>"
     def example_open(self, token: Token, tokens: Sequence[Token], i: int) -> str:
         if id := cast(str, token.attrs.get('id', '')):

--- a/pkgs/tools/nix/nixos-render-docs/src/nixos_render_docs/manpage.py
+++ b/pkgs/tools/nix/nixos-render-docs/src/nixos_render_docs/manpage.py
@@ -1,10 +1,9 @@
 from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
-from typing import Any, cast, Iterable, Optional
+from typing import cast, Iterable, Optional
 
 import re
 
-import markdown_it
 from markdown_it.token import Token
 
 from .md import Renderer

--- a/pkgs/tools/nix/nixos-render-docs/src/nixos_render_docs/manual.py
+++ b/pkgs/tools/nix/nixos-render-docs/src/nixos_render_docs/manual.py
@@ -7,9 +7,8 @@ import xml.sax.saxutils as xml
 from abc import abstractmethod
 from collections.abc import Mapping, Sequence
 from pathlib import Path
-from typing import Any, cast, ClassVar, Generic, get_args, NamedTuple, Optional, Union
+from typing import Any, cast, ClassVar, Generic, get_args, NamedTuple
 
-import markdown_it
 from markdown_it.token import Token
 
 from . import md, options
@@ -17,7 +16,6 @@ from .docbook import DocBookRenderer, Heading, make_xml_id
 from .html import HTMLRenderer, UnresolvedXrefError
 from .manual_structure import check_structure, FragmentType, is_include, TocEntry, TocEntryType, XrefTarget
 from .md import Converter, Renderer
-from .utils import Freezeable
 
 class BaseConverter(Converter[md.TR], Generic[md.TR]):
     # per-converter configuration for ns:arg=value arguments to include blocks, following
@@ -519,7 +517,7 @@ class HTMLConverter(BaseConverter[ManualHTMLRenderer]):
             # we use blender-style //path to denote paths relative to the origin file
             # (usually index.html). this makes everything a lot easier and clearer.
             if not into.startswith("//") or '/' in into[2:]:
-                raise RuntimeError(f"html:into-file must be a relative-to-origin //filename", into)
+                raise RuntimeError("html:into-file must be a relative-to-origin //filename", into)
             into = token.meta['include-args']['into-file'] = into[2:]
             if into in self._redirection_targets:
                 raise RuntimeError(f"redirection target {into} in line {token.map[0] + 1} is already in use")
@@ -617,7 +615,7 @@ class HTMLConverter(BaseConverter[ManualHTMLRenderer]):
             for item in xref_queue:
                 try:
                     target = item if isinstance(item, XrefTarget) else self._render_xref(*item)
-                except UnresolvedXrefError as e:
+                except UnresolvedXrefError:
                     if failed:
                         raise
                     deferred.append(item)

--- a/pkgs/tools/nix/nixos-render-docs/src/nixos_render_docs/md.py
+++ b/pkgs/tools/nix/nixos-render-docs/src/nixos_render_docs/md.py
@@ -1,6 +1,6 @@
 from abc import ABC
 from collections.abc import Mapping, MutableMapping, Sequence
-from typing import Any, Callable, cast, Generic, get_args, Iterable, Literal, NoReturn, Optional, TypeVar
+from typing import Any, cast, Generic, get_args, Iterable, Literal, NoReturn, Optional, TypeVar
 
 import dataclasses
 import re

--- a/pkgs/tools/nix/nixos-render-docs/src/nixos_render_docs/options.py
+++ b/pkgs/tools/nix/nixos-render-docs/src/nixos_render_docs/options.py
@@ -11,7 +11,6 @@ from markdown_it.token import Token
 from typing import Any, Generic, Optional
 from urllib.parse import quote
 
-import markdown_it
 
 from . import md
 from . import parallel
@@ -265,7 +264,7 @@ class DocBookConverter(BaseConverter[OptionsDocBookRenderer]):
                 '  <title>Configuration Options</title>',
             ]
         result += [
-            f'<variablelist xmlns:xlink="http://www.w3.org/1999/xlink"',
+            '<variablelist xmlns:xlink="http://www.w3.org/1999/xlink"',
             '               xmlns:nixos="tag:nixos.org"',
             '               xmlns="http://docbook.org/ns/docbook"',
             f'              xml:id="{self._varlist_id}">',

--- a/pkgs/tools/nix/nixos-render-docs/src/nixos_render_docs/parallel.py
+++ b/pkgs/tools/nix/nixos-render-docs/src/nixos_render_docs/parallel.py
@@ -4,7 +4,7 @@
 
 import multiprocessing
 
-from typing import Any, Callable, ClassVar, Iterable, Optional, TypeVar
+from typing import Any, Callable, Iterable, Optional, TypeVar
 
 R = TypeVar('R')
 S = TypeVar('S')

--- a/pkgs/tools/nix/nixos-render-docs/src/nixos_render_docs/types.py
+++ b/pkgs/tools/nix/nixos-render-docs/src/nixos_render_docs/types.py
@@ -1,5 +1,5 @@
 from collections.abc import Sequence
-from typing import Any, Callable, Optional, Tuple, NamedTuple
+from typing import Callable, Optional, NamedTuple
 
 from markdown_it.token import Token
 

--- a/pkgs/tools/nix/nixos-render-docs/src/tests/test_commonmark.py
+++ b/pkgs/tools/nix/nixos-render-docs/src/tests/test_commonmark.py
@@ -2,9 +2,8 @@ import nixos_render_docs as nrd
 
 from sample_md import sample1
 
-from typing import Mapping, Optional
+from typing import Mapping
 
-import markdown_it
 
 class Converter(nrd.md.Converter[nrd.commonmark.CommonMarkRenderer]):
     def __init__(self, manpage_urls: Mapping[str, str]):
@@ -27,7 +26,7 @@ def test_indented_fence() -> None:
 
 def test_full() -> None:
     c = Converter({ 'man(1)': 'http://example.org' })
-    assert c._render(sample1) == f"""\
+    assert c._render(sample1) == """\
 **Warning:** foo
 
 **Note:** nested

--- a/pkgs/tools/nix/nixos-render-docs/src/tests/test_manpage.py
+++ b/pkgs/tools/nix/nixos-render-docs/src/tests/test_manpage.py
@@ -2,9 +2,8 @@ import nixos_render_docs as nrd
 
 from sample_md import sample1
 
-from typing import Mapping, Optional
+from typing import Mapping
 
-import markdown_it
 
 class Converter(nrd.md.Converter[nrd.manpage.ManpageRenderer]):
     def __init__(self, manpage_urls: Mapping[str, str], options_by_id: dict[str, str] = {}):


### PR DESCRIPTION
###### Description of changes

This automated de-linting has applied a few different refactors:

- Remove unused imports and variables
- Change f-strings with no variables to regular strings
- Remove trailing semicolon

(This PR purposely doesn't include _all_ `ruff --fix .` changes in the nixpkgs tree, since that affects more than 20 files all over the place.)

###### Things done

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes (or backporting 23.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).