### PR TITLE
build-rust-package: by default set well known environment variables to build with system libraries

### DIFF
--- a/pkgs/applications/blockchains/nearcore/default.nix
+++ b/pkgs/applications/blockchains/nearcore/default.nix
@@ -28,8 +28,6 @@ rustPlatform.buildRustPackage rec {
   CARGO_PROFILE_RELEASE_LTO = "fat";
   NEAR_RELEASE_BUILD = "release";
 
-  OPENSSL_NO_VENDOR = 1; # we want to link to OpenSSL provided by Nix
-
   # don't build SDK samples that require wasm-enabled rust
   buildAndTestSubdir = "neard";
   doCheck = false; # needs network

--- a/pkgs/applications/blockchains/polkadot/default.nix
+++ b/pkgs/applications/blockchains/polkadot/default.nix
@@ -1,12 +1,15 @@
 { fetchFromGitHub
 , lib
+, pkg-config
 , protobuf
 , rocksdb
 , rustPlatform
 , stdenv
 , Security
 , SystemConfiguration
+, zstd
 }:
+
 rustPlatform.buildRustPackage rec {
   pname = "polkadot";
   version = "0.9.42";
@@ -39,9 +42,10 @@ rustPlatform.buildRustPackage rec {
     };
   };
 
-  buildInputs = lib.optionals stdenv.isDarwin [ Security SystemConfiguration ];
+  buildInputs = [ zstd ]
+    ++ lib.optionals stdenv.isDarwin [ Security SystemConfiguration ];
 
-  nativeBuildInputs = [ rustPlatform.bindgenHook ];
+  nativeBuildInputs = [ rustPlatform.bindgenHook pkg-config ];
 
   preBuild = ''
     export SUBSTRATE_CLI_GIT_COMMIT_HASH=$(cat .git_commit)

--- a/pkgs/applications/blockchains/snarkos/default.nix
+++ b/pkgs/applications/blockchains/snarkos/default.nix
@@ -25,8 +25,6 @@ rustPlatform.buildRustPackage rec {
 
   nativeBuildInputs = lib.optionals stdenv.isLinux [ pkg-config rustPlatform.bindgenHook ];
 
-  # Needed to get openssl-sys to use pkg-config.
-  OPENSSL_NO_VENDOR = 1;
   OPENSSL_LIB_DIR = "${lib.getLib openssl}/lib";
   OPENSSL_DIR="${lib.getDev openssl}";
 

--- a/pkgs/applications/blockchains/solana/default.nix
+++ b/pkgs/applications/blockchains/solana/default.nix
@@ -94,9 +94,6 @@ rustPlatform.buildRustPackage rec {
   CPPFLAGS=lib.optionals stdenv.isDarwin "-isystem ${lib.getDev libcxx}/include/c++/v1";
   LDFLAGS=lib.optionals stdenv.isDarwin "-L${lib.getLib libcxx}/lib";
 
-  # If set, always finds OpenSSL in the system, even if the vendored feature is enabled.
-  OPENSSL_NO_VENDOR = 1;
-
   meta = with lib; {
     description = "Web-Scale Blockchain for fast, secure, scalable, decentralized apps and marketplaces. ";
     homepage = "https://solana.com";

--- a/pkgs/applications/editors/lapce/default.nix
+++ b/pkgs/applications/editors/lapce/default.nix
@@ -93,9 +93,6 @@ rustPlatform.buildRustPackage rec {
     gobject-introspection
   ];
 
-  # Get openssl-sys to use pkg-config
-  OPENSSL_NO_VENDOR = 1;
-
   buildInputs = [
     glib
     gtk3

--- a/pkgs/applications/file-managers/felix-fm/default.nix
+++ b/pkgs/applications/file-managers/felix-fm/default.nix
@@ -3,6 +3,7 @@
 , fetchFromGitHub
 , pkg-config
 , bzip2
+, oniguruma
 , zstd
 , zoxide
 }:
@@ -29,6 +30,7 @@ rustPlatform.buildRustPackage rec {
 
   buildInputs = [
     bzip2
+    oniguruma
     zstd
   ];
 

--- a/pkgs/applications/graphics/artem/default.nix
+++ b/pkgs/applications/graphics/artem/default.nix
@@ -23,8 +23,6 @@ rustPlatform.buildRustPackage rec {
 
   buildInputs = [ openssl ];
 
-  OPENSSL_NO_VENDOR = 1;
-
   checkFlags = [
     # require internet access
     "--skip=arguments::input::url_input"

--- a/pkgs/applications/misc/faircamp/default.nix
+++ b/pkgs/applications/misc/faircamp/default.nix
@@ -7,6 +7,7 @@
 , libopus
 , vips
 , ffmpeg
+, zstd
 , callPackage
 , unstableGitUpdater
 }:
@@ -39,6 +40,7 @@ rustPlatform.buildRustPackage {
     glib
     libopus
     vips
+    zstd
   ];
 
   postInstall = ''

--- a/pkgs/applications/misc/oranda/default.nix
+++ b/pkgs/applications/misc/oranda/default.nix
@@ -43,10 +43,6 @@ rustPlatform.buildRustPackage rec {
     "--skip=build"
   ];
 
-  env = {
-    ZSTD_SYS_USE_PKG_CONFIG = true;
-  };
-
   meta = with lib; {
     description = "Generate beautiful landing pages for your developer tools";
     homepage = "https://github.com/axodotdev/oranda";

--- a/pkgs/applications/misc/oranda/default.nix
+++ b/pkgs/applications/misc/oranda/default.nix
@@ -44,7 +44,6 @@ rustPlatform.buildRustPackage rec {
   ];
 
   env = {
-    RUSTONIG_SYSTEM_LIBONIG = true;
     ZSTD_SYS_USE_PKG_CONFIG = true;
   };
 

--- a/pkgs/applications/misc/tickrs/default.nix
+++ b/pkgs/applications/misc/tickrs/default.nix
@@ -32,10 +32,6 @@ rustPlatform.buildRustPackage rec {
     darwin.apple_sdk.frameworks.SystemConfiguration
   ];
 
-  env = {
-    OPENSSL_NO_VENDOR = true;
-  };
-
   meta = with lib; {
     description = "Realtime ticker data in your terminal";
     homepage = "https://github.com/tarkah/tickrs";

--- a/pkgs/applications/misc/watchmate/default.nix
+++ b/pkgs/applications/misc/watchmate/default.nix
@@ -9,6 +9,7 @@
 , openssl
 , wrapGAppsHook4
 , glib
+, zstd
 }:
 
 rustPlatform.buildRustPackage rec {
@@ -40,6 +41,7 @@ rustPlatform.buildRustPackage rec {
     bluez
     dbus
     openssl
+    zstd
   ];
 
   postInstall = ''

--- a/pkgs/applications/misc/zola/default.nix
+++ b/pkgs/applications/misc/zola/default.nix
@@ -39,8 +39,6 @@ rustPlatform.buildRustPackage rec {
     CoreServices
   ];
 
-  RUSTONIG_SYSTEM_LIBONIG = true;
-
   postInstall = ''
     installShellCompletion --cmd zola \
       --bash <($out/bin/zola completion bash) \

--- a/pkgs/applications/networking/cluster/habitat/default.nix
+++ b/pkgs/applications/networking/cluster/habitat/default.nix
@@ -49,7 +49,6 @@ rustPlatform.buildRustPackage rec {
   cargoTestFlags = cargoBuildFlags;
 
   env = {
-    SODIUM_USE_PKG_CONFIG = true;
     SSL_CERT_FILE = "${cacert}/etc/ssl/certs/ca-bundle.crt";
   };
 

--- a/pkgs/applications/networking/cluster/habitat/default.nix
+++ b/pkgs/applications/networking/cluster/habitat/default.nix
@@ -49,7 +49,6 @@ rustPlatform.buildRustPackage rec {
   cargoTestFlags = cargoBuildFlags;
 
   env = {
-    OPENSSL_NO_VENDOR = true;
     SODIUM_USE_PKG_CONFIG = true;
     SSL_CERT_FILE = "${cacert}/etc/ssl/certs/ca-bundle.crt";
   };

--- a/pkgs/applications/networking/remote/rustdesk/default.nix
+++ b/pkgs/applications/networking/remote/rustdesk/default.nix
@@ -11,6 +11,7 @@
 , clang
 , gtk3
 , xdotool
+, libsodium
 , libxcb
 , libXfixes
 , alsa-lib
@@ -96,7 +97,7 @@ rustPlatform.buildRustPackage rec {
     '';
 
   nativeBuildInputs = [ pkg-config cmake makeWrapper copyDesktopItems yasm nasm clang wrapGAppsHook rustPlatform.bindgenHook ];
-  buildInputs = [ alsa-lib pulseaudio libXfixes libxcb xdotool gtk3 libvpx libopus libXtst libyuv ];
+  buildInputs = [ alsa-lib pulseaudio libsodium libXfixes libxcb xdotool gtk3 libvpx libopus libXtst libyuv ];
 
   # Checks require an active X display.
   doCheck = false;

--- a/pkgs/applications/science/logic/elan/default.nix
+++ b/pkgs/applications/science/logic/elan/default.nix
@@ -16,7 +16,6 @@ rustPlatform.buildRustPackage rec {
 
   nativeBuildInputs = [ pkg-config makeWrapper ];
 
-  OPENSSL_NO_VENDOR = 1;
   buildInputs = [ curl zlib openssl ]
     ++ lib.optional stdenv.isDarwin libiconv;
 

--- a/pkgs/applications/terminal-emulators/wezterm/default.nix
+++ b/pkgs/applications/terminal-emulators/wezterm/default.nix
@@ -19,11 +19,13 @@
 , xcbutilwm
 , wayland
 , zlib
+, zstd
 , CoreGraphics
 , Cocoa
 , Foundation
 , System
 , libiconv
+, oniguruma
 , UserNotifications
 , nixosTests
 , runCommand
@@ -66,7 +68,9 @@ rustPlatform.buildRustPackage rec {
 
   buildInputs = [
     fontconfig
+    oniguruma
     zlib
+    zstd
   ] ++ lib.optionals stdenv.isLinux [
     libX11
     libxcb

--- a/pkgs/applications/version-management/delta/default.nix
+++ b/pkgs/applications/version-management/delta/default.nix
@@ -35,10 +35,6 @@ rustPlatform.buildRustPackage rec {
 
   nativeCheckInputs = [ git ];
 
-  env = {
-    RUSTONIG_SYSTEM_LIBONIG = true;
-  };
-
   postInstall = ''
     installShellCompletion --cmd delta \
       etc/completion/completion.{bash,fish,zsh}

--- a/pkgs/applications/version-management/git-cinnabar/default.nix
+++ b/pkgs/applications/version-management/git-cinnabar/default.nix
@@ -26,8 +26,6 @@ stdenv.mkDerivation rec {
     sha256 = "GApYgE7AezKmcGWNY+dF1Yp1TZmEeUdq3CsjvMvo/Rw=";
   };
 
-  ZSTD_SYS_USE_PKG_CONFIG = true;
-
   enableParallelBuilding = true;
 
   installPhase = ''

--- a/pkgs/applications/version-management/git-dive/default.nix
+++ b/pkgs/applications/version-management/git-dive/default.nix
@@ -54,8 +54,6 @@ rustPlatform.buildRustPackage rec {
     git config --global user.email nixbld@example.com
   '';
 
-  RUSTONIG_SYSTEM_LIBONIG = true;
-
   meta = with lib; {
     description = "Dive into a file's history to find root cause";
     homepage = "https://github.com/gitext-rs/git-dive";

--- a/pkgs/applications/version-management/git-trim/default.nix
+++ b/pkgs/applications/version-management/git-trim/default.nix
@@ -32,8 +32,6 @@ rustPlatform.buildRustPackage rec {
     })
   ];
 
-  OPENSSL_NO_VENDOR = 1;
-
   nativeBuildInputs = [ pkg-config ];
 
   buildInputs = [ openssl libgit2 ]

--- a/pkgs/applications/version-management/gitoxide/default.nix
+++ b/pkgs/applications/version-management/gitoxide/default.nix
@@ -29,9 +29,6 @@ rustPlatform.buildRustPackage rec {
     then [ libiconv Security SystemConfiguration ]
     else [ openssl ]);
 
-  # Needed to get openssl-sys to use pkg-config.
-  OPENSSL_NO_VENDOR = 1;
-
   meta = with lib; {
     description = "A command-line application for interacting with git repositories";
     homepage = "https://github.com/Byron/gitoxide";

--- a/pkgs/applications/version-management/gitui/default.nix
+++ b/pkgs/applications/version-management/gitui/default.nix
@@ -29,9 +29,6 @@ rustPlatform.buildRustPackage rec {
     ++ lib.optional stdenv.isLinux xclip
     ++ lib.optionals stdenv.isDarwin [ libiconv Security AppKit ];
 
-  # Needed to get openssl-sys to use pkg-config.
-  OPENSSL_NO_VENDOR = 1;
-
   # The cargo config overrides linkers for some targets, breaking the build
   # on e.g. `aarch64-linux`. These overrides are not required in the Nix
   # environment: delete them.

--- a/pkgs/applications/version-management/jujutsu/default.nix
+++ b/pkgs/applications/version-management/jujutsu/default.nix
@@ -26,9 +26,6 @@ rustPlatform.buildRustPackage rec {
 
   cargoHash = "sha256-PydDgXp47KUSLvAQgfO+09lrzTnBjzGd+zA5f/jZfRc=";
 
-  # Needed to get openssl-sys to use pkg-config.
-  OPENSSL_NO_VENDOR = 1;
-
   nativeBuildInputs = [
     pkg-config
   ];

--- a/pkgs/applications/video/dmlive/default.nix
+++ b/pkgs/applications/video/dmlive/default.nix
@@ -24,8 +24,6 @@ rustPlatform.buildRustPackage rec {
 
   cargoHash = "sha256-0zOwqxD3WX/4e19ywpghdfoGmh2KC+70HbTSYkVHzUA=";
 
-  OPENSSL_NO_VENDOR = true;
-
   nativeBuildInputs = [ pkg-config makeWrapper ];
   buildInputs = [ openssl ] ++ lib.optional stdenv.isDarwin Security;
 

--- a/pkgs/applications/virtualization/cloud-hypervisor/default.nix
+++ b/pkgs/applications/virtualization/cloud-hypervisor/default.nix
@@ -31,8 +31,6 @@ rustPlatform.buildRustPackage rec {
   nativeBuildInputs = [ pkg-config ];
   buildInputs = [ openssl ] ++ lib.optional stdenv.isAarch64 dtc;
 
-  OPENSSL_NO_VENDOR = true;
-
   # Integration tests require root.
   cargoTestFlags = [ "--bins" ];
 

--- a/pkgs/build-support/rust/build-rust-package/default.nix
+++ b/pkgs/build-support/rust/build-rust-package/default.nix
@@ -46,6 +46,7 @@
 , checkFeatures ? buildFeatures
 , useNextest ? false
 , auditable ? !cargo-auditable.meta.broken
+, useSystemLibraries ? true
 
 , depsExtraArgs ? {}
 
@@ -169,4 +170,12 @@ stdenv.mkDerivation ((removeAttrs args [ "depsExtraArgs" "cargoUpdateHook" "carg
       "wasm32-wasi"
     ];
   } // meta;
-})
+} // lib.optionalAttrs useSystemLibraries (
+# doesn't work on darwin
+lib.optionalAttrs stdenv.isLinux {
+  OPENSSL_NO_VENDOR = 1;
+} // {
+  RUSTONIG_SYSTEM_LIBONIG = true;
+  SODIUM_USE_PKG_CONFIG = true;
+  ZSTD_SYS_USE_PKG_CONFIG = true;
+}))

--- a/pkgs/development/compilers/scryer-prolog/default.nix
+++ b/pkgs/development/compilers/scryer-prolog/default.nix
@@ -2,6 +2,7 @@
 , rustPlatform
 , fetchFromGitHub
 , pkg-config
+, libsodium
 , openssl
 , gmp
 , libmpc
@@ -28,7 +29,7 @@ rustPlatform.buildRustPackage rec {
   };
 
   nativeBuildInputs = [ pkg-config ];
-  buildInputs = [ openssl gmp libmpc mpfr ];
+  buildInputs = [ libsodium openssl gmp libmpc mpfr ];
 
   CARGO_FEATURE_USE_SYSTEM_LIBS = true;
 

--- a/pkgs/development/tools/build-managers/moon/default.nix
+++ b/pkgs/development/tools/build-managers/moon/default.nix
@@ -5,6 +5,7 @@
 , stdenv
 , openssl
 , pkg-config
+, zstd
 }:
 
 rustPlatform.buildRustPackage rec {
@@ -24,10 +25,12 @@ rustPlatform.buildRustPackage rec {
     RUSTFLAGS = "-C strip=symbols";
   };
 
-  buildInputs = [ openssl ] ++
-    lib.optionals stdenv.isDarwin [
-      darwin.apple_sdk.frameworks.Security
-      darwin.apple_sdk.frameworks.SystemConfiguration
+  buildInputs = [
+    openssl
+    zstd
+  ] ++ lib.optionals stdenv.isDarwin [
+    darwin.apple_sdk.frameworks.Security
+    darwin.apple_sdk.frameworks.SystemConfiguration
   ];
   nativeBuildInputs = [ pkg-config ];
 

--- a/pkgs/development/tools/build-managers/moon/default.nix
+++ b/pkgs/development/tools/build-managers/moon/default.nix
@@ -22,7 +22,6 @@ rustPlatform.buildRustPackage rec {
 
   env = {
     RUSTFLAGS = "-C strip=symbols";
-    OPENSSL_NO_VENDOR = 1;
   };
 
   buildInputs = [ openssl ] ++

--- a/pkgs/development/tools/database/prisma-engines/default.nix
+++ b/pkgs/development/tools/database/prisma-engines/default.nix
@@ -23,9 +23,6 @@ rustPlatform.buildRustPackage rec {
     sha256 = "sha256-NJQvu+EREF40u5P3i8h2yGYC1vM6Q8xEXX9WyOnJkBM=";
   };
 
-  # Use system openssl.
-  OPENSSL_NO_VENDOR = 1;
-
   cargoLock = {
     lockFile = ./Cargo.lock;
     outputHashes = {

--- a/pkgs/development/tools/misc/namaka/default.nix
+++ b/pkgs/development/tools/misc/namaka/default.nix
@@ -30,7 +30,6 @@ rustPlatform.buildRustPackage rec {
 
   env = {
     GEN_ARTIFACTS = "artifacts";
-    RUSTONIG_SYSTEM_LIBONIG = true;
   };
 
   postInstall = ''

--- a/pkgs/development/tools/railway/default.nix
+++ b/pkgs/development/tools/railway/default.nix
@@ -19,8 +19,6 @@ rustPlatform.buildRustPackage rec {
   buildInputs = [ openssl ]
     ++ lib.optionals stdenv.isDarwin [ CoreServices Security ];
 
-  OPENSSL_NO_VENDOR = 1;
-
   meta = with lib; {
     mainProgram = "railway";
     description = "Railway.app CLI";

--- a/pkgs/development/tools/rust/cargo-about/default.nix
+++ b/pkgs/development/tools/rust/cargo-about/default.nix
@@ -26,10 +26,6 @@ rustPlatform.buildRustPackage rec {
     darwin.apple_sdk.frameworks.Security
   ];
 
-  env = {
-    ZSTD_SYS_USE_PKG_CONFIG = true;
-  };
-
   meta = with lib; {
     description = "Cargo plugin to generate list of all licenses for a crate";
     homepage = "https://github.com/EmbarkStudios/cargo-about";

--- a/pkgs/development/tools/rust/cargo-deny/default.nix
+++ b/pkgs/development/tools/rust/cargo-deny/default.nix
@@ -38,10 +38,6 @@ rustPlatform.buildRustPackage rec {
 
   buildNoDefaultFeatures = true;
 
-  env = {
-    ZSTD_SYS_USE_PKG_CONFIG = true;
-  };
-
   # tests require internet access
   doCheck = false;
 

--- a/pkgs/development/tools/rust/cargo-dist/default.nix
+++ b/pkgs/development/tools/rust/cargo-dist/default.nix
@@ -32,10 +32,6 @@ rustPlatform.buildRustPackage rec {
     zstd
   ];
 
-  env = {
-    ZSTD_SYS_USE_PKG_CONFIG = true;
-  };
-
   nativeCheckInputs = lib.optionals stdenv.isDarwin [
     rustup
   ];

--- a/pkgs/development/tools/rust/cargo-semver-checks/default.nix
+++ b/pkgs/development/tools/rust/cargo-semver-checks/default.nix
@@ -53,9 +53,6 @@ rustPlatform.buildRustPackage rec {
     scripts/regenerate_test_rustdocs.sh
   '';
 
-  # use system openssl
-  OPENSSL_NO_VENDOR = true;
-
   meta = with lib; {
     description = "A tool to scan your Rust crate for semver violations";
     homepage = "https://github.com/obi1kenobi/cargo-semver-checks";

--- a/pkgs/development/tools/rye/default.nix
+++ b/pkgs/development/tools/rye/default.nix
@@ -28,10 +28,6 @@ rustPlatform.buildRustPackage rec {
     };
   };
 
-  env = {
-    OPENSSL_NO_VENDOR = 1;
-  };
-
   nativeBuildInputs = [ pkg-config ];
 
   buildInputs = [

--- a/pkgs/development/tools/rye/default.nix
+++ b/pkgs/development/tools/rye/default.nix
@@ -6,6 +6,7 @@
 , pkg-config
 , stdenv
 , SystemConfiguration
+, zstd
 }:
 
 rustPlatform.buildRustPackage rec {
@@ -33,8 +34,8 @@ rustPlatform.buildRustPackage rec {
   buildInputs = [
     git
     openssl
-  ]
-  ++ lib.optional stdenv.isDarwin SystemConfiguration;
+    zstd
+  ] ++ lib.optional stdenv.isDarwin SystemConfiguration;
 
   nativeCheckInputs = [ git ];
 

--- a/pkgs/development/tools/sentry-cli/default.nix
+++ b/pkgs/development/tools/sentry-cli/default.nix
@@ -19,9 +19,6 @@ rustPlatform.buildRustPackage rec {
   };
   doCheck = false;
 
-  # Needed to get openssl-sys to use pkgconfig.
-  OPENSSL_NO_VENDOR = 1;
-
   buildInputs = [ openssl ] ++ lib.optionals stdenv.isDarwin [ Security SystemConfiguration ];
   nativeBuildInputs = [ pkg-config ];
 

--- a/pkgs/development/tools/squawk/default.nix
+++ b/pkgs/development/tools/squawk/default.nix
@@ -35,8 +35,6 @@ rustPlatform.buildRustPackage rec {
     Security
   ]);
 
-  OPENSSL_NO_VENDOR = 1;
-
   LIBPG_QUERY_PATH = libpg_query;
 
   meta = with lib; {

--- a/pkgs/development/tools/wasm-pack/default.nix
+++ b/pkgs/development/tools/wasm-pack/default.nix
@@ -29,9 +29,6 @@ rustPlatform.buildRustPackage rec {
     libressl
   ] ++ lib.optionals stdenv.isDarwin [ curl Security ];
 
-  # Needed to get openssl-sys to use pkg-config.
-  OPENSSL_NO_VENDOR = 1;
-
   # Most tests rely on external resources and build artifacts.
   # Disabling check here to work with build sandboxing.
   doCheck = false;

--- a/pkgs/development/tools/wasm-pack/default.nix
+++ b/pkgs/development/tools/wasm-pack/default.nix
@@ -5,6 +5,7 @@
 , libressl
 , curl
 , Security
+, zstd
 }:
 
 rustPlatform.buildRustPackage rec {
@@ -27,6 +28,7 @@ rustPlatform.buildRustPackage rec {
     # gracefully exit while doing work.
     # See: https://github.com/rustwasm/wasm-pack/issues/650
     libressl
+    zstd
   ] ++ lib.optionals stdenv.isDarwin [ curl Security ];
 
   # Most tests rely on external resources and build artifacts.

--- a/pkgs/development/tools/wrangler_1/default.nix
+++ b/pkgs/development/tools/wrangler_1/default.nix
@@ -18,8 +18,6 @@ rustPlatform.buildRustPackage rec {
   buildInputs = [ openssl ]
     ++ lib.optionals stdenv.isDarwin [ curl CoreFoundation CoreServices Security libiconv ];
 
-  OPENSSL_NO_VENDOR = 1;
-
   # tries to use "/homeless-shelter" and fails
   doCheck = false;
 

--- a/pkgs/development/web/deno/default.nix
+++ b/pkgs/development/web/deno/default.nix
@@ -2,10 +2,12 @@
 , lib
 , callPackage
 , fetchFromGitHub
+, pkg-config
 , rustPlatform
 , installShellFiles
 , libiconv
 , darwin
+, zstd
 , librusty_v8 ? callPackage ./librusty_v8.nix { }
 }:
 
@@ -27,8 +29,9 @@ rustPlatform.buildRustPackage rec {
     substituteInPlace .cargo/config.toml --replace '"-C", "link-arg=-fuse-ld=lld"' ""
   '';
 
-  nativeBuildInputs = [ installShellFiles ];
-  buildInputs = lib.optionals stdenv.isDarwin (
+  nativeBuildInputs = [ installShellFiles pkg-config ];
+  buildInputs = [ zstd ]
+    ++ lib.optionals stdenv.isDarwin (
     [ libiconv darwin.libobjc ] ++
     (with darwin.apple_sdk.frameworks; [ Security CoreServices Metal Foundation QuartzCore ])
   );
@@ -62,8 +65,10 @@ rustPlatform.buildRustPackage rec {
     runHook postInstallCheck
   '';
 
-  passthru.updateScript = ./update/update.ts;
-  passthru.tests = callPackage ./tests { };
+  passthru = {
+    updateScript = ./update/update.ts;
+    tests = callPackage ./tests { };
+  };
 
   meta = with lib; {
     homepage = "https://deno.land/";

--- a/pkgs/games/jumpy/default.nix
+++ b/pkgs/games/jumpy/default.nix
@@ -63,10 +63,6 @@ rustPlatform.buildRustPackage rec {
 
   cargoBuildFlags = [ "--bin" "jumpy" ];
 
-  env = {
-    ZSTD_SYS_USE_PKG_CONFIG = true;
-  };
-
   postInstall = ''
     mkdir $out/share
     cp -r assets $out/share

--- a/pkgs/servers/krill/default.nix
+++ b/pkgs/servers/krill/default.nix
@@ -23,9 +23,6 @@ rustPlatform.buildRustPackage rec {
   buildInputs = [ openssl ] ++ lib.optional stdenv.isDarwin Security;
   nativeBuildInputs = [ pkg-config ];
 
-  # Needed to get openssl-sys to use pkgconfig.
-  OPENSSL_NO_VENDOR = 1;
-
   meta = with lib; {
     description = "RPKI Certificate Authority and Publication Server written in Rust";
     longDescription = ''

--- a/pkgs/servers/ldap/lldap/default.nix
+++ b/pkgs/servers/ldap/lldap/default.nix
@@ -1,16 +1,16 @@
 { binaryen
 , fetchFromGitHub
-, fetchpatch
-, fetchzip
 , lib
 , lldap
 , nixosTests
+, pkg-config
 , rustPlatform
 , rustc
 , stdenv
 , wasm-bindgen-cli
 , wasm-pack
 , which
+, zstd
 }:
 
 let
@@ -91,6 +91,10 @@ in rustPlatform.buildRustPackage (commonDerivationAttrs // {
   postPatch = commonDerivationAttrs.postPatch + ''
     substituteInPlace server/src/infra/tcp_server.rs --subst-var-by frontend '${frontend}'
   '';
+
+  nativeBuildInputs = [ pkg-config ];
+
+  buildInputs = [ zstd ];
 
   postInstall = ''
     mv $out/bin/migration-tool $out/bin/lldap_migration_tool

--- a/pkgs/servers/networking/rustus/default.nix
+++ b/pkgs/servers/networking/rustus/default.nix
@@ -24,8 +24,6 @@ rustPlatform.buildRustPackage {
 
   cargoHash = "sha256-ueZIKFnXuhQ4MHZX2e5yJXOyKuzhWOIBJbTbvoeV3m8=";
 
-  env.OPENSSL_NO_VENDOR = 1;
-
   nativeBuildInputs = [
     pkg-config
   ];

--- a/pkgs/servers/search/meilisearch/default.nix
+++ b/pkgs/servers/search/meilisearch/default.nix
@@ -2,7 +2,9 @@
 , lib
 , rustPlatform
 , fetchFromGitHub
+, pkg-config
 , Security
+, zstd
 , nixosTests
 , nix-update-script
 }:
@@ -37,15 +39,19 @@ rustPlatform.buildRustPackage {
   # Default features include mini dashboard which downloads something from the internet.
   buildNoDefaultFeatures = true;
 
-  buildInputs = lib.optionals stdenv.isDarwin [
+  nativeBuildInputs = [
+    pkg-config
+  ];
+
+  buildInputs = [
+    zstd
+  ] ++ lib.optionals stdenv.isDarwin [
     Security
   ];
 
   passthru = {
     updateScript = nix-update-script { };
-    tests = {
-      meilisearch = nixosTests.meilisearch;
-    };
+    tests = { inherit (nixosTests) meilisearch; };
   };
 
   # Tests will try to compile with mini-dashboard features which downloads something from the internet.

--- a/pkgs/servers/search/qdrant/default.nix
+++ b/pkgs/servers/search/qdrant/default.nix
@@ -34,9 +34,6 @@ rustPlatform.buildRustPackage rec {
       --replace "linker = \"aarch64-linux-gnu-gcc\"" ""
   '';
 
-  # Needed to get openssl-sys to use pkg-config.
-  OPENSSL_NO_VENDOR = 1;
-
   buildInputs = [ openssl ] ++ lib.optionals stdenv.isDarwin [ Security ];
 
   nativeBuildInputs = [ protobuf rustPlatform.bindgenHook pkg-config ];

--- a/pkgs/servers/sql/materialize/default.nix
+++ b/pkgs/servers/sql/materialize/default.nix
@@ -72,9 +72,6 @@ rustPlatform.buildRustPackage rec {
     # Provides the mig command used by the krb5-src build script
     ++ lib.optional stdenv.isDarwin bootstrap_cmds;
 
-  # Needed to get openssl-sys to use pkg-config.
-  OPENSSL_NO_VENDOR = 1;
-
   buildInputs = [ openssl ]
     ++ lib.optionals stdenv.isDarwin [ libiconv DiskArbitration Foundation ];
 

--- a/pkgs/servers/teleport/generic.nix
+++ b/pkgs/servers/teleport/generic.nix
@@ -51,8 +51,6 @@ let
     # buildRustPackage sets strictDeps = true;
     nativeCheckInputs = buildInputs;
 
-    OPENSSL_NO_VENDOR = "1";
-
     postInstall = ''
       mkdir -p $out/include
       cp ${buildAndTestSubdir}/librdprs.h $out/include/

--- a/pkgs/servers/windmill/default.nix
+++ b/pkgs/servers/windmill/default.nix
@@ -19,6 +19,7 @@
 , rustfmt
 , stdenv
 , swagger-cli
+, zstd
 }:
 
 let
@@ -103,7 +104,7 @@ rustPlatform.buildRustPackage {
       --replace '"/bin/bash"' '"${bash}/bin/bash"'
   '';
 
-  buildInputs = [ openssl rustfmt lld ];
+  buildInputs = [ openssl rustfmt lld zstd ];
 
   nativeBuildInputs = [ pkg-config makeWrapper swagger-cli ];
 

--- a/pkgs/tools/filesystems/garage/default.nix
+++ b/pkgs/tools/filesystems/garage/default.nix
@@ -25,8 +25,6 @@ let
       cacert
     ];
 
-    OPENSSL_NO_VENDOR = true;
-
     # See https://git.deuxfleurs.fr/Deuxfleurs/garage/src/tag/v0.8.2/nix/compile.nix#L192-L198
     # on version changes for checking if changes are required here
     buildFeatures = [

--- a/pkgs/tools/filesystems/garage/default.nix
+++ b/pkgs/tools/filesystems/garage/default.nix
@@ -1,5 +1,5 @@
-{ lib, stdenv, rustPlatform, fetchFromGitea, openssl, pkg-config, protobuf
-, cacert, testers, Security, garage, nixosTests }:
+{ lib, stdenv, rustPlatform, fetchFromGitea, libsodium, openssl, pkg-config, protobuf, zstd
+, cacert, Security, garage, nixosTests }:
 let
   generic = { version, sha256, cargoSha256, eol ? false, broken ? false }: rustPlatform.buildRustPackage {
     pname = "garage";
@@ -18,7 +18,9 @@ let
     nativeBuildInputs = [ protobuf pkg-config ];
 
     buildInputs = [
+      libsodium
       openssl
+      zstd
     ] ++ lib.optional stdenv.isDarwin Security;
 
     checkInputs = [
@@ -62,7 +64,7 @@ let
       homepage = "https://garagehq.deuxfleurs.fr";
       license = lib.licenses.agpl3Only;
       maintainers = with lib.maintainers; [ nickcao _0x4A6F teutat3s raitobezarius ];
-      knownVulnerabilities = (lib.optional eol "Garage version ${version} is EOL");
+      knownVulnerabilities = lib.optional eol "Garage version ${version} is EOL";
       inherit broken;
     };
   };

--- a/pkgs/tools/games/ukmm/default.nix
+++ b/pkgs/tools/games/ukmm/default.nix
@@ -7,6 +7,7 @@
 , atk
 , glib
 , gtk3-x11
+, pkgsStatic
 , nix-update-script
 }:
 
@@ -47,6 +48,7 @@ rustPlatform.buildRustPackage rec {
     atk
     glib
     gtk3-x11
+    pkgsStatic.zstd
   ];
 
   cargoTestFlags = [

--- a/pkgs/tools/misc/boxxy/default.nix
+++ b/pkgs/tools/misc/boxxy/default.nix
@@ -27,10 +27,6 @@ rustPlatform.buildRustPackage rec {
     oniguruma
   ];
 
-  env = {
-    RUSTONIG_SYSTEM_LIBONIG = true;
-  };
-
   meta = with lib; {
     description = "Puts bad Linux applications in a box with only their files";
     homepage = "https://github.com/queer/boxxy";

--- a/pkgs/tools/misc/broot/default.nix
+++ b/pkgs/tools/misc/broot/default.nix
@@ -39,8 +39,6 @@ rustPlatform.buildRustPackage rec {
     zlib
   ];
 
-  RUSTONIG_SYSTEM_LIBONIG = true;
-
   postPatch = ''
     # Fill the version stub in the man page. We can't fill the date
     # stub reproducibly.

--- a/pkgs/tools/misc/codemov/default.nix
+++ b/pkgs/tools/misc/codemov/default.nix
@@ -36,10 +36,6 @@ rustPlatform.buildRustPackage {
     oniguruma
   ];
 
-  env = {
-    RUSTONIG_SYSTEM_LIBONIG = true;
-  };
-
   postInstall = ''
     wrapProgram $out/bin/codemov \
       --prefix PATH : ${lib.makeBinPath [ ffmpeg git ]}

--- a/pkgs/tools/misc/codevis/default.nix
+++ b/pkgs/tools/misc/codevis/default.nix
@@ -26,10 +26,6 @@ rustPlatform.buildRustPackage rec {
     oniguruma
   ];
 
-  env = {
-    RUSTONIG_SYSTEM_LIBONIG = true;
-  };
-
   meta = with lib; {
     description = "A tool to take all source code in a folder and render them to one image";
     homepage = "https://github.com/sloganking/codevis";

--- a/pkgs/tools/misc/fw/default.nix
+++ b/pkgs/tools/misc/fw/default.nix
@@ -27,7 +27,6 @@ rustPlatform.buildRustPackage rec {
     Security
   ];
 
-  OPENSSL_NO_VENDOR = 1;
   USER = "nixbld";
 
   meta = with lib; {

--- a/pkgs/tools/misc/rust-motd/default.nix
+++ b/pkgs/tools/misc/rust-motd/default.nix
@@ -30,8 +30,6 @@ rustPlatform.buildRustPackage rec {
     Security
   ];
 
-  OPENSSL_NO_VENDOR = 1;
-
   meta = with lib; {
     description = "Beautiful, useful MOTD generation with zero runtime dependencies";
     homepage = "https://github.com/rust-motd/rust-motd";

--- a/pkgs/tools/misc/tremor-rs/default.nix
+++ b/pkgs/tools/misc/tremor-rs/default.nix
@@ -5,6 +5,7 @@
 , openssl
 , fetchFromGitHub
 , installShellFiles
+, oniguruma
 , stdenv
 , Security
 , libiconv
@@ -34,7 +35,7 @@ rustPlatform.buildRustPackage rec {
 
   nativeBuildInputs = [ cmake pkg-config installShellFiles rustPlatform.bindgenHook ];
 
-  buildInputs = [ openssl ]
+  buildInputs = [ oniguruma openssl ]
     ++ lib.optionals stdenv.hostPlatform.isDarwin [ Security libiconv ];
 
   # relax lints to fix an error caused by invalid macro_export

--- a/pkgs/tools/misc/tremor-rs/default.nix
+++ b/pkgs/tools/misc/tremor-rs/default.nix
@@ -56,9 +56,6 @@ rustPlatform.buildRustPackage rec {
       --zsh <($out/bin/tremor completions zsh)
   '';
 
-  # OPENSSL_NO_VENDOR - If set, always find OpenSSL in the system, even if the vendored feature is enabled.
-  OPENSSL_NO_VENDOR = 1;
-
   # needed for internal protobuf c wrapper library
   PROTOC = "${protobuf}/bin/protoc";
   PROTOC_INCLUDE = "${protobuf}/include";

--- a/pkgs/tools/misc/vector/default.nix
+++ b/pkgs/tools/misc/vector/default.nix
@@ -63,7 +63,6 @@ rustPlatform.buildRustPackage {
   # needed for internal protobuf c wrapper library
   PROTOC = "${protobuf}/bin/protoc";
   PROTOC_INCLUDE = "${protobuf}/include";
-  RUSTONIG_SYSTEM_LIBONIG = true;
 
   TZDIR = "${tzdata}/share/zoneinfo";
 

--- a/pkgs/tools/misc/websocat/default.nix
+++ b/pkgs/tools/misc/websocat/default.nix
@@ -20,9 +20,6 @@ rustPlatform.buildRustPackage rec {
 
   buildFeatures = [ "ssl" ];
 
-  # Needed to get openssl-sys to use pkg-config.
-  OPENSSL_NO_VENDOR=1;
-
   # The wrapping is required so that the "sh-c" option of websocat works even
   # if sh is not in the PATH (as can happen, for instance, when websocat is
   # started as a systemd service).

--- a/pkgs/tools/networking/cjdns/default.nix
+++ b/pkgs/tools/networking/cjdns/default.nix
@@ -52,7 +52,6 @@ rustPlatform.buildRustPackage rec {
     libsodium
   ];
 
-  env.SODIUM_USE_PKG_CONFIG = 1;
   env.NIX_CFLAGS_COMPILE = toString ([
     "-O2"
     "-Wno-error=array-bounds"

--- a/pkgs/tools/networking/findomain/default.nix
+++ b/pkgs/tools/networking/findomain/default.nix
@@ -40,10 +40,6 @@ rustPlatform.buildRustPackage rec {
     Security
   ];
 
-  env = {
-    OPENSSL_NO_VENDOR = true;
-  };
-
   postInstall = ''
     installManPage findomain.1
   '';

--- a/pkgs/tools/networking/ratman/default.nix
+++ b/pkgs/tools/networking/ratman/default.nix
@@ -37,8 +37,6 @@ rustPlatform.buildRustPackage rec {
     installManPage docs/man/ratmand.1
   '';
 
-  SODIUM_USE_PKG_CONFIG = 1;
-
   dashboard = stdenv.mkDerivation rec {
     pname = "ratman-dashboard";
     inherit version src;

--- a/pkgs/tools/networking/termscp/default.nix
+++ b/pkgs/tools/networking/termscp/default.nix
@@ -38,9 +38,6 @@ rustPlatform.buildRustPackage rec {
     Security
   ];
 
-  # Needed to get openssl-sys to use pkg-config.
-  OPENSSL_NO_VENDOR = 1;
-
   env.NIX_CFLAGS_COMPILE = toString (lib.optionals stdenv.isDarwin [
     "-framework" "AppKit"
   ]);

--- a/pkgs/tools/networking/xh/default.nix
+++ b/pkgs/tools/networking/xh/default.nix
@@ -7,6 +7,7 @@
 , stdenv
 , Security
 , openssl
+, oniguruma
 }:
 
 rustPlatform.buildRustPackage rec {
@@ -26,7 +27,9 @@ rustPlatform.buildRustPackage rec {
 
   nativeBuildInputs = [ installShellFiles pkg-config ];
 
-  buildInputs = lib.optionals withNativeTls
+  buildInputs = [
+    oniguruma
+  ] ++ lib.optionals withNativeTls
     (if stdenv.isDarwin then [ Security ] else [ openssl ]);
 
   postInstall = ''

--- a/pkgs/tools/networking/xh/default.nix
+++ b/pkgs/tools/networking/xh/default.nix
@@ -29,9 +29,6 @@ rustPlatform.buildRustPackage rec {
   buildInputs = lib.optionals withNativeTls
     (if stdenv.isDarwin then [ Security ] else [ openssl ]);
 
-  # Get openssl-sys to use pkg-config
-  OPENSSL_NO_VENDOR = 1;
-
   postInstall = ''
     installShellCompletion \
       completions/xh.{bash,fish} \

--- a/pkgs/tools/nix/nix-init/default.nix
+++ b/pkgs/tools/nix/nix-init/default.nix
@@ -84,7 +84,6 @@ rustPlatform.buildRustPackage rec {
 
   env = {
     GEN_ARTIFACTS = "artifacts";
-    ZSTD_SYS_USE_PKG_CONFIG = true;
   };
 
   meta = with lib; {

--- a/pkgs/tools/security/feroxbuster/default.nix
+++ b/pkgs/tools/security/feroxbuster/default.nix
@@ -25,8 +25,6 @@ rustPlatform.buildRustPackage rec {
 
   cargoHash = "sha256-rPFj53KQkucz1/yAr6U2nk6gTdxcBxyRHVqGeawBYZU=";
 
-  OPENSSL_NO_VENDOR = true;
-
   nativeBuildInputs = [
     pkg-config
   ];

--- a/pkgs/tools/security/noseyparker/default.nix
+++ b/pkgs/tools/security/noseyparker/default.nix
@@ -36,8 +36,6 @@ rustPlatform.buildRustPackage rec {
     hyperscan
   ];
 
-  OPENSSL_NO_VENDOR = 1;
-
   meta = with lib; {
     description = "Find secrets and sensitive information in textual data";
     homepage = "https://github.com/praetorian-inc/noseyparker";

--- a/pkgs/tools/text/mdbook-linkcheck/default.nix
+++ b/pkgs/tools/text/mdbook-linkcheck/default.nix
@@ -18,8 +18,6 @@ rustPlatform.buildRustPackage rec {
 
   nativeBuildInputs = lib.optionals (!stdenv.isDarwin) [ pkg-config ];
 
-  OPENSSL_NO_VENDOR = 1;
-
   doCheck = false; # tries to access network to test broken web link functionality
 
   passthru.tests.version = testers.testVersion { package = mdbook-linkcheck; };

--- a/pkgs/tools/text/termbook/default.nix
+++ b/pkgs/tools/text/termbook/default.nix
@@ -34,10 +34,6 @@ rustPlatform.buildRustPackage rec {
     darwin.apple_sdk.frameworks.Security
   ];
 
-  env = {
-    RUSTONIG_SYSTEM_LIBONIG = true;
-  };
-
   # update dependencies to fix build failure caused by unaligned packed structs
   postPatch = ''
     ln -sf ${./Cargo.lock} Cargo.lock


### PR DESCRIPTION
###### Description of changes

Verified with

changed packages in this PR:
```
nix build .#polkadot .#felix-fm .#faircamp .#watchmate .#wezterm .#wasm-pack .#deno .#lldap .#meilisearch .#windmill .#ukmm .#temor-rs .#rye .#namaka .#railway .#cargo-semver-checks .#sentry-cli .#squawk .#wrangler_1 .#krill .#rustus .#qdrant .#materialize .#teleport .#garage .#boxxy .#broot .#codemov .#codevis .#fw .#rust-motd .#vector .#websocat .#cjdns .#finddomain .#ratman .#termscp .#xh .#eroxbuster .#noseyparker .#mdbook-linkcheck .#termbook .#nearcore .#snarkos .#solana-cli .#solana-validator .#lapce .#artem .#tickrs .#zola .#habitat .#elan .#delta .#git-dive .#git-trim .#gitoxide .#gitui .#jujutsu .#dmlive .#cloud-hypervisor .#scryer-prolog .#moon .#prisma-engines
```

packages containing libsodium-sys:
```
NIXPKGS_ALLOW_UNFREE=1 NIXPKGS_ALLOW_NONSOURCE=1 nix build --impure .#cjdns .#habitat .#rustdesk .#gst_all_1.gst-plugins-rs .#scryer-prolog
```


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes (or backporting 23.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
