### PR TITLE
emacs: add back nativeComp/treeSitter passthru

### DIFF
--- a/pkgs/applications/editors/emacs/generic.nix
+++ b/pkgs/applications/editors/emacs/generic.nix
@@ -388,6 +388,7 @@ mkDerivation (finalAttrs: (lib.optionalAttrs withNativeCompilation {
     tests = { inherit (nixosTests) emacs-daemon; };
     # Backwards compatibility aliases. Remove this at some point before 23.11 release cut-off.
     nativeComp = builtins.trace "emacs.passthru: nativeComp was renamed to withNativeCompilation and will be removed in 23.11" withNativeCompilation;
+    treeSitter = builtins.trace "emacs.passthru: treeSitter was renamed to withTreeSitter and will be removed in 23.11" withTreeSitter;
   };
 
   meta = {

--- a/pkgs/applications/editors/emacs/generic.nix
+++ b/pkgs/applications/editors/emacs/generic.nix
@@ -386,6 +386,8 @@ mkDerivation (finalAttrs: (lib.optionalAttrs withNativeCompilation {
     inherit withTreeSitter;
     pkgs = recurseIntoAttrs (emacsPackagesFor finalAttrs.finalPackage);
     tests = { inherit (nixosTests) emacs-daemon; };
+    # Backwards compatibility aliases. Remove this at some point before 23.11 release cut-off.
+    nativeComp = builtins.trace "emacs.passthru: nativeComp was renamed to withNativeCompilation and will be removed in 23.11" withNativeCompilation;
   };
 
   meta = {

--- a/pkgs/build-support/emacs/wrapper.nix
+++ b/pkgs/build-support/emacs/wrapper.nix
@@ -36,7 +36,7 @@ in customEmacsPackages.withPackages (epkgs: [ epkgs.evil epkgs.magit ])
 self:
 let
   inherit (self) emacs;
-  withNativeCompilation = emacs.withNativeCompilation or false;
+  withNativeCompilation = emacs.withNativeCompilation or emacs.nativeComp or false;
   withTreeSitter = emacs.withTreeSitter or false;
 in
 packagesFun: # packages explicitly requested by the user

--- a/pkgs/build-support/emacs/wrapper.nix
+++ b/pkgs/build-support/emacs/wrapper.nix
@@ -37,7 +37,7 @@ self:
 let
   inherit (self) emacs;
   withNativeCompilation = emacs.withNativeCompilation or emacs.nativeComp or false;
-  withTreeSitter = emacs.withTreeSitter or false;
+  withTreeSitter = emacs.withTreeSitter or emacs.treeSitter or false;
 in
 packagesFun: # packages explicitly requested by the user
 let


### PR DESCRIPTION
###### Description of changes

As reported by @terlar in https://github.com/NixOS/nixpkgs/pull/235859#issuecomment-1597012885 the removal of nativeComp in passthru breaks external tooling.

This adds back `passthru.nativeComp` with a deprecation notice which sets the removal for 23.11.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
