### PR TITLE
tmate, tmate-ssh-server: update and use msgpack-c instead of msgpack

### DIFF
--- a/nixos/tests/tmate-ssh-server.nix
+++ b/nixos/tests/tmate-ssh-server.nix
@@ -24,6 +24,7 @@ in
         services.tmate-ssh-server = {
           enable = true;
           port = 2223;
+          openFirewall = true;
         };
       };
       client = { ... }: {

--- a/pkgs/servers/tmate-ssh-server/default.nix
+++ b/pkgs/servers/tmate-ssh-server/default.nix
@@ -10,26 +10,45 @@
 , libevent
 , ncurses
 , ruby
-, msgpack
+, msgpack-c
 , libssh
 , nixosTests
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation {
   pname = "tmate-ssh-server";
-  version = "unstable-2021-10-17";
+  version = "unstable-2023-06-02";
 
   src = fetchFromGitHub {
     owner = "tmate-io";
     repo = "tmate-ssh-server";
-    rev = "1f314123df2bb29cb07427ed8663a81c8d9034fd";
-    sha256 = "sha256-9/xlMvtkNWUBRYYnJx20qEgtEcjagH2NtEKZcDOM1BY=";
+    rev = "d7334ee4c3c8036c27fb35c7a24df3a88a15676b";
+    sha256 = "sha256-V3p0vagt13YjQPdqpbSatx5DnIEXL4t/kfxETSFYye0=";
   };
 
-  dontUseCmakeConfigure = true;
+  postPatch = ''
+    substituteInPlace configure.ac \
+      --replace 'msgpack >= 1.2.0' 'msgpack-c >= 1.2.0'
+  '';
 
-  buildInputs = [ libtool zlib openssl libevent ncurses ruby msgpack libssh ];
-  nativeBuildInputs = [ autoreconfHook cmake pkg-config ];
+  nativeBuildInputs = [
+    autoreconfHook
+    cmake
+    pkg-config
+  ];
+
+  buildInputs = [
+    libtool
+    zlib
+    openssl
+    libevent
+    ncurses
+    ruby
+    msgpack-c
+    libssh
+  ];
+
+  dontUseCmakeConfigure = true;
 
   passthru.tests.tmate-ssh-server = nixosTests.tmate-ssh-server;
 

--- a/pkgs/tools/misc/tmate/default.nix
+++ b/pkgs/tools/misc/tmate/default.nix
@@ -1,7 +1,20 @@
-{ lib, stdenv, fetchFromGitHub, autoreconfHook, cmake, libtool, pkg-config
-, zlib, openssl, libevent, ncurses, ruby, msgpack, libssh }:
+{ lib
+, stdenv
+, fetchFromGitHub
+, autoreconfHook
+, cmake
+, libtool
+, pkg-config
+, zlib
+, openssl
+, libevent
+, ncurses
+, ruby
+, msgpack-c
+, libssh
+}:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation {
   pname = "tmate";
   version = "unstable-2022-08-07";
 
@@ -12,10 +25,29 @@ stdenv.mkDerivation rec {
     sha256 = "sha256-t96gfmAMcsjkGf8pvbEx2fNx4Sj3W6oYoQswB3Dklb8=";
   };
 
-  dontUseCmakeConfigure = true;
+  postPatch = ''
+    substituteInPlace configure.ac \
+      --replace 'msgpack >= 1.1.0' 'msgpack-c >= 1.1.0'
+  '';
 
-  buildInputs = [ libtool zlib openssl libevent ncurses ruby msgpack libssh ];
-  nativeBuildInputs = [ autoreconfHook cmake pkg-config ];
+  nativeBuildInputs = [
+    autoreconfHook
+    cmake
+    pkg-config
+  ];
+
+  buildInputs = [
+    libtool
+    zlib
+    openssl
+    libevent
+    ncurses
+    ruby
+    msgpack-c
+    libssh
+  ];
+
+  dontUseCmakeConfigure = true;
 
   meta = with lib; {
     homepage    = "https://tmate.io/";


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
