### PR TITLE
texlive: fix licensing information for doc-only-packages

### DIFF
--- a/lib/licenses.nix
+++ b/lib/licenses.nix
@@ -873,6 +873,11 @@ in mkLicense lset) ({
     fullName = "OpenSSL License";
   };
 
+  opubl = {
+    spdxId = "OPUBL-1.0";
+    fullName = "Open Publication License v1.0";
+  };
+
   osl2 = {
     spdxId = "OSL-2.0";
     fullName = "Open Software License 2.0";

--- a/pkgs/tools/typesetting/tex/texlive/default.nix
+++ b/pkgs/tools/typesetting/tex/texlive/default.nix
@@ -49,6 +49,12 @@ let
         license = [  "lppl13c" ];
       };
 
+      # TODO: remove this when updating to texlive-2023, npp-for-context is no longer in texlive
+      npp-for-context = orig.npp-for-context // {
+        # tlpdb lists license as "noinfo", but it's gpl3: https://github.com/luigiScarso/context-npp
+        license = [  "gpl3Only" ];
+      };
+
       # remove dependency-heavy packages from the basic collections
       collection-basic = orig.collection-basic // {
         deps = lib.filter (n: n != "metafont" && n != "xdvi") orig.collection-basic.deps;

--- a/pkgs/tools/typesetting/tex/texlive/tl2nix.sed
+++ b/pkgs/tools/typesetting/tex/texlive/tl2nix.sed
@@ -58,6 +58,7 @@ $a}
     s/"lppl1\.3a"/"lppl13a"/g
     s/"lppl1\.3c"/"lppl13c"/g
     s/"other-free"/"free"/g
+    s/"opl"/"opubl"/g
     s/"pd"/"publicDomain"/g
 
     s/^catalogue-license (.*)/  license = [ \1 ];/p

--- a/pkgs/tools/typesetting/tex/texlive/tlpdb.nix
+++ b/pkgs/tools/typesetting/tex/texlive/tlpdb.nix
@@ -25886,7 +25886,7 @@ lshort-german = {
   stripPrefix = 0;
   sha512.run = "c937bb8da86a3ef6d428d134903bf8af74a286d644bedfe4766841b2b5234b34e2caed70460ecaf7a1b1dc57f1faf1396435cca7f714f84d75f15acea12e79f8";
   sha512.doc = "69cebdd6a1444670a154d5cdd199022f6f1d6612b24b05fc8dc1e9f54a89fb65cda1f545341cd37616dbf6dd94077ccb924bf4b49f1473e45eb0bcd33f5f33a6";
-  license = [ "opl" ];
+  license = [ "opubl" ];
   version = "3.0c";
 };
 lshort-italian = {


### PR DESCRIPTION
###### Description of changes

Some packages that only consist of documentation have had invalid license information which resulted in evaluation failures when documentation was allowed in a custom `pkgFilter`.

 - [lshort-german](https://github.com/dante-ev/l2kurz) is licensed under the OPUBL, which this adds to licenses.nix
 - [npp-for-context](https://github.com/luigiScarso/context-npp) is licensed under the GPL3 (only?). This overrides the incorrect tlpdb metadata which says "noinfo".

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
