### PR TITLE
msgpack-{c,cxx}: init at 6.0.0

### DIFF
--- a/pkgs/applications/editors/neovim/default.nix
+++ b/pkgs/applications/editors/neovim/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchFromGitHub, cmake, gettext, msgpack, libtermkey, libiconv
+{ lib, stdenv, fetchFromGitHub, cmake, gettext, msgpack-c, libtermkey, libiconv
 , libuv, lua, ncurses, pkg-config
 , unibilium, gperf
 , libvterm-neovim
@@ -66,7 +66,7 @@ in
       # https://github.com/luarocks/luarocks/issues/1402#issuecomment-1080616570
       # and it's definition at: pkgs/development/lua-modules/overrides.nix
       lua.pkgs.libluv
-      msgpack
+      msgpack-c
       ncurses
       neovimLuaEnv
       tree-sitter

--- a/pkgs/applications/networking/instant-messengers/jami/default.nix
+++ b/pkgs/applications/networking/instant-messengers/jami/default.nix
@@ -24,7 +24,7 @@
 , libpulseaudio
 , libupnp
 , yaml-cpp
-, msgpack
+, msgpack-cxx
 , openssl
 , restinio
 , secp256k1
@@ -132,7 +132,7 @@ stdenv.mkDerivation rec {
       libpulseaudio
       libupnp
       yaml-cpp
-      msgpack
+      msgpack-cxx
       opendht-jami
       openssl
       pjsip-jami

--- a/pkgs/development/libraries/msgpack-c/default.nix
+++ b/pkgs/development/libraries/msgpack-c/default.nix
@@ -1,0 +1,44 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, cmake
+, gtest
+, zlib
+}:
+
+stdenv.mkDerivation rec {
+  pname = "msgpack-c";
+  version = "6.0.0";
+
+  src = fetchFromGitHub {
+    owner = "msgpack";
+    repo = "msgpack-c";
+    rev = "refs/tags/c-${version}";
+    hash = "sha256-TfC37QKwqvHxsLPgsEqJYkb7mpRQekbntbBPV4v4FO8=";
+  };
+
+  strictDeps = true;
+
+  nativeBuildInputs = [
+    cmake
+  ];
+
+  cmakeFlags = [
+    "-DMSGPACK_BUILD_EXAMPLES=OFF" # examples are not installed even if built
+  ] ++ lib.optional (!doCheck) "-DMSGPACK_BUILD_TESTS=OFF";
+
+  checkInputs = [
+    gtest
+    zlib
+  ];
+
+  doCheck = stdenv.buildPlatform.canExecute stdenv.hostPlatform;
+
+  meta = with lib; {
+    description = "MessagePack implementation for C";
+    homepage = "https://github.com/msgpack/msgpack-c";
+    changelog = "https://github.com/msgpack/msgpack-c/blob/${src.rev}/CHANGELOG.md";
+    license = licenses.boost;
+    maintainers = with maintainers; [ nickcao ];
+  };
+}

--- a/pkgs/development/libraries/msgpack-cxx/default.nix
+++ b/pkgs/development/libraries/msgpack-cxx/default.nix
@@ -1,0 +1,47 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, cmake
+, boost
+, zlib
+}:
+
+stdenv.mkDerivation rec {
+  pname = "msgpack-cxx";
+  version = "6.0.0";
+
+  src = fetchFromGitHub {
+    owner = "msgpack";
+    repo = "msgpack-c";
+    rev = "refs/tags/cpp-${version}";
+    hash = "sha256-p0eLd0fHhsgnRomubYadumMNiC2itdePJC9B55m49LI=";
+  };
+
+  strictDeps = true;
+
+  nativeBuildInputs = [
+    cmake
+  ];
+
+  buildInputs = [
+    boost
+  ];
+
+  cmakeFlags = [
+    "-DMSGPACK_BUILD_DOCS=OFF" # docs are not installed even if built
+  ] ++ lib.optional doCheck "-DMSGPACK_BUILD_TESTS=ON";
+
+  checkInputs = [
+    zlib
+  ];
+
+  doCheck = stdenv.buildPlatform.canExecute stdenv.hostPlatform;
+
+  meta = with lib; {
+    description = "MessagePack implementation for C++";
+    homepage = "https://github.com/msgpack/msgpack-c";
+    changelog = "https://github.com/msgpack/msgpack-c/blob/${src.rev}/CHANGELOG.md";
+    license = licenses.boost;
+    maintainers = with maintainers; [ nickcao ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -23305,6 +23305,8 @@ with pkgs;
 
   msgpack = callPackage ../development/libraries/msgpack { };
 
+  msgpack-c = callPackage ../development/libraries/msgpack-c { };
+
   msoffcrypto-tool = with python3.pkgs; toPythonApplication msoffcrypto-tool;
 
   msilbc = callPackage ../development/libraries/msilbc { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -23307,6 +23307,8 @@ with pkgs;
 
   msgpack-c = callPackage ../development/libraries/msgpack-c { };
 
+  msgpack-cxx = callPackage ../development/libraries/msgpack-cxx { };
+
   msoffcrypto-tool = with python3.pkgs; toPythonApplication msoffcrypto-tool;
 
   msilbc = callPackage ../development/libraries/msilbc { };


### PR DESCRIPTION
###### Description of changes
msgpack-c and msgpack-cxx are now two separated packages despite being developed in the same repo (on two branches).

~~Targeting master for now to ease testing.~~ Doing the switch over gradually as many packages does not seem to be compatible with the new version yet.

supersedes https://github.com/NixOS/nixpkgs/pull/220323
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
