### PR TITLE
Allow disabling of TPM related kernel modules in stage 1 systemd.

### DIFF
--- a/nixos/modules/system/boot/systemd/initrd.nix
+++ b/nixos/modules/system/boot/systemd/initrd.nix
@@ -333,6 +333,13 @@ in {
       visible = "shallow";
       description = lib.mdDoc "Definition of slice configurations.";
     };
+
+    withTpmModules = mkOption {
+      default = true;
+      type = types.bool;
+      visible = "shallow";
+      description = lib.mdDoc "withTpmModules.";
+    };
   };
 
   config = mkIf (config.boot.initrd.enable && cfg.enable) {
@@ -341,9 +348,10 @@ in {
     boot.initrd.availableKernelModules = [
       # systemd needs this for some features
       "autofs4"
+    ] ++ lib.optionals cfg.withTpmModules ([
       # systemd-cryptenroll
       "tpm-tis"
-    ] ++ lib.optional (pkgs.stdenv.hostPlatform.system != "riscv64-linux") "tpm-crb";
+    ] ++ lib.optional (pkgs.stdenv.hostPlatform.system != "riscv64-linux") "tpm-crb");
 
     boot.initrd.systemd = {
       initrdBin = [pkgs.bash pkgs.coreutils cfg.package.kmod cfg.package] ++ config.system.fsPackages;


### PR DESCRIPTION
###### Description of changes

Note: Draft PR - I don't think this is the proper solution. But using this PR as a place to comment on how to solve this.

This PR allows disabling of TPM related modules in stage1 when using systemd.

I ran into issues on Raspberry Pi where the `tpm-crb` module is not available when using the [rpi4 kernel](https://search.nixos.org/packages?channel=23.05&from=0&size=50&sort=relevance&type=packages&query=linuxKernel.kernels.linux_rpi4) and trying to add it into stage1 causes a build failure:
```
building '/nix/store/l797k7pjhf5bxvw47y16ms3n5wrdabr8-linux-6.1.21-1.20230405-modules-shrunk.drv'...
error: builder for '/nix/store/l797k7pjhf5bxvw47y16ms3n5wrdabr8-linux-6.1.21-1.20230405-modules-shrunk.drv' failed with exit code 1;
       last 10 log lines:
       > root module: reset-raspberrypi
       >   builtin dependency: reset_raspberrypi
       > root module: autofs4
       >   builtin dependency: autofs4
       > root module: tpm-tis
       >   copying dependency: /nix/store/gckkn0lkm1w8gb52b4d6as03c2xpkzbp-linux-6.1.21-1.20230405-modules/lib/modules/6.1.21/kernel/drivers/char/tpm/tpm.ko.xz
       >   copying dependency: /nix/store/gckkn0lkm1w8gb52b4d6as03c2xpkzbp-linux-6.1.21-1.20230405-modules/lib/modules/6.1.21/kernel/drivers/char/tpm/tpm_tis_core.ko.xz
       >   copying dependency: /nix/store/gckkn0lkm1w8gb52b4d6as03c2xpkzbp-linux-6.1.21-1.20230405-modules/lib/modules/6.1.21/kernel/drivers/char/tpm/tpm_tis.ko.xz
       > root module: tpm-crb
       > modprobe: FATAL: Module tpm-crb not found in directory /nix/store/gckkn0lkm1w8gb52b4d6as03c2xpkzbp-linux-6.1.21-1.20230405-modules/lib/modules/6.1.21
       For full logs, run 'nix log /nix/store/l797k7pjhf5bxvw47y16ms3n5wrdabr8-linux-6.1.21-1.20230405-modules-shrunk.drv'.
error: 1 dependencies of derivation '/nix/store/w86n3yzhlcm54fvbdsg6z971fz92znrg-initrd-linux-6.1.21-1.20230405.drv' failed to build
error: 1 dependencies of derivation '/nix/store/1zwijwxc67aaag0yia842d73kjshwr6m-nixos-system-ersa-23.11.20230624.eeb32bd.drv' failed to build
sudo nixos-rebuild -vvv switch --flake   52.19s user 34.45s system 109% cpu 1:19.09 total

```

On the raspberryi Pi (checked against https://github.com/raspberrypi/linux/blob/4b60cbf0149f5b5fa5eb9149bd35c750cbc02b25/drivers/char/tpm/Makefile#L42):
```
% cat /proc/config.gz | gzip -d | less | grep TCG_CRB
% echo $?
1
```

I am not quite sure why this module is not built...

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [X] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
