### PR TITLE
c2ffi: unstable-2021-06-15 -> unstable-2023-06-08

### DIFF
--- a/pkgs/development/tools/misc/c2ffi/default.nix
+++ b/pkgs/development/tools/misc/c2ffi/default.nix
@@ -1,24 +1,25 @@
-{ lib
+{ stdenv
+, lib
 , fetchFromGitHub
 , cmake
-, llvmPackages_11
+, llvmPackages_15
 , unstableGitUpdater
 }:
 
 let
-  c2ffiBranch = "llvm-11.0.0";
-  llvmPackages = llvmPackages_11;
+  c2ffiBranch = "llvm-15.0.0";
+  llvmPackages = llvmPackages_15;
 in
 
 llvmPackages.stdenv.mkDerivation {
   pname = "c2ffi-${c2ffiBranch}";
-  version = "unstable-2021-06-15";
+  version = "unstable-2023-06-08";
 
   src = fetchFromGitHub {
     owner = "rpav";
     repo = "c2ffi";
-    rev = "f50243926a0afb589de1078a073ac08910599582";
-    sha256 = "UstGicFzFY0/Jge5HGYTPwYSnh9OUBY5346ObZYfR54=";
+    rev = "3078cb57ccfa43736aa93720a72f1074034cb37d";
+    sha256 = "sha256-q4TWNJF6mtVUJ/97NSS6Eep2aSYDU5UbOC+wcrBW610";
   };
 
   passthru.updateScript = unstableGitUpdater {
@@ -52,5 +53,6 @@ llvmPackages.stdenv.mkDerivation {
     description = "An LLVM based tool for extracting definitions from C, C++, and Objective C header files for use with foreign function call interfaces";
     license = licenses.lgpl21Only;
     maintainers = with maintainers; [ attila-lendvai ];
+    meta.broken = stdenv.hostPlatform.isDarwin;
  };
 }


### PR DESCRIPTION
Also switching to llvm 15, as that's the new "current" version.


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
