### PR TITLE
trigger-control: init at unstable-2023-06-18

### DIFF
--- a/pkgs/tools/games/trigger-control/default.nix
+++ b/pkgs/tools/games/trigger-control/default.nix
@@ -1,0 +1,68 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, cmake
+, makeWrapper
+, pkg-config
+, SDL2
+, dbus
+, libdecor
+, libnotify
+, dejavu_fonts
+, gnome
+}:
+
+let
+  inherit (gnome) zenity;
+in
+
+stdenv.mkDerivation rec {
+  pname = "trigger-control";
+  version = "unstable-2023-06-18";
+
+  src = fetchFromGitHub {
+    owner = "Etaash-mathamsetty";
+    repo = "trigger-control";
+    rev = "d457ebd9e0844cfc456bfa4fa4bb694bb8ad982a";
+    hash = "sha256-QWhUQ8xqS8oRVF0KUpEthlrOoXmhcfEkIHauDI1/5a8=";
+  };
+
+  nativeBuildInputs = [
+    cmake
+    makeWrapper
+    pkg-config
+  ];
+
+  buildInputs = [
+    SDL2
+    dbus
+    libnotify
+  ] ++ lib.optionals stdenv.isLinux [
+    libdecor
+  ];
+
+  # The app crashes without a changed fontdir and upstream recommends dejavu as font
+  postPatch = ''
+    substituteInPlace trigger-control.cpp --replace "/usr/share/fonts/" "${dejavu_fonts}/share/fonts/"
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    install -D trigger-control $out/bin/trigger-control
+
+    runHook postInstall
+  '';
+
+  postInstall = lib.optionalString stdenv.isLinux ''
+    wrapProgram $out/bin/trigger-control \
+      --prefix PATH : ${lib.makeBinPath [ zenity ]}
+  '';
+
+  meta = with lib; {
+    description = "Control the dualsense's triggers on Linux (and Windows) with a gui and C++ api";
+    homepage = "https://github.com/Etaash-mathamsetty/trigger-control";
+    license = licenses.mit;
+    maintainers = with maintainers; [ azuwis ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1797,6 +1797,8 @@ with pkgs;
 
   topicctl = callPackage ../tools/misc/topicctl { };
 
+  trigger-control = callPackage ../tools/games/trigger-control { };
+
   ttchat = callPackage ../tools/misc/ttchat { };
 
   ukmm = callPackage ../tools/games/ukmm { };


### PR DESCRIPTION
homepage: https://github.com/Etaash-mathamsetty/trigger-control
description: Control the dualsense's triggers on Linux (and Windows) with a gui and C++ api

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
