### PR TITLE
extra-container: 0.11 -> 0.12

### DIFF
--- a/pkgs/tools/virtualization/extra-container/default.nix
+++ b/pkgs/tools/virtualization/extra-container/default.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation rec {
   pname = "extra-container";
-  version = "0.11";
+  version = "0.12";
 
   src = fetchFromGitHub {
     owner = "erikarvstedt";
     repo = pname;
     rev = version;
-    hash = "sha256-ORe1tSWhmgIaDj3CTEovsFCq+60LQmYy8RUx9v7De30=";
+    hash = "sha256-/5wPv962ZHvZoZMOr4nMz7qcvbzlExRYS2nrnay/PU8=";
   };
 
   buildCommand = ''
@@ -31,6 +31,7 @@ stdenv.mkDerivation rec {
   meta = with lib; {
     description = "Run declarative containers without full system rebuilds";
     homepage = "https://github.com/erikarvstedt/extra-container";
+    changelog = "https://github.com/erikarvstedt/extra-container/blob/${version}/CHANGELOG.md";
     license = licenses.mit;
     platforms = platforms.linux;
     maintainers = [ maintainers.erikarvstedt ];


### PR DESCRIPTION
This adds compatibility with NixOS 23.05.

[Release notes](https://github.com/erikarvstedt/extra-container/blob/master/CHANGELOG.md#012-2023-06-15).

- [x] Tested on x86_64-linux

cc @Lassulus