### PR TITLE
nixos/manual: rename references to services.udev.initrdRules

### DIFF
--- a/nixos/doc/manual/configuration/renaming-interfaces.section.md
+++ b/nixos/doc/manual/configuration/renaming-interfaces.section.md
@@ -37,7 +37,7 @@ even if networkd is disabled.
 Alternatively, we can use a plain old udev rule:
 
 ```nix
-services.udev.initrdRules = ''
+boot.initrd.services.udev.rules = ''
   SUBSYSTEM=="net", ACTION=="add", DRIVERS=="?*", \
   ATTR{address}=="52:54:00:12:01:01", KERNEL=="eth*", NAME="wan"
 '';
@@ -45,7 +45,7 @@ services.udev.initrdRules = ''
 
 ::: {.warning}
 The rule must be installed in the initrd using
-`services.udev.initrdRules`, not the usual `services.udev.extraRules`
+`boot.initrd.services.udev.rules`, not the usual `services.udev.extraRules`
 option. This is to avoid race conditions with other programs controlling
 the interface.
 :::


### PR DESCRIPTION
###### Description of changes

The manual contains a section on renaming network interfaces using udev rules, however it references the `services.udev.initrdRules` option, which was renamed to `boot.initrd.services.udev.rules` in 7024b4e5e369 (which was included in 22.05). This change updates the manual to use the correct option.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
