### PR TITLE
nitrokey-app2: init at 2.0.1

### DIFF
--- a/pkgs/tools/security/nitrokey-app2/default.nix
+++ b/pkgs/tools/security/nitrokey-app2/default.nix
@@ -1,0 +1,96 @@
+{ lib
+, fetchFromGitHub
+, fetchpatch
+, wrapQtAppsHook
+, python3
+, pynitrokey
+}:
+
+let
+  python' = python3.override {
+    self = python';
+    packageOverrides = final: prev: {
+      pyqt5 = prev.pyqt5.override {
+        withConnectivity = true;
+        withMultimedia = true;
+        withLocation = true;
+        withSerialPort = true;
+        withTools = true;
+      };
+
+      pyqt5-stubs = final.callPackage ./pyqt5-stubs.nix { };
+    };
+  };
+
+  inherit (python'.pkgs) buildPythonApplication pythonOlder pyudev pyqt5-stubs;
+in
+
+buildPythonApplication rec {
+  pname = "nitrokey-app2";
+  version = "2.0.1";
+  format = "flit";
+
+  disabled = pythonOlder "3.9";
+
+  src = fetchFromGitHub {
+    owner = "Nitrokey";
+    repo = "nitrokey-app2";
+    rev = "v${version}";
+    hash = "sha256-RCHXFlZUtBycCO+1nMAqRJliFZcbCqCo7HFmKagYa7U=";
+  };
+
+  patches = [
+    (fetchpatch {
+      url = "https://github.com/Nitrokey/nitrokey-app2/commit/3c20cf98216ed77ff9014d983fe2a242fbbeee07.patch";
+      name = "fix-entry-point.patch";
+      hash = "sha256-yP2Bjf4cOFukT/ImkW33xMiE89w4KlO0CCLdTiQ7Pus=";
+    })
+    (fetchpatch {
+      url = "https://github.com/Nitrokey/nitrokey-app2/commit/8b980ef1f556919c6d94265d896c7dbdd7f8fd79.patch";
+      name = "add-name-check-to-main.patch";
+      hash = "sha256-Zxn2CUkKrk0P+4a9kWEikqBwU8OpreHWqqhyH8jv8L0=";
+    })
+  ];
+
+  postPatch = ''
+    # upstream pins the exact version :-(
+    substituteInPlace pyproject.toml \
+      --replace 'pynitrokey ==0.4.35' 'pynitrokey >=0.4.35'
+  '';
+
+  nativeBuildInputs = [
+    wrapQtAppsHook
+    # for running pyrcc5 and pyuic5
+    pyqt5-stubs
+  ];
+
+  propagatedBuildInputs = [
+    pyudev
+    pyqt5-stubs
+    pynitrokey
+  ];
+
+  # the pyproject.toml file seems to be incomplete and does not generate
+  # resources (i.e. run pyrcc5 and pyuic5) but the Makefile can do it
+  preBuild = ''
+    make build-ui
+  '';
+
+  dontWrapQtApps = true;
+
+  preFixup = ''
+    wrapQtApp "$out/bin/nitrokeyapp"
+  '';
+
+  pythonImportsCheck = [
+    "nitrokeyapp"
+  ];
+
+  meta = with lib; {
+    description = "Graphical application to manage Nitrokey devices";
+    homepage = "https://github.com/Nitrokey/nitrokey-app2";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ panicgh ];
+    mainProgram = "nitrokeyapp";
+  };
+}

--- a/pkgs/tools/security/nitrokey-app2/default.nix
+++ b/pkgs/tools/security/nitrokey-app2/default.nix
@@ -90,7 +90,7 @@ buildPythonApplication rec {
     description = "Graphical application to manage Nitrokey devices";
     homepage = "https://github.com/Nitrokey/nitrokey-app2";
     license = licenses.asl20;
-    maintainers = with maintainers; [ panicgh ];
+    maintainers = with maintainers; [ panicgh frogamic ];
     mainProgram = "nitrokeyapp";
   };
 }

--- a/pkgs/tools/security/nitrokey-app2/pyqt5-stubs.nix
+++ b/pkgs/tools/security/nitrokey-app2/pyqt5-stubs.nix
@@ -1,0 +1,60 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, pythonOlder
+, pyqt5
+, pyqtwebengine
+, pyqtchart
+, pyqt3d
+, pyqtdatavisualization
+, pytestCheckHook
+, pytest-xvfb
+}:
+
+buildPythonPackage rec {
+  pname = "pyqt5-stubs";
+  version = "5.15.6.0";
+  format = "setuptools";
+
+  disabled = pythonOlder "3.7";
+
+  src = fetchFromGitHub {
+    owner = "python-qt-tools";
+    repo = "PyQt5-stubs";
+    rev = version;
+    hash = "sha256-qWnvlHnFRy8wbZJ28C0pYqAxod623Epe5z5FZufheDc=";
+  };
+
+  postPatch = ''
+    # pulls in a dependency to mypy, but we don't want to run linters
+    rm tests/test_stubs.py
+    '';
+
+  propagatedBuildInputs = [
+    pyqt5
+    pyqtwebengine
+    pyqtchart
+    pyqt3d
+    pyqtdatavisualization
+  ];
+
+  nativeCheckInputs = [
+    pytestCheckHook
+    pytest-xvfb
+  ];
+
+  disabledTests = [
+    "test_files"
+  ];
+
+  pythonImportsCheck = [
+    "PyQt5-stubs"
+  ];
+
+  meta = with lib; {
+    description = "PEP561 stub files for the PyQt5 framework";
+    homepage = "https://github.com/python-qt-tools/PyQt5-stubs";
+    license = licenses.gpl3Only;
+    maintainers = with maintainers; [ panicgh ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -40599,6 +40599,8 @@ with pkgs;
 
   nitrokey-app = libsForQt5.callPackage ../tools/security/nitrokey-app { };
 
+  nitrokey-app2 = libsForQt5.callPackage ../tools/security/nitrokey-app2 { };
+
   fpm2 = callPackage ../tools/security/fpm2 { };
 
   simplenote = callPackage ../applications/misc/simplenote { };


### PR DESCRIPTION
###### Description of changes

A graphical application to manage Nitrokey devices.

It may one day succeed the nitrokey-app package. The functionality is *very* limited at the moment, e.g. it detects Nitrokey devices and offers the firmware update (and then fails, for me at least).

The package comes with an internal Python dependency (pyqt5-stubs), which needs a pyqt5 with special additional features. To remain consistent in python3Packages, it was decided to move pyqt5-stubs and the custom pyqt5 out of the normal python3Packages and instead to provide an own override.

@frogamic: since you use a Nitrokey 3, you might be interested to review or even co-maintain this.

###### Things done

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).