### PR TITLE
sbt: 1.9.0 -> 1.9.1

### DIFF
--- a/pkgs/development/tools/build-managers/sbt/default.nix
+++ b/pkgs/development/tools/build-managers/sbt/default.nix
@@ -8,11 +8,11 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "sbt";
-  version = "1.9.0";
+  version = "1.9.1";
 
   src = fetchurl {
     url = "https://github.com/sbt/sbt/releases/download/v${finalAttrs.version}/sbt-${finalAttrs.version}.tgz";
-    hash = "sha256-zFWTSOr5z75s4i9omx5EDI4FtOSc1r6jmHZHd7N5SMQ=";
+    hash = "sha256-KcylFTzJYxXW5CN3flgAuDHkVyO0dzLCB6Zu+lyk/Cs=";
   };
 
   postPatch = ''


### PR DESCRIPTION
###### Description of changes

Bump sbt version from 1.9.0 to 1.9.1 following yesterday's release https://github.com/sbt/sbt/releases/tag/v1.9.1

No change to release note for 23.11 as it's only a fix release.

<details>
<summary>Local build log on `x86_64-ps-linux`</summary>

```
$ nix-build -A sbt

this derivation will be built:
  /nix/store/jzp7jvl74sii5jpwfs55b8hb8k5xp394-sbt-1.9.1.drv
building '/nix/store/jzp7jvl74sii5jpwfs55b8hb8k5xp394-sbt-1.9.1.drv'...
unpacking sources
unpacking source archive /nix/store/vw2bxl30kr05aigs1iipnarszzvgcb05-sbt-1.9.1.tgz
source root is sbt
setting SOURCE_DATE_EPOCH to timestamp 1687753375 of file sbt/conf/sbtopts
patching sources
configuring
no configure script, doing nothing
building
no Makefile or custom buildPhase, doing nothing
installing
post-installation fixup
shrinking RPATHs of ELF executables and libraries in /nix/store/fjvf1jigi8qa3lilgfmd44k2bwbry2ql-sbt-1.9.1
shrinking /nix/store/fjvf1jigi8qa3lilgfmd44k2bwbry2ql-sbt-1.9.1/share/sbt/bin/sbtn-x86_64-pc-linux
shrinking /nix/store/fjvf1jigi8qa3lilgfmd44k2bwbry2ql-sbt-1.9.1/share/sbt/bin/sbtn-aarch64-pc-linux
checking for references to /build/ in /nix/store/fjvf1jigi8qa3lilgfmd44k2bwbry2ql-sbt-1.9.1...
patching script interpreter paths in /nix/store/fjvf1jigi8qa3lilgfmd44k2bwbry2ql-sbt-1.9.1
/nix/store/fjvf1jigi8qa3lilgfmd44k2bwbry2ql-sbt-1.9.1/share/sbt/bin/sbt: interpreter directive changed from "#!/usr/bin/env bash" to "/nix/store/mh1c3p23xby3chc3q0c0g78fa1nn65yw-bash-5.2-p15/bin/bash"
stripping (with command strip and flags -S -p) in  /nix/store/fjvf1jigi8qa3lilgfmd44k2bwbry2ql-sbt-1.9.1/bin
automatically fixing dependencies for ELF files
{'append_rpaths': [],
 'ignore_missing': [],
 'libs': [PosixPath('/nix/store/wgzhw8dxciginyalxf1ikqpdihnlhqyb-auto-patchelf-hook/lib'),
          PosixPath('/nix/store/8kfx5qh4kraggz5ssymijf23za7cn062-binutils-wrapper-2.40/lib'),
          PosixPath('/nix/store/qnhxqzl7m0zkxqvcva3ws0rnki4bwyky-patchelf-0.15.0/lib'),
          PosixPath('/nix/store/h9lc1dpi14z7is86ffhl3ld569138595-audit-tmpdir.sh/lib'),
          PosixPath('/nix/store/m54bmrhj6fqz8nds5zcj97w9s9bckc9v-compress-man-pages.sh/lib'),
          PosixPath('/nix/store/wgrbkkaldkrlrni33ccvm3b6vbxzb656-make-symlinks-relative.sh/lib'),
          PosixPath('/nix/store/5yzw0vhkyszf2d179m0qfkgxmp5wjjx4-move-docs.sh/lib'),
          PosixPath('/nix/store/fyaryjvghbkpfnsyw97hb3lyb37s1pd6-move-lib64.sh/lib'),
          PosixPath('/nix/store/kd4xwxjpjxi71jkm6ka0np72if9rm3y0-move-sbin.sh/lib'),
          PosixPath('/nix/store/pag6l61paj1dc9sv15l7bm5c17xn5kyk-move-systemd-user-units.sh/lib'),
          PosixPath('/nix/store/bxsly8a56yb8kyrq03s82a3vyc8fqrb3-multiple-outputs.sh/lib'),
          PosixPath('/nix/store/nf1lkdrhapsx5lr6diyxyjr7pb7r20gr-patch-shebangs.sh/lib'),
          PosixPath('/nix/store/cickvswrvann041nqxb0rxilc46svw1n-prune-libtool-files.sh/lib'),
          PosixPath('/nix/store/xyff06pkhki3qy1ls77w10s0v79c9il0-reproducible-builds.sh/lib'),
          PosixPath('/nix/store/ngg1cv31c8c7bcm2n8ww4g06nq7s4zhm-set-source-date-epoch-to-latest.sh/lib'),
          PosixPath('/nix/store/a9ndjg0b1ivi0av9m93vfkrndp7fqbw1-strip.sh/lib'),
          PosixPath('/nix/store/8phn3d072kcfvwvf6p5ys8pk8yxh236x-gcc-wrapper-12.3.0/lib'),
          PosixPath('/nix/store/h38wry0vp16pr5bk3iykaf1bhsgm8zyp-binutils-wrapper-2.40/lib'),
          PosixPath('/nix/store/sa3kirarbizwzyz36j8cbac2kgyh28yk-gcc-12.3.0/lib'),
          PosixPath('/nix/store/75622q2wranjp6zl81ldq5j54s788dqz-gcc-12.3.0-lib/lib'),
          PosixPath('/nix/store/w99lhkib7z3hx9lcmlz17apzcm1qpsr7-zlib-1.2.13-dev/lib'),
          PosixPath('/nix/store/s9zl0rv45yc3ymx61q6n97c3l7196pq4-zlib-1.2.13/lib'),
          PosixPath('/nix/store/wgzhw8dxciginyalxf1ikqpdihnlhqyb-auto-patchelf-hook/lib'),
          PosixPath('/nix/store/8kfx5qh4kraggz5ssymijf23za7cn062-binutils-wrapper-2.40/lib'),
          PosixPath('/nix/store/qnhxqzl7m0zkxqvcva3ws0rnki4bwyky-patchelf-0.15.0/lib'),
          PosixPath('/nix/store/h9lc1dpi14z7is86ffhl3ld569138595-audit-tmpdir.sh/lib'),
          PosixPath('/nix/store/m54bmrhj6fqz8nds5zcj97w9s9bckc9v-compress-man-pages.sh/lib'),
          PosixPath('/nix/store/wgrbkkaldkrlrni33ccvm3b6vbxzb656-make-symlinks-relative.sh/lib'),
          PosixPath('/nix/store/5yzw0vhkyszf2d179m0qfkgxmp5wjjx4-move-docs.sh/lib'),
          PosixPath('/nix/store/fyaryjvghbkpfnsyw97hb3lyb37s1pd6-move-lib64.sh/lib'),
          PosixPath('/nix/store/kd4xwxjpjxi71jkm6ka0np72if9rm3y0-move-sbin.sh/lib'),
          PosixPath('/nix/store/pag6l61paj1dc9sv15l7bm5c17xn5kyk-move-systemd-user-units.sh/lib'),
          PosixPath('/nix/store/bxsly8a56yb8kyrq03s82a3vyc8fqrb3-multiple-outputs.sh/lib'),
          PosixPath('/nix/store/nf1lkdrhapsx5lr6diyxyjr7pb7r20gr-patch-shebangs.sh/lib'),
          PosixPath('/nix/store/cickvswrvann041nqxb0rxilc46svw1n-prune-libtool-files.sh/lib'),
          PosixPath('/nix/store/xyff06pkhki3qy1ls77w10s0v79c9il0-reproducible-builds.sh/lib'),
          PosixPath('/nix/store/ngg1cv31c8c7bcm2n8ww4g06nq7s4zhm-set-source-date-epoch-to-latest.sh/lib'),
          PosixPath('/nix/store/a9ndjg0b1ivi0av9m93vfkrndp7fqbw1-strip.sh/lib'),
          PosixPath('/nix/store/8phn3d072kcfvwvf6p5ys8pk8yxh236x-gcc-wrapper-12.3.0/lib'),
          PosixPath('/nix/store/h38wry0vp16pr5bk3iykaf1bhsgm8zyp-binutils-wrapper-2.40/lib'),
          PosixPath('/nix/store/sa3kirarbizwzyz36j8cbac2kgyh28yk-gcc-12.3.0/lib'),
          PosixPath('/nix/store/75622q2wranjp6zl81ldq5j54s788dqz-gcc-12.3.0-lib/lib'),
          PosixPath('/nix/store/w99lhkib7z3hx9lcmlz17apzcm1qpsr7-zlib-1.2.13-dev/lib'),
          PosixPath('/nix/store/s9zl0rv45yc3ymx61q6n97c3l7196pq4-zlib-1.2.13/lib')],
 'paths': [PosixPath('/nix/store/fjvf1jigi8qa3lilgfmd44k2bwbry2ql-sbt-1.9.1')],
 'recursive': True,
 'runtime_dependencies': []}
setting interpreter of /nix/store/fjvf1jigi8qa3lilgfmd44k2bwbry2ql-sbt-1.9.1/share/sbt/bin/sbtn-x86_64-pc-linux
searching for dependencies of /nix/store/fjvf1jigi8qa3lilgfmd44k2bwbry2ql-sbt-1.9.1/share/sbt/bin/sbtn-x86_64-pc-linux
    libstdc++.so.6 -> found: /nix/store/75622q2wranjp6zl81ldq5j54s788dqz-gcc-12.3.0-lib/lib
    libz.so.1 -> found: /nix/store/s9zl0rv45yc3ymx61q6n97c3l7196pq4-zlib-1.2.13/lib
setting RPATH to: /nix/store/75622q2wranjp6zl81ldq5j54s788dqz-gcc-12.3.0-lib/lib:/nix/store/s9zl0rv45yc3ymx61q6n97c3l7196pq4-zlib-1.2.13/lib
skipping /nix/store/fjvf1jigi8qa3lilgfmd44k2bwbry2ql-sbt-1.9.1/share/sbt/bin/sbtn-aarch64-pc-linux because its architecture (AArch64) differs from target (x64)
auto-patchelf: 0 dependencies could not be satisfied
/nix/store/fjvf1jigi8qa3lilgfmd44k2bwbry2ql-sbt-1.9.1
```

</details>

<details>
<summary>Local `nixpkgs-review` log</summary>

```
$ nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"

this path will be fetched (0.04 MiB download, 0.14 MiB unpacked):
  /nix/store/vpqi3pk18c23fxpx3mj956ij6a59i35q-nixpkgs-review-2.9.2
copying path '/nix/store/vpqi3pk18c23fxpx3mj956ij6a59i35q-nixpkgs-review-2.9.2' from 'https://cache.nixos.org'...
$ git -c fetch.prune=false fetch --no-tags --force https://github.com/NixOS/nixpkgs master:refs/nixpkgs-review/0
remote: Enumerating objects: 5566, done.
remote: Counting objects: 100% (3484/3484), done.
remote: Compressing objects: 100% (404/404), done.
remote: Total 5566 (delta 3204), reused 3258 (delta 3051), pack-reused 2082
Receiving objects: 100% (5566/5566), 5.81 MiB | 19.71 MiB/s, done.
Resolving deltas: 100% (3945/3945), completed with 1120 local objects.
From https://github.com/NixOS/nixpkgs
 * [new branch]              master     -> refs/nixpkgs-review/0
$ git worktree add /home/wahtique/.cache/nixpkgs-review/rev-3fffef22c308f2d717589a09134a9fd23615b755/nixpkgs 1fab0a6526d0be9e091f18b9d4ace330a726a45e
Preparing worktree (detached HEAD 1fab0a6526d)
Updating files: 100% (35795/35795), done.
HEAD is now at 1fab0a6526d Merge pull request #240077 from bobby285271/upd/pantheon
$ nix-env --extra-experimental-features no-url-literals --option system x86_64-linux -f /home/wahtique/.cache/nixpkgs-review/rev-3fffef22c308f2d717589a09134a9fd23615b755/nixpkgs -qaP --xml --out-path --show-trace --no-allow-import-from-derivation
$ git merge --no-commit --no-ff 3fffef22c308f2d717589a09134a9fd23615b755
Automatic merge went well; stopped before committing as requested
$ nix-env --extra-experimental-features no-url-literals --option system x86_64-linux -f /home/wahtique/.cache/nixpkgs-review/rev-3fffef22c308f2d717589a09134a9fd23615b755/nixpkgs -qaP --xml --out-path --show-trace --no-allow-import-from-derivation --meta
2 packages updated:
sbt-with-scala-native (1.9.0 → 1.9.1) sbt (1.9.0 → 1.9.1)

$ nix build --extra-experimental-features nix-command no-url-literals --no-link --keep-going --no-allow-import-from-derivation --option build-use-sandbox relaxed -f /home/wahtique/.cache/nixpkgs-review/rev-3fffef22c308f2d717589a09134a9fd23615b755/build.nix
2 packages built:
sbt sbt-with-scala-native

warning: The interpretation of store paths arguments ending in `.drv` recently changed. If this command is now failing try again with '/nix/store/2sfnymhhilljm0dbfigqd42yai3c4k59-sbt-1.9.1.drv^*'
warning: The interpretation of store paths arguments ending in `.drv` recently changed. If this command is now failing try again with '/nix/store/2j6di7znkdlmv1gw83pv5hdyh3rp20hp-sbt-1.9.1.drv^*'
$ /nix/store/sb6085v95h0ndaqxfyx3nfny0jsl34nx-nix-2.15.1/bin/nix-shell /home/wahtique/.cache/nixpkgs-review/rev-3fffef22c308f2d717589a09134a9fd23615b755/shell.nix

[nix-shell:~/.cache/nixpkgs-review/rev-3fffef22c308f2d717589a09134a9fd23615b755]$ 
```

</details>

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
