### PR TITLE
treewide: fetchgit -> fetchzip (git.kernel.org)

### DIFF
--- a/pkgs/applications/virtualization/kvmtool/default.nix
+++ b/pkgs/applications/virtualization/kvmtool/default.nix
@@ -1,13 +1,12 @@
-{ stdenv, fetchgit, lib, dtc }:
+{ stdenv, fetchzip, lib, dtc }:
 
 stdenv.mkDerivation {
   pname = "kvmtool";
   version = "unstable-2023-07-12";
 
-  src = fetchgit {
-    url = "https://git.kernel.org/pub/scm/linux/kernel/git/will/kvmtool.git";
-    rev = "106e2ea7756d980454d68631b87d5e25ba4e4881";
-    sha256 = "sha256-wpc5DfHnui0lBVH4uOq6a7pXVUZStjNLRvauu6QpRvE=";
+  src = fetchzip {
+    url = "https://git.kernel.org/pub/scm/linux/kernel/git/will/kvmtool.git/snapshot/kvmtool-106e2ea7756d980454d68631b87d5e25ba4e4881.tar.gz";
+    hash = "sha256-wpc5DfHnui0lBVH4uOq6a7pXVUZStjNLRvauu6QpRvE=";
   };
 
   patches = [ ./strlcpy-glibc-2.38-fix.patch ];

--- a/pkgs/development/compilers/dtc/default.nix
+++ b/pkgs/development/compilers/dtc/default.nix
@@ -1,6 +1,6 @@
 { stdenv
 , lib
-, fetchgit
+, fetchzip
 , fetchpatch
 , meson
 , ninja
@@ -18,9 +18,8 @@ stdenv.mkDerivation (finalAttrs: {
   pname = "dtc";
   version = "1.7.0";
 
-  src = fetchgit {
-    url = "https://git.kernel.org/pub/scm/utils/dtc/dtc.git";
-    rev = "refs/tags/v${finalAttrs.version}";
+  src = fetchzip {
+    url = "https://git.kernel.org/pub/scm/utils/dtc/dtc.git/snapshot/dtc-v${finalAttrs.version}.tar.gz";
     sha256 = "sha256-FMh3VvlY3fUK8fbd0M+aCmlUrmG9YegiOOQ7MOByffc=";
   };
 

--- a/pkgs/development/python-modules/python-linux-procfs/default.nix
+++ b/pkgs/development/python-modules/python-linux-procfs/default.nix
@@ -1,13 +1,12 @@
-{ lib, buildPythonPackage, fetchgit, six }:
+{ lib, buildPythonPackage, fetchzip, six }:
 
 buildPythonPackage rec {
   pname = "python-linux-procfs";
   version = "0.6.3";
 
-  src = fetchgit {
-    url = "https://git.kernel.org/pub/scm/libs/python/${pname}/${pname}.git";
-    rev = "v${version}";
-    hash = "sha256-PPgMlL9oj4HYUsr444ZrGo1LSZBl9hL5SE98IASUpbc=";
+  src = fetchzip {
+    url = "https://git.kernel.org/pub/scm/libs/python/python-linux-procfs/python-linux-procfs.git/snapshot/python-linux-procfs-v${version}.tar.gz";
+    hash = "sha256-iaKL7CWJbIvvcUCah7bKdwKZoZJehbQpZ7n0liO8N64=";
   };
 
   propagatedBuildInputs = [ six ];

--- a/pkgs/development/tools/ofono-phonesim/default.nix
+++ b/pkgs/development/tools/ofono-phonesim/default.nix
@@ -1,6 +1,6 @@
 { lib
 , mkDerivation
-, fetchgit
+, fetchzip
 , autoreconfHook
 , pkg-config
 , qtbase
@@ -10,9 +10,8 @@ mkDerivation {
   pname = "ofono-phonesim";
   version = "unstable-2019-11-18";
 
-  src = fetchgit {
-    url = "https://git.kernel.org/pub/scm/network/ofono/phonesim.git";
-    rev = "adf231a84cd3708b825dc82c56e841dd7e3b4541";
+  src = fetchzip {
+    url = "https://git.kernel.org/pub/scm/network/ofono/phonesim.git/snapshot/phonesim-adf231a84cd3708b825dc82c56e841dd7e3b4541.tar.gz";
     sha256 = "1840914sz46l8h2jwa0lymw6dvgj72wq9bhp3k4v4rk6masbf6hp";
   };
 

--- a/pkgs/os-specific/linux/error-inject/default.nix
+++ b/pkgs/os-specific/linux/error-inject/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchgit
+{ lib, stdenv, fetchzip
 , bison, flex, rasdaemon
 }:
 
@@ -9,9 +9,8 @@
     pname = "mce-inject";
     version = "4cbe46321b4a81365ff3aafafe63967264dbfec5";
 
-    src = fetchgit {
-      url = "https://git.kernel.org/pub/scm/utils/cpu/mce/mce-inject.git";
-      rev = version;
+    src = fetchzip {
+      url = "https://git.kernel.org/pub/scm/utils/cpu/mce/mce-inject.git/snapshot/mce-inject-${version}.tar.gz";
       sha256 = "0gjapg2hrlxp8ssrnhvc19i3r1xpcnql7xv0zjgbv09zyha08g6z";
     };
 
@@ -39,9 +38,8 @@
     pname = "aer-inject";
     version = "9bd5e2c7886fca72f139cd8402488a2235957d41";
 
-    src = fetchgit {
-      url = "https://git.kernel.org/pub/scm/linux/kernel/git/gong.chen/aer-inject.git";
-      rev = version;
+    src = fetchzip {
+      url = "https://git.kernel.org/pub/scm/linux/kernel/git/gong.chen/aer-inject.git/snapshot/aer-inject-${version}.tar.gz";
       sha256 = "0bh6mzpk2mr4xidkammmkfk21b4dbq793qjg25ryyxd1qv0c6cg4";
     };
 

--- a/pkgs/os-specific/linux/fsverity-utils/default.nix
+++ b/pkgs/os-specific/linux/fsverity-utils/default.nix
@@ -1,6 +1,6 @@
 { stdenv
 , lib
-, fetchgit
+, fetchzip
 , openssl
 , enableShared ? !stdenv.hostPlatform.isStatic
 , enableManpages ? false
@@ -13,9 +13,8 @@ stdenv.mkDerivation rec {
 
   outputs = [ "out" "lib" "dev" ] ++ lib.optional enableManpages "man";
 
-  src = fetchgit {
-    url = "https://git.kernel.org/pub/scm/fs/fsverity/fsverity-utils.git";
-    rev = "v${version}";
+  src = fetchzip {
+    url = "https://git.kernel.org/pub/scm/fs/fsverity/fsverity-utils.git/snapshot/fsverity-utils-v${version}.tar.gz";
     sha256 = "sha256-ygBOkp2PBe8Z2ak6SXEJ6HHuT4NRKmIsbJDHcY+h8PQ=";
   };
 

--- a/pkgs/os-specific/linux/fsverity-utils/default.nix
+++ b/pkgs/os-specific/linux/fsverity-utils/default.nix
@@ -14,7 +14,7 @@ stdenv.mkDerivation rec {
   outputs = [ "out" "lib" "dev" ] ++ lib.optional enableManpages "man";
 
   src = fetchgit {
-    url = "https://git.kernel.org/pub/scm/linux/kernel/git/ebiggers/fsverity-utils.git";
+    url = "https://git.kernel.org/pub/scm/fs/fsverity/fsverity-utils.git";
     rev = "v${version}";
     sha256 = "sha256-ygBOkp2PBe8Z2ak6SXEJ6HHuT4NRKmIsbJDHcY+h8PQ=";
   };
@@ -42,7 +42,7 @@ stdenv.mkDerivation rec {
 
   meta = with lib; {
     homepage = "https://www.kernel.org/doc/html/latest/filesystems/fsverity.html#userspace-utility";
-    changelog = "https://git.kernel.org/pub/scm/linux/kernel/git/ebiggers/fsverity-utils.git/tree/NEWS.md";
+    changelog = "https://git.kernel.org/pub/scm/fs/fsverity/fsverity-utils.git/tree/NEWS.md";
     description = "A set of userspace utilities for fs-verity";
     license = licenses.mit;
     maintainers = with maintainers; [ jk ];

--- a/pkgs/os-specific/linux/i2c-tools/default.nix
+++ b/pkgs/os-specific/linux/i2c-tools/default.nix
@@ -1,6 +1,6 @@
 { lib
 , stdenv
-, fetchgit
+, fetchzip
 , perl
 , read-edid
 }:
@@ -9,9 +9,8 @@ stdenv.mkDerivation rec {
   pname = "i2c-tools";
   version = "4.3";
 
-  src = fetchgit {
-    url = "https://git.kernel.org/pub/scm/utils/i2c-tools/i2c-tools.git";
-    rev = "v${version}";
+  src = fetchzip {
+    url = "https://git.kernel.org/pub/scm/utils/i2c-tools/i2c-tools.git/snapshot/i2c-tools-v${version}.tar.gz";
     sha256 = "sha256-HlmIocum+HZEKNiS5BUwEIswRfTMUhD1vCPibAuAK0Q=";
   };
 

--- a/pkgs/os-specific/linux/libtraceevent/default.nix
+++ b/pkgs/os-specific/linux/libtraceevent/default.nix
@@ -1,13 +1,12 @@
-{ lib, stdenv, fetchgit, pkg-config, asciidoc, xmlto, docbook_xml_dtd_45, docbook_xsl, meson, ninja, cunit }:
+{ lib, stdenv, fetchzip, pkg-config, asciidoc, xmlto, docbook_xml_dtd_45, docbook_xsl, meson, ninja, cunit }:
 
 stdenv.mkDerivation rec {
   pname = "libtraceevent";
   version = "1.7.3";
 
-  src = fetchgit {
-    url = "https://git.kernel.org/pub/scm/libs/libtrace/libtraceevent.git";
-    rev = "libtraceevent-${version}";
-    sha256 = "sha256-poF+Cqcdj0KIgEJWW7XDAlRLz2/Egi948s1M24ETvBo=";
+  src = fetchzip {
+    url = "https://git.kernel.org/pub/scm/libs/libtrace/libtraceevent.git/snapshot/libtraceevent-libtraceevent-${version}.tar.gz";
+    hash = "sha256-poF+Cqcdj0KIgEJWW7XDAlRLz2/Egi948s1M24ETvBo=";
   };
 
   postPatch = ''

--- a/pkgs/os-specific/linux/libtracefs/default.nix
+++ b/pkgs/os-specific/linux/libtracefs/default.nix
@@ -1,6 +1,6 @@
 { lib
 , stdenv
-, fetchgit
+, fetchzip
 , pkg-config
 , libtraceevent
 , asciidoc
@@ -21,10 +21,9 @@ stdenv.mkDerivation rec {
   pname = "libtracefs";
   version = "1.7.0";
 
-  src = fetchgit {
-    url = "https://git.kernel.org/pub/scm/libs/libtrace/libtracefs.git";
-    rev = "libtracefs-${version}";
-    sha256 = "sha256-64eXFFdnZHHf4C3vbADtPuIMsfJ85VZ6t8A1gIc1CW0=";
+  src = fetchzip {
+    url = "https://git.kernel.org/pub/scm/libs/libtrace/libtracefs.git/snapshot/libtracefs-libtracefs-${version}.tar.gz";
+    hash = "sha256-64eXFFdnZHHf4C3vbADtPuIMsfJ85VZ6t8A1gIc1CW0=";
   };
 
   postPatch = ''

--- a/pkgs/os-specific/linux/trace-cmd/default.nix
+++ b/pkgs/os-specific/linux/trace-cmd/default.nix
@@ -1,12 +1,11 @@
-{ lib, stdenv, fetchgit, pkg-config, asciidoc, xmlto, docbook_xsl, docbook_xml_dtd_45, libxslt, libtraceevent, libtracefs, zstd, sourceHighlight }:
+{ lib, stdenv, fetchzip, pkg-config, asciidoc, xmlto, docbook_xsl, docbook_xml_dtd_45, libxslt, libtraceevent, libtracefs, zstd, sourceHighlight }:
 stdenv.mkDerivation rec {
   pname = "trace-cmd";
   version = "3.2";
 
-  src = fetchgit {
-    url    = "https://git.kernel.org/pub/scm/utils/trace-cmd/trace-cmd.git/";
-    rev    = "trace-cmd-v${version}";
-    sha256 = "sha256-KlykIYF4uy1phgWRG5j76FJqgO7XhNnyrTDVTs8YOXY=";
+  src = fetchzip {
+    url    = "https://git.kernel.org/pub/scm/utils/trace-cmd/trace-cmd.git/snapshot/trace-cmd-v${version}.tar.gz";
+    hash   = "sha256-rTcaaEQ3Y4cneNnZSGiMZNp+Z7dyAa3oNTNMAEXr28g=";
   };
 
   # Don't build and install html documentation

--- a/pkgs/os-specific/linux/trace-cmd/kernelshark.nix
+++ b/pkgs/os-specific/linux/trace-cmd/kernelshark.nix
@@ -1,4 +1,4 @@
-{ lib, mkDerivation, fetchgit, qtbase, cmake, asciidoc
+{ lib, mkDerivation, fetchzip, qtbase, cmake, asciidoc
 , docbook_xsl, json_c, mesa_glu, freeglut, trace-cmd, pkg-config
 , libtraceevent, libtracefs, freefont_ttf
 }:
@@ -7,9 +7,8 @@ mkDerivation rec {
   pname = "kernelshark";
   version = "2.2.1";
 
-  src = fetchgit {
-    url = "https://git.kernel.org/pub/scm/utils/trace-cmd/kernel-shark.git/";
-    rev = "kernelshark-v${version}";
+  src = fetchzip {
+    url = "https://git.kernel.org/pub/scm/utils/trace-cmd/kernel-shark.git/snapshot/kernelshark-v${version}.tar.gz";
     hash = "sha256-V25IzPDOt6V03wgIa/AJ0T8mRaGmXYuMCcvbSOKleY0=";
   };
 

--- a/pkgs/os-specific/linux/tuna/default.nix
+++ b/pkgs/os-specific/linux/tuna/default.nix
@@ -21,7 +21,7 @@ buildPythonApplication rec {
     sha256 = "MwyLBwKz5ur1sBXHiCLq/Nq2u5aaiC+KzXqvGBmQii8=";
   };
 
-  patchPhase = ''
+  postPatch = ''
     mv tuna-cmd.py tuna/cmd.py
 
     substituteInPlace setup.py \

--- a/pkgs/os-specific/linux/tuna/default.nix
+++ b/pkgs/os-specific/linux/tuna/default.nix
@@ -1,6 +1,6 @@
 { lib
 , buildPythonApplication
-, fetchgit
+, fetchzip
 , pygobject3
 , pytestCheckHook
 , gdk-pixbuf
@@ -16,10 +16,9 @@ buildPythonApplication rec {
   pname = "tuna";
   version = "0.15";
 
-  src = fetchgit {
-    url = "https://git.kernel.org/pub/scm/utils/${pname}/${pname}.git";
-    rev = "v${version}";
-    sha256 = "sha256-lRHlbdCQ0NcjcWgLvCze67kN8NsK0f5RmKfPbkHhk78=";
+  src = fetchzip {
+    url = "https://git.kernel.org/pub/scm/utils/tuna/tuna.git/snapshot/tuna-v${version}.tar.gz";
+    sha256 = "MwyLBwKz5ur1sBXHiCLq/Nq2u5aaiC+KzXqvGBmQii8=";
   };
 
   patchPhase = ''

--- a/pkgs/tools/filesystems/f2fs-tools/default.nix
+++ b/pkgs/tools/filesystems/f2fs-tools/default.nix
@@ -1,12 +1,11 @@
-{ lib, stdenv, fetchgit, autoreconfHook, libselinux, libuuid, pkg-config }:
+{ lib, stdenv, fetchzip, autoreconfHook, libselinux, libuuid, pkg-config }:
 
 stdenv.mkDerivation rec {
   pname = "f2fs-tools";
   version = "1.16.0";
 
-  src = fetchgit {
-    url = "https://git.kernel.org/pub/scm/linux/kernel/git/jaegeuk/f2fs-tools.git";
-    rev = "refs/tags/v${version}";
+  src = fetchzip {
+    url = "https://git.kernel.org/pub/scm/linux/kernel/git/jaegeuk/f2fs-tools.git/snapshot/f2fs-tools-v${version}.tar.gz";
     sha256 = "sha256-zNG1F//+BTBzlEc6qNVixyuCB6PMZD5Kf8pVK0ePYiA=";
   };
 

--- a/pkgs/tools/misc/xfstests/default.nix
+++ b/pkgs/tools/misc/xfstests/default.nix
@@ -1,5 +1,5 @@
 { stdenv, acl, attr, autoconf, automake, bash, bc, coreutils, e2fsprogs
-, fetchgit, fio, gawk, keyutils, killall, lib, libaio, libcap, libtool
+, fetchzip, fio, gawk, keyutils, killall, lib, libaio, libcap, libtool
 , libuuid, libxfs, lvm2, openssl, perl, procps, quota
 , time, util-linux, which, writeScript, xfsprogs, runtimeShell }:
 
@@ -7,10 +7,9 @@ stdenv.mkDerivation rec {
   pname = "xfstests";
   version = "2023.05.14";
 
-  src = fetchgit {
-    url = "https://git.kernel.org/pub/scm/fs/xfs/xfstests-dev.git";
-    rev = "v${version}";
-    sha256 = "sha256-yyjY9Q3eUH+q+o15zFUjOcNz1HpXPCwdcxWXoycOx98=";
+  src = fetchzip {
+    url = "https://git.kernel.org/pub/scm/fs/xfs/xfstests-dev.git/snapshot/xfstests-dev-v${version}.tar.gz";
+    hash = "sha256-yyjY9Q3eUH+q+o15zFUjOcNz1HpXPCwdcxWXoycOx98=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/tools/networking/mmsd/default.nix
+++ b/pkgs/tools/networking/mmsd/default.nix
@@ -1,5 +1,5 @@
 { lib, stdenv
-, fetchgit
+, fetchzip
 , autoreconfHook
 , pkg-config
 , glib
@@ -10,9 +10,8 @@ stdenv.mkDerivation rec {
   pname = "mmsd";
   version = "unstable-2019-07-15";
 
-  src = fetchgit {
-    url = "https://git.kernel.org/pub/scm/network/ofono/mmsd.git";
-    rev = "f4b8b32477a411180be1823fdc460b4f7e1e3c9c";
+  src = fetchzip {
+    url = "https://git.kernel.org/pub/scm/network/ofono/mmsd.git/snapshot/mmsd-f4b8b32477a411180be1823fdc460b4f7e1e3c9c.tar.gz";
     sha256 = "0hcnpyhsi7b5m825dhnwbp65yi0961wi8mipzdvaw5nc693xv15b";
   };
 

--- a/pkgs/tools/networking/ofono/default.nix
+++ b/pkgs/tools/networking/ofono/default.nix
@@ -1,5 +1,5 @@
 { lib, stdenv
-, fetchgit
+, fetchzip
 , autoreconfHook
 , pkg-config
 , glib
@@ -16,9 +16,8 @@ stdenv.mkDerivation rec {
 
   outputs = [ "out" "dev" ];
 
-  src = fetchgit {
-    url = "https://git.kernel.org/pub/scm/network/ofono/ofono.git";
-    rev = version;
+  src = fetchzip {
+    url = "https://git.kernel.org/pub/scm/network/ofono/ofono.git/snapshot/ofono-${version}.tar.gz";
     sha256 = "sha256-GxQfh/ps5oM9G6B1EVgnjo8LqHD1hMqdnju1PCQq3kA=";
   };
 

--- a/pkgs/tools/security/efitools/default.nix
+++ b/pkgs/tools/security/efitools/default.nix
@@ -1,5 +1,5 @@
 { lib, stdenv, gnu-efi, openssl, sbsigntool, perl, perlPackages,
-help2man, fetchgit }:
+help2man, fetchzip }:
 stdenv.mkDerivation rec {
   pname = "efitools";
   version = "1.9.2";
@@ -16,9 +16,8 @@ stdenv.mkDerivation rec {
     help2man
   ];
 
-  src = fetchgit {
-    url = "https://git.kernel.org/pub/scm/linux/kernel/git/jejb/efitools.git";
-    rev = "v${version}";
+  src = fetchzip {
+    url = "https://git.kernel.org/pub/scm/linux/kernel/git/jejb/efitools.git/snapshot/efitools-v${version}.tar.gz";
     sha256 = "0jabgl2pxvfl780yvghq131ylpf82k7banjz0ksjhlm66ik8gb1i";
   };
 

--- a/pkgs/tools/text/l2md/default.nix
+++ b/pkgs/tools/text/l2md/default.nix
@@ -1,12 +1,11 @@
-{ lib, stdenv, fetchgit, libgit2 }:
+{ lib, stdenv, fetchzip, libgit2 }:
 
 stdenv.mkDerivation rec {
   pname = "l2md";
   version = "unstable-2021-10-27";
 
-  src = fetchgit {
-    url = "https://git.kernel.org/pub/scm/linux/kernel/git/dborkman/l2md.git";
-    rev = "9db252bc1716ebaf0abd3a47a59ea78e4e6253d6";
+  src = fetchzip {
+    url = "https://git.kernel.org/pub/scm/linux/kernel/git/dborkman/l2md.git/snapshot/l2md-9db252bc1716ebaf0abd3a47a59ea78e4e6253d6.tar.gz";
     sha256 = "sha256-H/leDUwQM55akyXsmTnI2YsnG4i1KQtf4bBt1fizy8E=";
   };
 


### PR DESCRIPTION
###### Description of changes

fetchzip is more efficient, because it doesn't do a full git clone, so it should be preferred where possible.

Where hashes have not been changed, I have verified that they don't need to be.  Where hashes have changed, in all cases this is because of .gitattributes files that exclude certain files from the tarball, and in these cases I have verified that the packages still build.

sbsigntool still uses fetchgit because it has a submodule, and ell and iwd still use fetchgit because git.kernel.org does not provide snapshot links for them.  I have contacted helpdesk@kernel.org to ask if this can be fixed.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes (or backporting 23.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
