### PR TITLE
evdi: unstable-20221013 -> 1.13.1

### DIFF
--- a/pkgs/os-specific/linux/evdi/0000-fix-drm-path.patch
+++ b/pkgs/os-specific/linux/evdi/0000-fix-drm-path.patch
@@ -1,0 +1,31 @@
+diff --git a/module/Makefile b/module/Makefile
+index fe573de..c8022c8 100644
+--- a/module/Makefile
++++ b/module/Makefile
+@@ -50,7 +50,7 @@ ifneq ($(KERNELRELEASE),)
+ # inside kbuild
+ # Note: this can be removed once it is in kernel tree and Kconfig is properly used
+ CONFIG_DRM_EVDI := m
+-ccflags-y := -isystem include/uapi/drm include/drm $(CFLAGS) $(EL8FLAG) $(EL9FLAG) $(RPIFLAG)
++ccflags-y := -isystem include/uapi/drm $(CFLAGS) $(EL8FLAG) $(EL9FLAG) $(RPIFLAG)
+ evdi-y := evdi_platform_drv.o evdi_platform_dev.o evdi_sysfs.o evdi_modeset.o evdi_connector.o evdi_encoder.o evdi_drm_drv.o evdi_fb.o evdi_gem.o evdi_painter.o evdi_params.o evdi_cursor.o evdi_debug.o evdi_i2c.o
+ evdi-$(CONFIG_COMPAT) += evdi_ioc32.o
+ obj-$(CONFIG_DRM_EVDI) := evdi.o
+diff --git a/module/evdi_drm.h b/module/evdi_drm.h
+index 29b8427..5012693 100644
+--- a/module/evdi_drm.h
++++ b/module/evdi_drm.h
+@@ -12,12 +12,11 @@
+ 
+ #ifdef __KERNEL__
+ #include <linux/types.h>
++#include <drm/drm.h>
+ #else
+ #include <stdint.h>
+ #endif
+ 
+-#include "drm.h"
+-
+ /* Output events sent from driver to evdi lib */
+ #define DRM_EVDI_EVENT_UPDATE_READY  0x80000000
+ #define DRM_EVDI_EVENT_DPMS          0x80000001

--- a/pkgs/os-specific/linux/evdi/default.nix
+++ b/pkgs/os-specific/linux/evdi/default.nix
@@ -1,21 +1,25 @@
-{ lib, stdenv, fetchFromGitHub, kernel, libdrm }:
-
+{ lib, stdenv, fetchFromGitHub, kernel, libdrm, python3 }:
+let
+  python3WithLibs = python3.withPackages (ps: with ps; [
+    pybind11
+  ]);
+in
 stdenv.mkDerivation rec {
   pname = "evdi";
-  version = "unstable-2022-10-13";
+  version = "1.13.1";
 
   src = fetchFromGitHub {
     owner = "DisplayLink";
     repo = pname;
-    rev = "bdc258b25df4d00f222fde0e3c5003bf88ef17b5";
-    hash = "sha256-mt+vEp9FFf7smmE2PzuH/3EYl7h89RBN1zTVvv2qJ/o=";
+    rev = "v${version}";
+    hash = "sha256-Or4hhnFOtC8vmB4kFUHbFHn2wg/NsUMY3d2Tiea6YbY=";
   };
 
   env.NIX_CFLAGS_COMPILE = "-Wno-error -Wno-error=sign-compare";
 
   nativeBuildInputs = kernel.moduleBuildDependencies;
 
-  buildInputs = [ kernel libdrm ];
+  buildInputs = [ kernel libdrm python3WithLibs ];
 
   makeFlags = kernel.makeFlags ++ [
     "KVER=${kernel.modDirVersion}"
@@ -30,6 +34,10 @@ stdenv.mkDerivation rec {
   '';
 
   enableParallelBuilding = true;
+
+  patches = [
+    ./0000-fix-drm-path.patch
+  ];
 
   meta = with lib; {
     description = "Extensible Virtual Display Interface";


### PR DESCRIPTION
###### Description of changes


- Pull request to update evdi to 1.13.1
- Needed to use with Linux kernel >= 6.2

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
