### PR TITLE
scenebuilder: 15.0.1 -> 20.0.0, enable javaFX and webkit

### DIFF
--- a/pkgs/development/tools/scenic-view/default.nix
+++ b/pkgs/development/tools/scenic-view/default.nix
@@ -1,5 +1,10 @@
-{ lib, stdenv, fetchFromGitHub, jdk, gradle_7, makeDesktopItem, copyDesktopItems, perl, writeText, runtimeShell, makeWrapper }:
+{ lib, stdenv, fetchFromGitHub, openjdk, openjfx, gradle_7, makeDesktopItem, perl, writeText, makeWrapper }:
 let
+  jdk = openjdk.override (lib.optionalAttrs stdenv.isLinux {
+    enableJavaFX = true;
+    openjfx = openjfx.override { withWebKit = true; };
+  });
+
   pname = "scenic-view";
   version = "11.0.2";
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -19863,7 +19863,12 @@ with pkgs;
     jre = jre.override { enableJavaFX = true; };
   };
 
-  scenic-view = callPackage ../development/tools/scenic-view { jdk = jdk11; };
+  scenic-view = callPackage ../development/tools/scenic-view {
+    jdk = jdk.override {
+      enableJavaFX = true;
+      openjfx = openjfx.override { withWebKit = true; };
+    };
+  };
 
   shncpd = callPackage ../tools/networking/shncpd { };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -19859,16 +19859,9 @@ with pkgs;
 
   schemaspy = callPackage ../development/tools/database/schemaspy { };
 
-  scenebuilder = callPackage ../development/tools/scenebuilder {
-    jre = jre.override { enableJavaFX = true; };
-  };
+  scenebuilder = callPackage ../development/tools/scenebuilder { };
 
-  scenic-view = callPackage ../development/tools/scenic-view {
-    jdk = jdk.override {
-      enableJavaFX = true;
-      openjfx = openjfx.override { withWebKit = true; };
-    };
-  };
+  scenic-view = callPackage ../development/tools/scenic-view { };
 
   shncpd = callPackage ../tools/networking/shncpd { };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -19859,7 +19859,9 @@ with pkgs;
 
   schemaspy = callPackage ../development/tools/database/schemaspy { };
 
-  scenebuilder = callPackage ../development/tools/scenebuilder { };
+  scenebuilder = callPackage ../development/tools/scenebuilder {
+    jre = jre.override { enableJavaFX = true; };
+  };
 
   scenic-view = callPackage ../development/tools/scenic-view { jdk = jdk11; };
 


### PR DESCRIPTION
Update scenebuilder to the latest version supported by the jdk versions available in nixpkgs.

For changelogs see: https://github.com/gluonhq/scenebuilder/releases

The changes are rather big, because the project switched from gradle to maven.

This was triggered by #238902, which reported that scenebuilder broke and fails to find the javafx module on startup. There are different ways to handle the move of javafx from core jdk modules to external modules, with many distributions including nixkpgs shipping versions of the jdk which have the javafx modules added back in.
This used to be the default but got changed in https://github.com/NixOS/nixpkgs/pull/206643 / ce6bc62
to reduce the closure of non javafx java apps.

Since scenic-view has the same situation and is closely related to scene-builder concerning packaging and userbase, I fixed scenic-view in a second commit. Additionally 1caf19b from the same PR mentioned earlier also removed webkit support from openjfx which is also required for scenic-view and therefore explicitly enabled.

I've tested that the packages build correctly again and produce runnable binaries, but I didn't go into deep testing of functionalities.

fixes #238902 

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).