### PR TITLE
Fix dictdDBs reproducibility with faketime

### DIFF
--- a/pkgs/servers/dict/dictd-db-collector.nix
+++ b/pkgs/servers/dict/dictd-db-collector.nix
@@ -1,4 +1,4 @@
-{ stdenv, lib, dict }:
+{ stdenv, lib, dict, libfaketime }:
 ({ dictlist, allowList ? [ "127.0.0.1" ], denyList ? [ ] }:
 
 /*
@@ -56,7 +56,8 @@ let
         ln -s "$i".dict.dz
       else
         cp "$i".dict .
-        dictzip "$base".dict
+        source_date=$(date --utc --date=@$SOURCE_DATE_EPOCH "+%F %T")
+        faketime -f "$source_date" dictzip "$base".dict
       fi
       ln -s "$i".index .
       dictfmt_index2word --locale $locale < "$base".index > "$base".word || true
@@ -76,6 +77,7 @@ in
 stdenv.mkDerivation {
   name = "dictd-dbs";
 
+  nativeBuildInputs = [ libfaketime ];
   buildInputs = [ dict ];
 
   dontUnpack = true;

--- a/pkgs/servers/dict/dictd-wordnet.nix
+++ b/pkgs/servers/dict/dictd-wordnet.nix
@@ -1,10 +1,10 @@
-{lib, stdenv, python3, wordnet, writeScript}:
+{lib, stdenv, python3, wordnet, writeScript, libfaketime}:
 
 stdenv.mkDerivation rec {
   version = "542";
   pname = "dict-db-wordnet";
 
-  buildInputs = [python3 wordnet];
+  buildInputs = [python3 wordnet libfaketime];
   convert = ./wordnet_structures.py;
 
   builder = writeScript "builder.sh" ''
@@ -16,7 +16,8 @@ stdenv.mkDerivation rec {
       DATA="$DATA `echo $i | sed -e s,data,index,` $i";
     done
 
-    python ${convert} $DATA
+    source_date=$(date --utc --date=@$SOURCE_DATE_EPOCH "+%F %T")
+    faketime -f "$source_date" python ${convert} $DATA
     echo en_US.UTF-8 > locale
   '';
 

--- a/pkgs/servers/dict/wiktionary/default.nix
+++ b/pkgs/servers/dict/wiktionary/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchurl, python3, dict, glibcLocales }:
+{ lib, stdenv, fetchurl, python3, dict, glibcLocales, libfaketime }:
 
 stdenv.mkDerivation rec {
   pname = "dict-db-wiktionary";
@@ -9,7 +9,7 @@ stdenv.mkDerivation rec {
     sha256 = "qsha26LL2513SDtriE/0zdPX1zlnpzk1KKk+R9dSdew=";
   };
 
-  nativeBuildInputs = [ python3 dict glibcLocales ];
+  nativeBuildInputs = [ python3 dict glibcLocales libfaketime ];
 
   dontUnpack = true;
 
@@ -17,8 +17,9 @@ stdenv.mkDerivation rec {
     mkdir -p $out/share/dictd/
     cd $out/share/dictd
 
-    ${python3.interpreter} -O ${./wiktionary2dict.py} "${src}"
-    dictzip wiktionary-en.dict
+    source_date=$(date --utc --date=@$SOURCE_DATE_EPOCH "+%F %T")
+    faketime -f "$source_date" ${python3.interpreter} -O ${./wiktionary2dict.py} "${src}"
+    faketime -f "$source_date" dictzip wiktionary-en.dict
     echo en_US.UTF-8 > locale
   '';
 


### PR DESCRIPTION
###### Description of changes
- dictdDBs.wiktionary: fix reproducibility with faketime
- dictdDBs.wordnet: fix reproducibility with faketime
- dictDBCollector: fix reproducibility with faketime

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
