### PR TITLE
mesonEmulatorHook: fix canExecute safety assertion

### DIFF
--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5808,18 +5808,23 @@ with pkgs;
   # example of an error which this fixes
   # [Errno 8] Exec format error: './gdk3-scan'
   mesonEmulatorHook =
-    if (!stdenv.buildPlatform.canExecute stdenv.targetPlatform) then
-      makeSetupHook
-        {
-          name = "mesonEmulatorHook";
-          substitutions = {
-            crossFile = writeText "cross-file.conf" ''
+    makeSetupHook
+      {
+        name = "mesonEmulatorHook";
+        substitutions = {
+          crossFile = writeText "cross-file.conf" ''
               [binaries]
-              exe_wrapper = ${lib.escapeShellArg (stdenv.targetPlatform.emulator buildPackages)}
+              exe_wrapper = ${lib.escapeShellArg (stdenv.targetPlatform.emulator pkgs)}
             '';
-          };
-        } ../development/tools/build-managers/meson/emulator-hook.sh
-    else throw "mesonEmulatorHook has to be in a conditional to check if the target binaries can be executed i.e. (!stdenv.buildPlatform.canExecute stdenv.hostPlatform)";
+        };
+      }
+      # The throw is moved into the `makeSetupHook` derivation, so that its
+      # outer level, but not its outPath can still be evaluated if the condition
+      # doesn't hold. This ensures that splicing still can work correctly.
+      (if (!stdenv.hostPlatform.canExecute stdenv.targetPlatform) then
+        ../development/tools/build-managers/meson/emulator-hook.sh
+       else
+         throw "mesonEmulatorHook may only be added to nativeBuildInputs when the target binaries can't be executed; however you are attempting to use it in a situation where ${stdenv.hostPlatform.config} can execute ${stdenv.targetPlatform.config}. Consider only adding mesonEmulatorHook according to a conditional based canExecute in your package expression.");
 
   meson-tools = callPackage ../misc/meson-tools { };
 


### PR DESCRIPTION
Currently the throw codepath will never be hit. Specifically it doesn't guard against a misuse of the hook:

    pkgsCross.aarch64-multiplatform.mesonEmulatorHook # this should fail
    pkgsCross.aarch64-multiplatform.buildPackages.mesonEmulatorHook # this should (and does) succeed

The check sort of worked to guard against use in situations where the hook wasn't misplaced between nativeBuildInputs and buildInputs, but the build platform was actually able to execute binaries built for the host platform.

This worked because nativeBuildInputs would first of all need to evaluate pkgsHostTarget.mesonEmulatorHook in order to access the spliced derivation it wants, pkgsBuildHost.mesonEmulatorHook. For this, you'd need to pass the if expression, at which point buildPlatform and targetPlatform would match the build and target platform of the derivation that uses the hook. Consequently the check is “correct”, since it is its build platform that needs not to be able execute stuff built for its host platform.

The target platform is technically wrong here, but it works out since (at least currently) in nixpkgs either build and host or host and target platform are equal. When doing the check in pkgsHostTarget, target and host platform are equal.

However, this is a kind of incomprehensible rube goldberg machine, let's some mistakes slip through the cracks and relies on implementation details of splicing.

To alleviate this, we do the following:

- We move the check _into_ the derivation. By doing the check when obtaining the file for the setup hook and not before calling `makeSetupHook`. This means that we can force `mesonEmulatorHook` even if forcing `mesonEmulatorHook.outPath` would throw. This ensures that splicing can work even if the some of the derivation variants would fail to evaluate.

- Since splicing works now, we can no longer have to do the check “globally” before splicing happens. This means we can use the setup hook derivation's own platforms. buildPlatform is irrelevant here, since this is only the platform on which the shell script is put together. hostPlatform matters, since it is were the setup hook is executed later (i.e. the using derivation's build platform). target platform is the platform the adjacent meson builds executables for, i.e. the platform we may need to emulate for.

To verify this change, I have evaluated all derivations using mesonEmulatorHook in `pkgsCross.aarch64-multiplatform` before and after this change. The hashes don't change.

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
