### PR TITLE
raycast: 1.53.2 -> 1.53.3

### DIFF
--- a/pkgs/os-specific/darwin/raycast/default.nix
+++ b/pkgs/os-specific/darwin/raycast/default.nix
@@ -6,18 +6,12 @@
 
 stdenvNoCC.mkDerivation rec {
   pname = "raycast";
-  version = "1.53.2";
+  version = "1.53.3";
 
   src = fetchurl {
-    # https://github.com/NixOS/nixpkgs/pull/223495
-    # official download API: https://api.raycast.app/v2/download
-    # this returns an AWS CloudFront signed URL with expiration timestamp and signature
-    # the returned URL will always be the latest Raycast which might result in an impure derivation
-    # the package maintainer created a repo (https://github.com/stepbrobd/raycast-overlay)
-    # to host GitHub Actions to periodically check for updates
-    # and re-release the `.dmg` file to Internet Archive (https://archive.org/details/raycast)
-    url = "https://archive.org/download/raycast/raycast-${version}.dmg";
-    sha256 = "sha256-e2UGS1LSBj0xZu0gWlb8SiXhx1sZzcZDOGPhg6ziI9c=";
+    name = "Raycast.dmg";
+    url = "https://releases.raycast.com/releases/${version}/download?build=universal";
+    sha256 = "sha256-FHCNySTtP7Dxa2UAlYoHD4u5ammLuhOQKC3NGpxcyYo=";
   };
 
   dontPatch = true;

--- a/pkgs/os-specific/darwin/raycast/update.sh
+++ b/pkgs/os-specific/darwin/raycast/update.sh
@@ -3,10 +3,10 @@
 
 set -eo pipefail
 
-new_version="$(ia list raycast | grep -Eo '^raycast-.*\.dmg$' | sort -r | head -n1 | sed -E 's/^raycast-([0-9]+\.[0-9]+\.[0-9]+)\.dmg$/\1/')"
-old_version="$(sed -nE 's/\s*version = "(.*)".*/\1/p' ./default.nix)"
+new_version=$(curl --silent https://releases.raycast.com/releases/latest | jq -r '.version')
+old_version=$(sed -nE 's/\s*version = "(.*)".*/\1/p' ./default.nix)
 
-if [[ "$new_version" == "$old_version" ]]; then
+if [[ $new_version == $old_version ]]; then
     echo "Already up to date."
     exit 0
 else
@@ -15,6 +15,6 @@ else
     rm ./default.nix.bak
 fi
 
-hash="$(nix --extra-experimental-features nix-command store prefetch-file --json --hash-type sha256 "https://archive.org/download/raycast/raycast-$new_version.dmg" | jq -r '.hash')"
+hash=$(nix --extra-experimental-features nix-command store prefetch-file --json --hash-type sha256 "https://releases.raycast.com/releases/$new_version/download?build=universal" | jq -r '.hash')
 sed -Ei.bak '/ *sha256 = /{N;N; s@("sha256-)[^;"]+@"'"$hash"'@}' ./default.nix
 rm ./default.nix.bak


### PR DESCRIPTION
###### Description of changes

After communicating with the Raycast team (thanks Sorin), they added API for:

1. Getting the latest version of Raycast via REST endpoint `https://releases.raycast.com/releases/latest`, and

2. Versioned download in the format of `https://releases.raycast.com/releases/<version>/download`.

This update deprecates download via Internet Archive and switches to official download API.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes (or backporting 23.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
