### PR TITLE
cloudflare-warp: 2023.3.398 -> 2023.3.470

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -3947,6 +3947,13 @@
     githubId = 17111639;
     name = "Devin Singh";
   };
+  devpikachu = {
+    email = "andrei.hava@proton.me";
+    matrix = "@andrei:matrix.detpikachu.dev";
+    github = "devpikachu";
+    githubId = 30475873;
+    name = "Andrei Hava";
+  };
   devusb = {
     email = "mhelton@devusb.us";
     github = "devusb";

--- a/pkgs/tools/networking/cloudflare-warp/default.nix
+++ b/pkgs/tools/networking/cloudflare-warp/default.nix
@@ -12,11 +12,11 @@
 
 stdenv.mkDerivation rec {
   pname = "cloudflare-warp";
-  version = "2023.3.398";
+  version = "2023.3.470";
 
   src = fetchurl {
-    url = "https://pkg.cloudflareclient.com/uploads/cloudflare_warp_2023_3_398_1_amd64_002e48d521.deb";
-    hash = "sha256-1var+/G3WwICRLXsMHke277tmPYRPFW8Yf9b1Ex9OmU=";
+    url = "https://pkg.cloudflareclient.com/pool/jammy/main/c/cloudflare-warp/cloudflare-warp_2023.3.470-1_amd64.deb";
+    sha256 = "0189e68ac1102858840768912627c4a916ddcc0c8171fad4d084de52890a2da8";
   };
 
   nativeBuildInputs = [
@@ -72,7 +72,7 @@ stdenv.mkDerivation rec {
     homepage = "https://pkg.cloudflareclient.com/packages/cloudflare-warp";
     sourceProvenance = with sourceTypes; [ binaryNativeCode ];
     license = licenses.unfree;
-    maintainers = with maintainers; [ wolfangaukang ];
+    maintainers = with maintainers; [ wolfangaukang, devpikachu ];
     platforms = [ "x86_64-linux" ];
   };
 }


### PR DESCRIPTION
Update Warp client version and fix 404 error when trying to fetch DEB package by pointing it to the APT repository instead.

###### Description of changes

Update Warp client version and fix 404 error when trying to fetch DEB package by pointing it to the APT repository instead.

Previously:
```bash
building '/nix/store/8rish5jmip40877yp4zbry881kcmpxkl-com.cloudflare.WarpCli.desktop.drv'...
building '/nix/store/hjd0m06q94ly0d6128irvsiirfbjj7zb-cloudflare_warp_2023_3_398_1_amd64_002e48d521.deb.drv'...
/nix/store/8dj707xxi1q071bhsq11pk5fc98psr80-com.cloudflare.WarpCli.desktop/share/applications/com.cloudflare.WarpCli.desktop: hint: value item "Security" in key "Categories" in group "Desktop Entry" can be extended with another category among the following categories: Settings, or System
copying path '/nix/store/j9sknxp3ds2i8fwxbz8fml7vi0f5l8q8-tor-0.4.7.13' from 'https://cache.nixos.org'...

trying https://pkg.cloudflareclient.com/uploads/cloudflare_warp_2023_3_398_1_amd64_002e48d521.deb
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
curl: (22) The requested URL returned error: 404
error: cannot download cloudflare_warp_2023_3_398_1_amd64_002e48d521.deb from any mirror
error: builder for '/nix/store/hjd0m06q94ly0d6128irvsiirfbjj7zb-cloudflare_warp_2023_3_398_1_amd64_002e48d521.deb.drv' failed with exit code 1
error: 1 dependencies of derivation '/nix/store/82icrwdvybdv6g0k03d5knjiqqydhs79-cloudflare-warp-2023.3.398.drv' failed to build
```

This is due to a 404 error on that URL:
![image](https://github.com/NixOS/nixpkgs/assets/30475873/62e152eb-89b7-48d1-bb45-bbfcdccf2844)

Retargeted the DEB retrieval to use the [APT repository](https://pkg.cloudflareclient.com/dists/jammy/main/binary-amd64/Packages) and updated it to the latest version.

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
