### PR TITLE
wsl-vpnkit: init at 0.4.1

### DIFF
--- a/pkgs/tools/networking/wsl-vpnkit/default.nix
+++ b/pkgs/tools/networking/wsl-vpnkit/default.nix
@@ -1,0 +1,84 @@
+{ lib
+, resholve
+, fetchFromGitHub
+
+  # Runtime dependencies
+, coreutils
+, dnsutils
+, gawk
+, gnugrep
+, gvproxy
+, iproute2
+, iptables
+, iputils
+, wget
+}:
+
+let
+  version = "0.4.1";
+  gvproxyWin = gvproxy.overrideAttrs (_: {
+    buildPhase = ''
+      GOARCH=amd64 GOOS=windows go build -ldflags '-s -w' -o bin/gvproxy-windows.exe ./cmd/gvproxy
+    '';
+  });
+in
+resholve.mkDerivation {
+  pname = "wsl-vpnkit";
+  inherit version;
+
+  src = fetchFromGitHub {
+    owner = "sakai135";
+    repo = "wsl-vpnkit";
+    rev = "v${version}";
+    hash = "sha256-Igbr3L2W32s4uBepllSz07bkbI3qwAKMZkBrXLqGrGA=";
+  };
+
+  postPatch = ''
+    substituteInPlace wsl-vpnkit \
+      --replace "/app/wsl-vm" "${gvproxy}/bin/gvforwarder" \
+      --replace "/app/wsl-gvproxy.exe" "${gvproxyWin}/bin/gvproxy-windows.exe"
+  '';
+
+  installPhase = ''
+    mkdir -p $out/bin
+    cp wsl-vpnkit $out/bin
+  '';
+
+  solutions.wsl-vpnkit = {
+    scripts = [ "bin/wsl-vpnkit" ];
+    interpreter = "none";
+    inputs = [
+      coreutils
+      dnsutils
+      gawk
+      gnugrep
+      iproute2
+      iptables
+      iputils
+      wget
+    ];
+
+    keep = {
+      "$VMEXEC_PATH" = true;
+      "$GVPROXY_PATH" = true;
+    };
+
+    execer = [
+      "cannot:${iproute2}/bin/ip"
+      "cannot:${wget}/bin/wget"
+    ];
+
+    fix = {
+      aliases = true;
+      ping = "${iputils}/bin/ping";
+    };
+  };
+
+  meta = with lib; {
+    description = "Provides network connectivity to Windows Subsystem for Linux (WSL) when blocked by VPN";
+    homepage = "https://github.com/sakai135/wsl-vpnkit";
+    changelog = "https://github.com/sakai135/wsl-vpnkit/releases/tag/v${version}";
+    license = licenses.mit;
+    maintainers = with maintainers; [ terlar ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7441,6 +7441,8 @@ with pkgs;
 
   wsl-open = callPackage ../tools/misc/wsl-open { };
 
+  wsl-vpnkit = callPackage ../tools/networking/wsl-vpnkit { };
+
   xkcdpass = with python3Packages; toPythonApplication xkcdpass;
 
   xjobs = callPackage ../tools/misc/xjobs { };


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
Add the package [wsl-vpnkit](https://github.com/sakai135/wsl-vpnkit) which can be used to revive network connectivity within WSL when connecting to certain VPN:s that would otherwise break the network within WSL. The main caveat with the packaging was that I could not re-use the nixpkgs `gvproxy` since it needed the Windows version, hence there is an override to cross-compile it and then refer to the produced exe in the wrapper. Script also needs to be run as root.

[Cross linking previous issue from NixOS-WSL](https://github.com/nix-community/NixOS-WSL/issues/262)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
