### PR TITLE
pulsar: 1.105.0 -> 1.106.0

### DIFF
--- a/pkgs/applications/editors/pulsar/001-patch-wrapper.patch
+++ b/pkgs/applications/editors/pulsar/001-patch-wrapper.patch
@@ -1,27 +1,11 @@
 --- a/resources/pulsar.sh	2023-03-16 04:11:14.000000000 +0100
 +++ b/resources/pulsar.sh	2023-03-24 14:37:13.468813964 +0100
-@@ -123,22 +123,9 @@
+@@ -123,7 +123,7 @@
  elif [ $OS == 'Linux' ]; then
    SCRIPT=$(readlink -f "$0")
  
 -  PULSAR_PATH="/opt/Pulsar/pulsar"
 +  # PULSAR_PATH is set-up via `wrapProgram` in the postFixup phase
-
--  #Will allow user to get context menu on cinnamon desktop enviroment
--  #Add a check to make sure that DESKTOP_SESSION is set before attempting to grep it
--  #expr substr is expecting 3 arguments string, index, length
--  #If grep doesnt find anything is provides an empty string which causes the expr: syntax error: missing argument after '8' error - see pulsar-edit/pulsar#174
--  #Im also not quite sure why they used grep instead of simply [ "${DESKTOP_SESSION}" == "cinnamon" ]
--  if [ -n "${DESKTOP_SESSION}" ] && [ "$(expr substr $(printenv | grep 'DESKTOP_SESSION=') 17 8)" == "cinnamon" ]; then
--    #This local path is almost assuredly wrong as it shouldnt exist in a standard install
--    ACTION_PATH="resources/linux/desktopenviroment/cinnamon/pulsar.nemo_action"
--
--    #Validate the file exists before attempting to copy it
--    if [ -f "${ACTION_PATH}" ]; then
--        cp "${$ACTION_PATH}" "/usr/share/nemo/actions/pulsar.nemo_action"
--    fi
--  fi
-+  # We remove the nemo integration. It is handled by the postFixup phase
  
    #Set tmpdir only if tmpdir is unset
    : ${TMPDIR:=/tmp}

--- a/pkgs/applications/editors/pulsar/default.nix
+++ b/pkgs/applications/editors/pulsar/default.nix
@@ -23,13 +23,13 @@
 
 let
   pname = "pulsar";
-  version = "1.105.0";
+  version = "1.106.0";
 
   sourcesPath = {
     x86_64-linux.tarname = "Linux.${pname}-${version}.tar.gz";
-    x86_64-linux.hash = "sha256-j2d83m8B6lt1eRAwOOTEq4o+CNe8I+6rkz9qyux55Qw=";
+    x86_64-linux.hash = "sha256-Wd0z6kHd6qZgrgZBxZQjwVC1dDqYtJ94L7aAnbuJoO8=";
     aarch64-linux.tarname = "ARM.Linux.${pname}-${version}-arm64.tar.gz";
-    aarch64-linux.hash = "sha256-iZVE1R30Tynyn/cAwNIiGrsCMTkWKFUforOkGXSzMsw=";
+    aarch64-linux.hash = "sha256-Xadjqw8PRrq0ksif6te0gxn8xeYTCYnJcsrezfl2SYs=";
   }.${stdenv.hostPlatform.system} or (throw "Unsupported system: ${stdenv.hostPlatform.system}");
 
   additionalLibs = lib.makeLibraryPath [


### PR DESCRIPTION
###### Description of changes

Update Pulsar from 1.105.0 to 1.106.0

https://github.com/pulsar-edit/pulsar/releases/tag/v1.106.0

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
