### PR TITLE
kodiPackages.libretro-fuse: init at 1.6.0.34

### DIFF
--- a/pkgs/applications/video/kodi/addons/libretro-fuse/default.nix
+++ b/pkgs/applications/video/kodi/addons/libretro-fuse/default.nix
@@ -1,0 +1,31 @@
+{ lib, buildKodiBinaryAddon, fetchFromGitHub, libretro, fuse }:
+
+buildKodiBinaryAddon rec {
+  pname = "libretro-fuse";
+  namespace = "game.libretro.fuse";
+  version = "1.6.0.34";
+
+  src = fetchFromGitHub {
+    owner = "kodi-game";
+    repo = "game.libretro.fuse";
+    rev = "${version}-Nexus";
+    hash = "sha256-MimwEV7YD6pMshxqbKTVbLDsPmMbqSy4HPnxwmKswpc=";
+  };
+
+  extraCMakeFlags = [
+    "-DFUSE_LIB=${fuse}/lib/retroarch/cores/fuse_libretro.so"
+  ];
+
+  extraBuildInputs = [ fuse ];
+  propagatedBuildInputs = [
+    libretro
+  ];
+
+  meta = with lib; {
+    homepage = "https://github.com/kodi-game/game.libretro.fuse";
+    description = "Sinclair - ZX Spectrum (Fuse) GameClient for Kodi";
+    platforms = platforms.all;
+    license = licenses.gpl3Only;
+    maintainers = with maintainers; teams.kodi.members ++ [ kazenyuk ];
+  };
+}

--- a/pkgs/top-level/kodi-packages.nix
+++ b/pkgs/top-level/kodi-packages.nix
@@ -3,7 +3,7 @@
 with lib;
 
 let
-  inherit (libretro) genesis-plus-gx mgba snes9x twenty-fortyeight;
+  inherit (libretro) fuse genesis-plus-gx mgba snes9x twenty-fortyeight;
 in
 
 let self = rec {
@@ -63,6 +63,8 @@ let self = rec {
   libretro = callPackage ../applications/video/kodi/addons/libretro { };
 
   libretro-2048 = callPackage ../applications/video/kodi/addons/libretro-2048 { inherit twenty-fortyeight; };
+
+  libretro-fuse = callPackage ../applications/video/kodi/addons/libretro-fuse { inherit fuse; };
 
   libretro-genplus = callPackage ../applications/video/kodi/addons/libretro-genplus { inherit genesis-plus-gx; };
 


### PR DESCRIPTION
###### Description of changes

Sinclair - ZX Spectrum (Fuse) GameClient for Kodi
Project’s page: https://github.com/kodi-game/game.libretro.fuse

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
