### PR TITLE
rofi-pass: 2.0.2 -> unstable-2023-07-04 and init rofi-pass-wayland

### DIFF
--- a/pkgs/tools/security/pass/rofi-pass.nix
+++ b/pkgs/tools/security/pass/rofi-pass.nix
@@ -1,16 +1,41 @@
-{ lib, stdenv, fetchFromGitHub, pass, rofi, coreutils, util-linux, xdotool, gnugrep
-, libnotify, pwgen, findutils, gawk, gnused, xclip, makeWrapper
+{ lib
+, stdenv
+, fetchFromGitHub
+, makeWrapper
+, unstableGitUpdater
+, coreutils
+, util-linux
+, gnugrep
+, libnotify
+, pwgen
+, findutils
+, gawk
+, gnused
+# wayland-only deps
+, rofi-wayland
+, pass-wayland
+, wl-clipboard
+, wtype
+# x11-only deps
+, rofi
+, pass
+, xclip
+, xdotool
+# backend selector
+, backend ? "x11"
 }:
 
-stdenv.mkDerivation rec {
+assert lib.assertOneOf "backend" backend [ "x11" "wayland" ];
+
+stdenv.mkDerivation {
   pname = "rofi-pass";
-  version = "2.0.2";
+  version = "unstable-2023-07-04";
 
   src = fetchFromGitHub {
     owner = "carnager";
     repo = "rofi-pass";
-    rev = version;
-    sha256 = "131jpcwyyzgzjn9lx4k1zn95pd68pjw4i41jfzcp9z9fnazyln5n";
+    rev = "fa16c0211d898d337e76397d22de4f92e2405ede";
+    hash = "sha256-GGa8ZNHZZD/sU+oL5ekHXxAe3bpX/42x6zO2LJuypNw=";
   };
 
   nativeBuildInputs = [ makeWrapper ];
@@ -25,32 +50,43 @@ stdenv.mkDerivation rec {
     cp -a config.example $out/share/doc/rofi-pass/config.example
   '';
 
-  wrapperPath = with lib; makeBinPath [
+  wrapperPath = lib.makeBinPath ([
     coreutils
     findutils
     gawk
     gnugrep
     gnused
     libnotify
-    (pass.withExtensions (ext: [ ext.pass-otp ]))
     pwgen
-    rofi
     util-linux
+  ] ++ lib.optionals (backend == "x11") [
+    rofi
+    (pass.withExtensions (ext: [ ext.pass-otp ]))
     xclip
     xdotool
-  ];
+  ] ++ lib.optionals (backend == "wayland") [
+    rofi-wayland
+    (pass-wayland.withExtensions (ext: [ ext.pass-otp ]))
+    wl-clipboard
+    wtype
+  ]);
 
   fixupPhase = ''
     patchShebangs $out/bin
 
     wrapProgram $out/bin/rofi-pass \
-      --prefix PATH : "${wrapperPath}"
+      --prefix PATH : "$wrapperPath" \
+      --set-default ROFI_PASS_BACKEND ${if backend == "wayland" then "wtype" else "xdotool"} \
+      --set-default ROFI_PASS_CLIPBOARD_BACKEND ${if backend == "wayland" then "wl-clipboard" else "xclip"}
   '';
+
+  passthru.updateScript = unstableGitUpdater { };
 
   meta = {
     description = "A script to make rofi work with password-store";
     homepage = "https://github.com/carnager/rofi-pass";
     license = lib.licenses.gpl3;
     platforms = with lib.platforms; linux;
+    maintainers = with lib.maintainers; [ lilyinstarlight ];
   };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -34259,6 +34259,9 @@ with pkgs;
   };
 
   rofi-pass = callPackage ../tools/security/pass/rofi-pass.nix { };
+  rofi-pass-wayland = callPackage ../tools/security/pass/rofi-pass.nix {
+    backend = "wayland";
+  };
 
   rofi-menugen = callPackage ../applications/misc/rofi-menugen { };
 


### PR DESCRIPTION
###### Description of changes

Updates rofi-pass to the latest unstable version (since it's been a long while since release and there have since been fixes) and adds native wayland support through upstream PR carnager/rofi-pass#231

Wayland rofi-pass can be selected via the `rofi-pass-wayland` package attribute in addition to the existing X11 `rofi-pass` attribute

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).