### PR TITLE
nccl-tests: init at 2.13.6

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -7753,6 +7753,12 @@
     githubId = 2308444;
     name = "Joshua Gilman";
   };
+  jmillerpdt = {
+    email = "jcmiller@pdtpartners.com";
+    github = "jmillerpdt";
+    githubId = 54179289;
+    name = "Jason Miller";
+  };
   jnsgruk = {
     email = "jon@sgrs.uk";
     github = "jnsgruk";

--- a/pkgs/development/libraries/science/math/nccl/tests.nix
+++ b/pkgs/development/libraries/science/math/nccl/tests.nix
@@ -1,0 +1,54 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, which
+, cudaPackages
+, mpiSupport ? false
+, mpi
+}:
+
+assert mpiSupport -> mpi != null;
+
+with cudaPackages;
+
+cudaPackages.backendStdenv.mkDerivation rec {
+
+  pname = "nccl-tests";
+  version = "2.13.6";
+
+  src = fetchFromGitHub {
+    owner = "NVIDIA";
+    repo = pname;
+    rev = "v${version}";
+    hash = "sha256-3gSBQ0g6mnQ/MFXGflE+BqqrIUoiBgp8+fWRQOvLVkw=";
+  };
+
+  nativeBuildInputs = [ which cuda_nvcc ];
+
+  buildInputs = [
+    cuda_cudart
+    nccl
+  ] ++ lib.optional mpiSupport mpi;
+
+  makeFlags = [
+    "CUDA_HOME=${cudatoolkit}"
+    "NCCL_HOME=${nccl}"
+  ] ++ lib.optionals mpiSupport [
+    "MPI=1"
+  ];
+
+  enableParallelBuilding = true;
+
+  installPhase = ''
+    mkdir -p $out/bin
+    cp -r build/* $out/bin/
+  '';
+
+  meta = with lib; {
+    description = "Tests to check both the performance and the correctness of NVIDIA NCCL operations.";
+    homepage = "https://github.com/NVIDIA/nccl-tests";
+    platforms = [ "x86_64-linux" ];
+    license = licenses.bsd3;
+    maintainers = with maintainers; [ jmillerpdt ];
+  };
+}

--- a/pkgs/top-level/cuda-packages.nix
+++ b/pkgs/top-level/cuda-packages.nix
@@ -47,6 +47,8 @@ let
 
     nccl = final.callPackage ../development/libraries/science/math/nccl { };
 
+    nccl-tests = final.callPackage ../development/libraries/science/math/nccl/tests.nix { };
+
     autoAddOpenGLRunpathHook = final.callPackage ( { makeSetupHook, addOpenGLRunpath }:
       makeSetupHook {
         name = "auto-add-opengl-runpath-hook";


### PR DESCRIPTION
###### Description of changes

Adds tests to check both the performance and the correctness of NVIDIA NCCL operations.

Closes [Package request: nccl-tests#239212](https://github.com/NixOS/nixpkgs/issues/239212)

CC @NixOS/cuda-maintainers @ConnorBaker 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

```
$ nix-build --expr 'with (import ./. { config = { allowUnfree = true; cudaSupport = true; }; }).pkgs; cudaPackages.nccl-tests'
/nix/store/l6n4w81qnwb05fpjgg4dv3lnanb40z3g-nccl-tests-2.13.6
```
