### PR TITLE
nixos/fontconfig: add fonts.fontconfig.hinting.interpreterVersion

### DIFF
--- a/nixos/modules/config/fonts/fontconfig.nix
+++ b/nixos/modules/config/fonts/fontconfig.nix
@@ -402,6 +402,19 @@ in
               in
               lib.warnIf (lib.hasPrefix "hint" val) warning val';
           };
+
+          interpreterVersion = mkOption {
+            type = types.nullOr types.int;
+            default = null;
+            description = lib.mdDoc ''
+              Subpixel hinting mode can be chosen by setting the TrueType
+              interpreter version. The available settings are:
+
+              - 35: Classic mode (default in 2.6)
+              - 38: Infinality mode
+              - 40: Minimal mode (default in 2.7)
+            '';
+          };
         };
 
         includeUserConf = mkOption {
@@ -522,6 +535,10 @@ in
     })
     (mkIf cfg.enable {
       fonts.fontconfig.confPackages = [ confPkg ];
+    })
+    (mkIf (cfg.enable && cfg.hinting.interpreterVersion != null) {
+      environment.sessionVariables.FREETYPE_PROPERTIES =
+        "truetype:interpreter-version=${toString cfg.hinting.interpreterVersion}";
     })
   ];
 


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

I want an easier and documented way to enable Infinality subpixel rendering (yes, this is still supported by upstream), because at least in my monitor (~110PPI) it results in, in my opinion, better font rendering. So this PR adds support for changing it by setting `fonts.fontconfig.hinting.interpreterVersion`.

To avoid breaking anyone setups, this accepts a `null` value that is also the default. This is also good to avoid having a hardcoded value in case upstream updates the interpreter version again.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
