### PR TITLE
libtoxcore: drop unnecessary dependency on msgpack

### DIFF
--- a/pkgs/development/libraries/libtoxcore/default.nix
+++ b/pkgs/development/libraries/libtoxcore/default.nix
@@ -1,5 +1,15 @@
-{ lib, stdenv, fetchurl, cmake, libsodium, ncurses, libopus, msgpack
-, libvpx, check, libconfig, pkg-config }:
+{ lib
+, stdenv
+, fetchurl
+, cmake
+, libsodium
+, ncurses
+, libopus
+, libvpx
+, check
+, libconfig
+, pkg-config
+}:
 
 let buildToxAV = !stdenv.isAarch32;
 in stdenv.mkDerivation rec {
@@ -14,14 +24,18 @@ in stdenv.mkDerivation rec {
       sha256 = "sha256-8pQFN5mIY1k+KLxqa19W8JZ19s2KKDJre8MbSDbAiUI=";
     };
 
-  cmakeFlags =
-    [ "-DBUILD_NTOX=ON" "-DDHT_BOOTSTRAP=ON" "-DBOOTSTRAP_DAEMON=ON" ]
-    ++ lib.optional buildToxAV "-DMUST_BUILD_TOXAV=ON";
+  cmakeFlags = [
+    "-DDHT_BOOTSTRAP=ON"
+    "-DBOOTSTRAP_DAEMON=ON"
+  ] ++ lib.optional buildToxAV "-DMUST_BUILD_TOXAV=ON";
 
   buildInputs = [
-    libsodium msgpack ncurses libconfig
+    libsodium
+    ncurses
+    libconfig
   ] ++ lib.optionals buildToxAV [
-    libopus libvpx
+    libopus
+    libvpx
   ];
 
   nativeBuildInputs = [ cmake pkg-config ];


### PR DESCRIPTION
###### Description of changes
Check output and there is no difference other than prefix in generated .pc files.
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
