### PR TITLE
pkgsStatic.cyrus_sasl: fix build

### DIFF
--- a/pkgs/applications/misc/xautoclick/default.nix
+++ b/pkgs/applications/misc/xautoclick/default.nix
@@ -1,8 +1,8 @@
 { lib, stdenv, fetchFromGitHub, xorg, pkg-config
 , cmake, libevdev
-, gtkSupport ? true, gtk3, pcre, glib, wrapGAppsHook
-, fltkSupport ? true, fltk
-, qtSupport ? true, qt5
+, withGtk3 ? true, gtk3, pcre, glib, wrapGAppsHook
+, withFltk ? true, fltk
+, withQt5 ? true, qt5
 }:
 
 stdenv.mkDerivation rec {
@@ -18,9 +18,9 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ cmake pkg-config ];
   buildInputs = [ libevdev xorg.libXtst ]
-    ++ lib.optionals gtkSupport [ gtk3 pcre glib wrapGAppsHook ]
-    ++ lib.optionals fltkSupport [ fltk ]
-    ++ lib.optionals qtSupport [ qt5.qtbase qt5.wrapQtAppsHook ];
+    ++ lib.optionals withGtk3 [ gtk3 pcre glib wrapGAppsHook ]
+    ++ lib.optionals withFltk [ fltk ]
+    ++ lib.optionals withQt5 [ qt5.qtbase qt5.wrapQtAppsHook ];
 
   meta = with lib; {
     description = "Autoclicker application, which enables you to automatically click the left mousebutton";


### PR DESCRIPTION
# pkgsStatic.cyrus_sasl: fix build

```
pkgsStatic.cyrus_sasl: fix build
```

## Build info of packages affected directly
### pkgsStatic.cyrus_sasl

<details><summary>content of pkgsStatic.cyrus_sasl.bin</summary>

```
/nix/store/h1p7q88fqg9zbzkpn319m8ifxb026dsa-cyrus-sasl-static-x86_64-unknown-linux-musl-2.1.28-bin
├── bin
│   ├── pluginviewer
│   ├── saslauthd
│   ├── sasldblistusers2
│   ├── saslpasswd2
│   └── testsaslauthd
└── sbin -> bin

2 directories, 5 files
```
</details>

<details><summary>content of pkgsStatic.cyrus_sasl.dev</summary>

```
/nix/store/cvwh9jqrlj1fp5dqwpbdi5qs5s37k9wh-cyrus-sasl-static-x86_64-unknown-linux-musl-2.1.28-dev
├── include
│   └── sasl
│       ├── hmac-md5.h
│       ├── md5.h
│       ├── md5global.h
│       ├── prop.h
│       ├── sasl.h
│       ├── saslplug.h
│       └── saslutil.h
├── lib
│   └── pkgconfig
│       └── libsasl2.pc
└── nix-support
    └── propagated-build-inputs

5 directories, 9 files
```
</details>

<details><summary>content of pkgsStatic.cyrus_sasl.devdoc</summary>

```
/nix/store/zsif9aar7hp83q0cd6yf40n01ws1z8gp-cyrus-sasl-static-x86_64-unknown-linux-musl-2.1.28-devdoc
└── share
    └── man
        └── man3
            ├── sasl.3.gz
            ├── sasl_authorize_t.3.gz
            ├── sasl_auxprop.3.gz
            ├── sasl_auxprop_getctx.3.gz
            ├── sasl_auxprop_request.3.gz
            ├── sasl_callbacks.3.gz
            ├── sasl_canon_user_t.3.gz
            ├── sasl_chalprompt_t.3.gz
            ├── sasl_checkapop.3.gz
            ├── sasl_checkpass.3.gz
            ├── sasl_client_init.3.gz
            ├── sasl_client_new.3.gz
            ├── sasl_client_start.3.gz
            ├── sasl_client_step.3.gz
            ├── sasl_decode.3.gz
            ├── sasl_dispose.3.gz
            ├── sasl_done.3.gz
            ├── sasl_encode.3.gz
            ├── sasl_encodev.3.gz
            ├── sasl_errdetail.3.gz
            ├── sasl_errors.3.gz
            ├── sasl_errstring.3.gz
            ├── sasl_getconfpath_t.3.gz
            ├── sasl_getopt_t.3.gz
            ├── sasl_getpath_t.3.gz
            ├── sasl_getprop.3.gz
            ├── sasl_getrealm_t.3.gz
            ├── sasl_getsecret_t.3.gz
            ├── sasl_getsimple_t.3.gz
            ├── sasl_global_listmech.3.gz
            ├── sasl_idle.3.gz
            ├── sasl_listmech.3.gz
            ├── sasl_log_t.3.gz
            ├── sasl_server_init.3.gz
            ├── sasl_server_new.3.gz
            ├── sasl_server_start.3.gz
            ├── sasl_server_step.3.gz
            ├── sasl_server_userdb_checkpass_t.3.gz
            ├── sasl_server_userdb_setpass_t.3.gz
            ├── sasl_setpass.3.gz
            ├── sasl_setprop.3.gz
            ├── sasl_user_exists.3.gz
            └── sasl_verifyfile_t.3.gz

3 directories, 43 files
```
</details>

<details><summary>content of pkgsStatic.cyrus_sasl.man</summary>

```
/nix/store/jh5zrhpa9gbqma2sxqjah2fazwxr1ix9-cyrus-sasl-static-x86_64-unknown-linux-musl-2.1.28-man
└── share
    └── man
        └── man8
            ├── pluginviewer.8.gz
            ├── saslauthd.8.gz
            ├── sasldblistusers2.8.gz
            ├── saslpasswd2.8.gz
            └── testsaslauthd.8.gz

3 directories, 5 files
```
</details>

<details><summary>content of pkgsStatic.cyrus_sasl.out</summary>

```
/nix/store/8bkcif2fhz2iwcxdggi0cwh7hb1hhmsz-cyrus-sasl-static-x86_64-unknown-linux-musl-2.1.28
└── lib
    ├── libsasl2.a
    ├── libsasl2.la
    └── sasl2
        ├── libanonymous.a
        ├── libanonymous.la
        ├── libcrammd5.a
        ├── libcrammd5.la
        ├── libdigestmd5.a
        ├── libdigestmd5.la
        ├── liblogin.a
        ├── liblogin.la
        ├── libotp.a
        ├── libotp.la
        ├── libplain.a
        ├── libplain.la
        ├── libsasldb.a
        ├── libsasldb.la
        ├── libscram.a
        └── libscram.la

2 directories, 18 files
```
</details>
