### PR TITLE
tunnelx: init at 2023-07-nix

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -5960,6 +5960,12 @@
     githubId = 25820499;
     name = "Roman Kretschmer";
   };
+  goatchurchprime = {
+    email = "julian@goatchurch.org.uk";
+    github = "goatchurchprime";
+    githubId = 677254;
+    name = "Julian Todd";
+  };
   gobidev = {
     email = "adrian.groh@t-online.de";
     github = "Gobidev";

--- a/pkgs/applications/gis/tunnelx/default.nix
+++ b/pkgs/applications/gis/tunnelx/default.nix
@@ -1,0 +1,52 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, jdk
+, jre
+, survex
+, makeWrapper
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "tunnelx";
+  version = "2023-07-nix";
+
+  src = fetchFromGitHub {
+    owner = "CaveSurveying";
+    repo = "tunnelx";
+    rev = "v${finalAttrs.version}";
+    hash = "sha256-H6lHqc9on/pv/KihNcaHPwbWf4JXRkeRqNoYq6yVKqM=";
+  };
+
+  nativeBuildInputs = [
+    makeWrapper
+  ];
+
+  buildInputs = [
+    jdk
+  ];
+
+  runtimeInputs = [
+    survex
+  ];
+
+  buildPhase = ''
+    javac -d . src/*.java
+  '';
+
+  installPhase = ''
+    mkdir -p $out/bin $out/java
+    cp -r symbols Tunnel tutorials $out/java
+    makeWrapper ${jre}/bin/java $out/bin/tunnelx \
+      --add-flags "-cp $out/java Tunnel.MainBox" \
+      --set SURVEX_EXECUTABLE_DIR ${survex}/bin/ \
+      --set TUNNEL_USER_DIR $out/java/
+  '';
+
+  meta = with lib; {
+    description = "A program for drawing cave surveys in 2D";
+    homepage = "https://github.com/CaveSurveying/tunnelx/";
+    license = licenses.gpl3;
+    maintainers = with maintainers; [ goatchurchprime ];
+  };
+})

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -40202,6 +40202,8 @@ with pkgs;
 
   trufflehog = callPackage ../tools/security/trufflehog { };
 
+  tunnelx = callPackage ../applications/gis/tunnelx { };
+
   tvbrowser = callPackage ../applications/misc/tvbrowser { };
 
   tvheadend = callPackage ../servers/tvheadend { };


### PR DESCRIPTION
###### Description of changes

First solo attempt by at getting a cave surveying software package into nixpkgs.  (It's already packaged in Debian.)

It runs directly from the compiled java code (ie directory of .class files), because this is reproducible using a call to `makeWrapper`.  If I batch these up into a .jar file (which is standard practice), then the hash of the result seems to vary.

I am putting it into the `/applications/gis/`directory because it is mapping software.

In the future I hope to move the other two new cave survey packages `/applications/misc/survex` and `/applications/misc/therion` (which I helped @MatthewCroughan to package) into the proper '/applications/gis/`directory.

Homepage for this one: https://github.com/CaveSurveying/tunnelx/

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
