### PR TITLE
tbe: fix build, clean up dependencies

### DIFF
--- a/pkgs/games/the-butterfly-effect/default.nix
+++ b/pkgs/games/the-butterfly-effect/default.nix
@@ -1,4 +1,4 @@
-{ lib, mkDerivation, fetchFromGitHub, qt5, box2d, which, cmake, gettext }:
+{ lib, mkDerivation, fetchFromGitHub, cmake, qttools, wrapQtAppsHook, qtbase, qtsvg }:
 
 mkDerivation rec {
   pname = "tbe";
@@ -11,13 +11,16 @@ mkDerivation rec {
     sha256 = "1ag2cp346f9bz9qy6za6q54id44d2ypvkyhvnjha14qzzapwaysj";
   };
 
-  postPatch = "sed '1i#include <vector>' -i src/model/World.h";
+  postPatch = ''
+    sed '1i#include <vector>' -i src/model/World.h
 
-  nativeBuildInputs = [ cmake ];
-  buildInputs = [
-    qt5.qtbase qt5.qtsvg qt5.qttranslations box2d which
-    gettext
-  ];
+    # fix translations not building: https://gitlab.kitware.com/cmake/cmake/-/issues/21931
+    substituteInPlace i18n/CMakeLists.txt --replace qt5_create_translation qt_add_translation
+  '';
+
+  nativeBuildInputs = [ cmake qttools wrapQtAppsHook ];
+  buildInputs = [ qtbase qtsvg ];
+  strictDeps = true;
 
   installPhase = ''
     make DESTDIR=.. install


### PR DESCRIPTION
###### Description of changes

Fixes breakage uncovered by https://github.com/NixOS/nixpkgs/pull/225336#issuecomment-1598267813

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
