### PR TITLE
inkscape/silhouette: init at 1.28

### DIFF
--- a/pkgs/applications/graphics/inkscape/extensions.nix
+++ b/pkgs/applications/graphics/inkscape/extensions.nix
@@ -44,6 +44,7 @@
     mkdir -p $out/share/inkscape/extensions
     cp ${inkcut}/share/inkscape/extensions/* $out/share/inkscape/extensions
   '');
+  silhouette = callPackage ./extensions/silhouette { };
   textext = callPackage ./extensions/textext {
     pdflatex = texlive.combined.scheme-basic;
     lualatex = texlive.combined.scheme-basic;

--- a/pkgs/applications/graphics/inkscape/extensions/silhouette/default.nix
+++ b/pkgs/applications/graphics/inkscape/extensions/silhouette/default.nix
@@ -1,0 +1,91 @@
+{ fetchFromGitHub
+, lib
+, gettext
+, pkgs
+, python3
+, umockdev
+, writeScript
+}:
+
+let
+  # We need these simple wrapper shell scripts because Inkscape extensions with
+  # interpreter="shell" always get invoked with the `sh` command [0], regardless of
+  # the shebang at the top of the script.
+  # [0]: https://gitlab.com/inkscape/inkscape/-/blob/d61d917afb94721c92a650b2c4b116b0a4826f41/src/extension/implementation/script.cpp#L93
+  launch-sendto_silhouette = writeScript "sendto_silhouette.sh" ''
+    cd $(dirname $0)
+    ./sendto_silhouette.py "$@"
+  '';
+  launch-silhouette_multi = writeScript "silhouette_multi.sh" ''
+    cd $(dirname $0)
+    ./silhouette_multi.py "$@"
+  '';
+in
+python3.pkgs.buildPythonApplication rec {
+  pname = "inkscape-silhouette";
+  version = "1.28";
+  format = "setuptools";
+
+  src = fetchFromGitHub {
+    owner = "fablabnbg";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "sha256-uNVhdkZFadL7QNlCsXq51TbhzRKH9KYDPDNCFhw3cQs=";
+  };
+
+  patches = [
+    ./interpreter.patch
+    ./use-prefix-for-udev.patch
+  ];
+
+  propagatedBuildInputs = [
+    python3.pkgs.pyusb
+    python3.pkgs.lxml
+    python3.pkgs.inkex
+    python3.pkgs.matplotlib
+    python3.pkgs.wxPython_4_2
+    python3.pkgs.xmltodict
+  ];
+
+  nativeBuildInputs = [
+    gettext # msgfmt
+  ];
+
+  nativeCheckInputs = [
+    python3.pkgs.pytestCheckHook
+    umockdev
+  ];
+
+  pytestFlagsArray = [
+    "test"
+  ];
+
+  doCheck = true;
+
+  installPhase = ''
+    runHook preInstall
+    make install PREFIX=$out
+    runHook postInstall
+  '';
+
+  postInstall = ''
+    # Unmark read_dump.py as executable so wrapPythonProgramsIn won't turn it
+    # into a shell script (thereby making it impossible to import as a Python
+    # module).
+    chmod -x $out/share/inkscape/extensions/silhouette/read_dump.py
+    cp ${launch-sendto_silhouette} $out/share/inkscape/extensions/sendto_silhouette.sh
+    cp ${launch-silhouette_multi} $out/share/inkscape/extensions/silhouette_multi.sh
+  '';
+
+  postFixup = ''
+    wrapPythonProgramsIn "$out/share/inkscape/extensions/" "$out $pythonPath"
+  '';
+
+  meta = with lib; {
+    description = "An extension to drive Silhouette vinyl cutters (e.g. Cameo, Portrait, Curio series) from within Inkscape.";
+    homepage = "https://github.com/fablabnbg/inkscape-silhouette";
+    license = licenses.gpl2Only;
+    maintainers = with maintainers; [ jfly ];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/applications/graphics/inkscape/extensions/silhouette/interpreter.patch
+++ b/pkgs/applications/graphics/inkscape/extensions/silhouette/interpreter.patch
@@ -1,0 +1,24 @@
+diff --git a/sendto_silhouette.inx b/sendto_silhouette.inx
+index 55a3278..d780730 100644
+--- a/sendto_silhouette.inx
++++ b/sendto_silhouette.inx
+@@ -188,6 +188,6 @@ Always use the least amount of blade possible.
+   </effect>
+ 
+   <script>
+-      <command location="inx" interpreter="python">sendto_silhouette.py</command>
++      <command location="inx" interpreter="shell">sendto_silhouette.sh</command>
+   </script>
+ </inkscape-extension>
+diff --git a/silhouette_multi.inx b/silhouette_multi.inx
+index f6fd2ed..2d9dba6 100644
+--- a/silhouette_multi.inx
++++ b/silhouette_multi.inx
+@@ -31,6 +31,6 @@
+   </effect>
+   
+   <script>
+-      <command location="inx" interpreter="python">silhouette_multi.py</command>
++      <command location="inx" interpreter="shell">silhouette_multi.sh</command>
+   </script>
+ </inkscape-extension>

--- a/pkgs/applications/graphics/inkscape/extensions/silhouette/use-prefix-for-udev.patch
+++ b/pkgs/applications/graphics/inkscape/extensions/silhouette/use-prefix-for-udev.patch
@@ -1,0 +1,13 @@
+diff --git a/Makefile b/Makefile
+index 5aff25d..43c3fb0 100644
+--- a/Makefile
++++ b/Makefile
+@@ -22,7 +22,7 @@ VERS=$$(python3 ./sendto_silhouette.py --version)
+ 
+ DEST=$(DESTDIR)$(PREFIX)/share/inkscape/extensions
+ LOCALE=$(DESTDIR)$(PREFIX)/share/locale
+-UDEV=$(DESTDIR)/lib/udev
++UDEV=$(DESTDIR)$(PREFIX)/lib/udev
+ INKSCAPE_TEMPLATES=$(DESTDIR)$(PREFIX)/share/inkscape/templates
+ 
+ # User-specifc inkscape extensions folder for local install


### PR DESCRIPTION
###### Description of changes

Introduce the 'silhouette' extension for printing to Silhouette vinyl
cutters in Inkscape.

Tested with `nix-build -E "with import ./. { }; inkscape-with-extensions.override { inkscapeExtensions = [ inkscape-extensions.silhouette ]; }"`.

This completes https://github.com/NixOS/nixpkgs/issues/224852

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
