### PR TITLE
soupault: 4.4.0 → 4.6.0

### DIFF
--- a/pkgs/tools/typesetting/soupault/default.nix
+++ b/pkgs/tools/typesetting/soupault/default.nix
@@ -1,5 +1,6 @@
 { lib
 , fetchFromGitea
+, fetchpatch
 , ocamlPackages
 , soupault
 , testers
@@ -8,7 +9,7 @@
 let
   pname = "soupault";
 
-  version = "4.4.0";
+  version = "4.6.0";
 in
 ocamlPackages.buildDunePackage {
   inherit pname version;
@@ -22,8 +23,16 @@ ocamlPackages.buildDunePackage {
     owner = "PataphysicalSociety";
     repo = pname;
     rev = version;
-    sha256 = "sha256-M4gaPxBxQ1Bk2C3BwvobYHyaWKIZgQ6buZ6S5wBlvPg=";
+    sha256 = "MblwVacfK9CfoO0TEND+bqdi7iQayBOJKKOhzE7oiVk=";
   };
+
+  patches = lib.lists.optional
+    (lib.strings.versionAtLeast "2.0.0" ocamlPackages.camomile.version)
+    (fetchpatch {
+      name = "camomile-1_x";
+      url = "https://files.baturin.org/software/soupault/soupault-4.6.0-camomile-1.x.patch";
+      sha256 = "J5RGyLDDVRzf6MLLI+73lqClxoovcPD2ZFawk+f6cE4=";
+    });
 
   buildInputs = with ocamlPackages; [
     base64


### PR DESCRIPTION
https://codeberg.org/PataphysicalSociety/soupault/src/branch/main/CHANGELOG.md

###### Description of changes

The maintainer graciously made a patch for Soupault to work with Camomile 1.x to work with Nixpkgs until a version that satisfies the maintainers is pull in.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
