### PR TITLE
nixos/postgresql: add `upgradeFrom` option

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2311.section.md
+++ b/nixos/doc/manual/release-notes/rl-2311.section.md
@@ -100,6 +100,8 @@ The module update takes care of the new config syntax and the data itself (user 
 
 - `programs.gnupg.agent.pinentryFlavor` is now set in `/etc/gnupg/gpg-agent.conf`, and will no longer take precedence over a `pinentry-program` set in `~/.gnupg/gpg-agent.conf`.
 
+- `services.postgresql` gained `upgradeFrom` and `analyzeAfterUpgrade` options to specify upgrades from prior postgresql versions.
+
 ## Nixpkgs internals {#sec-release-23.11-nixpkgs-internals}
 
 - The `qemu-vm.nix` module by default now identifies block devices via

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -627,6 +627,7 @@ in {
   apache_datasketches = handleTest ./apache_datasketches.nix {};
   postgresql = handleTest ./postgresql.nix {};
   postgresql-jit = handleTest ./postgresql-jit.nix {};
+  postgresql-upgrade = handleTest ./postgresql-upgrade.nix {};
   postgresql-wal-receiver = handleTest ./postgresql-wal-receiver.nix {};
   powerdns = handleTest ./powerdns.nix {};
   powerdns-admin = handleTest ./powerdns-admin.nix {};

--- a/nixos/tests/postgresql-upgrade.nix
+++ b/nixos/tests/postgresql-upgrade.nix
@@ -1,0 +1,144 @@
+{ system ? builtins.currentSystem
+, config ? { }
+, pkgs ? import ../.. { inherit system config; }
+}:
+
+let
+  lib = pkgs.lib;
+
+  inherit (import ../lib/testing-python.nix { inherit system pkgs; })
+    makeTest;
+
+  pgPackages = lib.filterAttrs (_: p: !p.jitSupport)
+    (import ../../pkgs/servers/sql/postgresql pkgs);
+
+  end = lib.last (lib.mapAttrsToList lib.nameValuePair pgPackages);
+
+  startPackages = lib.attrsets.removeAttrs pgPackages [ end.name ];
+
+  mkInsert = package: pkgs.writeShellApplication {
+    name = "insert";
+    runtimeInputs = [ package pkgs.gnugrep ];
+    text = ''
+      run_sql() {
+        su -c 'psql testdb -At -v ON_ERROR_STOP=1' postgres
+      }
+
+      run_sql <<- 'QUERY'
+        CREATE TABLE books (
+          title   text,
+          author  text,
+          year    int
+        );
+
+        INSERT INTO books (title, author, year) VALUES
+        ('Do Androids Dream Of Electric Sheep?', 'Philip K. Dick', 1968),
+        ('Neuromancer', 'William Gibson', 1984),
+        ('Cryptonomicon', 'Neal Stephenson', 1999),
+        ('Accelerando', 'Charles Stross', 2005);
+      QUERY
+    '';
+  };
+
+  verify = pkgs.writeShellApplication {
+    name = "verify";
+    runtimeInputs = [ end.value pkgs.gnugrep ];
+    text = ''
+      run_sql() {
+        su -c 'psql testdb -At -v ON_ERROR_STOP=1' postgres
+      }
+
+      die() {
+        echo "$1" >&2 && exit 1
+      }
+
+      run_sql <<- 'QUERY' | grep 't' || die 'No author found 1'
+        SELECT exists(SELECT * FROM books WHERE author = 'Philip K. Dick');
+      QUERY
+
+      run_sql <<- 'QUERY' | grep 't' || die 'No title found'
+        SELECT exists(SELECT * FROM books WHERE title = 'Neuromancer');
+      QUERY
+
+      run_sql <<- 'QUERY' | grep 't' || die 'No year found'
+        SELECT exists(SELECT * FROM books WHERE year = 1999);
+      QUERY
+
+      run_sql <<- 'QUERY' | grep 't' || die 'No author found 2'
+        SELECT exists(SELECT * FROM books WHERE author = 'Charles Stross');
+      QUERY
+    '';
+  };
+
+  mkTest = start: makeTest rec {
+    name = "postgresql-upgrade-${start.psqlSchema}-to-${end.value.psqlSchema}";
+
+    meta.maintainers = [ lib.maintainers.jsoo1 ];
+
+    nodes = {
+      start = {
+        services.postgresql = {
+          enable = true;
+
+          package = start;
+
+          dataDir = "/var/lib/postgresql/${start.psqlSchema}";
+
+          ensureDatabases = [ "testdb" ];
+        };
+      };
+      end = {
+        services.postgresql = {
+          enable = true;
+
+          package = end.value;
+
+          dataDir = "/var/lib/postgresql/${end.value.psqlSchema}";
+
+          upgradeFrom.package = start;
+
+          upgradeFrom.settings = {
+            link = true;
+            # Test listOf settings
+            old-options = lib.cli.toGNUCommandLine { } {
+              d = 3;
+            };
+            new-options = lib.cli.toGNUCommandLine { } {
+              d = 3;
+            };
+          };
+
+          analyzeAfterUpgrade = true;
+        };
+
+        # We want the service to start after the data directory has been copied.
+        systemd.services.postgresql.wantedBy = lib.mkForce [ ];
+      };
+    };
+
+    testScript = ''
+      import os
+      import tempfile
+
+      with tempfile.TemporaryDirectory(dir=os.getenv("out")) as tmp:
+          start.wait_for_unit("postgresql.service")
+          start.succeed("${mkInsert start}/bin/insert")
+          start.succeed("systemctl stop postgresql.service")
+          start.copy_from_vm(
+            source="${nodes.start.services.postgresql.dataDir}",
+            target_dir=tmp,
+          )
+
+          end.copy_from_host(
+              source=tmp,
+              target="${builtins.dirOf nodes.end.services.postgresql.dataDir}",
+          )
+          end.succeed("systemctl start postgresql.service")
+          end.succeed("${verify}/bin/verify")
+
+          end.succeed("systemctl restart postgresql.service")
+          end.succeed("${verify}/bin/verify")
+    '';
+  };
+in
+lib.mapAttrs (_: pkg: mkTest pkg) startPackages

--- a/pkgs/servers/sql/postgresql/default.nix
+++ b/pkgs/servers/sql/postgresql/default.nix
@@ -249,6 +249,7 @@ let
 
       tests = {
         postgresql = nixosTests.postgresql-wal-receiver.${thisAttr};
+        upgrade = nixosTests.postgresql-upgrade.${thisAttr};
       } // lib.optionalAttrs jitSupport {
         postgresql-jit = nixosTests.postgresql-jit.${thisAttr};
       };


### PR DESCRIPTION
We use postgres quite a bit and upgrading from old versions has proven to be too manual.

The goal here is to automate the `pg_upgrade` process to ease postgres version changes.

###### Description of changes

This adds `upgradeFrom` and `analyzeAfterUpgrade` options to `services.postgresql`.

`upgradeFrom` is used to specify an optional postgres package to upgrade from. For example:

```nix
config.services.postgresql.package = pkgs.postgresql_15;

config.services.postgresql.upgradeFrom = {
  package = pkgs.postgresql_11;
  settings.old-datadir = "/var/lib/postgresql/11.1";
  settings.link = true;
};
```

Will upgrade from 11.1 to 15 on the next `nixos-rebuild` during the pre-start script using the `link` setting.
If the old data dir is either missing or marked as upgraded, the upgrade script is noop.

The package is required since `pg_upgrade` requires paths to old binaries.

When specified, `analyzeAfterUpgrade` will run `vacuumdb --all --analyze-in-stages` as postgres suggests when `pg_upgrade` is done in the post-start script.


Comes with accompanying nixos test and documentation changes on upgrades.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [X] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes (or backporting 23.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [X] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
