### PR TITLE
dynein: init at 0.2.1

### DIFF
--- a/pkgs/development/tools/database/dynein/default.nix
+++ b/pkgs/development/tools/database/dynein/default.nix
@@ -1,0 +1,48 @@
+{ fetchFromGitHub
+, lib
+, Security
+, openssl
+, pkg-config
+, rustPlatform
+, stdenv
+}:
+
+rustPlatform.buildRustPackage rec {
+  pname = "dynein";
+  version = "0.2.1";
+
+  src = fetchFromGitHub {
+    owner = "awslabs";
+    repo = "dynein";
+    rev = "v${version}";
+    sha256 = "sha256-QhasTFGOFOjzNKdQtA+eBhKy51O4dFt6vpeIAIOM2rQ=";
+  };
+
+  # Use system openssl.
+  OPENSSL_NO_VENDOR = 1;
+
+  cargoHash = "sha256-QyhoYgqBfK6LCdtLuo0feVCgIMPueYeA8MMGspGLbGQ=";
+
+  nativeBuildInputs = [ pkg-config ];
+
+  buildInputs = [
+    openssl
+  ] ++ lib.optionals stdenv.isDarwin [ Security ];
+
+  preBuild = ''
+    export OPENSSL_DIR=${lib.getDev openssl}
+    export OPENSSL_LIB_DIR=${lib.getLib openssl}/lib
+  '';
+
+  # The integration tests will start downloading docker image of DynamoDB, which
+  # will naturally fail for nix build. The CLI tests do not need DynamoDB.
+  cargoTestFlags = [ "cli_tests" ];
+
+  meta = with lib; {
+    description = "DynamoDB CLI written in Rust";
+    homepage = "https://github.com/awslabs/dynein";
+    license = licenses.asl20;
+    platforms = platforms.unix;
+    maintainers = with maintainers; [ pimeys ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -555,6 +555,10 @@ with pkgs;
     inherit (darwin.apple_sdk.frameworks) Security;
   };
 
+  dynein = callPackage ../development/tools/database/dynein {
+    inherit (darwin.apple_sdk.frameworks) Security;
+  };
+
   ea = callPackage ../tools/misc/ea { };
 
   each = callPackage ../tools/text/each { };


### PR DESCRIPTION
###### Description of changes

Adds AWS dynein CLI for dynamodb. Homepage: https://github.com/awslabs/dynein

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).