### PR TITLE
ocamlPackage.{cohttp,github-unix}: fix for OCaml 5.0

### DIFF
--- a/pkgs/development/ocaml-modules/cohttp/default.nix
+++ b/pkgs/development/ocaml-modules/cohttp/default.nix
@@ -9,12 +9,15 @@ buildDunePackage rec {
   version = "5.1.0";
 
   minimalOCamlVersion = "4.08";
-  duneVersion = "3";
 
   src = fetchurl {
     url = "https://github.com/mirage/ocaml-cohttp/releases/download/v${version}/cohttp-v${version}.tbz";
-    sha256 = "sha256-mINgeBO7DSsWd84gYjQNUQFqbh8KBZ+S2bYI/iVWMAc=";
+    hash = "sha256-mINgeBO7DSsWd84gYjQNUQFqbh8KBZ+S2bYI/iVWMAc=";
   };
+
+  postPatch = ''
+    substituteInPlace cohttp/src/dune --replace 'bytes base64' 'base64'
+  '';
 
   buildInputs = [ jsonm ppx_sexp_conv ];
 

--- a/pkgs/development/ocaml-modules/github/unix.nix
+++ b/pkgs/development/ocaml-modules/github/unix.nix
@@ -7,7 +7,7 @@ buildDunePackage {
   inherit (github) version src;
 
   postPatch = ''
-    substituteInPlace unix/dune --replace 'github bytes' github
+    substituteInPlace unix/dune --replace 'github bytes' 'github'
   '';
 
   propagatedBuildInputs = [

--- a/pkgs/development/ocaml-modules/github/unix.nix
+++ b/pkgs/development/ocaml-modules/github/unix.nix
@@ -6,7 +6,9 @@ buildDunePackage {
   pname = "github-unix";
   inherit (github) version src;
 
-  duneVersion = "3";
+  postPatch = ''
+    substituteInPlace unix/dune --replace 'github bytes' github
+  '';
 
   propagatedBuildInputs = [
     github


### PR DESCRIPTION
###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes (or backporting 23.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
