### PR TITLE
pwnat: 2014-09-08 -> 2023-03-31

### DIFF
--- a/pkgs/tools/networking/pwnat/default.nix
+++ b/pkgs/tools/networking/pwnat/default.nix
@@ -1,21 +1,33 @@
-{ lib, stdenv, fetchFromGitHub }:
+{ lib
+, stdenv
+, fetchFromGitHub
+}:
 
 stdenv.mkDerivation rec {
-  name  = "${pname}-${date}";
   pname = "pwnat";
-  date  = "2014-09-08";
+  # Latest release has an annoying segmentation fault bug, see:
+  # https://github.com/samyk/pwnat/pull/25 . Merging only #25 is impossible due
+  # to major code refactoring.
+  version = "2023-03-31";
 
   src = fetchFromGitHub {
     owner  = "samyk";
     repo   = pname;
-    rev    = "1d07c2eb53171733831c0cd01e4e96a3204ec446";
-    sha256 = "056xhlnf1axa6k90i018xwijkwc9zc7fms35hrkzwgs40g9ybrx5";
+    rev    = "8ec62cdae53a2d573c9f9c906133ca45bbd3360a";
+    sha256 = "sha256-QodNw3ab8/TurKamg6AgMfQ08aalp4j6q663B+sWmRM=";
   };
 
+  # See https://github.com/samyk/pwnat/issues/28
+  preBuild = ''
+    mkdir obj
+  '';
+
   installPhase = ''
-    mkdir -p $out/bin $out/share/pwnat
-    cp pwnat $out/bin
-    cp README* COPYING* $out/share/pwnat
+    runHook preInstall
+
+    install -D pwnat $out/bin/pwnat
+
+    runHook postInstall
   '';
 
   meta = with lib; {


### PR DESCRIPTION
###### Motivation for this change


###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
