### PR TITLE
libiconvReal: implement ABI compatibility on Darwin

### DIFF
--- a/pkgs/development/libraries/libiconv/default.nix
+++ b/pkgs/development/libraries/libiconv/default.nix
@@ -1,6 +1,7 @@
 { fetchurl, stdenv, lib
 , enableStatic ? stdenv.hostPlatform.isStatic
 , enableShared ? !stdenv.hostPlatform.isStatic
+, enableDarwinABICompat ? false
 }:
 
 # assert !stdenv.hostPlatform.isLinux || stdenv.hostPlatform != stdenv.buildPlatform; # TODO: improve on cross
@@ -28,7 +29,34 @@ stdenv.mkDerivation rec {
       ''
     + lib.optionalString (!enableShared) ''
       sed -i -e '/preload/d' Makefile.in
+    ''
+    # The system libiconv is based on libiconv 1.11 with some ABI differences. The following changes
+    # build a compatible libiconv on Darwin, allowing it to be sustituted in place of the system one
+    # using `install_name_tool`. This removes the need to for a separate, Darwin-specific libiconv
+    # derivation and allows Darwin to benefit from upstream updates and fixes.
+    + lib.optionalString enableDarwinABICompat ''
+      for iconv_h_in in iconv.h.in iconv.h.build.in; do
+        substituteInPlace "include/$iconv_h_in" \
+          --replace "#define iconv libiconv" "" \
+          --replace "#define iconv_close libiconv_close" "" \
+          --replace "#define iconv_open libiconv_open" "" \
+          --replace "#define iconv_open_into libiconv_open_into" "" \
+          --replace "#define iconvctl libiconvctl" "" \
+          --replace "#define iconvlist libiconvlist" ""
+      done
     '';
+
+  # This is hacky, but `libiconv.dylib` needs to reexport `libcharset.dylib` to match the behavior
+  # of the system libiconv on Darwin. Trying to do this by modifying the `Makefile` results in an
+  # error linking `iconv` because `libcharset.dylib` is not at its final path yet. Avoid the error
+  # by building without the reexport then clean and rebuild `libiconv.dylib` with the reexport.
+  #
+  # For an explanation why `libcharset.dylib` is reexported, see:
+  # https://github.com/apple-oss-distributions/libiconv/blob/a167071feb7a83a01b27ec8d238590c14eb6faff/xcodeconfig/libiconv.xcconfig
+  postBuild = lib.optionalString enableDarwinABICompat ''
+    make clean -C lib
+    NIX_CFLAGS_COMPILE+=" -Wl,-reexport-lcharset -L. " make -C lib -j$NIX_BUILD_CORES SHELL=$SHELL
+  '';
 
   configureFlags = [
     (lib.enableFeature enableStatic "static")


### PR DESCRIPTION
###### Things done

This commit prepares libiconvReal to replace darwin.libiconv, allowing it to be used with binary derivations that patch out references to the system libiconv with one from nixpkgs.

Apple’s libiconv is based on GNU libiconv 1.11 (the last version before it switched to LGPLv3+). Any newer releases by Apple appear to be build system tweaks. The core sources are barely updated. This means that Darwin users won’t get any fixes from upstream updates, and maintaining darwin.libiconv requires dealing with a separate and different build system (because Apple now builds it with Xcode). Fortunately, it is possible to build upstream libiconv in a way that is compatible with Apple’s distribution of it.

There are two things that need to happen to produce an ABI-compatible build of libiconv:

* Existing symbols need to be exported with the `iconv_` prefix instead of the `libiconv_` prefix. New symbols can have the `libiconv` prefix, and one symbol in Apple’s distribution does, but older ones must have the older prefix; and
* Reexport `libcharset.dylib` from `libiconv.dylib`. This is explained by Apple as the result of a bug in their transition to an Xcode-based build system.

Both these these are doable and have been done by this commit. I have tested it with building GHC, which downloads a binary distribution as part of its bootstrap and replaces references to the system libiconv with darwin.libiconv. Using this patch, libiconvReal is able to work without any changes to the GHC derivation.

Note that this patch does not actually deprecate or remove darwin.libiconv yet. That will be done in a future patch after Darwin support is added for aliases and deprecating packages in the `darwin` attrset.

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
