### PR TITLE
openra_2019: fix build

### DIFF
--- a/pkgs/games/openra_2019/common.nix
+++ b/pkgs/games/openra_2019/common.nix
@@ -27,7 +27,7 @@ in {
     sed -i 's|locations=.*|locations=${lua}/lib|' ${dir}/thirdparty/configure-native-deps.sh
   '';
 
-  wrapLaunchGame = openraSuffix: ''
+  wrapLaunchGame = openraSuffix: binaryName: ''
     # Setting TERM=xterm fixes an issue with terminfo in mono: System.Exception: Magic number is wrong: 542
     # https://github.com/mono/mono/issues/6752#issuecomment-365212655
     wrapProgram $out/lib/openra${openraSuffix}/launch-game.sh \
@@ -35,7 +35,7 @@ in {
       --prefix LD_LIBRARY_PATH : "${rpath}" \
       --set TERM xterm
 
-    makeWrapper $out/lib/openra${openraSuffix}/launch-game.sh $(mkdirp $out/bin)/openra${openraSuffix} \
+    makeWrapper $out/lib/openra${openraSuffix}/launch-game.sh $(mkdirp $out/bin)/${binaryName} \
       --chdir "$out/lib/openra${openraSuffix}"
   '';
 

--- a/pkgs/games/openra_2019/engine.nix
+++ b/pkgs/games/openra_2019/engine.nix
@@ -46,7 +46,7 @@ stdenv.mkDerivation (recursiveUpdate packageAttrs rec {
   ];
 
   postInstall = ''
-    ${wrapLaunchGame ""}
+    ${wrapLaunchGame "" "openra"}
 
     ${concatStrings (map (mod: ''
       makeWrapper $out/bin/openra $out/bin/openra-${mod} --add-flags Game.Mod=${mod}

--- a/pkgs/games/openra_2019/mod-launch-game.sh
+++ b/pkgs/games/openra_2019/mod-launch-game.sh
@@ -8,7 +8,7 @@ show_error() {
   exit 1
 }
 
-cd "@out@/lib/openra-@name@"
+pushd "@out@/lib/openra_2019-@name@" > /dev/null
 
 # Check for missing assets
 assetsError='@assetsError@'
@@ -17,7 +17,7 @@ if [[ -n "$assetsError" && ! -d "$HOME/.openra/Content/@name@" ]]; then
 fi
 
 # Run the game
-mono --debug OpenRA.Game.exe Game.Mod=@name@ Engine.LaunchPath="@out@/bin/openra-@name@" Engine.ModSearchPaths="@out@/lib/openra-@name@/mods" "$@"
+mono --debug OpenRA.Game.exe Game.Mod=@name@ Engine.LaunchPath="@out@/bin/openra-@name@" Engine.ModSearchPaths="@out@/lib/openra_2019-@name@/mods" "$@"
 
 # Show a crash dialog if something went wrong
 if (( $? != 0 && $? != 1 )); then

--- a/pkgs/games/openra_2019/mod.nix
+++ b/pkgs/games/openra_2019/mod.nix
@@ -70,14 +70,14 @@ in stdenv.mkDerivation (recursiveUpdate packageAttrs rec {
     cp -r ${engineSourceName}/mods/{${concatStringsSep "," ([ "common" "modcontent" ] ++ engine.mods)}} mods/* \
       $out/lib/${pname}/mods/
 
-    substitute ${./mod-launch-game.sh} $out/lib/${pname}/launch-game.sh \
+    substitute ${./mod-launch-game.sh} $out/lib/openra_2019-${mod.name}/launch-game.sh \
       --subst-var out \
       --subst-var-by name ${escapeShellArg mod.name} \
       --subst-var-by title ${escapeShellArg mod.title} \
       --subst-var-by assetsError ${escapeShellArg mod.assetsError}
-    chmod +x $out/lib/${pname}/launch-game.sh
+    chmod +x $out/lib/openra_2019-${mod.name}/launch-game.sh
 
-    ${wrapLaunchGame "-${mod.name}"}
+    ${wrapLaunchGame "_2019-${mod.name}" "openra-${mod.name}"}
 
     substitute ${./openra-mod.desktop} $(mkdirp $out/share/applications)/${pname}.desktop \
       --subst-var-by name ${escapeShellArg mod.name} \


### PR DESCRIPTION
All mods and engines were failing to build due to path issues after package name changes.

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes (or backporting 23.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
