### PR TITLE
wine: fix gstreamer on WoW builds 

### DIFF
--- a/pkgs/applications/emulators/wine/base.nix
+++ b/pkgs/applications/emulators/wine/base.nix
@@ -1,4 +1,4 @@
-{ stdenv, lib, pkgArches, callPackage, makeSetupHook,
+{ stdenv, lib, pkgArches, makeSetupHook,
   pname, version, src, mingwGccs, monos, geckos, platforms,
   bison, flex, fontforge, makeWrapper, pkg-config,
   nixosTests,
@@ -84,8 +84,7 @@ stdenv.mkDerivation ((lib.optionalAttrs (buildScript != null) {
   ++ lib.optional sdlSupport             pkgs.SDL2
   ++ lib.optional usbSupport             pkgs.libusb1
   ++ lib.optionals gstreamerSupport      (with pkgs.gst_all_1;
-    [ gstreamer gst-plugins-base gst-plugins-good gst-plugins-ugly gst-libav
-    (gst-plugins-bad.override { enableZbar = false; }) ])
+    [ gstreamer gst-plugins-base gst-plugins-good gst-plugins-ugly gst-libav gst-plugins-bad ])
   ++ lib.optionals gtkSupport    [ pkgs.gtk3 pkgs.glib ]
   ++ lib.optionals openclSupport [ pkgs.opencl-headers pkgs.ocl-icd ]
   ++ lib.optionals tlsSupport    [ pkgs.openssl pkgs.gnutls ]

--- a/pkgs/applications/emulators/wine/builder-wow.sh
+++ b/pkgs/applications/emulators/wine/builder-wow.sh
@@ -1,4 +1,4 @@
-## build described at http://wiki.winehq.org/Wine64
+## build described at https://wiki.winehq.org/Building_Wine#Shared_WoW64
 
 source $stdenv/setup
 preFlags="${configureFlags}"
@@ -16,6 +16,26 @@ configureFlags="${preFlags} --enable-win64"
 configurePhase
 buildPhase
 # checkPhase
+
+# Remove 64 bit gstreamer from PKG_CONFIG_PATH
+IFS=":" read -ra LIST_ARRAY <<< "$PKG_CONFIG_PATH"
+IFS=":" read -ra REMOVE_ARRAY <<< "@pkgconfig64remove@"
+NEW_LIST_ARRAY=()
+
+for ELEMENT in "${LIST_ARRAY[@]}"; do
+  TO_ADD=1
+  for REMOVE in "${REMOVE_ARRAY[@]}"; do
+    if [[ "$REMOVE" == "$ELEMENT" ]]; then
+      TO_ADD=0
+      break
+    fi
+  done
+
+  if [[ $TO_ADD -eq 1 ]]; then
+    NEW_LIST_ARRAY+=("$ELEMENT")
+  fi
+done
+PKG_CONFIG_PATH=$(IFS=":"; echo "${NEW_LIST_ARRAY[*]}")
 
 cd $TMP/wine-wow
 sourceRoot=`pwd`

--- a/pkgs/applications/emulators/wine/packages.nix
+++ b/pkgs/applications/emulators/wine/packages.nix
@@ -1,4 +1,4 @@
-{ stdenv_32bit, lib, pkgs, pkgsi686Linux, pkgsCross, callPackage, moltenvk,
+{ stdenv_32bit, lib, pkgs, pkgsi686Linux, pkgsCross, callPackage, substituteAll, moltenvk,
   wineRelease ? "stable",
   supportFlags
 }:
@@ -34,7 +34,11 @@ in with src; {
     geckos = [ gecko32 gecko64 ];
     mingwGccs = with pkgsCross; [ mingw32.buildPackages.gcc mingwW64.buildPackages.gcc ];
     monos =  [ mono ];
-    buildScript = ./builder-wow.sh;
+    buildScript = substituteAll {
+        src = ./builder-wow.sh;
+        # pkgconfig has trouble picking the right architecture
+        pkgconfig64remove = lib.makeSearchPathOutput "dev" "lib/pkgconfig" [ pkgs.glib pkgs.gst_all_1.gstreamer ];
+      };
     platforms = [ "x86_64-linux" ];
     mainProgram = "wine64";
   };


### PR DESCRIPTION
###### Description of changes

Fixes  #132352.
This is *so* dirty...

Tested The Elder Scrolls IV: Oblivion.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
