### PR TITLE
texlive.combine: expose licensing information of combined packages [v2]

### DIFF
--- a/pkgs/tools/typesetting/tex/texlive/UPGRADING.md
+++ b/pkgs/tools/typesetting/tex/texlive/UPGRADING.md
@@ -72,6 +72,23 @@ CTAN and the various mirrors) and that the build recipe continues to produce
 the same output. Should those assumptions not hold, remove the previous fixed
 hashes for the relevant package, or for all packages.
 
+### Updating the licensing information
+
+The license of each package in texlive is automatically extracted from texlive's
+texlive.tlpdb into tlpdb.nix. The combined licenses of the schemes is stored
+separately in `default.nix` and must be kept in sync with the licenses of the
+actual contents of these schemes. Whether this is the case can be verified with the
+`pkgs.tests.texlive.licenses` test. In case of a mismatch, copy the “correct”
+license lists reported by the test into `default.nix`.
+
+### Running the testsuite
+
+There are a some other useful tests that haven't been mentioned before. Build them with
+```
+nix-build ../../../../.. -A tests.texlive --no-out-link
+```
+
+
 ### Commit changes
 
 Commit the updated `tlpdb.nix` and `fixed-hashes.nix` to the repository with

--- a/pkgs/tools/typesetting/tex/texlive/default.nix
+++ b/pkgs/tools/typesetting/tex/texlive/default.nix
@@ -43,6 +43,7 @@ let
       # it seems to need it to transform fonts
       xdvi.deps = (orig.xdvi.deps or []) ++  [ "metafont" ];
 
+      # TODO: remove when updating to texlive-2023, metadata has been corrected in the TeX catalogue
       # tlpdb lists license as "unknown", but the README says lppl13: http://mirrors.ctan.org/language/arabic/arabi-add/README
       arabi-add.license = [  "lppl13c" ];
 

--- a/pkgs/tools/typesetting/tex/texlive/default.nix
+++ b/pkgs/tools/typesetting/tex/texlive/default.nix
@@ -254,13 +254,38 @@ in
 
     # Pre-defined combined packages for TeX Live schemes,
     # to make nix-env usage more comfortable and build selected on Hydra.
-    combined = with lib; recurseIntoAttrs (
+    combined = with lib;
+      let
+        # these license lists should be the sorted union of the licenses of the packages the schemes contain.
+        # The correctness of this collation is tested by tests.texlive.licenses
+        licenses = with lib.licenses; {
+          scheme-basic = [ free gfl gpl1Only gpl2 gpl2Plus knuth lgpl21 lppl1 lppl13c mit ofl publicDomain ];
+          scheme-context = [ bsd2 bsd3 cc-by-sa-40 free gfl gfsl gpl1Only gpl2 gpl2Plus gpl3 gpl3Plus knuth lgpl2 lgpl21
+            lppl1 lppl13c mit ofl publicDomain x11 ];
+          scheme-full = [ artistic1 artistic1-cl8 asl20 bsd2 bsd3 bsdOriginal cc-by-10 cc-by-40 cc-by-sa-10 cc-by-sa-20
+            cc-by-sa-30 cc-by-sa-40 cc0 fdl13Only free gfl gfsl gpl1Only gpl1Plus gpl2 gpl2Plus gpl3 gpl3Plus isc knuth
+            lgpl2 lgpl21 lgpl3 lppl1 lppl12 lppl13a lppl13c mit ofl publicDomain x11 ];
+          scheme-gust = [ artistic1-cl8 asl20 bsd2 bsd3 cc-by-40 cc-by-sa-40 cc0 fdl13Only free gfl gfsl gpl1Only gpl2
+            gpl2Plus gpl3 gpl3Plus knuth lgpl2 lgpl21 lppl1 lppl12 lppl13a lppl13c mit ofl publicDomain x11 ];
+          scheme-infraonly = [ gpl2 lgpl21 ];
+          scheme-medium = [ artistic1-cl8 asl20 bsd2 bsd3 cc-by-40 cc-by-sa-20 cc-by-sa-30 cc-by-sa-40 cc0 fdl13Only
+            free gfl gpl1Only gpl2 gpl2Plus gpl3 gpl3Plus isc knuth lgpl2 lgpl21 lgpl3 lppl1 lppl12 lppl13a lppl13c mit ofl
+            publicDomain x11 ];
+          scheme-minimal = [ free gpl1Only gpl2 gpl2Plus knuth lgpl21 lppl1 lppl13c mit ofl publicDomain ];
+          scheme-small = [ asl20 cc-by-40 cc-by-sa-40 cc0 fdl13Only free gfl gpl1Only gpl2 gpl2Plus gpl3 gpl3Plus knuth
+            lgpl2 lgpl21 lppl1 lppl12 lppl13a lppl13c mit ofl publicDomain x11 ];
+          scheme-tetex = [ artistic1-cl8 asl20 bsd2 bsd3 cc-by-40 cc-by-sa-10 cc-by-sa-20 cc-by-sa-30 cc-by-sa-40 cc0
+            fdl13Only free gfl gpl1Only gpl2 gpl2Plus gpl3 gpl3Plus isc knuth lgpl2 lgpl21 lgpl3 lppl1 lppl12 lppl13a
+            lppl13c mit ofl publicDomain x11];
+        };
+      in recurseIntoAttrs (
       mapAttrs
         (pname: attrs:
           addMetaAttrs rec {
             description = "TeX Live environment for ${pname}";
             platforms = lib.platforms.all;
             maintainers = with lib.maintainers;  [ veprbl ];
+            license = licenses.${pname};
           }
           (combine {
             ${pname} = attrs;


### PR DESCRIPTION
~~This is a slight modification of fa7428470abdfea7a4e1e1ac5d3e9ebac452f2a2, which has been reverted in 205ee073b053fc4d87d5adf2ebd44ebbef7bca4d due to it breaking the evaluation on Hydra (probably because of excessive stack usage). Sorry about that.~~

~~In this version, `lib.foldl` has been replaced by `builtins.foldl'` in both folds, which does indeed cut down the neccessary stack size significantly: `nix-instantiate -A texlive.combined.scheme-full` runs successfully with the stack limited to 300kB (`ulimit -s 300`), whereas the version with `lib.foldl` required more than 20MB.~~

~~I could not measure a significant difference in runtime between the versions without licensing metadata, `lib.foldl` and `builtins.foldl'`. All three versions need around 2.4s to instantiate `texlive.combined.scheme-full` on my machine with run-to-run deviations being larger than the differences between the versions.~~

~~Not sure how to correctly test this, as `nixpkgs-review` as well as @ofborg also evaluated nixpkgs in the previous version without problems.~~

This now uses hardcoded version information to reduce the evaluation hit further. A tests ensures that the hardcoded information is kept up to date.

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
