### PR TITLE
php83: init at 8.3.0alpha2

### DIFF
--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -597,6 +597,7 @@ in {
   php = handleTest ./php {};
   php81 = handleTest ./php { php = pkgs.php81; };
   php82 = handleTest ./php { php = pkgs.php82; };
+  php83 = handleTest ./php { php = pkgs.php83; };
   phylactery = handleTest ./web-apps/phylactery.nix {};
   pict-rs = handleTest ./pict-rs.nix {};
   pinnwand = handleTest ./pinnwand.nix {};

--- a/pkgs/development/interpreters/php/8.3.nix
+++ b/pkgs/development/interpreters/php/8.3.nix
@@ -1,0 +1,57 @@
+{ callPackage, fetchurl, ... }@_args:
+
+let
+  base = (callPackage ./generic.nix (_args // {
+    version = "8.3.0alpha2";
+    hash = null;
+  })).overrideAttrs (oldAttrs: {
+    src = fetchurl {
+      url = "https://downloads.php.net/~eric/php-8.3.0alpha2.tar.xz";
+      hash = "sha256-YLCxgiDcsBisOmAodf0h8HyaCIh+4i1Q7QZw/h4KR5I=";
+    };
+  });
+in
+base.withExtensions ({ all, ... }: with all; ([
+  bcmath
+  calendar
+  curl
+  ctype
+  dom
+  exif
+  fileinfo
+  filter
+  ftp
+  gd
+  gettext
+  gmp
+  iconv
+  imap
+  intl
+  ldap
+  mbstring
+  mysqli
+  mysqlnd
+  opcache
+  openssl
+  pcntl
+  pdo
+  pdo_mysql
+  pdo_odbc
+  pdo_pgsql
+  pdo_sqlite
+  pgsql
+  posix
+  readline
+  session
+  simplexml
+  sockets
+  soap
+  sodium
+  sysvsem
+  sqlite3
+  tokenizer
+  xmlreader
+  xmlwriter
+  zip
+  zlib
+]))

--- a/pkgs/development/interpreters/php/fix-fileinfo-ext-php83.patch
+++ b/pkgs/development/interpreters/php/fix-fileinfo-ext-php83.patch
@@ -1,0 +1,14 @@
+diff --git a/ext/fileinfo/fileinfo.c b/ext/fileinfo/fileinfo.c
+index a6f3e64db6..c3047233db 100644
+--- a/ext/fileinfo/fileinfo.c
++++ b/ext/fileinfo/fileinfo.c
+@@ -14,6 +14,9 @@
+   +----------------------------------------------------------------------+
+ */
+
++#ifdef HAVE_CONFIG_H
++#include "config.h"
++#endif
+ #include "php.h"
+
+ #include "libmagic/magic.h"

--- a/pkgs/development/php-packages/apcu/default.nix
+++ b/pkgs/development/php-packages/apcu/default.nix
@@ -1,4 +1,4 @@
-{ buildPecl, lib, pcre2, fetchFromGitHub }:
+{ buildPecl, lib, pcre2, fetchFromGitHub, php, fetchpatch }:
 
 let
   version = "5.1.22";
@@ -12,6 +12,13 @@ in buildPecl {
     rev = "v${version}";
     sha256 = "sha256-L4a+/kWT95a1Km+FzFNiAaBw8enU6k4ZiCFRErjj9o8=";
   };
+
+  patches = lib.optionals (lib.versionAtLeast php.version "8.3") [
+    (fetchpatch {
+      url = "https://github.com/krakjoe/apcu/commit/c9a29161c68c0faf71046e8f03f6a90900023ded.patch";
+      hash = "sha256-B0ZKk9TJy2+sYGs7TEX2KxUiOVawIb+RXNgToU1Fz5I=";
+    })
+  ];
 
   buildInputs = [ pcre2 ];
   doCheck = true;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -17330,6 +17330,16 @@ with pkgs;
   phpExtensions = php.extensions;
   phpPackages = php.packages;
 
+  # Import PHP83 interpreter, extensions and packages
+  php83 = callPackage ../development/interpreters/php/8.3.nix {
+    stdenv = if stdenv.cc.isClang then llvmPackages.stdenv else stdenv;
+    pcre2 = pcre2.override {
+      withJitSealloc = false; # See https://bugs.php.net/bug.php?id=78927 and https://bugs.php.net/bug.php?id=78630
+    };
+  };
+  php83Extensions = recurseIntoAttrs php83.extensions;
+  php83Packages = recurseIntoAttrs php83.packages;
+
   # Import PHP82 interpreter, extensions and packages
   php82 = callPackage ../development/interpreters/php/8.2.nix {
     stdenv = if stdenv.cc.isClang then llvmPackages.stdenv else stdenv;

--- a/pkgs/top-level/php-packages.nix
+++ b/pkgs/top-level/php-packages.nix
@@ -1,7 +1,6 @@
 { stdenv
 , lib
 , pkgs
-, fetchgit
 , phpPackage
 , autoconf
 , pkg-config
@@ -10,22 +9,16 @@
 , curl
 , cyrus_sasl
 , enchant2
-, fetchpatch
 , freetds
-, freetype
 , gd
 , gettext
 , gmp
 , html-tidy
 , icu64
-, libXpm
 , libffi
 , libiconv
-, libjpeg
 , libkrb5
-, libpng
 , libsodium
-, libwebp
 , libxml2
 , libxslt
 , libzip
@@ -85,15 +78,15 @@ lib.makeScope pkgs.newScope (self: with self; {
   # will mark the extension as a zend extension or not.
   mkExtension = lib.makeOverridable
     ({ name
-    , configureFlags ? [ "--enable-${extName}" ]
-    , internalDeps ? [ ]
-    , postPhpize ? ""
-    , buildInputs ? [ ]
-    , zendExtension ? false
-    , doCheck ? true
-    , extName ? name
-    , ...
-    }@args: stdenv.mkDerivation ((builtins.removeAttrs args [ "name" ]) // {
+     , configureFlags ? [ "--enable-${extName}" ]
+     , internalDeps ? [ ]
+     , postPhpize ? ""
+     , buildInputs ? [ ]
+     , zendExtension ? false
+     , doCheck ? true
+     , extName ? name
+     , ...
+     }@args: stdenv.mkDerivation ((builtins.removeAttrs args [ "name" ]) // {
       pname = "php-${name}";
       extensionName = extName;
 
@@ -217,8 +210,6 @@ lib.makeScope pkgs.newScope (self: with self; {
 
     ast = callPackage ../development/php-packages/ast { };
 
-    blackfire = pkgs.callPackage ../development/tools/misc/blackfire/php-probe.nix { inherit php; };
-
     couchbase = callPackage ../development/php-packages/couchbase { };
 
     datadog_trace = callPackage ../development/php-packages/datadog_trace { };
@@ -283,7 +274,7 @@ lib.makeScope pkgs.newScope (self: with self; {
 
     redis = callPackage ../development/php-packages/redis { };
 
-    relay = callPackage ../development/php-packages/relay  { inherit php; };
+    relay = callPackage ../development/php-packages/relay { inherit php; };
 
     smbclient = callPackage ../development/php-packages/smbclient { };
 
@@ -646,5 +637,7 @@ lib.makeScope pkgs.newScope (self: with self; {
       # Produce the final attribute set of all extensions defined.
     in
     builtins.listToAttrs namedExtensions
-  );
+  ) // lib.optionalAttrs (!(lib.versionAtLeast php.version "8.3")) {
+    blackfire = callPackage ../development/tools/misc/blackfire/php-probe.nix { inherit php; };
+  };
 })

--- a/pkgs/top-level/php-packages.nix
+++ b/pkgs/top-level/php-packages.nix
@@ -46,6 +46,7 @@
 , uwimap
 , valgrind
 , zlib
+, fetchpatch
 }:
 
 lib.makeScope pkgs.newScope (self: with self; {
@@ -332,7 +333,16 @@ lib.makeScope pkgs.newScope (self: with self; {
         }
         { name = "exif"; doCheck = false; }
         { name = "ffi"; buildInputs = [ libffi ]; }
-        { name = "fileinfo"; buildInputs = [ pcre2 ]; }
+        {
+          name = "fileinfo";
+          buildInputs = [ pcre2 ];
+          patches = lib.optionals (lib.versionAtLeast php.version "8.3") [
+            # Fix the extension unable to be loaded due to missing `get_module` function.
+            # `ZEND_GET_MODULE` macro that creates it is conditional on `COMPILE_DL_FILEINFO` being defined.
+            # https://github.com/php/php-src/issues/11408#issuecomment-1602106200
+            ../development/interpreters/php/fix-fileinfo-ext-php83.patch
+          ];
+        }
         { name = "filter"; buildInputs = [ pcre2 ]; }
         { name = "ftp"; buildInputs = [ openssl ]; }
         {
@@ -519,7 +529,18 @@ lib.makeScope pkgs.newScope (self: with self; {
           '';
           doCheck = false;
         }
-        { name = "session"; doCheck = false; }
+        { name = "session";
+          doCheck = false;
+          patches = lib.optionals (lib.versionAtLeast php.version "8.3") [
+            # Fix GH-11529: Crash after dealing with an Apache request
+            # To be removed in next alpha
+            # See https://github.com/php/php-src/issues/11529
+            (fetchpatch {
+              url = "https://github.com/php/php-src/commit/8d4370954ec610164a4503431bb0c52da6954aa7.patch";
+              hash = "sha256-w1uF9lRdfhz9I0gux0J4cvMzNS93uSHL1fYG23VLDPc=";
+            })
+          ];
+        }
         { name = "shmop"; }
         {
           name = "simplexml";


### PR DESCRIPTION
This PR:

- Introduces PHP 8.3.0 at version alpha2
- Includes a patch from @nielsdos (_thanks mate!_) for fixing the issue with fileinfo extension (see https://github.com/php/php-src/issues/11408)
- Includes a patch for APCU extension from https://github.com/krakjoe/apcu/issues/489
- Includes a patch for session extension from https://github.com/php/php-src/pull/11530

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
