### PR TITLE
sensible-utils: init at 0.0.18

### DIFF
--- a/pkgs/tools/misc/sensible-utils/default.nix
+++ b/pkgs/tools/misc/sensible-utils/default.nix
@@ -1,0 +1,40 @@
+{ stdenv, lib, fetchFromGitLab, makeWrapper, bash }:
+
+stdenv.mkDerivation rec {
+  pname = "sensible-utils";
+  version = "0.0.18";
+
+  src = fetchFromGitLab {
+    domain = "salsa.debian.org";
+    owner = "debian";
+    repo = "sensible-utils";
+    rev = "debian/${version}";
+    sha256 = "sha256-fZJKPnEkPfo/3luUcHzAmGB2k1nkA4ATEQMSz0aN0YY=";
+  };
+
+  nativeBuildInputs = [ makeWrapper ];
+
+  dontConfigure = true;
+
+  installPhase = ''
+    mkdir -p $out/bin
+
+    cp sensible-browser sensible-editor sensible-pager sensible-terminal $out/bin/
+  '';
+
+  meta = with lib; {
+    description = "The package provides utilities used by programs to sensibly select and spawn an appropriate browser, editor, or pager.";
+    longDescription = ''
+       The specific utilities included are:
+       - sensible-browser
+       - sensible-editor
+       - sensible-pager
+    '';
+    homepage = "https://salsa.debian.org/debian/sensible-utils";
+    changelog = "https://salsa.debian.org/debian/sensible-utils/-/tags";
+    license = licenses.gpl2;
+    maintainers = with maintainers; [ pbek ];
+    platforms = platforms.unix;
+  };
+}
+

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1162,6 +1162,8 @@ with pkgs;
 
   closureInfo = callPackage ../build-support/closure-info.nix { };
 
+  sensible-utils = callPackage ../tools/misc/sensible-utils { };
+
   serverspec = callPackage ../tools/misc/serverspec { };
 
   setupSystemdUnits = callPackage ../build-support/setup-systemd-units.nix { };


### PR DESCRIPTION
###### Description of changes

Some packages, like [pet](https://github.com/NixOS/nixpkgs/blob/nixos-unstable/pkgs/development/tools/pet/default.nix) and [qc](https://github.com/NixOS/nixpkgs/blob/nixos-unstable/pkgs/development/tools/qc/default.nix) depend on "sensible-editor" to select an editor for editing its config file.

This package provides that script via Debian's [sensible-utils](https://salsa.debian.org/debian/sensible-utils).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes (or backporting 23.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
