### PR TITLE
pr-template: Move contributor instructions to CONTRIBUTING.md

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,32 +1,24 @@
-###### Description of changes
+## Changes
 
 <!--
-For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
+For package updates please link to a changelog or describe changes. This helps your fellow maintainers discover breaking updates.
+
 For new packages please briefly describe the package or provide a link to its homepage.
+
+Please see https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md for more details on contributing to nixpkgs.
 -->
 
-###### Things done
+## Manual tests
 
-<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->
+<!-- Please explain any manual tests you've performed, such as running files in `./result/bin/`. -->
 
-- Built on platform(s)
-  - [ ] x86_64-linux
-  - [ ] aarch64-linux
-  - [ ] x86_64-darwin
-  - [ ] aarch64-darwin
-- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
-- [ ] Tested, as applicable:
-  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
-  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
-  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
-  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
-- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
-- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
-- [23.11 Release Notes (or backporting 23.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
-  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
-  - [ ] (Module updates) Added a release notes entry if the change is significant
-  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
-- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
+## Sandboxed non-Linux build?
+
+If this change is applicable to non-Linux platforms such as macOS, please indicate your [`nix.conf` `sandbox` setting](https://nixos.org/manual/nix/stable/command-ref/conf-file.html#conf-sandbox):
+
+- [ ] `sandbox = true`
+- [ ] `sandbox` is not set
+- [ ] `sandbox = false`
 
 <!--
 To help with the large amounts of pull requests, we would appreciate your

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -61,6 +61,22 @@ Pull requests should not be squash merged in order to keep complete commit messa
 This means that, when addressing review comments in order to keep the pull request in an always mergeable status, you will sometimes need to rewrite your branch's history and then force-push it with `git push --force-with-lease`.
 Useful git commands that can help a lot with this are `git commit --patch --amend` and `git rebase --interactive`. For more details consult the git man pages or online resources like [git-rebase.io](https://git-rebase.io/) or [The Pro Git Book](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History).
 
+## Testing changes
+
+To run the main types of tests locally:
+
+- Run [NixOS tests](https://nixos.org/manual/nixos/unstable/#sec-nixos-tests) with `nix-build nixos/tests/NAME.nix`, where `NAME` is the name of a specific test file
+- Run [global package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests) with `nix-build --attr PACKAGE pkgs/test/default.nix`, where `PACKAGE` is the package name
+- Run package-internal tests with `nix-build --attr pkgs.PACKAGE.passthru.tests`
+- Run library tests with `nix-build lib/tests/NAME.nix`
+
+Make sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages.
+
+To compile all packages that depend on this change:
+
+1. Commit all changes (see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage))
+2. Run `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`
+
 ## Rebasing between branches (i.e. from master to staging)
 
 From time to time, changes between branches must be rebased, for example, if the


### PR DESCRIPTION
Example PR template filled in below:

## Changes

- Move contributor instructions to CONTRIBUTING.md
- Use semantically valid H2 tags for level-2 headings.

## Manual tests

Discussed changes with the [community](https://app.element.io/#/room/#nix:nixos.org).

## Sandboxed non-Linux build?

If this change is applicable to non-Linux platforms such as macOS, please indicate your [`nix.conf` `sandbox` setting](https://nixos.org/manual/nix/stable/command-ref/conf-file.html#conf-sandbox):

- [ ] `sandbox = true`
- [ ] `sandbox` is not set
- [ ] `sandbox = false`

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
