### PR TITLE
github-runner: skip OOM test

### DIFF
--- a/pkgs/development/tools/continuous-integration/github-runner/default.nix
+++ b/pkgs/development/tools/continuous-integration/github-runner/default.nix
@@ -131,7 +131,10 @@ buildDotnetModule rec {
 
   # Fully qualified name of disabled tests
   disabledTests =
-    [ "GitHub.Runner.Common.Tests.Listener.SelfUpdaterL0.TestSelfUpdateAsync" ]
+    [
+      "GitHub.Runner.Common.Tests.Listener.SelfUpdaterL0.TestSelfUpdateAsync"
+      "GitHub.Runner.Common.Tests.ProcessInvokerL0.OomScoreAdjIsInherited"
+    ]
     ++ map (x: "GitHub.Runner.Common.Tests.Listener.SelfUpdaterL0.TestSelfUpdateAsync_${x}") [
       "Cancel_CloneHashTask_WhenNotNeeded"
       "CloneHash_RuntimeAndExternals"


### PR DESCRIPTION
###### Description of changes

It's failing with access denied error because of sandbox.

```
  [xUnit.net 00:00:04.76]     GitHub.Runner.Common.Tests.ProcessInvokerL0.OomScoreAdjIsInherited [FAIL]
  [xUnit.net 00:00:04.77]       System.UnauthorizedAccessException : Access to the path '/proc/1042/oom_score_adj' is denied.
  [xUnit.net 00:00:04.77]       ---- System.IO.IOException : Permission denied
  [xUnit.net 00:00:04.77]       Stack Trace:
  [xUnit.net 00:00:04.77]            at System.IO.RandomAccess.WriteAtOffset(SafeFileHandle handle, ReadOnlySpan`1 buffer, Int64 fileOffset)
  [xUnit.net 00:00:04.77]            at System.IO.Strategies.OSFileStreamStrategy.Write(ReadOnlySpan`1 buffer)
  [xUnit.net 00:00:04.77]            at System.IO.Strategies.BufferedFileStreamStrategy.FlushWrite()
  [xUnit.net 00:00:04.77]            at System.IO.Strategies.BufferedFileStreamStrategy.Dispose(Boolean disposing)
  [xUnit.net 00:00:04.77]            at System.IO.StreamWriter.CloseStreamFromDispose(Boolean disposing)
  [xUnit.net 00:00:04.77]            at System.IO.StreamWriter.Dispose(Boolean disposing)
  [xUnit.net 00:00:04.77]            at System.IO.File.WriteAllText(String path, String contents)
  [xUnit.net 00:00:04.77]         /build/src/src/Test/L0/ProcessInvokerL0.cs(486,0): at GitHub.Runner.Common.Tests.ProcessInvokerL0.OomScoreAdjIsInherited()
  [xUnit.net 00:00:04.77]         --- End of stack trace from previous location ---
  [xUnit.net 00:00:04.77]         ----- Inner Stack Trace -----
```

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
