### PR TITLE
pypy3.pkgs.watchdog: avoid eventlet dependency on pypy, cleanups

### DIFF
--- a/pkgs/development/python-modules/watchdog/default.nix
+++ b/pkgs/development/python-modules/watchdog/default.nix
@@ -3,9 +3,9 @@
 , buildPythonPackage
 , CoreServices
 , eventlet
-, fetchpatch
 , fetchPypi
 , flaky
+, isPyPy
 , pytest-timeout
 , pytestCheckHook
 , pythonOlder
@@ -39,10 +39,11 @@ buildPythonPackage rec {
   ];
 
   nativeCheckInputs = [
-    eventlet
     flaky
     pytest-timeout
     pytestCheckHook
+  ] ++ lib.optionals (!isPyPy) [
+    eventlet
   ] ++ passthru.optional-dependencies.watchmedo;
 
   postPatch = ''
@@ -54,7 +55,7 @@ buildPythonPackage rec {
   pytestFlagsArray = [
     "--deselect=tests/test_emitter.py::test_create_wrong_encoding"
     "--deselect=tests/test_emitter.py::test_close"
-  ] ++ lib.optionals (stdenv.isDarwin) [
+  ] ++ lib.optionals stdenv.isDarwin [
     # fails to stop process in teardown
     "--deselect=tests/test_0_watchmedo.py::test_auto_restart_subprocess_termination"
     # assert cap.out.splitlines(keepends=False).count('+++++ 0') == 2 != 3
@@ -89,7 +90,7 @@ buildPythonPackage rec {
   disabledTestPaths = [
     # tests timeout easily
     "tests/test_inotify_buffer.py"
-  ] ++ lib.optionals (stdenv.isDarwin) [
+  ] ++ lib.optionals stdenv.isDarwin [
     # segfaults the testsuite
     "tests/test_emitter.py"
     # unsupported on x86_64-darwin


### PR DESCRIPTION
eventlet does not support pypy

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
