### PR TITLE
sv-lang: init at 3.0

### DIFF
--- a/pkgs/applications/science/electronics/sv-lang/default.nix
+++ b/pkgs/applications/science/electronics/sv-lang/default.nix
@@ -1,0 +1,75 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, boost182
+, catch2_3
+, cmake
+, ninja
+, fmt_9
+, python3
+}:
+
+let
+  # dependency for this library has been removed in master (i.e. next release)
+  unordered_dense = stdenv.mkDerivation rec {
+    version = "2.0.1";
+    pname = "unordered_dense";
+    src = fetchFromGitHub {
+      owner = "martinus";
+      repo = pname;
+      rev = "v${version}";
+      sha256 = "sha256-9zlWYAY4lOQsL9+MYukqavBi5k96FvglRgznLIwwRyw=";
+    };
+    nativeBuildInputs = [
+      cmake
+    ];
+  };
+
+in
+stdenv.mkDerivation rec {
+  pname = "sv-lang";
+  version = "3.0";
+
+  src = fetchFromGitHub {
+    owner = "MikePopoloski";
+    repo = "slang";
+    rev = "v${version}";
+    sha256 = "sha256-v2sStvukLFMRXGeATxvizmnwEPDE4kwnS06n+37OrJA=";
+  };
+
+  cmakeFlags = [
+    # fix for https://github.com/NixOS/nixpkgs/issues/144170
+    "-DCMAKE_INSTALL_INCLUDEDIR=include"
+    "-DCMAKE_INSTALL_LIBDIR=lib"
+
+    "-DSLANG_INCLUDE_TESTS=${if doCheck then "ON" else "OFF"}"
+  ];
+
+  nativeBuildInputs = [
+    cmake
+    python3
+    ninja
+
+    # though only used in tests, cmake will complain its absence when configuring
+    catch2_3
+  ];
+
+  buildInputs = [
+    unordered_dense
+    boost182
+    fmt_9
+  ];
+
+  # TODO: a mysterious linker error occurs when building the unittests on darwin.
+  # The error occurs when using catch2_3 in nixpkgs, not when fetching catch2_3 using CMake
+  doCheck = !stdenv.isDarwin;
+
+  meta = with lib; {
+    description = "SystemVerilog compiler and language services";
+    homepage = "https://github.com/MikePopoloski/slang";
+    license = licenses.mit;
+    maintainers = with maintainers; [ sharzy ];
+    mainProgram = "slang";
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -24608,6 +24608,8 @@ with pkgs;
 
   stxxl = callPackage ../development/libraries/stxxl { };
 
+  sv-lang = callPackage ../applications/science/electronics/sv-lang { };
+
   sqlite = lowPrio (callPackage ../development/libraries/sqlite { });
 
   unqlite = lowPrio (callPackage ../development/libraries/unqlite { });


### PR DESCRIPTION
###### Description of changes

sv-lang (also known as slang) provides a SystemVerilog compiler and language services.

Homepage: https://github.com/MikePopoloski/slang

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes (or backporting 23.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
