### PR TITLE
global-platform-pro: convert to mavenfod

### DIFF
--- a/pkgs/development/tools/global-platform-pro/default.nix
+++ b/pkgs/development/tools/global-platform-pro/default.nix
@@ -1,8 +1,13 @@
-{ lib, stdenv, fetchFromGitHub, jdk8, maven, makeWrapper, jre8_headless, pcsclite }:
+{ lib, javaPackages, fetchFromGitHub, jdk8, maven, makeWrapper, jre8_headless, pcsclite }:
 
-let jdk = jdk8; jre_headless = jre8_headless; in
-# TODO: This is quite a bit of duplicated logic with gephi. Factor it out?
-stdenv.mkDerivation rec {
+let
+  mavenJdk8 = maven.override {
+    jdk = jdk8;
+  };
+in
+(javaPackages.mavenfod.override {
+  maven = mavenJdk8;
+}) rec {
   pname = "global-platform-pro";
   version = "18.09.14";
   GPPRO_VERSION = "18.09.14-0-gb439b52"; # git describe --tags --always --long --dirty
@@ -14,39 +19,14 @@ stdenv.mkDerivation rec {
     sha256 = "1vws6cbgm3mrwc2xz9j1y262vw21x3hjc9m7rqc4hn3m7gjpwsvg";
   };
 
-  deps = stdenv.mkDerivation {
-    name = "${pname}-${version}-deps";
-    inherit src;
-    nativeBuildInputs = [ jdk maven ];
-    installPhase = ''
-      # Download the dependencies
-      while ! mvn package "-Dmaven.repo.local=$out/.m2" -Dmaven.wagon.rto=5000; do
-        echo "timeout, restart maven to continue downloading"
-      done
+  mvnHash = "sha256-rRLsCTY3fEAvGRDvNXqpjac2Gb5fdlyhK2wTK5CVN9k=";
 
-      # And keep only *.{pom,jar,sha1,nbm} and delete all ephemeral files
-      # with lastModified timestamps inside
-      find "$out/.m2" -type f \
-        -regex '.+\(\.lastUpdated\|resolver-status\.properties\|_remote\.repositories\)' \
-        -delete
-    '';
-    outputHashAlgo = "sha256";
-    outputHashMode = "recursive";
-    outputHash = "sha256-rRLsCTY3fEAvGRDvNXqpjac2Gb5fdlyhK2wTK5CVN9k=";
-  };
-
-  nativeBuildInputs = [ jdk maven makeWrapper ];
-
-  buildPhase = ''
-    cp -dpR "${deps}/.m2" ./
-    chmod -R +w .m2
-    mvn package --offline -Dmaven.repo.local="$(pwd)/.m2"
-  '';
+  nativeBuildInputs = [ jdk8 mavenJdk8 makeWrapper ];
 
   installPhase = ''
     mkdir -p "$out/lib/java" "$out/share/java"
     cp target/gp.jar "$out/share/java"
-    makeWrapper "${jre_headless}/bin/java" "$out/bin/gp" \
+    makeWrapper "${jre8_headless}/bin/java" "$out/bin/gp" \
       --add-flags "-jar '$out/share/java/gp.jar'" \
       --prefix LD_LIBRARY_PATH : "${pcsclite.out}/lib"
   '';


### PR DESCRIPTION
###### Description of changes

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
