### PR TITLE
neovim: add perl to supported providers

### DIFF
--- a/pkgs/applications/editors/neovim/utils.nix
+++ b/pkgs/applications/editors/neovim/utils.nix
@@ -175,6 +175,8 @@ let
       withPython3 ? true
     , withNodeJs ? false
     , withRuby ? true
+    # perl is problematic https://github.com/NixOS/nixpkgs/issues/132368
+    , withPerl ? false
 
     # so that we can pass the full neovim config while ignoring it
     , ...
@@ -184,6 +186,7 @@ let
         python = false;
         python3 = withPython3;
         ruby = withRuby;
+        perl = withPerl;
       };
 
       genProviderCommand = prog: withProg:

--- a/pkgs/applications/editors/neovim/wrapper.nix
+++ b/pkgs/applications/editors/neovim/wrapper.nix
@@ -6,6 +6,7 @@
 , callPackage
 , neovimUtils
 , vimUtils
+, perl
 }:
 neovim:
 
@@ -19,6 +20,7 @@ let
     , withPython2 ? false
     , withPython3 ? true,  python3Env ? python3
     , withNodeJs ? false
+    , withPerl ? false
     , rubyEnv ? null
     , vimAlias ? false
     , viAlias ? false
@@ -32,7 +34,7 @@ let
     # entry to load in packpath
     , packpathDirs
     , ...
-  }@args:
+  }:
   let
 
     wrapperArgsStr = if lib.isString wrapperArgs then wrapperArgs else lib.escapeShellArgs wrapperArgs;
@@ -50,8 +52,10 @@ let
           ]
           ;
 
-    providerLuaRc = neovimUtils.generateProviderRc args;
-    # providerLuaRc = "toto";
+    providerLuaRc = neovimUtils.generateProviderRc {
+      inherit withPython3 withNodeJs withPerl;
+      withRuby = rubyEnv != null;
+    };
 
     # If configure != {}, we can't generate the rplugin.vim file with e.g
     # NVIM_SYSTEM_RPLUGIN_MANIFEST *and* NVIM_RPLUGIN_MANIFEST env vars set in
@@ -85,6 +89,9 @@ let
       ''
       + lib.optionalString withNodeJs ''
         ln -s ${nodePackages.neovim}/bin/neovim-node-host $out/bin/nvim-node
+      ''
+      + lib.optionalString withPerl ''
+        ln -s ${perl}/bin/perl $out/bin/nvim-perl
       ''
       + lib.optionalString vimAlias ''
         ln -s $out/bin/nvim $out/bin/vim


### PR DESCRIPTION
false by default.
I noticed checkhealth complaining about it

Which made me realize the providers ignored user config and were always using default config when generating providers (because the `args` in `generateProviderRc args` didn't contain any withXXX parameter). It's a bad bug hence the backport. 

neovim.tests fail because of a neovim crash so I've not added any test but plan to improve that later.

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
