### PR TITLE
yandex-cloud: init at 0.129.0

### DIFF
--- a/pkgs/by-name/ya/yandex-cloud/package.nix
+++ b/pkgs/by-name/ya/yandex-cloud/package.nix
@@ -1,0 +1,99 @@
+{
+  lib,
+  stdenv,
+  fetchurl,
+  makeBinaryWrapper,
+  installShellFiles,
+  buildPackages,
+  withShellCompletions ? stdenv.hostPlatform.emulatorAvailable buildPackages,
+  # update script
+  writers,
+  python3Packages,
+  nix,
+  # tests
+  testers,
+  yandex-cloud,
+}:
+let
+  pname = "yandex-cloud";
+  sources = lib.importJSON ./sources.json;
+  inherit (sources) version binaries;
+in
+stdenv.mkDerivation {
+  inherit pname version;
+
+  src = fetchurl binaries.${stdenv.hostPlatform.system};
+
+  dontUnpack = true;
+
+  strictDeps = true;
+
+  nativeBuildInputs = [
+    installShellFiles
+    makeBinaryWrapper
+  ];
+
+  emulator = lib.optionalString (
+    withShellCompletions && !stdenv.buildPlatform.canExecute stdenv.hostPlatform
+  ) (stdenv.hostPlatform.emulator buildPackages);
+
+  installPhase =
+    ''
+      runHook preInstall
+      mkdir -p -- "$out/bin"
+      cp -- "$src" "$out/bin/yc"
+      chmod +x -- "$out/bin/yc"
+    ''
+    + lib.optionalString withShellCompletions ''
+      for shell in bash zsh; do
+        ''${emulator:+"$emulator"} "$out/bin/yc" completion $shell >yc.$shell
+        installShellCompletion yc.$shell
+      done
+    ''
+    + ''
+      makeWrapper "$out/bin/yc" "$out/bin/docker-credential-yc" \
+        --add-flags --no-user-output \
+        --add-flags container \
+        --add-flags docker-credential
+      runHook postInstall
+    '';
+
+  passthru = {
+    updateScript = writers.writePython3 "${pname}-updater" {
+      libraries = with python3Packages; [ requests ];
+      makeWrapperArgs = [
+        "--prefix"
+        "PATH"
+        ":"
+        (lib.makeBinPath [ nix ])
+      ];
+    } ./update.py;
+    tests.version = testers.testVersion { package = yandex-cloud; };
+  };
+
+  meta = {
+    description = "Command line interface that helps you interact with Yandex Cloud services";
+    homepage = "https://cloud.yandex/docs/cli";
+    changelog = "https://cloud.yandex/docs/cli/release-notes#version${version}";
+    sourceProvenance = [ lib.sourceTypes.binaryNativeCode ];
+    license = lib.licenses.unfree;
+    maintainers = [ lib.maintainers.tie ];
+    platforms = [
+      "aarch64-darwin"
+      "x86_64-darwin"
+      "aarch64-linux"
+      "x86_64-linux"
+      # Built with GO386=sse2.
+      #
+      # Unfortunately, we don’t have anything about SSE2 support in lib.systems,
+      # so we can’t mark this a broken or bad platform if host platform does not
+      # support SSE2. See also https://github.com/NixOS/nixpkgs/issues/132217
+      #
+      # Perhaps it would be possible to mark it as broken if platform declares
+      # GO386=softfloat once https://github.com/NixOS/nixpkgs/pull/256761 is
+      # ready and merged.
+      "i686-linux"
+    ];
+    mainProgram = "yc";
+  };
+}

--- a/pkgs/by-name/ya/yandex-cloud/sources.json
+++ b/pkgs/by-name/ya/yandex-cloud/sources.json
@@ -1,0 +1,25 @@
+{
+  "version": "0.129.0",
+  "binaries": {
+    "aarch64-darwin": {
+      "url": "https://storage.yandexcloud.net/yandexcloud-yc/release/0.129.0/darwin/arm64/yc",
+      "hash": "sha256-ULd/fmWDBPPALf6Rb95n6zXsSuDBAkeWNH11f5PLIpE="
+    },
+    "aarch64-linux": {
+      "url": "https://storage.yandexcloud.net/yandexcloud-yc/release/0.129.0/linux/arm64/yc",
+      "hash": "sha256-Tvy9hTpp37EUrEIDglNFqrH0laD0O+wwVWlCIBh6Jag="
+    },
+    "i686-linux": {
+      "url": "https://storage.yandexcloud.net/yandexcloud-yc/release/0.129.0/linux/386/yc",
+      "hash": "sha256-rmcXdz7z1iXOUQTq0sFNNcZ1jG/Dypxfl2oyeJiwkjs="
+    },
+    "x86_64-darwin": {
+      "url": "https://storage.yandexcloud.net/yandexcloud-yc/release/0.129.0/darwin/amd64/yc",
+      "hash": "sha256-DjAifjGBiRvJDx3j4iMR/t7zOITaz/iulfeDUZCvIhE="
+    },
+    "x86_64-linux": {
+      "url": "https://storage.yandexcloud.net/yandexcloud-yc/release/0.129.0/linux/amd64/yc",
+      "hash": "sha256-igj1iwznsL1OG3V8hOQVCbticzOtDH8dF8jLzMxO5Fg="
+    }
+  }
+}

--- a/pkgs/by-name/ya/yandex-cloud/update.py
+++ b/pkgs/by-name/ya/yandex-cloud/update.py
@@ -1,0 +1,107 @@
+import json
+import os
+import requests
+import shutil
+import subprocess
+import sys
+import tempfile
+
+# See YC_SDK_STORAGE_URL in
+# https://storage.yandexcloud.net/yandexcloud-yc/install.sh
+storage_url = "https://storage.yandexcloud.net/yandexcloud-yc"
+
+systems = [
+    ("aarch64", "darwin"),
+    ("aarch64", "linux"),
+    ("i686", "linux"),
+    ("x86_64", "darwin"),
+    ("x86_64", "linux"),
+]
+
+
+def to_goarch(cpu):
+    return {
+        "aarch64": "arm64",
+        "i686": "386",
+        "x86_64": "amd64",
+    }.get(cpu, cpu)
+
+
+nixpkgs_path = "."
+attr_path = os.getenv("UPDATE_NIX_ATTR_PATH", "yandex-cloud")
+
+package_attrs = json.loads(subprocess.run(
+    [
+        "nix",
+        "--extra-experimental-features", "nix-command",
+        "eval",
+        "--json",
+        "--file", nixpkgs_path,
+        "--apply", """p: {
+          dir = builtins.dirOf p.meta.position;
+          version = p.version;
+        }""",
+        "--",
+        attr_path,
+    ],
+    stdout=subprocess.PIPE,
+    text=True,
+    check=True,
+).stdout)
+
+old_version = package_attrs["version"]
+new_version = requests.get(f"{storage_url}/release/stable").text.rstrip()
+
+if new_version == old_version:
+    sys.exit()
+
+binaries = {}
+for cpu, kernel in systems:
+    goos = kernel
+    goarch = to_goarch(cpu)
+    system = f"{cpu}-{kernel}"
+
+    url = f"{storage_url}/release/{new_version}/{goos}/{goarch}/yc"
+
+    nix_hash = subprocess.run(
+        [
+            "nix-prefetch-url",
+            "--type", "sha256",
+            url,
+        ],
+        stdout=subprocess.PIPE,
+        text=True,
+        check=True,
+    ).stdout.rstrip()
+
+    sri_hash = subprocess.run(
+        [
+            "nix",
+            "--extra-experimental-features", "nix-command",
+            "hash",
+            "to-sri",
+            "--type", "sha256",
+            "--",
+            nix_hash,
+        ],
+        stdout=subprocess.PIPE,
+        text=True,
+        check=True,
+    ).stdout.rstrip()
+
+    binaries[system] = {
+        "url": url,
+        "hash": sri_hash,
+    }
+
+package_dir = package_attrs["dir"]
+file_path = os.path.join(package_dir, "sources.json")
+file_content = json.dumps({
+    "version": new_version,
+    "binaries": binaries,
+}, indent=2) + "\n"
+
+with tempfile.NamedTemporaryFile(mode="w") as t:
+    t.write(file_content)
+    t.flush()
+    shutil.copyfile(t.name, file_path)


### PR DESCRIPTION
###### Description of changes

Packages [yc](https://cloud.yandex/en/docs/cli), a command-line tool for managing [Yandex.Cloud](https://cloud.yandex/en) resources.

###### Things done

- Built on platform(s)
  - [x] x86_64-linux (pkgsCross.gnu64)
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
