### PR TITLE
python3Packages.meeko: init at 0.4.0

### DIFF
--- a/pkgs/development/python-modules/meeko/default.nix
+++ b/pkgs/development/python-modules/meeko/default.nix
@@ -1,0 +1,52 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, numpy
+, pytestCheckHook
+, pythonOlder
+, rdkit
+, scipy
+}:
+
+buildPythonPackage rec {
+  pname = "meeko";
+  version = "0.4.0";
+  format = "setuptools";
+
+  disabled = pythonOlder "3.5";
+
+  src = fetchFromGitHub {
+    owner = "forlilab";
+    repo = "Meeko";
+    rev = "refs/tags/v${version}";
+    hash = "sha256-BCkKRwz3jK5rNAMtKcGxuvfdIFxRRJpABcedyd1zSKE=";
+  };
+
+  postPatch = ''
+    substituteInPlace setup.py \
+      --replace "python_requires='>=3.5.*'" "python_requires='>=3.5'"
+  '';
+
+  propagatedBuildInputs = [
+    # setup.py only requires numpy but others are needed at runtime
+    numpy
+    rdkit
+    scipy
+  ];
+
+  nativeCheckInputs = [
+    pytestCheckHook
+  ];
+
+  pythonImportsCheck = [
+    "meeko"
+  ];
+
+  meta = {
+    description = "Python package for preparing small molecule for docking";
+    homepage = "https://github.com/forlilab/Meeko";
+    changelog = "https://github.com/forlilab/Meeko/releases/tag/${src.rev}";
+    license = lib.licenses.lgpl21Only;
+    maintainers = with lib.maintainers; [ natsukium ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -6162,6 +6162,8 @@ self: super: with self; {
 
   mediapy = callPackage ../development/python-modules/mediapy { };
 
+  meeko = callPackage ../development/python-modules/meeko { };
+
   meep = callPackage ../development/python-modules/meep { };
 
   meilisearch = callPackage ../development/python-modules/meilisearch { };


### PR DESCRIPTION
###### Description of changes

Meeko reads an RDKit molecule object and writes a PDBQT string (or file) for [AutoDock-Vina](https://github.com/ccsb-scripps/AutoDock-Vina) and [AutoDock-GPU](https://github.com/ccsb-scripps/AutoDock-GPU). It converts the docking output to RDKit molecules and SD files, without loss of bond orders.

homepage: https://github.com/forlilab/Meeko

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes (or backporting 23.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
