### PR TITLE
proxysql: 2.5.2 -> 2.5.3

### DIFF
--- a/pkgs/servers/sql/proxysql/default.nix
+++ b/pkgs/servers/sql/proxysql/default.nix
@@ -33,13 +33,13 @@
 
 stdenv.mkDerivation rec {
   pname = "proxysql";
-  version = "2.5.2";
+  version = "2.5.3";
 
   src = fetchFromGitHub {
     owner = "sysown";
     repo = pname;
     rev = version;
-    hash = "sha256-KPTvFbEreWQBAs5ofcdVzlVqL0t5pM/mMLv4+E4lJ5M=";
+    hash = "sha256-D/AUjndpu4QJmlgLBXRqMj9gsHYitEYhHVMQzoab1ik=";
   };
 
   patches = [

--- a/pkgs/servers/sql/proxysql/makefiles.patch
+++ b/pkgs/servers/sql/proxysql/makefiles.patch
@@ -1,8 +1,8 @@
 diff --git a/Makefile b/Makefile
-index df7ed196..3a3b393d 100644
+index c053ab64..03f38a21 100644
 --- a/Makefile
 +++ b/Makefile
-@@ -57,11 +57,7 @@ endif
+@@ -59,11 +59,7 @@ endif
  
  export MAKEOPT=-j ${NPROCS}
  
@@ -15,7 +15,7 @@ index df7ed196..3a3b393d 100644
  USERCHECK := $(shell getent passwd proxysql)
  GROUPCHECK := $(shell getent group proxysql)
  
-@@ -784,16 +780,10 @@ cleanbuild:
+@@ -868,16 +864,10 @@ cleanbuild:
  
  .PHONY: install
  install: src/proxysql
@@ -36,10 +36,10 @@ index df7ed196..3a3b393d 100644
  	install -m 0755 etc/init.d/proxysql /etc/init.d
  ifeq ($(DISTRO),"CentOS Linux")
 diff --git a/deps/Makefile b/deps/Makefile
-index 47c0f3c3..80d33d11 100644
+index dbe495c0..9c50bab8 100644
 --- a/deps/Makefile
 +++ b/deps/Makefile
-@@ -66,10 +66,7 @@ endif
+@@ -69,10 +69,7 @@ default: $(tmpdefault)
  
  
  libinjection/libinjection/src/libinjection.a:
@@ -50,8 +50,8 @@ index 47c0f3c3..80d33d11 100644
  	cd libinjection/libinjection && patch -p1 < ../libinjection_sqli.c.patch
  endif
  ifeq ($(UNAME_S),Darwin)
-@@ -83,8 +80,6 @@ libinjection: libinjection/libinjection/src/libinjection.a
- 
+@@ -91,8 +88,6 @@ $(error Incompatible OpenSSL version: struct bio_st mismatch!)
+ endif
  
  libssl/openssl/libssl.a:
 -	cd libssl && rm -rf openssl-openssl-*/ openssl-3*/ || true
@@ -59,7 +59,7 @@ index 47c0f3c3..80d33d11 100644
  #	cd libssl/openssl && patch crypto/ec/curve448/curve448.c < ../curve448.c-multiplication-overflow.patch
  #	cd libssl/openssl && patch crypto/asn1/a_time.c < ../a_time.c-multiplication-overflow.patch
  	cd libssl/openssl && ./config no-ssl3 no-tests
-@@ -103,8 +98,6 @@ ifeq ($(MIN_VERSION),$(lastword $(SORTED_VERSIONS)))
+@@ -112,8 +107,6 @@ ifeq ($(MIN_VERSION),$(lastword $(SORTED_VERSIONS)))
  endif
  
  libhttpserver/libhttpserver/build/src/.libs/libhttpserver.a: libmicrohttpd/libmicrohttpd/src/microhttpd/.libs/libmicrohttpd.a re2/re2/obj/libre2.a
@@ -68,7 +68,7 @@ index 47c0f3c3..80d33d11 100644
  #ifeq ($(REQUIRE_PATCH), true)
  	cd libhttpserver/libhttpserver && patch -p1 < ../noexcept.patch
  	cd libhttpserver/libhttpserver && patch -p1 < ../re2_regex.patch
-@@ -122,8 +115,6 @@ libhttpserver: libhttpserver/libhttpserver/build/src/.libs/libhttpserver.a
+@@ -131,8 +124,6 @@ libhttpserver: libhttpserver/libhttpserver/build/src/.libs/libhttpserver.a
  
  
  libev/libev/.libs/libev.a:
@@ -77,16 +77,16 @@ index 47c0f3c3..80d33d11 100644
  	cd libev/libev && patch ev.c < ../ev.c-multiplication-overflow.patch
  	cd libev/libev && ./configure
  	cd libev/libev && CC=${CC} CXX=${CXX} ${MAKE}
-@@ -132,8 +123,6 @@ ev: libev/libev/.libs/libev.a
- 
+@@ -148,8 +139,6 @@ coredumper/coredumper/src/libcoredumper.a:
+ coredumper: coredumper/coredumper/src/libcoredumper.a
  
  curl/curl/lib/.libs/libcurl.a: libssl/openssl/libssl.a
 -	cd curl && rm -rf curl-*/ || true
 -	cd curl && tar -zxf curl-*.tar.gz
  #	cd curl/curl && ./configure --disable-debug --disable-ftp --disable-ldap --disable-ldaps --disable-rtsp --disable-proxy --disable-dict --disable-telnet --disable-tftp --disable-pop3 --disable-imap --disable-smb --disable-smtp --disable-gopher --disable-manual --disable-ipv6 --disable-sspi --disable-crypto-auth --disable-ntlm-wb --disable-tls-srp --without-nghttp2 --without-libidn2 --without-libssh2 --without-brotli --with-ssl=$(shell pwd)/../../libssl/openssl/ && CC=${CC} CXX=${CXX} ${MAKE}
- #	cd curl/curl && patch configure < ../configure.patch
  	cd curl/curl && autoreconf -fi
-@@ -143,16 +132,6 @@ curl: curl/curl/lib/.libs/libcurl.a
+ ifeq ($(UNAME_S),Darwin)
+@@ -161,16 +150,6 @@ curl: curl/curl/lib/.libs/libcurl.a
  
  
  libmicrohttpd/libmicrohttpd/src/microhttpd/.libs/libmicrohttpd.a:
@@ -100,10 +100,10 @@ index 47c0f3c3..80d33d11 100644
 -	cd libmicrohttpd && tar -zxf libmicrohttpd-0.9.75.tar.gz
 -#	cd libmicrohttpd/libmicrohttpd && patch src/microhttpd/connection.c < ../connection.c-snprintf-overflow.patch
 -endif
- ifeq ($(UNAME_S),Darwin)
- 	cd libmicrohttpd/libmicrohttpd && patch src/microhttpd/mhd_sockets.c < ../mhd_sockets.c-issue-5977.patch
- endif
-@@ -171,8 +150,6 @@ cityhash: cityhash/cityhash/src/.libs/libcityhash.a
+ 	cd libmicrohttpd/libmicrohttpd && ./configure --enable-https && CC=${CC} CXX=${CXX} ${MAKE}
+ 
+ microhttpd: libmicrohttpd/libmicrohttpd/src/microhttpd/.libs/libmicrohttpd.a
+@@ -186,8 +165,6 @@ cityhash: cityhash/cityhash/src/.libs/libcityhash.a
  
  
  lz4/lz4/lib/liblz4.a:
@@ -112,7 +112,7 @@ index 47c0f3c3..80d33d11 100644
  	cd lz4/lz4 && CC=${CC} CXX=${CXX} ${MAKE}
  
  lz4: lz4/lz4/lib/liblz4.a
-@@ -197,8 +174,6 @@ clickhouse-cpp: clickhouse-cpp/clickhouse-cpp/clickhouse/libclickhouse-cpp-lib-s
+@@ -213,8 +190,6 @@ clickhouse-cpp: clickhouse-cpp/clickhouse-cpp/clickhouse/libclickhouse-cpp-lib-s
  
  
  libdaemon/libdaemon/libdaemon/.libs/libdaemon.a:
@@ -121,7 +121,7 @@ index 47c0f3c3..80d33d11 100644
  	cd libdaemon/libdaemon && cp ../config.guess . && chmod +x config.guess && cp ../config.sub . && chmod +x config.sub && ./configure --disable-examples
  	cd libdaemon/libdaemon && CC=${CC} CXX=${CXX} ${MAKE}
  
-@@ -282,8 +257,6 @@ sqlite3: sqlite3/sqlite3/sqlite3.o
+@@ -302,8 +277,6 @@ sqlite3: sqlite3/sqlite3/sqlite3.o
  
  
  libconfig/libconfig/lib/.libs/libconfig++.a:
@@ -130,7 +130,7 @@ index 47c0f3c3..80d33d11 100644
  	cd libconfig/libconfig && ./configure --disable-examples
  	cd libconfig/libconfig && CC=${CC} CXX=${CXX} ${MAKE}
  
-@@ -291,9 +264,6 @@ libconfig: libconfig/libconfig/lib/.libs/libconfig++.a
+@@ -311,9 +284,6 @@ libconfig: libconfig/libconfig/lib/.libs/libconfig++.a
  
  
  prometheus-cpp/prometheus-cpp/lib/libprometheus-cpp-core.a:
@@ -140,7 +140,7 @@ index 47c0f3c3..80d33d11 100644
  	cd prometheus-cpp/prometheus-cpp && patch -p1 < ../serial_exposer.patch
  	cd prometheus-cpp/prometheus-cpp && patch -p1 < ../registry_counters_reset.patch
  	cd prometheus-cpp/prometheus-cpp && patch -p1 < ../fix_old_distros.patch
-@@ -304,10 +274,6 @@ prometheus-cpp: prometheus-cpp/prometheus-cpp/lib/libprometheus-cpp-core.a
+@@ -324,10 +294,6 @@ prometheus-cpp: prometheus-cpp/prometheus-cpp/lib/libprometheus-cpp-core.a
  
  
  re2/re2/obj/libre2.a:
@@ -151,7 +151,7 @@ index 47c0f3c3..80d33d11 100644
  	cd re2/re2 && patch re2/onepass.cc < ../onepass.cc-multiplication-overflow.patch
  ifeq ($(UNAME_S),Darwin)
  	cd re2/re2 && sed -i '' -e 's/-O3 -g/-O3 -g -std=c++11 -fPIC -DMEMORY_SANITIZER -DRE2_ON_VALGRIND /' Makefile
-@@ -322,8 +288,6 @@ re2: re2/re2/obj/libre2.a
+@@ -342,8 +308,6 @@ re2: re2/re2/obj/libre2.a
  
  
  pcre/pcre/.libs/libpcre.a:


### PR DESCRIPTION
###### Description of changes
https://github.com/sysown/proxysql/releases/tag/v2.5.3

###### Things done
- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).