### PR TITLE
python3Packages.podman: init at 4.5.0

### DIFF
--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -607,6 +607,7 @@ in {
   plotinus = handleTest ./plotinus.nix {};
   podgrab = handleTest ./podgrab.nix {};
   podman = handleTestOn ["aarch64-linux" "x86_64-linux"] ./podman/default.nix {};
+  podman-py = handleTest ./podman-py.nix {};
   podman-tls-ghostunnel = handleTestOn ["aarch64-linux" "x86_64-linux"] ./podman/tls-ghostunnel.nix {};
   polaris = handleTest ./polaris.nix {};
   pomerium = handleTestOn ["x86_64-linux"] ./pomerium.nix {};

--- a/nixos/tests/podman-py.nix
+++ b/nixos/tests/podman-py.nix
@@ -1,0 +1,35 @@
+import ./make-test-python.nix ({ pkgs, ... }:
+  let
+    pythonWithPackages = pkgs.python3.withPackages (ps:
+      with ps; [
+        pyxdg
+        requests
+        sphinx
+        tomli
+        urllib3
+
+        pytest
+
+        fixtures
+        requests-mock
+      ]);
+
+    alpineImage = pkgs.dockerTools.pullImage {
+      imageName = "quay.io/libpod/alpine";
+      imageDigest = "sha256:fa93b01658e3a5a1686dc3ae55f170d8de487006fb53a28efcd12ab0710a2e5f"; # 3.10.2
+      sha256 = "sha256-ewZ3QgwUwt1CJJeWSvZsGb+xBleFJYcnBG5eUh2rTDY=";
+    };
+  in {
+    name = "podman-py";
+
+    nodes.machine.virtualisation.podman.enable = true;
+
+    testScript = ''
+      machine.wait_for_unit('sockets.target')
+
+      # this image is required for tests
+      machine.execute('${pkgs.podman}/bin/podman load -i ${alpineImage}')
+
+      machine.succeed('${pythonWithPackages}/bin/pytest ${pkgs.python3Packages.podman.src}/podman/tests/integration')
+    '';
+  })

--- a/pkgs/development/python-modules/podman/default.nix
+++ b/pkgs/development/python-modules/podman/default.nix
@@ -1,6 +1,7 @@
 { lib
 , buildPythonPackage
 , fetchFromGitHub
+, nixosTests
 , fixtures
 , pytestCheckHook
 , pyxdg
@@ -8,7 +9,6 @@
 , requests-mock
 , sphinx
 , tomli
-, tox
 , urllib3
 }:
 
@@ -36,7 +36,6 @@ buildPythonPackage rec {
     fixtures
     pytestCheckHook
     requests-mock
-    tox
   ];
 
   disabledTestPaths = [
@@ -47,6 +46,10 @@ buildPythonPackage rec {
   pythonImportsCheck = [
     "podman"
   ];
+
+  passthru.tests = {
+    inherit (nixosTests) podman-py;
+  };
 
   meta = with lib; {
     description = "This python package is a library of bindings to use the RESTful API of Podman";

--- a/pkgs/development/python-modules/podman/default.nix
+++ b/pkgs/development/python-modules/podman/default.nix
@@ -1,0 +1,57 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, fixtures
+, pytestCheckHook
+, pyxdg
+, requests
+, requests-mock
+, sphinx
+, tomli
+, tox
+, urllib3
+}:
+
+buildPythonPackage rec {
+  pname = "podman-py";
+  version = "4.5.0";
+  format = "pyproject";
+
+  src = fetchFromGitHub {
+    owner = "containers";
+    repo = "podman-py";
+    rev = "v${version}";
+    hash = "sha256-xG5a+l0pAFPe9lv7aOCQE7sAXEEUhyylmpBMIK7ymjw=";
+  };
+
+  propagatedBuildInputs = [
+    pyxdg
+    requests
+    sphinx
+    tomli
+    urllib3
+  ];
+
+  nativeCheckInputs = [
+    fixtures
+    pytestCheckHook
+    requests-mock
+    tox
+  ];
+
+  disabledTestPaths = [
+    # Tests require active podman service
+    "podman/tests/integration"
+  ];
+
+  pythonImportsCheck = [
+    "podman"
+  ];
+
+  meta = with lib; {
+    description = "This python package is a library of bindings to use the RESTful API of Podman";
+    homepage = "https://github.com/containers/podman-py";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ rhoriguchi ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -7951,6 +7951,8 @@ self: super: with self; {
 
   podcats = callPackage ../development/python-modules/podcats { };
 
+  podman = callPackage ../development/python-modules/podman { };
+
   poetry-core = callPackage ../development/python-modules/poetry-core { };
 
   poetry-dynamic-versioning = callPackage ../development/python-modules/poetry-dynamic-versioning { };


### PR DESCRIPTION
###### Description of changes

I would love some help since I can't get the integration tests to run correctly. The biggest issue is the missing internet connection inside of the test.

###### Things done

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes (or backporting 23.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
