### PR TITLE
libnatpmp: install natpmp_decspec.h

### DIFF
--- a/pkgs/development/libraries/libnatpmp/default.nix
+++ b/pkgs/development/libraries/libnatpmp/default.nix
@@ -9,6 +9,7 @@ stdenv.mkDerivation rec {
     hash = "sha256-BoTtLIQGQ351GaG9IOqDeA24cbOjpddSMRuj6Inb/HA=";
   };
 
+  patches = [ ./headers.patch ];
   makeFlags = [
     "INSTALLPREFIX=$(out)"
     "CC:=$(CC)"

--- a/pkgs/development/libraries/libnatpmp/headers.patch
+++ b/pkgs/development/libraries/libnatpmp/headers.patch
@@ -1,0 +1,12 @@
+diff a/Makefile b/Makefile
+--- a/Makefile
++++ b/Makefile
+@@ -56,7 +56,7 @@ else
+ endif
+ endif
+ 
+-HEADERS = natpmp.h
++HEADERS = natpmp.h natpmp_declspec.h
+ 
+ EXECUTABLES = testgetgateway natpmpc-shared natpmpc-static
+ 


### PR DESCRIPTION
This header is expected by some software (like transmission) during build
Without this header build for transmission is failing with:

```
[ 10%] Building C object libtransmission/CMakeFiles/transmission.dir/natpmp.c.o
In file included from /build/source/libtransmission/natpmp.c:16:
/nix/store/fcqb2zpinx868h5njkjs1pny94chfa62-libnatpmp-20230423/include/natpmp.h:52:10: fatal error: natpmp_declspec.h: No such file or directory
   52 | #include "natpmp_declspec.h"
      |          ^~~~~~~~~~~~~~~~~~~
compilation terminated.
make[2]: *** [libtransmission/CMakeFiles/transmission.dir/build.make:426: libtransmission/CMakeFiles/transmission.dir/natpmp.c.o] Error 1
make[1]: *** [CMakeFiles/Makefile2:242: libtransmission/CMakeFiles/transmission.dir/all] Error 2
make: *** [Makefile:166: all] Error 2
```

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
