### PR TITLE
pypy: cleanup install layout, fix sysconfig paths

### DIFF
--- a/pkgs/development/interpreters/python/pypy/site-prefix.patch
+++ b/pkgs/development/interpreters/python/pypy/site-prefix.patch
@@ -1,0 +1,15 @@
+diff --git a/lib-python/3/site.py b/lib-python/3/site.py
+index 94e8aae..c03947e 100644
+--- a/lib-python/3/site.py
++++ b/lib-python/3/site.py
+@@ -352,9 +352,7 @@ implementation = _get_implementation().lower()
+         ver = sys.version_info
+         if os.sep == '/':
+             for libdir in libdirs:
+-                path = os.path.join(prefix, libdir,
+-                                            f"{implementation}{ver[0]}.{ver[1]}",
+-                                            "site-packages")
++                path = os.path.join(prefix, "site-packages")
+                 sitepackages.append(path)
+         else:
+             sitepackages.append(prefix)

--- a/pkgs/development/interpreters/python/pypy/sysconfig-paths.patch
+++ b/pkgs/development/interpreters/python/pypy/sysconfig-paths.patch
@@ -1,0 +1,17 @@
+diff --git a/lib-python/3/sysconfig.py b/lib-python/3/sysconfig.py
+--- a/lib-python/3/sysconfig.py
++++ b/lib-python/3/sysconfig.py
+@@ -25,10 +25,10 @@
+
+ _INSTALL_SCHEMES = {
+     'posix_prefix': {
+-        'stdlib': '{installed_base}/{platlibdir}/{implementation_lower}{py_version_short}',
+-        'platstdlib': '{platbase}/{platlibdir}/{implementation_lower}{py_version_short}',
++        'stdlib': '{installed_base}',
++        'platstdlib': '{platbase}',
+         'purelib': '{base}/lib/{implementation_lower}{py_version_short}/site-packages',
+-        'platlib': '{platbase}/{platlibdir}/{implementation_lower}{py_version_short}/site-packages',
++        'platlib': '{platbase}',
+         'include':
+             '{installed_base}/include/{implementation_lower}{py_version_short}{abiflags}',
+         'platinclude':

--- a/pkgs/development/python-modules/pybind11/default.nix
+++ b/pkgs/development/python-modules/pybind11/default.nix
@@ -22,7 +22,7 @@ let
     substitutions = {
       out = placeholder "out";
       pythonInterpreter = python.pythonOnBuildForHost.interpreter;
-      pythonIncludeDir = "${python}/include/python${python.pythonVersion}";
+      pythonIncludeDir = "${python}/include/${python.libPrefix}";
       pythonSitePackages = "${python}/${python.sitePackages}";
     };
   } ./setup-hook.sh;


### PR DESCRIPTION
###### Description of changes
Fixes the same issue as #240187 but properly

Closes #39356
Closes #240187

Before:
```
>>>> import sys
>>>> sys.prefix
'/nix/store/dvrdpvw4j47q7snprr5xpkiqnwhsw4ck-pypy3.9-7.3.11/pypy3.9-c'
>>>> sys.exec_prefix
'/nix/store/dvrdpvw4j47q7snprr5xpkiqnwhsw4ck-pypy3.9-7.3.11/pypy3.9-c'
```

```
>>>> import sysconfig; sysconfig._main()
Platform: "linux-x86_64"
Python version: "3.9"
Current installation scheme: "posix_prefix"

Paths:
        data = "/nix/store/nc4h7pwpn4gnlmn6ykz1x0z3rsxbamrq-pypy3.9-7.3.11/lib/pypy3.9"
        include = "/nix/store/nc4h7pwpn4gnlmn6ykz1x0z3rsxbamrq-pypy3.9-7.3.11/lib/pypy3.9/include/pypy3.9"
        platinclude = "/nix/store/nc4h7pwpn4gnlmn6ykz1x0z3rsxbamrq-pypy3.9-7.3.11/lib/pypy3.9/include/pypy3.9"
        platlib = "/nix/store/nc4h7pwpn4gnlmn6ykz1x0z3rsxbamrq-pypy3.9-7.3.11/lib/pypy3.9/lib/pypy3.9/site-packages"
        platstdlib = "/nix/store/nc4h7pwpn4gnlmn6ykz1x0z3rsxbamrq-pypy3.9-7.3.11/lib/pypy3.9/lib/pypy3.9"
        purelib = "/nix/store/nc4h7pwpn4gnlmn6ykz1x0z3rsxbamrq-pypy3.9-7.3.11/lib/pypy3.9/lib/pypy3.9/site-packages"
        scripts = "/nix/store/nc4h7pwpn4gnlmn6ykz1x0z3rsxbamrq-pypy3.9-7.3.11/lib/pypy3.9/bin"
        stdlib = "/nix/store/nc4h7pwpn4gnlmn6ykz1x0z3rsxbamrq-pypy3.9-7.3.11/lib/pypy3.9/lib/pypy3.9"

Variables:
        ABIFLAGS = ""
        AR = "ar"
        ARFLAGS = "rc"
        CC = "gcc -pthread"
        CCSHARED = "-fPIC"
        CFLAGS = "-DNDEBUG -O2"
        CONFINCLUDEPY = "/nix/store/nc4h7pwpn4gnlmn6ykz1x0z3rsxbamrq-pypy3.9-7.3.11/lib/pypy3.9/include/pypy3.9"
        CXX = "g++ -pthread"
        EXE = ""
        EXT_SUFFIX = ".pypy39-pp73-x86_64-linux-gnu.so"
        GNULD = "yes"
        INCLUDEPY = "/nix/store/nc4h7pwpn4gnlmn6ykz1x0z3rsxbamrq-pypy3.9-7.3.11/lib/pypy3.9/include/pypy3.9"
        LDFLAGS = "-Wl,-Bsymbolic-functions"
        LDLIBRARY = "libpypy3.9-c.so"
        LDSHARED = "gcc -pthread -shared -Wl,-Bsymbolic-functions"
        LDVERSION = "3.9"
        LIBDIR = "/nix/store/nc4h7pwpn4gnlmn6ykz1x0z3rsxbamrq-pypy3.9-7.3.11/lib/pypy3.9/bin"
        LIBRARY = ""
        MULTIARCH = "x86_64-linux-gnu"
        OPT = "-DNDEBUG -O2"
        Py_DEBUG = "0"
        Py_ENABLE_SHARED = "0"
        SHLIB_SUFFIX = ".so"
        SIZEOF_VOID_P = "8"
        SO = ".pypy39-pp73-x86_64-linux-gnu.so"
        SOABI = "pypy39-pp73"
        TZPATH = "/nix/store/nc4h7pwpn4gnlmn6ykz1x0z3rsxbamrq-pypy3.9-7.3.11/lib/pypy3.9/share/zoneinfo:/nix/store/nc4h7pwpn4gnlmn6ykz1x0z3rsxbamrq-pypy3.9-7.3.11/lib/pypy3.9/lib/zoneinfo:/nix/store/nc4h7pwpn4gnlmn6ykz1x0z3rsxbamrq-pypy3.9-7.3.11/lib/pypy3.9/share/lib/zoneinfo:/nix/store/nc4h7pwpn4gnlmn6ykz1x0z3rsxbamrq-pypy3.9-7.3.11/lib/pypy3.9/../etc/zoneinfo:/usr/share/zoneinfo:/usr/lib/zoneinfo:/usr/share/lib/zoneinfo:/etc/zoneinfo"
        VERSION = "3.9"
        abiflags = ""
        base = "/nix/store/nc4h7pwpn4gnlmn6ykz1x0z3rsxbamrq-pypy3.9-7.3.11/lib/pypy3.9"
        exec_prefix = "/nix/store/nc4h7pwpn4gnlmn6ykz1x0z3rsxbamrq-pypy3.9-7.3.11/lib/pypy3.9"
        implementation = "PyPy"
        implementation_lower = "pypy"
        installed_base = "/nix/store/nc4h7pwpn4gnlmn6ykz1x0z3rsxbamrq-pypy3.9-7.3.11/lib/pypy3.9"
        installed_platbase = "/nix/store/nc4h7pwpn4gnlmn6ykz1x0z3rsxbamrq-pypy3.9-7.3.11/lib/pypy3.9"
        platbase = "/nix/store/nc4h7pwpn4gnlmn6ykz1x0z3rsxbamrq-pypy3.9-7.3.11/lib/pypy3.9"
        platlibdir = "lib"
        prefix = "/nix/store/nc4h7pwpn4gnlmn6ykz1x0z3rsxbamrq-pypy3.9-7.3.11/lib/pypy3.9"
        projectbase = "/nix/store/nc4h7pwpn4gnlmn6ykz1x0z3rsxbamrq-pypy3.9-7.3.11/lib/pypy3.9/bin"
        py_version = "3.9.16"
        py_version_nodot = "39"
        py_version_short = "3.9"
        srcdir = "/nix/store/nc4h7pwpn4gnlmn6ykz1x0z3rsxbamrq-pypy3.9-7.3.11/lib/pypy3.9/bin"
        userbase = "/home/sandro/.local"
User:
        data = "/home/sandro/.local"
        include = "/home/sandro/.local/include/pypy3.9"
        platlib = "/home/sandro/.local/lib/pypy3.9/site-packages"
        platstdlib = "/home/sandro/.local/lib/pypy3.9"
        purelib = "/home/sandro/.local/lib/pypy3.9/site-packages"
        scripts = "/home/sandro/.local/bin"
        stdlib = "/home/sandro/.local/lib/pypy3.9"
```

What it should look like according to Debian:

```
Python 3.7.10 (7.3.5+dfsg-2+deb11u2, Nov 01 2022, 20:16:36)
[PyPy 7.3.5 with GCC 10.2.1 20210110] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>>> import sys; sys.prefix; sys.exec_prefix
'/usr/lib/pypy3'
'/usr/lib/pypy3'
>>>> site.getsitepackages()
['/usr/local/lib/pypy3.7/dist-packages', '/usr/lib/python3/dist-packages']
```

After:
```
$ ./result/bin/pypy3
Python 3.9.16 (feeb267ead3e6771d3f2f49b83e1894839f64fb7, Jun 28 2023, 07:04:39)
[PyPy 7.3.11 with GCC 12.3.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>>> import setuptools
>>>> import sys ; sys.prefix ; sys.exec_prefix
'/nix/store/qnmhhfhllzn259jf4afll4nvqag679yc-pypy3.9-7.3.11-env'
'/nix/store/qnmhhfhllzn259jf4afll4nvqag679yc-pypy3.9-7.3.11-env'
>>>> import sysconfig; sysconfig._main()
Platform: "linux-x86_64"
Python version: "3.9"
Current installation scheme: "posix_prefix"

Paths:
        data = "/nix/store/qnmhhfhllzn259jf4afll4nvqag679yc-pypy3.9-7.3.11-env"
        include = "/nix/store/rjw1k8grc7y93z7g8ns6zbvg0ss128m9-pypy3.9-7.3.11/lib/pypy3.9/include/pypy3.9"
        platinclude = "/nix/store/rjw1k8grc7y93z7g8ns6zbvg0ss128m9-pypy3.9-7.3.11/lib/pypy3.9/include/pypy3.9"
        platlib = "/nix/store/qnmhhfhllzn259jf4afll4nvqag679yc-pypy3.9-7.3.11-env"
        platstdlib = "/nix/store/qnmhhfhllzn259jf4afll4nvqag679yc-pypy3.9-7.3.11-env"
        purelib = "/nix/store/qnmhhfhllzn259jf4afll4nvqag679yc-pypy3.9-7.3.11-env/lib/pypy3.9/site-packages"
        scripts = "/nix/store/qnmhhfhllzn259jf4afll4nvqag679yc-pypy3.9-7.3.11-env/bin"
        stdlib = "/nix/store/rjw1k8grc7y93z7g8ns6zbvg0ss128m9-pypy3.9-7.3.11/lib/pypy3.9"

Variables:
        ABIFLAGS = ""
        AR = "ar"
        ARFLAGS = "rc"
        CC = "cc -pthread"
        CCSHARED = "-fPIC"
        CFLAGS = "-DNDEBUG -O2"
        CONFINCLUDEPY = "/nix/store/rjw1k8grc7y93z7g8ns6zbvg0ss128m9-pypy3.9-7.3.11/lib/pypy3.9/include/pypy3.9"
        CXX = "c++ -pthread"
        EXE = ""
        EXT_SUFFIX = ".pypy39-pp73-x86_64-linux-gnu.so"
        INCLUDEPY = "/nix/store/rjw1k8grc7y93z7g8ns6zbvg0ss128m9-pypy3.9-7.3.11/lib/pypy3.9/include/pypy3.9"
        LDCXXSHARED = "c++ -shared"
        LDFLAGS = "-Wl,-Bsymbolic-functions"
        LDLIBRARY = "libpypy3.9-c.so"
        LDSHARED = "cc -pthread -shared -Wl,-Bsymbolic-functions"
        LDVERSION = "3.9"
        LIBDIR = "/nix/store/rjw1k8grc7y93z7g8ns6zbvg0ss128m9-pypy3.9-7.3.11/lib/pypy3.9/bin"
        LIBRARY = ""
        MULTIARCH = "x86_64-linux-gnu"
        OPT = "-DNDEBUG -O2"
        Py_DEBUG = "0"
        Py_ENABLE_SHARED = "0"
        SHLIB_SUFFIX = ".so"
        SIZEOF_VOID_P = "8"
        SO = ".pypy39-pp73-x86_64-linux-gnu.so"
        SOABI = "pypy39-pp73"
        TZPATH = "/nix/store/rjw1k8grc7y93z7g8ns6zbvg0ss128m9-pypy3.9-7.3.11/lib/pypy3.9/share/zoneinfo:/nix/store/rjw1k8grc7y93z7g8ns6zbvg0ss128m9-pypy3.9-7.3.11/lib/pypy3.9/lib/zoneinfo:/
nix/store/rjw1k8grc7y93z7g8ns6zbvg0ss128m9-pypy3.9-7.3.11/lib/pypy3.9/share/lib/zoneinfo:/nix/store/rjw1k8grc7y93z7g8ns6zbvg0ss128m9-pypy3.9-7.3.11/lib/pypy3.9/../etc/zoneinfo:/usr/share/zo
neinfo:/usr/lib/zoneinfo:/usr/share/lib/zoneinfo:/etc/zoneinfo"
        VERSION = "3.9"
        abiflags = ""
        base = "/nix/store/qnmhhfhllzn259jf4afll4nvqag679yc-pypy3.9-7.3.11-env"
        exec_prefix = "/nix/store/qnmhhfhllzn259jf4afll4nvqag679yc-pypy3.9-7.3.11-env"
        implementation = "PyPy"
        implementation_lower = "pypy"
        installed_base = "/nix/store/rjw1k8grc7y93z7g8ns6zbvg0ss128m9-pypy3.9-7.3.11/lib/pypy3.9"
        installed_platbase = "/nix/store/rjw1k8grc7y93z7g8ns6zbvg0ss128m9-pypy3.9-7.3.11/lib/pypy3.9"
        platbase = "/nix/store/qnmhhfhllzn259jf4afll4nvqag679yc-pypy3.9-7.3.11-env"
        platlibdir = "lib"
        prefix = "/nix/store/qnmhhfhllzn259jf4afll4nvqag679yc-pypy3.9-7.3.11-env"
        projectbase = "/nix/store/qnmhhfhllzn259jf4afll4nvqag679yc-pypy3.9-7.3.11-env/bin"
        py_version = "3.9.16"
        py_version_nodot = "39"
        py_version_short = "3.9"
        srcdir = "/nix/store/qnmhhfhllzn259jf4afll4nvqag679yc-pypy3.9-7.3.11-env/bin"
        userbase = "/home/hotpi/.local"
User:
        data = "/home/hotpi/.local"
        include = "/home/hotpi/.local/include/pypy3.9"
        platlib = "/home/hotpi/.local/lib/pypy3.9/site-packages"
        platstdlib = "/home/hotpi/.local/lib/pypy3.9"
        purelib = "/home/hotpi/.local/lib/pypy3.9/site-packages"
        scripts = "/home/hotpi/.local/bin"
        stdlib = "/home/hotpi/.local/lib/pypy3.9"
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
