### PR TITLE
build-support: Use response-expanded params in pie test

### DIFF
--- a/pkgs/build-support/bintools-wrapper/add-hardening.sh
+++ b/pkgs/build-support/bintools-wrapper/add-hardening.sh
@@ -37,11 +37,11 @@ fi
 for flag in "${!hardeningEnableMap[@]}"; do
   case $flag in
     pie)
-      if [[ ! (" $* " =~ " -shared " \
-            || " $* " =~ " -static " \
-            || " $* " =~ " -r " \
-            || " $* " =~ " -Ur " \
-            || " $* " =~ " -i ") ]]; then
+      if [[ ! (" ${params[*]} " =~ " -shared " \
+            || " ${params[*]} " =~ " -static " \
+            || " ${params[*]} " =~ " -r " \
+            || " ${params[*]} " =~ " -Ur " \
+            || " ${params[*]} " =~ " -i ") ]]; then
         if (( "${NIX_DEBUG:-0}" >= 1 )); then echo HARDENING: enabling LDFlags -pie >&2; fi
         hardeningLDFlags+=('-pie')
       fi

--- a/pkgs/build-support/cc-wrapper/add-hardening.sh
+++ b/pkgs/build-support/cc-wrapper/add-hardening.sh
@@ -71,7 +71,7 @@ for flag in "${!hardeningEnableMap[@]}"; do
       # NB: we do not use `+=` here, because PIE flags must occur before any PIC flags
       if (( "${NIX_DEBUG:-0}" >= 1 )); then echo HARDENING: enabling CFlags -fPIE >&2; fi
       hardeningCFlags=('-fPIE' "${hardeningCFlags[@]}")
-      if [[ ! (" $* " =~ " -shared " || " $* " =~ " -static ") ]]; then
+      if [[ ! (" ${params[*]} " =~ " -shared " || " ${params[*]} " =~ " -static ") ]]; then
         if (( "${NIX_DEBUG:-0}" >= 1 )); then echo HARDENING: enabling LDFlags -pie >&2; fi
         hardeningCFlags=('-pie' "${hardeningCFlags[@]}")
       fi


### PR DESCRIPTION
When a response file is in use, "$*" contains the response file and not the parameters; both the linker and compiler wrappers are updated to use the response-expanded params.

The compiler driver likes to pass parameters to the linker via a response file, including -shared.

LLD rejects the combination of (-shared -pie), whereas other linkers silently ignore the contradiction:

```
ld.lld: error: -shared and -pie may not be used together
```

Changing `add-hardening.sh` results in a full rebuild. To avoid the rebuild, here is a quick test case which shows the new hardening script allows the link to succeed:

```
{ pkgs ? import <nixpkgs> {} }:

let
  # gcc silently accepts -shared -pie together, lld does not.
  linker = pkgs.wrapBintoolsWith { bintools = pkgs.llvmPackages.lld; };

  patchWrapper = prev: prev.overrideAttrs (final: prev: let
    prevScript = builtins.match (".*(/nix/store/[a-z0-9]+-add-hardening.sh).*") prev.postFixup;
  in {
    postFixup = (builtins.replaceStrings prevScript ["${./new-add-hardening.sh}"] prev.postFixup);
  });
in

pkgs.stdenv.mkDerivation {
  name = "nixpkgs-hardening-bug";

  src = pkgs.writeText "src.c" "int main(int argc, char* argv[]) { return 0; }";
  NIX_HARDENING_ENABLE = "pie";

  unpackPhase = ":";
  buildPhase = ''
    $CC -c -o src.o $src
    bash -x ${patchWrapper linker}/bin/ld.lld -o $out @${pkgs.writeText "responsefile" "-shared"} src.o
  '';
}
```

Fixes: #178162


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
