### PR TITLE
[staging-next] gst_all_1.gst-plugins-rs: add temporary fix for cargo-c test issue

### DIFF
--- a/pkgs/development/libraries/gstreamer/rs/default.nix
+++ b/pkgs/development/libraries/gstreamer/rs/default.nix
@@ -1,6 +1,7 @@
 { lib
 , stdenv
 , fetchFromGitLab
+, fetchpatch
 , writeText
 , rustPlatform
 , meson
@@ -112,6 +113,17 @@ let
   ) (lib.attrNames validPlugins);
 
   invalidPlugins = lib.subtractLists (lib.attrNames validPlugins) selectedPlugins;
+
+  # TODO: figure out what must be done about this upstream - related lu-zero/cargo-c#323 lu-zero/cargo-c#138
+  cargo-c' = cargo-c.overrideAttrs (oldAttrs: {
+    patches = (oldAttrs.patches or []) ++ [
+      (fetchpatch {
+        name = "cargo-c-test-rlib-fix.patch";
+        url = "https://github.com/lu-zero/cargo-c/commit/596c582deed419b0cf1f80b9be77ff705df20e01.diff";
+        hash = "sha256-GETjZwYqX7h51rxWznAg5Ojozdp1SOYnUh+iuRGA4/w=";
+      })
+    ];
+  });
 in
   assert lib.assertMsg (invalidPlugins == [])
     "Invalid gst-plugins-rs plugin${lib.optionalString (lib.length invalidPlugins > 1) "s"}: ${lib.concatStringsSep ", " invalidPlugins}";
@@ -165,7 +177,7 @@ stdenv.mkDerivation rec {
     pkg-config
     rustc
     cargo
-    cargo-c
+    cargo-c'
     nasm
   ] ++ lib.optionals enableDocumentation [
     hotdoc


### PR DESCRIPTION
###### Description of changes

Yay, gst-plugins-rs broke for two staging cycles in a row now...

Tests fail to run due to upstream cargo-c issue after the bump in #236611, so this makes a temporary fix to allow it to still build for now while upstream comes up with a more permanent solution I suppose

Given this new behavior for cargo-c seems to be intentional and gst-plugins-rs is not testing with this cargo-c version yet upstream (and would require non-negligible amounts of reworking for this problem), I opted to just inline a patched cargo-c instead of trying to untangle the cargo_wrapper mess in gst-plugins-rs enough to fix it there (Meson cargo workspace support when...)

Related: lu-zero/cargo-c#323 lu-zero/cargo-c#138

###### Things done

- Built on platform(s)
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).