### PR TITLE
postgresqlPackages.pg_graphql: init at 1.2.2

### DIFF
--- a/pkgs/servers/sql/postgresql/ext/pg_graphql.nix
+++ b/pkgs/servers/sql/postgresql/ext/pg_graphql.nix
@@ -1,0 +1,42 @@
+{ lib
+, fetchFromGitHub
+, buildPgrxExtension
+, postgresql
+, nix-update-script
+}:
+let
+  version = "1.2.2";
+in
+buildPgrxExtension rec {
+  inherit postgresql version;
+
+  pname = "pg_graphql";
+
+  src = fetchFromGitHub {
+    owner = "supabase";
+    repo = "pg_graphql";
+    rev = "v${version}";
+    hash = "sha256-SKbUDasdhz/L5UDyMH4gXmFfHHhGx81H90gfIclGwjU=";
+  };
+
+  cargoHash = "sha256-wDgxk6xaX0LfnXkGtYLcDMOJZ5yxAHu9Kf+NxswayHk=";
+
+  passthru = {
+    updateScript = nix-update-script { };
+  };
+
+  # figure out how to do testing properly https://github.com/supabase/pg_graphql/issues/369
+  doCheck = false;
+
+  meta = with lib; {
+    description = "GraphQL support for PostgreSQL";
+    homepage = "https://supabase.github.io/pg_graphql";
+    maintainers = with maintainers; [ happysalada ];
+    # on darwin: Undefined symbols for architecture x86_64: "_MemoryContextDelete"
+    platforms = platforms.linux;
+    license = licenses.asl20;
+
+    # this wasn't released before postgres 14 so taking no chances there, but most likely it can be relaxed.
+    broken = versionOlder postgresql.version "14";
+  };
+}

--- a/pkgs/servers/sql/postgresql/packages.nix
+++ b/pkgs/servers/sql/postgresql/packages.nix
@@ -16,6 +16,8 @@ self: super: {
 
     pg_ed25519 = super.callPackage ./ext/pg_ed25519.nix { };
 
+    pg_graphql = super.callPackage ./ext/pg_graphql.nix { };
+
     pg_hint_plan = super.callPackage ./ext/pg_hint_plan.nix { };
 
     pg_ivm = super.callPackage ./ext/pg_ivm.nix { };


### PR DESCRIPTION
###### Description of changes

Finally we have a release with a lockfile.
(this makes use of the latest pgrx)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes (or backporting 23.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
