### PR TITLE
tiny-cuda-nn: quote strings; use strictDeps; format with alejandra

### DIFF
--- a/pkgs/development/libraries/science/math/tiny-cuda-nn/default.nix
+++ b/pkgs/development/libraries/science/math/tiny-cuda-nn/default.nix
@@ -1,20 +1,20 @@
-{ cmake
-, cudaPackages
-, fetchFromGitHub
-, lib
-, ninja
-, pkgs
-, python3Packages ? { }
-, pythonSupport ? false
-, stdenv
-, symlinkJoin
-, which
-}:
-let
+{
+  cmake,
+  cudaPackages,
+  fetchFromGitHub,
+  lib,
+  ninja,
+  python3Packages ? {},
+  pythonSupport ? false,
+  stdenv,
+  symlinkJoin,
+  which,
+}: let
   inherit (lib) lists strings;
   inherit (cudaPackages) backendStdenv cudaFlags;
 
   cuda-common-redist = with cudaPackages; [
+    cuda_cudart # cuda_runtime.h
     libcublas # cublas_v2.h
     libcusolver # cusolverDn.h
     libcusparse # cusparse.h
@@ -22,10 +22,9 @@ let
 
   cuda-native-redist = symlinkJoin {
     name = "cuda-redist";
-    paths = with cudaPackages; [
-      cuda_cudart # cuda_runtime.h
-      cuda_nvcc
-    ] ++ cuda-common-redist;
+    paths = with cudaPackages;
+      [cuda_nvcc]
+      ++ cuda-common-redist;
   };
 
   cuda-redist = symlinkJoin {
@@ -33,120 +32,127 @@ let
     paths = cuda-common-redist;
   };
 in
-stdenv.mkDerivation (finalAttrs: {
-  name = "tiny-cuda-nn";
-  version = "1.6";
+  stdenv.mkDerivation (finalAttrs: {
+    pname = "tiny-cuda-nn";
+    version = "1.6";
+    strictDeps = true;
 
-  format = strings.optionalString pythonSupport "setuptools";
+    format = strings.optionalString pythonSupport "setuptools";
 
-  src = fetchFromGitHub {
-    owner = "NVlabs";
-    repo = finalAttrs.name;
-    rev = "v${finalAttrs.version}";
-    fetchSubmodules = true;
-    hash = "sha256-qW6Fk2GB71fvZSsfu+mykabSxEKvaikZ/pQQZUycOy0=";
-  };
+    src = fetchFromGitHub {
+      owner = "NVlabs";
+      repo = finalAttrs.pname;
+      rev = "v${finalAttrs.version}";
+      fetchSubmodules = true;
+      hash = "sha256-qW6Fk2GB71fvZSsfu+mykabSxEKvaikZ/pQQZUycOy0=";
+    };
 
-  nativeBuildInputs = [
-    cmake
-    cuda-native-redist
-    ninja
-    which
-  ] ++ lists.optionals pythonSupport (with python3Packages; [
-    pip
-    setuptools
-    wheel
-  ]);
+    nativeBuildInputs =
+      [
+        cmake
+        cuda-native-redist
+        ninja
+        which
+      ]
+      ++ lists.optionals pythonSupport (with python3Packages; [
+        pip
+        setuptools
+        wheel
+      ]);
 
-  buildInputs = [
-    cuda-redist
-  ] ++ lib.optionals pythonSupport (
-    with python3Packages; [
-      pybind11
-      python
-    ]
-  );
+    buildInputs =
+      [
+        cuda-redist
+      ]
+      ++ lib.optionals pythonSupport (
+        with python3Packages; [
+          pybind11
+          python
+        ]
+      );
 
-  propagatedBuildInputs = lib.optionals pythonSupport (
-    with python3Packages; [
-      torch
-    ]
-  );
+    propagatedBuildInputs = lib.optionals pythonSupport (
+      with python3Packages; [
+        torch
+      ]
+    );
 
-  # NOTE: We cannot use pythonImportsCheck for this module because it uses torch to immediately
-  #   initailize CUDA and GPU access is not allowed in the nix build environment.
-  # NOTE: There are no tests for the C++ library or the python bindings, so we just skip the check
-  #   phase -- we're not missing anything.
-  doCheck = false;
+    # NOTE: We cannot use pythonImportsCheck for this module because it uses torch to immediately
+    #   initailize CUDA and GPU access is not allowed in the nix build environment.
+    # NOTE: There are no tests for the C++ library or the python bindings, so we just skip the check
+    #   phase -- we're not missing anything.
+    doCheck = false;
 
-  preConfigure = ''
-    export TCNN_CUDA_ARCHITECTURES=${
-      strings.concatStringsSep ";" (lists.map cudaFlags.dropDot cudaFlags.cudaCapabilities)
-    }
-    export CUDA_HOME=${cuda-native-redist}
-    export LIBRARY_PATH=${cuda-native-redist}/lib/stubs:$LIBRARY_PATH
-    export CC=${backendStdenv.cc}/bin/cc
-    export CXX=${backendStdenv.cc}/bin/c++
-  '';
+    preConfigure = ''
+      export TCNN_CUDA_ARCHITECTURES="${
+        strings.concatStringsSep ";" (lists.map cudaFlags.dropDot cudaFlags.cudaCapabilities)
+      }"
+      export CUDA_HOME="${cuda-native-redist}"
+      export LIBRARY_PATH="${cuda-native-redist}/lib/stubs:$LIBRARY_PATH"
+      export CC="${backendStdenv.cc}/bin/cc"
+      export CXX="${backendStdenv.cc}/bin/c++"
+    '';
 
-  # When building the python bindings, we cannot re-use the artifacts from the C++ build so we
-  # skip the CMake confurePhase and the buildPhase.
-  dontUseCmakeConfigure = pythonSupport;
+    # When building the python bindings, we cannot re-use the artifacts from the C++ build so we
+    # skip the CMake confurePhase and the buildPhase.
+    dontUseCmakeConfigure = pythonSupport;
 
-  # The configurePhase usually puts you in the build directory, so for the python bindings we
-  # need to change directories to the source directory.
-  configurePhase = strings.optionalString pythonSupport ''
-    runHook preConfigure
-    mkdir -p $NIX_BUILD_TOP/build
-    cd $NIX_BUILD_TOP/build
-    runHook postConfigure
-  '';
+    # The configurePhase usually puts you in the build directory, so for the python bindings we
+    # need to change directories to the source directory.
+    configurePhase = strings.optionalString pythonSupport ''
+      runHook preConfigure
+      mkdir -p "$NIX_BUILD_TOP/build"
+      cd "$NIX_BUILD_TOP/build"
+      runHook postConfigure
+    '';
 
-  buildPhase = strings.optionalString pythonSupport ''
-    runHook preBuild
-    python -m pip wheel \
-      --no-build-isolation \
-      --no-clean \
-      --no-deps \
-      --no-index \
-      --verbose \
-      --wheel-dir $NIX_BUILD_TOP/build \
-      $NIX_BUILD_TOP/source/bindings/torch
-    runHook postBuild
-  '';
+    buildPhase = strings.optionalString pythonSupport ''
+      runHook preBuild
+      python -m pip wheel \
+        --no-build-isolation \
+        --no-clean \
+        --no-deps \
+        --no-index \
+        --verbose \
+        --wheel-dir "$NIX_BUILD_TOP/build" \
+        "$NIX_BUILD_TOP/source/bindings/torch"
+      runHook postBuild
+    '';
 
-  installPhase = ''
-    runHook preInstall
-    mkdir -p $out/lib
-  ''
-  # Installing the C++ library just requires copying the static library to the output directory
-  + strings.optionalString (!pythonSupport) ''
-    cp libtiny-cuda-nn.a $out/lib/
-  ''
-  # Installing the python bindings requires building the wheel and installing it
-  + strings.optionalString pythonSupport ''
-    python -m pip install \
-      --no-build-isolation \
-      --no-cache-dir \
-      --no-deps \
-      --no-index \
-      --no-warn-script-location \
-      --prefix="$out" \
-      --verbose \
-      ./*.whl
-  '' + ''
-    runHook postInstall
-  '';
+    installPhase =
+      ''
+        runHook preInstall
+        mkdir -p "$out/lib"
+      ''
+      # Installing the C++ library just requires copying the static library to the output directory
+      + strings.optionalString (!pythonSupport) ''
+        cp libtiny-cuda-nn.a "$out/lib/"
+      ''
+      # Installing the python bindings requires building the wheel and installing it
+      + strings.optionalString pythonSupport ''
+        python -m pip install \
+          --no-build-isolation \
+          --no-cache-dir \
+          --no-deps \
+          --no-index \
+          --no-warn-script-location \
+          --prefix="$out" \
+          --verbose \
+          ./*.whl
+      ''
+      + ''
+        runHook postInstall
+      '';
 
-  passthru = {
-    inherit cudaPackages;
-  };
+    passthru = {
+      inherit cudaPackages;
+    };
 
-  meta = with lib; {
-    description = "Lightning fast C++/CUDA neural network framework";
-    homepage = "https://github.com/NVlabs/tiny-cuda-nn";
-    license = licenses.bsd3;
-    maintainers = with maintainers; [ connorbaker ];
-    platforms = platforms.linux;
-  };
-})
+    meta = with lib; {
+      description = "Lightning fast C++/CUDA neural network framework";
+      homepage = "https://github.com/NVlabs/tiny-cuda-nn";
+      license = licenses.bsd3;
+      maintainers = with maintainers; [connorbaker];
+      platforms = platforms.linux;
+    };
+  })


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Closes https://github.com/NixOS/nixpkgs/issues/238617.

- Quoted strings inside of shell script portions of the derivation to avoid breakages
- Switched to `strictDeps = true`, which caught an issue where `cuda_cudart` is both a build-time and runtime dependency
- Formatted the file with Alejandra (which I forgot to do when I committed, apparently)

Test with this flake:

<details>

```nix
{
  inputs = {
    nixGL = {
      inputs.nixpkgs.follows = "nixpkgs";
      url = "github:guibou/nixGL";
    };
    nixpkgs.url = "github:NixOS/nixpkgs/refs/pull/238619/head";
  };

  nixConfig = {
    # Add my own cache and the CUDA maintainer's cache
    extra-substituters = [
      "https://cantcache.me"
      "https://cuda-maintainers.cachix.org"
    ];
    extra-trusted-substituters = [
      "https://cantcache.me"
      "https://cuda-maintainers.cachix.org"
    ];
    extra-trusted-public-keys = [
      "cantcache.me:Y+FHAKfx7S0pBkBMKpNMQtGKpILAfhmqUSnr5oNwNMs="
      "cuda-maintainers.cachix.org-1:0dq3bujKpuEPMCX6U4WylrUDZ9JyUG0VpVZa7CNfq5E="
    ];
  };

  outputs = inputs: let
    system = "x86_64-linux";

    pkgs = import inputs.nixpkgs {
      inherit system;
      config = {
        allowUnfree = true;
        cudaSupport = true;
        cudaForwardCompat = true;
      };
    };

    nixGL = import inputs.nixGL {
      inherit pkgs;
      enableIntelX86Extensions = true;
      enable32bits = false;
      nvidiaVersion = "535.54.03";
      nvidiaHash = "sha256-RUdk9X6hueGRZqNw94vhDnHwYmQ4+xl/cm3DyvBbQII=";
    };

    test-tiny-cuda-nn = with pkgs;
      writeShellApplication {
        name = "test-tiny-cuda-nn";
        runtimeInputs = [
          nixGL.nixGLNvidia
          (python3.withPackages (ps:
            with ps; [
              tiny-cuda-nn
              torch
              tqdm
            ]))
        ];
        text =
          # If the script was run with --nixgl, then we need to wrap the
          # python interpreter with nixGL.
          ''
            PYTHON_CMDS=("python3")
            if [[ "$*" =~ "--nixgl" ]]; then
              echo "Running with nixGL..."
              PYTHON_CMDS=("${nixGL.nixGLNvidia.name}" "''${PYTHON_CMDS[@]}")
            fi
          ''
          # Set the SCRIPTS_DIR variable to the path of the scripts directory
          + ''
            SCRIPTS_DIR="${python3Packages.tiny-cuda-nn.src}/scripts"
          ''
          # Test torch bindings
          + ''
            echo "Testing the torch bindings..."
            # Yes, there is a typo in the filename.
            /usr/bin/env time -v \
              "''${PYTHON_CMDS[@]}" "$SCRIPTS_DIR/test_toch_bindings.py"
            echo "Done."
          ''
          # Test training
          + ''
            echo "Training a toy SDF model with eikonal term..."
            /usr/bin/env time -v \
              "''${PYTHON_CMDS[@]}" "$SCRIPTS_DIR/test_grid_bwdbwd.py"
            echo "Done."
          ''
          # Stress test
          + ''
            echo "Stress-testing the GPU memory arena of tiny-cuda-nn with randomly sized allocations..."
            /usr/bin/env time -v \
              "''${PYTHON_CMDS[@]}" "$SCRIPTS_DIR/test_random_input.py"
            echo "Done."
          '';
      };
  in {
    legacyPackages.${system} = pkgs;
    apps.${system} = {
      test-tiny-cuda-nn = {
        program = pkgs.lib.getExe test-tiny-cuda-nn;
        type = "app";
      };
    };
    formatter.${system} = pkgs.alejandra;
  };
}
```

</details>

To run on NixOS:

```bash
nix run .#test-tiny-cuda-nn -L
```

To run on non-NixOS:

```bash
nix run .#test-tiny-cuda-nn -L -- --nixgl
```

Note: I *strongly* recommend setting `cudaCapabilities` in the flake to whatever you intend to run the tests on. For such a tiny package, it take quite a while to compile!

Run `Nixpkgs-review`:

```bash
nixpkgs-review pr 238619 \
  --extra-nixpkgs-config '{ allowUnfree = true; cudaSupport = true; }' \
  --no-shell \
  --print-result
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
