### PR TITLE
ardour: fix default plugin search paths

### DIFF
--- a/pkgs/applications/audio/ardour/default-plugin-search-paths.patch
+++ b/pkgs/applications/audio/ardour/default-plugin-search-paths.patch
@@ -1,0 +1,55 @@
+From 1217722e4bf6c65b5c24da17a7de4bf712ca6775 Mon Sep 17 00:00:00 2001
+From: Tamara Schmitz <tamara.zoe.schmitz@posteo.de>
+Date: Sat, 17 Jun 2023 14:05:53 +0200
+Subject: [PATCH] add NixOS plugin paths as default search paths
+
+Since NixOS uses unusual paths, we should tell Ardour about this. During
+first launch, Ardour does indeed check for environmentals but not when
+you press the "Reset to Defaults" button in the Settings menu. This
+path fixes this by including NixOS paths in the defaults.
+---
+ libs/ardour/plugin_manager.cc | 5 +++--
+ libs/ardour/search_paths.cc   | 4 ++++
+ 2 files changed, 7 insertions(+), 2 deletions(-)
+
+diff --git a/libs/ardour/plugin_manager.cc b/libs/ardour/plugin_manager.cc
+index a572ed55dd..3dd6c2fda6 100644
+--- a/libs/ardour/plugin_manager.cc
++++ b/libs/ardour/plugin_manager.cc
+@@ -305,7 +305,8 @@ PluginManager::PluginManager ()
+ 	if (lxvst_path.length() == 0) {
+ 		lxvst_path = "/usr/local/lib64/lxvst:/usr/local/lib/lxvst:/usr/lib64/lxvst:/usr/lib/lxvst:"
+ 			"/usr/local/lib64/linux_vst:/usr/local/lib/linux_vst:/usr/lib64/linux_vst:/usr/lib/linux_vst:"
+-			"/usr/lib/vst:/usr/local/lib/vst";
++			"/usr/lib/vst:/usr/local/lib/vst:"
++			"$HOME/.lxvst:$HOME/.nix-profile/lib/lxvst:/run/current-system/sw/lib/lxvst:/etc/profiles/per-user/$USER/lib/lxvst";
+ 	}
+ 
+ 	/* first time setup, use 'default' path */
+@@ -2040,7 +2041,7 @@ PluginManager::vst3_refresh (bool cache_only)
+ 	std::string prog = PBD::get_win_special_folder_path (CSIDL_PROGRAM_FILES);
+ 	vst3_discover_from_path (Glib::build_filename (prog, "Common Files", "VST3"), cache_only);
+ #else
+-	vst3_discover_from_path ("~/.vst3:/usr/local/lib/vst3:/usr/lib/vst3", cache_only);
++	vst3_discover_from_path ("~/.vst3:/usr/local/lib/vst3:/usr/lib/vst3:~/.nix-profile/lib/vst3:/run/current-system/sw/lib/vst3:/etc/profiles/per-user/$USER/lib/vst3", cache_only);
+ #endif
+ }
+ 
+diff --git a/libs/ardour/search_paths.cc b/libs/ardour/search_paths.cc
+index e6d8744369..b9774cb006 100644
+--- a/libs/ardour/search_paths.cc
++++ b/libs/ardour/search_paths.cc
+@@ -112,6 +112,10 @@ ladspa_search_path ()
+ 	spath.push_back ("/usr/local/lib/ladspa");
+ 	spath.push_back ("/usr/lib64/ladspa");
+ 	spath.push_back ("/usr/lib/ladspa");
++	spath.push_back ("/run/current-system/sw/lib/ladspa");
++	spath.push_back (path_expand ("$HOME/.ladspa"));
++	spath.push_back (path_expand ("$HOME/.nix-profile/lib/ladspa"));
++	spath.push_back (path_expand ("/etc/profiles/per-user/$USER/lib/ladspa"));
+ #endif
+ 
+ #ifdef __APPLE__
+-- 
+2.40.1
+

--- a/pkgs/applications/audio/ardour/default.nix
+++ b/pkgs/applications/audio/ardour/default.nix
@@ -78,6 +78,7 @@ stdenv.mkDerivation rec {
   patches = [
     # AS=as in the environment causes build failure https://tracker.ardour.org/view.php?id=8096
     ./as-flags.patch
+    ./default-plugin-search-paths.patch
   ];
 
   # Ardour's wscript requires git revision and date to be available.


### PR DESCRIPTION
###### Description of changes

Since NixOS has different paths for plugins than what Ardour assumes by default, we should patch these defaults to be correct on NixOS.

While Ardour does indeed respect environment variables such as VST_PATH, it only does so if a profile configuration was never created. Using this patch the correct paths are also picked, when the user clicks the "Reset to Default" button in the path editor.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes (or backporting 23.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
