### PR TITLE
systemd: secureboot experiment with addons

### DIFF
--- a/pkgs/os-specific/linux/systemd/0002-Don-t-try-to-unmount-nix-or-nix-store.patch
+++ b/pkgs/os-specific/linux/systemd/0002-Don-t-try-to-unmount-nix-or-nix-store.patch
@@ -1,18 +1,20 @@
-From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
-From: Eelco Dolstra <eelco.dolstra@logicblox.com>
-Date: Fri, 12 Apr 2013 13:16:57 +0200
+From 400dfb2405f42da99c37a9a5c00edd2dd56e7cc1 Mon Sep 17 00:00:00 2001
+From: Raito Bezarius <masterancpp@gmail.com>
+Date: Mon, 19 Jun 2023 02:11:35 +0200
 Subject: [PATCH] Don't try to unmount /nix or /nix/store
 
 They'll still be remounted read-only.
 
 https://github.com/NixOS/nixos/issues/126
+
+Original-Author: Eelco Dolstra <eelco.dolstra@logicblox.com>
 ---
  src/shared/fstab-util.c | 2 ++
- src/shutdown/umount.c   | 2 ++
- 2 files changed, 4 insertions(+)
+ src/shutdown/umount.c   | 6 ++++--
+ 2 files changed, 6 insertions(+), 2 deletions(-)
 
 diff --git a/src/shared/fstab-util.c b/src/shared/fstab-util.c
-index 164e71a150..68e0766594 100644
+index b0e274afcc..3c80aef5cf 100644
 --- a/src/shared/fstab-util.c
 +++ b/src/shared/fstab-util.c
 @@ -41,6 +41,8 @@ bool fstab_is_extrinsic(const char *mount, const char *opts) {
@@ -25,15 +27,22 @@ index 164e71a150..68e0766594 100644
                          "/etc"))
                  return true;
 diff --git a/src/shutdown/umount.c b/src/shutdown/umount.c
-index 61bd9d2601..a6243da417 100644
+index 1586c2e214..fcae95f824 100644
 --- a/src/shutdown/umount.c
 +++ b/src/shutdown/umount.c
-@@ -531,6 +531,8 @@ static int delete_md(MountPoint *m) {
- 
+@@ -170,8 +170,10 @@ int mount_points_list_get(const char *mountinfo, MountPoint **head) {
  static bool nonunmountable_path(const char *path) {
-         return path_equal(path, "/")
+         assert(path);
+ 
+-        return PATH_IN_SET(path, "/", "/usr") ||
+-                path_startswith(path, "/run/initramfs");
++        return PATH_IN_SET(path, "/", "/usr")
 +                || path_equal(path, "/nix")
 +                || path_equal(path, "/nix/store")
- #if ! HAVE_SPLIT_USR
-                 || path_equal(path, "/usr")
- #endif
++                || path_startswith(path, "/run/initramfs");
+ }
+ 
+ static void log_umount_blockers(const char *mnt) {
+-- 
+2.41.0
+

--- a/pkgs/os-specific/linux/systemd/0004-Add-some-NixOS-specific-unit-directories.patch
+++ b/pkgs/os-specific/linux/systemd/0004-Add-some-NixOS-specific-unit-directories.patch
@@ -1,6 +1,6 @@
-From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
-From: Eelco Dolstra <eelco.dolstra@logicblox.com>
-Date: Fri, 19 Dec 2014 14:46:17 +0100
+From fdb447c500408248650317c576c08e9dfd8c872c Mon Sep 17 00:00:00 2001
+From: Raito Bezarius <masterancpp@gmail.com>
+Date: Mon, 19 Jun 2023 02:13:42 +0200
 Subject: [PATCH] Add some NixOS-specific unit directories
 
 Look in `/nix/var/nix/profiles/default/lib/systemd/{system,user}` for
@@ -8,13 +8,15 @@ units provided by packages installed into the default profile via
 `nix-env -iA nixos.$package`.
 
 Also, remove /usr and /lib as these don't exist on NixOS.
+
+Original-Author: Eelco Dolstra <eelco.dolstra@logicblox.com>
 ---
  src/basic/path-lookup.c | 17 ++---------------
  src/core/systemd.pc.in  |  8 ++++----
  2 files changed, 6 insertions(+), 19 deletions(-)
 
 diff --git a/src/basic/path-lookup.c b/src/basic/path-lookup.c
-index c99e9d8786..b9f85d1f8c 100644
+index 7d158a8295..f9bd62b631 100644
 --- a/src/basic/path-lookup.c
 +++ b/src/basic/path-lookup.c
 @@ -92,11 +92,7 @@ int xdg_user_data_dir(char **ret, const char *suffix) {
@@ -62,35 +64,37 @@ index c99e9d8786..b9f85d1f8c 100644
                                          STRV_IFNOTNULL(generator_late));
                          break;
  
-@@ -808,7 +799,6 @@ char **generator_binary_paths(LookupScope scope) {
-                 case LOOKUP_SCOPE_SYSTEM:
+@@ -808,7 +799,6 @@ char **generator_binary_paths(RuntimeScope scope) {
+                 case RUNTIME_SCOPE_SYSTEM:
                          add = strv_new("/run/systemd/system-generators",
                                         "/etc/systemd/system-generators",
 -                                       "/usr/local/lib/systemd/system-generators",
                                         SYSTEM_GENERATOR_DIR);
                          break;
  
-@@ -816,7 +806,6 @@ char **generator_binary_paths(LookupScope scope) {
-                 case LOOKUP_SCOPE_USER:
+@@ -816,7 +806,6 @@ char **generator_binary_paths(RuntimeScope scope) {
+                 case RUNTIME_SCOPE_USER:
                          add = strv_new("/run/systemd/user-generators",
                                         "/etc/systemd/user-generators",
 -                                       "/usr/local/lib/systemd/user-generators",
                                         USER_GENERATOR_DIR);
                          break;
  
-@@ -855,12 +844,10 @@ char **env_generator_binary_paths(bool is_system) {
-                 if (is_system)
+@@ -855,14 +844,12 @@ char **env_generator_binary_paths(RuntimeScope runtime_scope) {
+                 case RUNTIME_SCOPE_SYSTEM:
                          add = strv_new("/run/systemd/system-environment-generators",
                                          "/etc/systemd/system-environment-generators",
 -                                        "/usr/local/lib/systemd/system-environment-generators",
                                          SYSTEM_ENV_GENERATOR_DIR);
-                 else
+                         break;
+ 
+                 case RUNTIME_SCOPE_USER:
                          add = strv_new("/run/systemd/user-environment-generators",
                                         "/etc/systemd/user-environment-generators",
 -                                       "/usr/local/lib/systemd/user-environment-generators",
                                         USER_ENV_GENERATOR_DIR);
+                         break;
  
-                 if (!add)
 diff --git a/src/core/systemd.pc.in b/src/core/systemd.pc.in
 index 693433b34b..5932a21b5b 100644
 --- a/src/core/systemd.pc.in
@@ -121,3 +125,6 @@ index 693433b34b..5932a21b5b 100644
  systemdusergeneratorpath=${systemd_user_generator_path}
  
  systemd_sleep_dir=${root_prefix}/lib/systemd/system-sleep
+-- 
+2.41.0
+

--- a/pkgs/os-specific/linux/systemd/0019-load-addons-from-type1-entries.patch
+++ b/pkgs/os-specific/linux/systemd/0019-load-addons-from-type1-entries.patch
@@ -1,0 +1,68 @@
+From 3ed0b6a695f3e847bc00a7d024db4eadaba3033f Mon Sep 17 00:00:00 2001
+From: Raito Bezarius <masterancpp@gmail.com>
+Date: Fri, 16 Jun 2023 14:03:35 +0200
+Subject: [PATCH] systemd-boot(config): load addons paths from configuration
+
+This make it possible to attach addons to any Type #1 entry.
+---
+ src/boot/efi/boot.c | 16 +++++++++++++++-
+ 1 file changed, 15 insertions(+), 1 deletion(-)
+
+diff --git a/src/boot/efi/boot.c b/src/boot/efi/boot.c
+index cda6f56426..29d976d2ec 100644
+--- a/src/boot/efi/boot.c
++++ b/src/boot/efi/boot.c
+@@ -56,6 +56,7 @@ typedef struct {
+         char16_t *devicetree;
+         char16_t *options;
+         char16_t **initrd;
++        char16_t **addons; /* systemd-addons for this entry */
+         char16_t key;
+         EFI_STATUS (*call)(void);
+         int tries_done;
+@@ -576,6 +577,8 @@ static void print_status(Config *config, char16_t *loaded_image_path) {
+                         printf("        loader: %ls\n", entry->loader);
+                 STRV_FOREACH(initrd, entry->initrd)
+                         printf("        initrd: %ls\n", *initrd);
++                STRV_FOREACH(addon, entry->addons)
++                        printf("         addon: %ls\n", *addon);
+                 if (entry->devicetree)
+                         printf("    devicetree: %ls\n", entry->devicetree);
+                 if (entry->options)
+@@ -1092,6 +1095,7 @@ static void config_entry_free(ConfigEntry *entry) {
+         free(entry->devicetree);
+         free(entry->options);
+         strv_free(entry->initrd);
++        strv_free(entry->addons);
+         free(entry->path);
+         free(entry->current_name);
+         free(entry->next_name);
+@@ -1405,7 +1409,7 @@ static void config_entry_add_type1(
+ 
+         _cleanup_(config_entry_freep) ConfigEntry *entry = NULL;
+         char *line;
+-        size_t pos = 0, n_initrd = 0;
++        size_t pos = 0, n_initrd = 0, n_addons = 0;
+         char *key, *value;
+         EFI_STATUS err;
+ 
+@@ -1493,6 +1497,16 @@ static void config_entry_add_type1(
+                         continue;
+                 }
+ 
++                if (streq8(key, "add-on")) {
++                        entry->addons = xrealloc(
++                                entry->addons,
++                                n_addons == 0 ? 0 : (n_addons + 1) * sizeof(uint16_t *),
++                                (n_addons + 2) * sizeof(uint16_t *));
++                        entry->addons[n_addons++] = xstr8_to_path(value);
++                        entry->addons[n_addons] = NULL;
++                        continue;
++                }
++
+                 if (streq8(key, "options")) {
+                         _cleanup_free_ char16_t *new = NULL;
+ 
+-- 
+2.41.0
+

--- a/pkgs/os-specific/linux/systemd/0020-load-initrd-from-addons-in-stub.patch
+++ b/pkgs/os-specific/linux/systemd/0020-load-initrd-from-addons-in-stub.patch
@@ -1,0 +1,258 @@
+From 06a8375e55ae1469f7b9cc70fabdacd07c35492b Mon Sep 17 00:00:00 2001
+From: Raito Bezarius <masterancpp@gmail.com>
+Date: Mon, 19 Jun 2023 01:57:59 +0200
+Subject: [PATCH] systemd-stub: support loading `.initrd` via addons
+
+Loading `.initrd` via addons is now possible by transforming the "command line append via addon"
+into a generic "process addons and provide an set of 'what can change depending on policy choice' structure
+to the caller", this is `struct addon_additions`.
+
+Multiple design choices were made implicitly,
+for the best or the worse, some of them are discutable.
+
+- existing initrd in the UKI has priority over any addon:
+  if addons are to be used, the UKI should be built "without initrd" probably
+  as it can trivially regain his default initrd via an addon.
+
+- global addons cannot load `.initrd`, this is usually unwanted as only UKI-specific addon
+  can bring out the desired initrd for this particular boot entry rather than a generic one.
+
+- global addons will still measure `.initrd` if present in TPM PCR16
+
+- UKI-specific addon will consider only the unique `.initrd` section of the last addon provided
+  it is unclear if this is an good idea or not ; it means that priority is based on (more or less)
+  source path sorting which is semi-predictable if you know enough about it.
+
+- UKI-specific addon will still measure all passed `.initrd` if present in TPM PCR16
+
+- `addon_additions` will still count the number of measured initrds in total
+
+- `.initrd` via addons are measured in TPM PCR16, a new PCR introduced
+  for initrd addons measurements, exposed via EFI variable
+  `StubPcrInitRDAddons` if any measurement was done
+---
+ src/boot/efi/stub.c       | 124 ++++++++++++++++++++++++++++++--------
+ src/fundamental/tpm-pcr.h |   4 ++
+ 2 files changed, 104 insertions(+), 24 deletions(-)
+
+diff --git a/src/boot/efi/stub.c b/src/boot/efi/stub.c
+index 93a3641424..0a00642fc5 100644
+--- a/src/boot/efi/stub.c
++++ b/src/boot/efi/stub.c
+@@ -21,6 +21,15 @@
+ /* magic string to find in the binary image */
+ _used_ _section_(".sdmagic") static const char magic[] = "#### LoaderInfo: systemd-stub " GIT_VERSION " ####";
+ 
++struct addon_additions {
++        char16_t *cmdline_append; /* this gets append to the command line */
++        bool parameters_measured;
++
++        EFI_PHYSICAL_ADDRESS initrd_base_override; /* this replaces the initrd */
++        size_t initrd_size;
++        int initrd_measured;
++};
++
+ static EFI_STATUS combine_initrd(
+                 EFI_PHYSICAL_ADDRESS initrd_base, size_t initrd_size,
+                 const void * const extra_initrds[], const size_t extra_initrd_sizes[], size_t n_extra_initrds,
+@@ -246,25 +255,22 @@ static EFI_STATUS load_addons_from_dir(
+ 
+ }
+ 
+-static EFI_STATUS cmdline_append_and_measure_addons(
+-                EFI_HANDLE stub_image,
+-                EFI_LOADED_IMAGE_PROTOCOL *loaded_image,
+-                const char16_t *prefix,
+-                const char *uname,
+-                bool *ret_parameters_measured,
+-                char16_t **cmdline_append) {
++static EFI_STATUS process_and_measure_addons(
++        EFI_HANDLE stub_image,
++        EFI_LOADED_IMAGE_PROTOCOL *loaded_image,
++        const char16_t *prefix,
++        const char *uname,
++        struct addon_additions *additions) {
+ 
+         _cleanup_(strv_freep) char16_t **items = NULL;
+         _cleanup_(file_closep) EFI_FILE *root = NULL;
+-        _cleanup_free_ char16_t *buffer = NULL;
+         size_t n_items = 0, n_allocated = 0;
+         EFI_STATUS err;
+ 
+         assert(stub_image);
+         assert(loaded_image);
+         assert(prefix);
+-        assert(ret_parameters_measured);
+-        assert(cmdline_append);
++        assert(additions);
+ 
+         if (!loaded_image->DeviceHandle)
+                 return EFI_SUCCESS;
+@@ -318,11 +324,14 @@ static EFI_STATUS cmdline_append_and_measure_addons(
+                         return log_error_status(err, "Failed to find protocol in %ls: %m", items[i]);
+ 
+                 err = pe_memory_locate_sections(loaded_addon->ImageBase, unified_sections, addrs, szs);
+-                if (err != EFI_SUCCESS || szs[UNIFIED_SECTION_CMDLINE] == 0) {
++                /* an useful addon contains either cmdline or initrd */
++                bool contains_useful_section = (szs[UNIFIED_SECTION_CMDLINE] > 0
++                        || szs[UNIFIED_SECTION_INITRD] > 0);
++                if (err != EFI_SUCCESS || !contains_useful_section) {
+                         if (err == EFI_SUCCESS)
+                                 err = EFI_NOT_FOUND;
+                         log_error_status(err,
+-                                         "Unable to locate embedded .cmdline section in %ls, ignoring: %m",
++                                         "Unable to locate embedded .cmdline or .initrd section in %ls, ignoring: %m",
+                                          items[i]);
+                         continue;
+                 }
+@@ -343,22 +352,78 @@ static EFI_STATUS cmdline_append_and_measure_addons(
+                         continue;
+                 }
+ 
+-                _cleanup_free_ char16_t *tmp = TAKE_PTR(buffer),
++                /* Extract initrd if available */
++                if (szs[UNIFIED_SECTION_INITRD] > 0) {
++                        bool m = false;
++                        additions->initrd_size = szs[UNIFIED_SECTION_INITRD];
++                        additions->initrd_base_override =
++                                POINTER_TO_PHYSICAL_ADDRESS(loaded_addon->ImageBase) +
++                                addrs[UNIFIED_SECTION_INITRD];
++
++                        (void) tpm_log_event_ascii(
++                                TPM_PCR_INDEX_INITRD_ADDONS,
++                                POINTER_TO_PHYSICAL_ADDRESS(unified_sections[UNIFIED_SECTION_INITRD]),
++                                strsize8(unified_sections[UNIFIED_SECTION_INITRD]),
++                                unified_sections[UNIFIED_SECTION_INITRD],
++                                &m);
++
++                        (void) tpm_log_event_ascii(
++                                TPM_PCR_INDEX_INITRD_ADDONS,
++                                additions->initrd_base_override,
++                                additions->initrd_size,
++                                unified_sections[UNIFIED_SECTION_INITRD],
++                                &m);
++
++                        additions->initrd_measured += (int)m;
++                }
++
++                /* Extract and join command line if available */
++                _cleanup_free_ char16_t *tmp = TAKE_PTR(additions->cmdline_append),
+                                         *extra16 = xstrn8_to_16((char *)loaded_addon->ImageBase + addrs[UNIFIED_SECTION_CMDLINE],
+                                                                 szs[UNIFIED_SECTION_CMDLINE]);
+-                buffer = xasprintf("%ls%ls%ls", strempty(tmp), isempty(tmp) ? u"" : u" ", extra16);
++                /* Python: " ".join(tmp, extra16) */
++                additions->cmdline_append = xasprintf("%ls%ls%ls", strempty(tmp), isempty(tmp) ? u"" : u" ", extra16);
+         }
+ 
+-        mangle_stub_cmdline(buffer);
++        mangle_stub_cmdline(additions->cmdline_append);
+ 
+-        if (!isempty(buffer)) {
+-                _cleanup_free_ char16_t *tmp = TAKE_PTR(*cmdline_append);
++        if (!isempty(additions->cmdline_append)) {
+                 bool m = false;
+ 
+-                (void) tpm_log_load_options(buffer, &m);
+-                *ret_parameters_measured = m;
++                (void) tpm_log_load_options(additions->cmdline_append, &m);
++                additions->parameters_measured = m;
++        }
++
++        return EFI_SUCCESS;
++
++}
++
++static EFI_STATUS cmdline_append_and_measure_addons(
++                EFI_HANDLE stub_image,
++                EFI_LOADED_IMAGE_PROTOCOL *loaded_image,
++                const char16_t *prefix,
++                const char *uname,
++                bool *ret_parameters_measured,
++                char16_t **cmdline_append) {
++        struct addon_additions addon_effects;
++        EFI_STATUS err;
+ 
+-                *cmdline_append = xasprintf("%ls%ls%ls", strempty(tmp), isempty(tmp) ? u"" : u" ", buffer);
++        err = process_and_measure_addons(
++                stub_image,
++                loaded_image,
++                prefix,
++                uname,
++                &addon_effects
++        );
++        if (err != EFI_SUCCESS)
++                return err;
++
++        *ret_parameters_measured = addon_effects.parameters_measured;
++        if (!isempty(addon_effects.cmdline_append)) {
++                _cleanup_free_ char16_t *tmp = TAKE_PTR(*cmdline_append);
++
++                *cmdline_append = xasprintf("%ls%ls%ls", strempty(tmp), isempty(tmp) ? u"" : u" ",
++                                            addon_effects.cmdline_append);
+         }
+ 
+         return EFI_SUCCESS;
+@@ -372,6 +437,7 @@ static EFI_STATUS run(EFI_HANDLE image) {
+         _cleanup_(devicetree_cleanup) struct devicetree_state dt_state = {};
+         EFI_LOADED_IMAGE_PROTOCOL *loaded_image;
+         size_t addrs[_UNIFIED_SECTION_MAX] = {}, szs[_UNIFIED_SECTION_MAX] = {};
++        struct addon_additions addon_effects;
+         _cleanup_free_ char16_t *cmdline = NULL;
+         int sections_measured = -1, parameters_measured = -1;
+         _cleanup_free_ char *uname = NULL;
+@@ -476,16 +542,20 @@ static EFI_STATUS run(EFI_HANDLE image) {
+         parameters_measured = parameters_measured < 0 ? m : (parameters_measured && m);
+ 
+         _cleanup_free_ char16_t *dropin_dir = get_extra_dir(loaded_image->FilePath);
+-        err = cmdline_append_and_measure_addons(
++        err = process_and_measure_addons(
+                         image,
+                         loaded_image,
+                         dropin_dir,
+                         uname,
+-                        &m,
+-                        &cmdline);
++                        &addon_effects);
+         if (err != EFI_SUCCESS)
+                 log_error_status(err, "Error loading UKI-specific addons, ignoring: %m");
+-        parameters_measured = parameters_measured < 0 ? m : (parameters_measured && m);
++        parameters_measured = parameters_measured < 0 ? addon_effects.parameters_measured : (parameters_measured
++                && addon_effects.parameters_measured);
++        if (addon_effects.initrd_measured > 0)
++                (void) efivar_set_uint_string(MAKE_GUID_PTR(LOADER), u"StubPcrInitRDAddons",
++                                              TPM_PCR_INDEX_INITRD_ADDONS, 0);
++
+ 
+         const char *extra = smbios_find_oem_string("io.systemd.stub.kernel-cmdline-extra");
+         if (extra) {
+@@ -589,6 +659,12 @@ static EFI_STATUS run(EFI_HANDLE image) {
+         initrd_size = szs[UNIFIED_SECTION_INITRD];
+         initrd_base = initrd_size != 0 ? POINTER_TO_PHYSICAL_ADDRESS(loaded_image->ImageBase) + addrs[UNIFIED_SECTION_INITRD] : 0;
+ 
++        /* If we do not have any initrd, but we do have an addon initrd, let's use it as a last resort? */
++        if (initrd_size == 0 && addon_effects.initrd_size != 0) {
++                initrd_size = addon_effects.initrd_size;
++                initrd_base = addon_effects.initrd_base_override;
++        }
++
+         dt_size = szs[UNIFIED_SECTION_DTB];
+         dt_base = dt_size != 0 ? POINTER_TO_PHYSICAL_ADDRESS(loaded_image->ImageBase) + addrs[UNIFIED_SECTION_DTB] : 0;
+ 
+diff --git a/src/fundamental/tpm-pcr.h b/src/fundamental/tpm-pcr.h
+index 4989d93f0c..5499be8baa 100644
+--- a/src/fundamental/tpm-pcr.h
++++ b/src/fundamental/tpm-pcr.h
+@@ -20,6 +20,10 @@
+ /* This TPM PCR is where we measure the root fs volume key (and maybe /var/'s) if it is split off */
+ #define TPM_PCR_INDEX_VOLUME_KEY 15U
+ 
++/* This TPM PCR is where we extend the initrd addon images into which we pass to the booted kernel
++ */
++#define TPM_PCR_INDEX_INITRD_ADDONS 16U
++
+ /* List of PE sections that have special meaning for us in unified kernels. This is the canonical order in
+  * which we measure the sections into TPM PCR 11 (see above). PLEASE DO NOT REORDER! */
+ typedef enum UnifiedSection {
+-- 
+2.41.0
+

--- a/pkgs/os-specific/linux/systemd/default.nix
+++ b/pkgs/os-specific/linux/systemd/default.nix
@@ -81,6 +81,7 @@
 , bpftools
 , libbpf
 
+, withAddons ? true
 , withAcl ? true
 , withAnalyze ? true
 , withApparmor ? true
@@ -190,6 +191,9 @@ stdenv.mkDerivation (finalAttrs: {
     ./0016-inherit-systemd-environment-when-calling-generators.patch
     ./0017-core-don-t-taint-on-unmerged-usr.patch
     ./0018-tpm2_context_init-fix-driver-name-checking.patch
+  ] ++ lib.optional withAddons [
+    ./0019-load-addons-from-type1-entries.patch
+    ./0020-load-initrd-from-addons-in-stub.patch
   ] ++ lib.optional stdenv.hostPlatform.isMusl (
     let
       oe-core = fetchzip {

--- a/pkgs/os-specific/linux/systemd/default.nix
+++ b/pkgs/os-specific/linux/systemd/default.nix
@@ -89,6 +89,7 @@
 , withCompression ? true  # adds bzip2, lz4, xz and zstd
 , withCoredump ? true
 , withCryptsetup ? true
+, withRepart ? true
 , withDocumentation ? true
 , withEfi ? stdenv.hostPlatform.isEfi
 , withFido2 ? true
@@ -141,6 +142,7 @@ assert withCoredump -> withCompression;
 assert withHomed -> withCryptsetup;
 assert withHomed -> withPam;
 assert withUkify -> withEfi;
+assert withRepart -> withCryptsetup;
 
 let
   wantCurl = withRemote || withImportd;
@@ -482,6 +484,7 @@ stdenv.mkDerivation (finalAttrs: {
     "-Dlibcurl=${lib.boolToString wantCurl}"
     "-Dlibidn=false"
     "-Dlibidn2=${lib.boolToString withLibidn2}"
+    "-Drepart=${lib.boolToString withRepart}"
     "-Dquotacheck=false"
     "-Dldconfig=false"
     "-Dsmack=true"

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -27891,6 +27891,7 @@ with pkgs;
     withCompression = false;
     withCoredump = false;
     withCryptsetup = false;
+    withRepart = false;
     withDocumentation = false;
     withEfi = false;
     withFido2 = false;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -27884,6 +27884,7 @@ with pkgs;
   };
   systemdMinimal = systemd.override {
     pname = "systemd-minimal";
+    withAddons = false;
     withAcl = false;
     withAnalyze = false;
     withApparmor = false;


### PR DESCRIPTION
###### Description of changes

For **systemd reviewers**: you are interested into the v254 bump commit for your own consumption. Otherwise, this is an internal development PR for showcase purpose.

For **lanzaboote contributors**: you are not interested here except if you want to touch systemd or read systemd stuff, everything should happen downstream in lanzaboote branch.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
