### PR TITLE
GNOME updates 2023-06-14

### DIFF
--- a/pkgs/desktops/gnome/core/zenity/default.nix
+++ b/pkgs/desktops/gnome/core/zenity/default.nix
@@ -1,7 +1,6 @@
 { stdenv
 , lib
 , fetchurl
-, fetchpatch2
 , meson
 , ninja
 , pkg-config
@@ -16,40 +15,12 @@
 
 stdenv.mkDerivation rec {
   pname = "zenity";
-  version = "3.92.0";
+  version = "3.99.0";
 
   src = fetchurl {
     url = "mirror://gnome/sources/zenity/${lib.versions.majorMinor version}/${pname}-${version}.tar.xz";
-    sha256 = "bSvCP2bL2PfhlVVvDDG9ZfClx4vLGuow6XFty/qxqKk=";
+    sha256 = "kOdDSnKLoD8fAkJIY8w5NV0kBxWNf5ZAPVHPVs8m7s8=";
   };
-
-  patches = [
-    # Add non-fatal deprecation warning for --attach, --icon-name, --hint
-    # To reduce issues like https://github.com/BuddiesOfBudgie/budgie-desktop/issues/356
-    (fetchpatch2 {
-      url = "https://gitlab.gnome.org/GNOME/zenity/-/commit/181ca36ad4790b425f79b20be40dd25804208463.patch";
-      sha256 = "Z6XOn5XnBzJSti8tD4EGezCpHmYAsIxBf7s4W3rBc9I=";
-    })
-    (fetchpatch2 {
-      url = "https://gitlab.gnome.org/GNOME/zenity/-/commit/70abb01173562dba40916c522bd20b4ba5a55904.patch";
-      sha256 = "yBm7AxJiTPh2BFb+79L4WSh8xOcM6AHuvLzIEEFY80s=";
-    })
-    (fetchpatch2 {
-      url = "https://gitlab.gnome.org/GNOME/zenity/-/commit/df445feb0c0fab6865d96fb693a32fbc26503d83.patch";
-      sha256 = "DTeBCsahceNZCfNziO2taXiMEdAFgm5Bx9OrlZv0LsM=";
-    })
-    (fetchpatch2 {
-      url = "https://gitlab.gnome.org/GNOME/zenity/-/commit/54bd43cbe30fbe5c9f01e42e8f3de63405770e2a.patch";
-      sha256 = "tR9CKt24w7D3EA6FLu6qroS5rTkfIsaQnuY4KzgDKMY=";
-    })
-
-    # Restore the availability of running multiple instances of zenity
-    # https://gitlab.gnome.org/GNOME/zenity/-/issues/58
-    (fetchpatch2 {
-      url = "https://gitlab.gnome.org/GNOME/zenity/-/commit/cd32ad7d3fa66dccc77d96a0fd3a61bf137250f6.patch";
-      sha256 = "4XCuJgXsNIiBXv4NM1JRoiqgBqyxnro0HHapkK2fM8o=";
-    })
-  ];
 
   nativeBuildInputs = [
     meson

--- a/pkgs/development/libraries/gtk/4.x.nix
+++ b/pkgs/development/libraries/gtk/4.x.nix
@@ -2,7 +2,6 @@
 , stdenv
 , substituteAll
 , fetchurl
-, fetchpatch2
 , pkg-config
 , gettext
 , graphene
@@ -65,7 +64,7 @@ in
 
 stdenv.mkDerivation rec {
   pname = "gtk4";
-  version = "4.10.3";
+  version = "4.10.4";
 
   outputs = [ "out" "dev" ] ++ lib.optionals x11Support [ "devdoc" ];
   outputBin = "dev";
@@ -77,26 +76,12 @@ stdenv.mkDerivation rec {
 
   src = fetchurl {
     url = "mirror://gnome/sources/gtk/${lib.versions.majorMinor version}/gtk-${version}.tar.xz";
-    sha256 = "RUVEGteeN3624KcFAm3HpGiG5GobA020CRKQnagBzqk=";
+    sha256 = "dyVABILgaF4oJl4ibGKEf05zz8qem0FqxYOCB/U3eiQ=";
   };
 
   patches = [
     # https://github.com/NixOS/nixpkgs/pull/218143#issuecomment-1501059486
     ./patches/4.0-fix-darwin-build.patch
-
-    # Fix deleting in Nautilus (part of 4.10.4)
-    # https://gitlab.gnome.org/GNOME/nautilus/-/issues/2945
-    (fetchpatch2 {
-      url = "https://gitlab.gnome.org/GNOME/gtk/-/commit/4f47683710bbb4b56c286c6ee6a5c394fcf2b755.patch";
-      sha256 = "fU9SX8MH37ZN6Ffk/YhYmipTC7+uT9JXnWggArWNkqA=";
-    })
-    # Fix border/artifact appearing in applications (part of 4.10.4)
-    # https://gitlab.gnome.org/GNOME/mutter/-/issues/2805
-    # https://gitlab.gnome.org/GNOME/gnome-shell/-/issues/6696
-    (fetchpatch2 {
-      url = "https://gitlab.gnome.org/GNOME/gtk/-/commit/b686ce1cb62dba505120e0f1116c516662a06e30.patch";
-      sha256 = "0zjY5s+T4CVe3WiowgWE58ruVvqBFUuY2juwBOzMRN4=";
-    })
   ];
 
   depsBuildBuild = [

--- a/pkgs/development/libraries/libadwaita/default.nix
+++ b/pkgs/development/libraries/libadwaita/default.nix
@@ -20,7 +20,7 @@
 
 stdenv.mkDerivation rec {
   pname = "libadwaita";
-  version = "1.3.2";
+  version = "1.3.3";
 
   outputs = [ "out" "dev" "devdoc" ];
   outputBin = "devdoc"; # demo app
@@ -30,7 +30,7 @@ stdenv.mkDerivation rec {
     owner = "GNOME";
     repo = "libadwaita";
     rev = version;
-    hash = "sha256-9Qha8xN3lC/t5dQNYPbgMX6HAKgEk80pyycrd5MGYLo=";
+    hash = "sha256-YIxGwl+/F7xkGjoi07GViSHAfCTE1RpEBhHfrlD0X/4=";
   };
 
   depsBuildBuild = [


### PR DESCRIPTION
###### Description of changes

I bumped zenity since 3.92.0 is already an unstable version and [there are crashes](https://src.fedoraproject.org/rpms/zenity/c/bc469906168832bd4f9027bc3ecd4f6f750ee7b5?branch=f38). With this bump it no longer requires `help2man` (I don't think **we** need to run `data/generate-manpage.sh`) though we never generate manpages before 

Tested gtk4 bump with nautilus, budgie ssd titlebar via `system.replaceRuntimeDependencies`, launched adwaita-1-demo, and confirmed zenity did not add `--class` support back (:upside_down_face:)

(I am offline in the next few hours due to timezone and might not address your review fast)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes (or backporting 23.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
