### PR TITLE
stratovirt: add micro_vm-allow-SYS_clock_gettime.patch

### DIFF
--- a/pkgs/applications/virtualization/stratovirt/default.nix
+++ b/pkgs/applications/virtualization/stratovirt/default.nix
@@ -13,6 +13,7 @@ rustPlatform.buildRustPackage rec {
     rev = "v${version}";
     sha256 = "sha256-K99CmaBrJu30/12FxnsNsDKsTyX4f2uQSO7cwHsPuDw=";
   };
+  patches = [ ./micro_vm-allow-SYS_clock_gettime.patch ];
 
   cargoSha256 = "sha256-SFIOGGRzGkVWHIXkviVWuhDN29pa0uD3GqKh+G421xI=";
 

--- a/pkgs/applications/virtualization/stratovirt/micro_vm-allow-SYS_clock_gettime.patch
+++ b/pkgs/applications/virtualization/stratovirt/micro_vm-allow-SYS_clock_gettime.patch
@@ -1,0 +1,25 @@
+From af3001b1b2697ae3165e2fdf47a560fd9ab19a68 Mon Sep 17 00:00:00 2001
+From: Astro <astro@spaceboyz.net>
+Date: Sun, 18 Jun 2023 23:10:23 +0200
+Subject: [PATCH] micro_vm: allow SYS_clock_gettime
+
+---
+ machine/src/micro_vm/syscall.rs | 2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git a/machine/src/micro_vm/syscall.rs b/machine/src/micro_vm/syscall.rs
+index 89ce5c29..2a6aa0cc 100644
+--- a/machine/src/micro_vm/syscall.rs
++++ b/machine/src/micro_vm/syscall.rs
+@@ -128,6 +128,8 @@ pub fn syscall_whitelist() -> Vec<BpfRule> {
+         #[cfg(all(target_env = "gnu", target_arch = "x86_64"))]
+         BpfRule::new(libc::SYS_readlink),
+         BpfRule::new(libc::SYS_getrandom),
++        #[cfg(target_env = "gnu")]
++        BpfRule::new(libc::SYS_clock_gettime),
+         madvise_rule(),
+     ]
+ }
+-- 
+2.41.0
+


### PR DESCRIPTION
###### Description of changes

This fixes the following error for me:
```
Received a bad system call, number: 228
```

I am still trying to upstream this fix but my fresh account on gitee.com got blocked.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
