### PR TITLE
starship: Remove INSIDE_EMACS checks

### DIFF
--- a/nixos/modules/programs/starship.nix
+++ b/nixos/modules/programs/starship.nix
@@ -43,21 +43,21 @@ in
 
   config = mkIf cfg.enable {
     programs.bash.${initOption} = ''
-      if [[ $TERM != "dumb" && (-z $INSIDE_EMACS || $INSIDE_EMACS == "vterm") ]]; then
+      if [[ $TERM != "dumb" ]]; then
         export STARSHIP_CONFIG=${settingsFile}
         eval "$(${pkgs.starship}/bin/starship init bash)"
       fi
     '';
 
     programs.fish.${initOption} = ''
-      if test "$TERM" != "dumb" -a \( -z "$INSIDE_EMACS" -o "$INSIDE_EMACS" = "vterm" \)
+      if test "$TERM" != "dumb"
         set -x STARSHIP_CONFIG ${settingsFile}
         eval (${pkgs.starship}/bin/starship init fish)
       end
     '';
 
     programs.zsh.${initOption} = ''
-      if [[ $TERM != "dumb" && (-z $INSIDE_EMACS || $INSIDE_EMACS == "vterm") ]]; then
+      if [[ $TERM != "dumb" ]]; then
         export STARSHIP_CONFIG=${settingsFile}
         eval "$(${pkgs.starship}/bin/starship init zsh)"
       fi


### PR DESCRIPTION
Many of the terminals supported inside emacs work perfectly fine with STARSHIP. The TERM=dumb case already handles the tramp and eterm cases, so as far as I can tell, this is basically just a check for the benefit of OLD versions of term-mode (see
https://www.emacswiki.org/emacs/AnsiTerm#:~:text=Historically%2C%20'M%2Dx%20ansi%2Dterm,the%20older%20'C%2Dc'%20binding., which indicates that it also now handles colors)

###### Description of changes

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

