### PR TITLE
mpd-notification: init at 0.8.7

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -2521,6 +2521,12 @@
       }
     ];
   };
+  CaitlinDavitt = {
+    email = "CaitlinDavitt@gmail.com";
+    github = "CaitlinDavitt";
+    githubId = 48105979;
+    name = "Caitlin Davitt";
+  };
   calavera = {
     email = "david.calavera@gmail.com";
     github = "calavera";

--- a/pkgs/tools/audio/mpd-notification/default.nix
+++ b/pkgs/tools/audio/mpd-notification/default.nix
@@ -1,0 +1,61 @@
+{ lib
+, stdenv
+, pkg-config
+, fetchFromGitHub
+, systemd
+, file
+, iniparser
+, ffmpeg
+, libnotify
+, libmpdclient
+, discount
+}:
+
+stdenv.mkDerivation rec {
+  pname = "mpd-notification";
+  version = "0.8.7";
+
+  src = fetchFromGitHub {
+    owner = "eworm-de";
+    repo = "mpd-notification";
+    rev = version;
+    hash = "sha256-lBvx2eYxFJUAxR1LrjWHZUeAo+WnQKmPYJVAJTeXqHY=";
+  };
+
+  nativeBuildInputs = [
+    pkg-config
+  ];
+
+  buildInputs = [
+    iniparser
+    libnotify
+    file
+    ffmpeg
+    libmpdclient
+    discount
+   ];
+
+   installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/bin
+    mv mpd-notification $out/bin
+
+    mkdir -p $out/lib/systemd/user
+    cp systemd/mpd-notification.service $out/lib/systemd/user
+
+    runHook postInstall
+  '';
+
+  postPatch = ''
+   substituteInPlace systemd/mpd-notification.service --replace /usr $out
+ '';
+
+   meta = with lib; {
+    description = "Notifications for mpd";
+    homepage = "https://github.com/eworm-de/mpd-notification";
+    license = licenses.gpl3Plus;
+    maintainers = with maintainers; [ CaitlinDavitt ];
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5631,6 +5631,8 @@ with pkgs;
 
   mpd-mpris = callPackage ../tools/audio/mpd-mpris { };
 
+  mpd-notification = callPackage ../tools/audio/mpd-notification { };
+
   mpd-sima = python3Packages.callPackage ../tools/audio/mpd-sima { };
 
   mpris-scrobbler = callPackage ../tools/audio/mpris-scrobbler { };


### PR DESCRIPTION
###### Description of changes

<!--
Pakages mpd-notification, for noifications with mpd. [Repo](https://github.com/eworm-de/mpd-notification)
-->

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).