### PR TITLE
technic-launcher: init at 1.6.56

### DIFF
--- a/pkgs/games/technic-launcher/default.nix
+++ b/pkgs/games/technic-launcher/default.nix
@@ -1,0 +1,54 @@
+{ lib
+, fetchFromGitHub
+, jre
+, maven
+, makeWrapper
+, openjdk
+, xdg-utils
+}:
+
+let
+  version = "1.6.56";
+  src = fetchFromGitHub {
+    owner = "TechnicPack";
+    repo = "LauncherV3";
+    rev = "2ea377bb81d6fe6a393c790fb659a134a571f03e";
+    hash = "sha256-4Bh0lzCZ5/GI/2QMOkawNx/9r2zp1JjCkKTjJCobLHA=";
+  };
+in
+maven.buildMavenPackage {
+  pname = "technic-launcher";
+  inherit version src;
+
+  mvnHash = "sha256-wtLX7lSaDu0WlcJIjARAdQMSmlWUnjrZLoCO+EGeJwQ=";
+
+  patchPhase = ''
+    # Hard-code xdg-open path
+    sed -i 's|ProcessBuilder("xdg-open", url)|ProcessBuilder("${xdg-utils}/bin/xdg-open", url)|g' src/main/java/net/technicpack/utilslib/DesktopUtils.java
+  '';
+
+  nativeBuildInputs = [ maven makeWrapper ];
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/bin
+    mkdir -p $out/share/java
+
+    mv target/launcher-*.jar $out/share/java/technic-launcher-${version}.jar
+
+    makeWrapper ${jre}/bin/java $out/bin/technic-launcher \
+      --add-flags "-cp $out/share/java/technic-launcher-${version}.jar net.technicpack.launcher.LauncherMain"
+    chmod +x $out/bin/technic-launcher
+
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    description = "Custom Minecraft launcher that automatically downloads and updates modpacks";
+    homepage = "https://www.technicpack.net/download";
+    platforms = openjdk.meta.platforms;
+    license = licenses.gpl3Only;
+    maintainers = with maintainers; [ tomodachi94 ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -33334,6 +33334,8 @@ with pkgs;
 
   tcping-go = callPackage ../applications/networking/tcping-go { };
 
+  technic-launcher = callPackage ../games/technic-launcher { };
+
   librep = callPackage ../development/libraries/librep { };
 
   rep-gtk = callPackage ../development/libraries/rep-gtk { };


### PR DESCRIPTION
###### Description of changes

Technic Launcher is an alternative Minecraft launcher.

Upstream URL: https://www.technicpack.net/download

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
