### PR TITLE
nixos: rebuild less derivations on nixpkgs/config hash changes.

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2311.section.md
+++ b/nixos/doc/manual/release-notes/rl-2311.section.md
@@ -112,6 +112,13 @@ The module update takes care of the new config syntax and the data itself (user 
 
 - `programs.gnupg.agent.pinentryFlavor` is now set in `/etc/gnupg/gpg-agent.conf`, and will no longer take precedence over a `pinentry-program` set in `~/.gnupg/gpg-agent.conf`.
 
+- A new top-level file was added to the NixOS system closure, `nixos-version.json`, containing the information displayed by the `nixos-version` script.
+  This file can be used by external tooling to discover version information regarding the NixOS system closure.
+  In addition, a new option, `system.installerTools.nixos-version.selfContained` was added.
+  When this option is set to `false`, the `nixos-version` script will no longer contain hard-coded version info but will instead display the information contained in `/run/current-system/nixos-version.json`.
+  By doing so, `nixos-version` becomes a static script without hard-coded values and thus we avoid changing the system path on every nixpkgs version bump, thereby reducing the amount of derivations that need to be rebuilt.
+  This option currently defaults to `true`, leading to the old behaviour with the version info hard-coded in the `nixos-version` script, but this default may be changed in the future.
+
 ## Nixpkgs internals {#sec-release-23.11-nixpkgs-internals}
 
 - The `qemu-vm.nix` module by default now identifies block devices via

--- a/nixos/modules/installer/tools/nixos-version.sh
+++ b/nixos/modules/installer/tools/nixos-version.sh
@@ -7,25 +7,25 @@ case "$1" in
     exit 1
     ;;
   --hash|--revision)
-    if ! [[ @revision@ =~ ^[0-9a-f]+$ ]]; then
+    revision="$(jq --raw-output '.nixpkgsRevision // "null"' < @nixosVersionJson@)"
+    if [ "$revision" == "null" ]; then
       echo "$0: Nixpkgs commit hash is unknown" >&2
       exit 1
     fi
-    echo "@revision@"
+    echo "$revision"
     ;;
   --configuration-revision)
-    if [[ "@configurationRevision@" =~ "@" ]]; then
+    revision="$(jq --raw-output '.configurationRevision // "null"' < @nixosVersionJson@)"
+    if [ "$revision" == "null" ]; then
       echo "$0: configuration revision is unknown" >&2
       exit 1
     fi
-    echo "@configurationRevision@"
+    echo "$revision"
     ;;
   --json)
-    cat <<EOF
-@json@
-EOF
+    cat @nixosVersionJson@
     ;;
   *)
-    echo "@version@ (@codeName@)"
+    jq --raw-output '.nixosVersion + " (" + .nixosCodeName + ")"' < @nixosVersionJson@
     ;;
 esac

--- a/nixos/modules/installer/tools/tools.nix
+++ b/nixos/modules/installer/tools/tools.nix
@@ -10,236 +10,278 @@ let
     dir = "bin";
     isExecutable = true;
   });
-
-  nixos-build-vms = makeProg {
-    name = "nixos-build-vms";
-    src = ./nixos-build-vms/nixos-build-vms.sh;
-    inherit (pkgs) runtimeShell;
-  };
-
-  nixos-install = makeProg {
-    name = "nixos-install";
-    src = ./nixos-install.sh;
-    inherit (pkgs) runtimeShell;
-    nix = config.nix.package.out;
-    path = makeBinPath [
-      pkgs.jq
-      nixos-enter
-      pkgs.util-linuxMinimal
-    ];
-  };
-
-  nixos-rebuild = pkgs.nixos-rebuild.override { nix = config.nix.package.out; };
-
-  nixos-generate-config = makeProg {
-    name = "nixos-generate-config";
-    src = ./nixos-generate-config.pl;
-    perl = "${pkgs.perl.withPackages (p: [ p.FileSlurp ])}/bin/perl";
-    hostPlatformSystem = pkgs.stdenv.hostPlatform.system;
-    detectvirt = "${config.systemd.package}/bin/systemd-detect-virt";
-    btrfs = "${pkgs.btrfs-progs}/bin/btrfs";
-    inherit (config.system.nixos-generate-config) configuration desktopConfiguration;
-    xserverEnabled = config.services.xserver.enable;
-  };
-
-  inherit (pkgs) nixos-option;
-
-  nixos-version = makeProg {
-    name = "nixos-version";
-    src = ./nixos-version.sh;
-    inherit (pkgs) runtimeShell;
-    inherit (config.system.nixos) version codeName revision;
-    inherit (config.system) configurationRevision;
-    json = builtins.toJSON ({
-      nixosVersion = config.system.nixos.version;
-    } // optionalAttrs (config.system.nixos.revision != null) {
-      nixpkgsRevision = config.system.nixos.revision;
-    } // optionalAttrs (config.system.configurationRevision != null) {
-      configurationRevision = config.system.configurationRevision;
-    });
-  };
-
-  nixos-enter = makeProg {
-    name = "nixos-enter";
-    src = ./nixos-enter.sh;
-    inherit (pkgs) runtimeShell;
-    path = makeBinPath [
-      pkgs.util-linuxMinimal
-    ];
-  };
-
 in
 
 {
+  options = {
+    system.nixos-generate-config = {
+      configuration = mkOption {
+        internal = true;
+        type = types.str;
+        description = lib.mdDoc ''
+          The NixOS module that `nixos-generate-config`
+          saves to `/etc/nixos/configuration.nix`.
 
-  options.system.nixos-generate-config = {
-    configuration = mkOption {
+          This is an internal option. No backward compatibility is guaranteed.
+          Use at your own risk!
+
+          Note that this string gets spliced into a Perl script. The perl
+          variable `$bootLoaderConfig` can be used to
+          splice in the boot loader configuration.
+        '';
+      };
+
+      desktopConfiguration = mkOption {
+        internal = true;
+        type = types.listOf types.lines;
+        default = [ ];
+        description = lib.mdDoc ''
+          Text to preseed the desktop configuration that `nixos-generate-config`
+          saves to `/etc/nixos/configuration.nix`.
+
+          This is an internal option. No backward compatibility is guaranteed.
+          Use at your own risk!
+
+          Note that this string gets spliced into a Perl script. The perl
+          variable `$bootLoaderConfig` can be used to
+          splice in the boot loader configuration.
+        '';
+      };
+    };
+
+    system.disableInstallerTools = mkOption {
       internal = true;
-      type = types.str;
+      type = types.bool;
+      default = false;
       description = lib.mdDoc ''
-        The NixOS module that `nixos-generate-config`
-        saves to `/etc/nixos/configuration.nix`.
-
-        This is an internal option. No backward compatibility is guaranteed.
-        Use at your own risk!
-
-        Note that this string gets spliced into a Perl script. The perl
-        variable `$bootLoaderConfig` can be used to
-        splice in the boot loader configuration.
+        Disable nixos-rebuild, nixos-generate-config, nixos-installer
+        and other NixOS tools. This is useful to shrink embedded,
+        read-only systems which are not expected to be rebuild or
+        reconfigure themselves. Use at your own risk!
       '';
     };
 
-    desktopConfiguration = mkOption {
+    system.installerTools = lib.mkOption {
       internal = true;
-      type = types.listOf types.lines;
-      default = [];
-      description = lib.mdDoc ''
-        Text to preseed the desktop configuration that `nixos-generate-config`
-        saves to `/etc/nixos/configuration.nix`.
+      type = lib.types.attrsOf (lib.types.submodule ({ name, config, lib, ... }: {
+        options = {
+          name = lib.mkOption {
+            type = lib.types.str;
+            description = lib.mdDoc ''
+              the name of the package
+            '';
+          };
 
-        This is an internal option. No backward compatibility is guaranteed.
-        Use at your own risk!
+          enable = lib.mkEnableOption (lib.mdDoc "the package as part of the installer tools.");
 
-        Note that this string gets spliced into a Perl script. The perl
-        variable `$bootLoaderConfig` can be used to
-        splice in the boot loader configuration.
+          package = lib.mkOption {
+            type = lib.types.package;
+            description = lib.mdDoc ''
+              the derivation providing the package
+            '';
+          };
+        };
+
+        config.name = lib.mkDefault name;
+      }));
+    };
+  };
+
+  config =
+    let
+      installerTools = lib.filterAttrs (_: tool: tool.enable) config.system.installerTools;
+    in
+    lib.mkIf (config.nix.enable && !config.system.disableInstallerTools) {
+
+      system.installerTools = {
+        nixos-build-vms = {
+          enable = true;
+          package = makeProg {
+            name = "nixos-build-vms";
+            src = ./nixos-build-vms/nixos-build-vms.sh;
+            inherit (pkgs) runtimeShell;
+          };
+        };
+
+        nixos-enter = {
+          enable = true;
+          package = makeProg {
+            name = "nixos-enter";
+            src = ./nixos-enter.sh;
+            inherit (pkgs) runtimeShell;
+            path = makeBinPath [
+              pkgs.util-linuxMinimal
+            ];
+          };
+        };
+
+        nixos-generate-config = {
+          enable = true;
+          package = makeProg {
+            name = "nixos-generate-config";
+            src = ./nixos-generate-config.pl;
+            perl = "${pkgs.perl.withPackages (p: [ p.FileSlurp ])}/bin/perl";
+            hostPlatformSystem = pkgs.stdenv.hostPlatform.system;
+            detectvirt = "${config.systemd.package}/bin/systemd-detect-virt";
+            btrfs = "${pkgs.btrfs-progs}/bin/btrfs";
+            inherit (config.system.nixos-generate-config) configuration desktopConfiguration;
+            xserverEnabled = config.services.xserver.enable;
+          };
+        };
+
+        nixos-install = {
+          enable = true;
+          package = makeProg {
+            name = "nixos-install";
+            src = ./nixos-install.sh;
+            inherit (pkgs) runtimeShell;
+            nix = config.nix.package.out;
+            path = makeBinPath [
+              pkgs.jq
+              config.system.installerTools.nixos-enter.package
+              pkgs.util-linuxMinimal
+            ];
+          };
+        };
+
+        nixos-option = {
+          enable = true;
+          package = pkgs.nixos-option;
+        };
+
+        nixos-rebuild = {
+          enable = true;
+          package = pkgs.nixos-rebuild.override { nix = config.nix.package.out; };
+        };
+
+        nixos-version = {
+          enable = true;
+          package = makeProg {
+            name = "nixos-version";
+            src = ./nixos-version.sh;
+            inherit (pkgs) runtimeShell;
+            inherit (config.system.nixos) version codeName revision;
+            inherit (config.system) configurationRevision;
+            json = builtins.toJSON ({
+              nixosVersion = config.system.nixos.version;
+            } // optionalAttrs (config.system.nixos.revision != null) {
+              nixpkgsRevision = config.system.nixos.revision;
+            } // optionalAttrs (config.system.configurationRevision != null) {
+              configurationRevision = config.system.configurationRevision;
+            });
+          };
+        };
+      };
+
+      system.nixos-generate-config.configuration = mkDefault ''
+        # Edit this configuration file to define what should be installed on
+        # your system.  Help is available in the configuration.nix(5) man page
+        # and in the NixOS manual (accessible by running `nixos-help`).
+
+        { config, pkgs, ... }:
+
+        {
+          imports =
+            [ # Include the results of the hardware scan.
+              ./hardware-configuration.nix
+            ];
+
+        $bootLoaderConfig
+          # networking.hostName = "nixos"; # Define your hostname.
+          # Pick only one of the below networking options.
+          # networking.wireless.enable = true;  # Enables wireless support via wpa_supplicant.
+          # networking.networkmanager.enable = true;  # Easiest to use and most distros use this by default.
+
+          # Set your time zone.
+          # time.timeZone = "Europe/Amsterdam";
+
+          # Configure network proxy if necessary
+          # networking.proxy.default = "http://user:password\@proxy:port/";
+          # networking.proxy.noProxy = "127.0.0.1,localhost,internal.domain";
+
+          # Select internationalisation properties.
+          # i18n.defaultLocale = "en_US.UTF-8";
+          # console = {
+          #   font = "Lat2-Terminus16";
+          #   keyMap = "us";
+          #   useXkbConfig = true; # use xkbOptions in tty.
+          # };
+
+        $xserverConfig
+
+        $desktopConfiguration
+          # Configure keymap in X11
+          # services.xserver.layout = "us";
+          # services.xserver.xkbOptions = "eurosign:e,caps:escape";
+
+          # Enable CUPS to print documents.
+          # services.printing.enable = true;
+
+          # Enable sound.
+          # sound.enable = true;
+          # hardware.pulseaudio.enable = true;
+
+          # Enable touchpad support (enabled default in most desktopManager).
+          # services.xserver.libinput.enable = true;
+
+          # Define a user account. Don't forget to set a password with ‘passwd’.
+          # users.users.alice = {
+          #   isNormalUser = true;
+          #   extraGroups = [ "wheel" ]; # Enable ‘sudo’ for the user.
+          #   packages = with pkgs; [
+          #     firefox
+          #     tree
+          #   ];
+          # };
+
+          # List packages installed in system profile. To search, run:
+          # \$ nix search wget
+          # environment.systemPackages = with pkgs; [
+          #   vim # Do not forget to add an editor to edit configuration.nix! The Nano editor is also installed by default.
+          #   wget
+          # ];
+
+          # Some programs need SUID wrappers, can be configured further or are
+          # started in user sessions.
+          # programs.mtr.enable = true;
+          # programs.gnupg.agent = {
+          #   enable = true;
+          #   enableSSHSupport = true;
+          # };
+
+          # List services that you want to enable:
+
+          # Enable the OpenSSH daemon.
+          # services.openssh.enable = true;
+
+          # Open ports in the firewall.
+          # networking.firewall.allowedTCPPorts = [ ... ];
+          # networking.firewall.allowedUDPPorts = [ ... ];
+          # Or disable the firewall altogether.
+          # networking.firewall.enable = false;
+
+          # Copy the NixOS configuration file and link it from the resulting system
+          # (/run/current-system/configuration.nix). This is useful in case you
+          # accidentally delete configuration.nix.
+          # system.copySystemConfiguration = true;
+
+          # This value determines the NixOS release from which the default
+          # settings for stateful data, like file locations and database versions
+          # on your system were taken. It's perfectly fine and recommended to leave
+          # this value at the release version of the first install of this system.
+          # Before changing this value read the documentation for this option
+          # (e.g. man configuration.nix or on https://nixos.org/nixos/options.html).
+          system.stateVersion = "${config.system.nixos.release}"; # Did you read the comment?
+
+        }
       '';
+
+      environment.systemPackages =
+        lib.attrValues (lib.mapAttrs (_: tool: tool.package) installerTools);
+
+      documentation.man.man-db.skipPackages =
+        lib.mkIf (installerTools ? nixos-version) [ config.system.installerTools.nixos-version.package ];
+
+      system.build = lib.mapAttrs (_: drv: drv.package) installerTools;
     };
-  };
-
-  options.system.disableInstallerTools = mkOption {
-    internal = true;
-    type = types.bool;
-    default = false;
-    description = lib.mdDoc ''
-      Disable nixos-rebuild, nixos-generate-config, nixos-installer
-      and other NixOS tools. This is useful to shrink embedded,
-      read-only systems which are not expected to be rebuild or
-      reconfigure themselves. Use at your own risk!
-    '';
-  };
-
-  config = lib.mkIf (config.nix.enable && !config.system.disableInstallerTools) {
-
-    system.nixos-generate-config.configuration = mkDefault ''
-      # Edit this configuration file to define what should be installed on
-      # your system.  Help is available in the configuration.nix(5) man page
-      # and in the NixOS manual (accessible by running `nixos-help`).
-
-      { config, pkgs, ... }:
-
-      {
-        imports =
-          [ # Include the results of the hardware scan.
-            ./hardware-configuration.nix
-          ];
-
-      $bootLoaderConfig
-        # networking.hostName = "nixos"; # Define your hostname.
-        # Pick only one of the below networking options.
-        # networking.wireless.enable = true;  # Enables wireless support via wpa_supplicant.
-        # networking.networkmanager.enable = true;  # Easiest to use and most distros use this by default.
-
-        # Set your time zone.
-        # time.timeZone = "Europe/Amsterdam";
-
-        # Configure network proxy if necessary
-        # networking.proxy.default = "http://user:password\@proxy:port/";
-        # networking.proxy.noProxy = "127.0.0.1,localhost,internal.domain";
-
-        # Select internationalisation properties.
-        # i18n.defaultLocale = "en_US.UTF-8";
-        # console = {
-        #   font = "Lat2-Terminus16";
-        #   keyMap = "us";
-        #   useXkbConfig = true; # use xkbOptions in tty.
-        # };
-
-      $xserverConfig
-
-      $desktopConfiguration
-        # Configure keymap in X11
-        # services.xserver.layout = "us";
-        # services.xserver.xkbOptions = "eurosign:e,caps:escape";
-
-        # Enable CUPS to print documents.
-        # services.printing.enable = true;
-
-        # Enable sound.
-        # sound.enable = true;
-        # hardware.pulseaudio.enable = true;
-
-        # Enable touchpad support (enabled default in most desktopManager).
-        # services.xserver.libinput.enable = true;
-
-        # Define a user account. Don't forget to set a password with ‘passwd’.
-        # users.users.alice = {
-        #   isNormalUser = true;
-        #   extraGroups = [ "wheel" ]; # Enable ‘sudo’ for the user.
-        #   packages = with pkgs; [
-        #     firefox
-        #     tree
-        #   ];
-        # };
-
-        # List packages installed in system profile. To search, run:
-        # \$ nix search wget
-        # environment.systemPackages = with pkgs; [
-        #   vim # Do not forget to add an editor to edit configuration.nix! The Nano editor is also installed by default.
-        #   wget
-        # ];
-
-        # Some programs need SUID wrappers, can be configured further or are
-        # started in user sessions.
-        # programs.mtr.enable = true;
-        # programs.gnupg.agent = {
-        #   enable = true;
-        #   enableSSHSupport = true;
-        # };
-
-        # List services that you want to enable:
-
-        # Enable the OpenSSH daemon.
-        # services.openssh.enable = true;
-
-        # Open ports in the firewall.
-        # networking.firewall.allowedTCPPorts = [ ... ];
-        # networking.firewall.allowedUDPPorts = [ ... ];
-        # Or disable the firewall altogether.
-        # networking.firewall.enable = false;
-
-        # Copy the NixOS configuration file and link it from the resulting system
-        # (/run/current-system/configuration.nix). This is useful in case you
-        # accidentally delete configuration.nix.
-        # system.copySystemConfiguration = true;
-
-        # This value determines the NixOS release from which the default
-        # settings for stateful data, like file locations and database versions
-        # on your system were taken. It's perfectly fine and recommended to leave
-        # this value at the release version of the first install of this system.
-        # Before changing this value read the documentation for this option
-        # (e.g. man configuration.nix or on https://nixos.org/nixos/options.html).
-        system.stateVersion = "${config.system.nixos.release}"; # Did you read the comment?
-
-      }
-    '';
-
-    environment.systemPackages =
-      [ nixos-build-vms
-        nixos-install
-        nixos-rebuild
-        nixos-generate-config
-        nixos-option
-        nixos-version
-        nixos-enter
-      ];
-
-    documentation.man.man-db.skipPackages = [ nixos-version ];
-
-    system.build = {
-      inherit nixos-install nixos-generate-config nixos-option nixos-rebuild nixos-enter;
-    };
-
-  };
-
 }


### PR DESCRIPTION
###### Description of changes

Before this change, nixpkgs and configuration revision hashes were hard-coded into the `nixos-version` script.
This means that even a trivial change (like an empty commit), would trigger a rebuild of every derivation that depends on the system path and every derivation that depends on those. On my config, this meant a minimum of 42 derivations that had to be rebuilt for every change, which adds to the feedback loop when hacking on my config.

With the change of this PR, `nixos-version` now reads a JSON file from /run/current-system instead of hard-coding the values in the script, which means that the `system-path` derivation no longer changes every time one of the commit revisions changes.  For my config, this change reduced the amount of derivations that need to be rebuilt after a trivial config change from 42 to 9.

On top of this, I restructured the tools module a bit so that it becomes possible to override the packages for these tools if needed, which was not possible before.

EDIT: as suggested by reviewers, I made the new behaviour opt-in. We can re-assess at a later point whether we want to change the default.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
