### PR TITLE
code-server: restore previous patch

### DIFF
--- a/pkgs/servers/code-server/build-vscode-nogit.patch
+++ b/pkgs/servers/code-server/build-vscode-nogit.patch
@@ -1,15 +1,8 @@
 diff --git a/ci/build/build-vscode.sh b/ci/build/build-vscode.sh
-index a72549fb..b1b6074b 100755
+index a72549fb..3aed1ad5 100755
 --- a/ci/build/build-vscode.sh
 +++ b/ci/build/build-vscode.sh
-@@ -52,13 +52,12 @@ main() {
-   # since Code tries to get the commit from the `.git` directory which will fail
-   # as it is a submodule.
-   export BUILD_SOURCEVERSION
--  BUILD_SOURCEVERSION=$(git rev-parse HEAD)
-+  BUILD_SOURCEVERSION=none
-
-   # Add the date, our name, links, and enable telemetry (this just makes
+@@ -58,7 +58,6 @@ main() {
    # telemetry available; telemetry can still be disabled by flag or setting).
    # This needs to be done before building as Code will read this file and embed
    # it into the client-side code.
@@ -17,21 +10,11 @@ index a72549fb..b1b6074b 100755
    cp product.json product.original.json # Since jq has no inline edit.
    jq --slurp '.[0] * .[1]' product.original.json <(
      cat << EOF
-@@ -105,17 +104,12 @@ EOF
+@@ -105,7 +104,6 @@ EOF
    # Reset so if you develop after building you will not be stuck with the wrong
    # commit (the dev client will use `oss-dev` but the dev server will still use
    # product.json which will have `stable-$commit`).
 -  git checkout product.json
-
+ 
    popd
-
-   pushd lib/vscode-reh-web-linux-x64
-   # Make sure Code took the version we set in the environment variable.  Not
-   # having a version will break display languages.
--  if ! jq -e .commit product.json; then
--    echo "'commit' is missing from product.json"
--    exit 1
--  fi
-   popd
-
-   # These provide a `code-server` command in the integrated terminal to open
+ 


### PR DESCRIPTION
Also add a note about the `commit` value and how to get it.

Follows #240001 

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
