### PR TITLE
obs-studio-plugins.obs-text-pthread: init at 2.0.2

### DIFF
--- a/pkgs/applications/video/obs-studio/plugins/default.nix
+++ b/pkgs/applications/video/obs-studio/plugins/default.nix
@@ -46,6 +46,8 @@
 
   obs-teleport = callPackage ./obs-teleport { };
 
+  obs-text-pthread = callPackage ./obs-text-pthread.nix { };
+
   obs-transition-table = qt6Packages.callPackage ./obs-transition-table.nix { };
 
   obs-vaapi = callPackage ./obs-vaapi { };

--- a/pkgs/applications/video/obs-studio/plugins/obs-text-pthread.nix
+++ b/pkgs/applications/video/obs-studio/plugins/obs-text-pthread.nix
@@ -1,0 +1,39 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, cmake
+, cairo
+, obs-studio
+, pango
+, pkg-config
+}:
+
+stdenv.mkDerivation rec {
+  pname = "obs-text-pthread";
+  version = "2.0.2";
+
+  src = fetchFromGitHub {
+    owner = "norihiro";
+    repo = "obs-text-pthread";
+    rev = version;
+    sha256 = "sha256-HN8tSagxmk6FusDrp7d0fi15ardFgUCZBiYkeBqUI34=";
+  };
+
+  nativeBuildInputs = [ cmake pkg-config ];
+  buildInputs = [ cairo obs-studio pango ];
+
+  postInstall = ''
+    mkdir $out/lib $out/share
+    mv $out/obs-plugins/64bit $out/lib/obs-plugins
+    rm -rf $out/obs-plugins
+    mv $out/data $out/share/obs
+  '';
+
+  meta = with lib; {
+    description = "Rich text source plugin for OBS Studio";
+    homepage = "https://github.com/norihiro/obs-text-pthread";
+    maintainers = with maintainers; [ flexiondotorg ];
+    license = licenses.gpl2Plus;
+    platforms = [ "x86_64-linux" "i686-linux" ];
+  };
+}


### PR DESCRIPTION
###### Description of changes

Rich text source plugin for OBS Studio: https://github.com/norihiro/obs-text-pthread

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

Result of `nixpkgs-review` run on x86_64-linux [1](https://github.com/Mic92/nixpkgs-review)
<details>
  <summary>1 package built:</summary>
  <ul>
    <li>obs-studio-plugins.obs-text-pthread</li>
  </ul>
</details>

```
 result
├──  lib
│  └──  obs-plugins
│     └──  obs-text-pthread.so
└──  share
   └──  obs
      └──  obs-plugins
         └──  obs-text-pthread
            └──  textalpha.effect
```