### PR TITLE
obs-studio-plugins.obs-rgb-levels-filter: init at 1.0.0

### DIFF
--- a/pkgs/applications/video/obs-studio/plugins/default.nix
+++ b/pkgs/applications/video/obs-studio/plugins/default.nix
@@ -40,6 +40,8 @@
 
   obs-pipewire-audio-capture = callPackage ./obs-pipewire-audio-capture.nix { };
 
+  obs-rgb-levels-filter = callPackage ./obs-rgb-levels-filter.nix { };
+
   obs-scale-to-sound = callPackage ./obs-scale-to-sound.nix { };
 
   obs-shaderfilter = qt6Packages.callPackage ./obs-shaderfilter.nix { };

--- a/pkgs/applications/video/obs-studio/plugins/obs-rgb-levels-filter.nix
+++ b/pkgs/applications/video/obs-studio/plugins/obs-rgb-levels-filter.nix
@@ -1,0 +1,33 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, cmake
+, obs-studio
+}:
+
+stdenv.mkDerivation rec {
+  pname = "obs-rgb-levels-filter";
+  version = "1.0.0";
+
+  src = fetchFromGitHub {
+    owner = "wimpysworld";
+    repo = "obs-rgb-levels-filter";
+    rev = version;
+    sha256 = "sha256-QREwK9nBhjCBFslXUj9bGUGPgfEns8QqlgP5e2O/0oU=";
+  };
+
+  nativeBuildInputs = [ cmake ];
+  buildInputs = [ obs-studio ];
+
+  cmakeFlags = [
+    "-DOBS_SRC_DIR=${obs-studio.src}"
+  ];
+
+  meta = with lib; {
+    description = "A simple OBS Studio filter to adjust RGB levels.";
+    homepage = "https://github.com/wimpysworld/obs-rgb-levels-filter";
+    maintainers = with maintainers; [ flexiondotorg ];
+    license = licenses.gpl2Plus;
+    platforms = [ "x86_64-linux" "i686-linux" ];
+  };
+}


### PR DESCRIPTION
###### Description of changes

RGB levels plugin for OBS: https://github.com/wimpysworld/obs-rgb-levels-filter

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

Result of `nixpkgs-review` run on x86_64-linux [1](https://github.com/Mic92/nixpkgs-review)
<details>
  <summary>1 package built:</summary>
  <ul>
    <li>obs-studio-plugins.obs-rgb-levels-filter</li>
  </ul>
</details>

```
 result
├──  lib
│  └──  obs-plugins
│     └──  obs-rgb-levels-filter.so
└──  share
   └──  obs
      └──  obs-plugins
         └──  obs-rgb-levels-filter
            ├──  locale
            │  └──  en-US.ini
            └──  rgb_levels.effect
```