### PR TITLE
libretro.fuse: init at unstable-2023-06-23

### DIFF
--- a/pkgs/applications/emulators/retroarch/cores.nix
+++ b/pkgs/applications/emulators/retroarch/cores.nix
@@ -426,6 +426,14 @@ in
     };
   };
 
+  fuse = mkLibretroCore {
+    core = "fuse";
+    meta = {
+      description = "A port of the Fuse Unix Spectrum Emulator to libretro";
+      license = lib.licenses.gpl3Only;
+    };
+  };
+
   gambatte = mkLibretroCore {
     core = "gambatte";
     meta = {

--- a/pkgs/applications/emulators/retroarch/hashes.json
+++ b/pkgs/applications/emulators/retroarch/hashes.json
@@ -180,6 +180,12 @@
         "rev": "9a65ec6e31d48ad0dae1f381c1ec61c897f970cb",
         "sha256": "ZeWw/K6i04XRympqZ6sQG/yjN8cJglVcIkxpyRHx424="
     },
+    "fuse": {
+        "owner": "libretro",
+        "repo": "fuse-libretro",
+        "rev": "847dbbd6f787823ac9a5dfacdd68ab181063374e",
+        "sha256": "jzS7SFALV/YjI77ST+IWHwUsuhT+Zr5w4t6C7O8yzFM="
+    },
     "gambatte": {
         "owner": "libretro",
         "repo": "gambatte-libretro",

--- a/pkgs/applications/emulators/retroarch/update_cores.py
+++ b/pkgs/applications/emulators/retroarch/update_cores.py
@@ -42,6 +42,7 @@ CORES = {
     "flycast": {"repo": "flycast"},
     "fmsx": {"repo": "fmsx-libretro"},
     "freeintv": {"repo": "freeintv"},
+    "fuse": {"repo": "fuse-libretro"},
     "gambatte": {"repo": "gambatte-libretro"},
     "genesis-plus-gx": {"repo": "Genesis-Plus-GX"},
     "gpsp": {"repo": "gpsp"},


### PR DESCRIPTION
###### Description of changes

A port of the Fuse Unix Spectrum Emulator to libretro: https://github.com/libretro/fuse-libretro.
For reference, homepage of the Fuse emulator itself: https://sourceforge.net/projects/fuse-emulator/

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
