### PR TITLE
nixos/tests/systemd-initrd-vconsole: fix test and improve reliability

### DIFF
--- a/nixos/lib/test-driver/test_driver/machine.py
+++ b/nixos/lib/test-driver/test_driver/machine.py
@@ -868,7 +868,7 @@ class Machine:
         # to match multiline regexes.
         console = io.StringIO()
 
-        def console_matches() -> bool:
+        def console_matches(_: Any) -> bool:
             nonlocal console
             try:
                 # This will return as soon as possible and
@@ -884,7 +884,7 @@ class Machine:
             if timeout is not None:
                 retry(console_matches, timeout)
             else:
-                while not console_matches():
+                while not console_matches(False):
                     pass
 
     def send_key(

--- a/nixos/tests/systemd-initrd-vconsole.nix
+++ b/nixos/tests/systemd-initrd-vconsole.nix
@@ -2,7 +2,7 @@ import ./make-test-python.nix ({ lib, pkgs, ... }: {
   name = "systemd-initrd-vconsole";
 
   nodes.machine = { pkgs, ... }: {
-    boot.kernelParams = [ "rd.systemd.unit=rescue.target" ];
+    boot.kernelParams = lib.mkAfter [ "rd.systemd.unit=rescue.target" "loglevel=3" "udev.log_level=3" "systemd.log_level=warning" ];
 
     boot.initrd.systemd = {
       enable = true;
@@ -20,14 +20,23 @@ import ./make-test-python.nix ({ lib, pkgs, ... }: {
     machine.start()
     machine.wait_for_console_text("Press Enter for maintenance")
     machine.send_console("\n")
-    machine.wait_for_console_text("Logging in with home")
+
+    # Wait for shell to become ready
+    for _ in range(300):
+      machine.send_console("printf '%s to receive commands:\\n' Ready\n")
+      try:
+        machine.wait_for_console_text("Ready to receive commands:", timeout=1)
+        break
+      except Exception:
+        continue
+    else:
+      raise RuntimeError("Rescue shell never became ready")
 
     # Check keymap
-    machine.send_console("(printf '%s to receive text: \\n' Ready && read text && echo \"$text\") </dev/tty1\n")
+    machine.send_console("(printf '%s to receive text:\\n' Ready && read text && echo \"$text\") </dev/tty1\n")
     machine.wait_for_console_text("Ready to receive text:")
     for key in "asdfjkl;\n":
       machine.send_key(key)
     machine.wait_for_console_text("arstneio")
-    machine.send_console("systemctl poweroff\n")
   '';
 })


### PR DESCRIPTION
###### Description of changes

I noticed that the test has been failing locally and apparently in Hydra since March (oops...)

This fixes it after what was probably some systemd update and improves the reliability of the test (sometimes it would start typing too fast and fail)

~~I hate having to use `pkgs.bash.version` to figure out what to search for on the console but just searching for `sh-` is probably too prone to false positives and we don't have other text now which indicates the prompt is ready. I'm open to suggestions though (e.g. creating a shell rc file that prints some special phrase)~~

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes (or backporting 23.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).