### PR TITLE
linux/kernel/common-config: support DFS radiations for ath(9|10)k drivers

### DIFF
--- a/pkgs/os-specific/linux/kernel/common-config.nix
+++ b/pkgs/os-specific/linux/kernel/common-config.nix
@@ -281,18 +281,30 @@ let
     };
 
     wireless = {
-      CFG80211_WEXT         = option yes; # Without it, ipw2200 drivers don't build
-      IPW2100_MONITOR       = option yes; # support promiscuous mode
-      IPW2200_MONITOR       = option yes; # support promiscuous mode
-      HOSTAP_FIRMWARE       = option yes; # Support downloading firmware images with Host AP driver
-      HOSTAP_FIRMWARE_NVRAM = option yes;
-      ATH9K_PCI             = option yes; # Detect Atheros AR9xxx cards on PCI(e) bus
-      ATH9K_AHB             = option yes; # Ditto, AHB bus
-      B43_PHY_HT            = option yes;
-      BCMA_HOST_PCI         = option yes;
-      RTW88                 = whenAtLeast "5.2" module;
-      RTW88_8822BE          = mkMerge [ (whenBetween "5.2" "5.8" yes) (whenAtLeast "5.8" module) ];
-      RTW88_8822CE          = mkMerge [ (whenBetween "5.2" "5.8" yes) (whenAtLeast "5.8" module) ];
+      CFG80211_WEXT               = option yes; # Without it, ipw2200 drivers don't build
+      IPW2100_MONITOR             = option yes; # support promiscuous mode
+      IPW2200_MONITOR             = option yes; # support promiscuous mode
+      HOSTAP_FIRMWARE             = option yes; # Support downloading firmware images with Host AP driver
+      HOSTAP_FIRMWARE_NVRAM       = option yes;
+      ATH9K_PCI                   = option yes; # Detect Atheros AR9xxx cards on PCI(e) bus
+      ATH9K_AHB                   = option yes; # Ditto, AHB bus
+      # The description of this option makes it sound dangerous or even illegal
+      # But OpenWRT enables it by default: https://github.com/openwrt/openwrt/blob/master/package/kernel/mac80211/Makefile#L55
+      # At the time of writing (25-06-2023): this is only used in a "correct" way by ath drivers for initiating DFS radiation
+      # for "certified devices"
+      EXPERT                      = option yes; # this is needed for offering the certification option
+      CFG80211_CERTIFICATION_ONUS = option yes;
+      # DFS: "Dynamic Frequency Selection" is a spectrum-sharing mechanism that allows
+      # you to use certain interesting frequency when your local regulatory domain mandates it.
+      # ATH drivers hides the feature behind this option and makes hostapd works with DFS frequencies.
+      # OpenWRT enables it too: https://github.com/openwrt/openwrt/blob/master/package/kernel/mac80211/ath.mk#L42
+      ATH9K_DFS_CERTIFIED         = option yes;
+      ATH10K_DFS_CERTIFIED        = option yes;
+      B43_PHY_HT                  = option yes;
+      BCMA_HOST_PCI               = option yes;
+      RTW88                       = whenAtLeast "5.2" module;
+      RTW88_8822BE                = mkMerge [ (whenBetween "5.2" "5.8" yes) (whenAtLeast "5.8" module) ];
+      RTW88_8822CE                = mkMerge [ (whenBetween "5.2" "5.8" yes) (whenAtLeast "5.8" module) ];
     };
 
     fb = {


### PR DESCRIPTION
###### Description of changes

This enables shady options because upstream and Atheros probably didn't fix the issue
and their idea of "certification" is quite extreme.

We follow OpenWRT here and apply those changes to reduce "WTFs/min" for users
wondering what is the difference between OpenWRT and NixOS for their APs.

This was tested on Qualcomm Atheros QCA986x/988x 802.11ac Wireless Network Adapter on a x86 machine
in the French regulatory domain on frequency 5600MHz, DFS was used successfully by hostapd
instead of a mind-boggling "device or resource busy" error which is what happens without those options.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
