### PR TITLE
flutter: Use wrapGAppsHook

### DIFF
--- a/pkgs/build-support/flutter/default.nix
+++ b/pkgs/build-support/flutter/default.nix
@@ -2,8 +2,10 @@
 , callPackage
 , stdenvNoCC
 , makeWrapper
+, wrapGAppsHook
 , llvmPackages_13
 , cacert
+, glib
 , flutter
 , jq
 }:
@@ -47,7 +49,11 @@ let
       deps
       flutter
       jq
+      glib
+      wrapGAppsHook
     ] ++ nativeBuildInputs;
+
+    dontWrapGApps = true;
 
     preUnpack = ''
       ${lib.optionalString (!autoDepsList) ''
@@ -123,6 +129,7 @@ let
       for f in "$out"/bin/*; do
         wrapProgram "$f" \
           --suffix LD_LIBRARY_PATH : '${lib.makeLibraryPath finalAttrs.runtimeDependencies}' \
+          ''${gappsWrapperArgs[@]} \
           ${extraWrapProgramArgs}
       done
 

--- a/pkgs/development/compilers/flutter/wrapper.nix
+++ b/pkgs/development/compilers/flutter/wrapper.nix
@@ -33,6 +33,7 @@
 , makeWrapper
 , runCommandLocal
 , writeShellScript
+, wrapGAppsHook
 , git
 , which
 , pkg-config
@@ -166,30 +167,42 @@ let
   includeFlags = map (pkg: "-isystem ${lib.getOutput "dev" pkg}/include") (appStaticBuildDeps ++ extraIncludes);
   linkerFlags = (map (pkg: "-rpath,${lib.getOutput "lib" pkg}/lib") appRuntimeDeps) ++ extraLinkerFlags;
 in
-(callPackage ./sdk-symlink.nix { }) (runCommandLocal "flutter-wrapped"
+(callPackage ./sdk-symlink.nix { }) (stdenv.mkDerivation
 {
-  nativeBuildInputs = [
-    makeWrapper
-  ] ++ lib.optionals stdenv.hostPlatform.isDarwin [ darwin.DarwinTools ];
+  pname = "flutter-wrapped";
+  inherit (flutter) version;
+
+  nativeBuildInputs = [ makeWrapper ]
+    ++ lib.optionals stdenv.hostPlatform.isDarwin [ darwin.DarwinTools ]
+    ++ lib.optionals supportsLinuxDesktop [ glib wrapGAppsHook ];
 
   passthru = flutter.passthru // {
-    inherit (flutter) version;
     unwrapped = flutter;
   };
 
-  inherit (flutter) meta;
-} ''
-  for path in ${builtins.concatStringsSep " " (builtins.foldl' (paths: pkg: paths ++ (map (directory: "'${pkg}/${directory}/pkgconfig'") ["lib" "share"])) [ ] pkgConfigPackages)}; do
-    addToSearchPath FLUTTER_PKG_CONFIG_PATH "$path"
-  done
+  dontUnpack = true;
+  dontWrapGApps = true;
 
-  mkdir -p $out/bin
-  makeWrapper '${immutableFlutter}' $out/bin/flutter \
-    --set-default ANDROID_EMULATOR_USE_SYSTEM_LIBS 1 \
-    --suffix PATH : '${lib.makeBinPath (tools ++ buildTools)}' \
-    --suffix PKG_CONFIG_PATH : "$FLUTTER_PKG_CONFIG_PATH" \
-    --suffix LIBRARY_PATH : '${lib.makeLibraryPath appStaticBuildDeps}' \
-    --prefix CXXFLAGS "''\t" '${builtins.concatStringsSep " " (includeFlags ++ extraCxxFlags)}' \
-    --prefix CFLAGS "''\t" '${builtins.concatStringsSep " " (includeFlags ++ extraCFlags)}' \
-    --prefix LDFLAGS "''\t" '${builtins.concatStringsSep " " (map (flag: "-Wl,${flag}") linkerFlags)}'
-'')
+  installPhase = ''
+    runHook preInstall
+
+    for path in ${builtins.concatStringsSep " " (builtins.foldl' (paths: pkg: paths ++ (map (directory: "'${pkg}/${directory}/pkgconfig'") ["lib" "share"])) [ ] pkgConfigPackages)}; do
+      addToSearchPath FLUTTER_PKG_CONFIG_PATH "$path"
+    done
+
+    mkdir -p $out/bin
+    makeWrapper '${immutableFlutter}' $out/bin/flutter \
+      --set-default ANDROID_EMULATOR_USE_SYSTEM_LIBS 1 \
+      --suffix PATH : '${lib.makeBinPath (tools ++ buildTools)}' \
+      --suffix PKG_CONFIG_PATH : "$FLUTTER_PKG_CONFIG_PATH" \
+      --suffix LIBRARY_PATH : '${lib.makeLibraryPath appStaticBuildDeps}' \
+      --prefix CXXFLAGS "''\t" '${builtins.concatStringsSep " " (includeFlags ++ extraCxxFlags)}' \
+      --prefix CFLAGS "''\t" '${builtins.concatStringsSep " " (includeFlags ++ extraCFlags)}' \
+      --prefix LDFLAGS "''\t" '${builtins.concatStringsSep " " (map (flag: "-Wl,${flag}") linkerFlags)}' \
+      ''${gappsWrapperArgs[@]}
+
+    runHook postInstall
+  '';
+
+  inherit (flutter) meta;
+})


### PR DESCRIPTION
###### Description of changes

This PR adds `makeWrapper` arguments from `wrapGAppsHook` to the Flutter CLI executable (for `flutter run`) and applications built with `buildFlutterApplication`.

Flutter's Linux desktop embedding uses GTK, so this is appropriate. While Flutter apps can mostly run without the GApps wrapper for now, there is no guarantee that future versions of Flutter won't start using a GTK feature that needs it. Furthermore, desktop-oriented plugins in the ecosystem may use GTK features that need it.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
