### PR TITLE
meek: init at 0.38.0

### DIFF
--- a/pkgs/tools/networking/meek/default.nix
+++ b/pkgs/tools/networking/meek/default.nix
@@ -1,0 +1,47 @@
+{ lib
+, buildGoModule
+, fetchFromGitLab
+, installShellFiles
+}:
+
+buildGoModule rec {
+  pname = "meek";
+  version = "0.38.0";
+
+  src = fetchFromGitLab {
+    domain = "gitlab.torproject.org";
+    group = "tpo";
+    owner = "anti-censorship/pluggable-transports";
+    repo = "meek";
+    rev = "v${version}";
+    sha256 = "sha256-zmIRXrHWrEzR+RcX/gkuqw2oBmyGoXDQ45ZjA4vwGSs=";
+  };
+
+  vendorHash = "sha256-eAO6vEPKqWWZkmJXmOCeTa7TE8opynYvvxzPDSe9p+I=";
+
+  subPackages = [
+    "meek-client"
+    "meek-server"
+  ];
+
+  nativeBuildInputs = [ installShellFiles ];
+
+  postInstall = ''
+    installManPage doc/meek-client.1
+    installManPage doc/meek-server.1
+  '';
+
+  meta = with lib; {
+    description = "Blocking-resistant pluggable transport for Tor";
+    longDescription = ''
+      meek is a blocking-resistant pluggable transport for Tor. It encodes a
+      data stream as a sequence of HTTPS requests and responses. Requests are
+      reflected through a hard-to-block third-party web server in order to
+      avoid talking directly to a Tor bridge. HTTPS encryption hides
+      fingerprintable byte patterns in Tor traffic.
+    '';
+    homepage = "https://gitlab.torproject.org/tpo/anti-censorship/pluggable-transports/meek";
+    maintainers = with maintainers; [ doronbehar ];
+    license = licenses.cc0;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -31561,6 +31561,8 @@ with pkgs;
 
   marker = callPackage ../applications/editors/marker { };
 
+  meek = callPackage ../tools/networking/meek { };
+
   meerk40t = callPackage ../applications/misc/meerk40t { };
 
   meerk40t-camera = callPackage ../applications/misc/meerk40t/camera.nix { };


### PR DESCRIPTION
###### Motivation for this change


###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
