### PR TITLE
lib/path/tests: Add --show-trace

### DIFF
--- a/lib/path/tests/default.nix
+++ b/lib/path/tests/default.nix
@@ -24,8 +24,9 @@ pkgs.runCommand "lib-path-tests" {
   export TEST_LIB=$PWD/lib
 
   echo "Running unit tests lib/path/tests/unit.nix"
-  nix-instantiate --eval lib/path/tests/unit.nix \
-    --argstr libpath "$TEST_LIB"
+  nix-instantiate --eval --show-trace \
+    --argstr libpath "$TEST_LIB" \
+    lib/path/tests/unit.nix
 
   echo "Running property tests lib/path/tests/prop.sh"
   bash lib/path/tests/prop.sh ${toString seed}

--- a/lib/path/tests/prop.sh
+++ b/lib/path/tests/prop.sh
@@ -71,7 +71,7 @@ fi
 
 # Precalculate all normalisations with a single Nix call. Calling Nix for each
 # string individually would take way too long
-nix-instantiate --eval --strict --json \
+nix-instantiate --eval --strict --json --show-trace \
     --argstr libpath "$TEST_LIB" \
     --argstr dir "$tmp/strings" \
     "$SCRIPT_DIR"/prop.nix \


### PR DESCRIPTION
###### Description of changes

This should help troubleshoot errors.
Fyi --eval is just a flag, not an option with a value.

May help (when backported)
 - https://github.com/NixOS/nix/pull/8569

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
