### PR TITLE
python3Packages.torch: statically link against magma

### DIFF
--- a/pkgs/development/libraries/science/math/magma/generic.nix
+++ b/pkgs/development/libraries/science/math/magma/generic.nix
@@ -28,6 +28,7 @@
 , ninja
 , openmp
 , rocmSupport ? false
+, static ? false
 , stdenv
 , symlinkJoin
 }:
@@ -145,6 +146,8 @@ stdenv.mkDerivation {
 
   cmakeFlags = [
     "-DGPU_TARGET=${gpuTargetString}"
+  ] ++ lists.optionals static [
+    "-DBUILD_SHARED_LIBS=OFF"
   ] ++ lists.optionals cudaSupport [
     "-DCMAKE_CUDA_ARCHITECTURES=${cudaArchitecturesString}"
     "-DMIN_ARCH=${minArch}" # Disarms magma's asserts

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -38238,6 +38238,10 @@ with pkgs;
     rocmSupport = false;
   };
 
+  magma-cuda-static = magma-cuda.override {
+    static = true;
+  };
+
   # TODO:AMD won't compile with anything newer than 2.6.2 -- it fails at the linking stage.
   magma-hip = magma_2_6_2.override {
     cudaSupport = false;

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -12319,6 +12319,10 @@ self: super: with self; {
 
   torch = callPackage ../development/python-modules/torch {
     cudaSupport = pkgs.config.cudaSupport or false;
+    magma =
+      if pkgs.config.cudaSupport or false
+      then pkgs.magma-cuda-static
+      else pkgs.magma;
     inherit (pkgs.darwin.apple_sdk.frameworks) Accelerate CoreServices;
     inherit (pkgs.darwin) libobjc;
     inherit (pkgs.llvmPackages_rocm) openmp;
@@ -12329,7 +12333,7 @@ self: super: with self; {
   };
 
   torchWithCuda = self.torch.override {
-    magma = pkgs.magma-cuda;
+    magma = pkgs.magma-cuda-static;
     cudaSupport = true;
     rocmSupport = false;
   };


### PR DESCRIPTION
###### Description of changes

Closes https://github.com/NixOS/nixpkgs/issues/238460.

This is specifically for CUDA -- @NixOS/rocm-maintainers you all might be interested in this as well due to the reductions in closure size. I did have trouble getting the static Magma to build with ROCm though :(

Removed from closure:

```diff
< /nix/store/0c69kcii932w6lxdxqzmqcm7g4gyqngk-cuda-native-redist-11.7      	  63.0K	   2.1G
< /nix/store/27w6gbs50zsi7k0l87n8fy3kn8f27309-libcusparse-11.7.3.50        	 488.1M	 488.2M
< /nix/store/2pccj9km8klxwzlba68l1s3xshi6gamy-blas-3                       	  53.3M	 121.1M
< /nix/store/4sl827a5hcj5h6pa6imcmyxxavn8fbdn-cuda_nvcc-11.7.64            	 114.8M	 397.0M
< /nix/store/6pcwgva8fgqj4qsr53pqh3c957dsbl80-magma-2.7.1                  	   1.7G	   3.9G
< /nix/store/8klnjyanarww18nm4rnfwfhr0dg3h7g8-cuda_nvprof-11.7.50          	   9.9M	 129.6M
< /nix/store/9dq1mkizzbp03wl8ph93slj3izpirzw0-cuda_cupti-11.7.50           	  88.4M	  88.6M
< /nix/store/9n1a99ja790p6f4mw2q43gipnqx95pw2-libcublas-11.10.1.25         	   1.1G	   1.2G
< /nix/store/pdmr79kcqjnd7d38wrx23fkmbrd6njsf-cuda_cudart-11.7.60          	   6.3M	   6.3M
```

The `torch-lib` NAR increases by about 300 MB, but the closure size decreases by 3.2 GB.

```diff
< /nix/store/nfi14jlj14qjlcwp8fl113xir9xp2zs1-python3.10-torch-2.0.1-lib   	1006.5M	  12.3G
> /nix/store/x3kh1adanqylak6jbzpacdd4zgk944yv-python3.10-torch-2.0.1-lib   	   1.3G	   9.1G

The `torch` NAR size doesn't change, but the closure size decreases by 3.2 GB (due to the `torch-lib` closure).

```diff
< /nix/store/zlyam0ii825f26az586mpqiy0wqrw3x2-python3.10-torch-2.0.1       	  74.4M	  12.4G
> /nix/store/kscv7gr52w3j0mh39w0byfa9sqzj7p7h-python3.10-torch-2.0.1       	  74.4M	   9.2G
```

Run `Nixpkgs-review`:

```bash
nixpkgs-review pr 238465 \
  --extra-nixpkgs-config '{ allowUnfree = true; cudaSupport = true; }' \
  --no-shell \
  --print-result
```

Or build from this flake:

```nix
{
  # Update if PR is rebased.
  inputs.nixpkgs-master.url = "github:NixOS/nixpkgs/fb11cd49294c4cbb3bd6a56f50f9b8cba2cac949";
  inputs.nixpkgs-pr-238465.url = "github:NixOS/nixpkgs/refs/pull/238465/head";

  nixConfig = {
    extra-substituters = [
      "https://cantcache.me"
      "https://cuda-maintainers.cachix.org"
    ];
    extra-trusted-substituters = [
      "https://cantcache.me"
      "https://cuda-maintainers.cachix.org"
    ];
    extra-trusted-public-keys = [
      "cantcache.me:Y+FHAKfx7S0pBkBMKpNMQtGKpILAfhmqUSnr5oNwNMs="
      "cuda-maintainers.cachix.org-1:0dq3bujKpuEPMCX6U4WylrUDZ9JyUG0VpVZa7CNfq5E="
    ];
  };

  outputs = inputs: let
    system = "x86_64-linux";
    config = {
      allowUnfree = true;
      cudaSupport = true;
    };
    pkgsMaster = import inputs.nixpkgs-master {inherit system config;};
    pkgsPR = import inputs.nixpkgs-pr-238465 {inherit system config;};
  in {
    packages.${system} = {
      master-torchWithCuda = pkgsMaster.python3Packages.torchWithCuda;
      pr-torchWithCuda = pkgsPR.python3Packages.torchWithCuda;
    };
    formatter.${system} = pkgsMaster.alejandra;
  };
}
```

Build:

```bash
nix build --no-link .#master-torchWithCuda .#pr-torchWithCuda
```

<details><summary>Diff</summary>

```bash
diff \
  --color=always \
  --ignore-all-space \
  --minimal \
  <(nix path-info -rSsh .#master-torchWithCuda | sort) \
  <(nix path-info -rSsh .#pr-torchWithCuda | sort)
```

```diff
4d3
< /nix/store/0c69kcii932w6lxdxqzmqcm7g4gyqngk-cuda-native-redist-11.7      	  63.0K	   2.1G
18,19d16
< /nix/store/27w6gbs50zsi7k0l87n8fy3kn8f27309-libcusparse-11.7.3.50        	 488.1M	 488.2M
< /nix/store/2pccj9km8klxwzlba68l1s3xshi6gamy-blas-3                       	  53.3M	 121.1M
26d22
< /nix/store/4sl827a5hcj5h6pa6imcmyxxavn8fbdn-cuda_nvcc-11.7.64            	 114.8M	 397.0M
34d29
< /nix/store/6pcwgva8fgqj4qsr53pqh3c957dsbl80-magma-2.7.1                  	   1.7G	   3.9G
52d46
< /nix/store/8klnjyanarww18nm4rnfwfhr0dg3h7g8-cuda_nvprof-11.7.50          	   9.9M	 129.6M
59d52
< /nix/store/9dq1mkizzbp03wl8ph93slj3izpirzw0-cuda_cupti-11.7.50           	  88.4M	  88.6M
65d57
< /nix/store/9n1a99ja790p6f4mw2q43gipnqx95pw2-libcublas-11.10.1.25         	   1.1G	   1.2G
113a106
> /nix/store/kscv7gr52w3j0mh39w0byfa9sqzj7p7h-python3.10-torch-2.0.1       	  74.4M	   9.2G
131d123
< /nix/store/nfi14jlj14qjlcwp8fl113xir9xp2zs1-python3.10-torch-2.0.1-lib   	1006.5M	  12.3G
136d127
< /nix/store/pdmr79kcqjnd7d38wrx23fkmbrd6njsf-cuda_cudart-11.7.60          	   6.3M	   6.3M
169a161
> /nix/store/x3kh1adanqylak6jbzpacdd4zgk944yv-python3.10-torch-2.0.1-lib   	   1.3G	   9.1G
181d172
< /nix/store/zlyam0ii825f26az586mpqiy0wqrw3x2-python3.10-torch-2.0.1       	  74.4M	  12.4G
```
</details>

<details><summary>Column diff</summary>

```bash
diff \
  --color=always \
  --ignore-all-space \
  --minimal \
  --side-by-side \
  --width=200 \
  <(nix path-info -rSsh .#master-torchWithCuda | sort) \
  <(nix path-info -rSsh .#pr-torchWithCuda | sort)
```

```diff
/nix/store/02dr9ymdqpkb75vf0v1z2l91z2q3izy9-coreutils-9.3                	   1.4M	  41.1M		/nix/store/02dr9ymdqpkb75vf0v1z2l91z2q3izy9-coreutils-9.3                	   1.4M	  41.1M
/nix/store/08vd6kq597fbz3g7x95g87is32603bmh-gdbm-1.23                    	 805.4K	  31.9M		/nix/store/08vd6kq597fbz3g7x95g87is32603bmh-gdbm-1.23                    	 805.4K	  31.9M
/nix/store/09fm8d6r0nf060f7f3551cvlb0lsbw53-libsndfile-1.2.0             	 591.9K	  42.8M		/nix/store/09fm8d6r0nf060f7f3551cvlb0lsbw53-libsndfile-1.2.0             	 591.9K	  42.8M
/nix/store/0c69kcii932w6lxdxqzmqcm7g4gyqngk-cuda-native-redist-11.7      	  63.0K	   2.1G	   <
/nix/store/0cp8ksa1sb67zcidfblrck0bd84qzwlf-pcre2-10.42                  	   1.8M	  32.9M		/nix/store/0cp8ksa1sb67zcidfblrck0bd84qzwlf-pcre2-10.42                  	   1.8M	  32.9M
/nix/store/0pfxmlqg9zbmzlfh3s2a08scr92wznfn-glibc-2.37-8-bin             	   2.7M	  33.8M		/nix/store/0pfxmlqg9zbmzlfh3s2a08scr92wznfn-glibc-2.37-8-bin             	   2.7M	  33.8M
/nix/store/0s4z6hiz46iryciigvzr7k5pvhax2nki-xcb-util-keysyms-0.4.1       	  18.1K	  32.5M		/nix/store/0s4z6hiz46iryciigvzr7k5pvhax2nki-xcb-util-keysyms-0.4.1       	  18.1K	  32.5M
/nix/store/1334msr6whbnraxs69mc03iv4655gxb2-libselinux-3.3               	   1.1M	  32.7M		/nix/store/1334msr6whbnraxs69mc03iv4655gxb2-libselinux-3.3               	   1.1M	  32.7M
/nix/store/16n59d82lzifl6bmydjl63q1w1gsz616-kbd-2.5.1                    	   2.6M	  50.6M		/nix/store/16n59d82lzifl6bmydjl63q1w1gsz616-kbd-2.5.1                    	   2.6M	  50.6M
/nix/store/19gk9iflwyxpv214zn8nmfhyzrjg91br-alsa-topology-conf-1.2.5.1   	 336.1K	 336.1K		/nix/store/19gk9iflwyxpv214zn8nmfhyzrjg91br-alsa-topology-conf-1.2.5.1   	 336.1K	 336.1K
/nix/store/1bf25an0scjknv2i23zg0yq9id72qdzl-cudatoolkit-11.7.0           	   4.3G	   4.9G		/nix/store/1bf25an0scjknv2i23zg0yq9id72qdzl-cudatoolkit-11.7.0           	   4.3G	   4.9G
/nix/store/1hgk46w2n5fkw9n5b2z1wlx7swfahwg9-xgcc-12.3.0-libgcc           	 139.1K	 139.1K		/nix/store/1hgk46w2n5fkw9n5b2z1wlx7swfahwg9-xgcc-12.3.0-libgcc           	 139.1K	 139.1K
/nix/store/1i0bd768frp0s9pwfcf5qqrjfk36fa7x-iptables-1.8.9               	   2.6M	  38.4M		/nix/store/1i0bd768frp0s9pwfcf5qqrjfk36fa7x-iptables-1.8.9               	   2.6M	  38.4M
/nix/store/1lp76l54hjr466dk539qrpxyzjv07b0r-libkrb5-1.20.1               	   2.2M	  35.0M		/nix/store/1lp76l54hjr466dk539qrpxyzjv07b0r-libkrb5-1.20.1               	   2.2M	  35.0M
/nix/store/204j1yqxw4iin087p53x9jg5pa02yr65-dbus-1.14.8-lib              	 449.6K	 101.5M		/nix/store/204j1yqxw4iin087p53x9jg5pa02yr65-dbus-1.14.8-lib              	 449.6K	 101.5M
/nix/store/227f9hlnd044vn491fs1i1cbkx8sfn7v-libgcrypt-1.10.2             	   1.4M	  33.3M		/nix/store/227f9hlnd044vn491fs1i1cbkx8sfn7v-libgcrypt-1.10.2             	   1.4M	  33.3M
/nix/store/24q97dx4kdkpcqchn1crm1845jj10rmq-zstd-1.5.5-bin               	 343.7K	  44.5M		/nix/store/24q97dx4kdkpcqchn1crm1845jj10rmq-zstd-1.5.5-bin               	 343.7K	  44.5M
/nix/store/27w6gbs50zsi7k0l87n8fy3kn8f27309-libcusparse-11.7.3.50        	 488.1M	 488.2M	   <
/nix/store/2pccj9km8klxwzlba68l1s3xshi6gamy-blas-3                       	  53.3M	 121.1M	   <
/nix/store/31rjnw4c0cp7fp02vy5qm9qrga08zq1b-gfortran-12.3.0-lib          	  10.5M	  41.7M		/nix/store/31rjnw4c0cp7fp02vy5qm9qrga08zq1b-gfortran-12.3.0-lib          	  10.5M	  41.7M
/nix/store/32pb1677dhg0yz36zfyi4yfdycvyjhdq-bzip2-1.0.8                  	  79.5K	  31.2M		/nix/store/32pb1677dhg0yz36zfyi4yfdycvyjhdq-bzip2-1.0.8                  	  79.5K	  31.2M
/nix/store/381s0sghqfdxx2fnx02xqgrkrg6dclnr-linux-pam-1.5.2              	   1.8M	  46.5M		/nix/store/381s0sghqfdxx2fnx02xqgrkrg6dclnr-linux-pam-1.5.2              	   1.8M	  46.5M
/nix/store/3pb6zaaa60jm1asgzn3l6x2iyzdvs1fr-nss-3.79.4                   	   3.7M	  49.6M		/nix/store/3pb6zaaa60jm1asgzn3l6x2iyzdvs1fr-nss-3.79.4                   	   3.7M	  49.6M
/nix/store/44x4pk1d6q8gixdn03j2pmbjbspff296-libidn2-2.3.4                	 350.4K	   2.1M		/nix/store/44x4pk1d6q8gixdn03j2pmbjbspff296-libidn2-2.3.4                	 350.4K	   2.1M
/nix/store/4rfy25ddysfbyw63yqfhxsmdx26plpsn-speexdsp-1.2.1               	  74.4K	  45.8M		/nix/store/4rfy25ddysfbyw63yqfhxsmdx26plpsn-speexdsp-1.2.1               	  74.4K	  45.8M
/nix/store/4sl827a5hcj5h6pa6imcmyxxavn8fbdn-cuda_nvcc-11.7.64            	 114.8M	 397.0M	   <
/nix/store/53bh0jh0q1b50mm46gx5w9nkdia7y0wf-libcbor-unstable-2023-01-29  	 161.7K	  31.3M		/nix/store/53bh0jh0q1b50mm46gx5w9nkdia7y0wf-libcbor-unstable-2023-01-29  	 161.7K	  31.3M
/nix/store/5a457g4zr7q11b4mz0ifc9z88kwcp8g7-python3-3.10.12              	  83.0M	 139.3M		/nix/store/5a457g4zr7q11b4mz0ifc9z88kwcp8g7-python3-3.10.12              	  83.0M	 139.3M
/nix/store/5a8zvsw039b6z8n2ql9c84i4l2h65xss-binutils-2.40                	  28.2M	  69.8M		/nix/store/5a8zvsw039b6z8n2ql9c84i4l2h65xss-binutils-2.40                	  28.2M	  69.8M
/nix/store/5k0mnswnsnxxaw8zv1jajg73f9yimp3v-cudatoolkit-11-cudnn-8.9.1   	   2.3G	   2.4G		/nix/store/5k0mnswnsnxxaw8zv1jajg73f9yimp3v-cudatoolkit-11-cudnn-8.9.1   	   2.3G	   2.4G
/nix/store/5rqirrzzb2wq50l1vvkq0hhg8fb8a4pj-tzdata-2023c                 	   2.0M	   2.0M		/nix/store/5rqirrzzb2wq50l1vvkq0hhg8fb8a4pj-tzdata-2023c                 	   2.0M	   2.0M
/nix/store/5yzc2574x16f5fyxz01ns5dhs22d5d3c-alsa-ucm-conf-1.2.9          	 429.0K	 429.0K		/nix/store/5yzc2574x16f5fyxz01ns5dhs22d5d3c-alsa-ucm-conf-1.2.9          	 429.0K	 429.0K
/nix/store/60zh9n7zj2lxd0i8lq69fnnlvhb55832-unbound-1.17.1-lib           	   1.0M	  42.0M		/nix/store/60zh9n7zj2lxd0i8lq69fnnlvhb55832-unbound-1.17.1-lib           	   1.0M	  42.0M
/nix/store/6pcwgva8fgqj4qsr53pqh3c957dsbl80-magma-2.7.1                  	   1.7G	   3.9G	   <
/nix/store/6xzx5hni7r0sl363ybz27dw4ddv43arb-fontconfig-2.14.2            	   1.6M	   2.3M		/nix/store/6xzx5hni7r0sl363ybz27dw4ddv43arb-fontconfig-2.14.2            	   1.6M	   2.3M
/nix/store/71l0943lpvdrd580rhcg34p2nz4d1yqn-kexec-tools-2.0.26           	 237.0K	  31.5M		/nix/store/71l0943lpvdrd580rhcg34p2nz4d1yqn-kexec-tools-2.0.26           	 237.0K	  31.5M
/nix/store/73pk27f2v67div76wyzbbign26dg0hs3-xcb-util-wm-0.4.2            	 107.8K	  32.6M		/nix/store/73pk27f2v67div76wyzbbign26dg0hs3-xcb-util-wm-0.4.2            	 107.8K	  32.6M
/nix/store/75622q2wranjp6zl81ldq5j54s788dqz-gcc-12.3.0-lib               	   7.5M	  38.8M		/nix/store/75622q2wranjp6zl81ldq5j54s788dqz-gcc-12.3.0-lib               	   7.5M	  38.8M
/nix/store/7d6wz570fp2h4k5i65hvr6154m7m55y8-libbpf-1.2.0                 	   1.7M	  59.2M		/nix/store/7d6wz570fp2h4k5i65hvr6154m7m55y8-libbpf-1.2.0                 	   1.7M	  59.2M
/nix/store/7jhfm535qjjd7f81c3vh43f364a4imj6-xcb-util-0.4.1               	  31.8K	  32.5M		/nix/store/7jhfm535qjjd7f81c3vh43f364a4imj6-xcb-util-0.4.1               	  31.8K	  32.5M
/nix/store/7p0m3l0k6w1h1x9z7lj2sy0yanfsglnc-libxkbcommon-1.5.0           	 553.6K	  43.4M		/nix/store/7p0m3l0k6w1h1x9z7lj2sy0yanfsglnc-libxkbcommon-1.5.0           	 553.6K	  43.4M
/nix/store/7q58h7q21h9zir3zzhrxxc7ba6bkpv01-libmnl-1.0.5                 	  42.2K	  31.1M		/nix/store/7q58h7q21h9zir3zzhrxxc7ba6bkpv01-libmnl-1.0.5                 	  42.2K	  31.1M
/nix/store/7s66yqwdxc414j942p3hch88pp5b3wx2-libcap-2.69-lib              	  77.9K	  31.2M		/nix/store/7s66yqwdxc414j942p3hch88pp5b3wx2-libcap-2.69-lib              	  77.9K	  31.2M
/nix/store/7ws5zmh4llmml550x02pqpcyzv5j4m4c-gnugrep-3.11                 	 923.1K	  33.8M		/nix/store/7ws5zmh4llmml550x02pqpcyzv5j4m4c-gnugrep-3.11                 	 923.1K	  33.8M
/nix/store/7xhrcm6a01qri8z2wa4lxzkpc2wfnagm-bash-interactive-5.2-p15     	   6.9M	  42.0M		/nix/store/7xhrcm6a01qri8z2wa4lxzkpc2wfnagm-bash-interactive-5.2-p15     	   6.9M	  42.0M
/nix/store/82l3h9kjn1zna08imm0nwm7l1izcynj2-libnetfilter_conntrack-1.0.9 	 191.6K	  31.4M		/nix/store/82l3h9kjn1zna08imm0nwm7l1izcynj2-libnetfilter_conntrack-1.0.9 	 191.6K	  31.4M
/nix/store/887ah57n3qswyzpp9xw1rp1f34ic6iij-mpfr-4.2.0                   	 774.0K	  40.2M		/nix/store/887ah57n3qswyzpp9xw1rp1f34ic6iij-mpfr-4.2.0                   	 774.0K	  40.2M
/nix/store/8d4qv95rk4j2j6pjy9ms58v00qn6kvdh-libmpg123-1.31.3             	   1.0M	  32.1M		/nix/store/8d4qv95rk4j2j6pjy9ms58v00qn6kvdh-libmpg123-1.31.3             	   1.0M	  32.1M
/nix/store/8gyspdnmixflq9yz40qakx99g0p61dlh-gnutls-3.8.0                 	   3.1M	  50.5M		/nix/store/8gyspdnmixflq9yz40qakx99g0p61dlh-gnutls-3.8.0                 	   3.1M	  50.5M
/nix/store/8h3m8xp2gd12k86rlxdjrwpw0awfw5gb-libcap-ng-0.8.3              	 124.3K	  31.2M		/nix/store/8h3m8xp2gd12k86rlxdjrwpw0awfw5gb-libcap-ng-0.8.3              	 124.3K	  31.2M
/nix/store/8kfx5qh4kraggz5ssymijf23za7cn062-binutils-wrapper-2.40        	  50.1K	  84.7M		/nix/store/8kfx5qh4kraggz5ssymijf23za7cn062-binutils-wrapper-2.40        	  50.1K	  84.7M
/nix/store/8klnjyanarww18nm4rnfwfhr0dg3h7g8-cuda_nvprof-11.7.50          	   9.9M	 129.6M	   <
/nix/store/8ms33xrly9iqn17i3i63q8q08b4gp9b3-gcc-11.3.0-libgcc            	 114.3K	 114.3K		/nix/store/8ms33xrly9iqn17i3i63q8q08b4gp9b3-gcc-11.3.0-libgcc            	 114.3K	 114.3K
/nix/store/8smsbzym6v3g2lbmpsrgs03h1s4igvlq-gcc-11.3.0                   	 183.1M	 244.6M		/nix/store/8smsbzym6v3g2lbmpsrgs03h1s4igvlq-gcc-11.3.0                   	 183.1M	 244.6M
/nix/store/948365qwrzdm33wr80s8qx0qf0yvdb6i-elfutils-0.189               	   3.5M	  57.4M		/nix/store/948365qwrzdm33wr80s8qx0qf0yvdb6i-elfutils-0.189               	   3.5M	  57.4M
/nix/store/99kyqdivq646j0w4smh2bfqd2pkrcrai-libxcb-1.14                  	   1.3M	  32.5M		/nix/store/99kyqdivq646j0w4smh2bfqd2pkrcrai-libxcb-1.14                  	   1.3M	  32.5M
/nix/store/9adpz6y8s4mgkxfhc9rzy25r7f3wdyll-systemd-253.5                	  31.4M	 174.4M		/nix/store/9adpz6y8s4mgkxfhc9rzy25r7f3wdyll-systemd-253.5                	  31.4M	 174.4M
/nix/store/9c9lw70phd4nq0qvrkpajn059g6v0m0i-libogg-1.3.5                 	  44.3K	  31.1M		/nix/store/9c9lw70phd4nq0qvrkpajn059g6v0m0i-libogg-1.3.5                 	  44.3K	  31.1M
/nix/store/9dq1mkizzbp03wl8ph93slj3izpirzw0-cuda_cupti-11.7.50           	  88.4M	  88.6M	   <
/nix/store/9dvq1hgk5fvrnjq4sd6w9m7m0zha70mf-libXdamage-1.1.5             	  18.1K	  35.1M		/nix/store/9dvq1hgk5fvrnjq4sd6w9m7m0zha70mf-libXdamage-1.1.5             	  18.1K	  35.1M
/nix/store/9iinah4b33nxsy385s4bwbsxh9frp8p8-xcb-util-image-0.4.1         	  27.1K	  32.5M		/nix/store/9iinah4b33nxsy385s4bwbsxh9frp8p8-xcb-util-image-0.4.1         	  27.1K	  32.5M
/nix/store/9jds127qlgrdimvdar717z1f6mzs1lm6-isl-0.20                     	   2.5M	  41.9M		/nix/store/9jds127qlgrdimvdar717z1f6mzs1lm6-isl-0.20                     	   2.5M	  41.9M
/nix/store/9lasijmsk42n22rgbcd2z2pf78j770hq-gcc-wrapper-11.3.0           	  58.6K	 282.2M		/nix/store/9lasijmsk42n22rgbcd2z2pf78j770hq-gcc-wrapper-11.3.0           	  58.6K	 282.2M
/nix/store/9ml14aglvyn87spm90v4q2m35wh0brqd-openblas-0.3.21              	  26.1M	  67.8M		/nix/store/9ml14aglvyn87spm90v4q2m35wh0brqd-openblas-0.3.21              	  26.1M	  67.8M
/nix/store/9n1a99ja790p6f4mw2q43gipnqx95pw2-libcublas-11.10.1.25         	   1.1G	   1.2G	   <
/nix/store/9v86kmgcd6p75ljv2gl591v7k7lmpj4l-xcb-util-renderutil-0.3.10   	  28.1K	  32.5M		/nix/store/9v86kmgcd6p75ljv2gl591v7k7lmpj4l-xcb-util-renderutil-0.3.10   	  28.1K	  32.5M
/nix/store/a6vivcl5j98l3ccb046i623vah0x4zy8-attr-2.5.1                   	  78.8K	  31.2M		/nix/store/a6vivcl5j98l3ccb046i623vah0x4zy8-attr-2.5.1                   	  78.8K	  31.2M
/nix/store/aicch09ly6spvdma29srgq9nfw6y9pkw-libnfnetlink-1.0.2           	  55.2K	  31.1M		/nix/store/aicch09ly6spvdma29srgq9nfw6y9pkw-libnfnetlink-1.0.2           	  55.2K	  31.1M
/nix/store/aipzqp7a4691ir6igrdlisv2axxy235q-pulseaudio-16.1              	   8.6M	 225.0M		/nix/store/aipzqp7a4691ir6igrdlisv2axxy235q-pulseaudio-16.1              	   8.6M	 225.0M
/nix/store/b4xcs9rdnlizcjvh9x25x7x7ysm4n7wg-libjpeg-turbo-2.1.5.1        	   1.6M	  32.7M		/nix/store/b4xcs9rdnlizcjvh9x25x7x7ysm4n7wg-libjpeg-turbo-2.1.5.1        	   1.6M	  32.7M
/nix/store/bkmq392ya9qdbkhvxwp50shwlva2sy65-gcc-11.3.0-lib               	   7.4M	  46.3M		/nix/store/bkmq392ya9qdbkhvxwp50shwlva2sy65-gcc-11.3.0-lib               	   7.4M	  46.3M
/nix/store/bnpy6ypmsi21gym32qj8yb26sbsmf8bq-libXext-1.3.4                	  94.2K	  35.1M		/nix/store/bnpy6ypmsi21gym32qj8yb26sbsmf8bq-libXext-1.3.4                	  94.2K	  35.1M
/nix/store/bx5qbszgqlpvynimjnz9nb9kfpkglvvk-shadow-4.13                  	   4.3M	  53.5M		/nix/store/bx5qbszgqlpvynimjnz9nb9kfpkglvvk-shadow-4.13                  	   4.3M	  53.5M
/nix/store/c7bic6rgsy763r395kva24q3p642ixj5-fftw-single-3.3.10           	   4.0M	  45.7M		/nix/store/c7bic6rgsy763r395kva24q3p642ixj5-fftw-single-3.3.10           	   4.0M	  45.7M
/nix/store/ca7bdv2jdqflpg9vqbz6gpclh6cwmk4m-lz4-1.9.4                    	 231.5K	  31.3M		/nix/store/ca7bdv2jdqflpg9vqbz6gpclh6cwmk4m-lz4-1.9.4                    	 231.5K	  31.3M
/nix/store/cak8yw2svq9p0dn869pklvlzrbnq357x-curl-8.1.1                   	 837.4K	  53.1M		/nix/store/cak8yw2svq9p0dn869pklvlzrbnq357x-curl-8.1.1                   	 837.4K	  53.1M
/nix/store/cg0f1vdqgfx78n8rn60bzrbl2lhvh5y8-pcre-8.45                    	 513.3K	  31.6M		/nix/store/cg0f1vdqgfx78n8rn60bzrbl2lhvh5y8-pcre-8.45                    	 513.3K	  31.6M
/nix/store/cgmbz0wglid7v5m0m0a70ksvgyxppsgn-glib-2.76.3                  	  13.2M	  49.6M		/nix/store/cgmbz0wglid7v5m0m0a70ksvgyxppsgn-glib-2.76.3                  	  13.2M	  49.6M
/nix/store/cgxmicqj51758mbv0qz9y4ry31h4h2w8-kmod-30-lib                  	 120.4K	  40.7M		/nix/store/cgxmicqj51758mbv0qz9y4ry31h4h2w8-kmod-30-lib                  	 120.4K	  40.7M
/nix/store/d4grvyvpnc1f1p2ypl3ayxqqykbi6dv2-libtasn1-4.19.0              	  91.7K	  31.2M		/nix/store/d4grvyvpnc1f1p2ypl3ayxqqykbi6dv2-libtasn1-4.19.0              	  91.7K	  31.2M
/nix/store/d4wb4vw0i85xyy7qs82l4s4mr2yigvc9-gcc-12.3.0-libgcc            	 139.1K	 139.1K		/nix/store/d4wb4vw0i85xyy7qs82l4s4mr2yigvc9-gcc-12.3.0-libgcc            	 139.1K	 139.1K
/nix/store/d9s241xhxhxr0ncixhq8kj9iw79rg56b-gnupg-2.4.0                  	   1.1M	  36.1M		/nix/store/d9s241xhxhxr0ncixhq8kj9iw79rg56b-gnupg-2.4.0                  	   1.1M	  36.1M
/nix/store/df9c7n5hdx7ml0jrvrv7blmkygznpz81-libXcomposite-0.4.5          	  25.1K	  35.1M		/nix/store/df9c7n5hdx7ml0jrvrv7blmkygznpz81-libXcomposite-0.4.5          	  25.1K	  35.1M
/nix/store/dg9h4d3xw6ppmkranywi2845jxj9c71s-xz-5.4.3-bin                 	 174.5K	  32.0M		/nix/store/dg9h4d3xw6ppmkranywi2845jxj9c71s-xz-5.4.3-bin                 	 174.5K	  32.0M
/nix/store/dsra7fps6lbdkz9xv8hh863q7r8kray2-expand-response-params       	  16.4K	  31.1M		/nix/store/dsra7fps6lbdkz9xv8hh863q7r8kray2-expand-response-params       	  16.4K	  31.1M
/nix/store/dsrzdvab2kl6n4nl3kvwjqvm72r1yh7y-xkeyboard-config-2.33        	   5.7M	   5.7M		/nix/store/dsrzdvab2kl6n4nl3kvwjqvm72r1yh7y-xkeyboard-config-2.33        	   5.7M	   5.7M
/nix/store/fbiggz755ajhjpv615fgnr64imjghbsh-nspr-4.35                    	 337.8K	  31.4M		/nix/store/fbiggz755ajhjpv615fgnr64imjghbsh-nspr-4.35                    	 337.8K	  31.4M
/nix/store/fn3k787ly5hi0ak66w3zql86mlcsj07l-libgpg-error-1.47            	 815.0K	  31.9M		/nix/store/fn3k787ly5hi0ak66w3zql86mlcsj07l-libgpg-error-1.47            	 815.0K	  31.9M
/nix/store/fqrbxmsp3p0fn9icbh20nwnyq7xqrb0y-gmp-with-cxx-6.2.1           	 730.4K	  39.5M		/nix/store/fqrbxmsp3p0fn9icbh20nwnyq7xqrb0y-gmp-with-cxx-6.2.1           	 730.4K	  39.5M
/nix/store/g78ycfn68n2mmf76yfczdrrqnziy8ksl-gmp-with-cxx-6.2.1           	 729.2K	  39.5M		/nix/store/g78ycfn68n2mmf76yfczdrrqnziy8ksl-gmp-with-cxx-6.2.1           	 729.2K	  39.5M
/nix/store/gkh0lkj9wmlkhbkkpf8fp7zjf1521pyl-freetype-2.13.0              	   2.0M	  35.2M		/nix/store/gkh0lkj9wmlkhbkkpf8fp7zjf1521pyl-freetype-2.13.0              	   2.0M	  35.2M
/nix/store/glk21f0vr9lfjjmw6qh0rky9haslhijr-expat-2.5.0                  	 253.0K	  31.3M		/nix/store/glk21f0vr9lfjjmw6qh0rky9haslhijr-expat-2.5.0                  	 253.0K	  31.3M
/nix/store/gqa04d6hmzp3iirfkhly3ssdarfj2zc3-gzip-1.12                    	 153.1K	  32.8M		/nix/store/gqa04d6hmzp3iirfkhly3ssdarfj2zc3-gzip-1.12                    	 153.1K	  32.8M
/nix/store/gvy6qzrbhbk5lyplz4dajmqxqmmf7714-tcb-1.2                      	  88.8K	  46.5M		/nix/store/gvy6qzrbhbk5lyplz4dajmqxqmmf7714-tcb-1.2                      	  88.8K	  46.5M
/nix/store/gx7s27xmdyhn66975q9hymq0dqbx640c-libGL-1.6.0                  	 520.0 	  37.6M		/nix/store/gx7s27xmdyhn66975q9hymq0dqbx640c-libGL-1.6.0                  	 520.0 	  37.6M
/nix/store/gxwsa0w5f8krfgwfk9axn58hpa6pbiy2-fontconfig-2.14.2-lib        	 389.7K	  38.2M		/nix/store/gxwsa0w5f8krfgwfk9axn58hpa6pbiy2-fontconfig-2.14.2-lib        	 389.7K	  38.2M
/nix/store/gxx0r925z1rsfjqhq1l83pk3aszfkd11-brotli-1.0.9-lib             	   1.7M	  32.8M		/nix/store/gxx0r925z1rsfjqhq1l83pk3aszfkd11-brotli-1.0.9-lib             	   1.7M	  32.8M
/nix/store/h2ws458h5gwavr8bygklc3kyrkfayf30-readline-8.2p1               	 459.3K	  35.1M		/nix/store/h2ws458h5gwavr8bygklc3kyrkfayf30-readline-8.2p1               	 459.3K	  35.1M
/nix/store/h449fmwdwj5dx3qk45shzxpx7hx4iciq-libXcursor-1.2.0             	  68.4K	  35.2M		/nix/store/h449fmwdwj5dx3qk45shzxpx7hx4iciq-libXcursor-1.2.0             	  68.4K	  35.2M
/nix/store/hklzbmhk9b34ivyvr7ad9jnv6cv2ixsz-linux-headers-6.3            	   6.1M	   6.1M		/nix/store/hklzbmhk9b34ivyvr7ad9jnv6cv2ixsz-linux-headers-6.3            	   6.1M	   6.1M
/nix/store/i4mwwpgwfihb14nkd99dcqx6s2i8kaxw-libevent-2.1.12              	 841.5K	  31.9M		/nix/store/i4mwwpgwfihb14nkd99dcqx6s2i8kaxw-libevent-2.1.12              	 841.5K	  31.9M
/nix/store/i56iy2wh77lvsz4r7d3fi7gybf72qg3r-wayland-1.22.0               	 385.6K	  31.5M		/nix/store/i56iy2wh77lvsz4r7d3fi7gybf72qg3r-wayland-1.22.0               	 385.6K	  31.5M
/nix/store/i9z5bii1j2imwk6054ib79291ka89dvx-libtool-2.4.7-lib            	  55.9K	  31.1M		/nix/store/i9z5bii1j2imwk6054ib79291ka89dvx-libtool-2.4.7-lib            	  55.9K	  31.1M
/nix/store/ifq0va0bw4yn7p9ysd48q9a2g9lh39ms-gnutar-1.34                  	   2.8M	  34.0M		/nix/store/ifq0va0bw4yn7p9ysd48q9a2g9lh39ms-gnutar-1.34                  	   2.8M	  34.0M
/nix/store/ih1lp7zs2shysnj0vvqhwm3d326q7cx4-dejavu-fonts-minimal-2.37    	 742.6K	 742.6K		/nix/store/ih1lp7zs2shysnj0vvqhwm3d326q7cx4-dejavu-fonts-minimal-2.37    	 742.6K	 742.6K
/nix/store/ii5lq0igwk9xpq16s98yqswsgr1dbfi2-openssl-3.0.9                	   6.2M	  37.3M		/nix/store/ii5lq0igwk9xpq16s98yqswsgr1dbfi2-openssl-3.0.9                	   6.2M	  37.3M
/nix/store/jk6jc5x1pv2zz0vzm7mg62rm79ycnb5j-binutils-2.40-lib            	   2.7M	  33.9M		/nix/store/jk6jc5x1pv2zz0vzm7mg62rm79ycnb5j-binutils-2.40-lib            	   2.7M	  33.9M
/nix/store/jnrr7v49llxvdyif25symk076spkp696-glibc-2.37-8-dev             	   2.2M	  42.0M		/nix/store/jnrr7v49llxvdyif25symk076spkp696-glibc-2.37-8-dev             	   2.2M	  42.0M
/nix/store/js2x4ms31sdgjf0w7icv10ddhc0z3acw-ncurses-6.4                  	   3.5M	  34.6M		/nix/store/js2x4ms31sdgjf0w7icv10ddhc0z3acw-ncurses-6.4                  	   3.5M	  34.6M
/nix/store/k3xam7hvravqdc6qrr3w4m6vh0q507kv-cryptsetup-2.6.1             	   2.1M	 106.0M		/nix/store/k3xam7hvravqdc6qrr3w4m6vh0q507kv-cryptsetup-2.6.1             	   2.1M	 106.0M
/nix/store/kbhs7xxh914c47rvvww7cm9vbj1c4ips-cudatoolkit-11.7.0-lib       	   1.8M	   1.8M		/nix/store/kbhs7xxh914c47rvvww7cm9vbj1c4ips-cudatoolkit-11.7.0-lib       	   1.8M	   1.8M
/nix/store/kgk0dgq5jircsxcq6rab53knw43fiyvj-cudatoolkit-11.7.0-unsplit   	 669.7K	   5.4G		/nix/store/kgk0dgq5jircsxcq6rab53knw43fiyvj-cudatoolkit-11.7.0-unsplit   	 669.7K	   5.4G
/nix/store/kl31xb2ik0yb073km4zzbvg394nz5vr8-nccl-2.16.5-1-cuda-11-dev    	 300.6M	 635.5M		/nix/store/kl31xb2ik0yb073km4zzbvg394nz5vr8-nccl-2.16.5-1-cuda-11-dev    	 300.6M	 635.5M
												   >	/nix/store/kscv7gr52w3j0mh39w0byfa9sqzj7p7h-python3.10-torch-2.0.1       	  74.4M	   9.2G
/nix/store/l3q0p387arx1lka7ygqjdy3nibm2x8jr-db-4.8.30                    	   3.4M	  42.2M		/nix/store/l3q0p387arx1lka7ygqjdy3nibm2x8jr-db-4.8.30                    	   3.4M	  42.2M
/nix/store/l5q7gplbncwj6y3ybmy60lvqwzghp9x9-numactl-2.0.16               	 243.2K	  31.3M		/nix/store/l5q7gplbncwj6y3ybmy60lvqwzghp9x9-numactl-2.0.16               	 243.2K	  31.3M
/nix/store/l6pmvf3d45k0y45m2hiv7sfxvwf77m95-nghttp2-1.51.0-lib           	 220.9K	  31.3M		/nix/store/l6pmvf3d45k0y45m2hiv7sfxvwf77m95-nghttp2-1.51.0-lib           	 220.9K	  31.3M
/nix/store/l6x7jz2qkriwf1ms80cpln0kfnly75y5-libpng-apng-1.6.39           	 249.3K	  31.5M		/nix/store/l6x7jz2qkriwf1ms80cpln0kfnly75y5-libpng-apng-1.6.39           	 249.3K	  31.5M
/nix/store/lisv3xjdm5zmbfxhh50b8kz9dqrqmkkv-systemd-minimal-253.5        	  12.4M	  97.1M		/nix/store/lisv3xjdm5zmbfxhh50b8kz9dqrqmkkv-systemd-minimal-253.5        	  12.4M	  97.1M
/nix/store/lnmzbbzb2jw1h9zx5f5vclss9w4qgz2j-openssl-3.0.9                	   6.2M	  37.3M		/nix/store/lnmzbbzb2jw1h9zx5f5vclss9w4qgz2j-openssl-3.0.9                	   6.2M	  37.3M
/nix/store/lpfpyp4rkh7i3bxj39p17v4x0g36r5w7-gfortran-12.3.0-libgcc       	 139.1K	 139.1K		/nix/store/lpfpyp4rkh7i3bxj39p17v4x0g36r5w7-gfortran-12.3.0-libgcc       	 139.1K	 139.1K
/nix/store/lz5r68apazpkvnqpy7007485gr6l1dr8-libxml2-2.10.4               	   1.5M	  32.7M		/nix/store/lz5r68apazpkvnqpy7007485gr6l1dr8-libxml2-2.10.4               	   1.5M	  32.7M
/nix/store/lz73kn62ikbii0711g8m21siiflrifyj-util-linux-minimal-2.39-bin  	   7.3M	  62.8M		/nix/store/lz73kn62ikbii0711g8m21siiflrifyj-util-linux-minimal-2.39-bin  	   7.3M	  62.8M
/nix/store/m65kpc27s8b7nyg3pwzmp489d5la9yp6-libpcap-1.10.4               	   1.1M	  35.2M		/nix/store/m65kpc27s8b7nyg3pwzmp489d5la9yp6-libpcap-1.10.4               	   1.1M	  35.2M
/nix/store/m7i0mj1ng64ddnkqahpbjfjfg6qkk9cv-audit-3.1.1                  	 785.9K	  33.5M		/nix/store/m7i0mj1ng64ddnkqahpbjfjfg6qkk9cv-audit-3.1.1                  	 785.9K	  33.5M
/nix/store/mh1c3p23xby3chc3q0c0g78fa1nn65yw-bash-5.2-p15                 	   1.6M	  32.7M		/nix/store/mh1c3p23xby3chc3q0c0g78fa1nn65yw-bash-5.2-p15                 	   1.6M	  32.7M
/nix/store/mj2javl078b56lkml97jn8k410b8lzlf-mailcap-2.1.53               	 109.4K	 109.4K		/nix/store/mj2javl078b56lkml97jn8k410b8lzlf-mailcap-2.1.53               	 109.4K	 109.4K
/nix/store/mr4590j5gwg8p53rncr8pd1y8ap6x08m-getent-glibc-2.37-8          	 520.0 	  33.8M		/nix/store/mr4590j5gwg8p53rncr8pd1y8ap6x08m-getent-glibc-2.37-8          	 520.0 	  33.8M
/nix/store/n32rla0prb7hi1ycrrhqks6i8b9zc35q-libXrandr-1.5.2              	  62.9K	  35.3M		/nix/store/n32rla0prb7hi1ycrrhqks6i8b9zc35q-libXrandr-1.5.2              	  62.9K	  35.3M
/nix/store/nbhykjdirn8yfkizmsw9fvzf0vh7j1dn-libapparmor-3.1.4            	 440.8K	  31.5M		/nix/store/nbhykjdirn8yfkizmsw9fvzf0vh7j1dn-libapparmor-3.1.4            	 440.8K	  31.5M
/nix/store/ncpmwy10fdzjq7g8x7xhj0hv0b5wfydd-libmicrohttpd-0.9.71         	 159.4K	  50.6M		/nix/store/ncpmwy10fdzjq7g8x7xhj0hv0b5wfydd-libmicrohttpd-0.9.71         	 159.4K	  50.6M
/nix/store/nfi14jlj14qjlcwp8fl113xir9xp2zs1-python3.10-torch-2.0.1-lib   	1006.5M	  12.3G	   <
/nix/store/nfs7kcfxjjad2hl8i52jiwkacrf2sb6r-libassuan-2.5.5              	  97.3K	  32.0M		/nix/store/nfs7kcfxjjad2hl8i52jiwkacrf2sb6r-libassuan-2.5.5              	  97.3K	  32.0M
/nix/store/np8qiak9f1p9hg3m9a8d5lc6f9jw6z4r-tpm2-tss-3.2.0               	   2.5M	  55.8M		/nix/store/np8qiak9f1p9hg3m9a8d5lc6f9jw6z4r-tpm2-tss-3.2.0               	   2.5M	  55.8M
/nix/store/nwym4ys464vziikfjwmc9ngamcfaygvm-libX11-1.8.4                 	   2.6M	  35.0M		/nix/store/nwym4ys464vziikfjwmc9ngamcfaygvm-libX11-1.8.4                 	   2.6M	  35.0M
/nix/store/p7njqfc1l00hxvm5zvjshahxqca5k9vm-dconf-0.40.0-lib             	 299.7K	  49.9M		/nix/store/p7njqfc1l00hxvm5zvjshahxqca5k9vm-dconf-0.40.0-lib             	 299.7K	  49.9M
/nix/store/pdmr79kcqjnd7d38wrx23fkmbrd6njsf-cuda_cudart-11.7.60          	   6.3M	   6.3M	   <
/nix/store/pf3si7nkxwdbg07q0m5zx9mkgzdp9g9y-libxcrypt-4.4.35             	 128.0K	  31.2M		/nix/store/pf3si7nkxwdbg07q0m5zx9mkgzdp9g9y-libxcrypt-4.4.35             	 128.0K	  31.2M
/nix/store/pp5xprzcjd0i1x5fav0z1qc5nfnwkiz3-sbc-2.0                      	 260.1K	  31.3M		/nix/store/pp5xprzcjd0i1x5fav0z1qc5nfnwkiz3-sbc-2.0                      	 260.1K	  31.3M
/nix/store/ps4675zc6vwk47ssvq56qza9hs2s8p12-libopus-1.4                  	 401.5K	  31.5M		/nix/store/ps4675zc6vwk47ssvq56qza9hs2s8p12-libopus-1.4                  	 401.5K	  31.5M
/nix/store/q2r07izn69ipnhkjdsnwz28p0rzfas0a-libXfixes-6.0.0              	  38.2K	  35.1M		/nix/store/q2r07izn69ipnhkjdsnwz28p0rzfas0a-libXfixes-6.0.0              	  38.2K	  35.1M
/nix/store/q7vpyclsq7dbiibmyp98ba8p7as8p5gf-dns-root-data-2019-01-11     	   4.4K	   4.4K		/nix/store/q7vpyclsq7dbiibmyp98ba8p7as8p5gf-dns-root-data-2019-01-11     	   4.4K	   4.4K
/nix/store/qg3qxiaj261jhkkcvc7wjgphkykn33ck-libXdmcp-1.1.3               	  31.4K	  31.1M		/nix/store/qg3qxiaj261jhkkcvc7wjgphkykn33ck-libXdmcp-1.1.3               	  31.4K	  31.1M
/nix/store/qzs91y7s4rwl7mihvh87h8zs29hzcs2i-libffi-3.4.4                 	  55.2K	  31.1M		/nix/store/qzs91y7s4rwl7mihvh87h8zs29hzcs2i-libffi-3.4.4                 	  55.2K	  31.1M
/nix/store/r06lkppz8w5v6vp37czy0xnyaj1hqwfy-npth-1.6                     	  52.0K	  32.7M		/nix/store/r06lkppz8w5v6vp37czy0xnyaj1hqwfy-npth-1.6                     	  52.0K	  32.7M
/nix/store/r2j7iy2rnba5h37fwxpws6dnkflr6i1w-json-c-0.16                  	 219.6K	  31.3M		/nix/store/r2j7iy2rnba5h37fwxpws6dnkflr6i1w-json-c-0.16                  	 219.6K	  31.3M
/nix/store/r81gh1j2qcybfgwibylcz6alfc6qpvag-lame-3.100-lib               	 325.4K	  31.4M		/nix/store/r81gh1j2qcybfgwibylcz6alfc6qpvag-lame-3.100-lib               	 325.4K	  31.4M
/nix/store/r8mn5j3m5m1m5vnb6f9i0z80zdlkykcn-libvorbis-1.3.7              	   1.1M	  32.2M		/nix/store/r8mn5j3m5m1m5vnb6f9i0z80zdlkykcn-libvorbis-1.3.7              	   1.1M	  32.2M
/nix/store/rbsx8rfk9kv7x17np4a0kb2b6lyr69dk-nettle-3.9.1                 	 697.8K	  40.2M		/nix/store/rbsx8rfk9kv7x17np4a0kb2b6lyr69dk-nettle-3.9.1                 	 697.8K	  40.2M
/nix/store/rhgnd19svycj2mda64q9yn32r6qjdkgz-libdeflate-1.18              	 391.9K	  31.5M		/nix/store/rhgnd19svycj2mda64q9yn32r6qjdkgz-libdeflate-1.18              	 391.9K	  31.5M
/nix/store/rnnrmrcsywlrml2yfbc4yazp92m7glxm-bzip2-1.0.8-bin              	  68.5K	  31.2M		/nix/store/rnnrmrcsywlrml2yfbc4yazp92m7glxm-bzip2-1.0.8-bin              	  68.5K	  31.2M
/nix/store/rrcbm65kag76snp2wjhkrmkr621xr4yy-webrtc-audio-processing-0.3.1	 849.2K	  39.6M		/nix/store/rrcbm65kag76snp2wjhkrmkr621xr4yy-webrtc-audio-processing-0.3.1	 849.2K	  39.6M
/nix/store/rsb5c85xwscxzard8axyvbih6f983gi5-xz-5.4.3                     	 781.5K	  31.9M		/nix/store/rsb5c85xwscxzard8axyvbih6f983gi5-xz-5.4.3                     	 781.5K	  31.9M
/nix/store/s9zl0rv45yc3ymx61q6n97c3l7196pq4-zlib-1.2.13                  	 129.6K	  31.2M		/nix/store/s9zl0rv45yc3ymx61q6n97c3l7196pq4-zlib-1.2.13                  	 129.6K	  31.2M
/nix/store/sbj4jbm1svdlssfybwnhw5z2k1864dif-kmod-30                      	 206.2K	  40.8M		/nix/store/sbj4jbm1svdlssfybwnhw5z2k1864dif-kmod-30                      	 206.2K	  40.8M
/nix/store/sh7r7lkkdyrq46kq5y7nwi9c139mmwcz-libglvnd-1.6.0               	   2.5M	  37.6M		/nix/store/sh7r7lkkdyrq46kq5y7nwi9c139mmwcz-libglvnd-1.6.0               	   2.5M	  37.6M
/nix/store/siq4zkpmxvkzfvjsp4lr5rk7pk576hzf-libtiff-4.5.0                	 597.5K	  42.2M		/nix/store/siq4zkpmxvkzfvjsp4lr5rk7pk576hzf-libtiff-4.5.0                	 597.5K	  42.2M
/nix/store/sj74dfn1nx3br6gbrksdr41yvwfii34g-libXau-1.0.9                 	  23.4K	  31.1M		/nix/store/sj74dfn1nx3br6gbrksdr41yvwfii34g-libXau-1.0.9                 	  23.4K	  31.1M
/nix/store/v51vdfbgvk3vq81l3z4s1mcynyfic171-libseccomp-2.5.4-lib         	 138.9K	  31.2M		/nix/store/v51vdfbgvk3vq81l3z4s1mcynyfic171-libseccomp-2.5.4-lib         	 138.9K	  31.2M
/nix/store/vjjppwmdmrs1bnr5czcdn5xd8qh2pv3i-libasyncns-0.8               	  56.1K	  31.1M		/nix/store/vjjppwmdmrs1bnr5czcdn5xd8qh2pv3i-libasyncns-0.8               	  56.1K	  31.1M
/nix/store/vza500i228agfnb4rpihh5nd1knxvmrr-acl-2.3.1                    	 108.9K	  31.3M		/nix/store/vza500i228agfnb4rpihh5nd1knxvmrr-acl-2.3.1                    	 108.9K	  31.3M
/nix/store/w4lwvqgf0v5846ygqfq0zga54fvbrgpv-libXtst-1.2.3                	 121.8K	  35.3M		/nix/store/w4lwvqgf0v5846ygqfq0zga54fvbrgpv-libXtst-1.2.3                	 121.8K	  35.3M
/nix/store/w5vammzy1lc6bz0idnxb3ln3wxk8wgj3-libmpc-1.3.1                 	 273.4K	  40.5M		/nix/store/w5vammzy1lc6bz0idnxb3ln3wxk8wgj3-libmpc-1.3.1                 	 273.4K	  40.5M
/nix/store/w5w0w4apy89wajsvik06p0xwb4zbzrbw-util-linux-minimal-2.39-lib  	   1.8M	  32.9M		/nix/store/w5w0w4apy89wajsvik06p0xwb4zbzrbw-util-linux-minimal-2.39-lib  	   1.8M	  32.9M
/nix/store/wcycj7mjx18d1d9iyzik16fag9pzcznc-zstd-1.5.5                   	   1.1M	  39.9M		/nix/store/wcycj7mjx18d1d9iyzik16fag9pzcznc-zstd-1.5.5                   	   1.1M	  39.9M
/nix/store/wlb0hlks3j9vlqy2ph6s2jrlzmh0ikgr-libnl-3.7.0                  	   1.4M	  32.5M		/nix/store/wlb0hlks3j9vlqy2ph6s2jrlzmh0ikgr-libnl-3.7.0                  	   1.4M	  32.5M
/nix/store/wldwl0c1x2lfhd6s8l82ily6wd5j60qb-libnftnl-1.2.5               	 300.5K	  31.4M		/nix/store/wldwl0c1x2lfhd6s8l82ily6wd5j60qb-libnftnl-1.2.5               	 300.5K	  31.4M
/nix/store/wpgrc564ys39vbyv0m50qxmq8dvhi7cc-glibc-2.37-8                 	  28.8M	  31.1M		/nix/store/wpgrc564ys39vbyv0m50qxmq8dvhi7cc-glibc-2.37-8                 	  28.8M	  31.1M
/nix/store/wx5f74rwx4xb9rg416im6w3w8qxgk78z-sqlite-3.42.0                	   1.4M	  32.6M		/nix/store/wx5f74rwx4xb9rg416im6w3w8qxgk78z-sqlite-3.42.0                	   1.4M	  32.6M
/nix/store/x250qmlrr39gb2lgdn34nbk2138d6yj6-pcsclite-1.9.5               	  87.8K	  31.2M		/nix/store/x250qmlrr39gb2lgdn34nbk2138d6yj6-pcsclite-1.9.5               	  87.8K	  31.2M
												   >	/nix/store/x3kh1adanqylak6jbzpacdd4zgk944yv-python3.10-torch-2.0.1-lib   	   1.3G	   9.1G
/nix/store/x5zbhgg6rf5g9098jc8w1q71fq7179b2-soxr-0.1.3                   	 290.4K	  39.1M		/nix/store/x5zbhgg6rf5g9098jc8w1q71fq7179b2-soxr-0.1.3                   	 290.4K	  39.1M
/nix/store/xr0rc6y719iyks4lq5xba0g2inqng1zy-libssh2-1.11.0               	 309.7K	  37.7M		/nix/store/xr0rc6y719iyks4lq5xba0g2inqng1zy-libssh2-1.11.0               	 309.7K	  37.7M
/nix/store/xr4ms7hais72qx2lx6mc2xa0w8gf2m78-lvm2-2.03.21-lib             	 408.3K	  97.5M		/nix/store/xr4ms7hais72qx2lx6mc2xa0w8gf2m78-lvm2-2.03.21-lib             	 408.3K	  97.5M
/nix/store/y306322qv2dh5qrb5f3hgj9rmdpkzxb4-gdk-pixbuf-2.42.10           	   2.8M	  63.6M		/nix/store/y306322qv2dh5qrb5f3hgj9rmdpkzxb4-gdk-pixbuf-2.42.10           	   2.8M	  63.6M
/nix/store/y4bkflfiprrz1f7zkax1707rwqc7aj0x-libXi-1.8                    	  84.4K	  35.2M		/nix/store/y4bkflfiprrz1f7zkax1707rwqc7aj0x-libXi-1.8                    	  84.4K	  35.2M
/nix/store/y8clqrrm47j3vw2z9vy5ryqsrhad1imp-libfido2-1.13.0              	 981.3K	 104.5M		/nix/store/y8clqrrm47j3vw2z9vy5ryqsrhad1imp-libfido2-1.13.0              	 981.3K	 104.5M
/nix/store/ylm9xzdbznl6ymqwzy6i7f89ig323ilm-libunistring-1.1             	   1.8M	   1.8M		/nix/store/ylm9xzdbznl6ymqwzy6i7f89ig323ilm-libunistring-1.1             	   1.8M	   1.8M
/nix/store/ylwqkikzvl571iql3cj6ghqzis7d5kjp-libXrender-0.9.10            	  53.6K	  35.1M		/nix/store/ylwqkikzvl571iql3cj6ghqzis7d5kjp-libXrender-0.9.10            	  53.6K	  35.1M
/nix/store/zc7vf2b6qkacgdkqkna6aa7afhnfmr0x-alsa-lib-1.2.9               	   1.6M	  33.4M		/nix/store/zc7vf2b6qkacgdkqkna6aa7afhnfmr0x-alsa-lib-1.2.9               	   1.6M	  33.4M
/nix/store/zhja0pvyj1xr5gqlf4qfsj2qnwjgb8r7-p11-kit-0.24.1               	   3.5M	  36.3M		/nix/store/zhja0pvyj1xr5gqlf4qfsj2qnwjgb8r7-p11-kit-0.24.1               	   3.5M	  36.3M
/nix/store/zhpm4kw1sx324gxi7c9d6yyv2mc51kvr-flac-1.4.2                   	 683.9K	  39.5M		/nix/store/zhpm4kw1sx324gxi7c9d6yyv2mc51kvr-flac-1.4.2                   	 683.9K	  39.5M
/nix/store/zlyam0ii825f26az586mpqiy0wqrw3x2-python3.10-torch-2.0.1       	  74.4M	  12.4G	   <
/nix/store/zqvld83ifnkq7947ccki5gi4cniwl0ip-nccl-2.16.5-1-cuda-11        	 296.1M	 334.9M		/nix/store/zqvld83ifnkq7947ccki5gi4cniwl0ip-nccl-2.16.5-1-cuda-11        	 296.1M	 334.9M
/nix/store/zx8v56ga7hadl9hrnv4sj5rlrvqhjq13-keyutils-1.6.3-lib           	  41.5K	  31.1M		/nix/store/zx8v56ga7hadl9hrnv4sj5rlrvqhjq13-keyutils-1.6.3-lib           	  41.5K	  31.1M
```
</details>

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

Verified PyTorch still works on my 4090 on NixOS by cloning https://github.com/ConnorBaker/nix-cuda-test and running

```bash
nix develop \
  --override-input nixpkgs "github:NixOS/nixpkgs/refs/pull/238465/head" \
  --command -- python3 -m nix_cuda_test --batch-size 160
```

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
