### PR TITLE
photoview: init at 2.3.13

### DIFF
--- a/pkgs/by-name/ph/photoview/backend.nix
+++ b/pkgs/by-name/ph/photoview/backend.nix
@@ -1,0 +1,45 @@
+{
+  src,
+  version,
+  lib,
+  buildGoModule,
+  makeWrapper,
+  dlib,
+  libjpeg,
+  libheif,
+  blas,
+  lapack,
+  exiftool,
+  pkg-config,
+}:
+buildGoModule {
+  pname = "photoview-backend";
+  inherit version;
+
+  src = src + "/api/";
+
+  nativeBuildInputs = [
+    pkg-config
+    makeWrapper
+  ];
+  buildInputs = [
+    dlib
+    libjpeg
+    libheif
+    blas
+    lapack
+  ];
+
+  vendorHash = "sha256-0SWywy9YdPtgvxRhwKhKvspPmhbnibSuhvzhsjIQvZk=";
+
+  postInstall = ''
+    mkdir -p $out/share/photoview
+    cp -R data $out/share/photoview/
+  '';
+
+  postFixup = ''
+    wrapProgram $out/bin/api \
+      --set PHOTOVIEW_FACE_RECOGNITION_MODELS_PATH $out/share/photoview/data/models \
+      --set PATH ${lib.makeBinPath [ exiftool ]}
+  '';
+}

--- a/pkgs/by-name/ph/photoview/frontend.nix
+++ b/pkgs/by-name/ph/photoview/frontend.nix
@@ -1,0 +1,24 @@
+{
+  src,
+  version,
+  lib,
+  buildNpmPackage,
+  nodejs_20,
+}:
+buildNpmPackage {
+  pname = "photoview-frontend";
+  inherit version;
+  nodejs = nodejs_20;
+
+  src = src + "/ui/";
+
+  npmDepsHash = "sha256-31CyjyNd85hNg4MXIWctoQ3YgorGqCMz+wDAu/K1lWo=";
+  makeCacheWritable = true;
+  npmPackFlags = [
+    "--ignore-scripts"
+    "--cache"
+    "cache"
+  ];
+
+  NODE_ENV = "production npm prune";
+}

--- a/pkgs/by-name/ph/photoview/package.nix
+++ b/pkgs/by-name/ph/photoview/package.nix
@@ -1,0 +1,46 @@
+{
+  fetchFromGitHub,
+  callPackage,
+  stdenv,
+  makeWrapper,
+  lib,
+}:
+let
+  version = "2.3.13";
+  pname = "photoview";
+  src = fetchFromGitHub {
+    owner = pname;
+    repo = pname;
+    rev = "v" + version;
+    hash = "sha256-O6k5nbiWTsuOi8YLX0rsZJ9dOIo5d6pdwjhFZrdwI0E=";
+  };
+  backend = callPackage ./backend.nix { inherit src version; };
+  frontend = callPackage ./frontend.nix { inherit src version; };
+in
+stdenv.mkDerivation {
+  inherit pname version;
+  dontUnpack = true;
+  dontBuild = true;
+
+  nativeBuildInputs = [ makeWrapper ];
+
+  installPhase = ''
+    runHook preInstall
+    mkdir -p $out/bin
+    ln -s ${backend}/bin/api $out/bin/photoview-backend
+    wrapProgram $out/bin/photoview-backend \
+      --set PHOTOVIEW_UI_PATH $out/lib/node_modules/photoview-ui/dist \
+      --set PHOTOVIEW_SERVE_UI 1
+    ln -s ${frontend}/lib $out/lib
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    homepage = "https://photoview.github.io/";
+    description = "Photo gallery for self-hosted personal servers";
+    platforms = platforms.unix;
+    license = licenses.agpl3Only;
+    maintainers = with maintainers; [ samw ];
+    mainProgram = "photoview-backend";
+  };
+}


### PR DESCRIPTION
###### Description of changes
This is based off @Skallwar's gist at https://gist.github.com/Skallwar/e68c10b4380e6d01a99636d3cc9e55ac, modified to split the front/backend into separate derivations and with some wrapping to combine them into a single derivation.

Closes #217236.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [X] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [X] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
