### PR TITLE
blueprint-compiler: 0.6.0 -> 0.8.1

### DIFF
--- a/pkgs/development/compilers/blueprint/default.nix
+++ b/pkgs/development/compilers/blueprint/default.nix
@@ -1,23 +1,27 @@
-{ fetchFromGitLab
+{ dbus
+, fetchFromGitLab
 , gobject-introspection
 , gtk4
 , lib
+, libadwaita
+, makeFontsConf
 , meson
 , ninja
 , python3
 , stdenv
 , testers
+, xvfb-run
 }:
 stdenv.mkDerivation (finalAttrs: {
   pname = "blueprint-compiler";
-  version = "0.6.0";
+  version = "0.8.1";
 
   src = fetchFromGitLab {
     domain = "gitlab.gnome.org";
     owner = "jwestman";
     repo = "blueprint-compiler";
     rev = "v${finalAttrs.version}";
-    hash = "sha256-L6EGterkZ8EB6xSnJDZ3IMuOumpTpEGnU74X3UgC7k0=";
+    hash = "sha256-3lj9BMN5aNujbhhZjObdTOCQfH5ERQCgGqIAw5eZIQc=";
   };
 
   nativeBuildInputs = [
@@ -26,6 +30,7 @@ stdenv.mkDerivation (finalAttrs: {
   ];
 
   buildInputs = [
+    libadwaita
     (python3.withPackages (ps: with ps; [
       pygobject3
     ]))
@@ -36,11 +41,33 @@ stdenv.mkDerivation (finalAttrs: {
     gobject-introspection
   ];
 
-  doCheck = true;
-
   nativeCheckInputs = [
+    xvfb-run
+    dbus
     gtk4
   ];
+
+  env = {
+    # Fontconfig error: Cannot load default config file: No such file: (null)
+    FONTCONFIG_FILE = makeFontsConf { fontDirectories = [ ]; };
+  };
+
+  doCheck = true;
+
+  preBuild = ''
+    # Fontconfig error: No writable cache directories
+    export XDG_CACHE_HOME="$(mktemp -d)"
+  '';
+
+  checkPhase = ''
+    runHook preCheck
+
+    xvfb-run dbus-run-session \
+      --config-file=${dbus}/share/dbus-1/session.conf \
+      meson test --no-rebuild --print-errorlogs
+
+    runHook postCheck
+  '';
 
   passthru.tests.version = testers.testVersion {
     package = finalAttrs.finalPackage;
@@ -51,6 +78,6 @@ stdenv.mkDerivation (finalAttrs: {
     homepage = "https://gitlab.gnome.org/jwestman/blueprint-compiler";
     license = licenses.lgpl3Plus;
     maintainers = with maintainers; [ benediktbroich ranfdev ];
-    platforms = platforms.unix;
+    platforms = platforms.linux;
   };
 })

--- a/pkgs/tools/text/textpieces/default.nix
+++ b/pkgs/tools/text/textpieces/default.nix
@@ -10,6 +10,7 @@
 , gtk4
 , libgee
 , libadwaita
+, libportal-gtk4
 , json-glib
 , blueprint-compiler
 , gtksourceview5
@@ -20,17 +21,17 @@
 }:
 
 let
-  pythonEnv = python3.withPackages ( ps: with ps; [ pyyaml ] );
+  pythonEnv = python3.withPackages (ps: with ps; [ pyyaml ]);
 in
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "textpieces";
-  version = "3.4.0";
+  version = "3.4.1";
 
   src = fetchFromGitHub {
     owner = "liferooter";
-    repo = pname;
-    rev = "v${version}";
-    hash = "sha256-LQq6pjue72a4kIHhWtoxJi/eKxPa4du5sBQY97SG1gY=";
+    repo = "textpieces";
+    rev = "v${finalAttrs.version}";
+    hash = "sha256-3ZUHzt3oXYgsnJVDf83JUDhcF+0DLgFfOMtpKI/FTcE=";
   };
 
   nativeBuildInputs = [
@@ -49,6 +50,7 @@ stdenv.mkDerivation rec {
     glib
     gtk4
     libadwaita
+    libportal-gtk4
     libgee
     json-glib
     gtksourceview5
@@ -72,5 +74,6 @@ stdenv.mkDerivation rec {
     license = licenses.gpl3Plus;
     platforms = platforms.linux;
     maintainers = with maintainers; [ zendo ];
+    broken = true; # https://github.com/liferooter/textpieces/issues/130
   };
-}
+})


### PR DESCRIPTION
###### Description of changes

[v0.8.1](https://gitlab.gnome.org/jwestman/blueprint-compiler/-/tree/v0.8.1?ref_type=tags)
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
