### PR TITLE
newlib: fix build of nano variant on non-ARM architectures

### DIFF
--- a/pkgs/development/misc/newlib/default.nix
+++ b/pkgs/development/misc/newlib/default.nix
@@ -73,10 +73,12 @@ stdenv.mkDerivation (finalAttrs: {
       cd $out${finalAttrs.passthru.libdir}
 
       for f in librdimon.a libc.a libg.a; do
-        cp "$f" "''${f%%\.a}_nano.a"
+        # Some libraries are only available for specific architectures.
+        # For example, librdimon.a is only available on ARM.
+        [ -f "$f" ] && cp "$f" "''${f%%\.a}_nano.a"
       done
     )
-  '';
+  '' + ''[ "$(find $out -type f | wc -l)" -gt 0 ] || (echo '$out is empty' 1>&2 && exit 1)'';
 
   passthru = {
     incdir = "/${stdenv.targetPlatform.config}/include";


### PR DESCRIPTION
###### Description of changes

librdimon.a is only available on ARM architectures, therefore building newlib-nano for other architectures (e.g. RISC-V) fails presently. This commit fixes this issue by only copying the library files that actually exist in the for loop body. Alternatively, it would be theoretically feasible to change the libraries iterated over based on the targeted architecture.

Flake to reproduce the build failure on RISC-V:

<details>
<pre>
$ cat flake.nix
{
  inputs = {
    nixpkgs.url = "nixpkgs";
  };

  outputs = { self, nixpkgs }:
    let
      system = "x86_64-linux";

      riscv-toolchain = import nixpkgs {
        localSystem = system;
        crossSystem = {
          config = "riscv32-none-elf";
          libc = "newlib-nano";
          abi = "ilp32";
        };
      };

      pkgs = import nixpkgs { inherit system; };
    in
    {
      devShells.x86_64-linux = {
        default = pkgs.mkShell {
          packages = with pkgs; [
            riscv-toolchain.buildPackages.gcc
          ];
        };
      };
    };
}
$ nix develop
error: builder for '/nix/store/xg6481431pq17dv5rlj7sbw2cj2d1li2-newlib-riscv32-none-elf-4.3.0.20230120.drv' failed with exit code 1;
       last 10 log lines:
       >  /nix/store/02dr9ymdqpkb75vf0v1z2l91z2q3izy9-coreutils-9.3/bin/install -c -m 644  libnosys/libnosys.a riscv/libgloss.a riscv/libsemihost.a '/nix/store/7w0i5hdygnqhx852935dkbgla4f6zqgr-newlib-riscv32-none-elf-4.3.0.20230120/riscv32-none-elf/lib'
       >  ( cd '/nix/store/7w0i5hdygnqhx852935dkbgla4f6zqgr-newlib-riscv32-none-elf-4.3.0.20230120/riscv32-none-elf/lib' && riscv32-none-elf-ranlib libnosys.a )
       >  ( cd '/nix/store/7w0i5hdygnqhx852935dkbgla4f6zqgr-newlib-riscv32-none-elf-4.3.0.20230120/riscv32-none-elf/lib' && riscv32-none-elf-ranlib libgloss.a )
       >  ( cd '/nix/store/7w0i5hdygnqhx852935dkbgla4f6zqgr-newlib-riscv32-none-elf-4.3.0.20230120/riscv32-none-elf/lib' && riscv32-none-elf-ranlib libsemihost.a )
       > make[4]: Leaving directory '/build/newlib-4.3.0.20230120/riscv32-none-elf/libgloss'
       > make[3]: Leaving directory '/build/newlib-4.3.0.20230120/riscv32-none-elf/libgloss'
       > make[2]: Leaving directory '/build/newlib-4.3.0.20230120/riscv32-none-elf/libgloss'
       > make[1]: Leaving directory '/build/newlib-4.3.0.20230120'
       > cp: cannot stat 'librdimon.a': No such file or directory
       > /nix/store/q8xlnkq3mb1sj6n87zps2mc86cd2xmjn-stdenv-linux/setup: line 146: pop_var_context: head of shell_variables not a function context
       For full logs, run 'nix log /nix/store/xg6481431pq17dv5rlj7sbw2cj2d1li2-newlib-riscv32-none-elf-4.3.0.20230120.drv'.
error: 1 dependencies of derivation '/nix/store/ghjqz1sy73qknaiqfz0lragsxh6xjfjz-riscv32-none-elf-stage-final-gcc-wrapper-12.3.0.drv' failed to build
error: 1 dependencies of derivation '/nix/store/9g9b7jkhqa1z46mxhpfdbjsjiq3gbizb-nix-shell-env.drv' failed to build
</pre>
</details>

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
