### PR TITLE
degrib: init at 2.25

### DIFF
--- a/pkgs/applications/science/misc/degrib/default.nix
+++ b/pkgs/applications/science/misc/degrib/default.nix
@@ -1,0 +1,47 @@
+{ lib
+, stdenv
+, zlib
+, tcl
+, tcltls
+, tk
+, fetchzip
+}:
+
+stdenv.mkDerivation {
+  pname = "degrib";
+  version = "2.25";
+
+  src = fetchzip {
+    url = "https://lamp.mdl.nws.noaa.gov/lamp/Data/degrib/download/archive/degrib-20200921.tar.gz";
+    sha256 = "1md33zbp3bs85d0v2i77zyq4clabhzqpwg17jy9rnyn40dc1kjc7";
+  };
+
+  buildInputs = [
+    tcl
+    tcltls
+    tk
+  ];
+
+  # https://gis.stackexchange.com/questions/45259/how-to-compile-degrib-on-ubuntu-12-04-lts
+  patchPhase = ''
+    runHook prePatch
+    cd src
+    cp --no-preserve=mode ${zlib.static}/lib/libz.a zlib
+    mkdir -p ../bin
+    runHook postPatch
+  '';
+
+  hardeningDisable = [ "format" ];
+
+  # There seems to be no way to override the install prefix due to hardcoded paths
+  postInstall = ''
+    mv ../bin $out
+  '';
+
+  meta = with lib; {
+    description = "Decode NDFD (and other) GRIB2 files";
+    homepage = "https://vlab.noaa.gov/web/mdl/degrib-download";
+    license = licenses.unfree;
+    maintainers = with maintainers; [ boozedog matthewcroughan ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -541,6 +541,8 @@ with pkgs;
 
   dec-decode = callPackage ../development/tools/dec-decode { };
 
+  degrib = callPackage ../applications/science/misc/degrib { };
+
   dsq = callPackage ../tools/misc/dsq { };
 
   dtv-scan-tables = callPackage ../data/misc/dtv-scan-tables { };


### PR DESCRIPTION
###### Description of changes

Adds 23 year old software, [degrib](https://vlab.noaa.gov/web/mdl/degrib-download) to Nixpkgs. In the interest of archival, it would be very nice if this program was in Nixpkgs, due to the fact that tarballs.nixos.org would play a role in mirroring and archiving this software.

The reason the latest (2.26) was not packaged is because it seems not to compile for various reasons in multiple contexts (Ubuntu, etc). Perhaps they forgot to test it. 

@boozedog and myself worked on this together.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes (or backporting 23.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
