### PR TITLE
[22.11] frescobaldi: 3.1.3 -> 3.2 

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -2218,6 +2218,12 @@
     githubId = 3212452;
     name = "Cameron Nemo";
   };
+  camillemndn = {
+    email = "camillemondon@free.fr";
+    github = "camillemndn";
+    githubId = 26444818;
+    name = "Camille M.";
+  };
   campadrenalin = {
     email = "campadrenalin@gmail.com";
     github = "campadrenalin";

--- a/pkgs/development/python-modules/qpageview/default.nix
+++ b/pkgs/development/python-modules/qpageview/default.nix
@@ -1,0 +1,33 @@
+{ lib
+, fetchFromGitHub
+, buildPythonPackage
+, python3Packages
+, pythonOlder
+}:
+
+python3Packages.buildPythonPackage rec {
+  pname = "qpageview";
+  version = "0.6.2";
+  format = "setuptools";
+
+  disabled = pythonOlder "3.6";
+
+  src = fetchFromGitHub {
+    owner = "frescobaldi";
+    repo = pname;
+    rev = "v${version}";
+    hash = "sha256-XFMTOD7ums8sbFHUViEI9q6/rCjUmEtXAdd3/OmLsHU=";
+  };
+
+  propagatedBuildInputs = with python3Packages; [ pyqt5 poppler-qt5 pycups ];
+
+  pythonImportsCheck = [ "qpageview" ];
+
+  meta = with lib; {
+    description = "A page-based viewer widget for Qt5/PyQt5";
+    homepage = "https://github.com/frescobaldi/qpageview";
+    changelog = "https://github.com/frescobaldi/qpageview/blob/${src.rev}/ChangeLog";
+    license = licenses.gpl3Only;
+    maintainers = with maintainers; [ camillemndn ];
+  };
+}

--- a/pkgs/misc/frescobaldi/default.nix
+++ b/pkgs/misc/frescobaldi/default.nix
@@ -2,18 +2,23 @@
 
 buildPythonApplication rec {
   pname = "frescobaldi";
-  version = "3.1.3";
+  version = "3.2";
 
   src = fetchFromGitHub {
     owner = "wbsoft";
     repo = "frescobaldi";
     rev = "v${version}";
-    sha256 = "1p8f4vn2dpqndw1dylmg7wms6vi69zcfj544c908s4r8rrmbycyf";
+    sha256 = "sha256-q340ChF7VZcbLMW/nd1so7WScsPfbdeJUjTzsY5dkec=";
   };
 
   propagatedBuildInputs = with python3Packages; [
-    lilypond pygame python-ly sip_4
-    pyqt5 poppler-qt5
+    qpageview
+    lilypond
+    pygame
+    python-ly
+    sip_4
+    pyqt5
+    poppler-qt5
     pyqtwebengine
   ];
 
@@ -30,7 +35,7 @@ buildPythonApplication rec {
 
   dontWrapQtApps = true;
   makeWrapperArgs = [
-      "\${qtWrapperArgs[@]}"
+    "\${qtWrapperArgs[@]}"
   ];
 
   meta = with lib; {

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -9515,6 +9515,8 @@ self: super: with self; {
 
   qnapstats = callPackage ../development/python-modules/qnapstats { };
 
+  qpageview = callPackage ../development/python-modules/qpageview { };
+
   qrcode = callPackage ../development/python-modules/qrcode { };
 
   qreactor = callPackage ../development/python-modules/qreactor { };


### PR DESCRIPTION
###### Description of changes

(cherry picked from commit 8e374f7c687d78f25ed03d908f38334fbf41bf39)

Additional cherry-picks from https://github.com/NixOS/nixpkgs/pull/214007 per https://github.com/NixOS/nixpkgs/pull/214013#issuecomment-1586975328.

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes (or backporting 23.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).