### PR TITLE
fakeroute: 0.2 -> 0.3

### DIFF
--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -251,6 +251,7 @@ in {
   etebase-server = handleTest ./etebase-server.nix {};
   etesync-dav = handleTest ./etesync-dav.nix {};
   evcc = handleTest ./evcc.nix {};
+  fakeroute = handleTest ./fakeroute.nix {};
   fancontrol = handleTest ./fancontrol.nix {};
   fcitx5 = handleTest ./fcitx5 {};
   fenics = handleTest ./fenics.nix {};

--- a/nixos/tests/fakeroute.nix
+++ b/nixos/tests/fakeroute.nix
@@ -1,0 +1,22 @@
+import ./make-test-python.nix ({ lib, pkgs, ...} : {
+  name = "fakeroute";
+  meta.maintainers = with lib.maintainers; [ rnhmjoj ];
+
+  nodes.machine = { ... }: {
+    imports = [ ../modules/profiles/minimal.nix ];
+    services.fakeroute.enable = true;
+    services.fakeroute.route =
+      [ "216.102.187.130" "4.0.1.122"
+        "198.116.142.34" "63.199.8.242"
+      ];
+    environment.systemPackages = [ pkgs.traceroute ];
+  };
+
+  testScript =
+    ''
+      start_all()
+      machine.wait_for_unit("fakeroute.service")
+      machine.succeed("traceroute 127.0.0.1 | grep -q 216.102.187.130")
+    '';
+})
+

--- a/pkgs/tools/networking/fakeroute/default.nix
+++ b/pkgs/tools/networking/fakeroute/default.nix
@@ -1,24 +1,19 @@
-{ lib, stdenv, fetchFromGitHub }:
+{ lib, stdenv, fetchurl }:
 
 stdenv.mkDerivation rec {
   pname = "fakeroute";
   version = "0.3";
 
-  src = fetchFromGitHub {
-    owner = "museoa";
-    repo = "fakeroute";
-    rev = "f8cb9c0ae3abb4c0662d9e1fcac67eefeeac3963";
-    sha256 = "12dhahwlpjzv79wpdpryjihamfbh4d8cfzfw4wi1jkl0dv2d41jg";
+  src = fetchurl {
+    url = "https://maxwell.ydns.eu/git/rnhmjoj/fakeroute/releases/download/v${version}/fakeroute-${version}.tar.gz";
+    hash = "sha256-DoXGJm8vOlAD6ZuvVAt6bkgfahc8WgyYIXCrgqzfiWg=";
   };
-
-  sourceRoot = "source/fakeroute-0.3";
 
   meta = with lib; {
     description = ''
-      Makes your machine appear to be anywhere on the internet
-      to any host running a (UDP) unix traceroute
+      Make your machine appears to be anywhere on the internet in a traceroute
     '';
-    homepage = "https://github.com/museoa/fakeroute"; # Formerly https://moxie.org/software/fakeroute/
+    homepage = "https://maxwell.ydns.eu/git/rnhmjoj/fakeroute";
     license = licenses.bsd3;
     platforms = platforms.linux;
   };

--- a/pkgs/tools/networking/fakeroute/default.nix
+++ b/pkgs/tools/networking/fakeroute/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchurl }:
+{ lib, stdenv, fetchurl, nixosTests }:
 
 stdenv.mkDerivation rec {
   pname = "fakeroute";
@@ -8,6 +8,8 @@ stdenv.mkDerivation rec {
     url = "https://maxwell.ydns.eu/git/rnhmjoj/fakeroute/releases/download/v${version}/fakeroute-${version}.tar.gz";
     hash = "sha256-DoXGJm8vOlAD6ZuvVAt6bkgfahc8WgyYIXCrgqzfiWg=";
   };
+
+  passthru.tests.fakeroute = nixosTests.fakeroute;
 
   meta = with lib; {
     description = ''


### PR DESCRIPTION
###### Description of changes

Fakeroute has been unmantained for a very long time and recently the source
code was close to being lost. Morover, the original program has not been working
for a while due to a combination of C++ breaking changes and pre-existing bugs.
So, I adopted the project, re-created the [git repository](https://maxwell.ydns.eu/git/rnhmjoj/fakeroute), fixed all the issues I could
find and made a new release.

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested via `fakeroute.tests`
- [x] Tested compilation of all packages that depend on this change
- [x] Tested basic functionality of all binary files
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
