### PR TITLE
searxng: unstable-2023-05-19 -> unstable-2023-06-26

### DIFF
--- a/pkgs/servers/web-apps/searxng/default.nix
+++ b/pkgs/servers/web-apps/searxng/default.nix
@@ -5,13 +5,13 @@
 
 python3.pkgs.buildPythonApplication rec {
   pname = "searxng";
-  version = "unstable-2023-05-19";
+  version = "unstable-2023-06-26";
 
   src = fetchFromGitHub {
     owner = pname;
     repo = pname;
-    rev = "d867bf17e6d2f9a7c83c9a1ffafda5184a24c0e3";
-    sha256 = "sha256-W7/8/3FzwErPkRlfuyqajova6LRKarANPtc6L/z20CI=";
+    rev = "da7c30291dcf53cc5b3d98f9aada5615cd1593a9";
+    sha256 = "sha256-kbNw/YgcBZNkmn2nmsnEnc9Y8MJg3zGFdW1x9GIo+dM=";
   };
 
   postPatch = ''
@@ -33,6 +33,7 @@ python3.pkgs.buildPythonApplication rec {
     jinja2
     lxml
     pygments
+    pytomlpp
     pyyaml
     redis
     uvloop
@@ -50,6 +51,9 @@ python3.pkgs.buildPythonApplication rec {
     # Create a symlink for easier access to static data
     mkdir -p $out/share
     ln -s ../${python3.sitePackages}/searx/static $out/share/
+
+    # copy config schema for the limiter
+    cp searx/botdetection/limiter.toml $out/${python3.sitePackages}/searx/botdetection/limiter.toml
   '';
 
   meta = with lib; {


### PR DESCRIPTION
###### Description of changes

Compare: https://github.com/searxng/searxng/compare/d867bf17e6d2f9a7c83c9a1ffafda5184a24c0e3...da7c30291dcf53cc5b3d98f9aada5615cd1593a9

This update includes the new limiter merged in https://github.com/searxng/searxng/pull/2357. Currently, its configuration file is hardcoded to `/etc/searxng/limiter.toml` (see https://github.com/searxng/searxng/blob/da7c30291dcf53cc5b3d98f9aada5615cd1593a9/searx/botdetection/limiter.py#L73) so the NixOS module for searx would need to write that file if using searxng (maybe as a symlink to `/run/searx/limiter.toml` which is then written by `searx-init.service`?).

The updated package is running with my own searxng instance, deployed with https://git.catgirl.cloud/999eagle/dotfiles-nix/-/commit/95290d72940cb40a7bcb64c9d5a58b9785cdeec7.
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
