### PR TITLE
gow: init at 0-unstable-2025-03-28

### DIFF
--- a/pkgs/by-name/go/gow/package.nix
+++ b/pkgs/by-name/go/gow/package.nix
@@ -1,0 +1,48 @@
+{
+  lib,
+  stdenv,
+  buildGoModule,
+  fetchFromGitHub,
+  versionCheckHook,
+}:
+
+buildGoModule {
+  pname = "gow";
+  version = "0-unstable-2025-03-28";
+
+  src = fetchFromGitHub {
+    owner = "mitranim";
+    repo = "gow";
+    rev = "576bf37beebc38106597ce1092f5b438027c8bdc";
+    hash = "sha256-+1u3eUwo7S7Iun98JobO9Y0nXNo8RVzKlKX5O1QCn/w=";
+  };
+
+  vendorHash = "sha256-L/GyzLH2j1rvSfsuxQ5pC8M42nxZDepuMRiGmKDS3vE=";
+
+  ldflags = [
+    "-s"
+    "-w"
+  ];
+
+  doInstallCheck = stdenv.buildPlatform.canExecute stdenv.hostPlatform;
+  installCheckPhase = ''
+    runHook preInstallCheck
+
+    $out/bin/gow -h
+
+    runHook postInstallCheck
+  '';
+
+  meta = {
+    description = "Missing watch mode for Go commands. Watch Go files and execute a command like \"go run\" or \"go test\"";
+    longDescription = ''
+      Go Watch: missing watch mode for the go command. It's invoked exactly
+      like go, but also watches Go files and reruns on changes.
+    '';
+    homepage = "https://github.com/mitranim/gow";
+    license = lib.licenses.unlicense;
+    maintainers = with lib.maintainers; [ jk ];
+    platforms = lib.platforms.unix;
+    mainProgram = "gow";
+  };
+}


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

`gow` init at 0-unstable-2025-03-28

The missing watch mode for go commands

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [X] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [X] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [X] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
