### PR TITLE
sequoia: 0.28.0 -> 0.30.1

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2311.section.md
+++ b/nixos/doc/manual/release-notes/rl-2311.section.md
@@ -20,6 +20,8 @@
 
 ## Backward Incompatibilities {#sec-release-23.11-incompatibilities}
 
+- `python3.pkgs.sequoia` was removed in favor of `python3.pkgs.pysequoia`. The latter package is based on upstream's dedicated repository for sequoia's Python bindings, where the Python bindings from [gitlab:sequoia-pgp/sequoia](https://gitlab.com/sequoia-pgp/sequoia) were removed long ago.
+
 - `writeTextFile` now requires `executable` to be boolean, values like `null` or `""` will now fail to evaluate.
 
 - The latest version of `clonehero` now stores custom content in `~/.clonehero`. See the [migration instructions](https://clonehero.net/2022/11/29/v23-to-v1-migration-instructions.html). Typically, these content files would exist along side the binary, but the previous build used a wrapper script that would store them in `~/.config/unity3d/srylain Inc_/Clone Hero`.

--- a/pkgs/development/python-modules/pysequoia/default.nix
+++ b/pkgs/development/python-modules/pysequoia/default.nix
@@ -1,0 +1,61 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitLab
+, pkg-config
+, rustPlatform
+, cargo
+, rustc
+, bzip2
+, nettle
+, openssl
+, pcsclite
+, stdenv
+, darwin
+}:
+
+buildPythonPackage rec {
+  pname = "pysequoia";
+  version = "0.1.14";
+  format = "pyproject";
+
+  src = fetchFromGitLab {
+    owner = "sequoia-pgp";
+    repo = "pysequoia";
+    rev = "v${version}";
+    hash = "sha256-63kUUxZTG33cB/IiD4AiDpLOI6Uew/fETgqhaGc7zp0=";
+  };
+
+  cargoDeps = rustPlatform.fetchCargoTarball {
+    inherit src;
+    name = "${pname}-${version}";
+    hash = "sha256-S/j3bGgU46nvVQFs35ih05teVEIJrFN4Ryq4B7rLFDE=";
+  };
+
+  nativeBuildInputs = [
+    pkg-config
+    rustPlatform.bindgenHook
+    rustPlatform.cargoSetupHook
+    rustPlatform.maturinBuildHook
+    cargo
+    rustc
+  ];
+
+  buildInputs = [
+    bzip2
+    nettle
+    openssl
+    pcsclite
+  ] ++ lib.optionals stdenv.isDarwin [
+    darwin.apple_sdk.frameworks.CoreFoundation
+    darwin.apple_sdk.frameworks.Security
+  ];
+
+  pythonImportsCheck = [ "pysequoia" ];
+
+  meta = with lib; {
+    description = "This library provides OpenPGP facilities in Python through the Sequoia PGP library";
+    homepage = "https://sequoia-pgp.gitlab.io/pysequoia";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ doronbehar ];
+  };
+}

--- a/pkgs/tools/security/sequoia-sq/default.nix
+++ b/pkgs/tools/security/sequoia-sq/default.nix
@@ -11,7 +11,7 @@
 }:
 
 rustPlatform.buildRustPackage rec {
-  pname = "sequoia";
+  pname = "sequoia-sq";
   version = "0.30.1";
 
   src = fetchFromGitLab {

--- a/pkgs/top-level/aliases.nix
+++ b/pkgs/top-level/aliases.nix
@@ -1528,6 +1528,7 @@ mapAliases ({
   seeks = throw "seeks has been removed from nixpkgs, as it was unmaintained"; # Added 2020-06-21
   sepolgen = throw "sepolgen was merged into selinux-python"; # Added 2021-11-11
   session-desktop-appimage = session-desktop;
+  sequoia = sequoia-sq; # Added 2023-06-26
   sget = throw "sget has been removed from nixpkgs, as it is not supported upstream anymore see https://github.com/sigstore/sget/issues/145"; # Added 2023-05-26
   shared_mime_info = throw "'shared_mime_info' has been renamed to/replaced by 'shared-mime-info'"; # Converted to throw 2022-02-22
   inherit (libsForQt5.mauiPackages) shelf; # added 2022-05-17

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -12371,7 +12371,7 @@ with pkgs;
 
   seqdiag = with python3Packages; toPythonApplication seqdiag;
 
-  sequoia = callPackage ../tools/security/sequoia { };
+  sequoia-sq = callPackage ../tools/security/sequoia-sq { };
 
   sequoia-chameleon-gnupg = callPackage ../tools/security/sequoia-chameleon-gnupg { };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -12371,9 +12371,7 @@ with pkgs;
 
   seqdiag = with python3Packages; toPythonApplication seqdiag;
 
-  sequoia = callPackage ../tools/security/sequoia {
-    pythonPackages = python3Packages;
-  };
+  sequoia = callPackage ../tools/security/sequoia { };
 
   sequoia-chameleon-gnupg = callPackage ../tools/security/sequoia-chameleon-gnupg { };
 

--- a/pkgs/top-level/python-aliases.nix
+++ b/pkgs/top-level/python-aliases.nix
@@ -291,6 +291,7 @@ mapAliases ({
   scikitimage = scikit-image; # added 2023-05-14
   scikitlearn = scikit-learn; # added 2021-07-21
   selectors34 = throw "selectors34 has been removed: functionality provided by Python itself; archived by upstream."; # added 2021-06-10
+  sequoia = throw "python3Packages.sequoia was replaced by pysequoia - built from a dedicated repository, with a new API."; # added 2023-06-24
   setuptools_scm = setuptools-scm; # added 2021-06-03
   sharkiqpy = sharkiq; # added 2022-05-21
   ssh-mitm = throw "ssh-mitm was removed in favor of the top-level ssh-mitm"; # added 2023-05-09

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -11104,10 +11104,7 @@ self: super: with self; {
 
   seqeval = callPackage ../development/python-modules/seqeval { };
 
-  sequoia = disabledIf isPyPy (toPythonModule (pkgs.sequoia.override {
-    pythonPackages = self;
-    pythonSupport = true;
-  }));
+  sequoia = disabledIf isPyPy (toPythonModule pkgs.sequoi);
 
   serialio = callPackage ../development/python-modules/serialio { };
 

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -7785,6 +7785,8 @@ self: super: with self; {
 
   pysbd = callPackage ../development/python-modules/pysbd { };
 
+  pysequoia = callPackage ../development/python-modules/pysequoia { };
+
   pyschemes = callPackage ../development/python-modules/pyschemes { };
 
   pyschlage = callPackage ../development/python-modules/pyschlage { };
@@ -11103,8 +11105,6 @@ self: super: with self; {
   seqdiag = callPackage ../development/python-modules/seqdiag { };
 
   seqeval = callPackage ../development/python-modules/seqeval { };
-
-  sequoia = disabledIf isPyPy (toPythonModule pkgs.sequoi);
 
   serialio = callPackage ../development/python-modules/serialio { };
 

--- a/pkgs/top-level/python2-packages.nix
+++ b/pkgs/top-level/python2-packages.nix
@@ -71,8 +71,6 @@ with self; with super; {
 
   scandir = callPackage ../development/python2-modules/scandir { };
 
-  sequoia = disabled super.sequoia;
-
   setuptools = callPackage ../development/python2-modules/setuptools { };
 
   setuptools-scm = callPackage ../development/python2-modules/setuptools-scm { };


### PR DESCRIPTION
and fetch from the new upstream, since sequoia-sq (the CLI) was split out of the main sequoia repo (the library).
- <https://gitlab.com/sequoia-pgp/sequoia-sq>

additionally, python bindings were deprecated and split out into their own repo in 0.25.0, but our build script wasn't updated and has been silently not building bindings since then. i've removed the dead `pythonSupport` option, but for the record:
- python ffi library: <https://gitlab.com/sequoia-pgp/sequoia-ffi>
- commit which removed bindings from the main repo: <https://gitlab.com/sequoia-pgp/sequoia/-/commit/cf4c70b46040a53bf3992a124ba70b1b1ca852f1>

upstream builds 100% with cargo now, no Makefile, so we can rely more on stock `buildRustPackage`.

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

changelog: <https://gitlab.com/sequoia-pgp/sequoia-sq/-/blob/v0.30.1/NEWS>
noteworthy/breaking changes:
- `sq` now supports and implicitly uses a certificate store.  By default, `sq` uses the standard OpenPGP certificate directory. This is located at `$HOME/.local/share/pgp.cert.d` on XDG compliant systems.
- `sq key generate --creation-time TIME` is deprecated in favor of `sq key generate --time TIME`.
- `sq key user id --creation-time TIME` is deprecated in favor of `sq user id --time TIME`.


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes (or backporting 23.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
