### PR TITLE
linux: build with GCC 13 for loongarch64

### DIFF
--- a/pkgs/top-level/linux-kernels.nix
+++ b/pkgs/top-level/linux-kernels.nix
@@ -12,6 +12,7 @@
 , lib
 , fetchurl
 , gcc10Stdenv
+, gcc13Stdenv
 }:
 
 # When adding a kernel:
@@ -166,6 +167,7 @@ in {
         kernelPatches.bridge_stp_helper
         kernelPatches.request_key_helper
       ];
+      stdenv = if stdenv.hostPlatform.isLoongArch64 then gcc13Stdenv else stdenv;
     };
 
     linux_rt_6_1 = callPackage ../os-specific/linux/kernel/linux-rt-6.1.nix {
@@ -174,6 +176,7 @@ in {
         kernelPatches.request_key_helper
         kernelPatches.export-rt-sched-migrate
       ];
+      stdenv = if stdenv.hostPlatform.isLoongArch64 then gcc13Stdenv else stdenv;
     };
 
     linux_6_3 = callPackage ../os-specific/linux/kernel/linux-6.3.nix {
@@ -181,6 +184,7 @@ in {
         kernelPatches.bridge_stp_helper
         kernelPatches.request_key_helper
       ];
+      stdenv = if stdenv.hostPlatform.isLoongArch64 then gcc13Stdenv else stdenv;
     };
 
     linux_testing = let
@@ -189,6 +193,7 @@ in {
           kernelPatches.bridge_stp_helper
           kernelPatches.request_key_helper
         ];
+        stdenv = if stdenv.hostPlatform.isLoongArch64 then gcc13Stdenv else stdenv;
       };
       latest = packageAliases.linux_latest.kernel;
     in if latest.kernelAtLeast testing.baseVersion


### PR DESCRIPTION
###### Description of changes

Linux requires either binutils ≤ 2.39 or GCC ≥ 13 to build for loongarch64.

Link: https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=0d8dad7048611e5ba02ae8519539ce4b8b1482d3
Link: https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=11cd8a648301af0ad6937ed9493519d1e93fd4c8

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
