### PR TITLE
tree: 2.0.4 -> 2.1.1

### DIFF
--- a/pkgs/tools/system/tree/default.nix
+++ b/pkgs/tools/system/tree/default.nix
@@ -2,7 +2,7 @@
 
 let
   # These settings are found in the Makefile, but there seems to be no
-  # way to select one ore the other setting other than editing the file
+  # way to select one or the other setting other than editing the file
   # manually, so we have to duplicate the know how here.
   systemFlags = lib.optionalString stdenv.isDarwin ''
     CFLAGS="-O2 -Wall -fomit-frame-pointer -no-cpp-precomp"
@@ -18,13 +18,13 @@ let
 in
 stdenv.mkDerivation rec {
   pname = "tree";
-  version = "2.0.4";
+  version = "2.1.1";
 
   src = fetchFromGitLab {
     owner = "OldManProgrammer";
     repo = "unix-tree";
     rev = version;
-    sha256 = "sha256-2voXL31JHh09yBBLuHhYyZsUapiPVF/cgRmTU6wSXk4=";
+    sha256 = "sha256-aPz1ROUeAKDmMjEtAaL2AguF54/CbIYWpL4Qovv2ftQ=";
   };
 
   preConfigure = ''


### PR DESCRIPTION
###### Description of changes

Changelog [2.1.0](https://gitlab.com/OldManProgrammer/unix-tree/-/commit/22a2e268206b8d2238a686458c4702f9b3689e5b)
Changelog [2.1.1](https://gitlab.com/OldManProgrammer/unix-tree/-/commit/84fa3ddff51b30835a0f9c4a9e4c9225970f9aff)

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes (or backporting 23.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---
Result of `nixpkgs-review` run on x86_64-linux [1](https://github.com/Mic92/nixpkgs-review)
<details>
  <summary>22 packages built:</summary>
  <ul>
    <li>hollywood</li>
    <li>krunner-pass</li>
    <li>memo</li>
    <li>pass</li>
    <li>pass-nodmenu</li>
    <li>pass-secret-service</li>
    <li>pass-secret-service.dist</li>
    <li>pass-wayland</li>
    <li>passExtensions.pass-audit</li>
    <li>passExtensions.pass-audit.man</li>
    <li>passExtensions.pass-import</li>
    <li>passExtensions.pass-import.dist</li>
    <li>passage</li>
    <li>passff-host</li>
    <li>pypass (python310Packages.pypass)</li>
    <li>pypass.dist (python310Packages.pypass.dist)</li>
    <li>python311Packages.pypass</li>
    <li>python311Packages.pypass.dist</li>
    <li>qtpass</li>
    <li>rofi-pass</li>
    <li>tessen</li>
    <li>tree</li>
  </ul>
</details>

###### Maintainer pings
cc @SuperSandro2000 
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
