### PR TITLE
checksec: Fix deps

### DIFF
--- a/pkgs/os-specific/linux/checksec/0001-Drop-env-purging.patch
+++ b/pkgs/os-specific/linux/checksec/0001-Drop-env-purging.patch
@@ -1,0 +1,25 @@
+From 4660ceb380f53aa38aef72d16a3b9ed7a5817214 Mon Sep 17 00:00:00 2001
+From: Jonathan Cooper <jonathan@cooper.cafe>
+Date: Wed, 21 Jun 2023 15:29:09 -0400
+Subject: [PATCH] Drop env purging
+
+---
+ checksec | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/checksec b/checksec
+index 4fc3c31..b3ab86f 100755
+--- a/checksec
++++ b/checksec
+@@ -3,7 +3,7 @@
+ # in the src directory. Any updates to this file will be overwritten when generated
+ 
+ # sanitize the environment before run
+-[[ "$(env | /bin/sed -r -e '/^(PWD|SHLVL|_)=/d')" ]] && exec -c "$0" "$@"
++[[ "$(env | /bin/sed -r -e '/^(PWD|SHLVL|_)=/d')" ]]
+ 
+ # --- Modified Version ---
+ # Name    : checksec.sh
+-- 
+2.40.1
+

--- a/pkgs/os-specific/linux/checksec/default.nix
+++ b/pkgs/os-specific/linux/checksec/default.nix
@@ -9,6 +9,12 @@
 , coreutils
 , sysctl
 , openssl
+, gnused
+, gnugrep
+, gawk
+, procps
+, which
+, binutils
 }:
 
 stdenv.mkDerivation rec {
@@ -24,6 +30,7 @@ stdenv.mkDerivation rec {
 
   patches = [
     ./0001-attempt-to-modprobe-config-before-checking-kernel.patch
+    ./0001-Drop-env-purging.patch
   ];
 
   nativeBuildInputs = [
@@ -33,18 +40,25 @@ stdenv.mkDerivation rec {
   installPhase =
     let
       path = lib.makeBinPath [
-        findutils
+        binutils
+        coreutils
         file
-        binutils-unwrapped
-        sysctl
+        findutils
+        gawk
+        gnugrep
+        gnused
         openssl
+        procps
+        sysctl
+        which
       ];
     in
     ''
       mkdir -p $out/bin
       install checksec $out/bin
-      substituteInPlace $out/bin/checksec --replace /lib/libc.so.6 ${glibc.out}/lib/libc.so.6
-      substituteInPlace $out/bin/checksec --replace "/usr/bin/id -" "${coreutils}/bin/id -"
+      substituteInPlace $out/bin/checksec --replace "/bin/sed" "${gnused}/bin/sed"
+      substituteInPlace $out/bin/checksec --replace "/usr/bin/id" "${coreutils}/bin/id"
+      substituteInPlace $out/bin/checksec --replace "/lib/libc.so.6" "${glibc}/lib/libc.so.6"
       wrapProgram $out/bin/checksec \
         --prefix PATH : ${path}
     '';


### PR DESCRIPTION
Fix dependencies that is required by checksec.

Previously, checksec would begin by sanitizing PATH which removes the program's ability to find binaries, i.e. `cat`, `sed`. Later in the program, checksec pointed to /usr/bin and /bin for binaries.

This commit corrects the aforementioned issues.

This is my first public contribution. Criticism welcomed :-)

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
