### PR TITLE
 jellyfin-ffmpeg: 5.1.2-8 -> 6.0-4, nv-codec-headers-12: init at 12.0.16.0 

### DIFF
--- a/pkgs/development/libraries/jellyfin-ffmpeg/default.nix
+++ b/pkgs/development/libraries/jellyfin-ffmpeg/default.nix
@@ -1,21 +1,21 @@
-{ ffmpeg_5-full
-, nv-codec-headers-11
+{ ffmpeg_6-full
+, nv-codec-headers-12
 , chromaprint
 , fetchFromGitHub
 , lib
 }:
 
-(ffmpeg_5-full.override {
-  nv-codec-headers = nv-codec-headers-11;
+(ffmpeg_6-full.override {
+  nv-codec-headers-11 = nv-codec-headers-12;
 }).overrideAttrs (old: rec {
   pname = "jellyfin-ffmpeg";
-  version = "5.1.2-8";
+  version = "6.0-4";
 
   src = fetchFromGitHub {
     owner = "jellyfin";
     repo = "jellyfin-ffmpeg";
     rev = "v${version}";
-    sha256 = "sha256-0ne9Xj9MnB5WOkPRtPX7W30qG1osHd0tyua+5RMrnQc=";
+    sha256 = "sha256-o0D/GWbSoy5onbYG29wTbpZ8z4sZ2s1WclGCXRMSekA=";
   };
 
   buildInputs = old.buildInputs ++ [ chromaprint ];

--- a/pkgs/development/libraries/nv-codec-headers/12_x.nix
+++ b/pkgs/development/libraries/nv-codec-headers/12_x.nix
@@ -1,0 +1,27 @@
+{ stdenv
+, lib
+, fetchgit
+}:
+
+stdenv.mkDerivation rec {
+  pname = "nv-codec-headers";
+  version = "12.0.16.0";
+
+  src = fetchgit {
+    url = "https://git.videolan.org/git/ffmpeg/nv-codec-headers.git";
+    rev = "n${version}";
+    sha256 = "sha256-8YZU9pb0kzat0JBVEotaZUkNicQvLNIrIyPU9KTTjwg=";
+  };
+
+  makeFlags = [
+    "PREFIX=$(out)"
+  ];
+
+  meta = with lib; {
+    description = "FFmpeg version of headers for NVENC";
+    homepage = "https://git.videolan.org/?p=ffmpeg/nv-codec-headers.git";
+    license = licenses.mit;
+    maintainers = with maintainers; [ MP2E ];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -23465,6 +23465,7 @@ with pkgs;
   nv-codec-headers = callPackage ../development/libraries/nv-codec-headers { };
   nv-codec-headers-10 = callPackage ../development/libraries/nv-codec-headers/10_x.nix { };
   nv-codec-headers-11 = callPackage ../development/libraries/nv-codec-headers/11_x.nix { };
+  nv-codec-headers-12 = callPackage ../development/libraries/nv-codec-headers/12_x.nix { };
 
   mkNvidiaContainerPkg = { name, containerRuntimePath, configTemplate, additionalPaths ? [] }:
     let


### PR DESCRIPTION
###### Description of changes

jellyfin-ffmpeg version 6 ([release notes](https://github.com/jellyfin/jellyfin-ffmpeg/releases/tag/v6.0-4)). Also introduces version 12 of nvidia codec headers which is required for Jellyfin's fork.

Fixes https://github.com/NixOS/nixpkgs/issues/239069

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
