### PR TITLE
enochecker-test: init at 0.9.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -5572,6 +5572,11 @@
     githubId = 17859309;
     name = "Fuzen";
   };
+  fwc = {
+    github = "fwc";
+    githubId = 29337229;
+    name = "mtths";
+  };
   fxfactorial = {
     email = "edgar.factorial@gmail.com";
     github = "fxfactorial";

--- a/pkgs/development/python-modules/enochecker-core/default.nix
+++ b/pkgs/development/python-modules/enochecker-core/default.nix
@@ -1,0 +1,35 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, pythonOlder
+}:
+
+buildPythonPackage rec {
+  pname = "enochecker-core";
+  version = "0.10.0";
+  format = "setuptools";
+
+  disabled = pythonOlder "3.7";
+
+  src = fetchPypi {
+    inherit version;
+    pname = "enochecker_core";
+    hash = "sha256-N41p2XRCp55rcPXLpA4rPIARsva/dQzK8qafjzXtavI=";
+  };
+
+
+  pythonImportsCheck = [
+    "enochecker_core"
+  ];
+
+  # no tests upstream
+  doCheck = false;
+
+  meta = with lib; {
+    description = "Base library for enochecker libs";
+    homepage = "https://github.com/enowars/enochecker_core";
+    changelog = "https://github.com/enowars/enochecker_core/releases/tag/v${version}";
+    license = licenses.mit;
+    maintainers = with maintainers; [ fwc ];
+  };
+}

--- a/pkgs/development/tools/enochecker-test/default.nix
+++ b/pkgs/development/tools/enochecker-test/default.nix
@@ -1,0 +1,69 @@
+{ lib
+, buildPythonApplication
+, fetchPypi
+, pythonOlder
+, pythonRelaxDepsHook
+
+, certifi
+, charset-normalizer
+, enochecker-core
+, exceptiongroup
+, idna
+, iniconfig
+, jsons
+, packaging
+, pluggy
+, pytest
+, requests
+, tomli
+, typish
+, urllib3
+}:
+
+buildPythonApplication rec {
+  pname = "enochecker-test";
+  version = "0.9.0";
+  format = "setuptools";
+
+  disabled = pythonOlder "3.8";
+
+  src = fetchPypi {
+    inherit version;
+    pname = "enochecker_test";
+    hash = "sha256-M0RTstFePU7O51YVEncVDuuR6F7R8mfdKbO0j7k/o8Q=";
+  };
+
+  nativeBuildInputs = [
+    pythonRelaxDepsHook
+  ];
+
+  pythonRelaxDeps = true;
+
+  propagatedBuildInputs = [
+    certifi
+    charset-normalizer
+    enochecker-core
+    exceptiongroup
+    idna
+    iniconfig
+    jsons
+    packaging
+    pluggy
+    pytest
+    requests
+    tomli
+    typish
+    urllib3
+  ];
+
+  # tests require network access
+  doCheck = false;
+
+  meta = with lib; {
+    description = "Automatically test services/checker using the enochecker API";
+    homepage = "https://github.com/enowars/enochecker_test";
+    changelog = "https://github.com/enowars/enochecker_test/releases/tag/v${version}";
+    license = licenses.mit;
+    maintainers = with maintainers; [ fwc ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -565,6 +565,8 @@ with pkgs;
     inherit (darwin.apple_sdk.frameworks) Security;
   };
 
+  enochecker-test = with python3Packages; callPackage ../development/tools/enochecker-test { };
+
   enumer = callPackage ../tools/misc/enumer { };
 
   evans = callPackage ../development/tools/evans { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -3242,6 +3242,8 @@ self: super: with self; {
 
   enocean = callPackage ../development/python-modules/enocean { };
 
+  enochecker-core = callPackage ../development/python-modules/enochecker-core { };
+
   enrich = callPackage ../development/python-modules/enrich { };
 
   entrance = callPackage ../development/python-modules/entrance {


### PR DESCRIPTION
###### Description of changes

Adds [enochecker_test](https://github.com/enowars/enochecker_test) python package to test [enowars](https://enowars.github.io/) attack-defense CTF services.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes (or backporting 23.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
