### PR TITLE
git-credential-manager: init at 2.1.2

### DIFF
--- a/pkgs/applications/version-management/git-credential-manager/default.nix
+++ b/pkgs/applications/version-management/git-credential-manager/default.nix
@@ -1,0 +1,51 @@
+{ lib, stdenv, autoPatchelfHook, fetchurl, dpkg, makeWrapper, fontconfig, zlib, libcxx, icu, openssl, libX11, libICE, libSM }:
+
+stdenv.mkDerivation rec {
+  pname = "git-credential-manager";
+  version = "2.1.2";
+
+  src = fetchurl {
+    url = "https://github.com/git-ecosystem/git-credential-manager/releases/download/v${version}/gcm-linux_amd64.${version}.deb";
+    sha256 = "sha256-H9VSlY2+MDgUTucttr5mVz+CNrDGhruE1sD5cbKrBqQ=";
+  };
+
+  nativeBuildInputs = [ autoPatchelfHook dpkg makeWrapper ];
+  sourceRoot = ".";
+  unpackCmd = "dpkg-deb -x $src .";
+
+  buildInputs = [
+    fontconfig
+    zlib
+    libcxx
+    icu
+    openssl
+    libX11
+    libICE
+    libSM
+  ];
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p "$out/bin"
+    cp -R "usr/local/share" "$out/share"
+    chmod -R g-w "$out"
+
+    makeWrapper $out/share/gcm-core/git-credential-manager $out/bin/git-credential-manager \
+      --prefix LD_LIBRARY_PATH : ${lib.makeLibraryPath buildInputs}
+    makeWrapper $out/share/gcm-core/git-credential-manager $out/bin/git-credential-manager-core \
+      --prefix LD_LIBRARY_PATH : ${lib.makeLibraryPath buildInputs}
+
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    description = "Secure, cross-platform Git credential storage with authentication to GitHub, Azure Repos, and other popular Git hosting services.";
+    homepage = "https://github.com/git-ecosystem/git-credential-manager";
+    changelog = "https://github.com/git-ecosystem/git-credential-manager/releases/tag/v${version}";
+    sourceProvenance = with sourceTypes; [ binaryNativeCode ];
+    license = licenses.mit;
+    maintainers = [ maintainers.wrmilling ];
+    platforms = [ "x86_64-linux" ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2011,6 +2011,8 @@ with pkgs;
     inherit (darwin.apple_sdk.frameworks) DiskArbitration Foundation;
   };
 
+  git-credential-manager = callPackage ../applications/version-management/git-credential-manager { };
+
   git-credential-oauth = callPackage ../applications/version-management/git-credential-oauth { };
 
   git-crypt = callPackage ../applications/version-management/git-crypt { };


### PR DESCRIPTION
###### Description of changes

This change is adding git-credential-manager at version 2.1.2. GCM is a secure, cross-platform Git credential storage with authentication to GitHub, Azure Repos, and other popular Git hosting services.

[Announcement Blog](https://github.blog/2022-04-07-git-credential-manager-authentication-for-everyone/)
[Git Repo](https://github.com/git-ecosystem/git-credential-manager)
[Latest Release](https://github.com/git-ecosystem/git-credential-manager/releases/tag/v2.1.2)

Tested tool's diagnostic function:

```
Running diagnostics...

 [ OK ] Environment
 [ OK ] File system
 [ OK ] Networking
 [ OK ] Git
 [ OK ] Credential storage
 [ OK ] Microsoft authentication (AAD/MSA)
 [ OK ] GitHub API

Diagnostic summary: 7 passed, 0 skipped, 0 failed.
```

As well as tested storing a local secret via git-credential-manager+gpg with `git send-email`.

###### Things done

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes (or backporting 23.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
