### PR TITLE
librealsense: Fix bad include directory in cmake

### DIFF
--- a/pkgs/development/libraries/librealsense/default.nix
+++ b/pkgs/development/libraries/librealsense/default.nix
@@ -80,6 +80,9 @@ stdenv.mkDerivation rec {
   # ( https://github.com/IntelRealSense/meta-intel-realsense/issues/20 )
   postInstall = lib.optionalString enablePython  ''
     cp ../wrappers/python/pyrealsense2/__init__.py $out/${pythonPackages.python.sitePackages}/pyrealsense2
+  '' + ''
+    substituteInPlace $out/lib/cmake/realsense2/realsense2Targets.cmake \
+    --replace "\''${_IMPORT_PREFIX}/include" "$dev/include"
   '';
 
   meta = with lib; {

--- a/pkgs/development/libraries/librealsense/default.nix
+++ b/pkgs/development/libraries/librealsense/default.nix
@@ -78,11 +78,11 @@ stdenv.mkDerivation rec {
   # script does not do this, and it's questionable if intel knows it should be
   # done
   # ( https://github.com/IntelRealSense/meta-intel-realsense/issues/20 )
-  postInstall = lib.optionalString enablePython  ''
-    cp ../wrappers/python/pyrealsense2/__init__.py $out/${pythonPackages.python.sitePackages}/pyrealsense2
-  '' + ''
+  postInstall = ''
     substituteInPlace $out/lib/cmake/realsense2/realsense2Targets.cmake \
     --replace "\''${_IMPORT_PREFIX}/include" "$dev/include"
+  '' + lib.optionalString enablePython  ''
+    cp ../wrappers/python/pyrealsense2/__init__.py $out/${pythonPackages.python.sitePackages}/pyrealsense2
   '';
 
   meta = with lib; {


### PR DESCRIPTION
###### Description of changes
The cmake manifest for `librealsense` set the `INTERFACE_INCLUDE_DIRECTORIES` directory as `$lib/include` which does not exist, leading to the following cmake error:
```
CMake Error in CMakeLists.txt:
  Imported target "realsense2::realsense2" includes non-existent path
                                                                                                                                                                                              
    "/nix/store/yv2838a3hfqd52qvpj1lrsk50h6q7svs-librealsense-2.45.0/include"
                                                                                                                                                                                              
  in its INTERFACE_INCLUDE_DIRECTORIES.  Possible reasons include:
                                                                                                                                                                                              
  * The path was deleted, renamed, or moved to another location.
                                                                                                                                                                                              
  * An install or uninstall procedure did not complete successfully.
                                                                                                                                                                                              
  * The installation package was faulty and references files it does not
  provide.
                                                                                                                                                                                              
                                                                                                                                                                                              
                                                                                                                                                                                              
-- Generating done
CMake Generate step failed.  Build files cannot be regenerated correctly.

```

To correct this, a solution similar to https://github.com/NixOS/nixpkgs/issues/86622 was implemented, setting the include directory to `$dev/include` which actually has the headers.

The binaries `realsense-viewer` and `rs-pointcloud` have been tested to work with this change. 

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
