### PR TITLE
tart: init at 1.5.0

### DIFF
--- a/pkgs/os-specific/darwin/tart/default.nix
+++ b/pkgs/os-specific/darwin/tart/default.nix
@@ -1,0 +1,35 @@
+{ lib
+, stdenvNoCC
+, fetchzip
+}:
+
+stdenvNoCC.mkDerivation rec {
+  pname = "tart";
+  version = "1.5.0";
+
+  src = fetchzip {
+    url = "https://github.com/cirruslabs/${pname}/releases/download/${version}/${pname}.tar.gz";
+    sha256 = "sha256-TdpCeCTpVNoCGSJVvQ+cH+HBhS3dagofKKPj/wn3VlM=";
+    stripRoot = false;
+  };
+
+  dontConfigure = true;
+  dontBuild = true;
+
+  installPhase = ''
+    runHook preInstall
+    mkdir -p $out/Applications $out/bin
+    cp -r tart.app $out/Applications
+    ln -s ../Applications/tart.app/Contents/MacOS/tart $out/bin/tart
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    description = "macOS VMs on Apple Silicon to use in CI and other automations";
+    homepage = "https://github.com/cirruslabs/tart";
+    license = licenses.agpl3Only;
+    maintainers = with maintainers; [ dhess Enzime ];
+    platforms = [ "aarch64-darwin" ];
+    sourceProvenance = with sourceTypes; [ binaryNativeCode ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -27873,6 +27873,8 @@ with pkgs;
     withoutInitTools = true;
   };
 
+  tart = callPackage ../os-specific/darwin/tart { };
+
   # FIXME: `tcp-wrapper' is actually not OS-specific.
   tcp_wrappers = callPackage ../os-specific/linux/tcp-wrappers { };
 


### PR DESCRIPTION
###### Description of changes

> Tart is a virtualization toolset to build, run and manage macOS and Linux virtual machines (VMs) on Apple Silicon.

https://tart.run/

@dhess I've left you as a maintainer as this derivation is based on yours

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes (or backporting 23.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).