### PR TITLE
trace-cmd + libraries: update

### DIFF
--- a/pkgs/os-specific/linux/libtraceevent/default.nix
+++ b/pkgs/os-specific/linux/libtraceevent/default.nix
@@ -2,18 +2,19 @@
 
 stdenv.mkDerivation rec {
   pname = "libtraceevent";
-  version = "1.6.2";
+  version = "1.7.3";
 
   src = fetchgit {
     url = "https://git.kernel.org/pub/scm/libs/libtrace/libtraceevent.git";
     rev = "libtraceevent-${version}";
-    sha256 = "sha256-iLy2rEKn0UJguRcY/W8RvUq7uX+snQojb/cXOmMsjwc=";
+    sha256 = "sha256-poF+Cqcdj0KIgEJWW7XDAlRLz2/Egi948s1M24ETvBo=";
   };
 
   # Don't build and install html documentation
   postPatch = ''
     sed -i -e '/^all:/ s/html//' -e '/^install:/ s/install-html//' Documentation/Makefile
     substituteInPlace scripts/utils.mk --replace /bin/pwd ${coreutils}/bin/pwd
+    patchShebangs --build check-manpages.sh
   '';
 
   outputs = [ "out" "dev" "devman" ];

--- a/pkgs/os-specific/linux/libtraceevent/default.nix
+++ b/pkgs/os-specific/linux/libtraceevent/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchgit, pkg-config, asciidoc, xmlto, docbook_xml_dtd_45, docbook_xsl, coreutils }:
+{ lib, stdenv, fetchgit, pkg-config, asciidoc, xmlto, docbook_xml_dtd_45, docbook_xsl, meson, ninja, cunit }:
 
 stdenv.mkDerivation rec {
   pname = "libtraceevent";
@@ -10,24 +10,18 @@ stdenv.mkDerivation rec {
     sha256 = "sha256-poF+Cqcdj0KIgEJWW7XDAlRLz2/Egi948s1M24ETvBo=";
   };
 
-  # Don't build and install html documentation
   postPatch = ''
-    sed -i -e '/^all:/ s/html//' -e '/^install:/ s/install-html//' Documentation/Makefile
-    substituteInPlace scripts/utils.mk --replace /bin/pwd ${coreutils}/bin/pwd
-    patchShebangs --build check-manpages.sh
+    chmod +x Documentation/install-docs.sh.in
+    patchShebangs --build check-manpages.sh Documentation/install-docs.sh.in
   '';
 
-  outputs = [ "out" "dev" "devman" ];
-  enableParallelBuilding = true;
-  nativeBuildInputs = [ pkg-config asciidoc xmlto docbook_xml_dtd_45 docbook_xsl ];
-  makeFlags = [
-    "prefix=${placeholder "out"}"
-    "doc"                       # build docs
-  ];
-  installFlags = [
-    "pkgconfig_dir=${placeholder "out"}/lib/pkgconfig"
-    "doc-install"
-  ];
+  outputs = [ "out" "dev" "devman" "doc" ];
+  nativeBuildInputs = [ meson ninja pkg-config asciidoc xmlto docbook_xml_dtd_45 docbook_xsl ];
+
+  ninjaFlags = [ "all" "docs" ];
+
+  doCheck = true;
+  checkInputs = [ cunit ];
 
   meta = with lib; {
     description = "Linux kernel trace event library";

--- a/pkgs/os-specific/linux/libtracefs/default.nix
+++ b/pkgs/os-specific/linux/libtracefs/default.nix
@@ -8,9 +8,13 @@
 , docbook_xml_dtd_45
 , docbook_xsl
 , coreutils
-, which
 , valgrind
 , sourceHighlight
+, meson
+, flex
+, bison
+, ninja
+, cunit
 }:
 
 stdenv.mkDerivation rec {
@@ -24,22 +28,30 @@ stdenv.mkDerivation rec {
   };
 
   postPatch = ''
-    substituteInPlace scripts/utils.mk --replace /bin/pwd ${coreutils}/bin/pwd
-    patchShebangs --build check-manpages.sh
+    chmod +x samples/extract-example.sh
+    patchShebangs --build check-manpages.sh samples/extract-example.sh Documentation/install-docs.sh.in
   '';
 
   outputs = [ "out" "dev" "devman" "doc" ];
-  enableParallelBuilding = true;
-  nativeBuildInputs = [ pkg-config asciidoc xmlto docbook_xml_dtd_45 docbook_xsl which valgrind sourceHighlight ];
+  nativeBuildInputs = [
+    meson
+    ninja
+    pkg-config
+    asciidoc
+    xmlto
+    docbook_xml_dtd_45
+    docbook_xsl
+    valgrind
+    sourceHighlight
+    flex
+    bison
+  ];
   buildInputs = [ libtraceevent ];
-  makeFlags = [
-    "prefix=${placeholder "out"}"
-    "doc"                       # build docs
-  ];
-  installFlags = [
-    "pkgconfig_dir=${placeholder "out"}/lib/pkgconfig"
-    "install_doc"
-  ];
+
+  ninjaFlags = [ "all" "docs" ];
+
+  doCheck = true;
+  checkInputs = [ cunit ];
 
   meta = with lib; {
     description = "Linux kernel trace file system library";

--- a/pkgs/os-specific/linux/libtracefs/default.nix
+++ b/pkgs/os-specific/linux/libtracefs/default.nix
@@ -15,17 +15,17 @@
 
 stdenv.mkDerivation rec {
   pname = "libtracefs";
-  version = "1.6.4";
+  version = "1.7.0";
 
   src = fetchgit {
     url = "https://git.kernel.org/pub/scm/libs/libtrace/libtracefs.git";
     rev = "libtracefs-${version}";
-    sha256 = "sha256-fWop0EMkoVulLBzU7q8x1IhMtdnEJ89wMz0cz964F6s=";
+    sha256 = "sha256-64eXFFdnZHHf4C3vbADtPuIMsfJ85VZ6t8A1gIc1CW0=";
   };
 
   postPatch = ''
     substituteInPlace scripts/utils.mk --replace /bin/pwd ${coreutils}/bin/pwd
-    patchShebangs check-manpages.sh
+    patchShebangs --build check-manpages.sh
   '';
 
   outputs = [ "out" "dev" "devman" "doc" ];

--- a/pkgs/os-specific/linux/trace-cmd/default.nix
+++ b/pkgs/os-specific/linux/trace-cmd/default.nix
@@ -59,6 +59,6 @@ stdenv.mkDerivation rec {
     homepage    = "https://www.trace-cmd.org/";
     license     = with licenses; [ lgpl21Only gpl2Only ];
     platforms   = platforms.linux;
-    maintainers = with maintainers; [ thoughtpolice basvandijk ];
+    maintainers = with maintainers; [ thoughtpolice basvandijk wentasah ];
   };
 }

--- a/pkgs/os-specific/linux/trace-cmd/default.nix
+++ b/pkgs/os-specific/linux/trace-cmd/default.nix
@@ -1,12 +1,12 @@
 { lib, stdenv, fetchgit, pkg-config, asciidoc, xmlto, docbook_xsl, docbook_xml_dtd_45, libxslt, libtraceevent, libtracefs, zstd, sourceHighlight }:
 stdenv.mkDerivation rec {
   pname = "trace-cmd";
-  version = "3.1.6";
+  version = "3.2";
 
   src = fetchgit {
     url    = "https://git.kernel.org/pub/scm/utils/trace-cmd/trace-cmd.git/";
     rev    = "trace-cmd-v${version}";
-    sha256 = "sha256-qjfeomeExjsx/6XrUaGm5szbL7XVlekGd4Hsuncv8NY=";
+    sha256 = "sha256-KlykIYF4uy1phgWRG5j76FJqgO7XhNnyrTDVTs8YOXY=";
   };
 
   # Don't build and install html documentation
@@ -20,7 +20,7 @@ stdenv.mkDerivation rec {
 
   buildInputs = [ libtraceevent libtracefs zstd ];
 
-  outputs = [ "out" "lib" "dev" "man" ];
+  outputs = [ "out" "lib" "dev" "man" "devman" ];
 
   MANPAGE_DOCBOOK_XSL="${docbook_xsl}/xml/xsl/docbook/manpages/docbook.xsl";
 


### PR DESCRIPTION
###### Description of changes

- This updates versions of `trace-cmd` and related libraries `libtracefs` and `libtraceevent`. 
- Building of libraries was switched to `meson`. This simplifies the packaging. `trace-cmd` can also be built with `meson`, but it will need heavier refactoring (due to the way how is `libtracecmd` built) and maybe some patches. This is left for future.
- I'm adding myself as maintainer of `trace-cmd`. @thoughtpolice @basvandijk do you agree? I did all updates of that package in the past two years.

Changelogs:

- trace-cmd: [3.2](https://git.kernel.org/pub/scm/utils/trace-cmd/trace-cmd.git/tag/?h=trace-cmd-v3.2)
- libtraceevent: [1.6.3](https://git.kernel.org/pub/scm/libs/libtrace/libtraceevent.git/tag/?h=libtraceevent-1.6.3), [1.6.4](https://git.kernel.org/pub/scm/libs/libtrace/libtraceevent.git/tag/?h=libtraceevent-1.6.4), [1.7.0](https://git.kernel.org/pub/scm/libs/libtrace/libtraceevent.git/tag/?h=libtraceevent-1.7.0), [1.7.1](https://git.kernel.org/pub/scm/libs/libtrace/libtraceevent.git/tag/?h=libtraceevent-1.7.1), [1.7.2](https://git.kernel.org/pub/scm/libs/libtrace/libtraceevent.git/tag/?h=libtraceevent-1.7.2), [1.7.3](https://git.kernel.org/pub/scm/libs/libtrace/libtraceevent.git/tag/?h=libtraceevent-1.7.3)
- libtracefs: [1.7.0](https://git.kernel.org/pub/scm/libs/libtrace/libtracefs.git/tag/?h=libtracefs-1.7.0)


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes (or backporting 23.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
