### PR TITLE
Create a .NET maintainers team

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -294,8 +294,10 @@ pkgs/development/python-modules/buildcatrust/ @ajs124 @lukegb @mweinelt
 /nixos/tests/matrix-conduit.nix                            @piegamesde
 
 # Dotnet
-/pkgs/build-support/dotnet          @IvarWithoutBones
-/pkgs/development/compilers/dotnet  @IvarWithoutBones
+/pkgs/build-support/dotnet                  @IvarWithoutBones
+/pkgs/development/compilers/dotnet          @IvarWithoutBones
+/pkgs/test/dotnet                           @IvarWithoutBones
+/doc/languages-frameworks/dotnet.section.md @IvarWithoutBones
 
 # Node.js
 /pkgs/build-support/node/build-npm-package      @lilyinstarlight @winterqt

--- a/doc/languages-frameworks/dotnet.section.md
+++ b/doc/languages-frameworks/dotnet.section.md
@@ -210,3 +210,5 @@ buildDotnetGlobalTool {
   };
 }
 ```
+
+When packaging a new .NET application in nixpkgs, you can tag the [`@NixOS/dotnet`](https://github.com/orgs/nixos/teams/dotnet) team for help and code review.

--- a/maintainers/team-list.nix
+++ b/maintainers/team-list.nix
@@ -181,6 +181,19 @@ with lib.maintainers; {
     shortName = "Cosmopolitan";
   };
 
+  dotnet = {
+    members = [
+      ivar
+      mdarocha
+      corngood
+      raphaelr
+      jamiemagee
+      anpin
+    ];
+    scope = "Maintainers of the .NET build tools and packages";
+    shortName = "dotnet";
+  };
+
   deepin = {
     members = [
       rewine


### PR DESCRIPTION
###### Description of changes

This would allow getting help with building .NET packages easier, as well as allows interested maintainers to get pinged about updates to the core .NET infrastructure

I added the initial members based on recent github activity and `git shortlog`. Comment on this PR if you would like to be added or removed - it shouldn't without everybody agreeing to be part of this team.

I also updated CODEOWNERS to not only contain @IvarWithoutBones, but all members of this dotnet team.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->