### PR TITLE
pritunl-client: refactor, add service and electron app

### DIFF
--- a/pkgs/tools/networking/pritunl-client/default.nix
+++ b/pkgs/tools/networking/pritunl-client/default.nix
@@ -1,9 +1,22 @@
-{ lib, buildGoModule, fetchFromGitHub, installShellFiles }:
-
-buildGoModule rec {
-  pname = "pritunl-client";
+{ lib
+, stdenv
+, fetchFromGitHub
+, runtimeShell
+, runCommand
+, makeWrapper
+, installShellFiles
+, buildGoModule
+, coreutils
+, which
+, gnugrep
+, gnused
+, openresolv
+, systemd
+, iproute2
+, openvpn
+, electron
+}: let
   version = "1.3.3584.5";
-
   src = fetchFromGitHub {
     owner = "pritunl";
     repo = "pritunl-client-electron";
@@ -11,25 +24,120 @@ buildGoModule rec {
     sha256 = "sha256-wWpP2u+oQSESjkRvAn5by7efvssYtKBYg2E+FZ/+tg0=";
   };
 
-  modRoot = "cli";
-  vendorHash = "sha256-miwGLWpoaavg/xcw/0pNBYCdovBnvjP5kdaaGPcRuWk=";
+  cli = buildGoModule {
+    pname = "pritunl-cli";
+    inherit version src;
+
+    modRoot = "cli";
+    vendorHash = "sha256-miwGLWpoaavg/xcw/0pNBYCdovBnvjP5kdaaGPcRuWk=";
+
+    postInstall = ''
+      mv $out/bin/cli $out/bin/pritunl-client
+    '';
+  };
+
+  service = buildGoModule {
+    pname = "pritunl-client-service";
+    inherit version src;
+
+    modRoot = "service";
+    vendorHash = "sha256-9Fv8m3eWlxv4WWDSdI0VMavgy+0OSIVZ98dkDBwm4Gc=";
+
+    nativeBuildInputs = [ makeWrapper ];
+
+    postPatch = ''
+      sed -Ei service/profile/scripts.go \
+        -e 's|#!\s*(/usr)?/bin/(env )?bash\b|#! ${runtimeShell}|g'
+    '' + lib.optionalString stdenv.isLinux ''
+      sed -Ei service/profile/scripts.go \
+        -e 's|(/usr)?/s?bin/busctl\b|busctl|g' \
+        -e 's|(/usr)?/s?bin/resolvectl\b|resolvectl|g' \
+        -e 's|(/usr)?/s?bin/ip\b|ip|g'
+    '';
+
+    postInstall = ''
+      mv $out/bin/service $out/bin/pritunl-client-service
+    '' + lib.optionalString stdenv.isLinux ''
+      mkdir -p $out/lib/systemd/system/
+      cp $src/resources_linux/pritunl-client.service $out/lib/systemd/system/
+      substituteInPlace $out/lib/systemd/system/pritunl-client.service \
+        --replace "/usr" "$out"
+    '';
+
+    postFixup = let
+      hookScriptsDeps = [
+        coreutils
+        which
+        gnused
+        gnugrep
+      ] ++ lib.optionals stdenv.isLinux [
+        openresolv
+        systemd
+        iproute2
+      ];
+      openvpn-wrapped = runCommand "openvpn-wrapped" {
+        nativeBuildInputs = [ makeWrapper ];
+      } ''
+        mkdir -p $out/bin
+        makeWrapper ${openvpn}/bin/openvpn $out/bin/openvpn \
+          --prefix PATH : ${lib.makeBinPath hookScriptsDeps} \
+          --add-flags "--setenv PATH \$PATH"
+      '';
+    in lib.optionalString stdenv.isLinux ''
+      wrapProgram $out/bin/pritunl-client-service \
+        --prefix PATH : "${lib.makeBinPath ([ openvpn-wrapped ])}"
+    '';
+  };
+in stdenv.mkDerivation {
+  pname = "pritunl-client";
+  inherit version src;
+
+  dontBuild = true;
+  dontConfigure = true;
 
   nativeBuildInputs = [
+    makeWrapper
     installShellFiles
   ];
 
-  postInstall = ''
-    mv $out/bin/cli $out/bin/pritunl-client
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/bin/
+    ln -s ${cli}/bin/pritunl-client $out/bin/
+    ln -s ${service}/bin/pritunl-client-service $out/bin/
+
+    mkdir -p $out/lib/
+    cp -r client $out/lib/pritunl_client_electron
+
+    makeWrapper ${electron}/bin/electron $out/bin/pritunl-client-electron \
+      --add-flags $out/lib/pritunl_client_electron
+
+  '' + lib.optionalString stdenv.isLinux ''
+    mkdir -p $out/lib/systemd/system/
+    ln -s ${service}/lib/systemd/system/pritunl-client.service $out/lib/systemd/system/
+
+    mkdir -p $out/share/icons/
+    cp -r resources_linux/icons $out/share/icons/hicolor
+
+    mkdir -p $out/share/applications/
+    cp resources_linux/pritunl-client-electron.desktop $out/share/applications/
+    substituteInPlace $out/share/applications/pritunl-client-electron.desktop \
+      --replace "/usr/lib/pritunl_client_electron/Pritunl" "$out/bin/pritunl-client-electron"
+  '' + ''
+    # install shell completions for pritunl-client
     installShellCompletion --cmd pritunl-client \
       --bash <($out/bin/pritunl-client completion bash) \
       --fish <($out/bin/pritunl-client completion fish) \
       --zsh <($out/bin/pritunl-client completion zsh)
+
+    runHook postInstall
   '';
 
   meta = with lib; {
-    description = "Pritunl OpenVPN client CLI";
-    homepage = "https://github.com/pritunl/pritunl-client-electron/tree/master/cli";
+    description = "Pritunl OpenVPN client";
+    homepage = "https://client.pritunl.com/";
     license = licenses.unfree;
-    maintainers = with maintainers; [ minizilla ];
+    maintainers = with maintainers; [ minizilla andrevmatos ];
   };
 }


### PR DESCRIPTION
###### Description of changes

Refactor of `pritunl-client`:
- `cli` is split in a subpackage
- `service` subpackage added, building the `pritunl-client-service` binary, similar to the official deb package structure.
  - includes a systemd .service, which can be enabled with:
 ```
systemd.packages = [ pkgs.pritunl-client ];
systemd.targets.multi-user.wants = [ "pritunl-client.service" ];
```
- electron app is copied to `lib/pritunl_client_electron/`, with icons and .desktop, ran using `electron` package
- ~~pull shell completion from #231292~~ (merged and rebased)
- add myself as maintainer

The service and electron app *should* work on Darwin, but I don't have a machine to test. This is working great though on Linux

Closes #233793 
~~Includes/supersedes #231292~~

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
