### PR TITLE
python310Packages.pysubs2: init at 1.6.1

### DIFF
--- a/pkgs/development/python-modules/pysubs2/default.nix
+++ b/pkgs/development/python-modules/pysubs2/default.nix
@@ -1,0 +1,38 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, pytestCheckHook
+, setuptools
+}:
+
+buildPythonPackage rec {
+  pname = "pysubs2";
+  version = "1.6.1";
+  format = "pyproject";
+
+  src = fetchFromGitHub {
+    owner = "tkarabela";
+    repo = pname;
+    rev =  version;
+    hash = "sha256-0bW9aB6ERRQK3psqeU0Siyi/8drEGisAp8UtTfOKlp0=";
+  };
+
+  nativeBuildInputs = [
+    setuptools
+  ];
+
+  nativeCheckInputs = [
+    pytestCheckHook
+  ];
+
+  pythonImportsCheck = [
+    "pysubs2"
+  ];
+
+  meta = with lib; {
+    homepage = "https://github.com/tkarabela/pysubs2";
+    description = "A Python library for editing subtitle files";
+    license = licenses.mit;
+    maintainers = with maintainers; [ Benjamin-L ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -7789,6 +7789,8 @@ self: super: with self; {
 
   pysolcast = callPackage ../development/python-modules/pysolcast { };
 
+  pysubs2 = callPackage ../development/python-modules/pysubs2 { };
+
   pysqlitecipher = callPackage ../development/python-modules/pysqlitecipher { };
 
   pysyncthru = callPackage ../development/python-modules/pysyncthru { };


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
Add the python library [pysubs2](https://github.com/tkarabela/pysubs2), which is a dependency of [ffsubsync](https://github.com/smacke/ffsubsync).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<details>
<summary>output of `nixpkgs-review rev HEAD`</summary>

```
$ git -c fetch.prune=false fetch --no-tags --force https://github.com/NixOS/nixpkgs master:refs/nixpkgs-review/0
remote: Enumerating objects: 3993, done.
remote: Counting objects: 100% (2009/2009), done.
remote: Compressing objects: 100% (346/346), done.
remote: Total 3993 (delta 1684), reused 1854 (delta 1591), pack-reused 1984
Receiving objects: 100% (3993/3993), 3.47 MiB | 9.95 MiB/s, done.
Resolving deltas: 100% (2628/2628), completed with 457 local objects.
From https://github.com/NixOS/nixpkgs
   cf1b7c4d5c0..5a193fb4ddb  master     -> refs/nixpkgs-review/0
$ git worktree add /home/benjamin/.cache/nixpkgs-review/rev-cc6cb70583033384f20abcb3b245981670d6d0fe/nixpkgs 5a193fb4ddbc0df84c96d213d36d27e60f14d7ae
Preparing worktree (detached HEAD 5a193fb4ddb)
Updating files: 100% (35899/35899), done.
HEAD is now at 5a193fb4ddb Merge pull request #232469 from natsukium/autodock-vina/init
$ nix-env --extra-experimental-features no-url-literals --option system x86_64-linux -f /home/benjamin/.cache/nixpkgs-review/rev-cc6cb70583033384f20abcb3b245981670d6d0fe/nixpkgs -qaP --xml --out-path --show-trace --no-allow-import-from-derivation
$ git merge --no-commit --no-ff cc6cb70583033384f20abcb3b245981670d6d0fe
Auto-merging pkgs/top-level/python-packages.nix
Automatic merge went well; stopped before committing as requested
$ nix-env --extra-experimental-features no-url-literals --option system x86_64-linux -f /home/benjamin/.cache/nixpkgs-review/rev-cc6cb70583033384f20abcb3b245981670d6d0fe/nixpkgs -qaP --xml --out-path --show-trace --no-allow-import-from-derivation --meta
2 packages added:
python310Packages.pysubs2 (init at 1.6.1) python311Packages.pysubs2 (init at 1.6.1)

$ nix build --extra-experimental-features nix-command no-url-literals --no-link --keep-going --no-allow-import-from-derivation --option build-use-sandbox relaxed -f /home/benjamin/.cache/nixpkgs-review/rev-cc6cb70583033384f20abcb3b245981670d6d0fe/build.nix
4 packages built:
python310Packages.pysubs2 python310Packages.pysubs2.dist python311Packages.pysubs2 python311Packages.pysubs2.dist

warning: The interpretation of store paths arguments ending in `.drv` recently changed. If this command is now failing try again with '/nix/store/nw97hj6596isg3m7a3hb6bd43dpr6lvs-python3.10-pysubs2-1.6.1.drv^*'
warning: The interpretation of store paths arguments ending in `.drv` recently changed. If this command is now failing try again with '/nix/store/nw97hj6596isg3m7a3hb6bd43dpr6lvs-python3.10-pysubs2-1.6.1.drv^*'
warning: The interpretation of store paths arguments ending in `.drv` recently changed. If this command is now failing try again with '/nix/store/93wfv51cw1r2cmxhfnwv5qbwpmqq69k3-python3.11-pysubs2-1.6.1.drv^*'
warning: The interpretation of store paths arguments ending in `.drv` recently changed. If this command is now failing try again with '/nix/store/93wfv51cw1r2cmxhfnwv5qbwpmqq69k3-python3.11-pysubs2-1.6.1.drv^*'
$ /nix/store/pw3s9hnn8m5y6pcqc94659r8gbznrlb8-nix-2.15.1/bin/nix-shell /home/benjamin/.cache/nixpkgs-review/rev-cc6cb70583033384f20abcb3b245981670d6d0fe/shell.nix
```
</details>


The other ffsubsync dependency that isn't packaged yet is [auditok](https://github.com/amsehili/auditok). There's [an open PR](https://github.com/NixOS/nixpkgs/pull/209430) to add it, however ffsubsync pins the dependency at 0.1.5, and the PR is for 0.2.0 (the most recent version). I've tested a branch with all three (pysubs2, auditok_0_1_5, and ffsubsync) and confirmed that ffsubsync works.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
