### PR TITLE
codesign_allocate: use absolute path

### DIFF
--- a/pkgs/build-support/writers/scripts.nix
+++ b/pkgs/build-support/writers/scripts.nix
@@ -79,16 +79,11 @@ rec {
     let
       name = last (builtins.split "/" nameOrPath);
     in
-    pkgs.runCommand name ((if (types.str.check content) then {
+    pkgs.runCommand name (if (types.str.check content) then {
       inherit content;
       passAsFile = [ "content" ];
     } else {
       contentPath = content;
-    }) // lib.optionalAttrs (stdenv.hostPlatform.isDarwin && stdenv.hostPlatform.isAarch64) {
-      # post-link-hook expects codesign_allocate to be in PATH
-      # https://github.com/NixOS/nixpkgs/issues/154203
-      # https://github.com/NixOS/nixpkgs/issues/148189
-      nativeBuildInputs = [ stdenv.cc.bintools ];
     }) ''
       ${compileScript}
       ${lib.optionalString strip

--- a/pkgs/os-specific/darwin/signing-utils/post-link-sign-hook.nix
+++ b/pkgs/os-specific/darwin/signing-utils/post-link-sign-hook.nix
@@ -1,0 +1,13 @@
+{ writeTextFile, cctools, sigtool }:
+
+writeTextFile {
+  name = "post-link-sign-hook";
+  executable = true;
+
+  text = ''
+    if [ "$linkerOutput" != "/dev/null" ]; then
+      CODESIGN_ALLOCATE=${cctools}/bin/${cctools.targetPrefix}codesign_allocate \
+        ${sigtool}/bin/codesign -f -s - "$linkerOutput"
+    fi
+  '';
+}

--- a/pkgs/stdenv/darwin/default.nix
+++ b/pkgs/stdenv/darwin/default.nix
@@ -464,6 +464,10 @@ in
           inherit (selfDarwin) sigtool;
         };
 
+        postLinkSignHook = prevStage.darwin.postLinkSignHook.override {
+          inherit (selfDarwin) sigtool;
+        };
+
         binutils = superDarwin.binutils.override {
           inherit (self) coreutils;
           inherit (selfDarwin) postLinkSignHook signingUtils;

--- a/pkgs/top-level/darwin-packages.nix
+++ b/pkgs/top-level/darwin-packages.nix
@@ -133,19 +133,9 @@ impure-cmds // appleSourcePackages // chooseLibs // {
 
   sigtool = callPackage ../os-specific/darwin/sigtool { };
 
-  postLinkSignHook = pkgs.writeTextFile {
-    name = "post-link-sign-hook";
-    executable = true;
-
-    text = ''
-      if [ "$linkerOutput" != "/dev/null" ]; then
-        CODESIGN_ALLOCATE=${targetPrefix}codesign_allocate \
-          ${self.sigtool}/bin/codesign -f -s - "$linkerOutput"
-      fi
-    '';
-  };
-
   signingUtils = callPackage ../os-specific/darwin/signing-utils { };
+
+  postLinkSignHook = callPackage ../os-specific/darwin/signing-utils/post-link-sign-hook.nix { };
 
   autoSignDarwinBinariesHook = pkgs.makeSetupHook {
     name = "auto-sign-darwin-binaries-hook";


### PR DESCRIPTION
###### Description of changes

Use absolute reference to `codesign_allocate`. This should fix the issue in a more reliable way so there shouldn't be a case where this still props up.

```
> libc++abi: terminating with uncaught exception of type std::runtime_error: Failed to spawn codesign_allocate: No such file or directory
       > /nix/store/apxhw055i0z86i3m27xn81w0qg2ssp1q-post-link-sign-hook: line 2: 50824 Abort trap: 6  
```

Issues:
https://github.com/NixOS/nixpkgs/issues/154203
https://github.com/NixOS/nixpkgs/issues/148189

Previous attempts:
https://github.com/NixOS/nixpkgs/pull/148282
https://github.com/NixOS/nixpkgs/pull/208120

Fixed writers-only:
https://github.com/NixOS/nixpkgs/pull/220966

To reproduce the issue, run `nix build .#pkgsCross.aarch64-multiplatform.freetype`. Works fine after applying these changes.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
