### PR TITLE
nixos/ruby-modules: proper treatment to ruby modules of type git/url

### DIFF
--- a/pkgs/development/ruby-modules/bundled-common/default.nix
+++ b/pkgs/development/ruby-modules/bundled-common/default.nix
@@ -56,9 +56,9 @@ let
   else
     let
       gem = gems.${pname};
-      version = gem.version;
+      suffix = gem.suffix;
     in
-      "${pname}-${version}";
+      "${pname}-${suffix}";
 
   pname' = if pname != null then
     pname
@@ -118,6 +118,7 @@ let
 
     passthru = rec {
       inherit ruby bundler gems confFiles envPaths;
+      inherit (gems.${pname}) gemType;
 
       wrappedRuby = stdenv.mkDerivation {
         name = "wrapped-ruby-${pname'}";

--- a/pkgs/development/ruby-modules/bundler-app/default.nix
+++ b/pkgs/development/ruby-modules/bundler-app/default.nix
@@ -68,7 +68,10 @@ in
     ${lib.optionalString installManpages ''
     for section in {1..9}; do
       mandir="$out/share/man/man$section"
-      find -L ${basicEnv}/${ruby.gemPath}/gems/${basicEnv.name} \( -wholename "*/man/*.$section" -o -wholename "*/man/man$section/*.$section" \) -print -execdir mkdir -p $mandir \; -execdir cp '{}' $mandir \;
+
+      # See: https://github.com/NixOS/nixpkgs/blob/master/pkgs/development/ruby-modules/gem/default.nix#L184-L200
+      # See: https://github.com/rubygems/rubygems/blob/7a7b234721c375874b7e22b1c5b14925b943f04e/bundler/lib/bundler.rb#L285-L291
+      find -L ${basicEnv}/${ruby.gemPath}/${lib.optionalString (basicEnv.gemType == "git" || basicEnv.gemType == "url") "bundler/"}gems/${basicEnv.name} \( -wholename "*/man/*.$section" -o -wholename "*/man/man$section/*.$section" \) -print -execdir mkdir -p $mandir \; -execdir cp '{}' $mandir \;
     done
     ''}
   ''

--- a/pkgs/development/ruby-modules/gem/default.nix
+++ b/pkgs/development/ruby-modules/gem/default.nix
@@ -75,6 +75,14 @@ let
     else
       throw "buildRubyGem: don't know how to build a gem of type \"${type}\""
   );
+
+  # See: https://github.com/rubygems/rubygems/blob/7a7b234721c375874b7e22b1c5b14925b943f04e/bundler/lib/bundler/source/git.rb#L103
+  suffix =
+    if type == "git" then
+      builtins.substring 0 12 attrs.source.rev
+    else
+      version;
+
   documentFlag =
     if document == []
     then "-N"
@@ -86,6 +94,7 @@ stdenv.mkDerivation ((builtins.removeAttrs attrs ["source"]) // {
   inherit ruby;
   inherit dontBuild;
   inherit dontStrip;
+  inherit suffix;
   gemType = type;
 
   nativeBuildInputs = [
@@ -100,7 +109,7 @@ stdenv.mkDerivation ((builtins.removeAttrs attrs ["source"]) // {
     ++ buildInputs;
 
   #name = builtins.trace (attrs.name or "no attr.name" ) "${namePrefix}${gemName}-${version}";
-  name = attrs.name or "${namePrefix}${gemName}-${version}";
+  name = attrs.name or "${namePrefix}${gemName}-${suffix}";
 
   inherit src;
 


### PR DESCRIPTION
###### Description of changes

Fixes https://github.com/NixOS/nixpkgs/issues/128223

`rubyPackages.bundlerApp` was failing for builds coming from :git or a :url.

###### This fixes it in regards to

* Mark suffix be 12 character ref instead of version as specified by [rubygems/bundler/.../git.rb#L103](https://github.com/rubygems/rubygems/blob/7a7b234721c375874b7e22b1c5b14925b943f04e/bundler/lib/bundler/source/git.rb#L103) bundler for `:git`.
* Add prefix `bundler/` when copying man pages when using either of `:git` or `:url` because -
  * nix delegates to bundler specified by [nixpkgs/.../gem/default.nix#L184-L200](https://github.com/NixOS/nixpkgs/blob/master/pkgs/development/ruby-modules/gem/default.nix#L184-L200)
  * which adds a `bundler/` prefix specified by [rubygems/bundler/.../bundler.rb#L285-L291](https://github.com/rubygems/rubygems/blob/7a7b234721c375874b7e22b1c5b14925b943f04e/bundler/lib/bundler.rb#L285-L291)).

If there's any problem in formatting or code style please let me know! Thanks!