### PR TITLE
cudaPackages: bump default cudaPackages_11_7 -> cudaPackages_11_8

### DIFF
--- a/pkgs/test/cuda/cuda-samples/generic.nix
+++ b/pkgs/test/cuda/cuda-samples/generic.nix
@@ -1,6 +1,5 @@
 { lib
 , cudaPackages
-, gcc11Stdenv
 , fetchFromGitHub
 , fetchpatch
 , addOpenGLRunpath

--- a/pkgs/test/cuda/cuda-samples/generic.nix
+++ b/pkgs/test/cuda/cuda-samples/generic.nix
@@ -1,14 +1,18 @@
 { lib
-, stdenv
+, cudaPackages
+, gcc11Stdenv
 , fetchFromGitHub
 , fetchpatch
 , addOpenGLRunpath
 , cudatoolkit
 , pkg-config
 , sha256
+, glfw3
+, freeimage
 }:
-
-stdenv.mkDerivation rec {
+let
+  stdenv = cudaPackages.backendStdenv;
+in stdenv.mkDerivation rec {
   pname = "cuda-samples";
   version = lib.versions.majorMinor cudatoolkit.version;
 
@@ -19,7 +23,7 @@ stdenv.mkDerivation rec {
     inherit sha256;
   };
 
-  nativeBuildInputs = [ pkg-config addOpenGLRunpath ];
+  nativeBuildInputs = [ pkg-config addOpenGLRunpath glfw3 freeimage ];
 
   buildInputs = [ cudatoolkit ];
 

--- a/pkgs/test/cuda/cuda-samples/generic.nix
+++ b/pkgs/test/cuda/cuda-samples/generic.nix
@@ -41,7 +41,7 @@ cudaPackages.backendStdenv.mkDerivation rec {
   installPhase = ''
     runHook preInstall
 
-    install -Dm755 -t $out/bin bin/${stdenv.hostPlatform.parsed.cpu.name}/${stdenv.hostPlatform.parsed.kernel.name}/release/*
+    install -Dm755 -t $out/bin bin/${cudaPackages.backendStdenv.hostPlatform.parsed.cpu.name}/${cudaPackages.backendStdenv.hostPlatform.parsed.kernel.name}/release/*
 
     runHook postInstall
   '';

--- a/pkgs/test/cuda/cuda-samples/generic.nix
+++ b/pkgs/test/cuda/cuda-samples/generic.nix
@@ -10,9 +10,7 @@
 , glfw3
 , freeimage
 }:
-let
-  stdenv = cudaPackages.backendStdenv;
-in stdenv.mkDerivation rec {
+cudaPackages.backendStdenv.mkDerivation rec {
   pname = "cuda-samples";
   version = lib.versions.majorMinor cudatoolkit.version;
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6767,7 +6767,7 @@ with pkgs;
   cudaPackages_11_6 = callPackage ./cuda-packages.nix { cudaVersion = "11.6"; };
   cudaPackages_11_7 = callPackage ./cuda-packages.nix { cudaVersion = "11.7"; };
   cudaPackages_11_8 = callPackage ./cuda-packages.nix { cudaVersion = "11.8"; };
-  cudaPackages_11 = cudaPackages_11_7;
+  cudaPackages_11 = cudaPackages_11_8;
 
   cudaPackages_12_0 = callPackage ./cuda-packages.nix { cudaVersion = "12.0"; };
   cudaPackages_12_1 = callPackage ./cuda-packages.nix { cudaVersion = "12.1"; };


### PR DESCRIPTION
###### Description of changes

Updated the default cudaPackages from 11.7 to 11.8 to address https://github.com/NixOS/nixpkgs/issues/222778. Pytorch doesn't support 12, yet, so this is an interim change. A nixpkgs-review with cudaSupport enabled is forthcoming.

Replaces 224927.

@ConnorBaker, @samuela, @SomeoneSerge - ugh, sorry about 224927. I think I managed to salvage the changes here.

###### Things done

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
