### PR TITLE
pypy: fix missing LDCXXSHARED in sysconfig.get_config_vars()

### DIFF
--- a/pkgs/development/interpreters/python/pypy/default.nix
+++ b/pkgs/development/interpreters/python/pypy/default.nix
@@ -87,6 +87,9 @@ in with passthru; stdenv.mkDerivation rec {
       src = ./sqlite_paths.patch;
       inherit (sqlite) out dev;
     })
+  ] ++ lib.optionals isPy3k [
+    # add missing LDCXXSHARED to sysconfig.get_config_vars() to prevent type errors when compiling eg. Pillow
+    ./sysconfig-config-vars.patch
   ];
 
   postPatch = ''

--- a/pkgs/development/interpreters/python/pypy/sysconfig-config-vars.patch
+++ b/pkgs/development/interpreters/python/pypy/sysconfig-config-vars.patch
@@ -1,0 +1,12 @@
+diff --git a/lib_pypy/_sysconfigdata.py b/lib_pypy/_sysconfigdata.py
+index d784211..5cc4d66 100644
+--- a/lib_pypy/_sysconfigdata.py
++++ b/lib_pypy/_sysconfigdata.py
+@@ -26,6 +26,7 @@
+     'CCSHARED': "-fPIC",
+     'LDFLAGS': "-Wl,-Bsymbolic-functions",
+     'LDSHARED': "cc -pthread -shared -Wl,-Bsymbolic-functions",
++    'LDCXXSHARED': "c++ -shared",
+     'EXT_SUFFIX': so_ext,
+     'SHLIB_SUFFIX': ".so",
+     'AR': "ar",


### PR DESCRIPTION
leading to a type error when compiling Pillow

This fixes the same underlying issue as #240199 but pypy wide.

```
pillow> warning: no files found matching '*.c'
pillow> warning: no files found matching '*.h'
pillow> warning: no files found matching '*.sh'
pillow> warning: no files found matching '*.txt'
pillow> warning: no previously-included files found matching '.appveyor.yml'
pillow> warning: no previously-included files found matching '.clang-format'
pillow> warning: no previously-included files found matching '.coveragerc'
pillow> warning: no previously-included files found matching '.editorconfig'
pillow> warning: no previously-included files found matching '.readthedocs.yml'
pillow> warning: no previously-included files found matching 'codecov.yml'
pillow> warning: no previously-included files found matching 'renovate.json'
pillow> warning: no previously-included files matching '.git*' found anywhere in distribution
pillow> warning: no previously-included files matching '*.pyc' found anywhere in distribution
pillow> warning: no previously-included files matching '*.so' found anywhere in distribution
pillow> no previously-included directories found matching '.ci'
pillow> adding license file 'LICENSE'
pillow> writing manifest file 'src/Pillow.egg-info/SOURCES.txt'
pillow> running build_ext
pillow> Traceback (most recent call last):
pillow>   File "/build/Pillow-9.4.0/nix_run_setup", line 8, in <module>
pillow>     exec(compile(getattr(tokenize, 'open', open)(__file__).read().replace('\\r\\n', '\\n'), __file__, 'exec'))
pillow>   File "setup.py", line 993, in <module>
pillow>     setup(
pillow>   File "/nix/store/rm4pw7i59733cs8frim5vr6221rl20ka-pypy3.9-setuptools-67.4.0/lib/pypy3.9/site-packages/setuptools/__init__.py", line 108, in setup
pillow>     return distutils.core.setup(**attrs)
pillow>   File "/nix/store/rm4pw7i59733cs8frim5vr6221rl20ka-pypy3.9-setuptools-67.4.0/lib/pypy3.9/site-packages/setuptools/_distutils/core.py", line 185, in setup
pillow>     return run_commands(dist)
pillow>   File "/nix/store/rm4pw7i59733cs8frim5vr6221rl20ka-pypy3.9-setuptools-67.4.0/lib/pypy3.9/site-packages/setuptools/_distutils/core.py", line 201, in run_commands
pillow>     dist.run_commands()
pillow>   File "/nix/store/rm4pw7i59733cs8frim5vr6221rl20ka-pypy3.9-setuptools-67.4.0/lib/pypy3.9/site-packages/setuptools/_distutils/dist.py", line 969, in run_commands
pillow>     self.run_command(cmd)
pillow>   File "/nix/store/rm4pw7i59733cs8frim5vr6221rl20ka-pypy3.9-setuptools-67.4.0/lib/pypy3.9/site-packages/setuptools/dist.py", line 1221, in run_command
pillow>     super().run_command(command)
pillow>   File "/nix/store/rm4pw7i59733cs8frim5vr6221rl20ka-pypy3.9-setuptools-67.4.0/lib/pypy3.9/site-packages/setuptools/_distutils/dist.py", line 988, in run_command
pillow>     cmd_obj.run()
pillow>   File "/nix/store/amp1rx9vihijrzgfy04arxa3wz6cjrq3-pypy3.9-wheel-0.38.4/lib/pypy3.9/site-packages/wheel/bdist_wheel.py", line 325, in run
pillow>     self.run_command("build")
pillow>   File "/nix/store/rm4pw7i59733cs8frim5vr6221rl20ka-pypy3.9-setuptools-67.4.0/lib/pypy3.9/site-packages/setuptools/_distutils/cmd.py", line 318, in run_command
pillow>     self.distribution.run_command(command)
pillow>   File "/nix/store/rm4pw7i59733cs8frim5vr6221rl20ka-pypy3.9-setuptools-67.4.0/lib/pypy3.9/site-packages/setuptools/dist.py", line 1221, in run_command
pillow>     super().run_command(command)
pillow>   File "/nix/store/rm4pw7i59733cs8frim5vr6221rl20ka-pypy3.9-setuptools-67.4.0/lib/pypy3.9/site-packages/setuptools/_distutils/dist.py", line 988, in run_command
pillow>     cmd_obj.run()
pillow>   File "/nix/store/rm4pw7i59733cs8frim5vr6221rl20ka-pypy3.9-setuptools-67.4.0/lib/pypy3.9/site-packages/setuptools/_distutils/command/build.py", line 131, in run
pillow>     self.run_command(cmd_name)
pillow>   File "/nix/store/rm4pw7i59733cs8frim5vr6221rl20ka-pypy3.9-setuptools-67.4.0/lib/pypy3.9/site-packages/setuptools/_distutils/cmd.py", line 318, in run_command
pillow>     self.distribution.run_command(command)
pillow>   File "/nix/store/rm4pw7i59733cs8frim5vr6221rl20ka-pypy3.9-setuptools-67.4.0/lib/pypy3.9/site-packages/setuptools/dist.py", line 1221, in run_command
pillow>     super().run_command(command)
pillow>   File "/nix/store/rm4pw7i59733cs8frim5vr6221rl20ka-pypy3.9-setuptools-67.4.0/lib/pypy3.9/site-packages/setuptools/_distutils/dist.py", line 988, in run_command
pillow>     cmd_obj.run()
pillow>   File "/nix/store/rm4pw7i59733cs8frim5vr6221rl20ka-pypy3.9-setuptools-67.4.0/lib/pypy3.9/site-packages/setuptools/command/build_ext.py", line 84, in run
pillow>     _build_ext.run(self)
pillow>   File "/nix/store/rm4pw7i59733cs8frim5vr6221rl20ka-pypy3.9-setuptools-67.4.0/lib/pypy3.9/site-packages/setuptools/_distutils/command/build_ext.py", line 315, in run
pillow>     customize_compiler(self.compiler)
pillow>   File "/nix/store/rm4pw7i59733cs8frim5vr6221rl20ka-pypy3.9-setuptools-67.4.0/lib/pypy3.9/site-packages/setuptools/_distutils/sysconfig.py", line 337, in customize_compiler
pillow>     ldcxxshared = ldcxxshared + ' ' + os.environ['LDFLAGS']
pillow> TypeError: unsupported operand type(s) for +: 'NoneType' and 'str'
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
