### PR TITLE
python3Packages.certifi: allow not overriding ca bundle

### DIFF
--- a/pkgs/development/python-modules/certifi/default.nix
+++ b/pkgs/development/python-modules/certifi/default.nix
@@ -4,6 +4,7 @@
 , pythonOlder
 , fetchFromGitHub
 , pytestCheckHook
+, overrideCerts ? true
 }:
 
 buildPythonPackage rec {
@@ -19,16 +20,16 @@ buildPythonPackage rec {
     hash = "sha256-r6TJ6YGL0cygz+F6g6wiqBfBa/QKhynZ92C6lHTZ2rI=";
   };
 
-  patches = [
+  patches = if overrideCerts then [
     # Add support for NIX_SSL_CERT_FILE
     ./env.patch
-  ];
+  ] else [];
 
-  postPatch = ''
+  postPatch = if overrideCerts then ''
     # Use our system-wide ca-bundle instead of the bundled one
     rm -v "certifi/cacert.pem"
     ln -snvf "${cacert}/etc/ssl/certs/ca-bundle.crt" "certifi/cacert.pem"
-  '';
+  '' else "";
 
   propagatedNativeBuildInputs = [
     # propagate cacerts setup-hook to set up `NIX_SSL_CERT_FILE`


### PR DESCRIPTION
###### Description of changes

We [replaced](https://github.com/NixOS/nixpkgs/blob/master/pkgs/development/python-modules/certifi/default.nix#L28) `certifi`'s CA bundle with the system-wide bundle, however, the system-wide bundle includes the openssl-specific `BEGIN TRUSTED CERTIFICATE` cert format, while the bundle that ships with `certifi` contains *only* the `BEGIN CERTIFICATE` cert format.

This breaks some things that expect to see only the latter, eg, I'm currently trying to fix tls support in the nixpkgs build of the `syncplay` client, and openssl throws an error when it tries to read one of these certificates, but syncplay just passes through a cryptic

```
[03:18:00 AM] [('PEM routines', '', 'no start line')]
```

Through playing with syncplay's cert-loading code in a python repl, I've been able to narrow the issue down to these erroneous certs.

Disabling our overriding of certs allows my syncplay patch to properly load the ca bundle, so I'm adding a simple toggle to do so.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes (or backporting 23.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
