### PR TITLE
lightdm-slick-greeter: 1.6.1 -> 1.8.1

### DIFF
--- a/pkgs/applications/display-managers/lightdm-slick-greeter/default.nix
+++ b/pkgs/applications/display-managers/lightdm-slick-greeter/default.nix
@@ -7,10 +7,12 @@
 , intltool
 , autoreconfHook
 , wrapGAppsHook
+, cinnamon
 , lightdm
 , gtk3
 , pixman
 , libcanberra
+, libgnomekbd
 , libX11
 , libXext
 , linkFarm
@@ -20,13 +22,13 @@
 
 stdenv.mkDerivation rec {
   pname = "lightdm-slick-greeter";
-  version = "1.6.1";
+  version = "1.8.1";
 
   src = fetchFromGitHub {
     owner = "linuxmint";
     repo = "slick-greeter";
     rev = version;
-    sha256 = "sha256-k/E3bR63kesHQ/we+ctC0UEYE5YdZ6Lv5lYuXqCOvKA=";
+    sha256 = "sha256-40RyGWn32ppPjsuPljGBO6o7bu2rKYBweDycRS7xAVA=";
   };
 
   nativeBuildInputs = [
@@ -40,10 +42,12 @@ stdenv.mkDerivation rec {
   ];
 
   buildInputs = [
+    cinnamon.xapp
     lightdm
     gtk3
     pixman
     libcanberra
+    libgnomekbd # needed by XApp.KbdLayoutController
     libX11
     libXext
   ];
@@ -61,6 +65,10 @@ stdenv.mkDerivation rec {
 
     substituteInPlace src/session-list.vala \
       --replace "/usr/share" "${placeholder "out"}/share"
+
+    # We prefer stable path here.
+    substituteInPlace data/x.dm.slick-greeter.gschema.xml \
+      --replace "/usr/share/onboard" "/run/current-system/sw/share/onboard"
 
     patchShebangs files/usr/bin/*
   '';


### PR DESCRIPTION
https://github.com/linuxmint/slick-greeter/compare/1.6.1...1.8.1

###### Description of changes

Picked from [#235371](https://github.com/NixOS/nixpkgs/pull/235371/files), this only relies on `XApp.KbdLayoutController`, which is available since https://github.com/linuxmint/xapp/commit/42cebaa061fc36adcbf29ca853ac869cc075afef so shouldn't blocked by xapp update.

3 new hardcode absolute paths are introduced:

- `/usr/bin/slick-greeter-enable-tap-to-click` in `src/slick-greeter.vala` - we already handled `/usr/bin/slick-greeter` so this will be handled in the same way.
- `/etc/default/keyboard` in `src/menubar.vala` - this is per-system configuration and the greeter should handle the case when this is missing
- `/usr/share/onboard/layouts/Small.onboard` in `data/x.dm.slick-greeter.gschema.xml` - fixed the path, since this is a schema key default I want this to be a stable path

Tested [touchpad tap-to-click](https://github.com/linuxmint/slick-greeter/commit/85f83be9977faf2482d38d2cc289f0542b1c06a4), [reveal password](https://github.com/linuxmint/slick-greeter/commit/2e8797c80a2d8febf8f89bf38e1040ccbf8be4e0), [custom keyboard layout](https://github.com/linuxmint/slick-greeter/commit/ae090039efff87ad8b9b856f3fe451f9f41d21be) (via NixOS config and via top menu) on this branch

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes (or backporting 23.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
