### PR TITLE
nixos/sysctl: raise default `vm.max_map_count` to 1048576

### DIFF
--- a/nixos/modules/config/malloc.nix
+++ b/nixos/modules/config/malloc.nix
@@ -97,7 +97,6 @@ in
   };
 
   config = mkIf (cfg.provider != "libc") {
-    boot.kernel.sysctl."vm.max_map_count" = mkIf (cfg.provider == "graphene-hardened") (mkDefault 1048576);
     environment.etc."ld-nix.so.preload".text = ''
       ${providerLibPath}
     '';

--- a/nixos/modules/config/sysctl.nix
+++ b/nixos/modules/config/sysctl.nix
@@ -72,5 +72,8 @@ in
     # Disable YAMA by default to allow easy debugging.
     boot.kernel.sysctl."kernel.yama.ptrace_scope" = mkDefault 0;
 
+    # Improve compatibility with applications that allocate
+    # a lot of memory, like modern games
+    boot.kernel.sysctl."vm.max_map_count" = mkDefault 1048576;
   };
 }

--- a/nixos/modules/virtualisation/lxd.nix
+++ b/nixos/modules/virtualisation/lxd.nix
@@ -177,7 +177,7 @@ in {
       "fs.inotify.max_queued_events" = 1048576;
       "fs.inotify.max_user_instances" = 1048576;
       "fs.inotify.max_user_watches" = 1048576;
-      "vm.max_map_count" = 262144;
+      "vm.max_map_count" = 262144; # TODO: Default vm.max_map_count has been increased system-wide
       "kernel.dmesg_restrict" = 1;
       "net.ipv4.neigh.default.gc_thresh3" = 8192;
       "net.ipv6.neigh.default.gc_thresh3" = 8192;

--- a/pkgs/applications/networking/browsers/firefox/common.nix
+++ b/pkgs/applications/networking/browsers/firefox/common.nix
@@ -357,6 +357,7 @@ buildStdenv.mkDerivation ({
     export MOZILLA_OFFICIAL=1
   '' + lib.optionalString stdenv.hostPlatform.isMusl ''
     # linking firefox hits the vm.max_map_count kernel limit with the default musl allocator
+    # TODO: Default vm.max_map_count has been increased, retest without this
     export LD_PRELOAD=${mimalloc}/lib/libmimalloc.so
   '';
 


### PR DESCRIPTION
###### Description of changes

Fixes #238412 (which contains the motivation).

I removed some mentions of that setting, because they set it to a lower value than 1048576.

Before merging: there are two mentions of `vm.max_map_count` I didn't remove, because they optionally set it in a script instead of using the NixOS option. It still is lower than 1048576, but they put a condition to not change it if the system one is higher. Should I remove these mentions too?