### PR TITLE
nix-ld: 1.1.0 -> 1.2.1

### DIFF
--- a/nixos/modules/programs/nix-ld.nix
+++ b/nixos/modules/programs/nix-ld.nix
@@ -2,15 +2,14 @@
 let
   cfg = config.programs.nix-ld;
 
-  # TODO make glibc here configurable?
-  nix-ld-so = pkgs.runCommand "ld.so" {} ''
-    ln -s "$(cat '${pkgs.stdenv.cc}/nix-support/dynamic-linker')" $out
-  '';
-
   nix-ld-libraries = pkgs.buildEnv {
     name = "lb-library-path";
     pathsToLink = [ "/lib" ];
     paths = map lib.getLib cfg.libraries;
+    # TODO make glibc here configurable?
+    postBuild = ''
+      ln -s ${pkgs.stdenv.cc.bintools.dynamicLinker} $out/share/nix-ld/lib/ld.so
+    '';
     extraPrefix = "/share/nix-ld";
     ignoreCollisions = true;
   };
@@ -60,7 +59,7 @@ in
     environment.pathsToLink = [ "/share/nix-ld" ];
 
     environment.variables = {
-      NIX_LD = toString nix-ld-so;
+      NIX_LD = "/run/current-system/sw/share/nix-ld/lib/ld.so";
       NIX_LD_LIBRARY_PATH = "/run/current-system/sw/share/nix-ld/lib";
     };
   };

--- a/nixos/modules/programs/nix-ld.nix
+++ b/nixos/modules/programs/nix-ld.nix
@@ -37,12 +37,7 @@ in
   meta.maintainers = [ lib.maintainers.mic92 ];
   options.programs.nix-ld = {
     enable = lib.mkEnableOption (lib.mdDoc ''nix-ld, Documentation: <https://github.com/Mic92/nix-ld>'');
-    package = lib.mkOption {
-      type = lib.types.package;
-      description = lib.mdDoc "Which package to use for the nix-ld.";
-      default = pkgs.nix-ld;
-      defaultText = lib.literalExpression "pkgs.nix-ld";
-    };
+    package = lib.mkPackageOptionMD pkgs "nix-ld" { };
     libraries = lib.mkOption {
       type = lib.types.listOf lib.types.package;
       description = lib.mdDoc "Libraries that automatically become available to all programs. The default set includes common libraries.";

--- a/nixos/tests/nix-ld.nix
+++ b/nixos/tests/nix-ld.nix
@@ -13,5 +13,8 @@ import ./make-test-python.nix ({ lib, pkgs, ...} :
   testScript = ''
     start_all()
     machine.succeed("hello")
+
+    # test fallback if NIX_LD is not set
+    machine.succeed("unset NIX_LD; unset NIX_LD_LIBRARY_PATH; hello")
  '';
 })

--- a/pkgs/os-specific/linux/nix-ld/default.nix
+++ b/pkgs/os-specific/linux/nix-ld/default.nix
@@ -12,13 +12,13 @@ let
 in
 stdenv.mkDerivation rec {
   pname = "nix-ld";
-  version = "1.1.0";
+  version = "1.2.1";
 
   src = fetchFromGitHub {
     owner = "mic92";
     repo = "nix-ld";
     rev = version;
-    sha256 = "sha256-dM9YPN+yq6sHmRhJQinYdAVXBkTgEtrVQcsd/mIIX0o=";
+    sha256 = "sha256-NitUt9LBJMpAbbKC98aRPYMfxZFq3PHH6ieqM4MVO08=";
   };
 
   doCheck = true;


### PR DESCRIPTION
Diff: https://github.com/mic92/nix-ld/compare/1.1.0...1.2.1

This makes nix-ld a lot more useful for snarky build systems that like to unset environment variables cc @sternenseemann 

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes (or backporting 23.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
