### PR TITLE
kodiPackages.vfs-rar: init at 20.1.0

### DIFF
--- a/pkgs/applications/video/kodi/addons/vfs-rar/default.nix
+++ b/pkgs/applications/video/kodi/addons/vfs-rar/default.nix
@@ -1,0 +1,22 @@
+{ lib, rel, buildKodiBinaryAddon, fetchFromGitHub, tinyxml }:
+buildKodiBinaryAddon rec {
+  pname = namespace;
+  namespace = "vfs.rar";
+  version = "20.1.0";
+
+  src = fetchFromGitHub {
+    owner = "xbmc";
+    repo = namespace;
+    rev = "${version}-${rel}";
+    sha256 = "sha256-8IEYA2gNchCa7O9kzrCbO5DxYWJqPzQN3SJIr9zCWc8=";
+  };
+
+  extraBuildInputs = [ tinyxml ];
+
+  meta = with lib; {
+    description = "RAR archive Virtual Filesystem add-on for Kodi";
+    license = licenses.gpl2Plus;
+    platforms = platforms.all;
+    maintainers = teams.kodi.members;
+  };
+}

--- a/pkgs/top-level/kodi-packages.nix
+++ b/pkgs/top-level/kodi-packages.nix
@@ -96,9 +96,11 @@ let self = rec {
 
   osmc-skin = callPackage ../applications/video/kodi/addons/osmc-skin { };
 
-  vfs-sftp = callPackage ../applications/video/kodi/addons/vfs-sftp { };
-
   vfs-libarchive = callPackage ../applications/video/kodi/addons/vfs-libarchive { };
+
+  vfs-rar = callPackage ../applications/video/kodi/addons/vfs-rar { };
+
+  vfs-sftp = callPackage ../applications/video/kodi/addons/vfs-sftp { };
 
   visualization-fishbmc = callPackage ../applications/video/kodi/addons/visualization-fishbmc { };
 


### PR DESCRIPTION
###### Description of changes

Binary [Kodi](https://kodi.tv/) VFS addon to extract RAR archives or direct playback stored files in RAR archives.
Optional dependency of Internet Archive Game Launcher (IAGL) plugin, which is already in nixpkgs (`kodiPackages.iagl`).

Plugin's page: https://github.com/xbmc/vfs.rar/

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
