### PR TITLE
plymouth: unstable-2021-10-18 -> unstable-2023-06-05

### DIFF
--- a/nixos/modules/system/boot/plymouth.nix
+++ b/nixos/modules/system/boot/plymouth.nix
@@ -98,7 +98,8 @@ in
         type = types.path;
         # Dimensions are 48x48 to match GDM logo
         default = "${nixos-icons}/share/icons/hicolor/48x48/apps/nix-snowflake-white.png";
-        defaultText = literalExpression ''pkgs.fetchurl {
+        defaultText = literalExpression ''"''${nixos-icons}/share/icons/hicolor/48x48/apps/nix-snowflake-white.png"'';
+        example = literalExpression ''pkgs.fetchurl {
           url = "https://nixos.org/logo/nixos-hires.png";
           sha256 = "1ivzgd7iz0i06y36p8m5w48fd8pjqwxhdaavc0pxs7w1g7mcy5si";
         }'';

--- a/nixos/modules/system/boot/plymouth.nix
+++ b/nixos/modules/system/boot/plymouth.nix
@@ -134,6 +134,13 @@ in
     # XXX: Needed because we supply a different set of plugins in initrd.
     environment.etc."plymouth/plugins".source = "${plymouth}/lib/plymouth";
 
+    systemd.tmpfiles.rules = [
+      "d /run/plymouth 0755 root root 0 -"
+      "L+ /run/plymouth/plymouthd.defaults - - - - /etc/plymouth/plymouthd.defaults"
+      "L+ /run/plymouth/themes - - - - /etc/plymouth/themes"
+      "L+ /run/plymouth/plugins - - - - /etc/plymouth/plugins"
+    ];
+
     systemd.packages = [ plymouth ];
 
     systemd.services.plymouth-kexec.wantedBy = [ "kexec.target" ];
@@ -160,8 +167,8 @@ in
       contents = {
         # Files
         "/etc/plymouth/plymouthd.conf".source = configFile;
-        "/etc/plymouth/plymouthd.defaults".source = "${plymouth}/share/plymouth/plymouthd.defaults";
         "/etc/plymouth/logo.png".source = cfg.logo;
+        "/etc/plymouth/plymouthd.defaults".source = "${plymouth}/share/plymouth/plymouthd.defaults";
         # Directories
         "/etc/plymouth/plugins".source = pkgs.runCommand "plymouth-initrd-plugins" {} ''
           # Check if the actual requested theme is here
@@ -174,8 +181,8 @@ in
 
           mkdir -p $out/renderers
           # module might come from a theme
-          cp ${themesEnv}/lib/plymouth/{text,details,label,$moduleName}.so $out
-          cp ${plymouth}/lib/plymouth/renderers/{drm,frame-buffer}.so $out/renderers
+          cp ${themesEnv}/lib/plymouth/*.so $out
+          cp ${plymouth}/lib/plymouth/renderers/*.so $out/renderers
         '';
         "/etc/plymouth/themes".source = pkgs.runCommand "plymouth-initrd-themes" {} ''
           # Check if the actual requested theme is here
@@ -184,18 +191,23 @@ in
               exit 1
           fi
 
-          mkdir $out
-          cp -r ${themesEnv}/share/plymouth/themes/${cfg.theme} $out
+          mkdir -p $out/${cfg.theme}
+          cp -r ${themesEnv}/share/plymouth/themes/${cfg.theme}/* $out/${cfg.theme}
           # Copy more themes if the theme depends on others
-          for theme in $(grep -hRo '/etc/plymouth/themes/.*$' $out | xargs -n1 basename); do
+          for theme in $(grep -hRo '/share/plymouth/themes/.*$' $out | xargs -n1 basename); do
               if [[ -d "${themesEnv}/share/plymouth/themes/$theme" ]]; then
                   if [[ ! -d "$out/$theme" ]]; then
                     echo "Adding dependent theme: $theme"
-                    cp -r "${themesEnv}/share/plymouth/themes/$theme" $out
+                    mkdir -p "$out/$theme"
+                    cp -r "${themesEnv}/share/plymouth/themes/$theme"/* "$out/$theme"
                   fi
               else
                 echo "Missing theme dependency: $theme"
               fi
+          done
+          # Fixup references
+          for theme in $out/*/*.plymouth; do
+            sed -i "s,${builtins.storeDir}/.*/share/plymouth/themes,$out," "$theme"
           done
         '';
 
@@ -225,6 +237,11 @@ in
         plymouth-switch-root-initramfs.wantedBy = [ "halt.target" "kexec.target" "plymouth-switch-root-initramfs.service" "poweroff.target" "reboot.target" ];
         plymouth-switch-root.wantedBy = [ "initrd-switch-root.target" ];
       };
+      # Link in runtime files before starting
+      services.plymouth-start.preStart = ''
+        mkdir -p /run/plymouth
+        ln -sf /etc/plymouth/{plymouthd.defaults,themes,plugins} /run/plymouth/
+      '';
     };
 
     # Insert required udev rules. We take stage 2 systemd because the udev
@@ -249,8 +266,8 @@ in
 
       mkdir -p $out/lib/plymouth/renderers
       # module might come from a theme
-      cp ${themesEnv}/lib/plymouth/{text,details,label,$moduleName}.so $out/lib/plymouth
-      cp ${plymouth}/lib/plymouth/renderers/{drm,frame-buffer}.so $out/lib/plymouth/renderers
+      cp ${themesEnv}/lib/plymouth/*.so $out/lib/plymouth
+      cp ${plymouth}/lib/plymouth/renderers/*.so $out/lib/plymouth/renderers
 
       mkdir -p $out/share/plymouth/themes
       cp ${plymouth}/share/plymouth/plymouthd.defaults $out/share/plymouth
@@ -267,7 +284,7 @@ in
       chmod -R +w themes
       find themes -type f | while read file
       do
-        sed -i "s,/nix/.*/share/plymouth/themes,$out/share/plymouth/themes,g" $file
+        sed -i "s,${builtins.storeDir}/.*/share/plymouth/themes,$out/share/plymouth/themes,g" $file
       done
 
       # Install themes
@@ -275,7 +292,7 @@ in
 
       # Install logo
       mkdir -p $out/etc/plymouth
-      cp -r -L ${themesEnv}/etc/plymouth $out
+      cp -r -L ${themesEnv}/etc/plymouth $out/etc
 
       # Setup font
       mkdir -p $out/share/fonts
@@ -304,11 +321,11 @@ in
     boot.initrd.preLVMCommands = mkIf (!config.boot.initrd.systemd.enable) (mkAfter ''
       mkdir -p /etc/plymouth
       mkdir -p /run/plymouth
+      ln -s $extraUtils/etc/plymouth/logo.png /etc/plymouth/logo.png
       ln -s ${configFile} /etc/plymouth/plymouthd.conf
-      ln -s $extraUtils/share/plymouth/plymouthd.defaults /etc/plymouth/plymouthd.defaults
-      ln -s $extraUtils/share/plymouth/logo.png /etc/plymouth/logo.png
-      ln -s $extraUtils/share/plymouth/themes /etc/plymouth/themes
-      ln -s $extraUtils/lib/plymouth /etc/plymouth/plugins
+      ln -s $extraUtils/share/plymouth/plymouthd.defaults /run/plymouth/plymouthd.defaults
+      ln -s $extraUtils/share/plymouth/themes /run/plymouth/themes
+      ln -s $extraUtils/lib/plymouth /run/plymouth/plugins
       ln -s $extraUtils/etc/fonts /etc/fonts
 
       plymouthd --mode=boot --pid-file=/run/plymouth/pid --attach-to-session

--- a/pkgs/os-specific/linux/plymouth/add-runtime-plugin-path.patch
+++ b/pkgs/os-specific/linux/plymouth/add-runtime-plugin-path.patch
@@ -1,0 +1,67 @@
+diff --git a/meson.build b/meson.build
+index 650ad189..1e1ebe1d 100644
+--- a/meson.build
++++ b/meson.build
+@@ -18,6 +18,11 @@ plymouth_time_dir = get_option('prefix') / get_option('localstatedir') / 'lib' /
+ 
+ plymouth_runtime_dir = get_option('runstatedir') / 'plymouth'
+ plymouth_runtime_theme_path = plymouth_runtime_dir / 'themes/'
++if get_option('runtime-plugins')
++  plymouth_runtime_plugin_path = plymouth_runtime_dir / 'plugins/'
++else
++  plymouth_runtime_plugin_path = plymouth_plugin_path
++endif
+ 
+ # Dependencies
+ cc = meson.get_compiler('c')
+@@ -76,7 +81,7 @@ conf.set('PLY_ENABLE_TRACING', get_option('tracing'))
+ conf.set_quoted('PLYMOUTH_RUNTIME_DIR', plymouth_runtime_dir)
+ conf.set_quoted('PLYMOUTH_THEME_PATH', plymouth_theme_path)
+ conf.set_quoted('PLYMOUTH_RUNTIME_THEME_PATH', plymouth_runtime_theme_path)
+-conf.set_quoted('PLYMOUTH_PLUGIN_PATH', plymouth_plugin_path)
++conf.set_quoted('PLYMOUTH_PLUGIN_PATH', plymouth_runtime_plugin_path)
+ conf.set_quoted('PLYMOUTH_POLICY_DIR', plymouth_policy_dir)
+ conf.set_quoted('PLYMOUTH_CONF_DIR', plymouth_conf_dir)
+ conf.set_quoted('PLYMOUTH_TIME_DIRECTORY', plymouth_time_dir)
+diff --git a/meson_options.txt b/meson_options.txt
+index 4f601bb0..61fccc12 100644
+--- a/meson_options.txt
++++ b/meson_options.txt
+@@ -28,6 +28,11 @@ option('runstatedir',
+   value: '/run',
+   description: 'runstatedir',
+ )
++option('runtime-plugins',
++  type: 'boolean',
++  value: false,
++  description: 'Use runstatedir for loading theme plugins',
++)
+ option('boot-tty',
+   type: 'string',
+   value: '/dev/tty1',
+diff --git a/src/libply-splash-core/meson.build b/src/libply-splash-core/meson.build
+index 69636b13..02bd5cbd 100644
+--- a/src/libply-splash-core/meson.build
++++ b/src/libply-splash-core/meson.build
+@@ -31,7 +31,7 @@ libply_splash_core_cflags = [
+   '-DPLYMOUTH_BACKGROUND_COLOR=@0@'.format(get_option('background-color')),
+   '-DPLYMOUTH_BACKGROUND_START_COLOR=@0@'.format(get_option('background-start-color-stop')),
+   '-DPLYMOUTH_BACKGROUND_END_COLOR=@0@'.format(get_option('background-end-color-stop')),
+-  '-DPLYMOUTH_PLUGIN_PATH="@0@"'.format(plymouth_plugin_path),
++  '-DPLYMOUTH_PLUGIN_PATH="@0@"'.format(plymouth_runtime_plugin_path),
+ ]
+ 
+ libply_splash_core = library('ply-splash-core',
+diff --git a/src/libply-splash-graphics/meson.build b/src/libply-splash-graphics/meson.build
+index 32fad963..02b8440b 100644
+--- a/src/libply-splash-graphics/meson.build
++++ b/src/libply-splash-graphics/meson.build
+@@ -20,7 +20,7 @@ libply_splash_graphics_cflags = [
+   '-DPLYMOUTH_BACKGROUND_COLOR=@0@'.format(get_option('background-color')),
+   '-DPLYMOUTH_BACKGROUND_START_COLOR=@0@'.format(get_option('background-start-color-stop')),
+   '-DPLYMOUTH_BACKGROUND_END_COLOR=@0@'.format(get_option('background-end-color-stop')),
+-  '-DPLYMOUTH_PLUGIN_PATH="@0@"'.format(plymouth_plugin_path),
++  '-DPLYMOUTH_PLUGIN_PATH="@0@"'.format(plymouth_runtime_plugin_path),
+ ]
+ 
+ libply_splash_graphics = library('ply-splash-graphics',

--- a/pkgs/os-specific/linux/plymouth/default.nix
+++ b/pkgs/os-specific/linux/plymouth/default.nix
@@ -1,96 +1,114 @@
 { lib
 , stdenv
-, fetchpatch
 , fetchFromGitLab
+, writeText
+, meson
 , pkg-config
-, autoreconfHook
-, libxslt
+, ninja
 , docbook-xsl-nons
 , gettext
+, libxslt
 , gtk3
-, systemd
-, pango
-, cairo
 , libdrm
+, libevdev
+, libpng
+, libxkbcommon
+, pango
+, systemd
+, xorg
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "plymouth";
-  version = "unstable-2021-10-18";
+  version = "unstable-2023-06-05";
 
-  outputs = [
-    "out"
-    "dev"
-  ];
+  outputs = [ "out" "dev" ];
 
   src = fetchFromGitLab {
     domain = "gitlab.freedesktop.org";
     owner = "plymouth";
     repo = "plymouth";
-    rev = "18363cd887dbfe7e82a2f4cc1a49ef9513919142";
-    sha256 = "sha256-+AP4ALOFdYFt/8MDXjMaHptkogCwK1iXKuza1zfMaws=";
+    rev = "a5eda165689864cc9a25ec14fd8c6da458598f42";
+    hash = "sha256-TpMZZ0naC4D0Knmclc8JpmXPfnpM6q8YotIkNX+aRVo=";
   };
 
+  patches = [
+    # do not create unnecessary symlink to non-existent header-image.png
+    ./dont-create-broken-symlink.patch
+    # add support for loading plugins from /run to assist NixOS module
+    ./add-runtime-plugin-path.patch
+  ];
+
+  strictDeps = true;
+
   nativeBuildInputs = [
-    autoreconfHook
+    meson
+    pkg-config
+    ninja
     docbook-xsl-nons
     gettext
     libxslt
-    pkg-config
   ];
 
   buildInputs = [
-    cairo
     gtk3
     libdrm
+    libevdev
+    libpng
+    libxkbcommon
     pango
     systemd
+    xorg.xkeyboardconfig
+  ];
+
+  mesonFlags = let
+    # https://gitlab.freedesktop.org/plymouth/plymouth/-/blob/a5eda165689864cc9a25ec14fd8c6da458598f42/meson.build#L47
+    crossFile = writeText "cross-file.conf" ''
+      [binaries]
+      systemd-tty-ask-password-agent = '${lib.getBin systemd}/bin/systemd-tty-ask-password-agent'
+    '';
+  in [
+    "--sysconfdir=/etc"
+    "--localstatedir=/var"
+    "-Dlogo=/etc/plymouth/logo.png"
+    "-Dbackground-color=0x000000"
+    "-Dbackground-start-color-stop=0x000000"
+    "-Dbackground-end-color-stop=0x000000"
+    "-Drelease-file=/etc/os-release"
+    "-Dudev=enabled"
+    "-Drunstatedir=/run"
+    "-Druntime-plugins=true"
+    "--cross-file=${crossFile}"
   ];
 
   postPatch = ''
-    sed -i \
-      -e "s#plymouthplugindir=.*#plymouthplugindir=/etc/plymouth/plugins/#" \
-      -e "s#plymouththemedir=.*#plymouththemedir=/etc/plymouth/themes#" \
-      -e "s#plymouthpolicydir=.*#plymouthpolicydir=/etc/plymouth/#" \
-      -e "s#plymouthconfdir=.*#plymouthconfdir=/etc/plymouth/#" \
-      configure.ac
+    substituteInPlace meson.build \
+      --replace "run_command(['scripts/generate-version.sh'], check: true).stdout().strip()" "'${finalAttrs.version}'"
+
+    # prevent installing unused non-$out dirs to DESTDIR
+    sed -i '/^install_emptydir/d' src/meson.build
   '';
-
-  configurePlatforms = [ "host" ];
-
-  configureFlags = [
-    "--enable-documentation"
-    "--enable-drm"
-    "--enable-gtk"
-    "--enable-pango"
-    "--enable-systemd-integration"
-    "--enable-tracing"
-    "--localstatedir=/var"
-    "--sysconfdir=/etc"
-    "--with-background-color=0x000000"
-    "--with-background-end-color-stop=0x000000"
-    "--with-background-start-color-stop=0x000000"
-    "--with-logo=/etc/plymouth/logo.png"
-    "--with-release-file=/etc/os-release"
-    "--with-runtimedir=/run"
-    "--with-systemdunitdir=${placeholder "out"}/etc/systemd/system"
-    "--without-rhgb-compat-link"
-    "--without-system-root-install"
-    "ac_cv_path_SYSTEMD_ASK_PASSWORD_AGENT=${lib.getBin systemd}/bin/systemd-tty-ask-password-agent"
-  ];
-
-  installFlags = [
-    "localstatedir=\${TMPDIR}"
-    "plymouthd_confdir=${placeholder "out"}/etc/plymouth"
-    "plymouthd_defaultsdir=${placeholder "out"}/share/plymouth"
-    "sysconfdir=${placeholder "out"}/etc"
-  ];
 
   postInstall = ''
-    # Makes a symlink to /usr/share/pixmaps/system-logo-white.png
-    # We'll handle it in the nixos module.
-    rm $out/share/plymouth/themes/spinfinity/header-image.png
+    # Move stuff from DESTDIR to proper location.
+    cp -a "$DESTDIR/etc" "$out"
+    rm -r "$DESTDIR/etc"
+    for o in $(getAllOutputNames); do
+        if [[ "$o" = "debug" ]]; then continue; fi
+        cp -a "$DESTDIR/''${!o}" "$(dirname "''${!o}")"
+        rm -r "$DESTDIR/''${!o}"
+    done
+    # Ensure the DESTDIR is removed.
+    rmdir "$DESTDIR/${builtins.storeDir}" "$DESTDIR/${builtins.dirOf builtins.storeDir}" "$DESTDIR"
   '';
+
+  # HACK: We want to install configuration files to $out/etc
+  # but Plymouth should read them from /etc on a NixOS system.
+  # With autotools, it was possible to override Make variables
+  # at install time but Meson does not support this
+  # so we need to convince it to install all files to a temporary
+  # location using DESTDIR and then move it to proper one in postInstall.
+  env.DESTDIR = "${placeholder "out"}/dest";
 
   meta = with lib; {
     homepage = "https://www.freedesktop.org/wiki/Software/Plymouth/";
@@ -99,4 +117,4 @@ stdenv.mkDerivation rec {
     maintainers = [ maintainers.goibhniu ] ++ teams.gnome.members;
     platforms = platforms.linux;
   };
-}
+})

--- a/pkgs/os-specific/linux/plymouth/dont-create-broken-symlink.patch
+++ b/pkgs/os-specific/linux/plymouth/dont-create-broken-symlink.patch
@@ -1,0 +1,13 @@
+diff --git a/themes/spinfinity/meson.build b/themes/spinfinity/meson.build
+index f48e8e55..5a2050c8 100644
+--- a/themes/spinfinity/meson.build
++++ b/themes/spinfinity/meson.build
+@@ -53,8 +53,3 @@ install_data(
+   'throbber-33.png',
+   install_dir: plymouth_theme_path / 'spinfinity',
+ )
+-
+-install_symlink('header-image.png',
+-  install_dir: plymouth_theme_path / 'spinfinity',
+-  pointing_to: plymouth_logo_file,
+-)


### PR DESCRIPTION
###### Description of changes

I'm going to go ahead and open up a full PR for review rather than [leaving the diff buried in comments](https://github.com/NixOS/nixpkgs/pull/217728#discussion_r1136088299)

This migrates the plymouth derivation from the old autotools-based build system to the newer meson-based one

This also updates the plymouth NixOS module to use `runstatedir` instead of hardcoding `/etc` since Plymouth can already pull most things from there and works without the sketchy autotools substitution to rewrite cpp definitions

I've tested this with a matrix of configs for `{scripted stage 1, systemd stage 1} x {plain, luks, nixos-bgrt theme, breeze-bgrt theme}` in a VM and watched for (more or less) flickerless boot

Supersedes and closes #217728 and closes #183024

cc: @Kranzes

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
  - [x] x86_64-linux -> aarch64-linux (cross)
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).