### PR TITLE
python311Packages.w3lib: disable regressed test

### DIFF
--- a/pkgs/development/python-modules/w3lib/default.nix
+++ b/pkgs/development/python-modules/w3lib/default.nix
@@ -26,7 +26,7 @@ buildPythonPackage rec {
     "w3lib"
   ];
 
-  disabledTests = lib.optional (pythonAtLeast "3.11") [
+  disabledTests = lib.optionals (pythonAtLeast "3.11") [
     # regressed on Python 3.11.4
     # https://github.com/scrapy/w3lib/issues/212
     "test_safe_url_string_url"

--- a/pkgs/development/python-modules/w3lib/default.nix
+++ b/pkgs/development/python-modules/w3lib/default.nix
@@ -2,6 +2,7 @@
 , buildPythonPackage
 , fetchPypi
 , pytestCheckHook
+, pythonAtLeast
 , pythonOlder
 }:
 
@@ -25,8 +26,10 @@ buildPythonPackage rec {
     "w3lib"
   ];
 
-  disabledTests = [
-    "test_add_or_replace_parameter"
+  disabledTests = lib.optional (pythonAtLeast "3.11") [
+    # regressed on Python 3.11.4
+    # https://github.com/scrapy/w3lib/issues/212
+    "test_safe_url_string_url"
   ];
 
   meta = with lib; {


### PR DESCRIPTION
And remove tests that are working again from disabledTests.

for #237233 

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes (or backporting 23.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
