### PR TITLE
bppsuite: fix homepage

### DIFF
--- a/pkgs/applications/science/biology/bppsuite/default.nix
+++ b/pkgs/applications/science/biology/bppsuite/default.nix
@@ -16,6 +16,7 @@ stdenv.mkDerivation rec {
   buildInputs = [ bpp-core bpp-seq bpp-phyl bpp-popgen ];
 
   meta = bpp-core.meta // {
+    homepage = "https://github.com/BioPP/bppsuite";
     changelog = "https://github.com/BioPP/bppsuite/blob/master/ChangeLog";
   };
 }

--- a/pkgs/development/libraries/science/biology/bpp-core/default.nix
+++ b/pkgs/development/libraries/science/biology/bpp-core/default.nix
@@ -23,7 +23,7 @@ stdenv.mkDerivation rec {
   doCheck = !stdenv.isDarwin;
 
   meta = with lib; {
-    homepage = "http://biopp.univ-montp2.fr/wiki/index.php/Main_Page";
+    homepage = "https://github.com/BioPP/bpp-core";
     changelog = "https://github.com/BioPP/bpp-core/blob/master/ChangeLog";
     description = "C++ bioinformatics libraries and tools";
     maintainers = with maintainers; [ bcdarwin ];

--- a/pkgs/development/libraries/science/biology/bpp-phyl/default.nix
+++ b/pkgs/development/libraries/science/biology/bpp-phyl/default.nix
@@ -23,6 +23,7 @@ stdenv.mkDerivation rec {
   doCheck = !stdenv.isDarwin;
 
   meta = bpp-core.meta // {
+    homepage = "https://github.com/BioPP/bpp-phyl";
     changelog = "https://github.com/BioPP/bpp-phyl/blob/master/ChangeLog";
   };
 }

--- a/pkgs/development/libraries/science/biology/bpp-popgen/default.nix
+++ b/pkgs/development/libraries/science/biology/bpp-popgen/default.nix
@@ -26,6 +26,7 @@ stdenv.mkDerivation rec {
   doCheck = !stdenv.isDarwin;
 
   meta = bpp-core.meta // {
+    homepage = "https://github.com/BioPP/bpp-popgen";
     changelog = "https://github.com/BioPP/bpp-popgen/blob/master/ChangeLog";
   };
 }

--- a/pkgs/development/libraries/science/biology/bpp-seq/default.nix
+++ b/pkgs/development/libraries/science/biology/bpp-seq/default.nix
@@ -26,6 +26,7 @@ stdenv.mkDerivation rec {
   doCheck = !stdenv.isDarwin;
 
   meta = bpp-core.meta // {
+    homepage = "https://github.com/BioPP/bpp-seq";
     changelog = "https://github.com/BioPP/bpp-seq/blob/master/ChangeLog";
   };
 }


### PR DESCRIPTION
###### Description of changes

Old homepage is down, so point to GitHub instead.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes (or backporting 23.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
