### PR TITLE
faust2sc: remove workaround

### DIFF
--- a/pkgs/applications/audio/faust/faust2sc.nix
+++ b/pkgs/applications/audio/faust/faust2sc.nix
@@ -22,17 +22,11 @@ stdenv.mkDerivation (faustDefaults // {
   '';
 
   postFixup = ''
-    # export parts of the build environment
-    mkdir "$out"/include
-    # until pr #887 is merged and released in faust we need to link the header folders
-    ln -s "${supercollider}"/include/SuperCollider/plugin_interface "$out"/include/plugin_interface
-    ln -s "${supercollider}"/include/SuperCollider/common "$out"/include/common
-    ln -s "${supercollider}"/include/SuperCollider/server "$out"/include/server
     wrapProgram "$out"/bin/${baseName} \
       --append-flags "--import-dir ${faust}/share/faust" \
       --append-flags "--architecture-dir ${faust}/share/faust" \
       --append-flags "--architecture-dir ${faust}/include" \
-      --append-flags "-p $out" \
+      --append-flags "-p ${supercollider}" \
       --prefix PATH : "$PATH"
   '';
 })


### PR DESCRIPTION
Before faust 2.59.6 faust2sc had a bug, now headers can be provided from the path of the source package.

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes (or backporting 23.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
