### PR TITLE
`nixos/nixpkgs`: Don't check when `_module.args.pkgs` is set

### DIFF
--- a/lib/modules.nix
+++ b/lib/modules.nix
@@ -920,14 +920,7 @@ let
       option -> attrsOf { highestPrio, value }
   */
   mergeAttrDefinitionsWithPrio = opt:
-        let subAttrDefs =
-              lib.concatMap
-                ({ value, ... }@def:
-                  map
-                    (value: def // { inherit value; })
-                    (lib.pushDownProperties value)
-                )
-                opt.definitionsWithLocations;
+        let
             defsByAttr =
               lib.zipAttrs (
                 lib.concatLists (
@@ -935,7 +928,7 @@ let
                     ({ value, ... }@def:
                       map
                         (lib.mapAttrsToList (k: value: { ${k} = def // { inherit value; }; }))
-                        (lib.pushDownProperties value)
+                        (pushDownProperties value)
                     )
                     opt.definitionsWithLocations
                 )

--- a/lib/tests/modules.sh
+++ b/lib/tests/modules.sh
@@ -61,6 +61,8 @@ checkConfigError() {
 # Shorthand meta attribute does not duplicate the config
 checkConfigOutput '^"one two"$' config.result ./shorthand-meta.nix
 
+checkConfigOutput '^true$' config.result ./test-mergeAttrDefinitionsWithPrio.nix
+
 # Check boolean option.
 checkConfigOutput '^false$' config.enable ./declare-enable.nix
 checkConfigError 'The option .* does not exist. Definition values:\n\s*- In .*: true' config.enable ./define-enable.nix

--- a/lib/tests/modules/test-mergeAttrDefinitionsWithPrio.nix
+++ b/lib/tests/modules/test-mergeAttrDefinitionsWithPrio.nix
@@ -1,0 +1,21 @@
+{ lib, options, ... }:
+
+let
+  defs = lib.modules.mergeAttrDefinitionsWithPrio options._module.args;
+  assertLazy = pos: throw "${pos.file}:${toString pos.line}:${toString pos.column}: The test must not evaluate this the assertLazy thunk, but it did. Unexpected strictness leads to unexpected errors and performance problems.";
+in
+
+{
+  options.result = lib.mkOption { };
+  config._module.args = {
+    default = lib.mkDefault (assertLazy __curPos);
+    regular = null;
+    force = lib.mkForce (assertLazy __curPos);
+    unused = assertLazy __curPos;
+  };
+  config.result =
+    assert defs.default.highestPrio == (lib.mkDefault (assertLazy __curPos)).priority;
+    assert defs.regular.highestPrio == lib.modules.defaultOverridePriority;
+    assert defs.force.highestPrio == (lib.mkForce (assertLazy __curPos)).priority;
+    true;
+}

--- a/nixos/modules/misc/nixpkgs.nix
+++ b/nixos/modules/misc/nixpkgs.nix
@@ -55,11 +55,6 @@ let
     description = "An evaluation of Nixpkgs; the top level attribute set of packages";
   };
 
-  # Whether `pkgs` was constructed by this module - not if nixpkgs.pkgs or
-  # _module.args.pkgs is set. However, determining whether _module.args.pkgs
-  # is defined elsewhere does not seem feasible.
-  constructedByMe = !opt.pkgs.isDefined;
-
   hasBuildPlatform = opt.buildPlatform.highestPrio < (mkOptionDefault {}).priority;
   hasHostPlatform = opt.hostPlatform.isDefined;
   hasPlatform = hasHostPlatform || hasBuildPlatform;
@@ -348,7 +343,17 @@ in
           finalPkgs.__splicedPackages;
     };
 
-    assertions = [
+    assertions = let
+      # Whether `pkgs` was constructed by this module. This is false when any of
+      # nixpkgs.pkgs or _module.args.pkgs is set.
+      constructedByMe =
+        # We set it with default priority and it can not be merged, so if the
+        # pkgs module argument has that priority, it's from us.
+        (lib.modules.mergeAttrDefinitionsWithPrio options._module.args).pkgs.highestPrio
+          == lib.modules.defaultOverridePriority
+        # Although, if nixpkgs.pkgs is set, we did forward it, but we did not construct it.
+          && !opt.pkgs.isDefined;
+    in [
       (
         let
           nixosExpectedSystem =

--- a/nixos/modules/misc/nixpkgs.nix
+++ b/nixos/modules/misc/nixpkgs.nix
@@ -337,7 +337,15 @@ in
 
   config = {
     _module.args = {
-      pkgs = finalPkgs.__splicedPackages;
+      pkgs =
+        # We explicitly set the default override priority, so that we do not need
+        # to evaluate finalPkgs in case an override is placed on `_module.args.pkgs`.
+        # After all, to determine a definition priority, we need to evaluate `._type`,
+        # which is somewhat costly for Nixpkgs. With an explicit priority, we only
+        # evaluate the wrapper to find out that the priority is lower, and then we
+        # don't need to evaluate `finalPkgs`.
+        lib.mkOverride lib.modules.defaultOverridePriority
+          finalPkgs.__splicedPackages;
     };
 
     assertions = [


### PR DESCRIPTION
###### Description of changes

This solves a previously unsolved problem:

>
> determining whether _module.args.pkgs
> is defined elsewhere does not seem feasible.

Fixes at least part of the problem experienced here https://github.com/NixOS/nixpkgs/pull/237427#issuecomment-1588463480

Changes:

 - Add a function to give access to priority values for the individual attributes of an `attrsOf` option.
 - Handle `_module.args.pkgs = lib.mkForce foo` correctly in the NixOS `nixpkgs.nix` module assertions.
 - Make it so that `finalPkgs` isn't evaluated when an override like previous point is set.


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes (or backporting 23.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
