### PR TITLE
recyclarr: init at 5.1.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -8090,6 +8090,12 @@
     email = "j.loos@posteo.net";
     githubId = 57965027;
   };
+  josephst = {
+    name = "Joseph Stahl";
+    email = "hello@josephstahl.com";
+    github = "josephst";
+    githubId = 1269177;
+  };
   joshniemela = {
     name = "Joshua Niemelä";
     email = "josh@jniemela.dk";

--- a/pkgs/tools/video/recyclarr/default.nix
+++ b/pkgs/tools/video/recyclarr/default.nix
@@ -1,0 +1,88 @@
+{ lib
+, stdenv
+, fetchurl
+, makeWrapper
+, autoPatchelfHook
+, fixDarwinDylibNames
+, darwin
+, recyclarr
+, git
+, icu
+, testers
+, zlib
+}:
+let
+  os =
+    if stdenv.isDarwin
+    then "osx"
+    else "linux";
+
+  arch = {
+    x86_64-linux = "x64";
+    aarch64-linux = "arm64";
+    x86_64-darwin = "x64";
+    aarch64-darwin = "arm64";
+  }."${stdenv.hostPlatform.system}"
+    or (throw "Unsupported system: ${stdenv.hostPlatform.system}");
+
+  hash = {
+    x64-linux_hash = "sha256-aEcinTJlO++rTeyqGJea0TWtleH6fyooA8RhT0Qj24c=";
+    arm64-linux_hash = "sha256-9Gyk09zAGzahP8FCGxj037vaK8h++3M5R2Qqop99Gs4=";
+    x64-osx_hash = "sha256-c87eOZBz+RtbIi+dlXKKVMyPI8JqYDuiaL4xOkDRFn0=";
+    arm64-osx_hash = "sha256-zSHgLXRDB6UA7V0LFgLq9ChqB40IHIJJxRqAYyVFlB8=";
+  }."${arch}-${os}_hash";
+
+  libPath = {
+    osx = "DYLD_LIBRARY_PATH : ${lib.makeLibraryPath [darwin.ICU zlib]}";
+    linux = "LD_LIBRARY_PATH : ${lib.makeLibraryPath [icu zlib]}";
+  }."${os}";
+
+in
+stdenv.mkDerivation rec {
+  pname = "recyclarr";
+  version = "5.1.0";
+
+  src = fetchurl {
+    url = "https://github.com/recyclarr/recyclarr/releases/download/v${version}/recyclarr-${os}-${arch}.tar.xz";
+    inherit hash;
+  };
+
+  sourceRoot = ".";
+
+  nativeBuildInputs = [ makeWrapper ]
+    ++ lib.optional stdenv.isLinux autoPatchelfHook
+    ++ lib.optional stdenv.isDarwin fixDarwinDylibNames;
+  buildInputs = [ icu zlib ];
+
+  installPhase = ''
+    runHook preInstall
+
+    install -Dm755 recyclarr -t $out/bin
+
+    runHook postInstall
+  '';
+
+  postInstall = ''
+    wrapProgram $out/bin/recyclarr \
+      --prefix PATH : ${lib.makeBinPath [git]} \
+      --prefix ${libPath}
+  '';
+
+  dontStrip = true; # stripping messes up dotnet single-file deployment
+
+  passthru = {
+    updateScript = ./update.sh;
+    tests.version = testers.testVersion {
+      package = recyclarr;
+    };
+  };
+
+  meta = with lib; {
+    description = "Automatically sync TRaSH guides to your Sonarr and Radarr instances";
+    homepage = "https://recyclarr.dev/";
+    changelog = "https://github.com/recyclarr/recyclarr/releases/tag/v${version}";
+    license = licenses.mit;
+    maintainers = with maintainers; [ josephst ];
+    platforms = [ "x86_64-linux" "aarch64-linux" "x86_64-darwin" "aarch64-darwin" ];
+  };
+}

--- a/pkgs/tools/video/recyclarr/update.sh
+++ b/pkgs/tools/video/recyclarr/update.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env nix-shell
+#!nix-shell -I nixpkgs=./. -i bash -p curl jq common-updater-scripts gnused nix coreutils
+#shellcheck shell=bash
+
+set -euo pipefail
+
+latestVersion=$(curl -s ${GITHUB_TOKEN:+ -H "Authorization: Bearer $GITHUB_TOKEN"} https://api.github.com/repos/recyclarr/recyclarr/releases?per_page=1 \
+    | jq -r ".[0].tag_name" \
+    | sed 's/^v//')
+currentVersion=$(nix-instantiate --eval -E "with import ./. {}; recyclarr.version or (lib.getVersion recyclarr)" | tr -d '"')
+
+if [[ "$currentVersion" == "$latestVersion" ]]; then
+    echo "recyclarr is up-to-date: $currentVersion"
+    exit 0
+fi
+
+function get_hash() {
+    local os=$1
+    local arch=$2
+    local version=$3
+
+    local pkg_hash=$(nix-prefetch-url --type sha256 \
+        https://github.com/recyclarr/recyclarr/releases/download/v"${version}"/recyclarr-"${os}"-"${arch}".tar.xz)
+    nix hash to-sri "sha256:$pkg_hash"
+}
+
+# aarch64-darwin
+# reset version first so that all platforms are always updated and in sync
+update-source-version recyclarr 0 "sha256-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=" --system="aarch64-darwin"
+update-source-version recyclarr "$latestVersion" $(get_hash osx arm64 "$latestVersion") --system="aarch64-darwin"
+
+# x86_64-darwin
+# reset version first so that all platforms are always updated and in sync
+update-source-version recyclarr 0 "sha256-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=" --system="x86_64-darwin"
+update-source-version recyclarr "$latestVersion" $(get_hash osx x64 "$latestVersion") --system="x86_64-darwin"
+
+# aarch64-linux
+# reset version first so that all platforms are always updated and in sync
+update-source-version recyclarr 0 "sha256-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=" --system="aarch64-linux"
+update-source-version recyclarr "$latestVersion" $(get_hash linux arm64 "$latestVersion") --system="aarch64-linux"
+
+# x86_64-linux
+# reset version first so that all platforms are always updated and in sync
+update-source-version recyclarr 0 "sha256-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=" --system="x86_64-linux"
+update-source-version recyclarr "$latestVersion" $(get_hash linux x64 "$latestVersion") --system="x86_64-linux"
+

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6091,6 +6091,8 @@ with pkgs;
 
   replay-sorcery = callPackage ../tools/video/replay-sorcery { };
 
+  recyclarr = callPackage ../tools/video/recyclarr { };
+
   tsduck = callPackage ../tools/video/tsduck { };
 
   ripasso-cursive = callPackage ../tools/security/ripasso/cursive.nix {


### PR DESCRIPTION
adds Recyclarr, a CLI app for syncing settings to Sonarr & Radarr (usenet downloaders).

Closes #239851 

The binary is a single-file dotnet application, which includes a hard-coded dependence on `libicucore.dylib` on MacOS (https://github.com/dotnet/runtime/blob/1ffb77d7c5b5b380dfd8146858a044fadf6f21d4/src/native/libs/System.Globalization.Native/pal_icushim.c#L167)

This file is not included in the `icu` package;
therefore, it is necessary to add `darwin.ICU` to the search path on MacOS (with DYLD_LIBRARY_PATH)

###### Description of changes

[Recyclarr homepage](https://github.com/recyclarr/recyclarr)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - [x] and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
