### PR TITLE
mya: init at 1.0.0

### DIFF
--- a/pkgs/applications/misc/mya/argp.patch
+++ b/pkgs/applications/misc/mya/argp.patch
@@ -1,0 +1,26 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 273968c..236e5fb 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -3,10 +3,6 @@ project(mya)
+ set(CMAKE_C_STANDARD 11 )
+ set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -g -Wall")
+ 
+-if(UNIX)
+-	set(LINUX TRUE)
+-endif()
+-
+ set(SRC_DIR src)
+ set(INC_DIR include)
+ 
+@@ -17,7 +13,8 @@ set_target_properties(mya PROPERTIES RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DI
+ target_include_directories(mya PRIVATE ${INC_DIR})
+ 
+ set(LIBS curl json-c bsd)
+-if(LINUX)
+-    list(APPEND LIBS)
++find_library(ARGP argp)
++if(ARGP)
++    list(APPEND LIBS argp)
+ endif()
+ target_link_libraries(mya ${LIBS})

--- a/pkgs/applications/misc/mya/default.nix
+++ b/pkgs/applications/misc/mya/default.nix
@@ -1,0 +1,67 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, cmake
+, ninja
+, curl
+, json_c
+, libbsd
+, argp-standalone
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "mya";
+  version = "1.0.0";
+
+  src = fetchFromGitHub {
+    owner = "jmakhack";
+    repo = "myanimelist-cli";
+    rev = "refs/tags/v${finalAttrs.version}";
+    hash = "sha256-EmdkPpYEUIk9hr6rbnixjvznKSEnTCSMZz/17BfHGCk=";
+  };
+
+  nativeBuildInputs = [
+    cmake
+    ninja
+  ];
+
+  buildInputs = [
+    curl
+    json_c
+    libbsd
+  ] ++ lib.optionals (!stdenv.hostPlatform.isGnu) [
+    argp-standalone
+  ];
+
+  patches = [
+    ./argp.patch
+  ];
+
+  installPhase = ''
+    runHook preInstall
+
+    # Based on the upstream PKGBUILD
+    mkdir -p $out/share/doc/${finalAttrs.pname}
+    cp -a bin $out
+    cp $cmakeDir/README.md $out/share/doc/${finalAttrs.pname}
+
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    description = "Minimalistic command line interface for fetching user anime data from MyAnimeList";
+    longDescription = ''
+      Minimalistic command line interface for fetching user anime data from MyAnimeList.
+
+      You have to run this with the MYANIMELIST_CLIENT_ID environ variable set.
+      Where to get one: <https://myanimelist.net/apiconfig>.
+      Select the type `other`.
+    '';
+    homepage = "https://github.com/jmakhack/myanimelist-cli";
+    changelog = "https://github.com/jmakhack/myanimelist-cli/releases/tag/v${finalAttrs.version}";
+    license = licenses.mit;
+    maintainers = with maintainers; [ pbsds ];
+    mainProgram = "mya";
+    platforms = platforms.all;
+  };
+})

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -951,6 +951,8 @@ with pkgs;
 
   mongosh = callPackage ../development/tools/mongosh { };
 
+  mya = callPackage ../applications/misc/mya { };
+
   mysql-shell = callPackage ../development/tools/mysql-shell {
     inherit (darwin) cctools developer_cmds DarwinTools;
     inherit (darwin.apple_sdk.frameworks) CoreServices;


### PR DESCRIPTION
###### Description of changes

Add `mya`, [myanimelist-cli](https://github.com/jmakhack/myanimelist-cli/).
The only headache when using it is https://github.com/jmakhack/myanimelist-cli/issues/112, since they don't provide a default api key i ~~added a way to set it using an override~~, document the environment variable to set in `meta.longDescription`.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
