### PR TITLE
mmlgui: unstable-2023-03-19 -> unstable-2023-06-12, fix cross

### DIFF
--- a/pkgs/applications/audio/mmlgui/default.nix
+++ b/pkgs/applications/audio/mmlgui/default.nix
@@ -15,14 +15,14 @@
 
 stdenv.mkDerivation rec {
   pname = "mmlgui";
-  version = "unstable-2023-03-19";
+  version = "unstable-2023-06-12";
 
   src = fetchFromGitHub {
     owner = "superctr";
     repo = "mmlgui";
-    rev = "59ac28c0008e227c03799cce85b77f96241159b1";
+    rev = "d680f576aba769b0d63300fbed57a0e9e54dfa4b";
     fetchSubmodules = true;
-    sha256 = "0CHRUizhg/WOWhDOsFqRiGu/m/U7xt5du8Uvnl7kxpU=";
+    hash = "sha256-BqwayGQBIa0ru22Xci8vHNYPFr9scZSdrUOlDtGBnno=";
   };
 
   postPatch = ''
@@ -31,9 +31,17 @@ stdenv.mkDerivation rec {
     # Removing a pkgconf-specific option makes it work with pkg-config
     substituteInPlace libvgm.mak \
       --replace '--with-path=/usr/local/lib/pkgconfig' ""
+
+    # Use correct pkg-config
+    substituteInPlace {imgui,libvgm}.mak \
+      --replace 'pkg-config' "\''$(PKG_CONFIG)"
+
+    # Don't force building tests
     substituteInPlace Makefile \
       --replace 'all: $(MMLGUI_BIN) test' 'all: $(MMLGUI_BIN)'
   '';
+
+  strictDeps = true;
 
   nativeBuildInputs = [
     pkg-config
@@ -51,7 +59,7 @@ stdenv.mkDerivation rec {
     Cocoa
   ];
 
-  nativeCheckInputs = [
+  checkInputs = [
     cppunit
   ];
 
@@ -61,7 +69,7 @@ stdenv.mkDerivation rec {
 
   enableParallelBuilding = true;
 
-  doCheck = true;
+  doCheck = stdenv.buildPlatform.canExecute stdenv.hostPlatform;
 
   installPhase = ''
     runHook preInstall


### PR DESCRIPTION
###### Description of changes

- Bumped to latest commit
- Fixed cross-compilation (tested i686-linux, aarch64-linux)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
