### PR TITLE
ocamlPackages.domain-local-await: 0.2.0 → 0.2.1; ocamlPackages.thread-table: init at 0.1.0

### DIFF
--- a/pkgs/development/ocaml-modules/domain-local-await/default.nix
+++ b/pkgs/development/ocaml-modules/domain-local-await/default.nix
@@ -1,22 +1,31 @@
 { lib
 , buildDunePackage
 , fetchurl
+, alcotest
 , mdx
+, thread-table
 }:
 
 buildDunePackage rec {
   pname = "domain-local-await";
-  version = "0.2.0";
+  version = "0.2.1";
 
   minimalOCamlVersion = "5.0";
   duneVersion = "3";
 
   src = fetchurl {
     url = "https://github.com/ocaml-multicore/${pname}/releases/download/${version}/${pname}-${version}.tbz";
-    sha256 = "2DCJsI3nGPtbXnU8jRvzR1iNAkNuekVy4Lid1qnHXDo=";
+    sha256 = "LQxshVpk9EnO2adGXBamF8Hw8CVTAzJ7W4yKIkSmLm4=";
   };
 
+  propagatedBuildInputs = [
+    thread-table
+  ];
+
+  doCheck = true;
+
   checkInputs = [
+    alcotest
     mdx
   ];
 

--- a/pkgs/development/ocaml-modules/thread-table/default.nix
+++ b/pkgs/development/ocaml-modules/thread-table/default.nix
@@ -1,0 +1,37 @@
+{ lib
+, fetchurl
+, buildDunePackage
+, alcotest
+, mdx
+}:
+
+buildDunePackage rec {
+  pname = "thread-table";
+  version = "0.1.0";
+
+  minimalOCamlVersion = "4.08";
+
+  src = fetchurl {
+    url = "https://github.com/ocaml-multicore/${pname}/releases/download/${version}/${pname}-${version}.tbz";
+    sha256 = "d84BwC9W5udWJgYuaQwmA1e2d6uk0v210M7nK72VjXs=";
+  };
+
+  doCheck = true;
+
+  checkInputs = [
+    alcotest
+    mdx
+  ];
+
+  nativeCheckInputs = [
+    mdx.bin
+  ];
+
+  meta = {
+    homepage = "https://github.com/ocaml-multicore/ocaml-${pname}";
+    changelog = "https://github.com/ocaml-multicore/ocaml-${pname}/raw/${version}/CHANGES.md";
+    description = "A lock-free thread-safe integer keyed hash table";
+    license = with lib.licenses; [ isc ];
+    maintainers = with lib.maintainers; [ toastal ];
+  };
+}

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -1603,6 +1603,8 @@ let
 
     theora = callPackage ../development/ocaml-modules/theora { };
 
+    thread-table = callPackage ../development/ocaml-modules/thread-table { };
+
     timed = callPackage ../development/ocaml-modules/timed { };
 
     tiny_httpd = callPackage ../development/ocaml-modules/tiny_httpd { };


### PR DESCRIPTION
###### Description of changes

The new version introduces a new dependency that needs to propagate. In my AMD Ryzen Zen 3 machine, I was able to build `thread-table`, `domain-local-await`, and `eio`. 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
