### PR TITLE
[release-23.05] nss: 3.89.1 -> 3.90

### DIFF
--- a/pkgs/development/libraries/nss/generic.nix
+++ b/pkgs/development/libraries/nss/generic.nix
@@ -47,6 +47,10 @@ stdenv.mkDerivation rec {
       ./85_security_load_3.85+.patch
     )
     ./fix-cross-compilation.patch
+  ] ++ lib.optionals (lib.versionAtLeast version "3.90") [
+    # https://bugzilla.mozilla.org/show_bug.cgi?id=1836925
+    # https://phabricator.services.mozilla.com/D180068
+    ./remove-c25519-support.patch
   ];
 
   patchFlags = [ "-p0" ];

--- a/pkgs/development/libraries/nss/latest.nix
+++ b/pkgs/development/libraries/nss/latest.nix
@@ -5,6 +5,6 @@
 #       Example: nix-shell ./maintainers/scripts/update.nix --argstr package cacert
 
 import ./generic.nix {
-  version = "3.89.1";
-  hash = "sha256-OtrtuecMPF9AYDv2CgHjNhkKbb4Bkp05XxawH+hKAVY=";
+  version = "3.90";
+  hash = "sha256-ms1lNMQdjq0Z/Kb8s//+0vnwnEN8PXn+5qTuZoqqk7Y=";
 }

--- a/pkgs/development/libraries/nss/remove-c25519-support.patch
+++ b/pkgs/development/libraries/nss/remove-c25519-support.patch
@@ -1,0 +1,69 @@
+diff --git a/nss/lib/freebl/Makefile b/nss/lib/freebl/Makefile
+index 74e8e65..aa9dd95 100644
+--- nss/lib/freebl/Makefile
++++ nss/lib/freebl/Makefile
+@@ -568,7 +568,6 @@ ifneq ($(shell $(CC) -? 2>&1 >/dev/null </dev/null | sed -e 's/:.*//;1q'),lcc)
+             HAVE_INT128_SUPPORT = 1
+             DEFINES += -DHAVE_INT128_SUPPORT
+     else ifeq (1,$(CC_IS_GCC))
+-        SUPPORTS_VALE_CURVE25519 = 1
+         ifneq (,$(filter 4.6 4.7 4.8 4.9,$(word 1,$(GCC_VERSION)).$(word 2,$(GCC_VERSION))))
+             HAVE_INT128_SUPPORT = 1
+             DEFINES += -DHAVE_INT128_SUPPORT
+@@ -593,11 +592,6 @@ ifndef HAVE_INT128_SUPPORT
+     DEFINES += -DKRML_VERIFIED_UINT128
+ endif
+ 
+-ifdef SUPPORTS_VALE_CURVE25519
+-    VERIFIED_SRCS += Hacl_Curve25519_64.c
+-    DEFINES += -DHACL_CAN_COMPILE_INLINE_ASM
+-endif
+-
+ ifndef NSS_DISABLE_CHACHAPOLY
+     ifeq ($(CPU_ARCH),x86_64)
+         ifndef NSS_DISABLE_AVX2
+diff --git a/nss/lib/freebl/freebl.gyp b/nss/lib/freebl/freebl.gyp
+index 65f9a80..23940ef 100644
+--- nss/lib/freebl/freebl.gyp
++++ nss/lib/freebl/freebl.gyp
+@@ -866,12 +866,6 @@
+           }],
+         ],
+       }],
+-      [ 'supports_vale_curve25519==1', {
+-        'defines': [
+-          # The Makefile does version-tests on GCC, but we're not doing that here.
+-          'HACL_CAN_COMPILE_INLINE_ASM',
+-        ],
+-      }],
+       [ 'OS=="linux" or OS=="android"', {
+         'conditions': [
+           [ 'target_arch=="x64"', {
+@@ -934,11 +928,6 @@
+   'variables': {
+     'module': 'nss',
+     'conditions': [
+-      [ 'target_arch=="x64" and cc_is_gcc==1', {
+-        'supports_vale_curve25519%': 1,
+-      }, {
+-        'supports_vale_curve25519%': 0,
+-      }],
+       [ 'target_arch=="x64" or target_arch=="arm64" or target_arch=="aarch64"', {
+         'have_int128_support%': 1,
+       }, {
+diff --git a/nss/lib/freebl/freebl_base.gypi b/nss/lib/freebl/freebl_base.gypi
+index d198c44..34b6b3c 100644
+--- nss/lib/freebl/freebl_base.gypi
++++ nss/lib/freebl/freebl_base.gypi
+@@ -151,11 +151,6 @@
+         'ecl/curve25519_32.c',
+       ],
+     }],
+-    ['supports_vale_curve25519==1', {
+-      'sources': [
+-        'verified/Hacl_Curve25519_64.c',
+-      ],
+-    }],
+     ['(target_arch!="ppc64" and target_arch!="ppc64le") or disable_altivec==1', {
+       'sources': [
+         # Gyp does not support per-file cflags, so working around like this.


### PR DESCRIPTION
https://github.com/nss-dev/nss/blob/NSS_3_90_BRANCH/doc/rst/releases/nss_3_90.rst
(cherry picked from commit 871fd1b)

backport #236270 


###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
