### PR TITLE
xash3d: init at unstable-2023-06-13

### DIFF
--- a/pkgs/games/xash3d/default.nix
+++ b/pkgs/games/xash3d/default.nix
@@ -1,0 +1,78 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, ensureNewerSourcesForZipFilesHook
+, python3
+, pkg-config
+, wafHook
+, SDL2
+, libopus
+, freetype
+, fontconfig
+, gamedir ? "valve"
+, enableGl ? true # opengl renderer
+# the features below were not tested
+, dedicated ? false # dedicated server
+, enableBsp2 ? false # bsp2 support (for quake)
+, enableGles1 ? false # gles1 renderer (nanogl)
+, enableGles2 ? false # gles2 renderer (glwes)
+, enableGl4es ? false # gles2 renderer (gl4es)
+, enableSoft ? false # soft renderer
+, enableUtils ? false # mdldec
+}:
+
+stdenv.mkDerivation {
+  pname = "xash3d-unwrapped";
+  version = "unstable-2023-07-02";
+
+  src = fetchFromGitHub {
+    owner = "FWGS";
+    repo = "xash3d-fwgs";
+    rev = "5e878aae89ab1517eeeb259191bd6f2f88a6eccb";
+    fetchSubmodules = true;
+    sha256 = "IrKWF7TYL9QV5UCHjm1rxZ4ZGT+Hmoq0nOj+X+GoiPQ=";
+  };
+
+  nativeBuildInputs = [
+    ensureNewerSourcesForZipFilesHook
+    python3
+    pkg-config
+    wafHook
+  ];
+
+  buildInputs = [
+    SDL2
+    libopus
+    freetype
+    fontconfig
+  ];
+
+  wafConfigureFlags = [ "--enable-packaging" "--build-type=release" ]
+    ++ lib.optional dedicated "-d"
+    ++ lib.optionals (gamedir != "valve") [ "--gamedir" gamedir ]
+    ++ lib.optional enableBsp2 "--enable-bsp2"
+    ++ lib.optional enableGles1 "--enable-gles1"
+    ++ lib.optional enableGles2 "--enable-gles2"
+    ++ lib.optional enableGl4es "--enable-gl4es"
+    ++ lib.optional (!enableGl) "--disable-gl"
+    ++ lib.optional (!enableSoft) "--disable-soft"
+    ++ lib.optional enableUtils "--enable-utils"
+    ++ lib.optional stdenv.is64bit "-8"
+  ;
+
+  wafInstallFlags = [ "--destdir=/" ];
+
+  postInstall = ''
+    install -Dm644 game_launch/icon-xash-material.png $out/share/icons/hicolor/256x256/apps/xash3d.png
+  '';
+
+  meta = with lib; {
+    description = "A reimplementation of the GoldSrc Engine capable of running Half-Life and more";
+    homepage = "https://github.com/FWGS/xash3d-fwgs";
+    # https://github.com/FWGS/xash3d-fwgs/issues/63
+    license = with licenses; [ unfree ];
+    maintainers = with maintainers; [ TheBrainScrambler ];
+    platforms = platforms.linux;
+    mainProgram = "xash3d";
+  };
+}

--- a/pkgs/games/xash3d/games.nix
+++ b/pkgs/games/xash3d/games.nix
@@ -1,0 +1,45 @@
+/* Each game needs its own version of the hlsdk.
+   There is a branch at upstream corresponding to each game's needed version.
+   For example for gearbox there is a opfor branch at
+   https://github.com/FWGS/hlsdk-portable/tree/opfor */
+{ lib, stdenv, fetchFromGitHub, callPackage }:
+
+let
+  games = {
+    valve = {
+      fullname = "Half-Life";
+      version = "unstable-2023-07-17";
+      rev = "8180cf60c270b933096506f61d07ed03ba3619af";
+      hash = "sha256-HPPsP2Y8LQFbMDek//xrsKaDULhDsdeTQyZYDnmOzt0=";
+      dllname = "hl";
+    };
+
+    bshift = {
+      fullname = "Half-Life: Blue Shift";
+      version = "unstable-2023-07-17";
+      rev = "818632f2baf2cf610c7fadbc2ec1ad906f1a8f29";
+      hash = "sha256-UymPWgiQKxZnPuoTCPdAaCMLmlZEjlr1aA5x+oYW6LI=";
+    };
+
+    gearbox = {
+      fullname = "Half-Life: Opposing Force";
+      version = "unstable-2023-07-17";
+      rev = "ee125707e2185d8bf3f35f8da67fafa893769c4f";
+      hash = "sha256-w4Gg5kTB6yUj+BZxDMLMEksMBAdjQlywHuFAROdTZBo=";
+      dllname = "opfor";
+    };
+  };
+
+  toDrv = name: attrs:
+    let
+      hlsdk = callPackage ./hlsdk.nix {
+        inherit name;
+        inherit (attrs) version rev hash;
+      };
+      game = callPackage ./wrapper.nix ({
+        inherit name hlsdk;
+        inherit (attrs) fullname;
+      } // lib.optionalAttrs (attrs ? dllname) { inherit (attrs) dllname; });
+  in lib.nameValuePair "xash3d-${name}" game;
+
+in lib.mapAttrs' toDrv games

--- a/pkgs/games/xash3d/hlsdk.nix
+++ b/pkgs/games/xash3d/hlsdk.nix
@@ -1,0 +1,52 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, cmake
+, name
+, version
+, rev
+, hash
+, gamedir ? name
+# changing these was not tested
+, enableGoldsourceSupport ? true
+, enableVoicemgr ? false
+, enableBugfixes ? false
+, enableCrowbarIdleAnim ? false
+}:
+
+stdenv.mkDerivation {
+  pname = "hlsdk-${name}";
+  inherit version;
+
+  src = fetchFromGitHub {
+    owner = "FWGS";
+    repo = "hlsdk-portable";
+    inherit rev hash;
+  };
+
+  nativeBuildInputs = [ cmake ];
+
+  cmakeFlags = let
+    cmakeBool = (x: if x then "ON" else "OFF");
+  in [
+    "-DGAMEDIR=${gamedir}"
+    "-DGOLDSOURCE_SUPPORT=${cmakeBool enableGoldsourceSupport}"
+    "-DUSE_VOICEMGR=${cmakeBool enableVoicemgr}"
+    "-DBARNACLE_FIX_VISIBILITY=${cmakeBool enableBugfixes}"
+    "-DCROWBAR_DELAY_FIX=${cmakeBool enableBugfixes}"
+    "-DCROWBAR_FIX_RAPID_CROWBAR=${cmakeBool enableBugfixes}"
+    "-DGAUSS_OVERCHARGE_FIX=${cmakeBool enableBugfixes}"
+    "-DTRIPMINE_BEAM_DUPLICATION_FIX=${cmakeBool enableBugfixes}"
+    "-DHANDGRENADE_DEPLOY_FIX=${cmakeBool enableBugfixes}"
+    "-DWEAPONS_ANIMATION_TIMES_FIX=${cmakeBool enableBugfixes}"
+    "-DCROWBAR_IDLE_ANIM=${cmakeBool enableCrowbarIdleAnim}"
+  ] ++ (lib.optional stdenv.is64bit "-D64BIT=ON");
+
+  meta = with lib; {
+    description = "Portable Half-Life SDK for the game ${name}";
+    homepage = "https://github.com/FWGS/hlsdk-portable";
+    license = with licenses; [ unfree ];
+    maintainers = with maintainers; [ TheBrainScrambler ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/games/xash3d/wrapper.nix
+++ b/pkgs/games/xash3d/wrapper.nix
@@ -1,0 +1,60 @@
+{ writeShellScriptBin
+, makeDesktopItem
+, symlinkJoin
+, hlsdk
+, xash3d-unwrapped
+, name # codename, normally matches gamedir
+, fullname # the human readable name (e.g. "Half-Life: Opposing Force")
+, gamedir ? name # the name of the directory containing game data (e.g. "gearbox")
+, dllname ? name # ARGH why couldn't this just be always name (e.g. "opfor")
+}:
+
+let
+  description = "${fullname} running using the Xash3D engine, a GoldSrc reimplementation";
+
+  wrapper = writeShellScriptBin "xash3d-${name}" ''
+    if [ -z "$XDG_DATA_HOME" ]; then
+        export XDG_DATA_HOME="$HOME/.local/share"
+    fi
+
+    if [ -z "$XASH3D_BASEDIR" ]; then
+      export XASH3D_BASEDIR="$XDG_DATA_HOME/xash3d"
+    fi
+
+    if [ ! -d "$XASH3D_BASEDIR" ]; then
+      echo "$XASH3D_BASEDIR not found"
+      exit 1
+    fi
+
+    export XASH3D_EXTRAS_PAK1=${xash3d-unwrapped}/share/xash3d/valve/extras.pk3
+
+    flags_dll="-dll ${hlsdk}/${gamedir}/dlls/${dllname}_amd64.so"
+    flags_clientlib="-clientlib ${hlsdk}/${gamedir}/cl_dlls/client_amd64.so"
+
+    export LD_LIBRARY_PATH=${xash3d-unwrapped}/lib/xash3d
+
+    exec ${xash3d-unwrapped}/bin/xash3d -game ${gamedir} $flags_dll $flags_clientlib "$@"
+  '';
+
+  desktopItem = makeDesktopItem {
+    inherit name;
+    desktopName = fullname;
+    comment = description;
+    exec = "xash3d-${name}";
+    # The game's icon is in the assets, which we may not have at build time
+    # so we use the xash3d icon.
+    icon = "xash3d";
+    categories = [ "Game" ];
+  };
+in symlinkJoin {
+  name = "xash3d-${name}";
+  paths = [ wrapper desktopItem ];
+  meta = xash3d-unwrapped.meta // {
+    inherit description;
+    longDescription = ''
+      To be able to run ${fullname} with Xash3D, you must first copy the "${gamedir}"
+      folder of your existing ${fullname} installating to $XASH3D_BASEDIR.
+      By default, $XASH3D_BASEDIR is $XDG_DATA_HOME/xash3d, but you can also set the environment variable.
+    '';
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -37374,6 +37374,9 @@ with pkgs;
     inherit (darwin.apple_sdk.frameworks) Foundation;
   };
 
+  xash3d-unwrapped = callPackage ../games/xash3d/default.nix { };
+  xash3dGames = recurseIntoAttrs (callPackage ../games/xash3d/games.nix { });
+
   ### GAMES/DOOM-PORTS
 
   dhewm3 = callPackage ../games/doom-ports/dhewm3 { };


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Xash3D is a GoldSrc reimplementation capable of running Half-Life.

Closes https://github.com/NixOS/nixpkgs/issues/231696.
Also closes https://github.com/NixOS/nixpkgs/pull/166081 which was targetting the old Xash3D engine. This pull requests targets the FWGS fork. I just named the package xash3d and not xash3d-fwgs since the old Xash3D is deprecated and never made it into nixpkgs anyway.

My only big issue with this is that it needs to modify the assets of Half-Life to properly run on 64bit. I wrote a wrapper for this that will make the required symlinks from the libraries in hlsdk to the assets. I don't know if there is a better way, but that's what the AUR does (https://aur.archlinux.org/packages/xash3d-git and the old https://aur.archlinux.org/packages/xash3d-fwgs-git).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
