### PR TITLE
Optionally install training data with libpostal

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -1745,7 +1745,8 @@
     email = "baduhai@pm.me";
     github = "baduhai";
     githubId = 31864305;
-    name = "William";
+    matrix = "@baduhai:matrix.org";
+    name = "William Hai";
   };
   baitinq = {
     email = "manuelpalenzuelamerino@gmail.com";

--- a/pkgs/development/libraries/libpostal/default.nix
+++ b/pkgs/development/libraries/libpostal/default.nix
@@ -1,6 +1,37 @@
-{ lib, stdenv, fetchFromGitHub, autoreconfHook }:
+{ lib, stdenv, fetchFromGitHub, autoreconfHook, withData ? false, fetchzip }:
+let
+  # languageClassifier, libpostalData and parser were not release for libpostal 1.1, using data from 1.0 instead.
+  languageClassifier = fetchzip {
+    url = "https://github.com/openvenues/libpostal/releases/download/v1.0.0/language_classifier.tar.gz";
+    sha256 = "sha256-/Gn931Nx4UDBaiFUgGqC/NJUIKQ5aZT/+OYSlcfXva8=";
+    stripRoot = false;
+  };
 
-stdenv.mkDerivation rec {
+  libpostalData = fetchzip {
+    url = "https://github.com/openvenues/libpostal/releases/download/v1.0.0/libpostal_data.tar.gz";
+    sha256 = "sha256-FpGCkkRhVzyr08YcO0/iixxw0RK+3Of0sv/DH3GbbME=";
+    stripRoot = false;
+  };
+
+  parser = fetchzip {
+    url = "https://github.com/openvenues/libpostal/releases/download/v1.0.0/parser.tar.gz";
+    sha256 = "sha256-OHETb3e0GtVS2b4DgklKDlrE/8gxF7XZ3FwmCTqZbqQ=";
+    stripRoot = false;
+  };
+
+  data = stdenv.mkDerivation {
+    name = "libpostal-data";
+    buildCommand = ''
+      mkdir -p $out/data/libpostal
+
+      ln -s ${languageClassifier}/language_classifier   $out/data/libpostal/languageClassifier
+      ln -s ${libpostalData}/transliteration            $out/data/libpostal/transliteration
+      ln -s ${libpostalData}/numex                      $out/data/libpostal/numex
+      ln -s ${libpostalData}/address_expansions         $out/data/libpostal/address_expansions
+      ln -s ${parser}/address_parser                    $out/data/libpostal/address_parser
+    '';
+  };
+in stdenv.mkDerivation rec {
   pname = "libpostal";
   version = "1.1";
 
@@ -13,9 +44,9 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ autoreconfHook ];
 
-  configureFlags = [
-    "--disable-data-download"
-  ] ++ lib.optionals stdenv.hostPlatform.isAarch64 [ "--disable-sse2" ];
+  configureFlags = [ "--disable-data-download" ]
+    ++ lib.optionals stdenv.hostPlatform.isAarch64 [ "--disable-sse2" ]
+    ++ lib.optionals withData [ "--datadir=${data}/data" ];
 
   meta = with lib; {
     description = "A C library for parsing/normalizing street addresses around the world. Powered by statistical NLP and open geo data";

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -22733,6 +22733,7 @@ with pkgs;
   libpng12 = callPackage ../development/libraries/libpng/12.nix { };
 
   libpostal = callPackage ../development/libraries/libpostal { };
+  libpostalWithData = callPackage ../development/libraries/libpostal { withData = true; };
 
   libpaper = callPackage ../development/libraries/libpaper { };
 


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Continues the work done in PR [#179613](https://github.com/NixOS/nixpkgs/pull/179613) and fixes issue [#38024](https://github.com/NixOS/nixpkgs/issues/38024).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

@Thra11 since withData is now an optional argument, closure size is only impacted when libpostalWithData is installed.
