### PR TITLE
xgboost: 1.7.5 -> 1.7.6

### DIFF
--- a/pkgs/development/libraries/xgboost/default.nix
+++ b/pkgs/development/libraries/xgboost/default.nix
@@ -45,14 +45,14 @@ stdenv.mkDerivation rec {
   #   in \
   #   rWrapper.override{ packages = [ xgb ]; }"
   pname = lib.optionalString rLibrary "r-" + pnameBase;
-  version = "1.7.5";
+  version = "1.7.6";
 
   src = fetchFromGitHub {
     owner = "dmlc";
     repo = pnameBase;
     rev = "v${version}";
     fetchSubmodules = true;
-    hash = "sha256-IBqtyz40VVHdncibnZQAe5oDsjb5isWBYQ6pGx/zt38=";
+    hash = "sha256-i7smd56rLbNY0qXysq818VYWYbjrnFbyIjQkIgf9aOs=";
   };
 
   nativeBuildInputs = [ cmake ]


### PR DESCRIPTION
###### Description of changes

Update xgboost to 1.7.6, [a patch release](https://github.com/dmlc/xgboost/releases/tag/v1.7.6).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
