### PR TITLE
gcc: fix c++ headers when same triplet cross compiling

### DIFF
--- a/pkgs/build-support/cc-wrapper/default.nix
+++ b/pkgs/build-support/cc-wrapper/default.nix
@@ -518,10 +518,10 @@ stdenv.mkDerivation {
     # additional -isystem flags will confuse gfortran (see
     # https://github.com/NixOS/nixpkgs/pull/209870#issuecomment-1500550903)
     + optionalString (libcxx == null && isClang && (useGccForLibs && gccForLibs.langCC or false)) ''
-      for dir in ${gccForLibs}${lib.optionalString (hostPlatform != targetPlatform) "/${targetPlatform.config}"}/include/c++/*; do
+      for dir in ${gccForLibs}/include/c++/*; do
         echo "-isystem $dir" >> $out/nix-support/libcxx-cxxflags
       done
-      for dir in ${gccForLibs}${lib.optionalString (hostPlatform != targetPlatform) "/${targetPlatform.config}"}/include/c++/*/${targetPlatform.config}; do
+      for dir in ${gccForLibs}/include/c++/*/${targetPlatform.config}; do
         echo "-isystem $dir" >> $out/nix-support/libcxx-cxxflags
       done
     ''

--- a/pkgs/development/compilers/gcc/common/configure-flags.nix
+++ b/pkgs/development/compilers/gcc/common/configure-flags.nix
@@ -135,6 +135,8 @@ let
       # We pick "/" path to effectively avoid sysroot offset and make it work
       # as a native case.
       "--with-build-sysroot=/"
+      # Same with the stdlibc++ headers embedded in the gcc output
+      "--with-gxx-include-dir=${placeholder "out"}/include/c++/${version}/"
     ]
 
     # Basic configuration


### PR DESCRIPTION
###### Description of changes

When build platform and host platform differ, but have the same triple, the code in nixpkgs will consider it a cross compilation, but gcc won't. This will lead some derivations to look for c++ headers in the wrong place. To solve this always output the headers in the non-cross location, like we do for the other gcc headers already.

Before:
```
$ nix-build -A pkgsCross.gnu64.boehmgc
...
gc_badalc.cc:29:10: fatal error: new: No such file or directory
   29 | #include <new> // for bad_alloc, precedes include of gc_cpp.h
      |          ^~~~~
compilation terminated.
gc_cpp.cc:36:10: fatal error: new: No such file or directory
   36 | #include <new> // for bad_alloc, precedes include of gc_cpp.h
      |          ^~~~~
compilation terminated.
make[1]: *** [Makefile:1780: gc_badalc.lo] Error 1
make[1]: *** Waiting for unfinished jobs....
make[1]: *** [Makefile:1780: gc_cpp.lo] Error 1
In file included from extra/gc.c:74:
In function 'GC_suspend_handler_inner',
    inlined from 'GC_suspend_handler' at extra/../pthread_stop_world.c:261:7:
extra/../pthread_stop_world.c:359:19: warning: '__atomic_load_8' writing 8 bytes into a region of size 0 overflows the destination [8;;https://gcc.gnu.org/onlinedocs/gcc/Warning-Options.html#index-Wstringop-overflow=-Wstringop-overflow=8;;]
  359 |     suspend_cnt = (word)ao_load_async(&(me -> stop_info.ext_suspend_cnt));
make[1]: Leaving directory '/build/gc-8.2.2'
make: *** [Makefile:1933: all-recursive] Error 1
error: builder for '/nix/store/3628wviya1i588nyp208lf3dhh1kchzr-boehm-gc-x86_64-unknown-linux-gnu-8.2.2.drv' failed with exit code 2;
       last 10 log lines:
       > make[1]: *** [Makefile:1780: gc_badalc.lo] Error 1
       > make[1]: *** Waiting for unfinished jobs....
       > make[1]: *** [Makefile:1780: gc_cpp.lo] Error 1
       > In file included from extra/gc.c:74:
       > In function 'GC_suspend_handler_inner',
       >     inlined from 'GC_suspend_handler' at extra/../pthread_stop_world.c:261:7:
       > extra/../pthread_stop_world.c:359:19: warning: '__atomic_load_8' writing 8 bytes into a region of size 0 overflows the destination [8;;https://gcc.gnu.org/onlinedocs/gcc/Warning-Options.html#index-Wstringop-overflow=-Wstringop-overflow=8;;]
       >   359 |     suspend_cnt = (word)ao_load_async(&(me -> stop_info.ext_suspend_cnt));
       > make[1]: Leaving directory '/build/gc-8.2.2'
       > make: *** [Makefile:1933: all-recursive] Error 1
       For full logs, run 'nix-store -l /nix/store/3628wviya1i588nyp208lf3dhh1kchzr-boehm-gc-x86_64-unknown-linux-gnu-8.2.2.drv'.
```

After:
```
$ nix-build -A pkgsCross.gnu64.boehmgc
...
/nix/store/ddfdqk6zi5rag4nvp8702g9frv6v2i1g-boehm-gc-x86_64-unknown-linux-gnu-8.2.2
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

Closes #243166
