### PR TITLE
kubo-migrator: add migration from 13 to 14

### DIFF
--- a/pkgs/applications/networking/kubo-migrator/all-migrations.nix
+++ b/pkgs/applications/networking/kubo-migrator/all-migrations.nix
@@ -36,8 +36,9 @@ let
   };
 
   # Concatenation of the latest repo version and the version of that migration
-  version = "13.1.0.0";
+  version = "14.1.0.0";
 
+  fs-repo-13-to-14 = fs-repo-common "fs-repo-13-to-14" "1.0.0";
   fs-repo-12-to-13 = fs-repo-common "fs-repo-12-to-13" "1.0.0";
   fs-repo-11-to-12 = fs-repo-common "fs-repo-11-to-12" "1.0.2";
   fs-repo-10-to-11 = fs-repo-common "fs-repo-10-to-11" "1.0.1";
@@ -53,6 +54,7 @@ let
   fs-repo-0-to-1   = fs-repo-common "fs-repo-0-to-1"   "1.0.1";
 
   all-migrations = [
+    fs-repo-13-to-14
     fs-repo-12-to-13
     fs-repo-11-to-12
     fs-repo-10-to-11

--- a/pkgs/applications/networking/kubo-migrator/unwrapped.nix
+++ b/pkgs/applications/networking/kubo-migrator/unwrapped.nix
@@ -11,12 +11,12 @@ buildGoModule rec {
     owner = "ipfs";
     repo = "fs-repo-migrations";
     # Use the latest git tag here, since v2.0.2 does not
-    # contain the latest migration fs-repo-11-to-12/v1.0.2
+    # contain the latest migration fs-repo-13-to-14/v1.0.0
     # The fs-repo-migrations code itself is the same between
     # the two versions but the migration code, which is built
     # into separate binaries, is not.
-    rev = "fs-repo-12-to-13/v1.0.0";
-    hash = "sha256-QQone7E2Be+jVfnrwqQ1Ny4jo6mSDHhaY3ErkNdn2f8=";
+    rev = "fs-repo-13-to-14/v1.0.0";
+    hash = "sha256-y0IYSKKZlFbPrTUC6XqYKhS3a79rieNGBL58teWMlC4=";
   };
 
   sourceRoot = "source/fs-repo-migrations";


### PR DESCRIPTION
###### Description of changes
https://github.com/ipfs/fs-repo-migrations/releases/tag/fs-repo-13-to-14%2Fv1.0.0

This will be used to upgrade the Kubo repo when updating to Kubo 0.21.

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).