### PR TITLE
insync: fix launching issue on wayland

### DIFF
--- a/pkgs/applications/networking/insync/default.nix
+++ b/pkgs/applications/networking/insync/default.nix
@@ -10,6 +10,7 @@
 , libdrm
 , libGL
 , wayland
+, xkeyboard_config
 , libthai
 }:
 
@@ -88,18 +89,16 @@ let
     # for including insync's xdg data dirs
     extraOutputsToInstall = [ "share" ];
 
-    targetPkgs = pkgs: [
+    targetPkgs = pkgs: with pkgs; [
       insync-pkg
-    ];
-
-    multiPkgs = pkgs: with pkgs; [
-      # apparently only package needed for the FHS :)
       libudev0-shim
     ];
 
     runScript = writeShellScript "insync-wrapper.sh" ''
     # QT_STYLE_OVERRIDE was used to suppress a QT warning, it should have no actual effect for this binary.
     export QT_STYLE_OVERRIDE=Fusion
+    # xkb configuration needed: https://github.com/NixOS/nixpkgs/issues/236365
+    export XKB_CONFIG_ROOT=${xkeyboard_config}/share/X11/xkb/
     exec "${insync-pkg.outPath}/lib/insync/insync" "$@"
     '';
 


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->


Per report from https://github.com/NixOS/nixpkgs/issues/236365#issuecomment-1581241418, after investigation, it is possible to reproduce that insync cannot start when wayland is enabled.

This patch fixes it, by setting XDG_ROOT_DIR correctly in the binary wrapper of insync.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes (or backporting 23.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
