### PR TITLE
bpftune: init at unstable-2023-07-14, nixos/bpftune: init

### DIFF
--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -1142,6 +1142,7 @@
   ./services/security/vaultwarden/default.nix
   ./services/security/yubikey-agent.nix
   ./services/system/automatic-timezoned.nix
+  ./services/system/bpftune.nix
   ./services/system/cachix-agent/default.nix
   ./services/system/cachix-watch-store.nix
   ./services/system/cloud-init.nix

--- a/nixos/modules/services/system/bpftune.nix
+++ b/nixos/modules/services/system/bpftune.nix
@@ -1,0 +1,22 @@
+{ config, lib, pkgs, ... }:
+let
+  cfg = config.services.bpftune;
+in
+{
+  meta = {
+    maintainers = with lib.maintainers; [ nickcao ];
+  };
+
+  options = {
+    services.bpftune = {
+      enable = lib.mkEnableOption (lib.mdDoc "bpftune BPF driven auto-tuning");
+
+      package = lib.mkPackageOptionMD pkgs "bpftune" { };
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    systemd.packages = [ cfg.package ];
+    systemd.services.bpftune.wantedBy = [ "multi-user.target" ];
+  };
+}

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -138,6 +138,7 @@ in {
   borgbackup = handleTest ./borgbackup.nix {};
   botamusique = handleTest ./botamusique.nix {};
   bpf = handleTestOn ["x86_64-linux" "aarch64-linux"] ./bpf.nix {};
+  bpftune = handleTest ./bpftune.nix {};
   breitbandmessung = handleTest ./breitbandmessung.nix {};
   brscan5 = handleTest ./brscan5.nix {};
   btrbk = handleTest ./btrbk.nix {};

--- a/nixos/tests/bpftune.nix
+++ b/nixos/tests/bpftune.nix
@@ -1,0 +1,37 @@
+import ./make-test-python.nix ({ lib, pkgs, ... }: {
+
+  name = "bpftune";
+
+  meta = {
+    maintainers = with lib.maintainers; [ nickcao ];
+  };
+
+  nodes = {
+    client = { pkgs, ... }: {
+      services.bpftune.enable = true;
+
+      boot.kernel.sysctl."net.ipv4.tcp_rmem" = "4096 131072 1310720";
+
+      environment.systemPackages = [ pkgs.iperf3 ];
+    };
+
+    server = { ... }: {
+      services.iperf3 = {
+        enable = true;
+        openFirewall = true;
+      };
+    };
+  };
+
+  testScript = ''
+    with subtest("bpftune startup"):
+      client.wait_for_unit("bpftune.service")
+      client.wait_for_console_text("bpftune works fully")
+
+    with subtest("bpftune tcp buffer size"):
+      server.wait_for_unit("iperf3.service")
+      client.succeed("iperf3 --reverse -c server")
+      client.wait_for_console_text("need to increase TCP buffer size")
+  '';
+
+})

--- a/nixos/tests/bpftune.nix
+++ b/nixos/tests/bpftune.nix
@@ -7,31 +7,14 @@ import ./make-test-python.nix ({ lib, pkgs, ... }: {
   };
 
   nodes = {
-    client = { pkgs, ... }: {
+    machine = { pkgs, ... }: {
       services.bpftune.enable = true;
-
-      boot.kernel.sysctl."net.ipv4.tcp_rmem" = "4096 131072 1310720";
-
-      environment.systemPackages = [ pkgs.iperf3 ];
-    };
-
-    server = { ... }: {
-      services.iperf3 = {
-        enable = true;
-        openFirewall = true;
-      };
     };
   };
 
   testScript = ''
-    with subtest("bpftune startup"):
-      client.wait_for_unit("bpftune.service")
-      client.wait_for_console_text("bpftune works fully")
-
-    with subtest("bpftune tcp buffer size"):
-      server.wait_for_unit("iperf3.service")
-      client.succeed("iperf3 --reverse -c server")
-      client.wait_for_console_text("need to increase TCP buffer size")
+    machine.wait_for_unit("bpftune.service")
+    machine.wait_for_console_text("bpftune works")
   '';
 
 })

--- a/pkgs/os-specific/linux/bpftune/default.nix
+++ b/pkgs/os-specific/linux/bpftune/default.nix
@@ -12,20 +12,21 @@
 
 stdenv.mkDerivation rec {
   pname = "bpftune";
-  version = "unstable-2023-05-30";
+  version = "unstable-2023-07-11";
 
   src = fetchFromGitHub {
     owner = "oracle-samples";
     repo = "bpftune";
-    rev = "bfec6668db29ec83afe2b030440f4d8f1476c1a6";
-    hash = "sha256-is7y53c9pBSyywVW8hO0iHsVPQlsCb4LU/cJMGf9ua4=";
+    rev = "f2eb8e9c020261cc8c58b312841dec32d287a0cc";
+    hash = "sha256-M5Zl4TzifQ3TkmCEBgKtv/kwichUY0PXQaQQThkTn2Q=";
   };
 
   postPatch = ''
     # otherwise shrink rpath would drop $out/lib from rpath
     substituteInPlace src/Makefile \
-      --replace /lib64 /lib \
-      --replace /sbin  /bin
+      --replace /lib64   /lib \
+      --replace /sbin    /bin \
+      --replace ldconfig true
     substituteInPlace src/bpftune.service \
       --replace /usr/sbin/bpftune "$out/bin/bpftune"
     substituteInPlace include/bpftune/libbpftune.h \
@@ -47,6 +48,7 @@ stdenv.mkDerivation rec {
 
   makeFlags = [
     "prefix=${placeholder "out"}"
+    "confprefix=${placeholder "out"}/etc"
     "BPFTUNE_VERSION=${version}"
     "BPF_INCLUDE=${lib.getDev libbpf}/include"
     "NL_INCLUDE=${lib.getDev libnl}/include/libnl3"

--- a/pkgs/os-specific/linux/bpftune/default.nix
+++ b/pkgs/os-specific/linux/bpftune/default.nix
@@ -1,0 +1,64 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, clang
+, bpftools
+, docutils
+, libbpf
+, libcap
+, libnl
+}:
+
+stdenv.mkDerivation rec {
+  pname = "bpftune";
+  version = "unstable-2023-05-30";
+
+  src = fetchFromGitHub {
+    owner = "oracle-samples";
+    repo = "bpftune";
+    rev = "bfec6668db29ec83afe2b030440f4d8f1476c1a6";
+    hash = "sha256-is7y53c9pBSyywVW8hO0iHsVPQlsCb4LU/cJMGf9ua4=";
+  };
+
+  postPatch = ''
+    # otherwise shrink rpath would drop $out/lib from rpath
+    substituteInPlace src/Makefile \
+      --replace /lib64 /lib \
+      --replace /sbin  /bin
+    substituteInPlace src/bpftune.service \
+      --replace /usr/sbin/bpftune "$out/bin/bpftune"
+    substituteInPlace include/bpftune/libbpftune.h \
+      --replace /usr/lib64/bpftune/       "$out/lib/bpftune/" \
+      --replace /usr/local/lib64/bpftune/ "$out/lib/bpftune/"
+  '';
+
+  nativeBuildInputs = [
+    clang
+    bpftools
+    docutils # rst2man
+  ];
+
+  buildInputs = [
+    libbpf
+    libcap
+    libnl
+  ];
+
+  makeFlags = [
+    "prefix=${placeholder "out"}"
+    "BPFTUNE_VERSION=${version}"
+    "BPF_INCLUDE=${lib.getDev libbpf}/include"
+    "NL_INCLUDE=${lib.getDev libnl}/include/libnl3"
+  ];
+
+  hardeningDisable = [
+    "stackprotector"
+  ];
+
+  meta = with lib; {
+    description = "BPF-based auto-tuning of Linux system parameters";
+    homepage = "https://github.com/oracle-samples/bpftune";
+    license = licenses.gpl2Only;
+    maintainers = with maintainers; [ nickcao ];
+  };
+}

--- a/pkgs/os-specific/linux/bpftune/default.nix
+++ b/pkgs/os-specific/linux/bpftune/default.nix
@@ -7,6 +7,7 @@
 , libbpf
 , libcap
 , libnl
+, nixosTests
 }:
 
 stdenv.mkDerivation rec {
@@ -54,6 +55,10 @@ stdenv.mkDerivation rec {
   hardeningDisable = [
     "stackprotector"
   ];
+
+  passthru.tests = {
+    inherit (nixosTests) bpftune;
+  };
 
   meta = with lib; {
     description = "BPF-based auto-tuning of Linux system parameters";

--- a/pkgs/os-specific/linux/bpftune/default.nix
+++ b/pkgs/os-specific/linux/bpftune/default.nix
@@ -12,13 +12,13 @@
 
 stdenv.mkDerivation rec {
   pname = "bpftune";
-  version = "unstable-2023-07-11";
+  version = "unstable-2023-07-14";
 
   src = fetchFromGitHub {
     owner = "oracle-samples";
     repo = "bpftune";
-    rev = "f2eb8e9c020261cc8c58b312841dec32d287a0cc";
-    hash = "sha256-M5Zl4TzifQ3TkmCEBgKtv/kwichUY0PXQaQQThkTn2Q=";
+    rev = "66620152bf8c37ab592e9273fe87e567126801c2";
+    hash = "sha256-U0O+F1DBF1xiaUKklwpZORBwF1T9wHM0SPQKUNaxKZk=";
   };
 
   postPatch = ''
@@ -61,6 +61,8 @@ stdenv.mkDerivation rec {
   passthru.tests = {
     inherit (nixosTests) bpftune;
   };
+
+  enableParallelBuilding = true;
 
   meta = with lib; {
     description = "BPF-based auto-tuning of Linux system parameters";

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -27219,6 +27219,8 @@ with pkgs;
 
   bpf-linker = callPackage ../development/tools/bpf-linker { };
 
+  bpftune = callPackage ../os-specific/linux/bpftune { };
+
   bpfmon = callPackage ../os-specific/linux/bpfmon { };
 
   bridge-utils = callPackage ../os-specific/linux/bridge-utils { };


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
