### PR TITLE
python38Packages.jsonschema: depend on pkgutil-resolve-name

### DIFF
--- a/pkgs/development/python-modules/jsonschema/default.nix
+++ b/pkgs/development/python-modules/jsonschema/default.nix
@@ -7,6 +7,7 @@
 , hatchling
 , importlib-metadata
 , importlib-resources
+, pkgutil-resolve-name
 , pyrsistent
 , pythonOlder
 , twisted
@@ -54,6 +55,7 @@ buildPythonPackage rec {
     typing-extensions
   ] ++ lib.optionals (pythonOlder "3.9") [
     importlib-resources
+    pkgutil-resolve-name
   ];
 
   passthru.optional-dependencies = {

--- a/pkgs/development/python-modules/pkgutil-resolve-name/default.nix
+++ b/pkgs/development/python-modules/pkgutil-resolve-name/default.nix
@@ -17,6 +17,9 @@ buildPythonPackage rec {
     hash = "sha256-NX1snmp1VlPP14iTgXwIU682XdUeyX89NYqBk3O70XQ=";
   };
 
+  # has no tests
+  doCheck = false;
+
   passthru.updateScript = nix-update-script { };
 
   meta = {

--- a/pkgs/development/python-modules/pkgutil-resolve-name/default.nix
+++ b/pkgs/development/python-modules/pkgutil-resolve-name/default.nix
@@ -1,0 +1,25 @@
+{ buildPythonPackage
+, fetchPypi
+, lib
+, nix-update-script
+, pythonOlder
+}:
+buildPythonPackage rec {
+  pname = "pkgutil_resolve_name";
+  version = "1.3.10";
+  src = fetchPypi {
+    inherit pname version;
+    hash = "sha256-NX1snmp1VlPP14iTgXwIU682XdUeyX89NYqBk3O70XQ=";
+  };
+  format = "flit";
+  disabled = pythonOlder "3.7";
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    homepage = "https://pypi.org/project/pkgutil_resolve_name/";
+    description = "A backport of Python 3.9’s pkgutil.resolve_name.";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ yajo ];
+  };
+}

--- a/pkgs/development/python-modules/pkgutil-resolve-name/default.nix
+++ b/pkgs/development/python-modules/pkgutil-resolve-name/default.nix
@@ -5,14 +5,17 @@
 , pythonOlder
 }:
 buildPythonPackage rec {
-  pname = "pkgutil_resolve_name";
+  pname = "pkgutil-resolve-name";
   version = "1.3.10";
+  format = "flit";
+
+  disabled = pythonOlder "3.7";
+
   src = fetchPypi {
-    inherit pname version;
+    pname = "pkgutil_resolve_name";
+    inherit version;
     hash = "sha256-NX1snmp1VlPP14iTgXwIU682XdUeyX89NYqBk3O70XQ=";
   };
-  format = "flit";
-  disabled = pythonOlder "3.7";
 
   passthru.updateScript = nix-update-script { };
 

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -7530,6 +7530,8 @@ self: super: with self; {
 
   phonenumbers = callPackage ../development/python-modules/phonenumbers { };
 
+  pkgutil-resolve-name = callPackage ../development/python-modules/pkgutil-resolve-name { };
+
   micloud = callPackage ../development/python-modules/micloud { };
 
   msgraph-core = callPackage ../development/python-modules/msgraph-core { };


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
python38Packages.jsonschema: depend on pkgutil-resolve-name

python38Packages.jsonschema: depend on pkgutil-resolve-name

The missing dependency was making the build fail.

See https://github.com/python-jsonschema/jsonschema/blob/d35f2c258a8a4fed7533d73e9fe3f3ec36c579e8/pyproject.toml#L42

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes (or backporting 23.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

@moduon MT-1075