### PR TITLE
fortran-fpm: init at 0.9.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -13103,6 +13103,12 @@
     githubId = 406946;
     name = "Valentin Lorentz";
   };
+  proofconstruction = {
+    email = "source@proof.construction";
+    github = "proofconstruction";
+    githubId = 74747193;
+    name = "Alexander Groleau";
+  };
   proofofkeags = {
     email = "keagan.mcclelland@gmail.com";
     github = "ProofOfKeags";

--- a/pkgs/tools/package-management/fortran-fpm/default.nix
+++ b/pkgs/tools/package-management/fortran-fpm/default.nix
@@ -1,0 +1,48 @@
+{ lib
+, fetchurl
+, pkgs
+, stdenv
+}:
+
+stdenv.mkDerivation rec {
+  pname = "fortran-fpm";
+
+  version = "0.9.0";
+
+  src = fetchurl {
+    url = "https://github.com/fortran-lang/fpm/releases/download/v${version}/fpm-${version}.F90";
+    sha256 = "sha256-VWs4g7odtv1iyZunFD8el+u0CXKcQgnwOqPG/JcMzj8=";
+  };
+
+  dontUnpack = true;
+
+  nativeBuildInputs = with pkgs; [ gfortran ];
+
+  buildPath = "build/bootstrap";
+
+  buildPhase = ''
+    runHook preBuild
+
+    mkdir -p ${buildPath}
+    gfortran -J ${buildPath} -o ${buildPath}/${pname} $src
+
+    runHook postBuild
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/bin
+    cp ${buildPath}/${pname} $out/bin
+
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    description = "Fortran Package Manager (fpm)";
+    homepage = "https://fpm.fortran-lang.org";
+    maintainers = [ maintainers.proofconstruction ];
+    license = licenses.mit;
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7792,6 +7792,8 @@ with pkgs;
 
   forktty = callPackage ../os-specific/linux/forktty { };
 
+  fortran-fpm = callPackage ../tools/package-management/fortran-fpm { };
+
   fortune = callPackage ../tools/misc/fortune { };
 
   fox = callPackage ../development/libraries/fox {


### PR DESCRIPTION
###### Description of changes
`fpm` is the package manager and build system for Fortran.

https://fpm.fortran-lang.org

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
