### PR TITLE
ayatana-webmail: init at 22.12.15

### DIFF
--- a/pkgs/applications/networking/mailreaders/ayatana-webmail/default.nix
+++ b/pkgs/applications/networking/mailreaders/ayatana-webmail/default.nix
@@ -1,0 +1,90 @@
+{ lib
+, fetchFromGitHub
+, gettext
+, gtk3
+, python3Packages
+, gdk-pixbuf
+, libnotify
+, glib
+, gobject-introspection
+, wrapGAppsHook
+# BTW libappindicator is also supported, but upstream recommends their
+# implementation, see:
+# https://github.com/AyatanaIndicators/ayatana-webmail/issues/24#issuecomment-1050352862
+, libayatana-appindicator
+, gsettings-desktop-schemas
+, libcanberra-gtk3
+}:
+
+python3Packages.buildPythonApplication rec {
+  pname = "ayatana-webmail";
+  version = "22.12.15";
+
+  src = fetchFromGitHub {
+    owner = "AyatanaIndicators";
+    repo = "ayatana-webmail";
+    rev = version;
+    hash = "sha256-K2jqCWrY1i1wYdZVpjN/3TcVyWariOQQ4slZf6sEPRU=";
+  };
+  postConfigure = ''
+    # Fix fhs paths
+    substituteInPlace \
+      ayatanawebmail/accounts.py \
+      ayatanawebmail/actions.py \
+      ayatanawebmail/dialog.py \
+      --replace /usr/share $out/share
+  '';
+
+  buildInputs = [
+    gtk3
+    gdk-pixbuf
+    glib
+    libnotify
+    gettext
+    libayatana-appindicator
+    gsettings-desktop-schemas
+  ];
+
+  nativeBuildInputs = [
+    gobject-introspection
+    wrapGAppsHook
+    glib # For compiling gsettings-schemas
+  ];
+
+  propagatedBuildInputs = with python3Packages; [
+    urllib3
+    babel
+    psutil
+    secretstorage
+    polib
+    pygobject3
+    dbus-python
+  ];
+
+  # No tests, and they cause a failure
+  doCheck = false;
+
+  postInstall = ''
+    # Fix fhs paths
+    mv $out/${python3Packages.python.sitePackages}/etc $out
+    mv $out/${python3Packages.python.sitePackages}/usr/{bin,share} $out/
+    rmdir $out/${python3Packages.python.sitePackages}/usr
+    # Compile gsettings desktop schemas
+    glib-compile-schemas $out/share/glib-2.0/schemas
+  '';
+
+  # See https://nixos.org/nixpkgs/manual/#ssec-gnome-common-issues-double-wrapped
+  dontWrapGApps = true;
+  preFixup = ''
+    makeWrapperArgs+=("''${gappsWrapperArgs[@]}")
+    makeWrapperArgs+=(--prefix PATH : ${lib.makeBinPath [ libcanberra-gtk3 ]})
+  '';
+
+  meta = with lib; {
+    description = "Webmail notifications and actions for any desktop";
+    homepage = "https://github.com/AyatanaIndicators/ayatana-webmail";
+    license = licenses.gpl3Plus;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ doronbehar ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -19965,6 +19965,8 @@ with pkgs;
 
   ayatana-ido = callPackage ../development/libraries/ayatana-ido { };
 
+  ayatana-webmail = callPackage ../applications/networking/mailreaders/ayatana-webmail { };
+
   babl = callPackage ../development/libraries/babl { };
 
   backward-cpp = callPackage ../development/libraries/backward-cpp { };


### PR DESCRIPTION
###### Motivation for this change

The best mail notification application (independent of mail reader) I've ever seen.

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
