### PR TITLE
firefox_decrypt: unstable-2022-12-21 -> unstable-2023-05-14

### DIFF
--- a/pkgs/tools/security/firefox_decrypt/default.nix
+++ b/pkgs/tools/security/firefox_decrypt/default.nix
@@ -1,39 +1,29 @@
 { lib
 , fetchFromGitHub
-, stdenvNoCC
+, buildPythonApplication
+, setuptools
 , nss
-, wrapPython
 , nix-update-script
 }:
 
-stdenvNoCC.mkDerivation rec {
+buildPythonApplication rec {
   pname = "firefox_decrypt";
-  version = "unstable-2022-12-21";
+  version = "unstable-2023-05-14";
+
+  format = "pyproject";
 
   src = fetchFromGitHub {
     owner = "unode";
     repo = pname;
-    rev = "84bb368cc2f8d2055a8374ab1a40c403e0486859";
-    sha256 = "sha256-dyQTf6fgsQEmp++DeXl85nvyezm0Lq9onyfIdhQoGgI=";
+    rev = "ac857efde75d86dd6bd5dfca25d4a0f73b75009f";
+    sha256 = "sha256-34QS98nmrL98nzoZgeFSng8TJJc9BU1+Tzh2b+dsuCc=";
   };
 
-  nativeBuildInputs = [ wrapPython ];
-
-  buildInputs = [ nss ];
-
-  installPhase = ''
-    runHook preInstall
-
-    install -Dm 0755 firefox_decrypt.py "$out/bin/firefox_decrypt"
-
-    runHook postInstall
-  '';
+  nativeBuildInputs = [
+    setuptools
+  ];
 
   makeWrapperArgs = [ "--prefix" "LD_LIBRARY_PATH" ":" (lib.makeLibraryPath [ nss ]) ];
-
-  postFixup = ''
-    wrapPythonPrograms
-  '';
 
   passthru.updateScript = nix-update-script {
     extraArgs = [ "--version=branch" ];


### PR DESCRIPTION
###### Description of changes
supersedes https://github.com/NixOS/nixpkgs/pull/238106
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes (or backporting 23.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
