### PR TITLE
baloo: patch to support btrfs better

### DIFF
--- a/pkgs/development/libraries/kde-frameworks/baloo.nix
+++ b/pkgs/development/libraries/kde-frameworks/baloo.nix
@@ -1,19 +1,44 @@
-{
-  mkDerivation, lib,
-  extra-cmake-modules,
-  kauth, kconfig, kcoreaddons, kcrash, kdbusaddons, kfilemetadata, ki18n,
-  kidletime, kio, lmdb, qtbase, qtdeclarative, solid,
+{ mkDerivation
+, lib
+, fetchpatch
+, extra-cmake-modules
+, kauth
+, kconfig
+, kcoreaddons
+, kcrash
+, kdbusaddons
+, kfilemetadata
+, ki18n
+, kidletime
+, kio
+, lmdb
+, qtbase
+, qtdeclarative
+, solid
+,
 }:
 
 mkDerivation {
   pname = "baloo";
   nativeBuildInputs = [ extra-cmake-modules ];
-  buildInputs = [
-    kauth kconfig kcrash kdbusaddons ki18n kio kidletime lmdb qtdeclarative
-    solid
-  ];
+  buildInputs = [ kauth kconfig kcrash kdbusaddons ki18n kio kidletime lmdb qtdeclarative solid ];
   outputs = [ "out" "dev" ];
   propagatedBuildInputs = [ kcoreaddons kfilemetadata qtbase ];
+
+  # baloo suffers from issues when running on btrfs as well as with certain LVM/dm-crypt setups
+  # where the device id will change on reboot causing baloo to reindex all the files and then having
+  # duplicate files. A patch has been proposed that addresses this, which has not been accepted yet.
+  # However, without this patch, people tend to disable baloo rather than dealing with the constant
+  # reindexing.
+  #
+  # https://bugs.kde.org/show_bug.cgi?id=402154
+  patches = [
+    (fetchpatch {
+      url = "https://bugsfiles.kde.org/attachment.cgi?id=159031";
+      hash = "sha256-hCtNXUpRhIP94f7gpwTGWWh1h/7JRRJaRASIwHWQjnY=";
+      name = "use_fsid.patch";
+    })
+  ];
 
   # kde-baloo.service uses `ExecCondition=@KDE_INSTALL_FULL_BINDIR@/kde-systemd-start-condition ...`
   # which comes from the "plasma-workspace" derivation, but KDE_INSTALL_* all point at the "baloo" one


### PR DESCRIPTION
###### Description of changes

baloo suffers from issues when running on btrfs as well as with certain LVM/dm-crypt setups
where the device id will change on reboot causing baloo to reindex all the files and then having
duplicate files. A patch has been proposed that addresses this, which has not been accepted yet.
However, without this patch, people tend to disable baloo rather than dealing with the constant
reindexing.

https://bugs.kde.org/show_bug.cgi?id=402154

I have been running with the patch applied for a quite a while and it makes a *huge* difference.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [X] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
