### PR TITLE
python310Packages.summarytools: init at 0.2.3

### DIFF
--- a/pkgs/development/python-modules/summarytools/default.nix
+++ b/pkgs/development/python-modules/summarytools/default.nix
@@ -1,0 +1,41 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, pythonOlder
+, ipython
+, matplotlib
+, numpy
+, pandas
+, pytestCheckHook
+}:
+
+buildPythonPackage rec {
+  pname = "summarytools";
+  version = "0.2.3";
+  format = "pyproject";
+
+  disabled = pythonOlder "3.7";
+
+  # no version tags in GitHub repo
+  src = fetchPypi {
+    inherit pname version;
+    hash = "sha256-wsDf9IXCMQe0cVfQQuRVwMhxkhhUxbPu06yWZPLvgw4=";
+  };
+
+  propagatedBuildInputs = [
+    ipython
+    matplotlib
+    numpy
+    pandas
+  ];
+
+  nativeCheckImports = [ pytestCheckHook ];
+  pythonImportsCheck = [ "summarytools" ];
+
+  meta = with lib; {
+    description = "Python port of the R summarytools package for summarizing dataframes";
+    homepage = "https://github.com/6chaoran/jupyter-summarytools";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ bcdarwin ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -11839,6 +11839,8 @@ self: super: with self; {
 
   sumtypes = callPackage ../development/python-modules/sumtypes { };
 
+  summarytools = callPackage ../development/python-modules/summarytools { };
+
   sunpy = callPackage ../development/python-modules/sunpy { };
 
   sunwatcher = callPackage ../development/python-modules/sunwatcher { };


### PR DESCRIPTION
###### Description of changes

Add  a package.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes (or backporting 23.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).