### PR TITLE
compressFirmwareXz: preserve meta attributes

### DIFF
--- a/pkgs/build-support/kernel/compress-firmware-xz.nix
+++ b/pkgs/build-support/kernel/compress-firmware-xz.nix
@@ -1,8 +1,12 @@
-{ runCommand }:
+{ runCommand, lib }:
 
 firmware:
 
-runCommand "${firmware.name}-xz" {} ''
+let
+  args = lib.optionalAttrs (firmware ? meta) { inherit (firmware) meta; };
+in
+
+runCommand "${firmware.name}-xz" args ''
   mkdir -p $out/lib
   (cd ${firmware} && find lib/firmware -type d -print0) |
       (cd $out && xargs -0 mkdir -v --)


### PR DESCRIPTION
###### Description of changes

Among other things, this preserves the package priority, which is important
when building the `hardware.firmware` environment in NixOS.

###### Things done

- [x] Tested on `linux-firmware` and `ath9k-htc-blobless-firmware`
- [x] Tested that priorities now works for `hardware.firmare` on NixOS
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
