### PR TITLE
fclones-gui: 0.1.4 -> 0.2.0

### DIFF
--- a/pkgs/tools/misc/fclones/gui.nix
+++ b/pkgs/tools/misc/fclones/gui.nix
@@ -12,16 +12,16 @@
 
 rustPlatform.buildRustPackage rec {
   pname = "fclones-gui";
-  version = "0.1.4";
+  version = "0.2.0";
 
   src = fetchFromGitHub {
     owner = "pkolaczk";
     repo = "fclones-gui";
     rev = "v${version}";
-    hash = "sha256-zJ5TqFmvUL1nKR8E+jGR4K6OGHJ4ckRky+bdKW0T30s=";
+    hash = "sha256-ad7wyoCjSQ8i6c+4IorImqAY2Q6pwBtI2JkkbkGa46U=";
   };
 
-  cargoHash = "sha256-QT4ZxjarPkEqJLKPsGAaMIaSUmKWZ1xtxWMe2uXaUek=";
+  cargoHash = "sha256-7+I0Tj+DcrItU2apB1iMiYiTv9AeDparke86HkJNF3A=";
 
   nativeBuildInputs = [
     pkg-config
@@ -35,6 +35,15 @@ rustPlatform.buildRustPackage rec {
   ] ++ lib.optionals stdenv.isDarwin [
     darwin.apple_sdk_11_0.frameworks.IOKit
   ];
+
+  postInstall = ''
+    substituteInPlace snap/gui/fclones-gui.desktop \
+      --replace Exec=fclones-gui Exec=$out/bin/fclones-gui \
+      --replace 'Icon=''${SNAP}/meta/gui/fclones-gui.png' Icon=fclones-gui
+
+    install -Dm444 snap/gui/fclones-gui.desktop -t $out/share/applications
+    install -Dm444 snap/gui/fclones-gui.png -t $out/share/pixmaps
+  '';
 
   meta = with lib; {
     description = "Interactive duplicate file remover";


### PR DESCRIPTION
Diff: https://github.com/pkolaczk/fclones-gui/compare/v0.1.4...v0.2.0

Changelog: https://github.com/pkolaczk/fclones-gui/releases/tag/v0.2.0

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
