### PR TITLE
flite: add audiobackend option

### DIFF
--- a/pkgs/development/libraries/flite/default.nix
+++ b/pkgs/development/libraries/flite/default.nix
@@ -45,6 +45,7 @@ stdenv.mkDerivation rec {
     description = "A small, fast run-time speech synthesis engine";
     homepage = "http://www.festvox.org/flite/";
     license = licenses.bsdOriginal;
+    maintainers = with maintainers; [ getchoo ];
     platforms = platforms.all;
   };
 }

--- a/pkgs/development/libraries/flite/default.nix
+++ b/pkgs/development/libraries/flite/default.nix
@@ -1,4 +1,13 @@
-{ lib, stdenv, fetchFromGitHub, alsa-lib, fetchpatch }:
+{ lib
+, stdenv
+, fetchFromGitHub
+, alsa-lib
+, fetchpatch
+, libpulseaudio
+, audioBackend ? "pulseaudio"
+}:
+
+assert lib.assertOneOf "audioBackend" audioBackend [ "alsa" "pulseaudio" ];
 
 stdenv.mkDerivation rec {
   pname = "flite";
@@ -11,7 +20,8 @@ stdenv.mkDerivation rec {
     sha256 = "1n0p81jzndzc1rzgm66kw9ls189ricy5v1ps11y0p2fk1p56kbjf";
   };
 
-  buildInputs = lib.optionals stdenv.isLinux [ alsa-lib ];
+  buildInputs = lib.optional (stdenv.isLinux && audioBackend == "alsa") alsa-lib
+    ++ lib.optional (stdenv.isLinux && audioBackend == "pulseaudio") libpulseaudio;
 
   # https://github.com/festvox/flite/pull/60.
   # Replaces `ar` with `$(AR)` in config/common_make_rules.
@@ -25,7 +35,7 @@ stdenv.mkDerivation rec {
 
   configureFlags = [
     "--enable-shared"
-  ] ++ lib.optionals stdenv.isLinux [ "--with-audio=alsa" ];
+  ] ++ lib.optionals stdenv.isLinux [ "--with-audio=${audioBackend}" ];
 
   # main/Makefile creates and removes 'flite_voice_list.c' from multiple targets:
   # make[1]: *** No rule to make target 'flite_voice_list.c', needed by 'all'.  Stop


### PR DESCRIPTION
###### Description of changes

this adds an `audioBackend` option to flite - letting users specify what audio backend they wish to use for building - along with making the package build against pulseaudio by default instead of alsa. this follows the example of other distros such as [fedora](https://src.fedoraproject.org/rpms/flite/blob/32cd5587c1b8744be0f0fe932048fc97b5e9e914/f/flite.spec#_58) and allows flite to work in minecraft (see https://github.com/NixOS/nixpkgs/pull/238645) and other software where flite built against pulse is preferred

i also noticed this package doesn't have a maintainer, so i added myself :)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
