### PR TITLE
Revert "build-rust-{crate,package}: cleanups"

### DIFF
--- a/pkgs/build-support/rust/build-rust-crate/build-crate.nix
+++ b/pkgs/build-support/rust/build-rust-crate/build-crate.nix
@@ -7,7 +7,7 @@
   dependencies,
   crateFeatures, crateRenames, libName, release, libPath,
   crateType, metadata, crateBin, hasCrateBin,
-  extraRustcOpts,
+  extraRustcOpts, verbose, colors,
   buildTests,
   codegenUnits
 }:
@@ -40,7 +40,9 @@
       ++ (map (x: "--crate-type ${x}") crateType)
     );
 
-    binRustcOpts = lib.concatStringsSep " " baseRustcOpts;
+    binRustcOpts = lib.concatStringsSep " " (
+      baseRustcOpts
+    );
 
     build_bin = if buildTests then "build_bin_test" else "build_bin";
   in ''

--- a/pkgs/build-support/rust/build-rust-crate/default.nix
+++ b/pkgs/build-support/rust/build-rust-crate/default.nix
@@ -300,7 +300,7 @@ crate_: lib.makeOverridable
           (crate.features ++ features)
         );
 
-      libName = crate.libName or crate.crateName;
+      libName = if crate ? libName then crate.libName else crate.crateName;
       libPath = lib.optionalString (crate ? libPath) crate.libPath;
 
       # Seed the symbol hashes with something unique every time.
@@ -329,7 +329,7 @@ crate_: lib.makeOverridable
       colors = lib.attrByPath [ "colors" ] "always" crate;
       extraLinkFlags = lib.concatStringsSep " " (crate.extraLinkFlags or [ ]);
       edition = crate.edition or null;
-      codegenUnits = crate.codegenUnits or 1;
+      codegenUnits = if crate ? codegenUnits then crate.codegenUnits else 1;
       extraRustcOpts =
         lib.optionals (crate ? extraRustcOpts) crate.extraRustcOpts
           ++ extraRustcOpts_

--- a/pkgs/build-support/rust/build-rust-package/default.nix
+++ b/pkgs/build-support/rust/build-rust-package/default.nix
@@ -34,6 +34,7 @@
 , buildInputs ? []
 , nativeBuildInputs ? []
 , cargoUpdateHook ? ""
+, cargoDepsHook ? ""
 , buildType ? "release"
 , meta ? {}
 , cargoLock ? null


### PR DESCRIPTION
Reverts NixOS/nixpkgs#237848

this PR removes the the verbose argument to buildCrate, which is still used in https://github.com/NixOS/nixpkgs/blob/ddad581c0d9d118dc2f376199ed5f65e44fd5950/pkgs/build-support/rust/build-rust-crate/default.nix#L347

This presumably breaks all usage of buildRustCrate, including crate2nix:
```
error: anonymous function at /nix/store/gkr8wg3dvxxvn0c4qpydklckc1rni5jk-source/pkgs/build-support/rust/build-rust-crate/build-crate.nix:6:1 called with unexpected argument 'verbose'

       at /nix/store/gkr8wg3dvxxvn0c4qpydklckc1rni5jk-source/pkgs/build-support/rust/build-rust-crate/default.nix:349:20:

          348|       };
          349|       buildPhase = buildCrate {
             |                    ^
          350|         inherit crateName dependencies
(use '--show-trace' to show detailed location information)
```

As this PR is mere cosmetic cleanup let's revert and think later.