### PR TITLE
fallout-ce: init at 1.0.0

### DIFF
--- a/pkgs/games/fallout-ce/build.nix
+++ b/pkgs/games/fallout-ce/build.nix
@@ -1,0 +1,77 @@
+{ cmake
+, fpattern
+, lib
+, SDL2
+, stdenv
+, writeShellScript
+
+, extraBuildInputs ? [ ]
+, extraMeta
+, pname
+, version
+, src
+}:
+
+let
+  launcher = writeShellScript "${pname}" ''
+    set -eu
+    assetDir="''${XDG_DATA_HOME:-$HOME/.local/share}/${pname}"
+    [ -d "$assetDir" ] || mkdir -p "$assetDir"
+    cd "$assetDir"
+
+    notice=0 fault=0
+    requiredFiles=(master.dat critter.dat)
+    for f in "''${requiredFiles[@]}"; do
+      if [ ! -f "$f" ]; then
+        echo "Required file $f not found in $PWD, note the files are case-sensitive"
+        notice=1 fault=1
+      fi
+    done
+
+    if [ ! -d "data/sound/music" ]; then
+      echo "data/sound/music directory not found in $PWD. This may prevent in-game music from functioning."
+      notice=1
+    fi
+
+    if [ $notice -ne 0 ]; then
+      echo "Please reference the installation instructions at https://github.com/alexbatalov/fallout2-ce"
+    fi
+
+    if [ $fault -ne 0 ]; then
+      exit $fault;
+    fi
+
+    exec @out@/libexec/${pname} "$@"
+  '';
+in
+stdenv.mkDerivation {
+  inherit pname version src;
+
+  nativeBuildInputs = [ cmake ];
+  buildInputs = [ SDL2 ] ++ extraBuildInputs;
+  hardeningDisable = [ "format" ];
+  cmakeBuildType = "RelWithDebInfo";
+
+  postPatch = ''
+    substituteInPlace third_party/fpattern/CMakeLists.txt \
+      --replace "FetchContent_Populate" "#FetchContent_Populate" \
+      --replace "{fpattern_SOURCE_DIR}" "${fpattern}/include" \
+      --replace "$/nix/" "/nix/"
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    install -D ${pname} $out/libexec/${pname}
+    install -D ${launcher} $out/bin/${pname}
+    substituteInPlace $out/bin/${pname} --subst-var out
+
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    license = licenses.sustainableUse;
+    maintainers = with maintainers; [ hughobrien TheBrainScrambler ];
+    platforms = platforms.linux;
+  } // extraMeta;
+}

--- a/pkgs/games/fallout-ce/fallout-ce.nix
+++ b/pkgs/games/fallout-ce/fallout-ce.nix
@@ -1,0 +1,20 @@
+{ callPackage
+, fetchFromGitHub
+}:
+
+callPackage ./build.nix rec {
+  pname = "fallout-ce";
+  version = "1.0.0";
+
+  src = fetchFromGitHub {
+    owner = "alexbatalov";
+    repo = "fallout1-ce";
+    rev = "v${version}";
+    hash = "sha256-EvRkOlvtiVao63S0WRKKuHlhfkdTgc0m6GTyv4EfJFU=";
+  };
+
+  extraMeta = {
+    description = "A fully working re-implementation of Fallout, with the same original gameplay, engine bugfixes, and some quality of life improvements";
+    homepage = "https://github.com/alexbatalov/fallout1-ce";
+  };
+}

--- a/pkgs/games/fallout-ce/fallout2-ce.nix
+++ b/pkgs/games/fallout-ce/fallout2-ce.nix
@@ -1,0 +1,23 @@
+{ callPackage
+, fetchFromGitHub
+, zlib
+}:
+
+callPackage ./build.nix rec {
+  pname = "fallout2-ce";
+  version = "1.2.0";
+
+  src = fetchFromGitHub {
+    owner = "alexbatalov";
+    repo = "fallout2-ce";
+    rev = "v${version}";
+    hash = "sha256-+N4jhmxBX6z48kaU0jm90OKhguHlggT3OF9uuyY0EV0=";
+  };
+
+  extraBuildInputs = [ zlib ];
+
+  extraMeta = {
+    description = "A fully working re-implementation of Fallout 2, with the same original gameplay, engine bugfixes, and some quality of life improvements";
+    homepage = "https://github.com/alexbatalov/fallout2-ce";
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -37522,6 +37522,8 @@ with pkgs;
 
   exult = callPackage ../games/exult { };
 
+  fallout-ce = callPackage ../games/fallout-ce/fallout-ce.nix { };
+
   flare = callPackage ../games/flare {
     inherit (darwin.apple_sdk.frameworks) Cocoa;
   };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -37523,6 +37523,7 @@ with pkgs;
   exult = callPackage ../games/exult { };
 
   fallout-ce = callPackage ../games/fallout-ce/fallout-ce.nix { };
+  fallout2-ce = callPackage ../games/fallout-ce/fallout2-ce.nix { };
 
   flare = callPackage ../games/flare {
     inherit (darwin.apple_sdk.frameworks) Cocoa;


### PR DESCRIPTION
###### Description of changes

Introduce [fallout-ce](https://github.com/alexbatalov/fallout1-ce), an open source re-implementation of the classic game.

Note this is the engine only, the original game assets are still required (available on digital platforms). Build steps are adapted from their [CI](https://github.com/alexbatalov/fallout1-ce/blob/55fb75bc7799830ac1a6dab71555fb9ef8c1e690/.github/workflows/release.yml#L146).

See also: [fallout2-ce PR](https://github.com/NixOS/nixpkgs/pull/239451)

REVIEW REQUESTS:

1. ~This game uses the 'Sustainable Use License' which I do not see as listed in `lib/licences.nix` - how should we proceed? [Here](https://github.com/NixOS/nixpkgs/blob/a2a7650c472726517c303bdb55d784829cf3ebdf/pkgs/applications/networking/n8n/default.nix#L43) is the only other usage of it within `nixpkgs`.~ Edit: I've made a [PR](https://github.com/NixOS/nixpkgs/pull/239455) for the licence.
1. The binary name is `fallout-ce` but the project is branded `fallout1-ce`, I have hewn to the original name but am open.
1. I was unable to have `substituteInPlace` handle the `${foo}` strings in the Makefile without triggering nix interpolation, so used a two pass process instead. I'm sure there's a better way of doing this.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
