### PR TITLE
cudaPackages_12_1.cudatoolkit: Fix build failure over missing QT dependencies

### DIFF
--- a/pkgs/development/compilers/cudatoolkit/common.nix
+++ b/pkgs/development/compilers/cudatoolkit/common.nix
@@ -9,6 +9,7 @@ args@
 , autoAddOpenGLRunpathHook
 , addOpenGLRunpath
 , alsa-lib
+, curlMinimal
 , expat
 , fetchurl
 , fontconfig
@@ -16,6 +17,7 @@ args@
 , gdk-pixbuf
 , glib
 , glibc
+, gst_all_1
 , gtk2
 , lib
 , libxkbcommon
@@ -129,7 +131,22 @@ backendStdenv.mkDerivation rec {
     ucx
     xorg.libxshmfence
     xorg.libxkbfile
-  ];
+  ] ++ lib.optionals (lib.versionAtLeast version "12.1") (map lib.getLib [
+    # Used by `/target-linux-x64/CollectX/clx` and `/target-linux-x64/CollectX/libclx_api.so` for:
+    # - `libcurl.so.4`
+    curlMinimal
+
+    # Used by `/target-linux-x64/libQt6Multimedia.so.6` for:
+    # - `libgstaudio-1.0.so.0`
+    # - `libgstvideo-1.0.so.0`
+    # - `libgstpbutils-1.0.so.0`
+    # - `libgstallocators-1.0.so.0`
+    # - `libgstapp-1.0.so.0`
+    # - `libgstbase-1.0.so.0`
+    # - `libgstreamer-1.0.so.0`
+    gst_all_1.gstreamer
+    gst_all_1.gst-plugins-base
+  ]);
 
   # Prepended to runpaths by autoPatchelf.
   # The order inherited from older rpath preFixup code


### PR DESCRIPTION
###### Description of changes

Dependencies on `libgstreamer` and `libcurl` were added starting in cudatoolkit 12.1.
This PR compensates for the resulting autoPatchelf failures.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).