### PR TITLE
python310Packages.clarifai: init at 9.5.2; python310Packages.langchain: add clarifai as an optional dependency

### DIFF
--- a/pkgs/development/python-modules/clarifai-grpc/default.nix
+++ b/pkgs/development/python-modules/clarifai-grpc/default.nix
@@ -1,0 +1,42 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, pythonOlder
+, googleapis-common-protos
+, grpcio
+, protobuf
+, requests
+}:
+
+buildPythonPackage rec {
+  pname = "clarifai-grpc";
+  version = "9.5.0";
+  format = "setuptools";
+
+  disabled = pythonOlder "3.8";
+
+  src = fetchPypi {
+    inherit pname version;
+    hash = "sha256-amMUgRXtvcrALfWwat7W0W60FJQnEeMvHhyxxBCMqUg=";
+  };
+
+  propagatedBuildInputs = [
+    googleapis-common-protos
+    grpcio
+    protobuf
+    requests
+  ];
+
+  # almost all tests require network access
+  doCheck = false;
+
+  pythonImportsCheck = [ "clarifai_grpc" ];
+
+  meta = with lib; {
+    description = "Clarifai gRPC API Client";
+    homepage = "https://github.com/Clarifai/clarifai-python-grpc";
+    changelog = "https://github.com/Clarifai/clarifai-python-grpc/releases/tag/${version}";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ natsukium ];
+  };
+}

--- a/pkgs/development/python-modules/clarifai/default.nix
+++ b/pkgs/development/python-modules/clarifai/default.nix
@@ -1,0 +1,40 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, pythonOlder
+, clarifai-grpc
+, pytestCheckHook
+}:
+
+buildPythonPackage rec {
+  pname = "clarifai";
+  version = "9.5.2";
+  format = "setuptools";
+
+  disabled = pythonOlder "3.8";
+
+  src = fetchFromGitHub {
+    owner = "Clarifai";
+    repo = "clarifai-python-utils";
+    rev = "refs/tags/${version}";
+    hash = "sha256-29by0YAQ7qc0gL/3lAFOk4FLDB5Qv4X9QDyK49gfyAo=";
+  };
+
+  propagatedBuildInputs = [
+    clarifai-grpc
+  ];
+
+  nativeCheckInputs = [
+    pytestCheckHook
+  ];
+
+  pythonImportsCheck = [ "clarifai" ];
+
+  meta = with lib; {
+    description = "Clarifai Python Utilities";
+    homepage = "https://github.com/Clarifai/clarifai-python-utils";
+    changelog = "https://github.com/Clarifai/clarifai-python-utils/releases/tag/${src.rev}";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ natsukium ];
+  };
+}

--- a/pkgs/development/python-modules/langchain/default.nix
+++ b/pkgs/development/python-modules/langchain/default.nix
@@ -17,6 +17,7 @@
 , bash
   # optional dependencies
 , anthropic
+, clarifai
 , cohere
 , openai
 , nlpcloud
@@ -123,6 +124,7 @@ buildPythonPackage rec {
   passthru.optional-dependencies = {
     llms = [
       anthropic
+      clarifai
       cohere
       openai
       nlpcloud
@@ -139,6 +141,9 @@ buildPythonPackage rec {
     ];
     text_helpers = [
       chardet
+    ];
+    clarifai = [
+      clarifai
     ];
     cohere = [
       cohere
@@ -157,6 +162,7 @@ buildPythonPackage rec {
     ];
     all = [
       anthropic
+      clarifai
       cohere
       openai
       nlpcloud

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1861,6 +1861,8 @@ self: super: with self; {
 
   ckcc-protocol = callPackage ../development/python-modules/ckcc-protocol { };
 
+  clarifai-grpc = callPackage ../development/python-modules/clarifai-grpc { };
+
   claripy = callPackage ../development/python-modules/claripy { };
 
   classify-imports = callPackage ../development/python-modules/classify-imports { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1861,6 +1861,8 @@ self: super: with self; {
 
   ckcc-protocol = callPackage ../development/python-modules/ckcc-protocol { };
 
+  clarifai = callPackage ../development/python-modules/clarifai { };
+
   clarifai-grpc = callPackage ../development/python-modules/clarifai-grpc { };
 
   claripy = callPackage ../development/python-modules/claripy { };


### PR DESCRIPTION
###### Description of changes

This is the official Clarifai gRPC Python client for interacting with our powerful recognition [API](https://docs.clarifai.com/). Clarifai provides a platform for data scientists, developers, researchers and enterprises to master the entire artificial intelligence lifecycle. Gather valuable business insights from images, video and text using computer vision and natural language processing.

Although 9.3 has already been released for clarifai, I selected 9.2 here. This is because the upstream forgot to tag it, and there are no meaningful changes.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
