### PR TITLE
clickhouse: 23.3.3.52 -> 23.3.5.9

### DIFF
--- a/pkgs/servers/clickhouse/default.nix
+++ b/pkgs/servers/clickhouse/default.nix
@@ -1,6 +1,7 @@
 { lib
 , llvmPackages
 , fetchFromGitHub
+, fetchpatch
 , cmake
 , ninja
 , python3
@@ -27,7 +28,7 @@ let
     else llvmPackages.stdenv).mkDerivation;
 in mkDerivation rec {
   pname = "clickhouse";
-  version = "23.3.3.52";
+  version = "23.3.5.9";
 
   src = fetchFromGitHub rec {
     owner = "ClickHouse";
@@ -35,9 +36,7 @@ in mkDerivation rec {
     rev = "v${version}-lts";
     fetchSubmodules = true;
     name = "clickhouse-${rev}.tar.gz";
-    hash = if stdenv.isDarwin
-           then "sha256-VaUGbUyDilYPK4iBv/nICOsfeolNQeBSEtC71gBTkpE="
-           else "sha256-NH+OW6zr8XBmJr68fX1WIy8Wt7cLWFMskIv7Be0TLEU=";
+    hash = "sha256-soF0L69oi95r0zgzPL0DfDhhXfRKekN5u/4+/mt8QwM=";
     postFetch = ''
       # delete files that make the source too big
       rm -rf $out/contrib/llvm-project/llvm/test
@@ -53,7 +52,7 @@ in mkDerivation rec {
       tar -I 'gzip -n' \
         --sort=name \
         --mtime=1970-01-01 \
-        --owner=root --group=root \
+        --owner=0 --group=0 \
         --numeric-owner --mode=go=rX,u+rw,a-s \
         --transform='s@^@source/@S' \
         -cf temp  -C "$out" .
@@ -157,8 +156,10 @@ in mkDerivation rec {
     "-DENABLE_TESTS=OFF"
     "-DCOMPILER_CACHE=disabled"
     "-DENABLE_EMBEDDED_COMPILER=ON"
-    "-DWERROR=OFF"
   ];
+
+  # https://github.com/ClickHouse/ClickHouse/issues/49988
+  hardeningDisable = [ "fortify" ];
 
   postInstall = ''
     rm -rf $out/share/clickhouse-test


### PR DESCRIPTION
###### Description of changes

- Updated to a new bugfix release of clickhouse.

- Changed the tar command to set owner and group by id instead of 'root'. Presumably this was the reason that darwin produced different hash, gid of the `root` group is not `0`? This was determined by running `vbindiff` on the gunzipped tarballs.

- Remove the `WERROR=OFF` and replace it with a `hardeningDisable = [ "fortify" ];` to match what upstream uses

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
