### PR TITLE
opensmalltalk-vm: fix evaluation on darwin

### DIFF
--- a/pkgs/development/compilers/opensmalltalk-vm/default.nix
+++ b/pkgs/development/compilers/opensmalltalk-vm/default.nix
@@ -180,5 +180,7 @@ let
 
   platform = stdenv.targetPlatform.system;
 in
-  vmsByPlatform.${platform} or
-    (throw "Unsupported platform ${platform}: only the following platforms are supported: ${builtins.attrNames vmsByPlatform}")
+  vmsByPlatform.${platform} or throw (
+    "Unsupported platform ${platform}: only the following platforms are supported: " +
+    builtins.toString (builtins.attrNames vmsByPlatform)
+  )


### PR DESCRIPTION
###### Description of changes

In the error message, the list of supported platforms needs to be converted explicitly to a string, or else the following error occurs:

```
❯ nix-build -A opensmalltalk-vm --show-trace
error:
       … from call site

         at /Users/tni/code/nixpkgs/pkgs/top-level/all-packages.nix:16679:22:

        16678|
        16679|   opensmalltalk-vm = callPackage ../development/compilers/opensmalltalk-vm { };
             |                      ^
        16680|

       … while calling 'callPackageWith'

         at /Users/tni/code/nixpkgs/lib/customisation.nix:128:35:

          127|   */
          128|   callPackageWith = autoArgs: fn: args:
             |                                   ^
          129|     let

       … from call site

         at /Users/tni/code/nixpkgs/lib/customisation.nix:179:34:

          178|
          179|     in if missingArgs == [] then makeOverridable f allArgs else abort error;
             |                                  ^
          180|

       … while calling 'makeOverridable'

         at /Users/tni/code/nixpkgs/lib/customisation.nix:78:24:

           77|   */
           78|   makeOverridable = f: origArgs:
             |                        ^
           79|     let

       … from call site

         at /Users/tni/code/nixpkgs/lib/customisation.nix:80:16:

           79|     let
           80|       result = f origArgs;
             |                ^
           81|

       … while calling anonymous lambda

         at /Users/tni/code/nixpkgs/pkgs/development/compilers/opensmalltalk-vm/default.nix:1:1:

            1| { stdenv
             | ^
            2| , lib

       error: cannot coerce a list to a string

```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes (or backporting 23.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
