### PR TITLE
stdenv: let overrideAttrs accept attrset OR function

### DIFF
--- a/doc/using/overrides.chapter.md
+++ b/doc/using/overrides.chapter.md
@@ -58,13 +58,15 @@ The argument `finalAttrs` refers to the final attributes passed to `mkDerivation
 
 If only a one-argument function is written, the argument has the meaning of `previousAttrs`.
 
+Function arguments can be omitted entirely if there is no need to access `previousAttrs` or `finalAttrs`.
+
 ```nix
 helloWithDebug = pkgs.hello.overrideAttrs {
   separateDebugInfo = true;
 };
 ```
 
-In the above example, the `separateDebugInfo` attribute is overridden to be true, thus building debug info for `helloWithDebug`. Function arguments can be omitted if there is no need to access previousAttrs or finalAttrs.
+In the above example, the `separateDebugInfo` attribute is overridden to be true, thus building debug info for `helloWithDebug`.
 
 ::: {.note}
 Note that `separateDebugInfo` is processed only by the `stdenv.mkDerivation` function, not the generated, raw Nix derivation. Thus, using `overrideDerivation` will not work in this case, as it overrides only the attributes of the final derivation. It is for this reason that `overrideAttrs` should be preferred in (almost) all cases to `overrideDerivation`, i.e. to allow using `stdenv.mkDerivation` to process input arguments, as well as the fact that it is easier to use (you can use the same attribute names you see in your Nix code, instead of the ones generated (e.g. `buildInputs` vs `nativeBuildInputs`), and it involves less typing).

--- a/doc/using/overrides.chapter.md
+++ b/doc/using/overrides.chapter.md
@@ -36,21 +36,29 @@ In the first example, `pkgs.foo` is the result of a function call with some defa
 
 The function `overrideAttrs` allows overriding the attribute set passed to a `stdenv.mkDerivation` call, producing a new derivation based on the original one. This function is available on all derivations produced by the `stdenv.mkDerivation` function, which is most packages in the nixpkgs expression `pkgs`.
 
-Example usage:
+Example usages:
 
 ```nix
-helloWithDebug = pkgs.hello.overrideAttrs (finalAttrs: previousAttrs: {
-  separateDebugInfo = true;
+helloBar = pkgs.hello.overrideAttrs (finalAttrs: previousAttrs: {
+  pname = previousAttrs.pname + "-bar";
 });
 ```
 
-In the above example, the `separateDebugInfo` attribute is overridden to be true, thus building debug info for `helloWithDebug`, while all other attributes will be retained from the original `hello` package.
+In the above example, "-bar" is appended to the pname attribute, while all other attributes will be retained from the original `hello` package.
 
 The argument `previousAttrs` is conventionally used to refer to the attr set originally passed to `stdenv.mkDerivation`.
 
 The argument `finalAttrs` refers to the final attributes passed to `mkDerivation`, plus the `finalPackage` attribute which is equal to the result of `mkDerivation` or subsequent `overrideAttrs` calls.
 
 If only a one-argument function is written, the argument has the meaning of `previousAttrs`.
+
+```nix
+helloWithDebug = pkgs.hello.overrideAttrs {
+  separateDebugInfo = true;
+};
+```
+
+In the above example, the `separateDebugInfo` attribute is overridden to be true, thus building debug info for `helloWithDebug`. Function arguments can be omitted if there is no need to access previousAttrs or finalAttrs.
 
 ::: {.note}
 Note that `separateDebugInfo` is processed only by the `stdenv.mkDerivation` function, not the generated, raw Nix derivation. Thus, using `overrideDerivation` will not work in this case, as it overrides only the attributes of the final derivation. It is for this reason that `overrideAttrs` should be preferred in (almost) all cases to `overrideDerivation`, i.e. to allow using `stdenv.mkDerivation` to process input arguments, as well as the fact that it is easier to use (you can use the same attribute names you see in your Nix code, instead of the ones generated (e.g. `buildInputs` vs `nativeBuildInputs`), and it involves less typing).

--- a/doc/using/overrides.chapter.md
+++ b/doc/using/overrides.chapter.md
@@ -16,6 +16,12 @@ Example usages:
 pkgs.foo.override { arg1 = val1; arg2 = val2; ... }
 ```
 
+It's also possible to access the previous arguments.
+
+```nix
+pkgs.foo.override (previous: { arg1 = previous.arg1; ... })
+```
+
 <!-- TODO: move below programlisting to a new section about extending and overlays and reference it -->
 
 ```nix

--- a/pkgs/stdenv/generic/make-derivation.nix
+++ b/pkgs/stdenv/generic/make-derivation.nix
@@ -41,7 +41,7 @@ let
               else x;
         in
           makeDerivationExtensible
-            (self: let super = rattrs self; in super // f self super);
+            (self: let super = rattrs self; in super // (if builtins.isFunction f0 || f0?__functor then f self super else f0));
 
       finalPackage =
         mkDerivationSimple overrideAttrs args;

--- a/pkgs/test/overriding.nix
+++ b/pkgs/test/overriding.nix
@@ -21,6 +21,11 @@ let
         expr = repeatedOverrides.entangled.pname == "a-better-figlet-with-blackjack";
         expected = true;
       })
+      ({
+        name = "overriding-using-only-attrset";
+        expr = (pkgs.hello.overrideAttrs { pname = "hello-overriden"; }).pname == "hello-overriden";
+        expected = true;
+      })
     ];
 
   addEntangled = origOverrideAttrs: f:


### PR DESCRIPTION
Rebased/Adapted https://github.com/NixOS/nixpkgs/pull/146347

Makes overrideAttrs usable in the same way that `override` can be used.
It allows the first argument of `overrideAttrs` to be either a function
or an attrset, instead of only a function:

hello.overrideAttrs (old: { postBuild = "echo hello"; })
hello.overrideAttrs { postBuild = "echo hello"; }

Previously only the first example was possible.


<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
