### PR TITLE
haskellPackages.sydtest: Unbreak by disabling test suite.

### DIFF
--- a/pkgs/development/haskell-modules/configuration-hackage2nix/broken.yaml
+++ b/pkgs/development/haskell-modules/configuration-hackage2nix/broken.yaml
@@ -5193,7 +5193,6 @@ broken-packages:
   - sws
   - syb-extras
   - syb-with-class-instances-text
-  - sydtest
   - syfco
   - sym
   - symantic

--- a/pkgs/development/haskell-modules/configuration-nix.nix
+++ b/pkgs/development/haskell-modules/configuration-nix.nix
@@ -1246,4 +1246,7 @@ self: super: builtins.intersectAttrs super {
   # Disable checks to break dependency loop with SCalendar
   scalendar = dontCheck super.scalendar;
 
+  # Sydtest has a brittle test suite that will only work with the exact
+  # versions that it ships with.
+  sydtest = dontCheck super.sydtest;
 }


### PR DESCRIPTION
https://github.com/NixOS/nixpkgs/pull/236093 but for `nixos-23.05`.