### PR TITLE
python3Packages.howdoi: 2.0.19 -> 2.0.20 enable more tests, unmark broken on aarch64-linux

### DIFF
--- a/pkgs/development/python-modules/howdoi/default.nix
+++ b/pkgs/development/python-modules/howdoi/default.nix
@@ -3,6 +3,7 @@
 , appdirs
 , buildPythonPackage
 , cachelib
+, colorama
 , cssselect
 , fetchFromGitHub
 , keep
@@ -10,13 +11,14 @@
 , pygments
 , pyquery
 , requests
+, rich
 , pytestCheckHook
 , pythonOlder
 }:
 
 buildPythonPackage rec {
   pname = "howdoi";
-  version = "2.0.19";
+  version = "2.0.20";
   format = "setuptools";
 
   disabled = pythonOlder "3.7";
@@ -25,18 +27,20 @@ buildPythonPackage rec {
     owner = "gleitz";
     repo = pname;
     rev = "v${version}";
-    hash = "sha256-uLAc6E8+8uPpo070vsG6Od/855N3gTQMf5pSUvtlh0I=";
+    hash = "sha256-u0k+h7Sp2t/JUnfPqRzDpEA+vNXB7CpyZ/SRvk+B9t0=";
   };
 
   propagatedBuildInputs = [
     appdirs
     cachelib
+    colorama
     cssselect
     keep
     lxml
     pygments
     pyquery
     requests
+    rich
   ];
 
   nativeCheckInputs = [
@@ -48,20 +52,7 @@ buildPythonPackage rec {
   '';
 
   disabledTests = [
-    # AssertionError: "The...
-    "test_get_text_with_one_link"
-    "test_get_text_without_links"
-    # Those tests are failing in the sandbox
-    # OSError: [Errno 24] Too many open files
-    "test_answers"
-    "test_answers_bing"
     "test_colorize"
-    "test_json_output"
-    "test_missing_pre_or_code_query"
-    "test_multiple_answers"
-    "test_position"
-    "test_unicode_answer"
-    "test_answer_links_using_l_option"
   ];
 
   pythonImportsCheck = [
@@ -69,7 +60,8 @@ buildPythonPackage rec {
   ];
 
   meta = with lib; {
-    broken = (stdenv.isLinux && stdenv.isAarch64) || stdenv.isDarwin;
+    broken = stdenv.isDarwin;
+    changelog = "https://github.com/gleitz/howdoi/blob/v${version}/CHANGES.txt";
     description = "Instant coding answers via the command line";
     homepage = "https://github.com/gleitz/howdoi";
     license = licenses.mit;


### PR DESCRIPTION
###### Description of changes

https://github.com/gleitz/howdoi/blob/v2.0.20/CHANGES.txt

- unmark as broken on aarch64-linux
- reenabled tests that pass

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes (or backporting 23.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
