### PR TITLE
tart: init at 1.6.0

### DIFF
--- a/lib/licenses.nix
+++ b/lib/licenses.nix
@@ -615,6 +615,13 @@ in mkLicense lset) ({
     free = true;
   };
 
+  fairsource09 = {
+    fullName = "Fair Source License, version 0.9";
+    url = "https://fair.io/v0.9.txt";
+    free = false;
+    redistributable = true;
+  };
+
   issl = {
     fullName = "Intel Simplified Software License";
     url = "https://software.intel.com/en-us/license/intel-simplified-software-license";

--- a/pkgs/applications/virtualization/tart/default.nix
+++ b/pkgs/applications/virtualization/tart/default.nix
@@ -1,0 +1,46 @@
+{ lib
+, stdenvNoCC
+, fetchurl
+, makeWrapper
+# Softnet support ("--net-softnet") is disabled by default as it requires
+# passwordless-sudo when installed through nix. Alternatively users may install
+# softnet through other means with "setuid"-bit enabled.
+# See https://github.com/cirruslabs/softnet#installing
+, enableSoftnet ? false, softnet
+}:
+stdenvNoCC.mkDerivation (finalAttrs: {
+  pname = "tart";
+  version = "1.6.0";
+
+  src = fetchurl {
+    url = "https://github.com/cirruslabs/tart/releases/download/${finalAttrs.version}/tart.tar.gz";
+    sha256 = "1n052nwsccc3sr0jqnvhyl0six8wi46vysxjchwrdm8brnsdpf84";
+  };
+  sourceRoot = ".";
+
+  nativeBuildInputs = [ makeWrapper ];
+
+  installPhase = ''
+    runHook preInstall
+
+    # ./tart.app/Contents/MacOS/tart binary is required to be used in order to
+    # trick macOS to pick tart.app/Contents/embedded.provision profile for elevated
+    # privileges that Tart needs
+    mkdir -p $out/bin $out/Applications
+    cp -r tart.app $out/Applications/tart.app
+    makeWrapper $out/Applications/tart.app/Contents/MacOS/tart $out/bin/tart \
+      --prefix PATH : ${lib.makeBinPath (lib.optional enableSoftnet softnet)}
+    install -Dm444 LICENSE $out/share/tart/LICENSE
+
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    description = "macOS VMs on Apple Silicon to use in CI and other automations";
+    homepage = "https://tart.run";
+    license = licenses.fairsource09;
+    maintainers = with maintainers; [ emilytrau Enzime ];
+    platforms = [ "aarch64-darwin" ];
+    sourceProvenance = with sourceTypes; [ binaryNativeCode ];
+  };
+})

--- a/pkgs/tools/networking/softnet/default.nix
+++ b/pkgs/tools/networking/softnet/default.nix
@@ -1,0 +1,34 @@
+{ lib
+, stdenvNoCC
+, fetchurl
+}:
+stdenvNoCC.mkDerivation (finalAttrs: {
+  pname = "softnet";
+  version = "0.7.1";
+
+  src = fetchurl {
+    url = "https://github.com/cirruslabs/softnet/releases/download/${finalAttrs.version}/softnet.tar.gz";
+    sha256 = "1g274x524xc85hfzxi3vb4xp720bjgk740bp6hc92d1ikmp0b664";
+  };
+  sourceRoot = ".";
+
+  installPhase = ''
+    runHook preInstall
+
+    install -D softnet $out/bin/softnet
+    install -Dm444 -t $out/share/softnet README.md LICENSE
+
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    description = "Software networking with isolation for Tart";
+    homepage = "https://github.com/cirruslabs/softnet";
+    license = licenses.agpl3Plus;
+    maintainers = with maintainers; [ emilytrau ];
+    platforms = [ "aarch64-darwin" ];
+    # Source build will be possible after darwin SDK 12.0 bump
+    # https://github.com/NixOS/nixpkgs/pull/229210
+    sourceProvenance = with sourceTypes; [ binaryNativeCode ];
+  };
+})

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -12682,6 +12682,8 @@ with pkgs;
 
   sockperf = callPackage ../tools/networking/sockperf { };
 
+  softnet = callPackage ../tools/networking/softnet { };
+
   solaar = callPackage ../applications/misc/solaar { };
 
   solanum = callPackage ../servers/irc/solanum {

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -34328,6 +34328,8 @@ with pkgs;
 
   sway-launcher-desktop = callPackage ../applications/misc/sway-launcher-desktop { };
 
+  tart = callPackage ../applications/virtualization/tart { };
+
   tecoc = callPackage ../applications/editors/tecoc { };
 
   viber = callPackage ../applications/networking/instant-messengers/viber { };


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

macOS VMs on Apple Silicon to use in CI and other automations https://tart.run

Resolves #228159

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes (or backporting 23.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
