### PR TITLE
esdm: init at 0.6.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -16381,6 +16381,12 @@
     github = "thielema";
     githubId = 898989;
   };
+  thillux = {
+    name = "Markus Theil";
+    email = "theil.markus@gmail.com";
+    github = "thillux";
+    githubId = 2171995;
+  };
   thilobillerbeck = {
     name = "Thilo Billerbeck";
     email = "thilo.billerbeck@officerent.de";

--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -12389,6 +12389,12 @@
     githubId = 75299;
     name = "Malcolm Matalka";
   };
+  orichter = {
+    email = "richter-oliver@gmx.net";
+    github = "RichterOliver";
+    githubId = 135209509;
+    name = "Oliver Richter";
+  };
   orivej = {
     email = "orivej@gmx.fr";
     github = "orivej";

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -1108,6 +1108,7 @@
   ./services/security/clamav.nix
   ./services/security/endlessh-go.nix
   ./services/security/endlessh.nix
+  ./services/security/esdm.nix
   ./services/security/fail2ban.nix
   ./services/security/fprintd.nix
   ./services/security/haka.nix

--- a/nixos/modules/services/security/esdm.nix
+++ b/nixos/modules/services/security/esdm.nix
@@ -1,0 +1,102 @@
+{ lib, config, pkgs, ... }:
+
+let
+  cfg = config.services.esdm;
+in
+{
+  options.services.esdm = {
+    enable = lib.mkEnableOption (lib.mdDoc "ESDM service configuration");
+    package = lib.mkPackageOptionMD pkgs "esdm" { };
+    serverEnable = lib.mkOption {
+      type = lib.types.bool;
+      default = true;
+      description = lib.mdDoc ''
+        Enable option for ESDM server service. If serverEnable == false, then the esdm-server
+        will not start. Also the subsequent services esdm-cuse-random, esdm-cuse-urandom
+        and esdm-proc will not start as these have the entry Want=esdm-server.service.
+      '';
+    };
+    cuseRandomEnable = lib.mkOption {
+      type = lib.types.bool;
+      default = true;
+      description = lib.mdDoc ''
+        Enable option for ESDM cuse-random service. Determines if the esdm-cuse-random.service
+        is started.
+      '';
+    };
+    cuseUrandomEnable = lib.mkOption {
+      type = lib.types.bool;
+      default = true;
+      description = lib.mdDoc ''
+        Enable option for ESDM cuse-urandom service. Determines if the esdm-cuse-urandom.service
+        is started.
+      '';
+    };
+    procEnable = lib.mkOption {
+      type = lib.types.bool;
+      default = true;
+      description = lib.mdDoc ''
+        Enable option for ESDM proc service. Determines if the esdm-proc.service
+        is started.
+      '';
+    };
+    verbose = lib.mkOption {
+      type = lib.types.bool;
+      default = false;
+      description = lib.mdDoc ''
+        Enable verbose ExecStart for ESDM. If verbose == true, then the corresponding "ExecStart"
+        values of the 4 aforementioned services are overwritten with the option
+        for the highest verbosity.
+      '';
+    };
+  };
+
+  config = lib.mkIf cfg.enable (
+    lib.mkMerge [
+      ({
+        systemd.packages = [ cfg.package ];
+      })
+      # It is necessary to set those options for these services to be started by systemd in NixOS
+      (lib.mkIf cfg.serverEnable {
+        systemd.services."esdm-server".wantedBy = [ "basic.target" ];
+        systemd.services."esdm-server".serviceConfig = lib.mkIf cfg.verbose {
+          ExecStart = [
+            " " # unset previous value defined in 'esdm-server.service'
+            "${cfg.package}/bin/esdm-server -f -vvvvvv"
+          ];
+        };
+      })
+
+      (lib.mkIf cfg.cuseRandomEnable {
+        systemd.services."esdm-cuse-random".wantedBy = [ "basic.target" ];
+        systemd.services."esdm-cuse-random".serviceConfig = lib.mkIf cfg.verbose {
+          ExecStart = [
+            " " # unset previous value defined in 'esdm-cuse-random.service'
+            "${cfg.package}/bin/esdm-cuse-random -f -v 6"
+          ];
+        };
+      })
+
+      (lib.mkIf cfg.cuseUrandomEnable {
+        systemd.services."esdm-cuse-urandom".wantedBy = [ "basic.target" ];
+        systemd.services."esdm-cuse-urandom".serviceConfig = lib.mkIf cfg.verbose {
+          ExecStart = [
+            " " # unset previous value defined in 'esdm-cuse-urandom.service'
+            "${config.services.esdm.package}/bin/esdm-cuse-urandom -f -v 6"
+          ];
+        };
+      })
+
+      (lib.mkIf cfg.procEnable {
+        systemd.services."esdm-proc".wantedBy = [ "basic.target" ];
+        systemd.services."esdm-proc".serviceConfig = lib.mkIf cfg.verbose {
+          ExecStart = [
+            " " # unset previous value defined in 'esdm-proc.service'
+            "${cfg.package}/bin/esdm-proc --relabel -f -o allow_other /proc/sys/kernel/random -v 6"
+          ];
+        };
+      })
+    ]);
+
+  meta.maintainers = with lib.maintainers; [ orichter thillux ];
+}

--- a/pkgs/os-specific/linux/esdm/default.nix
+++ b/pkgs/os-specific/linux/esdm/default.nix
@@ -1,0 +1,87 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, fetchpatch
+, protobufc
+, pkg-config
+, fuse3
+, meson
+, ninja
+, libselinux
+, jitterentropy
+  # A more detailed explaination of the following meson build options can be found
+  # in the source code of esdm.
+  # A brief explanation is given:
+, selinux ? false # enable selinux support
+, drngHashDrbg ? true  # set the default drng callback
+, drngChaCha20 ? false # set the default drng callback
+, ais2031 ? false # set the seeding strategy to be compliant with AIS 20/31
+, linuxDevFiles ? true # enable linux /dev/random and /dev/urandom support
+, linuxGetRandom ? true # enable linux getrandom support
+, esJitterRng ? true # enable support for the entropy source: jitter rng
+, esCPU ? true # enable support for the entropy source: cpu-based entropy
+, esKernel ? true # enable support for the entropy source: kernel-based entropy
+, esIRQ ? false # enable support for the entropy source: interrupt-based entropy
+, esSched ? false # enable support for the entropy source: scheduler-based entropy
+, esHwrand ? true # enable support for the entropy source: /dev/hwrng
+, hashSha512 ? false # set the conditioning hash: SHA2-512
+, hashSha3_512 ? true # set the conditioning hash: SHA3-512
+}:
+
+assert drngHashDrbg != drngChaCha20;
+assert hashSha512 != hashSha3_512;
+
+stdenv.mkDerivation rec {
+  pname = "esdm";
+  version = "0.6.0";
+
+  src = fetchFromGitHub {
+    owner = "smuellerDD";
+    repo = "esdm";
+    rev = "v${version}";
+    sha256 = "sha256-swBKVb5gnND76w2ULT+5hR/jVOqxEe4TAB1gyaLKE9Q=";
+  };
+
+  patches = [
+    (fetchpatch {
+      name = "arm64.patch";
+      url = "https://github.com/smuellerDD/esdm/commit/86b93a0ddf684448aba152c8f1b3baf40a6d41c0.patch";
+      sha256 = "sha256-gjp13AEsDNj23fcGanAAn2KCbYKA0cphhf4mCxek9Yg=";
+    })
+  ];
+
+  nativeBuildInputs = [ meson pkg-config ninja ];
+  buildInputs = [ protobufc fuse3 jitterentropy ]
+    ++ lib.optional selinux libselinux;
+
+  mesonFlags = [
+    (lib.mesonBool "b_lto" false)
+    (lib.mesonBool "ais2031" ais2031)
+    (lib.mesonEnable "linux-devfiles" linuxDevFiles)
+    (lib.mesonEnable "linux-getrandom" linuxGetRandom)
+    (lib.mesonEnable "es_jent" esJitterRng)
+    (lib.mesonEnable "es_cpu" esCPU)
+    (lib.mesonEnable "es_kernel" esKernel)
+    (lib.mesonEnable "es_irq" esIRQ)
+    (lib.mesonEnable "es_sched" esSched)
+    (lib.mesonEnable "es_hwrand" esHwrand)
+    (lib.mesonEnable "hash_sha512" hashSha512)
+    (lib.mesonEnable "hash_sha3_512" hashSha3_512)
+    (lib.mesonEnable "selinux" selinux)
+    (lib.mesonEnable "drng_hash_drbg" drngHashDrbg)
+    (lib.mesonEnable "drng_chacha20" drngChaCha20)
+  ];
+
+  doCheck = true;
+
+  strictDeps = true;
+  mesonBuildType = "release";
+
+  meta = {
+    homepage = "https://www.chronox.de/esdm.html";
+    description = "Entropy Source and DRNG Manager in user space";
+    license = with lib.licenses; [ gpl2Only bsd3 ];
+    platforms = lib.platforms.linux;
+    maintainers = with lib.maintainers; [ orichter thillux ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -27254,6 +27254,8 @@ with pkgs;
 
   dstat = callPackage ../os-specific/linux/dstat { };
 
+  esdm = callPackage ../os-specific/linux/esdm { };
+
   evdev-proto = callPackage ../os-specific/bsd/freebsd/evdev-proto { };
 
   fscryptctl = callPackage ../os-specific/linux/fscryptctl { };


### PR DESCRIPTION
###### Description of changes
The Entropy Source and DRNG Manager (ESDM) manages a set of deterministic random number generators (DRNG) and ensures their proper seeding and reseeding. To seed the DRNGs, a set of entropy sources are managed by the ESDM. The cryptographic strength of the entire ESDM is always 256 bits. All entropy processing is designed to maintain this strength. 
website: http://chronox.de/esdm.html

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).


