### PR TITLE
deqp-runner: init at 0.16.1

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -1957,6 +1957,16 @@
       fingerprint = "E9A3 7864 2165 28CE 507C  CA82 72EA BF75 C331 CD25";
     }];
   };
+  Benjamin-L = {
+    name = "Benjamin Lee";
+    email = "benjamin@computer.surgery";
+    matrix = "@benjamin:computer.surgery";
+    github = "Benjamin-L";
+    githubId = 6504174;
+    keys = [{
+      fingerprint = "9D84 09A0 44FC 1EEB AE2D  FA30 FB96 24E2 885D 55A4";
+    }];
+  };
   benkuhn = {
     email = "ben@ben-kuhn.com";
     github = "ben-kuhn";

--- a/pkgs/tools/graphics/deqp-runner/default.nix
+++ b/pkgs/tools/graphics/deqp-runner/default.nix
@@ -1,0 +1,24 @@
+{ lib, fetchFromGitLab, rustPlatform }:
+
+rustPlatform.buildRustPackage rec {
+  pname = "deqp-runner";
+  version = "0.16.1";
+
+  src = fetchFromGitLab {
+    domain = "gitlab.freedesktop.org";
+    owner = "anholt";
+    repo = "deqp-runner";
+    rev = "v${version}";
+    hash = "sha256-Spx7Y0es+s3k2dod/kdEgypncED8mNR23uRdOOcLxJc=";
+  };
+
+  cargoHash = "sha256-G4fxtpIhwAVleJ+0rN1+ZhKWw7QbWTB5aLUa3EdFyvA=";
+
+  meta = with lib; {
+    description = "A VK-GL-CTS/dEQP wrapper program to parallelize it across CPUs and report results against a baseline";
+    homepage = "https://gitlab.freedesktop.org/anholt/deqp-runner";
+    license = licenses.mit;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ Benjamin-L ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6858,6 +6858,8 @@ with pkgs;
 
   deno = callPackage ../development/web/deno { };
 
+  deqp-runner = callPackage ../tools/graphics/deqp-runner { };
+
   detox = callPackage ../tools/misc/detox { };
 
   devilspie2 = callPackage ../applications/misc/devilspie2 {


### PR DESCRIPTION
###### Description of changes

Add a package for [deqp-runner](https://gitlab.freedesktop.org/anholt/deqp-runner). This is a tool for running graphics test suites and comparing results against a baseline from previous runs.

###### Things done


- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).


I've tested this against the vulkan and OpenCL CTS, and it worked as expected in both cases. It's not straightforward to actually use this with the `vulkan-cts` package in nixpkgs, since some components needed by `deqp-runner` aren't included. I had to build this one manually, which is fairly typical for this kind of workflow anyway.