### PR TITLE
obfs4: 0.0.14 -> 0.1.0

### DIFF
--- a/pkgs/tools/networking/obfs4/default.nix
+++ b/pkgs/tools/networking/obfs4/default.nix
@@ -2,18 +2,20 @@
 
 buildGoModule rec {
   pname = "obfs4";
-  version = "0.0.14";
+  version = "0.1.0";
 
   src = fetchFromGitLab {
     domain = "gitlab.torproject.org";
     group = "tpo";
     owner = "anti-censorship/pluggable-transports";
-    repo = "obfs4";
-    rev = "obfs4proxy-${version}";
-    sha256 = "sha256-/d1qub/mhEzzLQFytgAlhz8ukIC9d+GPK2Hfi3NMv+M=";
+    # We don't use pname = lyrebird and we use the old obfs4 name as the first
+    # will collide with lyrebird Gtk3 program.
+    repo = "lyrebird";
+    rev = "lyrebird-${version}";
+    hash = "sha256-2qBSmAsaR3hfxuoR5U5UAFQAepUOEUnIGoxc/GZ5LmY=";
   };
 
-  vendorHash = "sha256-7NF3yMouhjSM9SBNKHkeWV7qy0XTGnepEX28kBpbgdk=";
+  vendorHash = "sha256-O8CsvpwL9cfipl4M0BquSnG9tBrt/+i+i80OYk2mNiI=";
 
   ldflags = [ "-s" "-w" ];
 
@@ -21,6 +23,7 @@ buildGoModule rec {
 
   postInstall = ''
     installManPage doc/obfs4proxy.1
+    ln -s $out/share/man/man1/{obfs4proxy,lyrebird}.1
   '';
 
   meta = with lib; {
@@ -36,10 +39,10 @@ buildGoModule rec {
       specification, and its modular architecture allows it to support
       multiple pluggable transports.
     '';
-    homepage = "https://gitlab.torproject.org/tpo/anti-censorship/pluggable-transports/obfs4";
+    homepage = "https://gitlab.torproject.org/tpo/anti-censorship/pluggable-transports/lyrebird";
     maintainers = with maintainers; [ thoughtpolice ];
-    mainProgram = "obfs4proxy";
-    changelog = "https://gitlab.torproject.org/tpo/anti-censorship/pluggable-transports/obfs4/-/raw/${src.rev}/ChangeLog";
+    mainProgram = "lyrebird";
+    changelog = "https://gitlab.torproject.org/tpo/anti-censorship/pluggable-transports/lyrebird/-/raw/${src.rev}/ChangeLog";
     license = with lib.licenses; [ bsd2 bsd3 gpl3 ];
   };
 }


### PR DESCRIPTION
###### Motivation for this change


###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
