### PR TITLE
fscan: init at 1.8.2

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -10679,6 +10679,15 @@
     githubId = 1776903;
     name = "Andrew Abbott";
   };
+  Misaka13514 = {
+    name = "Misaka13514";
+    email = "Misaka13514@gmail.com";
+    matrix = "@misaka13514:matrix.org";
+    github = "Misaka13514";
+    githubId = 54669781;
+    keys =
+      [{ fingerprint = "293B 93D8 A471 059F 85D7  16A6 5BA9 2099 D9BE 2DAA"; }];
+  };
   mislavzanic = {
     email = "mislavzanic3@gmail.com";
     github = "mislavzanic";

--- a/pkgs/tools/security/fscan/default.nix
+++ b/pkgs/tools/security/fscan/default.nix
@@ -1,0 +1,23 @@
+{ lib, fetchFromGitHub, buildGoModule }:
+
+buildGoModule rec {
+  pname = "fscan";
+  version = "1.8.2";
+
+  src = fetchFromGitHub {
+    owner = "shadow1ng";
+    repo = "fscan";
+    rev = version;
+    hash = "sha256-PbhCKIr7qy4/hzx3TC7lnrQQw8rlUlprAbHdKdxgVuY=";
+  };
+
+  vendorHash = "sha256-pzcZgBcjGU5AyZfh+mHnphEboDDvQqseiuouwgb8rN8=";
+
+  meta = with lib; {
+    description = "An intranet comprehensive scanning tool";
+    homepage = "https://github.com/shadow1ng/fscan";
+    license = licenses.mit;
+    maintainers = with maintainers; [ Misaka13514 ];
+    platforms = with platforms; unix ++ windows;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1571,6 +1571,8 @@ with pkgs;
 
   etlegacy = callPackage ../games/etlegacy { lua = lua5_4; };
 
+  fscan = callPackage ../tools/security/fscan { };
+
   copier = callPackage ../tools/misc/copier { };
 
   gabutdm = callPackage ../applications/networking/gabutdm { };


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

fscan (init at 1.8.2)

Not quite sure about if `meta.platforms` is set correctly, please help

```
$ nix-build --arg crossSystem '{ config = "x86_64-darwin"; }' -A fscan --show-trace
error:
       … while calling the 'derivationStrict' builtin

         at //builtin/derivation.nix:9:12: (source not available)

       … while evaluating derivation 'fscan-x86_64-darwin-1.8.2'
         whose name attribute is located at /home/nixos/nixpkgs/pkgs/stdenv/generic/make-derivation.nix:303:7

       … while evaluating attribute 'configurePhase' of derivation 'fscan-x86_64-darwin-1.8.2'

         at /home/nixos/nixpkgs/pkgs/build-support/go/module.nix:156:5:

          155|
          156|     configurePhase = args.configurePhase or (''
             |     ^
          157|       runHook preConfigure

       … from call site

         at /home/nixos/nixpkgs/pkgs/build-support/go/module.nix:164:10:

          163|       cd "$modRoot"
          164|     '' + lib.optionalString (vendorHash != null) ''
             |          ^
          165|       ${if proxyVendor then ''

       … while calling 'optionalString'

         at /home/nixos/nixpkgs/lib/strings.nix:242:5:

          241|     # String to return if condition is true
          242|     string: if cond then string else "";
             |     ^
          243|

       … while evaluating derivation 'fscan-1.8.2-go-modules-x86_64-darwin'
         whose name attribute is located at /home/nixos/nixpkgs/pkgs/stdenv/generic/make-derivation.nix:303:7

       … while evaluating attribute 'nativeBuildInputs' of derivation 'fscan-1.8.2-go-modules-x86_64-darwin'

         at /home/nixos/nixpkgs/pkgs/stdenv/generic/make-derivation.nix:347:7:

          346|       depsBuildBuild              = lib.elemAt (lib.elemAt dependencies 0) 0;
          347|       nativeBuildInputs           = lib.elemAt (lib.elemAt dependencies 0) 1;
             |       ^
          348|       depsBuildTarget             = lib.elemAt (lib.elemAt dependencies 0) 2;

       … while evaluating derivation 'go-1.20.5'
         whose name attribute is located at /home/nixos/nixpkgs/pkgs/stdenv/generic/make-derivation.nix:303:7

       … while evaluating attribute 'CC_FOR_TARGET' of derivation 'go-1.20.5'

         at /home/nixos/nixpkgs/pkgs/development/compilers/go/1.20.nix:102:3:

          101|   # to be different from CC/CXX
          102|   CC_FOR_TARGET =
             |   ^
          103|     if isCross then

       … from call site

         at /home/nixos/nixpkgs/pkgs/development/compilers/llvm/11/default.nix:135:19:

          134|
          135|     libcxxClang = wrapCCWith rec {
             |                   ^
          136|       cc = tools.clang-unwrapped;

       … while calling 'wrapCCWith'

         at /home/nixos/nixpkgs/pkgs/top-level/all-packages.nix:16899:5:

        16898|   wrapCCWith =
        16899|     { cc
             |     ^
        16900|     , # This should be the only bintools runtime dep with this sort of logic. The

       … from call site

         at /home/nixos/nixpkgs/pkgs/top-level/all-packages.nix:16921:7:

        16920|     } @ extraArgs:
        16921|       callPackage ../build-support/cc-wrapper (let self = {
             |       ^
        16922|     nativeTools = stdenv.targetPlatform == stdenv.hostPlatform && stdenv.cc.nativeTools or false;

       … while calling 'callPackageWith'

         at /home/nixos/nixpkgs/lib/customisation.nix:128:35:

          127|   */
          128|   callPackageWith = autoArgs: fn: args:
             |                                   ^
          129|     let

       … from call site

         at /home/nixos/nixpkgs/lib/customisation.nix:179:34:

          178|
          179|     in if missingArgs == [] then makeOverridable f allArgs else abort error;
             |                                  ^
          180|

       … while calling 'makeOverridable'

         at /home/nixos/nixpkgs/lib/customisation.nix:78:24:

           77|   */
           78|   makeOverridable = f: origArgs:
             |                        ^
           79|     let

       … from call site

         at /home/nixos/nixpkgs/lib/customisation.nix:80:16:

           79|     let
           80|       result = f origArgs;
             |                ^
           81|

       … while calling anonymous lambda

         at /home/nixos/nixpkgs/pkgs/build-support/cc-wrapper/default.nix:8:1:

            7|
            8| { name ? ""
             | ^
            9| , lib

       … from call site

         at /home/nixos/nixpkgs/pkgs/top-level/all-packages.nix:18115:14:

        18114|   };
        18115|   bintools = wrapBintoolsWith {
             |              ^
        18116|     bintools = bintools-unwrapped;

       … while calling 'wrapBintoolsWith'

         at /home/nixos/nixpkgs/pkgs/top-level/all-packages.nix:16938:5:

        16937|   wrapBintoolsWith =
        16938|     { bintools
             |     ^
        16939|     , libc ? if stdenv.targetPlatform != stdenv.hostPlatform then libcCross else stdenv.cc.libc

       … from call site

         at /home/nixos/nixpkgs/pkgs/top-level/all-packages.nix:16942:7:

        16941|     } @ extraArgs:
        16942|       callPackage ../build-support/bintools-wrapper (let self = {
             |       ^
        16943|     nativeTools = stdenv.targetPlatform == stdenv.hostPlatform && stdenv.cc.nativeTools or false;

       … while calling 'callPackageWith'

         at /home/nixos/nixpkgs/lib/customisation.nix:128:35:

          127|   */
          128|   callPackageWith = autoArgs: fn: args:
             |                                   ^
          129|     let

       … from call site

         at /home/nixos/nixpkgs/lib/customisation.nix:179:34:

          178|
          179|     in if missingArgs == [] then makeOverridable f allArgs else abort error;
             |                                  ^
          180|

       … while calling 'makeOverridable'

         at /home/nixos/nixpkgs/lib/customisation.nix:78:24:

           77|   */
           78|   makeOverridable = f: origArgs:
             |                        ^
           79|     let

       … from call site

         at /home/nixos/nixpkgs/lib/customisation.nix:80:16:

           79|     let
           80|       result = f origArgs;
             |                ^
           81|

       … while calling anonymous lambda

         at /home/nixos/nixpkgs/pkgs/build-support/bintools-wrapper/default.nix:8:1:

            7|
            8| { name ? ""
             | ^
            9| , lib

       … from call site

         at /home/nixos/nixpkgs/pkgs/top-level/all-packages.nix:20909:69:

        20908|
        20909|   libcCross = assert stdenv.targetPlatform != stdenv.buildPlatform; libcCrossChooser stdenv.targetPlatform.libc;
             |                                                                     ^
        20910|

       … while calling 'libcCrossChooser'

         at /home/nixos/nixpkgs/pkgs/top-level/all-packages.nix:20884:22:

        20883|   # We can choose:
        20884|   libcCrossChooser = name:
             |                      ^
        20885|     # libc is hackily often used from the previous stage. This `or`

       error: don't yet have a `targetPackages.darwin.LibsystemCross for x86_64-darwin`
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
