### PR TITLE
fcitx5: Remove unused import+variable

### DIFF
--- a/pkgs/tools/inputmethods/fcitx5/update.py
+++ b/pkgs/tools/inputmethods/fcitx5/update.py
@@ -2,7 +2,6 @@
 #!nix-shell -i python3 -p nix-update nix-prefetch-github python3Packages.requests
 
 from nix_prefetch_github import *
-import json
 import requests
 import subprocess
 

--- a/pkgs/tools/inputmethods/fcitx5/update.py
+++ b/pkgs/tools/inputmethods/fcitx5/update.py
@@ -33,7 +33,6 @@ def get_latest_tag(repo, owner=OWNER):
     return r.json()[0].get("name")
 
 def main():
-    sources = dict()
     for repo in REPOS:
         rev = get_latest_tag(repo)
         if repo == "fcitx5-qt":


### PR DESCRIPTION
###### Description of changes

Detected and changed by `ruff --fix`.

###### Things done

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes (or backporting 23.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).