### PR TITLE
Fix tuxedo-keyboard build on kernel >= 6.4

### DIFF
--- a/pkgs/os-specific/linux/tuxedo-keyboard/default.nix
+++ b/pkgs/os-specific/linux/tuxedo-keyboard/default.nix
@@ -13,6 +13,8 @@ stdenv.mkDerivation rec {
     hash = "sha256-SkSv9XHIMU+DplzJBegifBB88/AEGSqOf01GX7rtvXM=";
   };
 
+  patches = [ ./dmi_string_in.patch ];
+
   buildInputs = [
     pahole
     linuxHeaders

--- a/pkgs/os-specific/linux/tuxedo-keyboard/default.nix
+++ b/pkgs/os-specific/linux/tuxedo-keyboard/default.nix
@@ -2,13 +2,15 @@
 
 stdenv.mkDerivation rec {
   pname = "tuxedo-keyboard-${kernel.version}";
-  version = "3.2.5";
+  version = "unstable-2023-06-19";
+  # using unstable for now to allow building on linux kernels >= 6.4
+  # switch back to stable once a release containing 04112f65ec4099d43bca8c00acc61f3a2c0e185f is available
 
   src = fetchFromGitHub {
     owner = "tuxedocomputers";
     repo = "tuxedo-keyboard";
-    rev = "v${version}";
-    hash = "sha256-pSGshUyim06Sqkp5QFzhUjeIz/N3aORvVt6DEyzQLaU=";
+    rev = "04112f65ec4099d43bca8c00acc61f3a2c0e185f";
+    hash = "sha256-SkSv9XHIMU+DplzJBegifBB88/AEGSqOf01GX7rtvXM=";
   };
 
   buildInputs = [

--- a/pkgs/os-specific/linux/tuxedo-keyboard/dmi_string_in.patch
+++ b/pkgs/os-specific/linux/tuxedo-keyboard/dmi_string_in.patch
@@ -1,0 +1,24 @@
+diff --git a/src/tuxedo_io/tuxedo_io.c b/src/tuxedo_io/tuxedo_io.c
+index f420819..3e0481d 100644
+--- a/src/tuxedo_io/tuxedo_io.c
++++ b/src/tuxedo_io/tuxedo_io.c
+@@ -49,19 +49,6 @@ static u32 id_check_uniwill;
+ 
+ static struct uniwill_device_features_t *uw_feats;
+ 
+-/**
+- * strstr version of dmi_match
+- */
+-static bool dmi_string_in(enum dmi_field f, const char *str)
+-{
+-	const char *info = dmi_get_system_info(f);
+-
+-	if (info == NULL || str == NULL)
+-		return info == str;
+-
+-	return strstr(info, str) != NULL;
+-}
+-
+ static u32 clevo_identify(void)
+ {
+ 	return clevo_get_active_interface_id(NULL) == 0 ? 1 : 0;


### PR DESCRIPTION
###### Description of changes

Fix the tuxedo-keyboard build on 6.4 kernel by switching to recent master commit and adding a patch (that was also submitted as https://github.com/tuxedocomputers/tuxedo-keyboard/pull/162 to upstream some time ago).

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
