### PR TITLE
wl-screenrec: init at unstable-2023-05-31

### DIFF
--- a/pkgs/tools/wayland/wl-screenrec/default.nix
+++ b/pkgs/tools/wayland/wl-screenrec/default.nix
@@ -1,0 +1,39 @@
+{ lib
+, rustPlatform
+, fetchFromGitHub
+, pkg-config
+, wayland
+, ffmpeg
+}:
+
+rustPlatform.buildRustPackage rec {
+  pname = "wl-screenrec";
+  version = "unstable-2023-05-31";
+
+  src = fetchFromGitHub {
+    owner = "russelltg";
+    repo = pname;
+    rev = "fc918f7898900c1882c6f64c96ed2de8cb9a6300";
+    hash = "sha256-P/JELiw0qGcwLFgNPccN/uetNy8CNCJdlCLhgq0h4sc=";
+  };
+
+  cargoHash = "sha256-r9zmAiLiAntHcb5W/WKmKbVP9c9+15ElIWtHkks0wig=";
+
+  nativeBuildInputs = [
+    pkg-config
+    rustPlatform.bindgenHook
+  ];
+
+  buildInputs = [
+    wayland
+    ffmpeg
+  ];
+
+  meta = with lib; {
+    description = "High performance wlroots screen recording, featuring hardware encoding";
+    homepage = "https://github.com/russelltg/wl-screenrec";
+    license = licenses.asl20;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ colemickens ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4484,6 +4484,8 @@ with pkgs;
 
   wl-mirror = callPackage ../tools/wayland/wl-mirror { };
 
+  wl-screenrec = callPackage ../tools/wayland/wl-screenrec { };
+
   wlogout = callPackage ../tools/wayland/wlogout { };
 
   wlopm = callPackage ../tools/wayland/wlopm { };


### PR DESCRIPTION
###### Description of changes
closes https://github.com/NixOS/nixpkgs/issues/235103#

cc. @colemickens 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
