### PR TITLE
patcher9x: init at 0.8.50

### DIFF
--- a/pkgs/development/tools/patcher9x/default.nix
+++ b/pkgs/development/tools/patcher9x/default.nix
@@ -1,0 +1,47 @@
+{ fasm, lib, stdenv, fetchFromGitHub }:
+
+stdenv.mkDerivation (finalAttr: {
+  name = "patcher9x";
+  version = "0.8.50";
+
+  srcs = [
+    (fetchFromGitHub {
+      owner = "JHRobotics";
+      repo = "patcher9x";
+      rev = "v${finalAttr.version}";
+      hash = "sha256-TZw2+R7Dzojzxzal1Wp8jhe5gwU4CfZDROITi5Z+auo=";
+      name = "src";
+    })
+
+    (fetchFromGitHub {
+      owner = "JHRobotics";
+      repo = "nocrt";
+      rev = "f65cc7ef2a3cccd6264b2eb265d7fffbecb06ba4";
+      hash = "sha256-oeHcK9zYMDWk5sWfzYqLtC3MAJVtcaDJy4PvUGrxiPE=";
+      name = "nocrt";
+    })
+  ];
+
+  buildInputs = [ fasm ];
+  sourceRoot = "src";
+  hardeningDisable = [ "fortify" ];
+
+  preBuild = ''
+    rmdir nocrt
+    ln -s ../nocrt .
+  '';
+
+  installPhase = ''
+    runHook preInstall
+    install -D patcher9x $out/bin/patcher9x
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    description = "Patch for Windows 95/98/98 SE/Me to fix CPU issues";
+    homepage = "https://github.com/JHRobotics/patcher9x";
+    license = licenses.mit;
+    maintainers = with maintainers; [ hughobrien ];
+    platforms = platforms.linux;
+  };
+})

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -935,6 +935,8 @@ with pkgs;
 
   pacup = python3Packages.callPackage ../tools/package-management/pacup { };
 
+  patcher9x = callPackage ../development/tools/patcher9x { };
+
   perseus-cli = callPackage ../development/tools/perseus-cli {
     inherit (darwin.apple_sdk.frameworks) CoreServices;
   };


### PR DESCRIPTION
###### Description of changes

Introduce [patcher9x](https://github.com/JHRobotics/patcher9x/tree/main#patch-for-windows-959898-seme-to-fix-cpu-issues), a tool to unpack Windows9x installation media, apply patches necessary for modern clock speeds, and repack them.

Might also be worth putting under `applications/virtualisation`, it's not strictly for VMs but I doubt we have many bare-metal 9x machines on modern chips.


<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes (or backporting 23.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
