### PR TITLE
nixos/nextcloud: Add option to pre-compress assets

### DIFF
--- a/nixos/modules/services/web-apps/nextcloud.nix
+++ b/nixos/modules/services/web-apps/nextcloud.nix
@@ -52,7 +52,7 @@ let
     };
   };
 
-  webroot =
+  packageWithApps =
     pkgs.runCommand "${overridePackage.name or "nextcloud"}-with-apps"
       {
         preferLocalBuild = true;
@@ -73,6 +73,9 @@ let
           ) appStores
         )}
       '';
+
+  webroot =
+    if cfg.enableCompressedAssets then pkgs.compressDrvWeb packageWithApps { } else packageWithApps;
 
   inherit (cfg) datadir;
 
@@ -472,6 +475,12 @@ in
     phpPackage = lib.mkPackageOption pkgs "php" {
       default = [ "php84" ];
       example = "php82";
+    };
+
+    enableCompressedAssets = lib.mkOption {
+      type = lib.types.bool;
+      default = false;
+      description = "Whether to provide gzip, brotli and zstd pre-compressed assets for lower CPU usage and less transfer size in production. This leads to longer build times and bigger derivation size.";
     };
 
     finalPackage = lib.mkOption {


### PR DESCRIPTION
###### Description of changes

The schema is similar to Mastodon's packaging script, gnerating gzip and brotli compressed files ahead-of-time.

The find command only selects those folders that are publicly viewable according to the nginx config, and only compresses file types that are allowed in the nginx config.
The index.html and robots.txt files are too small to be relevant.

The gzip files are used through the default nginx config, brotli requires the administrators to set `services.nginx.recommendedBrotliSettings = true`.

###### Space changes
560MB /nix/store/i6b1aqrbjgvx6jc8psv1kcyhkayqg8xx-nextcloud-27.0.0 (previous)
683MB /nix/store/h2ai1zkdqp280xv4wp7xrfn4ax86l9xf-nextcloud-27.0.0 (new)

###### Bandwidth savings
I observed the login page with Firefox. The server has `services.nginx.recommendedGzipSettings` and `services.nginx.recommendedBrotliSettings` enabled.
_16.53MB uncompressed (according to Firefox dev tools)_
3.94MB on-the-fly compressed (old)
1.64MB ahead-of-time compressed (new)
That's a 2.4x compression improvement!

###### Compute savings
No measurements for CPU compute savings on the server side, but we avoid compressing the same files over and over again. Helps the environment :earth_africa: 

Brotli and gzip should be equally fast at decompression irrespective of compression level.

###### Build time increase
The build time increases by 15-23 minutes. Most of this can be attributed to zopfli. Only brotli (and standard gzip) would take more like 4 minutes.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`): **tested nextcloud26 in production**
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
