### PR TITLE
code-server: 4.12.0 -> 4.13.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -3098,6 +3098,15 @@
     githubId = 34317;
     name = "Corey O'Connor";
   };
+  code-asher = {
+    email = "ash@coder.com";
+    github = "code-asher";
+    githubId = 45609798;
+    name = "Asher";
+    keys = [{
+      fingerprint = "6E3A FA6D 915C C2A4 D26F  C53E 7BB4 BA9C 783D 2BBC";
+    }];
+  };
   CodeLongAndProsper90 = {
     github = "CodeLongAndProsper90";
     githubId = 50145141;

--- a/pkgs/servers/code-server/build-vscode-nogit.patch
+++ b/pkgs/servers/code-server/build-vscode-nogit.patch
@@ -1,14 +1,8 @@
---- ./ci/build/build-vscode.sh
-+++ ./ci/build/build-vscode.sh
-@@ -45,14 +45,12 @@
-   # Set the commit Code will embed into the product.json.  We need to do this
-   # since Code tries to get the commit from the `.git` directory which will fail
-   # as it is a submodule.
--  export VSCODE_DISTRO_COMMIT
--  VSCODE_DISTRO_COMMIT=$(git rev-parse HEAD)
-+  export VSCODE_DISTRO_COMMIT=none
- 
-   # Add the date, our name, links, and enable telemetry (this just makes
+diff --git a/ci/build/build-vscode.sh b/ci/build/build-vscode.sh
+index a72549fb..3aed1ad5 100755
+--- a/ci/build/build-vscode.sh
++++ b/ci/build/build-vscode.sh
+@@ -58,7 +58,6 @@ main() {
    # telemetry available; telemetry can still be disabled by flag or setting).
    # This needs to be done before building as Code will read this file and embed
    # it into the client-side code.
@@ -16,7 +10,7 @@
    cp product.json product.original.json # Since jq has no inline edit.
    jq --slurp '.[0] * .[1]' product.original.json <(
      cat << EOF
-@@ -99,7 +97,6 @@
+@@ -105,7 +104,6 @@ EOF
    # Reset so if you develop after building you will not be stuck with the wrong
    # commit (the dev client will use `oss-dev` but the dev server will still use
    # product.json which will have `stable-$commit`).

--- a/pkgs/servers/code-server/default.nix
+++ b/pkgs/servers/code-server/default.nix
@@ -297,7 +297,7 @@ stdenv.mkDerivation (finalAttrs: {
     '';
     homepage = "https://github.com/coder/code-server";
     license = lib.licenses.mit;
-    maintainers = with lib.maintainers; [ offline henkery ];
+    maintainers = with lib.maintainers; [ offline henkery code-asher ];
     platforms = [ "x86_64-linux" "aarch64-linux" "x86_64-darwin" ];
   };
 })

--- a/pkgs/servers/code-server/default.nix
+++ b/pkgs/servers/code-server/default.nix
@@ -54,17 +54,19 @@ let
     sed -i 's/${version}/${esbuild'.version}/g' ${path}/node_modules/esbuild/lib/main.js
     ln -s -f ${esbuild'}/bin/esbuild ${path}/node_modules/esbuild/bin/esbuild
   '';
+
+  commit = "2798322b03e7f446f59c5142215c11711ed7a427";
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "code-server";
-  version = "4.12.0";
+  version = "4.13.0";
 
   src = fetchFromGitHub {
     owner = "coder";
     repo = "code-server";
     rev = "v${finalAttrs.version}";
     fetchSubmodules = true;
-    hash = "sha256-PQp5dji2Ynp+LJRWBka41umwe1/IR76C+at/wyOWGcI=";
+    hash = "sha256-4hkKGQU9G3CllD+teWXnYoHaY3YdDz25fwaMUS5OlfM=";
   };
 
   yarnCache = stdenv.mkDerivation {
@@ -92,7 +94,7 @@ stdenv.mkDerivation (finalAttrs: {
 
     outputHashMode = "recursive";
     outputHashAlgo = "sha256";
-    outputHash = "sha256-4Vr9u3+W/IhbbTc39jyDyDNQODlmdF+M/N8oJn0Z4+w=";
+    outputHash = "sha256-xLcrOVhKC0cOPcS5XwIMyv1KiEE0azZ1z+wS9PPKjAQ=";
   };
 
   nativeBuildInputs = [
@@ -120,7 +122,8 @@ stdenv.mkDerivation (finalAttrs: {
   ];
 
   patches = [
-    # remove git calls from vscode build script
+    # Remove all git calls from the VS Code build script except `git rev-parse
+    # HEAD` which is replaced in postPatch with the commit.
     ./build-vscode-nogit.patch
   ];
 
@@ -130,8 +133,10 @@ stdenv.mkDerivation (finalAttrs: {
     patchShebangs ./ci
 
     # inject git commit
-    substituteInPlace ci/build/build-release.sh \
-      --replace '$(git rev-parse HEAD)' "$commit"
+    substituteInPlace ./ci/build/build-vscode.sh \
+      --replace '$(git rev-parse HEAD)' "${commit}"
+    substituteInPlace ./ci/build/build-release.sh \
+      --replace '$(git rev-parse HEAD)' "${commit}"
   '';
 
   configurePhase = ''
@@ -232,8 +237,8 @@ stdenv.mkDerivation (finalAttrs: {
       -execdir ln -s ${ripgrep}/bin/rg {}/bin/rg \;
 
     # run postinstall scripts after patching
-    find ./lib/vscode -path "*node_modules" -prune -o \
-      -path "./*/*/*/*/*" -name "yarn.lock" -printf "%h\n" | \
+    find ./lib/vscode \( -path "*/node_modules/*" -or -path "*/extensions/*" \) \
+      -and -type f -name "yarn.lock" -printf "%h\n" | \
         xargs -I {} sh -c 'jq -e ".scripts.postinstall" {}/package.json >/dev/null && yarn --cwd {} postinstall --frozen-lockfile --offline || true'
 
     # build code-server
@@ -241,6 +246,15 @@ stdenv.mkDerivation (finalAttrs: {
 
     # build vscode
     VERSION=${finalAttrs.version} yarn build:vscode
+
+    # inject version into package.json
+    jq --slurp '.[0] * .[1]' ./package.json <(
+      cat << EOF
+    {
+      "version": "${finalAttrs.version}"
+    }
+    EOF
+    ) | sponge ./package.json
 
     # create release
     yarn release


### PR DESCRIPTION
###### Description of changes

Update code-server from 4.12.0 to 4.13.0.

I replaced the commit with the actual commit instead of "none" and fixed the other replacement (`$commit` did not exist).

There was at least one postinstall script in `extensions` that was not being ran so I modified the `find` command to account for lock files in that directory in addition to `node_modules`.

Lastly, inject the version into the package.json otherwise it uses the placeholder version 0.0.0.

https://github.com/coder/code-server/releases/tag/v4.14.0-rc.1

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes (or backporting 23.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

I tested by building code-server and doing a few simple actions like opening files, editing, and confirming the version and commit show correctly in `--version` and the help dialog.