### PR TITLE
haskell: stop special casing aarch platforms to comply with Hydra output limit

### DIFF
--- a/pkgs/development/compilers/ghc/8.10.2-binary.nix
+++ b/pkgs/development/compilers/ghc/8.10.2-binary.nix
@@ -444,7 +444,6 @@ stdenv.mkDerivation rec {
     # long as the evaluator runs on a platform that supports
     # `pkgsMusl`.
     platforms = builtins.attrNames ghcBinDists.${distSetName};
-    hydraPlatforms = builtins.filter (p: minimal || p != "aarch64-linux") platforms;
     maintainers = with lib.maintainers; [
       guibou
     ] ++ lib.teams.haskell.members;

--- a/pkgs/development/compilers/ghc/8.10.7.nix
+++ b/pkgs/development/compilers/ghc/8.10.7.nix
@@ -28,8 +28,7 @@
 , # If enabled, use -fPIC when compiling static libs.
   enableRelocatedStaticLibs ? stdenv.targetPlatform != stdenv.hostPlatform
 
-  # aarch64 outputs otherwise exceed 2GB limit
-, enableProfiledLibs ? !stdenv.targetPlatform.isAarch64
+, enableProfiledLibs ? true
 
 , # Whether to build dynamic libs for the standard library (on the target
   # platform). Static libs are always built.

--- a/pkgs/development/compilers/ghc/8.8.4.nix
+++ b/pkgs/development/compilers/ghc/8.8.4.nix
@@ -27,8 +27,7 @@
 , # If enabled, use -fPIC when compiling static libs.
   enableRelocatedStaticLibs ? stdenv.targetPlatform != stdenv.hostPlatform
 
-  # aarch64 outputs otherwise exceed 2GB limit
-, enableProfiledLibs ? !stdenv.targetPlatform.isAarch64
+, enableProfiledLibs ? true
 
 , # Whether to build dynamic libs for the standard library (on the target
   # platform). Static libs are always built.

--- a/pkgs/development/compilers/ghc/9.0.2.nix
+++ b/pkgs/development/compilers/ghc/9.0.2.nix
@@ -30,8 +30,7 @@
 , # If enabled, use -fPIC when compiling static libs.
   enableRelocatedStaticLibs ? stdenv.targetPlatform != stdenv.hostPlatform
 
-  # aarch64 outputs otherwise exceed 2GB limit
-, enableProfiledLibs ? !stdenv.targetPlatform.isAarch64
+, enableProfiledLibs ? true
 
 , # Whether to build dynamic libs for the standard library (on the target
   # platform). Static libs are always built.

--- a/pkgs/development/compilers/ghc/9.2.4-binary.nix
+++ b/pkgs/development/compilers/ghc/9.2.4-binary.nix
@@ -426,7 +426,6 @@ stdenv.mkDerivation rec {
     # long as the evaluator runs on a platform that supports
     # `pkgsMusl`.
     platforms = builtins.attrNames ghcBinDists.${distSetName};
-    hydraPlatforms = builtins.filter (p: minimal || p != "aarch64-linux") platforms;
     maintainers = lib.teams.haskell.members;
   };
 }

--- a/pkgs/development/compilers/ghc/9.2.4.nix
+++ b/pkgs/development/compilers/ghc/9.2.4.nix
@@ -30,8 +30,7 @@
 , # If enabled, use -fPIC when compiling static libs.
   enableRelocatedStaticLibs ? stdenv.targetPlatform != stdenv.hostPlatform
 
-  # aarch64 outputs otherwise exceed 2GB limit
-, enableProfiledLibs ? !stdenv.targetPlatform.isAarch64
+, enableProfiledLibs ? true
 
 , # Whether to build dynamic libs for the standard library (on the target
   # platform). Static libs are always built.

--- a/pkgs/development/compilers/ghc/9.2.5.nix
+++ b/pkgs/development/compilers/ghc/9.2.5.nix
@@ -30,8 +30,7 @@
 , # If enabled, use -fPIC when compiling static libs.
   enableRelocatedStaticLibs ? stdenv.targetPlatform != stdenv.hostPlatform
 
-  # aarch64 outputs otherwise exceed 2GB limit
-, enableProfiledLibs ? !stdenv.targetPlatform.isAarch64
+, enableProfiledLibs ? true
 
 , # Whether to build dynamic libs for the standard library (on the target
   # platform). Static libs are always built.

--- a/pkgs/development/compilers/ghc/9.2.6.nix
+++ b/pkgs/development/compilers/ghc/9.2.6.nix
@@ -30,8 +30,7 @@
 , # If enabled, use -fPIC when compiling static libs.
   enableRelocatedStaticLibs ? stdenv.targetPlatform != stdenv.hostPlatform
 
-  # aarch64 outputs otherwise exceed 2GB limit
-, enableProfiledLibs ? !stdenv.targetPlatform.isAarch64
+, enableProfiledLibs ? true
 
 , # Whether to build dynamic libs for the standard library (on the target
   # platform). Static libs are always built.

--- a/pkgs/development/compilers/ghc/9.2.7.nix
+++ b/pkgs/development/compilers/ghc/9.2.7.nix
@@ -30,8 +30,7 @@
 , # If enabled, use -fPIC when compiling static libs.
   enableRelocatedStaticLibs ? stdenv.targetPlatform != stdenv.hostPlatform
 
-  # aarch64 outputs otherwise exceed 2GB limit
-, enableProfiledLibs ? !stdenv.targetPlatform.isAarch64
+, enableProfiledLibs ? true
 
 , # Whether to build dynamic libs for the standard library (on the target
   # platform). Static libs are always built.

--- a/pkgs/development/compilers/ghc/9.2.8.nix
+++ b/pkgs/development/compilers/ghc/9.2.8.nix
@@ -30,8 +30,7 @@
 , # If enabled, use -fPIC when compiling static libs.
   enableRelocatedStaticLibs ? stdenv.targetPlatform != stdenv.hostPlatform
 
-  # aarch64 outputs otherwise exceed 2GB limit
-, enableProfiledLibs ? !stdenv.targetPlatform.isAarch64
+, enableProfiledLibs ? true
 
 , # Whether to build dynamic libs for the standard library (on the target
   # platform). Static libs are always built.

--- a/pkgs/development/compilers/ghc/9.4.2.nix
+++ b/pkgs/development/compilers/ghc/9.4.2.nix
@@ -32,8 +32,7 @@
 , # If enabled, use -fPIC when compiling static libs.
   enableRelocatedStaticLibs ? stdenv.targetPlatform != stdenv.hostPlatform
 
-  # aarch64 outputs otherwise exceed 2GB limit
-, enableProfiledLibs ? !stdenv.targetPlatform.isAarch64
+, enableProfiledLibs ? true
 
 , # Whether to build dynamic libs for the standard library (on the target
   # platform). Static libs are always built.

--- a/pkgs/development/compilers/ghc/9.4.3.nix
+++ b/pkgs/development/compilers/ghc/9.4.3.nix
@@ -32,8 +32,7 @@
 , # If enabled, use -fPIC when compiling static libs.
   enableRelocatedStaticLibs ? stdenv.targetPlatform != stdenv.hostPlatform
 
-  # aarch64 outputs otherwise exceed 2GB limit
-, enableProfiledLibs ? !stdenv.targetPlatform.isAarch64
+, enableProfiledLibs ? true
 
 , # Whether to build dynamic libs for the standard library (on the target
   # platform). Static libs are always built.

--- a/pkgs/development/compilers/ghc/9.4.4.nix
+++ b/pkgs/development/compilers/ghc/9.4.4.nix
@@ -32,8 +32,7 @@
 , # If enabled, use -fPIC when compiling static libs.
   enableRelocatedStaticLibs ? stdenv.targetPlatform != stdenv.hostPlatform
 
-  # aarch64 outputs otherwise exceed 2GB limit
-, enableProfiledLibs ? !stdenv.targetPlatform.isAarch64
+, enableProfiledLibs ? true
 
 , # Whether to build dynamic libs for the standard library (on the target
   # platform). Static libs are always built.

--- a/pkgs/development/compilers/ghc/9.4.5.nix
+++ b/pkgs/development/compilers/ghc/9.4.5.nix
@@ -32,8 +32,7 @@
 , # If enabled, use -fPIC when compiling static libs.
   enableRelocatedStaticLibs ? stdenv.targetPlatform != stdenv.hostPlatform
 
-  # aarch64 outputs otherwise exceed 2GB limit
-, enableProfiledLibs ? !stdenv.targetPlatform.isAarch64
+, enableProfiledLibs ? true
 
 , # Whether to build dynamic libs for the standard library (on the target
   # platform). Static libs are always built.

--- a/pkgs/development/compilers/ghc/common-hadrian.nix
+++ b/pkgs/development/compilers/ghc/common-hadrian.nix
@@ -57,8 +57,7 @@
 , # If enabled, use -fPIC when compiling static libs.
   enableRelocatedStaticLibs ? stdenv.targetPlatform != stdenv.hostPlatform
 
-  # aarch64 outputs otherwise exceed 2GB limit
-, enableProfiledLibs ? !stdenv.targetPlatform.isAarch64
+, enableProfiledLibs ? true
 
 , # Whether to build dynamic libs for the standard library (on the target
   # platform). Static libs are always built.

--- a/pkgs/development/haskell-modules/generic-builder.nix
+++ b/pkgs/development/haskell-modules/generic-builder.nix
@@ -33,8 +33,7 @@ in
 , doHaddockQuickjump ? doHoogle && lib.versionAtLeast ghc.version "8.6"
 , doInstallIntermediates ? false
 , editedCabalFile ? null
-# aarch64 outputs otherwise exceed 2GB limit
-, enableLibraryProfiling ? !(ghc.isGhcjs or stdenv.hostPlatform.isAarch64 or false)
+, enableLibraryProfiling ? !(ghc.isGhcjs or false)
 , enableExecutableProfiling ? false
 , profilingDetail ? "exported-functions"
 # TODO enable shared libs for cross-compiling

--- a/pkgs/top-level/haskell-packages.nix
+++ b/pkgs/top-level/haskell-packages.nix
@@ -5,11 +5,8 @@ let
   integerSimpleExcludes = [
     "ghc865Binary"
     "ghc8102Binary"
-    "ghc8102BinaryMinimal"
     "ghc8107Binary"
-    "ghc8107BinaryMinimal"
     "ghc924Binary"
-    "ghc924BinaryMinimal"
     "ghcjs"
     "ghcjs810"
     "integer-simple"
@@ -90,36 +87,20 @@ in {
       llvmPackages = pkgs.llvmPackages_9;
     };
 
-    ghc8102BinaryMinimal = callPackage ../development/compilers/ghc/8.10.2-binary.nix {
-      llvmPackages = pkgs.llvmPackages_9;
-      minimal = true;
-    };
-
     ghc8107Binary = callPackage ../development/compilers/ghc/8.10.7-binary.nix {
       llvmPackages = pkgs.llvmPackages_12;
     };
 
-    ghc8107BinaryMinimal = callPackage ../development/compilers/ghc/8.10.7-binary.nix {
-      llvmPackages = pkgs.llvmPackages_12;
-      minimal = true;
-    };
-
     ghc924Binary = callPackage ../development/compilers/ghc/9.2.4-binary.nix {
       llvmPackages = pkgs.llvmPackages_12;
-    };
-    ghc924BinaryMinimal = callPackage ../development/compilers/ghc/9.2.4-binary.nix {
-      llvmPackages = pkgs.llvmPackages_12;
-      minimal = true;
     };
 
     ghc884 = callPackage ../development/compilers/ghc/8.8.4.nix {
       bootPkgs =
         # aarch64 ghc865Binary gets SEGVs due to haskell#15449 or similar
         # 8.10.2 is needed as using 8.10.7 is broken due to RTS-incompatibilities
-        if stdenv.isAarch64 then
-          packages.ghc8102BinaryMinimal
         # Musl bindists do not exist for ghc 8.6.5, so we use 8.10.* for them
-        else if stdenv.hostPlatform.isMusl then
+        if stdenv.hostPlatform.isAarch64 || stdenv.hostPlatform.isMusl then
           packages.ghc8102Binary
         else
           packages.ghc865Binary;
@@ -130,12 +111,8 @@ in {
     ghc88 = ghc884;
     ghc8107 = callPackage ../development/compilers/ghc/8.10.7.nix {
       bootPkgs =
-        # aarch64 ghc865Binary gets SEGVs due to haskell#15449 or similar
         # the oldest ghc with aarch64-darwin support is 8.10.5
-        # Musl bindists do not exist for ghc 8.6.5, so we use 8.10.* for them
-        if stdenv.hostPlatform.isAarch then
-          packages.ghc8107BinaryMinimal
-        else if stdenv.hostPlatform.isPower64 && stdenv.hostPlatform.isLittleEndian then
+        if stdenv.hostPlatform.isPower64 && stdenv.hostPlatform.isLittleEndian then
           # to my (@a-m-joseph) knowledge there are no newer official binaries for this platform
           packages.ghc865Binary
         else
@@ -151,11 +128,8 @@ in {
     ghc810 = ghc8107;
     ghc902 = callPackage ../development/compilers/ghc/9.0.2.nix {
       bootPkgs =
-        # aarch64 ghc8107Binary exceeds max output size on hydra
         # the oldest ghc with aarch64-darwin support is 8.10.5
-        if stdenv.hostPlatform.isAarch then
-          packages.ghc8107BinaryMinimal
-        else if stdenv.hostPlatform.isPower64 && stdenv.hostPlatform.isLittleEndian then
+        if stdenv.hostPlatform.isPower64 && stdenv.hostPlatform.isLittleEndian then
           packages.ghc810
         else
           packages.ghc8107Binary;
@@ -167,10 +141,7 @@ in {
     ghc90 = ghc902;
     ghc924 = callPackage ../development/compilers/ghc/9.2.4.nix {
       bootPkgs =
-        # aarch64 ghc8107Binary exceeds max output size on hydra
-        if stdenv.hostPlatform.isAarch then
-          packages.ghc8107BinaryMinimal
-        else if stdenv.hostPlatform.isPower64 && stdenv.hostPlatform.isLittleEndian then
+        if stdenv.hostPlatform.isPower64 && stdenv.hostPlatform.isLittleEndian then
           packages.ghc810
         else
           packages.ghc8107Binary;
@@ -184,10 +155,7 @@ in {
     };
     ghc925 = callPackage ../development/compilers/ghc/9.2.5.nix {
       bootPkgs =
-        # aarch64 ghc8107Binary exceeds max output size on hydra
-        if stdenv.hostPlatform.isAarch then
-          packages.ghc8107BinaryMinimal
-        else if stdenv.hostPlatform.isPower64 && stdenv.hostPlatform.isLittleEndian then
+        if stdenv.hostPlatform.isPower64 && stdenv.hostPlatform.isLittleEndian then
           packages.ghc810
         else
           packages.ghc8107Binary;
@@ -201,10 +169,7 @@ in {
     };
     ghc926 = callPackage ../development/compilers/ghc/9.2.6.nix {
       bootPkgs =
-        # aarch64 ghc8107Binary exceeds max output size on hydra
-        if stdenv.hostPlatform.isAarch then
-          packages.ghc8107BinaryMinimal
-        else if stdenv.hostPlatform.isPower64 && stdenv.hostPlatform.isLittleEndian then
+        if stdenv.hostPlatform.isPower64 && stdenv.hostPlatform.isLittleEndian then
           packages.ghc810
         else
           packages.ghc8107Binary;
@@ -218,10 +183,7 @@ in {
     };
     ghc927 = callPackage ../development/compilers/ghc/9.2.7.nix {
       bootPkgs =
-        # aarch64 ghc8107Binary exceeds max output size on hydra
-        if stdenv.hostPlatform.isAarch then
-          packages.ghc8107BinaryMinimal
-        else if stdenv.hostPlatform.isPower64 && stdenv.hostPlatform.isLittleEndian then
+        if stdenv.hostPlatform.isPower64 && stdenv.hostPlatform.isLittleEndian then
           packages.ghc810
         else
           packages.ghc8107Binary;
@@ -235,10 +197,7 @@ in {
     };
     ghc928 = callPackage ../development/compilers/ghc/9.2.8.nix {
       bootPkgs =
-        # aarch64 ghc8107Binary exceeds max output size on hydra
-        if stdenv.hostPlatform.isAarch then
-          packages.ghc8107BinaryMinimal
-        else if stdenv.hostPlatform.isPower64 && stdenv.hostPlatform.isLittleEndian then
+        if stdenv.hostPlatform.isPower64 && stdenv.hostPlatform.isLittleEndian then
           packages.ghc810
         else
           packages.ghc8107Binary;
@@ -355,8 +314,6 @@ in {
           packages.ghc924
         else if stdenv.hostPlatform.isPower64 && stdenv.hostPlatform.isLittleEndian then
           packages.ghc924
-        else if stdenv.isAarch64 then
-          packages.ghc924BinaryMinimal
         else
           packages.ghc924Binary;
       inherit (buildPackages.python3Packages) sphinx;
@@ -376,8 +333,6 @@ in {
           packages.ghc924
         else if stdenv.hostPlatform.isPower64 && stdenv.hostPlatform.isLittleEndian then
           packages.ghc924
-        else if stdenv.isAarch64 then
-          packages.ghc924BinaryMinimal
         else
           packages.ghc924Binary;
       inherit (buildPackages.python3Packages) sphinx;
@@ -436,33 +391,15 @@ in {
       compilerConfig = callPackage ../development/haskell-modules/configuration-ghc-8.10.x.nix { };
       packageSetConfig = bootstrapPackageSet;
     };
-    ghc8102BinaryMinimal = callPackage ../development/haskell-modules {
-      buildHaskellPackages = bh.packages.ghc8102BinaryMinimal;
-      ghc = bh.compiler.ghc8102BinaryMinimal;
-      compilerConfig = callPackage ../development/haskell-modules/configuration-ghc-8.10.x.nix { };
-      packageSetConfig = bootstrapPackageSet;
-    };
     ghc8107Binary = callPackage ../development/haskell-modules {
       buildHaskellPackages = bh.packages.ghc8107Binary;
       ghc = bh.compiler.ghc8107Binary;
       compilerConfig = callPackage ../development/haskell-modules/configuration-ghc-8.10.x.nix { };
       packageSetConfig = bootstrapPackageSet;
     };
-    ghc8107BinaryMinimal = callPackage ../development/haskell-modules {
-      buildHaskellPackages = bh.packages.ghc8107BinaryMinimal;
-      ghc = bh.compiler.ghc8107BinaryMinimal;
-      compilerConfig = callPackage ../development/haskell-modules/configuration-ghc-8.10.x.nix { };
-      packageSetConfig = bootstrapPackageSet;
-    };
     ghc924Binary = callPackage ../development/haskell-modules {
       buildHaskellPackages = bh.packages.ghc924Binary;
       ghc = bh.compiler.ghc924Binary;
-      compilerConfig = callPackage ../development/haskell-modules/configuration-ghc-9.2.x.nix { };
-      packageSetConfig = bootstrapPackageSet;
-    };
-    ghc924BinaryMinimal = callPackage ../development/haskell-modules {
-      buildHaskellPackages = bh.packages.ghc924BinaryMinimal;
-      ghc = bh.compiler.ghc924BinaryMinimal;
       compilerConfig = callPackage ../development/haskell-modules/configuration-ghc-9.2.x.nix { };
       packageSetConfig = bootstrapPackageSet;
     };


### PR DESCRIPTION
###### Description of changes

The output limit of Hydra has been increased a while ago. This now allows building GHC with profiling enable everywhere. Since there has been a genuine demand for this with the increasing popularity of aarch64-{darwin,linux} as an architecture to actually work on, it seems prudent to take advantage of this. Otherwise users wishing to profile their programs are forced to recompile GHC.

Additionally, we can simplify bootstrapping a bit, since we no longer need to special case aarch platforms—this change is not as essential as the other one and I'm happy to discuss it.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
