### PR TITLE
sexp: init at 0.8.6

### DIFF
--- a/pkgs/development/libraries/sexp/default.nix
+++ b/pkgs/development/libraries/sexp/default.nix
@@ -1,0 +1,48 @@
+{ lib
+, stdenv
+, bzip2
+, cmake
+, fetchFromGitHub
+, gtest
+, pkg-config
+, zlib
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "sexp";
+  version = "0.8.6";
+
+  src = fetchFromGitHub {
+    owner = "rnpgp";
+    repo = "sexp";
+    rev = "v${finalAttrs.version}";
+    hash = "sha256-NpDSoBxEM8g/SugLmT8E5+YZPDFIGHa4eXLjdzQxaiw=";
+  };
+
+  buildInputs = [ zlib bzip2 ];
+
+  cmakeFlags = [
+    "-DCMAKE_INSTALL_PREFIX=${placeholder "out"}"
+    "-DBUILD_SHARED_LIBS=on"
+    "-DWITH_SEXP_TESTS=on"
+    "-DDOWNLOAD_GTEST=off"
+    "-DWITH_SEXP_CLI=on"
+    "-DWITH_SANITIZERS=off"
+  ];
+
+  nativeBuildInputs = [ cmake gtest pkg-config ];
+
+  outputs = [ "out" "lib" "dev" ];
+
+  preConfigure = ''
+    echo "v${finalAttrs.version}" > version.txt
+  '';
+
+  meta = with lib; {
+    homepage = "https://github.com/rnpgp/sexp";
+    description = "S-expressions parser and generator C++ library, fully compliant to [https://people.csail.mit.edu/rivest/Sexp.txt]";
+    license = licenses.mit;
+    platforms = platforms.all;
+    maintainers = with maintainers; [ ribose-jeffreylau ];
+  };
+})

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -12453,6 +12453,8 @@ with pkgs;
 
   sewer = callPackage ../tools/admin/sewer { };
 
+  sexp = callPackage ../development/libraries/sexp { };
+
   sfeed = callPackage ../tools/misc/sfeed { };
 
   sftpman = callPackage ../tools/filesystems/sftpman { };


### PR DESCRIPTION
###### Description of changes

https://github.com/rnpgp/sexp

C++ Library for SEXP (S-expressions)

This is a dependency of the [next version](https://github.com/rnpgp/rnp/releases/tag/v0.17.0) of [rnp](https://github.com/NixOS/nixpkgs/blob/a04b45f10eddb02352574d95c7d0a76bfbfc11dc/pkgs/tools/security/rnp/default.nix#L17).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
