### PR TITLE
mullvad-vpn: support `aarch64-linux`

### DIFF
--- a/pkgs/applications/networking/mullvad-vpn/default.nix
+++ b/pkgs/applications/networking/mullvad-vpn/default.nix
@@ -64,15 +64,28 @@ let
     systemd
   ];
 
-in
-
-stdenv.mkDerivation rec {
-  pname = "mullvad-vpn";
   version = "2023.4";
 
+  selectSystem = attrs: attrs.${stdenv.hostPlatform.system} or (throw "Unsupported system: ${stdenv.hostPlatform.system}");
+
+  platform = selectSystem {
+    x86_64-linux = "amd64";
+    aarch64-linux = "arm64";
+  };
+
+  hash = selectSystem {
+    x86_64-linux = "sha256-7NoifrX1/3pUJHTYK+2dVos/oFsKiYwyhCGi07SsEhM=";
+    aarch64-linux = "sha256-e0lp+SpBUmtYBcJPvql8ALeCkVtneZ1Cd3IFMVX6R2Q=";
+  };
+in
+
+stdenv.mkDerivation {
+  pname = "mullvad-vpn";
+  inherit version;
+
   src = fetchurl {
-    url = "https://github.com/mullvad/mullvadvpn-app/releases/download/${version}/MullvadVPN-${version}_amd64.deb";
-    sha256 = "sha256-7NoifrX1/3pUJHTYK+2dVos/oFsKiYwyhCGi07SsEhM=";
+    url = "https://github.com/mullvad/mullvadvpn-app/releases/download/${version}/MullvadVPN-${version}_${platform}.deb";
+    inherit hash;
   };
 
   nativeBuildInputs = [
@@ -114,13 +127,15 @@ stdenv.mkDerivation rec {
     runHook postInstall
   '';
 
+  passthru.updateScript = ./update.sh;
+
   meta = with lib; {
     homepage = "https://github.com/mullvad/mullvadvpn-app";
     description = "Client for Mullvad VPN";
     changelog = "https://github.com/mullvad/mullvadvpn-app/blob/${version}/CHANGELOG.md";
     sourceProvenance = with sourceTypes; [ binaryNativeCode ];
     license = licenses.gpl3Only;
-    platforms = [ "x86_64-linux" ];
+    platforms = [ "x86_64-linux" "aarch64-linux" ];
     maintainers = with maintainers; [ Br1ght0ne ymarkus ataraxiasjel ];
   };
 

--- a/pkgs/applications/networking/mullvad-vpn/update.sh
+++ b/pkgs/applications/networking/mullvad-vpn/update.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env nix-shell
+#!nix-shell -i bash -p curl gnused gawk jq nix-prefetch
+
+set -euo pipefail
+
+ROOT="$(dirname "$(readlink -f "$0")")"
+NIX_DRV="$ROOT/default.nix"
+if [ ! -f "$NIX_DRV" ]; then
+  echo "ERROR: cannot find default.nix in $ROOT"
+  exit 1
+fi
+
+fetch_arch() {
+  VER="$1"; ARCH="$2"
+  URL="https://github.com/mullvad/mullvadvpn-app/releases/download/${VER}/MullvadVPN-${VER}_${ARCH}.deb"
+  nix-prefetch "{ stdenv, fetchzip }:
+stdenv.mkDerivation rec {
+  pname = \"mullvad-vpn\"; version = \"${VER}\";
+  src = fetchurl { url = \"$URL\"; };
+}
+"
+}
+
+replace_sha() {
+  sed -i "s#$1 = \"sha256-.\{44\}\"#$1 = \"$2\"#" "$NIX_DRV"
+}
+
+MULLVAD_VER=$(curl -s https://api.mullvad.net/app/v1/releases/linux/2022.5 | jq -r '.latest_stable')
+
+MULLVAD_LINUX_X64_SHA256=$(fetch_arch "$MULLVAD_VER" "amd64")
+MULLVAD_LINUX_AARCH64_SHA256=$(fetch_arch "$MULLVAD_VER" "arm64")
+
+sed -i "s/version = \".*\"/version = \"$MULLVAD_VER\"/" "$NIX_DRV"
+
+replace_sha "x86_64-linux" "$MULLVAD_LINUX_X64_SHA256"
+replace_sha "aarch64-linux" "$MULLVAD_LINUX_AARCH64_SHA256"

--- a/pkgs/development/compilers/fasmg/default.nix
+++ b/pkgs/development/compilers/fasmg/default.nix
@@ -32,7 +32,7 @@ stdenv.mkDerivation rec {
         bin = "source/macos/fasmg";
         asm = "source/macos/fasmg.asm";
       };
-    }.${system} or (throw "Unsopported system: ${system}");
+    }.${system} or (throw "Unsupported system: ${system}");
 
   in ''
     chmod +x ${path.bin}


### PR DESCRIPTION
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).