### PR TITLE
substitute-all.nix: Define in terms of the `substitute` bash function

### DIFF
--- a/pkgs/build-support/substitute/substitute-all.nix
+++ b/pkgs/build-support/substitute/substitute-all.nix
@@ -1,12 +1,52 @@
-{ stdenvNoCC }:
+{ lib
+, stdenvNoCC
+}:
 
-args:
+/*
+  Replaces all occurrences of `@varName@` in `src`, where `varName` is an
+  attribute passed to the `substituteAll` Nix function, writing the result to a
+  file in the Nix store.
 
-# see the substituteAll in the nixpkgs documentation for usage and constaints
-stdenvNoCC.mkDerivation ({
-  name = if args ? name then args.name else baseNameOf (toString args.src);
+  Example:
+
+  # Writes a text file to the Nix store with contents "Hello, World!"
+  substituteAll {
+    src = builtins.toFile "greeting.txt" "Hello, @subject@!";
+    subject = "World";
+  }
+*/
+{ src
+, name ? baseNameOf (toString src)
+, dir ? null
+, isExecutable ? false
+, preInstall ? null
+, postInstall ? null
+, passthru ? { }
+, meta ? { }
+# The remaining arguments are the variables to replace.
+, ...
+}@args:
+
+let
+  variables = builtins.removeAttrs args [
+    "name" "src" "dir" "isExecutable" "preInstall" "postInstall"
+    "passthru" "meta"
+  ];
+
+  # { cat = "meow"; dog = "woof"; } -> [ "--subst-var-by" "cat" "meow" "--subst-var-by" "dog" "woof" ]
+  substitutions = lib.foldlAttrs
+    (acc: variable: replacement: acc ++ [ "--subst-var-by" variable replacement ])
+    []
+    variables;
+in
+
+stdenvNoCC.mkDerivation {
   builder = ./substitute-all.sh;
-  inherit (args) src;
+  inherit name src dir isExecutable preInstall postInstall passthru meta;
+
+  substitutions = lib.toShellVar "substitutions" substitutions;
+  passAsFile = [ "substitutions" ];
+
   preferLocalBuild = true;
   allowSubstitutes = false;
-} // args)
+}

--- a/pkgs/build-support/substitute/substitute-all.sh
+++ b/pkgs/build-support/substitute/substitute-all.sh
@@ -10,7 +10,8 @@ if test -n "$dir"; then
     mkdir -p $out/$dir
 fi
 
-substituteAll $src $target
+source "$substitutionsPath"
+substitute $src $target "${substitutions[@]}"
 
 if test -n "$isExecutable"; then
     chmod +x $target


### PR DESCRIPTION
###### Description of changes

The `substituteAll` bash function that was previously used substitutes all environment variables. This can cause surprising behaviour, because some environment variables, like `system`, and not under control of the expression author that calls `substituteAll`.

This commit changes the nixpkgs `substituteAll` function to use `substitute` with an explicit variable list instead. This ensures that the only variables that will be substituted are those that the caller specified, and not any that stdenv.mkDerivation or Nix itself added/modified.

Partially addresses #237216.

TODO:
- [ ] Should this change be added to the release notes? This change can break users that depend on being able to substitute e.g. `@system@` without explicitly passing it to substituteAll
- [ ] This function is now very similar to the `substitute` nixpkgs function, but more ergonomic to use (`substitute` expects a list of arguments to the bash substitute function, while substituteAll accepts an attrset of variables to replace). Should one of them be removed?

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
