### PR TITLE
python3Packages.pylddwrap: patch to use ldd from stdenv.cc.bintools.libc_bin

### DIFF
--- a/pkgs/development/python-modules/pylddwrap/default.nix
+++ b/pkgs/development/python-modules/pylddwrap/default.nix
@@ -56,5 +56,8 @@ buildPythonPackage rec {
     changelog = "https://github.com/Parquery/pylddwrap/blob/v${version}/CHANGELOG.rst";
     license = licenses.mit;
     maintainers = with maintainers; [ thiagokokada ];
+    # should work in any Unix platform that uses glibc, except for darwin
+    # since it has its own tool (`otool`)
+    badPlatforms = platforms.darwin;
   };
 }

--- a/pkgs/development/python-modules/pylddwrap/replace_env_with_placeholder.patch
+++ b/pkgs/development/python-modules/pylddwrap/replace_env_with_placeholder.patch
@@ -1,0 +1,25 @@
+diff --git a/lddwrap/__init__.py b/lddwrap/__init__.py
+index 1222c97..db8a735 100644
+--- a/lddwrap/__init__.py
++++ b/lddwrap/__init__.py
+@@ -190,10 +190,8 @@ def list_dependencies(path: pathlib.Path,
+         Otherwise specified env is used.
+     :return: list of dependencies
+     """
+-    # We need to use /usr/bin/env since Popen ignores the PATH,
+-    # see https://stackoverflow.com/questions/5658622
+     proc = subprocess.Popen(
+-        ["/usr/bin/env", "ldd", path.as_posix()],
++        ["@ldd_bin@", path.as_posix()],
+         stdout=subprocess.PIPE,
+         stderr=subprocess.PIPE,
+         universal_newlines=True,
+@@ -209,7 +207,7 @@ def list_dependencies(path: pathlib.Path,
+ 
+     if unused:
+         proc_unused = subprocess.Popen(
+-            ["/usr/bin/env", "ldd", "--unused",
++            ["@ldd_bin@", "--unused",
+              path.as_posix()],
+             stdout=subprocess.PIPE,
+             stderr=subprocess.PIPE,


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

See issue: https://github.com/thiagokokada/nix-alien/issues/76

Instead of using the `ldd` from `PATH` (by calling `/usr/bin/env ldd`), let's hardcode the `ldd` from `stdenv.cc.bintools.libc_bin` so we can work even in environments that have no `ldd` installed.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
