### PR TITLE
cod: mark package as not broken on linux

### DIFF
--- a/pkgs/tools/misc/cod/default.nix
+++ b/pkgs/tools/misc/cod/default.nix
@@ -33,6 +33,6 @@ buildGoModule rec {
     homepage = "https://github.com/dim-an/cod/";
     license = licenses.asl20;
     maintainers = with maintainers; [ SuperSandro2000 ];
-    broken = true;
+    broken = stdenv.isDarwin;
   };
 }


### PR DESCRIPTION
###### Description of changes

Package was marked as broken in https://github.com/NixOS/nixpkgs/pull/179622.
Tried building it myself on my Linux => works fine.
Reverting to state before ie. broken if on darwin as I have no way to check this.

<details>
<summary>Build logs</summary>

```
$ nix-build -A cod

this derivation will be built:
  /nix/store/z1mvd5pw3xjin3yam2dndw9ir1x8qbbn-cod-0.1.0.drv
building '/nix/store/z1mvd5pw3xjin3yam2dndw9ir1x8qbbn-cod-0.1.0.drv'...
unpacking sources
unpacking source archive /nix/store/yl56z2vx72k6nx8prg66ybmm67vp2wqc-source
source root is source
patching sources
configuring
building
Building subPackage .
Building subPackage ./datastore
Building subPackage ./parse_doc
Building subPackage ./server
Building subPackage ./shells
Building subPackage ./shells/asciitable
Building subPackage ./test
Building subPackage ./util
buildPhase completed in 44 seconds
running tests
/build/source/test/binaries /build/source
patching script interpreter paths in argparse-subcommand.py
argparse-subcommand.py: interpreter directive changed from "#!/usr/bin/env python3" to "/nix/store/5a457g4zr7q11b4mz0ifc9z88kwcp8g7-python3-3.10.12/bin/python3"
patching script interpreter paths in cat.py
cat.py: interpreter directive changed from "#!/usr/bin/env python3" to "/nix/store/5a457g4zr7q11b4mz0ifc9z88kwcp8g7-python3-3.10.12/bin/python3"
patching script interpreter paths in default-subcommand.py
default-subcommand.py: interpreter directive changed from "#!/usr/bin/env python3" to "/nix/store/5a457g4zr7q11b4mz0ifc9z88kwcp8g7-python3-3.10.12/bin/python3"
patching script interpreter paths in foo_v1.py
foo_v1.py: interpreter directive changed from "#!/usr/bin/env python3" to "/nix/store/5a457g4zr7q11b4mz0ifc9z88kwcp8g7-python3-3.10.12/bin/python3"
patching script interpreter paths in foo_v2.py
foo_v2.py: interpreter directive changed from "#!/usr/bin/env python3" to "/nix/store/5a457g4zr7q11b4mz0ifc9z88kwcp8g7-python3-3.10.12/bin/python3"
patching script interpreter paths in naval-fate.py
naval-fate.py: interpreter directive changed from "#!/usr/bin/env python3" to "/nix/store/5a457g4zr7q11b4mz0ifc9z88kwcp8g7-python3-3.10.12/bin/python3"
/build/source
ok      github.com/dim-an/cod/datastore 0.008s
ok      github.com/dim-an/cod/parse_doc 0.005s
ok      github.com/dim-an/cod/shells    0.002s
ok      github.com/dim-an/cod/test      1.184s
ok      github.com/dim-an/cod/util      0.003s
checkPhase completed in 45 seconds
installing
post-installation fixup
shrinking RPATHs of ELF executables and libraries in /nix/store/646jl16r8k8pv71dcrp8czqfh17lx5h3-cod-0.1.0
shrinking /nix/store/646jl16r8k8pv71dcrp8czqfh17lx5h3-cod-0.1.0/bin/cod
checking for references to /build/ in /nix/store/646jl16r8k8pv71dcrp8czqfh17lx5h3-cod-0.1.0...
patching script interpreter paths in /nix/store/646jl16r8k8pv71dcrp8czqfh17lx5h3-cod-0.1.0
stripping (with command strip and flags -S -p) in  /nix/store/646jl16r8k8pv71dcrp8czqfh17lx5h3-cod-0.1.0/bin
/nix/store/646jl16r8k8pv71dcrp8czqfh17lx5h3-cod-0.1.0
```

</details>



###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
