### PR TITLE
nixos/fontconfig: remove misleading documentation

### DIFF
--- a/nixos/modules/config/fonts/fontconfig.nix
+++ b/nixos/modules/config/fonts/fontconfig.nix
@@ -299,11 +299,7 @@ in
         antialias = mkOption {
           type = types.bool;
           default = true;
-          description = lib.mdDoc ''
-            Enable font antialiasing. At high resolution (> 200 DPI),
-            antialiasing has no visible effect; users of such displays may want
-            to disable this option.
-          '';
+          description = lib.mdDoc "Enable font antialiasing.";
         };
 
         localConf = mkOption {
@@ -365,9 +361,7 @@ in
             default = true;
             description = lib.mdDoc ''
               Enable font hinting. Hinting aligns glyphs to pixel boundaries to
-              improve rendering sharpness at low resolution. At high resolution
-              (> 200 dpi) hinting will do nothing (at best); users of such
-              displays may want to disable this option.
+              improve rendering sharpness.
             '';
           };
 


### PR DESCRIPTION
These seemingly misguided comments were added by 65592837b6e62fb555d6e8c891f347428886c4f2, and are the source of the confusion in #194594 and #222236.

For reference, Android ships on devices with 400-500 DPI displays, and still makes use of greyscale anti-aliasing. It does not use subpixel AA which *does* hit diminishing returns at high resolutions, but can cause visible artifacts (at 300 DPI, we already have three times more pixels than a standard density display, catching up with the effective subpixel resolution of those screens).

For a subjective reference point, I already find subpixel anti-aliasing ineffective on a ~100 DPI monitor, and the color fringing is noticeable and intrusive.

According to [1], the v40 TrueType interpreter does not do subpixel hinting. Instead, it aligns to whole pixels. This helps with sharpness, and I have no reason to believe that it is harmful at higher resolutions.
It is still useful on displays that are between standard (96 DPI) and "retina" (250-300+ DPI) density. These are generally considered high-DPI because they require scaling. For example, a 14" 1080p laptop, or a 27" 4k monitor are around 150 DPI.

[1]: https://freetype.org/freetype2/docs/hinting/subpixel-hinting.html

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
