### PR TITLE
gitlab-container-registry: 3.76.0 -> 3.77.0

### DIFF
--- a/pkgs/applications/version-management/gitlab/gitlab-container-registry/Disable-inmemory-storage-driver-test.patch
+++ b/pkgs/applications/version-management/gitlab/gitlab-container-registry/Disable-inmemory-storage-driver-test.patch
@@ -1,0 +1,38 @@
+From bc359e8f51a17ba759121339e87e90eed16e98fe Mon Sep 17 00:00:00 2001
+From: Yaya <mak@nyantec.com>
+Date: Tue, 20 Jun 2023 10:01:23 +0000
+Subject: [PATCH] Disable inmemory storage driver test
+
+---
+ .../storage/driver/inmemory/driver_test.go    | 19 -------------------
+ 1 file changed, 19 deletions(-)
+ delete mode 100644 registry/storage/driver/inmemory/driver_test.go
+
+diff --git a/registry/storage/driver/inmemory/driver_test.go b/registry/storage/driver/inmemory/driver_test.go
+deleted file mode 100644
+index dbc1916f..00000000
+--- a/registry/storage/driver/inmemory/driver_test.go
++++ /dev/null
+@@ -1,19 +0,0 @@
+-package inmemory
+-
+-import (
+-	"testing"
+-
+-	storagedriver "github.com/docker/distribution/registry/storage/driver"
+-	"github.com/docker/distribution/registry/storage/driver/testsuites"
+-	"gopkg.in/check.v1"
+-)
+-
+-// Hook up gocheck into the "go test" runner.
+-func Test(t *testing.T) { check.TestingT(t) }
+-
+-func init() {
+-	inmemoryDriverConstructor := func() (storagedriver.StorageDriver, error) {
+-		return New(), nil
+-	}
+-	testsuites.RegisterSuite(inmemoryDriverConstructor, testsuites.NeverSkip)
+-}
+-- 
+2.40.1
+

--- a/pkgs/applications/version-management/gitlab/gitlab-container-registry/default.nix
+++ b/pkgs/applications/version-management/gitlab/gitlab-container-registry/default.nix
@@ -14,6 +14,10 @@ buildGoModule rec {
 
   vendorHash = "sha256-/ITZBh0vRYHb6fDUZQNRwW2pmQulJlDZ8EbObUBtsz4=";
 
+  patches = [
+    ./Disable-inmemory-storage-driver-test.patch
+  ];
+
   postPatch = ''
     substituteInPlace health/checks/checks_test.go \
       --replace \

--- a/pkgs/applications/version-management/gitlab/gitlab-container-registry/default.nix
+++ b/pkgs/applications/version-management/gitlab/gitlab-container-registry/default.nix
@@ -2,17 +2,17 @@
 
 buildGoModule rec {
   pname = "gitlab-container-registry";
-  version = "3.76.0";
+  version = "3.77.0";
   rev = "v${version}-gitlab";
 
   src = fetchFromGitLab {
     owner = "gitlab-org";
     repo = "container-registry";
     inherit rev;
-    sha256 = "sha256-A9c7c/CXRs5mYSvDOdHkYOYkl+Qm6M330TBUeTnegBs=";
+    sha256 = "sha256-tHNxPwm1h1wyXuzUUadz5YcRkPdc0QeayMIRt292uf8=";
   };
 
-  vendorHash = "sha256-9rO2GmoFZrNA3Udaktn8Ek9uM8EEoc0I3uv4UEq1c1k=";
+  vendorHash = "sha256-/ITZBh0vRYHb6fDUZQNRwW2pmQulJlDZ8EbObUBtsz4=";
 
   postPatch = ''
     substituteInPlace health/checks/checks_test.go \


### PR DESCRIPTION


###### Description of changes
https://gitlab.com/gitlab-org/container-registry/-/blob/v3.77.0-gitlab/CHANGELOG.md
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
