### PR TITLE
autokernel: init at 2.0.1

### DIFF
--- a/pkgs/tools/admin/autokernel/default.nix
+++ b/pkgs/tools/admin/autokernel/default.nix
@@ -1,0 +1,38 @@
+{ lib
+, rustPlatform
+, fetchFromGitHub
+, pkg-config
+, sqlite
+}:
+
+rustPlatform.buildRustPackage rec {
+  pname = "autokernel";
+  version = "2.0.1";
+
+  src = fetchFromGitHub {
+    owner = "oddlama";
+    repo = "autokernel";
+    rev = "v${version}";
+    hash = "sha256-upiENXRYVSZMPLcb9DeUx0FR97rMbW/sEAlYKi9dvI4=";
+  };
+
+  cargoHash = "sha256-yE9vIcy4OJrGyQPWnUAIyliiVsNews/CZfxwTmudXyU=";
+
+  nativeBuildInputs = [
+    pkg-config
+  ];
+
+  buildInputs = [
+    sqlite
+  ];
+
+  doCheck = false;
+
+  meta = with lib; {
+    description = "A tool for managing your kernel configuration that guarantees semantic correctness";
+    homepage = "https://github.com/oddlama/autokernel";
+    changelog = "https://github.com/oddlama/autokernel/blob/${src.rev}/CHANGELOG.md";
+    license = licenses.mit;
+    maintainers = with maintainers; [ oddlama janik ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -29659,6 +29659,8 @@ with pkgs;
 
   autokey = callPackage ../applications/office/autokey { };
 
+  autokernel = callPackage ../tools/admin/autokernel { };
+
   autotalent = callPackage ../applications/audio/autotalent { };
 
   autotrace = callPackage ../applications/graphics/autotrace { };


### PR DESCRIPTION
###### Description of changes

Currently the tests fail, maybe @oddlama knows why. 
```
running tests
Executing cargoCheckHook
++ cargo test -j 8 --release --target x86_64-unknown-linux-gnu --frozen -- --test-threads=8
   Compiling memchr v2.5.0
   Compiling futures-core v0.3.25
   Compiling slab v0.4.7
   Compiling futures-task v0.3.25
   Compiling futures-channel v0.3.25
   Compiling rlua-lua54-sys v0.1.3
   Compiling lock_api v0.4.9
   Compiling futures-sink v0.3.25
   Compiling futures-util v0.3.25
   Compiling parking_lot_core v0.9.4
   Compiling futures-io v0.3.25
   Compiling smallvec v1.10.0
   Compiling pin-project-lite v0.2.9
   Compiling pin-utils v0.1.0
   Compiling scopeguard v1.1.0
   Compiling log v0.4.17
   Compiling hashbrown v0.12.3
   Compiling serial_test_derive v0.9.0
   Compiling parking_lot v0.12.1
   Compiling object v0.29.0
   Compiling bstr v0.2.17
   Compiling dashmap v5.4.0
   Compiling backtrace v0.3.66
   Compiling futures-executor v0.3.25
   Compiling futures v0.3.25
   Compiling anyhow v1.0.66
   Compiling serial_test v0.9.0
   Compiling rlua v0.19.4
   Compiling autokernel v2.0.1 (/build/source)
    Finished release [optimized] target(s) in 1m 12s
     Running unittests src/lib.rs (target/x86_64-unknown-linux-gnu/release/deps/autokernel-06704b99c85178b0)

running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s

     Running unittests src/bin/autokernel.rs (target/x86_64-unknown-linux-gnu/release/deps/autokernel-e4dcedd69eced535)

running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s

     Running tests/integration_tests.rs (target/x86_64-unknown-linux-gnu/release/deps/integration_tests-ab093d28493d40fe)

running 4 tests
test integration_test_kconfig ... FAILED
test integration_setup ... FAILED
test integration_test_luaconfig ... FAILED
test integration_test_symbols ... FAILED

failures:

---- integration_test_kconfig stdout ----
creating /build/autokernel-test directory
downloading kernel linux-5.19.1 ...
thread 'integration_test_kconfig' panicked at 'called `Result::unwrap()` on an `Err` value: Os { code: 2, kind: NotFound, message: "No such file or directory" }', tests/setup_teardown.rs:27:10
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace

---- integration_setup stdout ----
could not remove tmp dir
creating /build/autokernel-test directory
downloading kernel linux-5.19.1 ...
thread 'integration_setup' panicked at 'called `Result::unwrap()` on an `Err` value: Os { code: 2, kind: NotFound, message: "No such file or directory" }', tests/setup_teardown.rs:27:10

---- integration_test_luaconfig stdout ----
creating /build/autokernel-test directory
downloading kernel linux-5.19.1 ...
thread 'integration_test_luaconfig' panicked at 'called `Result::unwrap()` on an `Err` value: Os { code: 2, kind: NotFound, message: "No such file or directory" }', tests/setup_teardown.rs:27:10

---- integration_test_symbols stdout ----
creating /build/autokernel-test directory
downloading kernel linux-5.19.1 ...
thread 'integration_test_symbols' panicked at 'called `Result::unwrap()` on an `Err` value: Os { code: 2, kind: NotFound, message: "No such file or directory" }', tests/setup_teardown.rs:27:10


failures:
    integration_setup
    integration_test_kconfig
    integration_test_luaconfig
    integration_test_symbols

test result: FAILED. 0 passed; 4 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.01s

error: test failed, to rerun pass `--test integration_tests`
error: builder for '/nix/store/hsr90dk4j0qpq9sqcd30glv6rqhd3bnl-autokernel-2.0.1.drv' failed with exit code 101;
       last 10 log lines:
       >
       > failures:
       >     integration_setup
       >     integration_test_kconfig
       >     integration_test_luaconfig
       >     integration_test_symbols
       >
       > test result: FAILED. 0 passed; 4 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.01s
       >
       > error: test failed, to rerun pass `--test integration_tests`
```
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [X] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
