### PR TITLE
openraPackages_2019: remove dependency on dotnetPackages

### DIFF
--- a/pkgs/games/openra_2019/common.nix
+++ b/pkgs/games/openra_2019/common.nix
@@ -2,7 +2,7 @@
     and out-of-tree mod packages (mod.nix).
 */
 { lib, makeSetupHook, curl, unzip, dos2unix, pkg-config, makeWrapper
-, lua, mono, dotnetPackages, python3
+, lua, mono, python3
 , libGL, freetype, openal, SDL2
 , zenity
 }:
@@ -40,24 +40,7 @@ in {
   '';
 
   packageAttrs = {
-    buildInputs = with dotnetPackages; [
-      FuzzyLogicLibrary
-      MaxMindDb
-      MaxMindGeoIP2
-      MonoNat
-      NewtonsoftJson
-      NUnit3
-      NUnitConsole
-      OpenNAT
-      RestSharp
-      SharpFont
-      SharpZipLib
-      SmartIrc4net
-      StyleCopMSBuild
-      StyleCopPlusMSBuild
-    ] ++ [
-      libGL
-    ];
+    buildInputs = [ libGL ];
 
     # TODO: Test if this is correct.
     nativeBuildInputs = [

--- a/pkgs/games/openra_2019/default.nix
+++ b/pkgs/games/openra_2019/default.nix
@@ -8,9 +8,9 @@
 */
 pkgs:
 
-with pkgs.lib;
-
 let
+  lib = pkgs.lib;
+
   /*  Building an engine or out-of-tree mod is very similar,
       but different enough not to be able to build them with the same package definition,
       so instaed we define what is common between them in a separate file.
@@ -21,7 +21,10 @@ let
       so either the attributes added by `makeOverridable` have to be removed
       or the engine and mod package definitions will need to add `...` to the argument list.
   */
-  common = let f = import ./common.nix; in f (builtins.intersectAttrs (functionArgs f) pkgs // {
+  common = let
+    f = import ./common.nix;
+    fArgs = lib.functionArgs f;
+  in f (builtins.intersectAttrs fArgs pkgs // {
     lua = pkgs.lua5_1;
     # It is not necessary to run the game, but it is nicer to be given an error dialog in the case of failure,
     # rather than having to look to the logs why it is not starting.
@@ -40,8 +43,8 @@ let
       to base the name on the attribute name instead, preventing the need to specify the name twice
       if the attribute name and engine/mod name are equal.
   */
-  callWithName = name: value: if isFunction value then value name else value;
-  buildOpenRASet = f: args: pkgs.recurseIntoAttrs (mapAttrs callWithName (f ({
+  callWithName = name: value: if lib.isFunction value then value name else value;
+  buildOpenRASet = f: args: pkgs.recurseIntoAttrs (lib.mapAttrs callWithName (f ({
     inherit (pkgs) fetchFromGitHub;
     postFetch = ''
       sed -i 's/curl/curl --insecure/g' $out/thirdparty/{fetch-thirdparty-deps,noget}.sh
@@ -56,14 +59,16 @@ in pkgs.recurseIntoAttrs rec {
     # Allow specifying the name at a later point if no name has been given.
     let builder = name: pkgs.callPackage ./engine.nix (common // {
       engine = engine // { inherit name; };
-    }); in if name == null then builder else builder name;
+    });
+    in if name == null then builder else builder name;
 
   # See `buildOpenRAEngine`.
   buildOpenRAMod = { name ? null, version, title, description, homepage, src, engine, assetsError ? "" }@mod: ({ version, mods ? [], src }@engine:
     let builder = name: pkgs.callPackage ./mod.nix (common // {
       mod = mod // { inherit name assetsError; };
       engine = engine // { inherit mods; };
-    }); in if name == null then builder else builder name) engine;
+    });
+    in if name == null then builder else builder name) engine;
 
   # See `buildOpenRASet`.
   engines = buildOpenRASet (import ./engines.nix) { inherit buildOpenRAEngine; };

--- a/pkgs/games/openra_2019/default.nix
+++ b/pkgs/games/openra_2019/default.nix
@@ -6,11 +6,9 @@
     Additional engines or mods can be added with `openraPackages.buildOpenRAEngine` (function around `engine.nix`)
     and `openraPackages.buildOpenRAMod` (function around `mod.nix`), respectively.
 */
-pkgs:
+{ pkgs, lib }:
 
 let
-  lib = pkgs.lib;
-
   /*  Building an engine or out-of-tree mod is very similar,
       but different enough not to be able to build them with the same package definition,
       so instaed we define what is common between them in a separate file.

--- a/pkgs/games/openra_2019/engine.nix
+++ b/pkgs/games/openra_2019/engine.nix
@@ -14,9 +14,7 @@
 , engine
 }:
 
-with lib;
-
-stdenv.mkDerivation (recursiveUpdate packageAttrs rec {
+stdenv.mkDerivation (lib.recursiveUpdate packageAttrs rec {
   pname = "openra_2019";
   version = "${engine.name}-${engine.version}";
 
@@ -27,7 +25,7 @@ stdenv.mkDerivation (recursiveUpdate packageAttrs rec {
   configurePhase = ''
     runHook preConfigure
 
-    make version VERSION=${escapeShellArg version}
+    make version VERSION=${lib.escapeShellArg version}
 
     runHook postConfigure
   '';
@@ -48,7 +46,7 @@ stdenv.mkDerivation (recursiveUpdate packageAttrs rec {
   postInstall = ''
     ${wrapLaunchGame "" "openra"}
 
-    ${concatStrings (map (mod: ''
+    ${lib.concatStrings (map (mod: ''
       makeWrapper $out/bin/openra $out/bin/openra-${mod} --add-flags Game.Mod=${mod}
     '') engine.mods)}
   '';

--- a/pkgs/games/openra_2019/mod.nix
+++ b/pkgs/games/openra_2019/mod.nix
@@ -14,14 +14,12 @@
 , engine
 }:
 
-with lib;
-
 let
   engineSourceName = engine.src.name or "engine";
   modSourceName = mod.src.name or "mod";
 
 # Based on: https://build.opensuse.org/package/show/home:fusion809/openra-ura
-in stdenv.mkDerivation (recursiveUpdate packageAttrs rec {
+in stdenv.mkDerivation (lib.recursiveUpdate packageAttrs rec {
   name = "${pname}-${version}";
   pname = "openra_2019-${mod.name}";
   inherit (mod) version;
@@ -54,8 +52,8 @@ in stdenv.mkDerivation (recursiveUpdate packageAttrs rec {
   configurePhase = ''
     runHook preConfigure
 
-    make version VERSION=${escapeShellArg version}
-    make -C ${engineSourceName} version VERSION=${escapeShellArg engine.version}
+    make version VERSION=${lib.escapeShellArg version}
+    make -C ${engineSourceName} version VERSION=${lib.escapeShellArg engine.version}
 
     runHook postConfigure
   '';
@@ -67,22 +65,22 @@ in stdenv.mkDerivation (recursiveUpdate packageAttrs rec {
 
     make -C ${engineSourceName} install-engine install-common-mod-files DATA_INSTALL_DIR=$out/lib/${pname}
 
-    cp -r ${engineSourceName}/mods/{${concatStringsSep "," ([ "common" "modcontent" ] ++ engine.mods)}} mods/* \
+    cp -r ${engineSourceName}/mods/{${lib.concatStringsSep "," ([ "common" "modcontent" ] ++ engine.mods)}} mods/* \
       $out/lib/${pname}/mods/
 
     substitute ${./mod-launch-game.sh} $out/lib/openra_2019-${mod.name}/launch-game.sh \
       --subst-var out \
-      --subst-var-by name ${escapeShellArg mod.name} \
-      --subst-var-by title ${escapeShellArg mod.title} \
-      --subst-var-by assetsError ${escapeShellArg mod.assetsError}
+      --subst-var-by name ${lib.escapeShellArg mod.name} \
+      --subst-var-by title ${lib.escapeShellArg mod.title} \
+      --subst-var-by assetsError ${lib.escapeShellArg mod.assetsError}
     chmod +x $out/lib/openra_2019-${mod.name}/launch-game.sh
 
     ${wrapLaunchGame "_2019-${mod.name}" "openra-${mod.name}"}
 
     substitute ${./openra-mod.desktop} $(mkdirp $out/share/applications)/${pname}.desktop \
-      --subst-var-by name ${escapeShellArg mod.name} \
-      --subst-var-by title ${escapeShellArg mod.title} \
-      --subst-var-by description ${escapeShellArg mod.description}
+      --subst-var-by name ${lib.escapeShellArg mod.name} \
+      --subst-var-by title ${lib.escapeShellArg mod.title} \
+      --subst-var-by description ${lib.escapeShellArg mod.description}
 
     cp README.md $(mkdirp $out/share/doc/packages/${pname})/README.md
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -37138,7 +37138,10 @@ with pkgs;
 
   otto-matic = callPackage ../games/otto-matic { };
 
-  openraPackages_2019 = import ../games/openra_2019 pkgs.__splicedPackages;
+  openraPackages_2019 = import ../games/openra_2019 {
+    inherit lib;
+    pkgs = pkgs.__splicedPackages;
+  };
 
   openra_2019 = openraPackages_2019.engines.release;
 


### PR DESCRIPTION
###### Description of changes

Helps with https://github.com/NixOS/nixpkgs/issues/234775. Turns out the packages defined
in `buildInputs` weren't actually used, since the dependencies are fetched in a `postFetch` step by an upstream script.

Also contains fixes to usages of `lib`, mentioned in a [previous PR review](https://github.com/NixOS/nixpkgs/pull/220888#discussion_r1141511993)

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
