### PR TITLE
elasticmq-server-bin: 1.4.1 -> 1.4.2

### DIFF
--- a/pkgs/servers/elasticmq-server-bin/default.nix
+++ b/pkgs/servers/elasticmq-server-bin/default.nix
@@ -3,11 +3,11 @@
 let
   elasticmq-server = stdenv.mkDerivation rec {
     pname = "elasticmq-server";
-    version = "1.4.1";
+    version = "1.4.2";
 
     src = fetchurl {
       url = "https://s3-eu-west-1.amazonaws.com/softwaremill-public/${pname}-${version}.jar";
-      sha256 = "sha256-F1G9shYvntFiSgLdXPkSTpN/MP86ewhHRIchbXues+s=";
+      sha256 = "sha256-71GlX8zwiC5tZm2LGSUdOa4ZDZUQQJ9zTY8viu2MQLk=";
     };
 
     # don't do anything?

--- a/pkgs/servers/elasticmq-server-bin/default.nix
+++ b/pkgs/servers/elasticmq-server-bin/default.nix
@@ -1,41 +1,41 @@
-{ lib, stdenv, fetchurl, jdk, jre, makeWrapper, runCommand, python3Packages, writeText }:
+{ lib, stdenv, fetchurl, jdk, jre, makeBinaryWrapper, runCommand, python3Packages, writeText }:
 
-let
-  elasticmq-server = stdenv.mkDerivation rec {
-    pname = "elasticmq-server";
-    version = "1.4.2";
+stdenv.mkDerivation (finalAttrs: {
+  pname = "elasticmq-server";
+  version = "1.4.2";
 
-    src = fetchurl {
-      url = "https://s3-eu-west-1.amazonaws.com/softwaremill-public/${pname}-${version}.jar";
-      sha256 = "sha256-71GlX8zwiC5tZm2LGSUdOa4ZDZUQQJ9zTY8viu2MQLk=";
-    };
-
-    # don't do anything?
-    unpackPhase = "${jdk}/bin/jar xf $src favicon.png";
-
-    nativeBuildInputs = [ makeWrapper ];
-
-    installPhase = ''
-      mkdir -p $out/bin $out/share/elasticmq-server
-
-      cp $src $out/share/elasticmq-server/elasticmq-server.jar
-
-      # TODO: how to add extraArgs? current workaround is to use JAVA_TOOL_OPTIONS environment to specify properties
-      makeWrapper ${jre}/bin/java $out/bin/elasticmq-server \
-        --add-flags "-jar $out/share/elasticmq-server/elasticmq-server.jar"
-    '';
-
-    meta = with lib; {
-      homepage = "https://github.com/softwaremill/elasticmq";
-      description = "Message queueing system with Java, Scala and Amazon SQS-compatible interfaces";
-      sourceProvenance = with sourceTypes; [ binaryBytecode ];
-      license = licenses.asl20;
-      platforms = platforms.unix;
-      maintainers = with maintainers; [ peterromfeldhk ];
-    };
+  src = fetchurl {
+    url = "https://s3-eu-west-1.amazonaws.com/softwaremill-public/${finalAttrs.pname}-${finalAttrs.version}.jar";
+    sha256 = "sha256-71GlX8zwiC5tZm2LGSUdOa4ZDZUQQJ9zTY8viu2MQLk=";
   };
-in elasticmq-server.overrideAttrs (_: {
+
+  # don't do anything?
+  unpackPhase = "${jdk}/bin/jar xf $src favicon.png";
+
+  nativeBuildInputs = [ makeBinaryWrapper ];
+
+  installPhase = ''
+    mkdir -p $out/bin $out/share/elasticmq-server
+
+    cp $src $out/share/elasticmq-server/elasticmq-server.jar
+
+    # TODO: how to add extraArgs? current workaround is to use JAVA_TOOL_OPTIONS environment to specify properties
+    makeWrapper ${jre}/bin/java $out/bin/elasticmq-server \
+      --add-flags "-jar $out/share/elasticmq-server/elasticmq-server.jar"
+  '';
+
   passthru.tests.elasticmqTest = import ./elasticmq-test.nix {
-    inherit elasticmq-server runCommand python3Packages writeText;
+    inherit runCommand python3Packages writeText;
+    elasticmq-server = finalAttrs.finalPackage;
+  };
+
+  meta = with lib; {
+    description = "Message queueing system with Java, Scala and Amazon SQS-compatible interfaces";
+    homepage = "https://github.com/softwaremill/elasticmq";
+    changelog = "https://github.com/softwaremill/elasticmq/releases/tag/v${finalAttrs.version}";
+    sourceProvenance = with sourceTypes; [ binaryBytecode ];
+    license = licenses.asl20;
+    platforms = platforms.unix;
+    maintainers = with maintainers; [ peterromfeldhk ];
   };
 })


### PR DESCRIPTION
###### Description of changes

Changelog: https://github.com/softwaremill/elasticmq/releases/tag/v1.4.2

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
