### PR TITLE
nng: 1.6.0-prerelease update for rPackages.nanonext

### DIFF
--- a/pkgs/development/libraries/nng/default.nix
+++ b/pkgs/development/libraries/nng/default.nix
@@ -7,8 +7,8 @@ stdenv.mkDerivation rec {
   src = fetchFromGitHub {
     owner = "nanomsg";
     repo = "nng";
-    rev = "539e559e65cd8f227c45e4b046ac41c0edcf6c32";
-    sha256 = "sha256-86+f0um25Ywn78S2JrV54K7k3O6ots0q2dCco1aK0xM=";
+    rev = "8e1836f57e8bcdb228dd5baadc71dfbf30b544e0";
+    sha256 = "sha256-Q08/Oxv9DLCHp7Hf3NqNa0sHq7qwM6TfGT8gNyiwin8=";
   };
 
   nativeBuildInputs = [ cmake ninja ]


### PR DESCRIPTION
###### Description of changes

Updating 1.6.0-prerelease to [8e1836f](https://github.com/shikokuchuo/nanonext/commit/ef5e83ea02088cfd90afb8c574b379c8bb66c4ee) for rPackages.nanonext, which is the only dependent package on this library in nixpkgs.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [X] aarch64-darwin
