### PR TITLE
gajim: 1.7.3 → 1.8.0

### DIFF
--- a/pkgs/applications/networking/instant-messengers/gajim/default.nix
+++ b/pkgs/applications/networking/instant-messengers/gajim/default.nix
@@ -15,18 +15,17 @@
 , enableRST ? true, docutils
 , enableSpelling ? true, gspell
 , enableUPnP ? true, gupnp-igd
-, enableOmemoPluginDependencies ? true
 , enableAppIndicator ? true, libappindicator-gtk3
 , extraPythonPackages ? ps: []
 }:
 
 python3.pkgs.buildPythonApplication rec {
   pname = "gajim";
-  version = "1.7.3";
+  version = "1.8.0";
 
   src = fetchurl {
     url = "https://gajim.org/downloads/${lib.versions.majorMinor version}/gajim-${version}.tar.gz";
-    hash = "sha256-t8yzWfdsY8pXye7Dn5hME0bOHgf+MzuyVY3hweXc0xg=";
+    hash = "sha256-EgH8mt0am2l9z4csGHH6rpLqTzFiBRzOPB4NCEP8TUM=";
   };
 
   format = "pyproject";
@@ -53,9 +52,9 @@ python3.pkgs.buildPythonApplication rec {
 
   propagatedBuildInputs = with python3.pkgs; [
     nbxmpp pygobject3 dbus-python pillow css-parser precis-i18n keyring setuptools packaging gssapi
+    omemo-dr qrcode
   ] ++ lib.optionals enableE2E [ pycrypto python-gnupg ]
     ++ lib.optional enableRST docutils
-    ++ lib.optionals enableOmemoPluginDependencies [ python-axolotl qrcode ]
     ++ extraPythonPackages python3.pkgs;
 
   nativeCheckInputs = [ xvfb-run dbus ];
@@ -75,7 +74,7 @@ python3.pkgs.buildPythonApplication rec {
     ${python3.interpreter} -m unittest discover -s test/common -v
   '';
 
-  # test are broken in 1.7.3
+  # test are broken in 1.7.3, 1.8.0
   doCheck = false;
 
   # necessary for wrapGAppsHook

--- a/pkgs/development/python-modules/nbxmpp/default.nix
+++ b/pkgs/development/python-modules/nbxmpp/default.nix
@@ -14,7 +14,7 @@
 
 buildPythonPackage rec {
   pname = "nbxmpp";
-  version = "4.2.2";
+  version = "4.3.1";
 
   disabled = pythonOlder "3.10";
 
@@ -23,7 +23,7 @@ buildPythonPackage rec {
     owner = "gajim";
     repo = "python-nbxmpp";
     rev = version;
-    hash = "sha256-ZTX8plcsO4zE7ruLtWIvsagQUvwPHuKdPKRwCrFwvgc=";
+    hash = "sha256-8Fh4sgQps6zUEN8o5ljrDIbRlbSZIMncbqh/qAnyOkw=";
   };
 
   format = "pyproject";

--- a/pkgs/development/python-modules/omemo-dr/default.nix
+++ b/pkgs/development/python-modules/omemo-dr/default.nix
@@ -1,0 +1,22 @@
+{ lib, buildPythonPackage, fetchPypi, cryptography, protobuf }:
+
+buildPythonPackage rec {
+  pname = "omemo-dr";
+  version = "1.0.0";
+
+  src = fetchPypi {
+    inherit pname version;
+    hash = "sha256-sP5QI+lHoXt0D7ftSqJGEg1vIdgZtYEulN/JVwUgvmE=";
+  };
+
+  propagatedBuildInputs = [
+    cryptography
+    protobuf
+  ];
+
+  meta = {
+    description = "OMEMO Double Ratchet";
+    license = lib.licenses.lgpl3;
+    homepage = "https://dev.gajim.org/gajim/omemo-dr/";
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -7061,6 +7061,8 @@ self: super: with self; {
 
   omegaconf = callPackage ../development/python-modules/omegaconf { };
 
+  omemo-dr = callPackage ../development/python-modules/omemo-dr { };
+
   ome-zarr = callPackage ../development/python-modules/ome-zarr { };
 
   omnikinverter = callPackage ../development/python-modules/omnikinverter { };


### PR DESCRIPTION
pythonPackages.nbxmpp: 4.2.2 → 4.3.1

pythonPackages.omemo-dr: init at 1.0.0

###### Description of changes

OMEMO is no longer a plug-in.

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
