### PR TITLE
muon-ssh: init at 2.2.0

### DIFF
--- a/pkgs/tools/networking/muon-ssh/default.nix
+++ b/pkgs/tools/networking/muon-ssh/default.nix
@@ -1,0 +1,55 @@
+{ stdenv
+, lib
+, fetchurl
+, dpkg
+, autoPatchelfHook
+, copyDesktopItems
+, makeDesktopItem
+, jdk11
+}:
+
+stdenv.mkDerivation rec {
+  pname = "muon-ssh";
+  version = "2.2.0";
+
+  src = fetchurl {
+    url = "https://github.com/devlinx9/muon-ssh/releases/download/v2.2.0/muonssh_2.2.0.deb";
+    sha256 = "cd7bbbb27f75f5538cef2ab599435251493023222086e165086b57f3ed6fac3a";
+  };
+
+  nativeBuildInputs = [
+    dpkg
+    autoPatchelfHook
+    copyDesktopItems
+    jdk11
+  ];
+
+  buildInputs = [
+    stdenv.cc.cc.lib
+  ];
+
+  unpackPhase = ''
+    dpkg-deb -x ${src} ./
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    mv usr $out
+    mv opt $out
+
+    sed -i -e "s|/opt/muonssh/muonssh.jar.*$|$out/opt/muonssh/muonssh.jar|" $out/bin/muonssh
+    sed -i -e "s|Exec=/usr/bin/muonssh.*$|Exec=$out/bin/muonssh|" $out/share/applications/muonssh.desktop
+  '';
+
+  meta = with lib; {
+    description = "Easy and fun way to work with remote servers over SSH.";
+    homepage = "https://github.com/devlinx9/muon-ssh";
+    sourceProvenance = with sourceTypes; [ binaryNativeCode ];
+    license = licenses.gpl3Only;
+    maintainers = with maintainers; [
+      devpikachu
+    ];
+    platforms = [ "x86_64-linux" ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -19039,6 +19039,8 @@ with pkgs;
 
   msitools = callPackage ../development/tools/misc/msitools { };
 
+  muon-ssh = callPackage ../tools/networking/muon-ssh { };
+
   haskell-ci = haskell.lib.compose.justStaticExecutables haskellPackages.haskell-ci;
 
   neoload = callPackage ../development/tools/neoload {


### PR DESCRIPTION
###### Description of changes

Added a new package, `muon-ssh`, init'ed at 2.2.0. See: https://github.com/devlinx9/muon-ssh

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
