### PR TITLE
prismlauncher: add some missing dependencies

### DIFF
--- a/pkgs/games/prismlauncher/wrapper.nix
+++ b/pkgs/games/prismlauncher/wrapper.nix
@@ -14,9 +14,11 @@
 , jdk8
 , jdk17
 , gamemode
+, flite
 
 , msaClientID ? null
 , gamemodeSupport ? stdenv.isLinux
+, textToSpeechSupport ? stdenv.isLinux
 , jdks ? [ jdk17 jdk8 ]
 , additionalLibs ? [ ]
 }:
@@ -61,6 +63,7 @@ symlinkJoin {
         stdenv.cc.cc.lib
       ]
       ++ lib.optional gamemodeSupport gamemode.lib
+      ++ lib.optional textToSpeechSupport flite
       ++ additionalLibs;
 
     in

--- a/pkgs/games/prismlauncher/wrapper.nix
+++ b/pkgs/games/prismlauncher/wrapper.nix
@@ -50,7 +50,7 @@ symlinkJoin {
 
   qtWrapperArgs =
     let
-      libs = (with xorg; [
+      runtimeLibs = (with xorg; [
         libX11
         libXext
         libXcursor
@@ -68,18 +68,18 @@ symlinkJoin {
       ++ lib.optional textToSpeechSupport flite
       ++ additionalLibs;
 
-      programs = [
+      runtimePrograms = [
         xorg.xrandr
-        mesa-demos  # need glxinfo
+        mesa-demos # need glxinfo
       ]
       ++ additionalPrograms;
 
     in
     [ "--prefix PRISMLAUNCHER_JAVA_PATHS : ${lib.makeSearchPath "bin/java" jdks}" ]
     ++ lib.optionals stdenv.isLinux [
-      "--set LD_LIBRARY_PATH /run/opengl-driver/lib:${lib.makeLibraryPath libs}"
+      "--set LD_LIBRARY_PATH /run/opengl-driver/lib:${lib.makeLibraryPath runtimeLibs}"
       # xorg.xrandr needed for LWJGL [2.9.2, 3) https://github.com/LWJGL/lwjgl/issues/128
-      "--prefix PATH : ${lib.makeBinPath programs}"
+      "--prefix PATH : ${lib.makeBinPath runtimePrograms}"
     ];
 
   inherit (prismlauncherFinal) meta;

--- a/pkgs/games/prismlauncher/wrapper.nix
+++ b/pkgs/games/prismlauncher/wrapper.nix
@@ -15,6 +15,7 @@
 , jdk17
 , gamemode
 , flite
+, mesa-demos
 
 , msaClientID ? null
 , gamemodeSupport ? stdenv.isLinux
@@ -69,6 +70,7 @@ symlinkJoin {
 
       programs = [
         xorg.xrandr
+        mesa-demos  # need glxinfo
       ]
       ++ additionalPrograms;
 

--- a/pkgs/games/prismlauncher/wrapper.nix
+++ b/pkgs/games/prismlauncher/wrapper.nix
@@ -21,6 +21,7 @@
 , textToSpeechSupport ? stdenv.isLinux
 , jdks ? [ jdk17 jdk8 ]
 , additionalLibs ? [ ]
+, additionalPrograms ? [ ]
 }:
 let
   prismlauncherFinal = prismlauncher-unwrapped.override {
@@ -66,12 +67,17 @@ symlinkJoin {
       ++ lib.optional textToSpeechSupport flite
       ++ additionalLibs;
 
+      programs = [
+        xorg.xrandr
+      ]
+      ++ additionalPrograms;
+
     in
     [ "--prefix PRISMLAUNCHER_JAVA_PATHS : ${lib.makeSearchPath "bin/java" jdks}" ]
     ++ lib.optionals stdenv.isLinux [
       "--set LD_LIBRARY_PATH /run/opengl-driver/lib:${lib.makeLibraryPath libs}"
       # xorg.xrandr needed for LWJGL [2.9.2, 3) https://github.com/LWJGL/lwjgl/issues/128
-      "--prefix PATH : ${lib.makeBinPath [xorg.xrandr]}"
+      "--prefix PATH : ${lib.makeBinPath programs}"
     ];
 
   inherit (prismlauncherFinal) meta;


### PR DESCRIPTION
###### Description of changes

Adding some missing dependencies, both for the launcher and the game itself. Also add a parameter to conveniently add more programs to PATH.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
