### PR TITLE
pcsx2: 1.7.4554 -> 1.7.4658

### DIFF
--- a/pkgs/applications/emulators/pcsx2/default.nix
+++ b/pkgs/applications/emulators/pcsx2/default.nix
@@ -1,11 +1,11 @@
 { cmake
 , fetchFromGitHub
 , lib
-, stdenv
+, llvmPackages_16
 , cubeb
 , curl
 , ffmpeg
-, fmt
+, fmt_8
 , gettext
 , harfbuzz
 , libaio
@@ -37,25 +37,26 @@ let
   pcsx2_patches = fetchFromGitHub {
     owner = "PCSX2";
     repo = "pcsx2_patches";
-    rev = "8db5ae467a35cc00dc50a65061aa78dc5115e6d1";
-    sha256 = "sha256-68kD7IAhBMASFmkGwvyQ7ppO/3B1csAKik+rU792JI4=";
+    rev = "c09d842168689aeba88b656e3e0a042128673a7c";
+    sha256 = "sha256-h1jqv3a3Ib/4C7toZpSlVB1VFNNF1MrrUxttqKJL794=";
   };
 in
-stdenv.mkDerivation rec {
+llvmPackages_16.stdenv.mkDerivation rec {
   pname = "pcsx2";
-  version = "1.7.4554";
+  version = "1.7.4658";
 
   src = fetchFromGitHub {
     owner = "PCSX2";
     repo = "pcsx2";
     fetchSubmodules = true;
     rev = "v${version}";
-    sha256 = "sha256-9MRbpm7JdVmZwv8zD4lErzVTm7A4tYM0FgXE9KpX+/8=";
+    sha256 = "sha256-5y7CYFWgNh9oCBuTITvw7Rn4sC6MbMczVMAwtWFkn9A=";
   };
 
   cmakeFlags = [
     "-DDISABLE_ADVANCE_SIMD=TRUE"
     "-DUSE_SYSTEM_LIBS=ON"
+    "-DUSE_LINKED_FFMPEG=ON"
     "-DDISABLE_BUILD_DATE=TRUE"
   ];
 
@@ -70,7 +71,7 @@ stdenv.mkDerivation rec {
   buildInputs = [
     curl
     ffmpeg
-    fmt
+    fmt_8
     gettext
     harfbuzz
     libaio
@@ -98,7 +99,7 @@ stdenv.mkDerivation rec {
     mkdir -p $out/bin
     cp -a bin/pcsx2-qt bin/resources $out/bin/
 
-    install -Dm644 $src/pcsx2/Resources/AppIcon64.png $out/share/pixmaps/PCSX2.png
+    install -Dm644 $src/pcsx2-qt/resources/icons/AppIcon64.png $out/share/pixmaps/PCSX2.png
     install -Dm644 $src/.github/workflows/scripts/linux/pcsx2-qt.desktop $out/share/applications/PCSX2.desktop
 
     zip -jq $out/bin/resources/patches.zip ${pcsx2_patches}/patches/*
@@ -107,7 +108,6 @@ stdenv.mkDerivation rec {
 
   qtWrapperArgs = [
     "--prefix LD_LIBRARY_PATH : ${lib.makeLibraryPath ([
-      ffmpeg # It's loaded with dlopen. They plan to change it https://github.com/PCSX2/pcsx2/issues/8624
       vulkan-loader
     ] ++ cubeb.passthru.backendLibs)}"
   ];


### PR DESCRIPTION
###### Description of changes

Diff: https://github.com/PCSX2/pcsx2/compare/v1.7.4554...v1.7.4658

- Remove `ffmpeg` from `LD_LIBRARY_PATH`, with the new option `USE_LINKED_FFMPEG`
- Switch to building with llvm_16, since that's what's used upstream
- Switch from `fmt` to `fmt_8`, doesn't build otherwise (and it's what's used upstream if system dependencies aren't used)

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
