### PR TITLE
uefitoolPackages.new-engine: A62 -> A71

### DIFF
--- a/pkgs/tools/system/uefitool/bundle-destination.patch
+++ b/pkgs/tools/system/uefitool/bundle-destination.patch
@@ -1,0 +1,17 @@
+---
+ UEFITool/CMakeLists.txt | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/UEFITool/CMakeLists.txt b/UEFITool/CMakeLists.txt
+index aef60d0..98723ac 100644
+--- a/UEFITool/CMakeLists.txt
++++ b/UEFITool/CMakeLists.txt
+@@ -143,4 +143,4 @@ IF(UNIX AND (NOT APPLE) AND (NOT CYGWIN))
+  INSTALL(FILES uefitool.desktop DESTINATION share/applications)
+ ENDIF()
+ 
+-INSTALL(TARGETS UEFITool BUNDLE DESTINATION "/Applications" )
++INSTALL(TARGETS UEFITool BUNDLE DESTINATION "Applications" )
+-- 
+2.40.1
+

--- a/pkgs/tools/system/uefitool/new-engine.nix
+++ b/pkgs/tools/system/uefitool/new-engine.nix
@@ -1,0 +1,38 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  qtbase,
+  cmake,
+  wrapQtAppsHook,
+  zip,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "uefitool";
+  version = "A71";
+
+  src = fetchFromGitHub {
+    hash = "sha256-NRlrKm5+eED6oyvFRSEhn0EUbMsPJtuFAyv3vgY/IUI=";
+    owner = "LongSoft";
+    repo = "uefitool";
+    tag = finalAttrs.version;
+  };
+
+  buildInputs = [ qtbase ];
+  nativeBuildInputs = [
+    cmake
+    zip
+    wrapQtAppsHook
+  ];
+  patches = lib.optionals stdenv.isDarwin [ ./bundle-destination.patch ];
+
+  meta = {
+    description = "UEFI firmware image viewer and editor";
+    homepage = "https://github.com/LongSoft/uefitool";
+    license = lib.licenses.bsd2;
+    maintainers = with lib.maintainers; [ athre0z ];
+    platforms = lib.platforms.unix;
+    mainProgram = "uefitool";
+  };
+})

--- a/pkgs/tools/system/uefitool/old-engine.nix
+++ b/pkgs/tools/system/uefitool/old-engine.nix
@@ -1,9 +1,4 @@
 {
-  version,
-  sha256,
-  installFiles,
-}:
-{
   lib,
   mkDerivation,
   fetchFromGitHub,
@@ -14,19 +9,14 @@
 }:
 
 mkDerivation rec {
-  passthru = {
-    inherit version;
-    inherit sha256;
-    inherit installFiles;
-  };
   pname = "uefitool";
-  inherit version;
+  version = "0.28.0";
 
   src = fetchFromGitHub {
-    inherit sha256;
+    hash = "sha256-StqrOMsKst2X2yQQ/Xl7iLAuA4QXEOyj2KtE7ZtoUNg=";
     owner = "LongSoft";
-    repo = pname;
-    rev = version;
+    repo = "uefitool";
+    tag = version;
   };
 
   buildInputs = [ qtbase ];
@@ -43,15 +33,16 @@ mkDerivation rec {
 
   installPhase = ''
     mkdir -p "$out"/bin
-    cp ${lib.concatStringsSep " " installFiles} "$out"/bin
+    cp UEFITool UEFIReplace/UEFIReplace UEFIPatch/UEFIPatch "$out"/bin
   '';
 
-  meta = with lib; {
+  meta = {
     description = "UEFI firmware image viewer and editor";
     homepage = "https://github.com/LongSoft/uefitool";
-    license = licenses.bsd2;
-    maintainers = [ ];
+    license = lib.licenses.bsd2;
+    maintainers = with lib.maintainers; [ athre0z ];
     # uefitool supposedly works on other platforms, but their build script only works on linux in nixpkgs
-    platforms = platforms.linux;
+    platforms = lib.platforms.linux;
+    mainProgram = "UEFITool";
   };
 }

--- a/pkgs/tools/system/uefitool/variants.nix
+++ b/pkgs/tools/system/uefitool/variants.nix
@@ -1,24 +1,5 @@
-{ libsForQt5 }:
-let
-  common = opts: libsForQt5.callPackage (import ./common.nix opts) { };
-in
-rec {
-  new-engine = common {
-    version = "A62";
-    sha256 = "sha256-U89j0BV57luv1c9hoYJtisKLxFezuaGFokZ29/NJ0xg=";
-    installFiles = [
-      "build/UEFITool/UEFITool"
-      "build/UEFIFind/UEFIFind"
-      "build/UEFIExtract/UEFIExtract"
-    ];
-  };
-  old-engine = common rec {
-    version = "0.28.0";
-    sha256 = "1n2hd2dysi5bv2iyq40phh1jxc48gdwzs414vfbxvcharcwapnja";
-    installFiles = [
-      "UEFITool"
-      "UEFIReplace/UEFIReplace"
-      "UEFIPatch/UEFIPatch"
-    ];
-  };
+{ libsForQt5, qt6Packages }:
+{
+  new-engine = qt6Packages.callPackage ./new-engine.nix { };
+  old-engine = libsForQt5.callPackage ./old-engine.nix { };
 }


### PR DESCRIPTION
###### Description of changes

This commit upgrades uefiToolPackages.new-engine to the latest version as of writing. Version A68 is now using Qt6 and no longer comes with a custom build script, so the build logic compared to the old-engine variant has become sufficiently divergent that I decided that it would be easier to split them into two entirely different derivations.

Additionally, I:

- added myself as a maintainer
- added a patch that allows the new-engine variant to build on Darwin
- correctly set `mainProgram` in the old-engine variant

A68 release on GitHub: https://github.com/LongSoft/UEFITool/releases/tag/A71

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux (via qemu)
  - [ ] x86_64-darwin (via rosetta)
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
