### PR TITLE
teller: init at 1.5.6

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -17263,6 +17263,15 @@
     githubId = 5228243;
     name = "waelwindows";
   };
+  wahtique = {
+    name = "William Veal Phan";
+    email = "williamvphan@yahoo.fr";
+    github = "wahtique";
+    githubId = 55251330;
+    keys = [{
+      fingerprint = "9262 E3A7 D129 C4DD A7C1  26CE 370D D9BE 9121 F0B3";
+    }];
+  };
   waiting-for-dev = {
     email = "marc@lamarciana.com";
     github = "waiting-for-dev";

--- a/pkgs/development/tools/teller/default.nix
+++ b/pkgs/development/tools/teller/default.nix
@@ -1,0 +1,68 @@
+{ lib, buildGoModule, fetchFromGitHub, nix-update-script }:
+let
+  pname = "teller";
+  version = "1.5.6";
+  date = "2022-10-13";
+in
+buildGoModule {
+  inherit pname version;
+
+  src = fetchFromGitHub {
+    owner = "tellerops";
+    repo = pname;
+    rev = "v${version}";
+    hash = "sha256-vgrfWKKXf4C4qkbGiB3ndtJy1VyTx2NJs2QiOSFFZkE=";
+  };
+
+  vendorHash = null;
+
+  # use make instead of default checks because e2e does not work with `buildGoDir`
+  checkPhase = ''
+    runHook preCheck
+    # We do not set trimpath for tests, in case they reference test assets
+    export GOFLAGS=''${GOFLAGS//-trimpath/}
+
+    make test
+
+    # e2e tests can fail on first try
+
+    max_iteration=3
+    for i in $(seq 1 $max_iteration)
+    do
+      make e2e
+      result=$?
+      if [[ $result -eq 0 ]]
+      then
+        echo "e2e tests passed"
+        break
+      else
+        echo "e2e tests failed, retrying..."
+        sleep 1
+      fi
+    done
+
+    if [[ $result -ne 0 ]]
+    then
+      echo "e2e tests failed after $max_iteration attempts"
+    fi
+
+    runHook postCheck
+  '';
+
+  passthru.updateScript = nix-update-script { };
+
+  ldflags = [
+    "-s"
+    "-w"
+    "-X main.version=${version}"
+    "-X main.commit=${version}"
+    "-X main.date=${date}"
+  ];
+
+  meta = with lib; {
+    homepage = "https://github.com/tellerops/teller/";
+    description = "Cloud native secrets management for developers";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ wahtique ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -17881,6 +17881,8 @@ with pkgs;
 
   phpunit = callPackage ../development/tools/misc/phpunit { };
 
+  teller = callPackage ../development/tools/teller { };
+
   ### DEVELOPMENT / TOOLS / LANGUAGE-SERVERS
 
   ansible-language-server = callPackage ../development/tools/language-servers/ansible-language-server { };


### PR DESCRIPTION
###### Description of changes

Add package [teller](https://github.com/tellerops/teller/) v1.5.6 in development/tools.
Built as a Go module with overriden checkPhase because their e2e breaks otherwise. Those also seemingly fail at random hence the dirty retry around make e2e.
Not 100% sure if I missed something as it's my first package. Please review :)

Second try after pinging the whole world on a rebase gone wrong in 
https://github.com/NixOS/nixpkgs/pull/240158 ( sorry )

<details>
<summary>Local build logs on `x86_64-pc-linux`</summary>

```
$ nix-build -A teller && ./result/bin/teller version

this derivation will be built:
  /nix/store/yrgk81394nb66y8a32ahz4r6r3bxzdpd-teller-1.5.6.drv
building '/nix/store/yrgk81394nb66y8a32ahz4r6r3bxzdpd-teller-1.5.6.drv'...
unpacking sources
unpacking source archive /nix/store/k2a5p5j67lwvlxzcj4wbqbnci7n3glx2-source
source root is source
patching sources
configuring
building
Building subPackage .
Building subPackage ./e2e
github.com/spectralops/teller/e2e: no non-test Go files in /build/source/e2e
Building subPackage ./e2e/register
Building subPackage ./e2e/tests
Building subPackage ./e2e/testutils
Building subPackage ./pkg
Building subPackage ./pkg/core
Building subPackage ./pkg/integration_test
package github.com/spectralops/teller/pkg/integration_test: build constraints exclude all Go files in /build/source/pkg/integration_test
Building subPackage ./pkg/logging
Building subPackage ./pkg/providers
Building subPackage ./pkg/providers/mock_providers
Building subPackage ./pkg/utils
running tests
go test -v ./pkg/... -cover
=== RUN   TestPorcelainNonInteractive
--- PASS: TestPorcelainNonInteractive (0.00s)
=== RUN   TestPorcelainPrintDrift
--- PASS: TestPorcelainPrintDrift (0.00s)
=== RUN   TestGetProvider
--- PASS: TestGetProvider (0.00s)
=== RUN   TestRedactorOverlap
--- PASS: TestRedactorOverlap (0.00s)
=== RUN   TestRedactorMultiple
--- PASS: TestRedactorMultiple (0.00s)
=== RUN   TestRedactor
--- PASS: TestRedactor (0.00s)
=== RUN   TestTellerExports
--- PASS: TestTellerExports (0.00s)
=== RUN   TestTellerShExportEscaped
--- PASS: TestTellerShExportEscaped (0.00s)
=== RUN   TestTellerCollect
--- PASS: TestTellerCollect (0.00s)
=== RUN   TestTellerCollectWithSync
--- PASS: TestTellerCollectWithSync (0.00s)
=== RUN   TestTellerCollectWithErrors
--- PASS: TestTellerCollectWithErrors (0.00s)
=== RUN   TestTellerPorcelainNonInteractive
--- PASS: TestTellerPorcelainNonInteractive (0.00s)
=== RUN   TestTellerEntriesOutputSort
--- PASS: TestTellerEntriesOutputSort (0.00s)
=== RUN   TestTellerDrift
--- PASS: TestTellerDrift (0.00s)
=== RUN   TestTellerMirrorDrift
--- PASS: TestTellerMirrorDrift (0.00s)
=== RUN   TestTellerSync
Synced target (../fixtures/sync/target.env): OK.
Synced target2 (../fixtures/sync/target2.env): OK.
--- PASS: TestTellerSync (0.00s)
=== RUN   TestTemplateFile
--- PASS: TestTemplateFile (0.00s)
=== RUN   TestTemplateFolder
/build/test-template2910698344/to
--- PASS: TestTemplateFolder (0.00s)
=== RUN   TestTellerDelete
--- PASS: TestTellerDelete (0.00s)
=== RUN   TestTellerDeleteAll
--- PASS: TestTellerDeleteAll (0.00s)
=== RUN   TestTemplating
--- PASS: TestTemplating (0.00s)
PASS
        github.com/spectralops/teller/pkg       coverage: 54.0% of statements
ok      github.com/spectralops/teller/pkg       0.019s  coverage: 54.0% of statements
=== RUN   TestPopulatePath
--- PASS: TestPopulatePath (0.00s)
=== RUN   TestPopulateDefaultValue
--- PASS: TestPopulateDefaultValue (0.00s)
PASS
        github.com/spectralops/teller/pkg/core  coverage: 42.9% of statements
ok      github.com/spectralops/teller/pkg/core  0.004s  coverage: 42.9% of statements
=== RUN   TestSetOutput
--- PASS: TestSetOutput (0.00s)
=== RUN   TestJSONFormat
--- PASS: TestJSONFormat (0.00s)
=== RUN   TestTextFormat
--- PASS: TestTextFormat (0.00s)
=== RUN   TestWithFields
--- PASS: TestWithFields (0.00s)
=== RUN   TestWithField
--- PASS: TestWithField (0.00s)
=== RUN   TestWithError
--- PASS: TestWithError (0.00s)
=== RUN   TestLevelSetter
--- PASS: TestLevelSetter (0.00s)
PASS
        github.com/spectralops/teller/pkg/logging       coverage: 51.3% of statements
ok      github.com/spectralops/teller/pkg/logging       0.004s  coverage: 51.3% of statements
?       github.com/spectralops/teller/pkg/providers/mock_providers      [no test files]
?       github.com/spectralops/teller/pkg/utils [no test files]
=== RUN   TestAWSSecretsManager
--- PASS: TestAWSSecretsManager (0.00s)
=== RUN   TestAWSSecretsManagerFailures
--- PASS: TestAWSSecretsManagerFailures (0.00s)
=== RUN   TestAWSSSM
--- PASS: TestAWSSSM (0.00s)
=== RUN   TestAWSSSMFailures
--- PASS: TestAWSSSMFailures (0.00s)
=== RUN   TestAzureKeyVault
--- PASS: TestAzureKeyVault (0.00s)
=== RUN   TestAzureKeyVaultFailures
--- PASS: TestAzureKeyVaultFailures (0.00s)
=== RUN   TestCloudflareWorkersKV
--- PASS: TestCloudflareWorkersKV (0.00s)
=== RUN   TestCloudflareReadWorkersKVFailures
--- PASS: TestCloudflareReadWorkersKVFailures (0.00s)
=== RUN   TestCloudflareListWorkersKVsFailures
--- PASS: TestCloudflareListWorkersKVsFailures (0.00s)
=== RUN   TestCloudflareWorkersSecretsPut
--- PASS: TestCloudflareWorkersSecretsPut (0.00s)
=== RUN   TestCloudflareWorkersSecretsDelete
--- PASS: TestCloudflareWorkersSecretsDelete (0.00s)
=== RUN   TestConsul
--- PASS: TestConsul (0.00s)
=== RUN   TestConsulFailures
--- PASS: TestConsulFailures (0.00s)
=== RUN   TestDoppler
--- PASS: TestDoppler (0.00s)
=== RUN   TestDotenv
--- PASS: TestDotenv (0.00s)
=== RUN   TestDotenvFailures
--- PASS: TestDotenvFailures (0.00s)
=== RUN   TestEtcd
--- PASS: TestEtcd (0.00s)
=== RUN   TestEtcdFailures
--- PASS: TestEtcdFailures (0.00s)
=== RUN   TestGenerateProvidersMetaJSON
--- PASS: TestGenerateProvidersMetaJSON (0.00s)
=== RUN   TestFileSystem
--- PASS: TestFileSystem (0.00s)
=== RUN   TestFileSystemSetEntry
--- PASS: TestFileSystemSetEntry (0.00s)
=== RUN   TestFileSystemDeleteEntry
--- PASS: TestFileSystemDeleteEntry (0.00s)
=== RUN   TestGitHubPut
--- PASS: TestGitHubPut (0.00s)
=== RUN   TestGitHubPutMapping
--- PASS: TestGitHubPutMapping (0.00s)
=== RUN   TestGitHubDelete
--- PASS: TestGitHubDelete (0.00s)
=== RUN   TestGitHubDeleteMaping
--- PASS: TestGitHubDeleteMaping (0.00s)
=== RUN   TestGitHubDeleteMapingWithError
--- PASS: TestGitHubDeleteMapingWithError (0.00s)
=== RUN   TestParsePathToOwnerAndRepo
--- PASS: TestParsePathToOwnerAndRepo (0.00s)
=== RUN   TestGoogleSM
--- PASS: TestGoogleSM (0.00s)
=== RUN   TestGoogleSMFailures
--- PASS: TestGoogleSMFailures (0.00s)
=== RUN   TestGopass
--- PASS: TestGopass (0.00s)
=== RUN   TestGopassFailures
--- PASS: TestGopassFailures (0.00s)
=== RUN   TestHashicorpVault
=== RUN   TestHashicorpVault/data
=== RUN   TestHashicorpVault/data.data
--- PASS: TestHashicorpVault (0.00s)
    --- PASS: TestHashicorpVault/data (0.00s)
    --- PASS: TestHashicorpVault/data.data (0.00s)
=== RUN   TestHashicorpVaultFailures
--- PASS: TestHashicorpVaultFailures (0.00s)
=== RUN   TestHeroku
--- PASS: TestHeroku (0.00s)
=== RUN   TestHerokuFailures
--- PASS: TestHerokuFailures (0.00s)
=== RUN   TestKetPass
--- PASS: TestKetPass (0.00s)
=== RUN   TestKeypassFailures
--- PASS: TestKeypassFailures (0.00s)
=== RUN   TestLastPass
--- PASS: TestLastPass (0.00s)
=== RUN   TestLastPassFailures
--- PASS: TestLastPassFailures (0.00s)
=== RUN   TestOnePassword
--- PASS: TestOnePassword (0.00s)
=== RUN   TestOnePasswordFailures
--- PASS: TestOnePasswordFailures (0.00s)
=== RUN   TestVercel
--- PASS: TestVercel (0.00s)
=== RUN   TestVercelFailures
--- PASS: TestVercelFailures (0.00s)
PASS
        github.com/spectralops/teller/pkg/providers     coverage: 49.1% of statements
ok      github.com/spectralops/teller/pkg/providers     0.024s  coverage: 49.1% of statements
go build -ldflags "-s -w -X main.version=0.0.0 -X main.commit=0000000000000000000000000000000000000000 -X main.date=2022-01-01"
BINARY_PATH="/build/source/teller" go test -v ./e2e
=== RUN   TestE2E
=== PAUSE TestE2E
=== CONT  TestE2E
=== RUN   TestE2E/yaml
=== RUN   TestE2E/Show_entries
=== RUN   TestE2E/Sh_print
=== RUN   TestE2E/scan_entries
=== RUN   TestE2E/Put_multiple_entires
=== RUN   TestE2E/Put_with_--sync_flag
=== RUN   TestE2E/Show_JSON_entries
=== RUN   TestE2E/Delete_multiple_entires
=== RUN   TestE2E/Custom_config_name
=== RUN   TestE2E/version
--- PASS: TestE2E (0.13s)
    --- PASS: TestE2E/yaml (0.01s)
    --- PASS: TestE2E/Show_entries (0.01s)
    --- PASS: TestE2E/Sh_print (0.01s)
    --- PASS: TestE2E/scan_entries (0.01s)
    --- PASS: TestE2E/Put_multiple_entires (0.01s)
    --- PASS: TestE2E/Put_with_--sync_flag (0.01s)
    --- PASS: TestE2E/Show_JSON_entries (0.01s)
    --- PASS: TestE2E/Delete_multiple_entires (0.01s)
    --- PASS: TestE2E/Custom_config_name (0.01s)
    --- PASS: TestE2E/version (0.01s)
PASS
ok      github.com/spectralops/teller/e2e       0.137s
e2e tests passed
installing
post-installation fixup
shrinking RPATHs of ELF executables and libraries in /nix/store/ayc9l6mp79i7q0237c4hjps472n3gyph-teller-1.5.6
shrinking /nix/store/ayc9l6mp79i7q0237c4hjps472n3gyph-teller-1.5.6/bin/teller
checking for references to /build/ in /nix/store/ayc9l6mp79i7q0237c4hjps472n3gyph-teller-1.5.6...
patching script interpreter paths in /nix/store/ayc9l6mp79i7q0237c4hjps472n3gyph-teller-1.5.6
stripping (with command strip and flags -S -p) in  /nix/store/ayc9l6mp79i7q0237c4hjps472n3gyph-teller-1.5.6/bin
/nix/store/ayc9l6mp79i7q0237c4hjps472n3gyph-teller-1.5.6
Teller 1.5.6
Revision 1.5.6, date: 2022-10-13
```

</details>


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
