### PR TITLE
lib/tests: compatibility with more Nix versions

### DIFF
--- a/lib/tests/filesystem.sh
+++ b/lib/tests/filesystem.sh
@@ -35,59 +35,50 @@ touch regular
 ln -s target symlink
 mkfifo fifo
 
-checkPathType() {
-    local path=$1
-    local expectedPathType=$2
-    local actualPathType=$(nix-instantiate --eval --strict --json 2>&1 \
-        -E '{ path }: let lib = import <nixpkgs/lib>; in lib.filesystem.pathType path' \
-        --argstr path "$path")
-    if [[ ! "$actualPathType" =~ $expectedPathType ]]; then
-        die "lib.filesystem.pathType \"$path\" == $actualPathType, but $expectedPathType was expected"
+expectSuccess() {
+    local expr=$1
+    local expectedResultRegex=$2
+    if ! result=$(nix-instantiate --eval --strict --json \
+        --expr "with (import <nixpkgs/lib>).filesystem; $expr"); then
+        die "$expr failed to evaluate, but it was expected to succeed"
+    fi
+    if [[ ! "$result" =~ $expectedResultRegex ]]; then
+        die "$expr == $result, but $expectedResultRegex was expected"
     fi
 }
 
-checkPathType "/" '"directory"'
-checkPathType "$PWD/directory" '"directory"'
-checkPathType "$PWD/regular" '"regular"'
-checkPathType "$PWD/symlink" '"symlink"'
-checkPathType "$PWD/fifo" '"unknown"'
+expectFailure() {
+    local expr=$1
+    local expectedErrorRegex=$2
+    if result=$(nix-instantiate --eval --strict --json 2>"$work/stderr" \
+        --expr "with (import <nixpkgs/lib>).filesystem; $expr"); then
+        die "$expr evaluated successfully to $result, but it was expected to fail"
+    fi
+    if [[ ! "$(<"$work/stderr")" =~ $expectedErrorRegex ]]; then
+        die "Error was $(<"$work/stderr"), but $expectedErrorRegex was expected"
+    fi
+}
+
+expectSuccess "pathType /." '"directory"'
+expectSuccess "pathType $PWD/directory" '"directory"'
+expectSuccess "pathType $PWD/regular" '"regular"'
+expectSuccess "pathType $PWD/symlink" '"symlink"'
+expectSuccess "pathType $PWD/fifo" '"unknown"'
 # Different errors depending on whether the builtins.readFilePath primop is available or not
-checkPathType "$PWD/non-existent" "error: (evaluation aborted with the following error message: 'lib.filesystem.pathType: Path $PWD/non-existent does not exist.'|getting status of '$PWD/non-existent': No such file or directory)"
+expectFailure "pathType $PWD/non-existent" "error: (evaluation aborted with the following error message: 'lib.filesystem.pathType: Path $PWD/non-existent does not exist.'|getting status of '$PWD/non-existent': No such file or directory)"
 
-checkPathIsDirectory() {
-    local path=$1
-    local expectedIsDirectory=$2
-    local actualIsDirectory=$(nix-instantiate --eval --strict --json 2>&1 \
-        -E '{ path }: let lib = import <nixpkgs/lib>; in lib.filesystem.pathIsDirectory path' \
-        --argstr path "$path")
-    if [[ "$actualIsDirectory" != "$expectedIsDirectory" ]]; then
-        die "lib.filesystem.pathIsDirectory \"$path\" == $actualIsDirectory, but $expectedIsDirectory was expected"
-    fi
-}
+expectSuccess "pathIsDirectory /." "true"
+expectSuccess "pathIsDirectory $PWD/directory" "true"
+expectSuccess "pathIsDirectory $PWD/regular" "false"
+expectSuccess "pathIsDirectory $PWD/symlink" "false"
+expectSuccess "pathIsDirectory $PWD/fifo" "false"
+expectSuccess "pathIsDirectory $PWD/non-existent" "false"
 
-checkPathIsDirectory "/" "true"
-checkPathIsDirectory "$PWD/directory" "true"
-checkPathIsDirectory "$PWD/regular" "false"
-checkPathIsDirectory "$PWD/symlink" "false"
-checkPathIsDirectory "$PWD/fifo" "false"
-checkPathIsDirectory "$PWD/non-existent" "false"
-
-checkPathIsRegularFile() {
-    local path=$1
-    local expectedIsRegularFile=$2
-    local actualIsRegularFile=$(nix-instantiate --eval --strict --json 2>&1 \
-        -E '{ path }: let lib = import <nixpkgs/lib>; in lib.filesystem.pathIsRegularFile path' \
-        --argstr path "$path")
-    if [[ "$actualIsRegularFile" != "$expectedIsRegularFile" ]]; then
-        die "lib.filesystem.pathIsRegularFile \"$path\" == $actualIsRegularFile, but $expectedIsRegularFile was expected"
-    fi
-}
-
-checkPathIsRegularFile "/" "false"
-checkPathIsRegularFile "$PWD/directory" "false"
-checkPathIsRegularFile "$PWD/regular" "true"
-checkPathIsRegularFile "$PWD/symlink" "false"
-checkPathIsRegularFile "$PWD/fifo" "false"
-checkPathIsRegularFile "$PWD/non-existent" "false"
+expectSuccess "pathIsRegularFile /." "false"
+expectSuccess "pathIsRegularFile $PWD/directory" "false"
+expectSuccess "pathIsRegularFile $PWD/regular" "true"
+expectSuccess "pathIsRegularFile $PWD/symlink" "false"
+expectSuccess "pathIsRegularFile $PWD/fifo" "false"
+expectSuccess "pathIsRegularFile $PWD/non-existent" "false"
 
 echo >&2 tests ok

--- a/lib/tests/filesystem.sh
+++ b/lib/tests/filesystem.sh
@@ -41,7 +41,7 @@ checkPathType() {
     local actualPathType=$(nix-instantiate --eval --strict --json 2>&1 \
         -E '{ path }: let lib = import <nixpkgs/lib>; in lib.filesystem.pathType path' \
         --argstr path "$path")
-    if [[ "$actualPathType" != "$expectedPathType" ]]; then
+    if [[ ! "$actualPathType" =~ $expectedPathType ]]; then
         die "lib.filesystem.pathType \"$path\" == $actualPathType, but $expectedPathType was expected"
     fi
 }
@@ -51,7 +51,8 @@ checkPathType "$PWD/directory" '"directory"'
 checkPathType "$PWD/regular" '"regular"'
 checkPathType "$PWD/symlink" '"symlink"'
 checkPathType "$PWD/fifo" '"unknown"'
-checkPathType "$PWD/non-existent" "error: evaluation aborted with the following error message: 'lib.filesystem.pathType: Path $PWD/non-existent does not exist.'"
+# Different errors depending on whether the builtins.readFilePath primop is available or not
+checkPathType "$PWD/non-existent" "error: (evaluation aborted with the following error message: 'lib.filesystem.pathType: Path $PWD/non-existent does not exist.'|getting status of '$PWD/non-existent': No such file or directory)"
 
 checkPathIsDirectory() {
     local path=$1

--- a/lib/tests/modules.sh
+++ b/lib/tests/modules.sh
@@ -378,7 +378,7 @@ checkConfigOutput '^{ }$' config.sub.nixosOk ./class-check.nix
 checkConfigError 'The module .*/module-class-is-darwin.nix was imported into nixos instead of darwin.' config.sub.nixosFail.config ./class-check.nix
 
 # submoduleWith type merge with different class
-checkConfigError 'error: A submoduleWith option is declared multiple times with conflicting class values "darwin" and "nixos".' config.sub.mergeFail.config ./class-check.nix
+checkConfigError 'A submoduleWith option is declared multiple times with conflicting class values "darwin" and "nixos".' config.sub.mergeFail.config ./class-check.nix
 
 # _type check
 checkConfigError 'Could not load a value as a module, because it is of type "flake", in file .*/module-imports-_type-check.nix' config.ok.config ./module-imports-_type-check.nix

--- a/lib/tests/release.nix
+++ b/lib/tests/release.nix
@@ -2,53 +2,63 @@
   # Don't test properties of pkgs.lib, but rather the lib in the parent directory
   pkgs ? import ../.. {} // { lib = throw "pkgs.lib accessed, but the lib tests should use nixpkgs' lib path directly!"; },
   nix ? pkgs.nix,
+  nixVersions ? [ pkgs.nixVersions.minimum nix pkgs.nixVersions.unstable ],
 }:
 
-pkgs.runCommand "nixpkgs-lib-tests" {
-  buildInputs = [
-    (import ./check-eval.nix)
-    (import ./maintainers.nix {
-      inherit pkgs;
-      lib = import ../.;
-    })
-    (import ./teams.nix {
-      inherit pkgs;
-      lib = import ../.;
-    })
-    (import ../path/tests {
-      inherit pkgs;
-    })
-  ];
-  nativeBuildInputs = [
-    nix
-  ];
-  strictDeps = true;
-} ''
-    datadir="${nix}/share"
-    export TEST_ROOT=$(pwd)/test-tmp
-    export NIX_BUILD_HOOK=
-    export NIX_CONF_DIR=$TEST_ROOT/etc
-    export NIX_LOCALSTATE_DIR=$TEST_ROOT/var
-    export NIX_LOG_DIR=$TEST_ROOT/var/log/nix
-    export NIX_STATE_DIR=$TEST_ROOT/var/nix
-    export NIX_STORE_DIR=$TEST_ROOT/store
-    export PAGER=cat
-    cacheDir=$TEST_ROOT/binary-cache
+let
+  testWithNix = nix:
+    pkgs.runCommand "nixpkgs-lib-tests-nix-${nix.version}" {
+      buildInputs = [
+        (import ./check-eval.nix)
+        (import ./maintainers.nix {
+          inherit pkgs;
+          lib = import ../.;
+        })
+        (import ./teams.nix {
+          inherit pkgs;
+          lib = import ../.;
+        })
+        (import ../path/tests {
+          inherit pkgs;
+        })
+      ];
+      nativeBuildInputs = [
+        nix
+      ];
+      strictDeps = true;
+    } ''
+      datadir="${nix}/share"
+      export TEST_ROOT=$(pwd)/test-tmp
+      export NIX_BUILD_HOOK=
+      export NIX_CONF_DIR=$TEST_ROOT/etc
+      export NIX_LOCALSTATE_DIR=$TEST_ROOT/var
+      export NIX_LOG_DIR=$TEST_ROOT/var/log/nix
+      export NIX_STATE_DIR=$TEST_ROOT/var/nix
+      export NIX_STORE_DIR=$TEST_ROOT/store
+      export PAGER=cat
+      cacheDir=$TEST_ROOT/binary-cache
 
-    mkdir -p $NIX_CONF_DIR
-    echo "experimental-features = nix-command" >> $NIX_CONF_DIR/nix.conf
+      mkdir -p $NIX_CONF_DIR
+      echo "experimental-features = nix-command" >> $NIX_CONF_DIR/nix.conf
 
-    nix-store --init
+      nix-store --init
 
-    cp -r ${../.} lib
-    echo "Running lib/tests/modules.sh"
-    bash lib/tests/modules.sh
+      cp -r ${../.} lib
+      echo "Running lib/tests/modules.sh"
+      bash lib/tests/modules.sh
 
-    echo "Running lib/tests/filesystem.sh"
-    TEST_LIB=$PWD/lib bash lib/tests/filesystem.sh
+      echo "Running lib/tests/filesystem.sh"
+      TEST_LIB=$PWD/lib bash lib/tests/filesystem.sh
 
-    echo "Running lib/tests/sources.sh"
-    TEST_LIB=$PWD/lib bash lib/tests/sources.sh
+      echo "Running lib/tests/sources.sh"
+      TEST_LIB=$PWD/lib bash lib/tests/sources.sh
 
-    touch $out
-''
+      mkdir $out
+      echo success > $out/${nix.version}
+    '';
+
+in
+  pkgs.symlinkJoin {
+    name = "nixpkgs-lib-tests";
+    paths = map testWithNix nixVersions;
+  }

--- a/lib/tests/sources.sh
+++ b/lib/tests/sources.sh
@@ -23,14 +23,19 @@ clean_up() {
 trap clean_up EXIT
 cd "$work"
 
+# Crudely unquotes a JSON string by just taking everything between the first and the second quote.
+# We're only using this for resulting /nix/store paths, which can't contain " anyways,
+# nor can they contain any other characters that would need to be escaped specially in JSON
+# This way we don't need to add a dependency on e.g. jq
+crudeUnquoteJSON() {
+    cut -d \" -f2
+}
+
 touch {README.md,module.o,foo.bar}
 
-# nix-instantiate doesn't write out the source, only computing the hash, so
-# this uses the experimental nix command instead.
-
-dir="$(nix eval --impure --raw --expr '(with import <nixpkgs/lib>; "${
+dir="$(nix-instantiate --eval --strict --read-write-mode --json --expr '(with import <nixpkgs/lib>; "${
   cleanSource ./.
-}")')"
+}")' | crudeUnquoteJSON)"
 (cd "$dir"; find) | sort -f | diff -U10 - <(cat <<EOF
 .
 ./foo.bar
@@ -39,9 +44,9 @@ EOF
 ) || die "cleanSource 1"
 
 
-dir="$(nix eval --impure --raw --expr '(with import <nixpkgs/lib>; "${
+dir="$(nix-instantiate --eval --strict --read-write-mode --json --expr '(with import <nixpkgs/lib>; "${
   cleanSourceWith { src = '"$work"'; filter = path: type: ! hasSuffix ".bar" path; }
-}")')"
+}")' | crudeUnquoteJSON)"
 (cd "$dir"; find) | sort -f | diff -U10 - <(cat <<EOF
 .
 ./module.o
@@ -49,9 +54,9 @@ dir="$(nix eval --impure --raw --expr '(with import <nixpkgs/lib>; "${
 EOF
 ) || die "cleanSourceWith 1"
 
-dir="$(nix eval --impure --raw --expr '(with import <nixpkgs/lib>; "${
+dir="$(nix-instantiate --eval --strict --read-write-mode --json --expr '(with import <nixpkgs/lib>; "${
   cleanSourceWith { src = cleanSource '"$work"'; filter = path: type: ! hasSuffix ".bar" path; }
-}")')"
+}")' | crudeUnquoteJSON)"
 (cd "$dir"; find) | sort -f | diff -U10 - <(cat <<EOF
 .
 ./README.md


### PR DESCRIPTION
Minimal pick from PR #234070

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
