### PR TITLE
penelope: init at 0.9.2

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -8733,6 +8733,12 @@
     githubId = 752510;
     name = "Martin Potier";
   };
+  jpts = {
+    email = "james+nixpkgs@cleverley-prance.uk";
+    github = "jpts";
+    githubId = 5352661;
+    name = "James Cleverley-Prance";
+  };
   jqqqqqqqqqq = {
     email = "jqqqqqqqqqq@gmail.com";
     github = "jqqqqqqqqqq";

--- a/pkgs/development/python-modules/penelope/default.nix
+++ b/pkgs/development/python-modules/penelope/default.nix
@@ -1,0 +1,56 @@
+{ lib
+, stdenv
+, buildPythonPackage
+, fetchFromGitHub
+, fetchpatch
+, setuptools
+, python3
+}:
+buildPythonPackage rec {
+  name = "penelope";
+  owner = "brightio";
+  version = "0.9.2";
+  repo = name;
+  format = "pyproject";
+
+  src = fetchFromGitHub {
+    inherit owner repo;
+    rev = "refs/tags/v${version}";
+    hash = "sha256-KlbB7i009UttTp+/MaF3y9CGUkAGEQQq/W+hQYKk9CY=";
+  };
+
+  patches = [
+    (fetchpatch {
+      url = "https://patch-diff.githubusercontent.com/raw/brightio/penelope/pull/17.patch";
+      sha256 = "sha256-nlhqQrmih7n4cDNqCqOJn3KJLnmKvd8HfUDk7+m8xLo=";
+    })
+  ];
+
+  nativeBuildInputs = with python3.pkgs; [
+    setuptools
+    wheel
+  ];
+
+  postPatch = ''
+    sed -i -e 's/^  version = .*/  version = "${version}"/g' pyproject.toml
+  '';
+
+  # We are a script, no tests
+  doCheck = false;
+
+  postInstall = ''
+    mv $out/bin/penelope.py $out/bin/penelope
+  '';
+
+  meta = {
+    homepage = "https://github.com/brightio/penelope";
+    changelog = "https://github.com/brightio/penelope/tag/v${version}";
+    description = "Reverse Shell Handler";
+    longDescription = ''
+      Penelope is a shell handler designed to be easy to use and intended to replace netcat when exploiting RCE vulnerabilities.
+    '';
+    license = lib.licenses.gpl3Plus;
+    maintainers = with lib.maintainers; [ jpts ];
+    platforms = lib.platforms.unix;
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -8865,6 +8865,8 @@ self: super: with self; {
 
   pendulum = callPackage ../development/python-modules/pendulum { };
 
+  penelope = callPackage ../development/python-modules/penelope { };
+
   pep440 = callPackage ../development/python-modules/pep440 { };
 
   pep517 = callPackage ../development/python-modules/pep517 { };


### PR DESCRIPTION
###### Description of changes

Adds `penelope`, a shell handler designed to be easy to use and intended to replace netcat when exploiting RCE vulnerabilities.

https://github.com/brightio/penelope

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).