### PR TITLE
hunspellDictsChromium: init at 115.0.5790.170

### DIFF
--- a/pkgs/development/libraries/hunspell/dictionaries-chromium.nix
+++ b/pkgs/development/libraries/hunspell/dictionaries-chromium.nix
@@ -1,0 +1,70 @@
+{ lib, stdenv, fetchgit }:
+
+let
+  mkDictFromChromium = { shortName, dictFileName, shortDescription }:
+    stdenv.mkDerivation {
+      pname = "hunspell-dict-${shortName}-chromium";
+      version = "115.0.5790.170";
+
+      src = fetchgit {
+        url = "https://chromium.googlesource.com/chromium/deps/hunspell_dictionaries";
+        rev = "41cdffd71c9948f63c7ad36e1fb0ff519aa7a37e";
+        hash = "sha256-67mvpJRFFa9eMfyqFMURlbxOaTJBICnk+gl0b0mEHl8=";
+      };
+
+      dontBuild = true;
+
+      installPhase = ''
+        cp ${dictFileName} $out
+      '';
+
+      passthru = {
+        # As chromium needs the exact filename in ~/.config/chromium/Dictionaries,
+        # this value needs to be known to tools using the package if they want to
+        # link the file correctly.
+        inherit dictFileName;
+
+        updateScript = ./update-chromium-dictionaries.py;
+      };
+
+      meta = {
+        homepage = "https://chromium.googlesource.com/chromium/deps/hunspell_dictionaries/";
+        description = "Chromium compatible hunspell dictionary for ${shortDescription}";
+        longDescription = ''
+          Humspell directories in Chromium's custom bdic format
+
+          See https://www.chromium.org/developers/how-tos/editing-the-spell-checking-dictionaries/
+        '';
+        license = with lib.licenses; [ gpl2 lgpl21 mpl11 lgpl3 ];
+        maintainers = with lib.maintainers; [ networkexception ];
+        platforms = lib.platforms.all;
+      };
+    };
+in
+rec {
+
+  /* ENGLISH */
+
+  en_US = en-us;
+  en-us = mkDictFromChromium {
+    shortName = "en-us";
+    dictFileName = "en-US-10-1.bdic";
+    shortDescription = "English (United States)";
+  };
+
+  en_GB = en-us;
+  en-gb = mkDictFromChromium {
+    shortName = "en-gb";
+    dictFileName = "en-GB-10-1.bdic";
+    shortDescription = "English (United Kingdom)";
+  };
+
+  /* GERMAN */
+
+  de_DE = de-de;
+  de-de = mkDictFromChromium {
+    shortName = "de-de";
+    dictFileName = "de-DE-3-0.bdic";
+    shortDescription = "German (Germany)";
+  };
+}

--- a/pkgs/development/libraries/hunspell/update-chromium-dictionaries.py
+++ b/pkgs/development/libraries/hunspell/update-chromium-dictionaries.py
@@ -1,0 +1,77 @@
+#! /usr/bin/env nix-shell
+#! nix-shell -i python3 -p python3 nix nix-prefetch-git
+
+import base64
+import fileinput
+import json
+import os
+import re
+import subprocess
+import sys
+
+from urllib.request import urlopen, Request
+
+
+DICTIONARIES_CHROMIUM_NIX = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'dictionaries-chromium.nix')
+
+
+def get_latest_chromium_stable_release():
+    RELEASES_URL = 'https://versionhistory.googleapis.com/v1/chrome/platforms/linux/channels/stable/versions/all/releases'
+    print(f'GET {RELEASES_URL}')
+    with urlopen(RELEASES_URL) as resp:
+        return json.load(resp)['releases'][0]
+
+
+def get_file_revision(revision, file_path):
+    """Fetches the requested Git revision of the given Chromium file."""
+    url = f'https://chromium.googlesource.com/chromium/src/+/refs/tags/{revision}/{file_path}?format=TEXT'
+    with urlopen(url) as http_response:
+        resp = http_response.read()
+        return base64.b64decode(resp)
+
+
+def nix_prefetch_git(url, rev):
+    """Prefetches the requested Git revision of the given repository URL."""
+    print(f'nix-prefetch-git {url} {rev}')
+    out = subprocess.check_output(['nix-prefetch-git', '--quiet', '--url', url, '--rev', rev])
+    return json.loads(out)
+
+
+def get_current_revision():
+    with open(DICTIONARIES_CHROMIUM_NIX) as f:
+        for line in f:
+            rev = re.search(r'^        rev = "(.*)";', line)
+            if rev:
+                return rev.group(1)
+    sys.exit(1)
+
+
+print('Getting latest chromium version...')
+chromium_release = get_latest_chromium_stable_release()
+chromium_version = chromium_release['version']
+print(f'chromium version: {chromium_version}')
+
+print('Getting corresponding hunspell_dictionaries commit...')
+deps = get_file_revision(chromium_version, 'DEPS')
+hunspell_dictionaries_pattern = r"^\s*Var\('chromium_git'\)\s*\+\s*'\/chromium\/deps\/hunspell_dictionaries\.git'\s*\+\s*'@'\s*\+\s*'(\w*)',$"
+hunspell_dictionaries_commit = re.search(hunspell_dictionaries_pattern, deps.decode(), re.MULTILINE).group(1)
+print(f'hunspell_dictionaries commit: {hunspell_dictionaries_commit}')
+
+current_commit = get_current_revision()
+if current_commit == hunspell_dictionaries_commit:
+    print('Commit is already packaged, no update needed.')
+    sys.exit(0)
+
+print('Commit has changed compared to the current package, updating...')
+
+print('Getting hash of hunspell_dictionaries revision...')
+hunspell_dictionaries_git = nix_prefetch_git("https://chromium.googlesource.com/chromium/deps/hunspell_dictionaries", hunspell_dictionaries_commit)
+hunspell_dictionaries_hash = hunspell_dictionaries_git['hash']
+print(f'hunspell_dictionaries commit hash: {hunspell_dictionaries_hash}')
+
+with fileinput.FileInput(DICTIONARIES_CHROMIUM_NIX, inplace=True) as file:
+    for line in file:
+        result = re.sub(r'^      version = ".+";', f'      version = "{chromium_version}";', line)
+        result = re.sub(r'^        rev = ".*";', f'        rev = "{hunspell_dictionaries_commit}";', result)
+        result = re.sub(r'^        hash = ".+";', f'        hash = "{hunspell_dictionaries_hash}";', result)
+        print(result, end='')

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -21341,6 +21341,8 @@ with pkgs;
 
   hunspellDicts = recurseIntoAttrs (callPackages ../development/libraries/hunspell/dictionaries.nix {});
 
+  hunspellDictsChromium = recurseIntoAttrs (callPackages ../development/libraries/hunspell/dictionaries-chromium.nix {});
+
   hunspellWithDicts = dicts: callPackage ../development/libraries/hunspell/wrapper.nix { inherit dicts; };
 
   hwloc = callPackage ../development/libraries/hwloc { };


### PR DESCRIPTION
chromium requires a custom format for hunspell dictionaries which they provide as blobs in an upstream repository.
    
building from source (using convert_dict from the chromium monorepo and applying it to already packaged dictionaries) would not yield the same results (chromium packages adjustments to the dictionaries themselves) and would increase the maintainance cost.
    
this pull request adds a new `hunspellDictsChromium` attribute which includes dictionaries from chromium.

these files could be linked into `~/.config/chromium/Dictionaries` to make spell checking work in ungoogled-chromium, my plan would be to adopt this into the chromium home-manager module.

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
