### PR TITLE
tmuxp: fix shell completion generation

### DIFF
--- a/pkgs/tools/misc/tmuxp/default.nix
+++ b/pkgs/tools/misc/tmuxp/default.nix
@@ -20,6 +20,7 @@ pypkgs.buildPythonApplication rec {
 
   nativeBuildInputs = [
     pypkgs.poetry-core
+    pypkgs.shtab
     installShellFiles
   ];
 
@@ -32,9 +33,8 @@ pypkgs.buildPythonApplication rec {
 
   postInstall = ''
     installShellCompletion --cmd tmuxp \
-      --bash <(_TMUXP_COMPLETE=bash_source $out/bin/tmuxp) \
-      --fish <(_TMUXP_COMPLETE=fish_source $out/bin/tmuxp) \
-      --zsh <(_TMUXP_COMPLETE=zsh_source $out/bin/tmuxp)
+      --bash <(shtab --shell=bash -u tmuxp.cli.create_parser) \
+      --zsh <(shtab --shell=zsh -u tmuxp.cli.create_parser)
   '';
 
   meta = with lib; {

--- a/pkgs/tools/misc/tmuxp/default.nix
+++ b/pkgs/tools/misc/tmuxp/default.nix
@@ -1,10 +1,6 @@
 { lib, python3Packages, fetchPypi, installShellFiles }:
 
-let
-  pypkgs = python3Packages;
-
-in
-pypkgs.buildPythonApplication rec {
+python3Packages.buildPythonApplication rec {
   pname = "tmuxp";
   version = "1.28.1";
 
@@ -19,12 +15,12 @@ pypkgs.buildPythonApplication rec {
   format = "pyproject";
 
   nativeBuildInputs = [
-    pypkgs.poetry-core
-    pypkgs.shtab
+    python3Packages.poetry-core
+    python3Packages.shtab
     installShellFiles
   ];
 
-  propagatedBuildInputs = with pypkgs; [
+  propagatedBuildInputs = with python3Packages; [
     click
     colorama
     kaptan


### PR DESCRIPTION

###### Description of changes

tmuxp 1.17+ uses shtab to generate the shell completion. This commit adapts the code to properly generate the shell completion module.

A side effect of use of shtab is that fish is not supported so it has been removed from postInstall.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
