### PR TITLE
syncplay: fix client tls support

### DIFF
--- a/pkgs/applications/networking/syncplay/default.nix
+++ b/pkgs/applications/networking/syncplay/default.nix
@@ -3,6 +3,7 @@
 , fetchFromGitHub
 , buildPythonApplication
 , fetchpatch
+, pem
 , pyside6
 , twisted
 , certifi
@@ -30,10 +31,11 @@ buildPythonApplication rec {
       url = "https://github.com/Syncplay/syncplay/commit/b62b038cdf58c54205987dfc52ebf228505ad03b.patch";
       hash = "sha256-pSP33Qn1I+nJBW8T1E1tSJKRh5OnZMRsbU+jr5z4u7c=";
     })
+    ./trusted_certificates.patch
   ];
 
   buildInputs = lib.optionals enableGUI [ (if stdenv.isLinux then qt6.qtwayland else qt6.qtbase) ];
-  propagatedBuildInputs = [ twisted certifi ]
+  propagatedBuildInputs = [ certifi pem twisted ]
     ++ twisted.optional-dependencies.tls
     ++ lib.optional enableGUI pyside6
     ++ lib.optional (stdenv.isDarwin && enableGUI) appnope;

--- a/pkgs/applications/networking/syncplay/trusted_certificates.patch
+++ b/pkgs/applications/networking/syncplay/trusted_certificates.patch
@@ -1,0 +1,12 @@
+diff --git a/syncplay/client.py b/syncplay/client.py
+index b7cb245..be72d94 100755
+--- a/syncplay/client.py
++++ b/syncplay/client.py
+@@ -848,6 +848,7 @@ class SyncplayClient(object):
+         self._endpoint = HostnameEndpoint(reactor, host, port)
+         try:
+             certs = pem.parse_file(SSL_CERT_FILE)
++            certs = [cert for cert in certs if type(cert) is pem.Certificate]
+             trustRoot = trustRootFromCertificates([Certificate.loadPEM(str(cert)) for cert in certs])
+             self.protocolFactory.options = optionsForClientTLS(hostname=host, trustRoot=trustRoot)
+             self._clientSupportsTLS = True

--- a/pkgs/development/python-modules/pem/default.nix
+++ b/pkgs/development/python-modules/pem/default.nix
@@ -1,0 +1,46 @@
+{ lib
+, buildPythonPackage
+, pythonOlder
+, fetchFromGitHub
+, pytestCheckHook
+, certifi
+, cryptography
+, pretend
+, pyopenssl
+, twisted
+}:
+
+buildPythonPackage rec {
+  pname = "pem";
+  version = "21.2.0";
+
+  disabled = pythonOlder "3.7";
+
+  src = fetchFromGitHub {
+    owner = "hynek";
+    repo = pname;
+    rev = version;
+    hash = "sha256-mftLdgtgb5J4zwsb1F/4v4K7XTy4VSZBMy3zPV2f1uA=";
+  };
+
+  nativeCheckInputs = [
+    certifi
+    cryptography
+    pretend
+    pyopenssl
+    pytestCheckHook
+    twisted
+    twisted.optional-dependencies.tls
+  ];
+
+  pythonImportsCheck = [
+    "pem"
+  ];
+
+  meta = with lib; {
+    homepage = "https://pem.readthedocs.io/";
+    description = "Easy PEM file parsing in Python.";
+    license = licenses.mit;
+    maintainers = with maintainers; [ nyanotech ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -7476,6 +7476,8 @@ self: super: with self; {
     inherit (pkgs) glibcLocales git;
   };
 
+  pem = callPackage ../development/python-modules/pem { };
+
   pendulum = callPackage ../development/python-modules/pendulum { };
 
   pep440 = callPackage ../development/python-modules/pep440 { };


### PR DESCRIPTION
###### Description of changes

Syncplay v1.7.0 added a dependency on `pem` for tls support in the client, but that was never added to the nixos build.

While fixing that, I noticed that the nixpkgs-patched version of `certifi` returned certs in a format that syncplay didn't like, so we patch syncplay to skip the certs that it would choke on.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes (or backporting 23.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
