### PR TITLE
clickhouse: compress tarball

### DIFF
--- a/pkgs/servers/clickhouse/default.nix
+++ b/pkgs/servers/clickhouse/default.nix
@@ -34,7 +34,10 @@ in mkDerivation rec {
     repo = "ClickHouse";
     rev = "v${version}-lts";
     fetchSubmodules = true;
-    hash = "sha256-fVwwMj0WbyCbe4WfpYMGVM6vXFgHsjg9MUZbNyd+a/w=";
+    name = "clickhouse-${rev}.tar.gz";
+    hash = if stdenv.isDarwin
+           then "sha256-VaUGbUyDilYPK4iBv/nICOsfeolNQeBSEtC71gBTkpE="
+           else "sha256-NH+OW6zr8XBmJr68fX1WIy8Wt7cLWFMskIv7Be0TLEU=";
     postFetch = ''
       # delete files that make the source too big
       rm -rf $out/contrib/llvm-project/llvm/test
@@ -44,6 +47,18 @@ in mkDerivation rec {
       # fix case insensitivity on macos https://github.com/NixOS/nixpkgs/issues/39308
       rm -rf $out/contrib/sysroot/linux-*
       rm -rf $out/contrib/liburing/man
+
+      # compress to not exceed the 2GB output limit
+      # try to make a deterministic tarball
+      tar -I 'gzip -n' \
+        --sort=name \
+        --mtime=1970-01-01 \
+        --owner=root --group=root \
+        --numeric-owner --mode=go=rX,u+rw,a-s \
+        --transform='s@^@source/@S' \
+        -cf temp  -C "$out" .
+      rm -r "$out"
+      mv temp "$out"
     '';
   };
 


### PR DESCRIPTION
The comment said the limit was 4GB, but it's really 2GB so we need to compress.