### PR TITLE
python311Packages.pycodestyle: Fix tests on python 3.11.4

### DIFF
--- a/pkgs/development/python-modules/pycodestyle/default.nix
+++ b/pkgs/development/python-modules/pycodestyle/default.nix
@@ -18,6 +18,13 @@ buildPythonPackage rec {
     hash = "sha256-NHGHvbR2Mp2Y9pXCE9cpWoRtEVL/T+m6y4qVkLjucFM=";
   };
 
+  patches = [
+    # https://github.com/PyCQA/pycodestyle/issues/1151
+    # Applies a modified version of an upstream patch that only applied
+    # to Python 3.12.
+    ./python-3.11.4-compat.patch
+  ];
+
   # https://github.com/PyCQA/pycodestyle/blob/2.10.0/tox.ini#L13
   checkPhase = ''
     ${python.interpreter} -m pycodestyle --statistics pycodestyle.py

--- a/pkgs/development/python-modules/pycodestyle/python-3.11.4-compat.patch
+++ b/pkgs/development/python-modules/pycodestyle/python-3.11.4-compat.patch
@@ -1,0 +1,16 @@
+diff --git a/testsuite/test_api.py b/testsuite/test_api.py
+index 8dde32ff..38e34acf 100644
+--- a/testsuite/test_api.py
++++ b/testsuite/test_api.py
+@@ -329,7 +329,10 @@ def test_check_nullbytes(self):
+         count_errors = pep8style.input_file('stdin', lines=['\x00\n'])
+ 
+         stdout = sys.stdout.getvalue()
+-        expected = "stdin:1:1: E901 ValueError"
++        if sys.version_info < (3, 11, 4):
++            expected = "stdin:1:1: E901 ValueError"
++        else:
++            expected = "stdin:1:1: E901 SyntaxError: source code string cannot contain null bytes"  # noqa: E501
+         self.assertTrue(stdout.startswith(expected),
+                         msg='Output %r does not start with %r' %
+                         (stdout, expected))


### PR DESCRIPTION
Applies a modified version of upstreams patch to fix the tests, only upstream only recognized the issue from 3.12, while it hit us on 3.11.4.

for #237233 

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes (or backporting 23.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
