### PR TITLE
avalanche-cli: init at 1.8.0

### DIFF
--- a/pkgs/by-name/av/avalanche-cli/package.nix
+++ b/pkgs/by-name/av/avalanche-cli/package.nix
@@ -1,0 +1,35 @@
+{
+  lib,
+  buildGoModule,
+  fetchFromGitHub,
+}:
+
+buildGoModule rec {
+  pname = "avalanche-cli";
+  version = "1.8.0";
+
+  src = fetchFromGitHub {
+    owner = "ava-labs";
+    repo = "avalanche-cli";
+    tag = "v${version}";
+    hash = "sha256-3Ejj3dcYWhLca2HXaqgW6eP88YxsZOaWD3H8yDk8DEM=";
+  };
+
+  proxyVendor = true;
+
+  vendorHash = "sha256-B0D2iZQ+ov+h5+a0oFAWcWdfoHk0pJAT5DOwd9BExt0=";
+
+  ldflags = [
+    "-X=github.com/ava-labs/avalanche-cli/cmd.Version=${version}"
+  ];
+
+  doCheck = false;
+
+  meta = {
+    description = "Command line tool for Avalanche";
+    homepage = "https://github.com/ava-labs/avalanche-cli";
+    license = lib.licenses.unfree;
+    maintainers = with lib.maintainers; [ ];
+    mainProgram = "avalanche-cli";
+  };
+}


### PR DESCRIPTION
###### Description of changes

This PR adds avalanche-cli to nixpkgs. This is my first submission, so I am sure there are mistakes. Please offer me feedback/review if you see necessary changes!

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes (or backporting 23.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).