### PR TITLE
cudaPackages_12_2.cudatoolkit: init at 12.2.0

### DIFF
--- a/pkgs/development/compilers/cudatoolkit/common.nix
+++ b/pkgs/development/compilers/cudatoolkit/common.nix
@@ -42,6 +42,7 @@ args@
 , libsForQt5
 , libtiff
 , qt6Packages
+, qt6
 , rdma-core
 , ucx
 , rsync
@@ -131,22 +132,23 @@ backendStdenv.mkDerivation rec {
     ucx
     xorg.libxshmfence
     xorg.libxkbfile
-  ] ++ lib.optionals (lib.versionAtLeast version "12.1") (map lib.getLib [
+  ] ++ (lib.optionals (lib.versionAtLeast version "12.1") (map lib.getLib ([
     # Used by `/target-linux-x64/CollectX/clx` and `/target-linux-x64/CollectX/libclx_api.so` for:
     # - `libcurl.so.4`
     curlMinimal
 
-    # Used by `/target-linux-x64/libQt6Multimedia.so.6` for:
-    # - `libgstaudio-1.0.so.0`
-    # - `libgstvideo-1.0.so.0`
-    # - `libgstpbutils-1.0.so.0`
-    # - `libgstallocators-1.0.so.0`
-    # - `libgstapp-1.0.so.0`
-    # - `libgstbase-1.0.so.0`
-    # - `libgstreamer-1.0.so.0`
+    # Used by `/host-linux-x64/Scripts/WebRTCContainer/setup/neko/server/bin/neko`
     gst_all_1.gstreamer
     gst_all_1.gst-plugins-base
-  ]);
+  ]) ++ (with qt6; [
+    qtmultimedia
+    qttools
+    qtpositioning
+    qtscxml
+    qtsvg
+    qtwebchannel
+    qtwebengine
+  ])));
 
   # Prepended to runpaths by autoPatchelf.
   # The order inherited from older rpath preFixup code
@@ -256,6 +258,10 @@ backendStdenv.mkDerivation rec {
     ${lib.optionalString (lib.versionOlder version "10.1") ''
     # let's remove the 32-bit libraries, they confuse the lib64->lib mover
     rm -rf $out/lib
+    ''}
+
+    ${lib.optionalString (lib.versionAtLeast version "12.0") ''
+    rm $out/host-linux-x64/libQt6*
     ''}
 
     # Remove some cruft.

--- a/pkgs/development/compilers/cudatoolkit/redist/extension.nix
+++ b/pkgs/development/compilers/cudatoolkit/redist/extension.nix
@@ -15,6 +15,7 @@ final: prev: let
     "11.8" = ./manifests/redistrib_11.8.0.json;
     "12.0" = ./manifests/redistrib_12.0.1.json;
     "12.1" = ./manifests/redistrib_12.1.1.json;
+    "12.2" = ./manifests/redistrib_12.2.0.json;
   };
 
   # Function to build a single cudatoolkit redist package

--- a/pkgs/development/compilers/cudatoolkit/redist/manifests/redistrib_12.2.0.json
+++ b/pkgs/development/compilers/cudatoolkit/redist/manifests/redistrib_12.2.0.json
@@ -1,0 +1,1151 @@
+{
+    "release_date": "2023-06-28",
+    "release_label": "12.2.0",
+    "release_product": "cuda",
+    "cuda_cccl": {
+        "name": "CXX Core Compute Libraries",
+        "license": "CUDA Toolkit",
+        "license_path": "cuda_cccl/LICENSE.txt",
+        "version": "12.2.53",
+        "linux-x86_64": {
+            "relative_path": "cuda_cccl/linux-x86_64/cuda_cccl-linux-x86_64-12.2.53-archive.tar.xz",
+            "sha256": "3a665ffb51a3d21dc08f28e316ee035ad2381301eca65a36e657d434a27f8aa2",
+            "md5": "1a44f8f3bb192c8139ddfc109818e41d",
+            "size": "1106044"
+        },
+        "linux-ppc64le": {
+            "relative_path": "cuda_cccl/linux-ppc64le/cuda_cccl-linux-ppc64le-12.2.53-archive.tar.xz",
+            "sha256": "6cb035a15fd91436b17c66c06c15f7bff6efe70a2ca6d7a89fc1c85ab3b146ad",
+            "md5": "52073df19d7f2925956888c72e2de461",
+            "size": "1106412"
+        },
+        "linux-sbsa": {
+            "relative_path": "cuda_cccl/linux-sbsa/cuda_cccl-linux-sbsa-12.2.53-archive.tar.xz",
+            "sha256": "fe020baf2784a7745cb7db1df22d9abe13528a4ce0984c10ffc892a27507a7d9",
+            "md5": "e991c3c63effb228b0ea38edb84414f6",
+            "size": "1105768"
+        },
+        "windows-x86_64": {
+            "relative_path": "cuda_cccl/windows-x86_64/cuda_cccl-windows-x86_64-12.2.53-archive.zip",
+            "sha256": "a2f5579e23f24dd50cfb72d2ee28fb8ed3a7cb1484602df66fa808fe9defb6b3",
+            "md5": "0e23f2e0f3dd484ae4b770183f9d63d3",
+            "size": "2957130"
+        },
+        "linux-aarch64": {
+            "relative_path": "cuda_cccl/linux-aarch64/cuda_cccl-linux-aarch64-12.2.53-archive.tar.xz",
+            "sha256": "6e6b4c01334778beed0b4320f067758c5c77701e573d8e502a7ffc51843faf7e",
+            "md5": "29a3d1c635fc4ee82aa1ab17a3aadc71",
+            "size": "1106468"
+        }
+    },
+    "cuda_compat": {
+        "name": "CUDA compat L4T",
+        "license": "CUDA Toolkit",
+        "license_path": "cuda_compat/LICENSE.txt",
+        "version": "12.2.33189084",
+        "linux-aarch64": {
+            "relative_path": "cuda_compat/linux-aarch64/cuda_compat-linux-aarch64-12.2.33189084-archive.tar.xz",
+            "sha256": "e31c801017be83f2ba875f5b9afec91f8ff7b9c71d19b6591f7a85c03043236e",
+            "md5": "7cbaca4d76bacbb657f0b21aa815deb4",
+            "size": "18690068"
+        }
+    },
+    "cuda_cudart": {
+        "name": "CUDA Runtime (cudart)",
+        "license": "CUDA Toolkit",
+        "license_path": "cuda_cudart/LICENSE.txt",
+        "version": "12.2.53",
+        "linux-x86_64": {
+            "relative_path": "cuda_cudart/linux-x86_64/cuda_cudart-linux-x86_64-12.2.53-archive.tar.xz",
+            "sha256": "e21fb4fc9152f5bbeea94b860b70546545d4a9a36ae3e33f508de15908d47b76",
+            "md5": "025fbfcecbb9b09e0ae2427b6d5a8472",
+            "size": "1000396"
+        },
+        "linux-ppc64le": {
+            "relative_path": "cuda_cudart/linux-ppc64le/cuda_cudart-linux-ppc64le-12.2.53-archive.tar.xz",
+            "sha256": "fa18c6c76182ded75ea76a5db54097ed852b1e164e15f29d48b95bd589e2a872",
+            "md5": "535ced6ae08940680ed4dd80735a4138",
+            "size": "989476"
+        },
+        "linux-sbsa": {
+            "relative_path": "cuda_cudart/linux-sbsa/cuda_cudart-linux-sbsa-12.2.53-archive.tar.xz",
+            "sha256": "77310096876cd6c4fae7508225d180f30f4ab6cca73634aa18a11c2e4f0ebde6",
+            "md5": "fab5c7525a3c4d959f042b4043556d4f",
+            "size": "999804"
+        },
+        "windows-x86_64": {
+            "relative_path": "cuda_cudart/windows-x86_64/cuda_cudart-windows-x86_64-12.2.53-archive.zip",
+            "sha256": "950c71e53aa168d8459ad49050eae5d531b0c024cf0a2d176024d83dea9d3555",
+            "md5": "3772988f5a5771c914aee8a2c9a2163a",
+            "size": "2416404"
+        },
+        "linux-aarch64": {
+            "relative_path": "cuda_cudart/linux-aarch64/cuda_cudart-linux-aarch64-12.2.53-archive.tar.xz",
+            "sha256": "7aaa03032bc9abb7a04f9215bc13e7a5fff5f8fd83a537b79c4f9dd7983bd1d1",
+            "md5": "9fd906e2964883d3df346ec5b0f8b6cb",
+            "size": "1066396"
+        }
+    },
+    "cuda_cuobjdump": {
+        "name": "cuobjdump",
+        "license": "CUDA Toolkit",
+        "license_path": "cuda_cuobjdump/LICENSE.txt",
+        "version": "12.2.53",
+        "linux-x86_64": {
+            "relative_path": "cuda_cuobjdump/linux-x86_64/cuda_cuobjdump-linux-x86_64-12.2.53-archive.tar.xz",
+            "sha256": "420e0a60e11b0187e107d791007b63f87eec143fdab50ba08cadcf45dfbba8c5",
+            "md5": "a5398dd80c504cc52138b3fb3bd58e9a",
+            "size": "170828"
+        },
+        "linux-ppc64le": {
+            "relative_path": "cuda_cuobjdump/linux-ppc64le/cuda_cuobjdump-linux-ppc64le-12.2.53-archive.tar.xz",
+            "sha256": "831692e3e23c9655fd02f9b19704d0adcd65c7cc1f2cf6143bc2dddbf0f2f468",
+            "md5": "292ace508f5c82d7e113b3fe2360817f",
+            "size": "212824"
+        },
+        "linux-sbsa": {
+            "relative_path": "cuda_cuobjdump/linux-sbsa/cuda_cuobjdump-linux-sbsa-12.2.53-archive.tar.xz",
+            "sha256": "b77c73ab4ea28a98f41ee88884bcfe3c93b7f6d646984376a0dca870cd73ec87",
+            "md5": "0da93b2444f0f7d413556a396607aab6",
+            "size": "179248"
+        },
+        "windows-x86_64": {
+            "relative_path": "cuda_cuobjdump/windows-x86_64/cuda_cuobjdump-windows-x86_64-12.2.53-archive.zip",
+            "sha256": "36676a17558a3a8137c7259f255854bd6eac8489787a4dc72796da8f100ad9bd",
+            "md5": "0def615994e278707a4609da17ed8a5d",
+            "size": "3776112"
+        },
+        "linux-aarch64": {
+            "relative_path": "cuda_cuobjdump/linux-aarch64/cuda_cuobjdump-linux-aarch64-12.2.53-archive.tar.xz",
+            "sha256": "aae7adce1a84af830c8a92dd46a60eeb7dcb8cedb9a18c6d9e619f50c6adf9f5",
+            "md5": "bf9ea89b071cfcab146add4ed365dcd0",
+            "size": "163804"
+        }
+    },
+    "cuda_cupti": {
+        "name": "CUPTI",
+        "license": "CUDA Toolkit",
+        "license_path": "cuda_cupti/LICENSE.txt",
+        "version": "12.2.60",
+        "linux-x86_64": {
+            "relative_path": "cuda_cupti/linux-x86_64/cuda_cupti-linux-x86_64-12.2.60-archive.tar.xz",
+            "sha256": "494663c1ac68f5f8ee86adc31de34089ec4f4fb5e174503298722474adf864f9",
+            "md5": "f6c81c9267e8af1188e6ef3a05b01049",
+            "size": "18800604"
+        },
+        "linux-ppc64le": {
+            "relative_path": "cuda_cupti/linux-ppc64le/cuda_cupti-linux-ppc64le-12.2.60-archive.tar.xz",
+            "sha256": "cbec530bb1c666a5ea336344705c1927f41f42254bb0051261ad8c13b35bd4b1",
+            "md5": "ec629ff4843c39b6b509b3b2e1238f80",
+            "size": "10630824"
+        },
+        "linux-sbsa": {
+            "relative_path": "cuda_cupti/linux-sbsa/cuda_cupti-linux-sbsa-12.2.60-archive.tar.xz",
+            "sha256": "653684dd10af3b810c69bfabe7d8b0ddee59629c779c1f005993cb50b774756e",
+            "md5": "53bcf073b379637c03984d55e59e5a2b",
+            "size": "9781820"
+        },
+        "windows-x86_64": {
+            "relative_path": "cuda_cupti/windows-x86_64/cuda_cupti-windows-x86_64-12.2.60-archive.zip",
+            "sha256": "cf85306b44197720e5078629e627874c7015891e83a94b1a298a7db2c8baa4b7",
+            "md5": "6d547a40c28f38cb63b34a863cebe476",
+            "size": "13151576"
+        },
+        "linux-aarch64": {
+            "relative_path": "cuda_cupti/linux-aarch64/cuda_cupti-linux-aarch64-12.2.60-archive.tar.xz",
+            "sha256": "e951c00abc6928928dbb687743841f0c0d73c436ffe797e6413e4627d749f96a",
+            "md5": "bee88796d6ef238540a5f517fec4e1b9",
+            "size": "7731940"
+        }
+    },
+    "cuda_cuxxfilt": {
+        "name": "CUDA cuxxfilt (demangler)",
+        "license": "CUDA Toolkit",
+        "license_path": "cuda_cuxxfilt/LICENSE.txt",
+        "version": "12.2.53",
+        "linux-x86_64": {
+            "relative_path": "cuda_cuxxfilt/linux-x86_64/cuda_cuxxfilt-linux-x86_64-12.2.53-archive.tar.xz",
+            "sha256": "becedc25d308be46b63ebcbc041dd791c5e10a9ff24227eb481b3cc0c53499b2",
+            "md5": "90257b8ec952759368e008b89d7c0ad8",
+            "size": "188028"
+        },
+        "linux-ppc64le": {
+            "relative_path": "cuda_cuxxfilt/linux-ppc64le/cuda_cuxxfilt-linux-ppc64le-12.2.53-archive.tar.xz",
+            "sha256": "0c5af08176f55c939692e0df87d3f61affe527a665fb321b65e49f608a88f0b0",
+            "md5": "510a67ba8e82af333848c4f25468f391",
+            "size": "179980"
+        },
+        "linux-sbsa": {
+            "relative_path": "cuda_cuxxfilt/linux-sbsa/cuda_cuxxfilt-linux-sbsa-12.2.53-archive.tar.xz",
+            "sha256": "069b5005b271ba1ba5de3edbbb3aabf945bdf7466ba89ee25477448c1ec27d04",
+            "md5": "991fbe08fc7e7ed0afe5da73833a8d7c",
+            "size": "174668"
+        },
+        "windows-x86_64": {
+            "relative_path": "cuda_cuxxfilt/windows-x86_64/cuda_cuxxfilt-windows-x86_64-12.2.53-archive.zip",
+            "sha256": "d1a8b508c33dc7488337b4744747d6a1deaf3e67f6279a04f2e9de638ba8334d",
+            "md5": "c6e567c6fa6339e4c50739f7f5c648b6",
+            "size": "169417"
+        },
+        "linux-aarch64": {
+            "relative_path": "cuda_cuxxfilt/linux-aarch64/cuda_cuxxfilt-linux-aarch64-12.2.53-archive.tar.xz",
+            "sha256": "d3aaa8f58aa6a7164f097bfec4ab2640d59224671465927f6dce328137c074b5",
+            "md5": "558919c2abb5c55d35d2b229737f69da",
+            "size": "167304"
+        }
+    },
+    "cuda_demo_suite": {
+        "name": "CUDA Demo Suite",
+        "license": "CUDA Toolkit",
+        "license_path": "cuda_demo_suite/LICENSE.txt",
+        "version": "12.2.53",
+        "linux-x86_64": {
+            "relative_path": "cuda_demo_suite/linux-x86_64/cuda_demo_suite-linux-x86_64-12.2.53-archive.tar.xz",
+            "sha256": "074d80c5b3eafa80efa18010b51e17b256ed84422cb9970c77391839bd2e86e8",
+            "md5": "edfd69322632e5a36f285951b8049177",
+            "size": "4011816"
+        },
+        "windows-x86_64": {
+            "relative_path": "cuda_demo_suite/windows-x86_64/cuda_demo_suite-windows-x86_64-12.2.53-archive.zip",
+            "sha256": "c90a2683593652cf7feae460a96c6240f61e9468ee49cef2ab848d30c3e5022e",
+            "md5": "ad5f3a4d59b3bcff7bbef6c771ddeaab",
+            "size": "5052163"
+        }
+    },
+    "cuda_documentation": {
+        "name": "CUDA Documentation",
+        "license": "CUDA Toolkit",
+        "license_path": "cuda_documentation/LICENSE.txt",
+        "version": "12.2.53",
+        "linux-x86_64": {
+            "relative_path": "cuda_documentation/linux-x86_64/cuda_documentation-linux-x86_64-12.2.53-archive.tar.xz",
+            "sha256": "166a02868d57a635b3810e2557ac0d0233b2de554a7070c412709eae8ec06ec9",
+            "md5": "c6a19cbc239d694066c6ee211288d369",
+            "size": "67148"
+        },
+        "linux-ppc64le": {
+            "relative_path": "cuda_documentation/linux-ppc64le/cuda_documentation-linux-ppc64le-12.2.53-archive.tar.xz",
+            "sha256": "790b9b948b058bda215bf8af0693638c90a2201a6910aa618ddbb4b540bdda15",
+            "md5": "9d8ca1deb21491627bc68e3b1c00a50c",
+            "size": "67072"
+        },
+        "linux-sbsa": {
+            "relative_path": "cuda_documentation/linux-sbsa/cuda_documentation-linux-sbsa-12.2.53-archive.tar.xz",
+            "sha256": "1a6ef53db09820f685792042c72c25d4395953a1ff63a6a6b8a63bd472c67959",
+            "md5": "88198884d70f7f5d29863becfb553348",
+            "size": "67076"
+        },
+        "windows-x86_64": {
+            "relative_path": "cuda_documentation/windows-x86_64/cuda_documentation-windows-x86_64-12.2.53-archive.zip",
+            "sha256": "b110874271a51c1ff1ecb91b421f75850400a3be8aee6cad9385c2a80ec93f5d",
+            "md5": "0d8949ba742832f32c90d6060e0d0032",
+            "size": "105364"
+        },
+        "linux-aarch64": {
+            "relative_path": "cuda_documentation/linux-aarch64/cuda_documentation-linux-aarch64-12.2.53-archive.tar.xz",
+            "sha256": "42bc8a0467a16b62c8976c433f9598d2835eec2c95e81cbe37b640301b118853",
+            "md5": "a9d34a1d043919b3abf79084925ad736",
+            "size": "67228"
+        }
+    },
+    "cuda_gdb": {
+        "name": "CUDA GDB",
+        "license": "CUDA Toolkit",
+        "license_path": "cuda_gdb/LICENSE.txt",
+        "version": "12.2.53",
+        "linux-x86_64": {
+            "relative_path": "cuda_gdb/linux-x86_64/cuda_gdb-linux-x86_64-12.2.53-archive.tar.xz",
+            "sha256": "7360b3b126052712d86e760cc9cd2e5977bda98f25a32a25a36f4e3e1d86477e",
+            "md5": "454e9bbcb8c44b12610372d67edc16f0",
+            "size": "65702272"
+        },
+        "linux-ppc64le": {
+            "relative_path": "cuda_gdb/linux-ppc64le/cuda_gdb-linux-ppc64le-12.2.53-archive.tar.xz",
+            "sha256": "d58bdf87458af81be178d0457ed666cdbf9307bca35819e92e13c9069a13bd7c",
+            "md5": "fadcec8f26e76b85740734b525596149",
+            "size": "65469448"
+        },
+        "linux-sbsa": {
+            "relative_path": "cuda_gdb/linux-sbsa/cuda_gdb-linux-sbsa-12.2.53-archive.tar.xz",
+            "sha256": "350fd284c81258b5a7e60eddfb74984d2369254d7a2cc2bbfc0afd14096ff501",
+            "md5": "aaf51203301579f7fd2517786ff00078",
+            "size": "65360012"
+        },
+        "linux-aarch64": {
+            "relative_path": "cuda_gdb/linux-aarch64/cuda_gdb-linux-aarch64-12.2.53-archive.tar.xz",
+            "sha256": "5659d69039b9215086fd294e437ed669bdacf2b9a203f4348b820a68d1564cde",
+            "md5": "ddfca3180674496e161f8de6fa858b2c",
+            "size": "65285732"
+        }
+    },
+    "cuda_nsight": {
+        "name": "Nsight Eclipse Edition Plugin",
+        "license": "CUDA Toolkit",
+        "license_path": "cuda_nsight/LICENSE.txt",
+        "version": "12.2.53",
+        "linux-x86_64": {
+            "relative_path": "cuda_nsight/linux-x86_64/cuda_nsight-linux-x86_64-12.2.53-archive.tar.xz",
+            "sha256": "6f3674d4ba97ba18152e5aaa9f36e38b43017441b002cf801d5177bccdd52679",
+            "md5": "5e60e672c7be453b4cde6243180663ba",
+            "size": "118606032"
+        },
+        "linux-ppc64le": {
+            "relative_path": "cuda_nsight/linux-ppc64le/cuda_nsight-linux-ppc64le-12.2.53-archive.tar.xz",
+            "sha256": "8599079e194fb17e08459d8f92e6dc4bb7910869158db83f02413946605a6aad",
+            "md5": "342c5efc729e3794aa975a2e1bd25cb0",
+            "size": "118606032"
+        }
+    },
+    "cuda_nvcc": {
+        "name": "CUDA NVCC",
+        "license": "CUDA Toolkit",
+        "license_path": "cuda_nvcc/LICENSE.txt",
+        "version": "12.2.91",
+        "linux-x86_64": {
+            "relative_path": "cuda_nvcc/linux-x86_64/cuda_nvcc-linux-x86_64-12.2.91-archive.tar.xz",
+            "sha256": "d703af09bea3999b40c8c04095a78ec76ccf02b11094059300a3a9c2bd52ec61",
+            "md5": "b3b07d9b0b874c09a0cafadfc32b8760",
+            "size": "46508716"
+        },
+        "linux-ppc64le": {
+            "relative_path": "cuda_nvcc/linux-ppc64le/cuda_nvcc-linux-ppc64le-12.2.91-archive.tar.xz",
+            "sha256": "a39ebc6ce0f952ae0a3272b770dda7752fa298a0d522f3799ccc3400a7ed0460",
+            "md5": "92f38d3dafbda1cfe42d5f4ff5fe514d",
+            "size": "41981244"
+        },
+        "linux-sbsa": {
+            "relative_path": "cuda_nvcc/linux-sbsa/cuda_nvcc-linux-sbsa-12.2.91-archive.tar.xz",
+            "sha256": "dcdb55340adc6239ed3cbdc1ad8c3b0409f4d71c488f10a819d9ee1a57e097d2",
+            "md5": "23440328c7ef2fe44e58d197c1c0e09e",
+            "size": "41062040"
+        },
+        "windows-x86_64": {
+            "relative_path": "cuda_nvcc/windows-x86_64/cuda_nvcc-windows-x86_64-12.2.91-archive.zip",
+            "sha256": "c83baba72ec53a9c69fac2a5db098ccbb0dbe029bb4552b13b07f624ddfc8fcf",
+            "md5": "905a2cb1107a480613972f7804ca1048",
+            "size": "60255563"
+        },
+        "linux-aarch64": {
+            "relative_path": "cuda_nvcc/linux-aarch64/cuda_nvcc-linux-aarch64-12.2.91-archive.tar.xz",
+            "sha256": "e338332a7c585cd79c7fab4aa17bf6b53f474156f6766c8d599d47a8bbbebb29",
+            "md5": "76f51119161076f894b9bd61c3e85144",
+            "size": "42640072"
+        }
+    },
+    "cuda_nvdisasm": {
+        "name": "CUDA nvdisasm",
+        "license": "CUDA Toolkit",
+        "license_path": "cuda_nvdisasm/LICENSE.txt",
+        "version": "12.2.53",
+        "linux-x86_64": {
+            "relative_path": "cuda_nvdisasm/linux-x86_64/cuda_nvdisasm-linux-x86_64-12.2.53-archive.tar.xz",
+            "sha256": "30ac135c709a39eb58f6a1f30bd340965499198c9fb0030762253fbaad1c43ff",
+            "md5": "4f6bd5e1ff724738b2d1909037f1629e",
+            "size": "49881548"
+        },
+        "linux-ppc64le": {
+            "relative_path": "cuda_nvdisasm/linux-ppc64le/cuda_nvdisasm-linux-ppc64le-12.2.53-archive.tar.xz",
+            "sha256": "2219a350d2d02e53a16190d17d6ae4384f6b77ac89f5d5530622d3edc974c72d",
+            "md5": "ff3a9c319c988267f318857d28df78f7",
+            "size": "49858640"
+        },
+        "linux-sbsa": {
+            "relative_path": "cuda_nvdisasm/linux-sbsa/cuda_nvdisasm-linux-sbsa-12.2.53-archive.tar.xz",
+            "sha256": "88d5394f92dd0e65e43ddc46b536f7db9425cb9ad12462e5cc9dc2b589c2a9b3",
+            "md5": "672fa265e1330a0a718766ebd58e7e6f",
+            "size": "49811968"
+        },
+        "windows-x86_64": {
+            "relative_path": "cuda_nvdisasm/windows-x86_64/cuda_nvdisasm-windows-x86_64-12.2.53-archive.zip",
+            "sha256": "2ffcff04d7134f6e7f262da5ebd37e1ca6119660e8d07963d86fa97b809ba344",
+            "md5": "04083830287f39e180a9073399709621",
+            "size": "50125121"
+        },
+        "linux-aarch64": {
+            "relative_path": "cuda_nvdisasm/linux-aarch64/cuda_nvdisasm-linux-aarch64-12.2.53-archive.tar.xz",
+            "sha256": "7cd16a90c25503073334ae896b6b176afa297a0e30556e61596e8c8e5ca0ebfa",
+            "md5": "5fce580872b7211d4d3c03d46139b0e9",
+            "size": "49808416"
+        }
+    },
+    "cuda_nvml_dev": {
+        "name": "CUDA NVML Headers",
+        "license": "CUDA Toolkit",
+        "license_path": "cuda_nvml_dev/LICENSE.txt",
+        "version": "12.2.81",
+        "linux-x86_64": {
+            "relative_path": "cuda_nvml_dev/linux-x86_64/cuda_nvml_dev-linux-x86_64-12.2.81-archive.tar.xz",
+            "sha256": "07efe02d5ecf7f9079150dfaea06e6b6b9f284e9b0322bb8e07fc743ca39ba98",
+            "md5": "cf77fec8ce77ade6dfb803d0f471ea6d",
+            "size": "85072"
+        },
+        "linux-ppc64le": {
+            "relative_path": "cuda_nvml_dev/linux-ppc64le/cuda_nvml_dev-linux-ppc64le-12.2.81-archive.tar.xz",
+            "sha256": "a72c79f32672a5fe3afa20fdabee9621fd57f5b21bbcdea6deb042026e040df1",
+            "md5": "0ad388bc765a0f483e2d8c51e5c070db",
+            "size": "84424"
+        },
+        "linux-sbsa": {
+            "relative_path": "cuda_nvml_dev/linux-sbsa/cuda_nvml_dev-linux-sbsa-12.2.81-archive.tar.xz",
+            "sha256": "d8c76caf01a2a9399c59f2a368fceec5b12df5d7ff2bbf0e5bdeb6d01a8b9e3c",
+            "md5": "fcd43cdaf216afc39ebcc5f96e18f514",
+            "size": "85016"
+        },
+        "windows-x86_64": {
+            "relative_path": "cuda_nvml_dev/windows-x86_64/cuda_nvml_dev-windows-x86_64-12.2.81-archive.zip",
+            "sha256": "04657b81d0012c7517f27da80eb572c3fbd0d354821e7a368cc0a677182baa78",
+            "md5": "63722c5bc70003a028d2ee057d443b50",
+            "size": "119150"
+        },
+        "linux-aarch64": {
+            "relative_path": "cuda_nvml_dev/linux-aarch64/cuda_nvml_dev-linux-aarch64-12.2.81-archive.tar.xz",
+            "sha256": "d585c5c3cdf3ae7253a78624776edf81b1a5ae1ad18c0a7fa5b61bdb3727a845",
+            "md5": "ff412e9af3a1d5fa9ebdab1a83997442",
+            "size": "85032"
+        }
+    },
+    "cuda_nvprof": {
+        "name": "CUDA nvprof",
+        "license": "CUDA Toolkit",
+        "license_path": "cuda_nvprof/LICENSE.txt",
+        "version": "12.2.60",
+        "linux-x86_64": {
+            "relative_path": "cuda_nvprof/linux-x86_64/cuda_nvprof-linux-x86_64-12.2.60-archive.tar.xz",
+            "sha256": "09dca174f073657b915de9be6585e654477b7336bf1f04753391cc35b1b9d660",
+            "md5": "42c6e437e27d8eee8aaad720de749e71",
+            "size": "2441200"
+        },
+        "linux-ppc64le": {
+            "relative_path": "cuda_nvprof/linux-ppc64le/cuda_nvprof-linux-ppc64le-12.2.60-archive.tar.xz",
+            "sha256": "db8302b6b5f9c490325d5f29e94f1b42c618e27fcf95f468ab9cce350cd77c66",
+            "md5": "2f98ce48278ceded6a9d721abb9c9089",
+            "size": "2119668"
+        },
+        "windows-x86_64": {
+            "relative_path": "cuda_nvprof/windows-x86_64/cuda_nvprof-windows-x86_64-12.2.60-archive.zip",
+            "sha256": "1330fd4803a37c2f8cb8ffdac62a538bf5e2a5d69169519b3bccecafa4b266ef",
+            "md5": "c4ed24f3d7a59a3ffc028f17abed7acf",
+            "size": "1700986"
+        }
+    },
+    "cuda_nvprune": {
+        "name": "CUDA nvprune",
+        "license": "CUDA Toolkit",
+        "license_path": "cuda_nvprune/LICENSE.txt",
+        "version": "12.2.53",
+        "linux-x86_64": {
+            "relative_path": "cuda_nvprune/linux-x86_64/cuda_nvprune-linux-x86_64-12.2.53-archive.tar.xz",
+            "sha256": "79550967b7975a3ad38d2b94605a71cbaeb6d24e37ed8cb604253bfeefdef241",
+            "md5": "066300fa3fa03553acec2ba4ca435330",
+            "size": "56152"
+        },
+        "linux-ppc64le": {
+            "relative_path": "cuda_nvprune/linux-ppc64le/cuda_nvprune-linux-ppc64le-12.2.53-archive.tar.xz",
+            "sha256": "59da797aaaed54f2a3e9e4d225c4552d15ef3e9d5af02a79979814c8bdda7f84",
+            "md5": "3cbbf747e4f2a41caf709b4d9bc92731",
+            "size": "57076"
+        },
+        "linux-sbsa": {
+            "relative_path": "cuda_nvprune/linux-sbsa/cuda_nvprune-linux-sbsa-12.2.53-archive.tar.xz",
+            "sha256": "5fb12b382a59ac9d7094f2885d769bc15b60da8ebdf259cab426348732f2bce9",
+            "md5": "384e0c4725ab1898a512338c01215198",
+            "size": "48144"
+        },
+        "windows-x86_64": {
+            "relative_path": "cuda_nvprune/windows-x86_64/cuda_nvprune-windows-x86_64-12.2.53-archive.zip",
+            "sha256": "581721f4a28ff1209e41d163d3575842a21f81d206569862d6d988d5cac16a68",
+            "md5": "b77d2561d486c69a8eb3e5c2292b6799",
+            "size": "145868"
+        },
+        "linux-aarch64": {
+            "relative_path": "cuda_nvprune/linux-aarch64/cuda_nvprune-linux-aarch64-12.2.53-archive.tar.xz",
+            "sha256": "e27db910927c1c84adc3d7982c49518428f6d331f149eb7ba4e98bebd4af81c1",
+            "md5": "f0f3e29643c1b45544c7e352d7757ec2",
+            "size": "49716"
+        }
+    },
+    "cuda_nvrtc": {
+        "name": "CUDA NVRTC",
+        "license": "CUDA Toolkit",
+        "license_path": "cuda_nvrtc/LICENSE.txt",
+        "version": "12.2.91",
+        "linux-x86_64": {
+            "relative_path": "cuda_nvrtc/linux-x86_64/cuda_nvrtc-linux-x86_64-12.2.91-archive.tar.xz",
+            "sha256": "c366d551840268b66420b216066f64ad471dc1063156bf8c63cf8538bf606141",
+            "md5": "01d50d7b944941e10c2cd5000d365a29",
+            "size": "30600936"
+        },
+        "linux-ppc64le": {
+            "relative_path": "cuda_nvrtc/linux-ppc64le/cuda_nvrtc-linux-ppc64le-12.2.91-archive.tar.xz",
+            "sha256": "74ca0a176515fb7f5fb73a8ea1b550425e376b5f471d45f793759045b85daddc",
+            "md5": "a7d0a50025a122d7f7b2db86b7b31066",
+            "size": "28230692"
+        },
+        "linux-sbsa": {
+            "relative_path": "cuda_nvrtc/linux-sbsa/cuda_nvrtc-linux-sbsa-12.2.91-archive.tar.xz",
+            "sha256": "be057dbc9cc098a2923057be985e068199d16ca1ead802f427ad2e9eee1b15e0",
+            "md5": "9bbff4319f82a1faf4f10fa996175078",
+            "size": "28229148"
+        },
+        "windows-x86_64": {
+            "relative_path": "cuda_nvrtc/windows-x86_64/cuda_nvrtc-windows-x86_64-12.2.91-archive.zip",
+            "sha256": "f92f8e71ac6a6efdfcb1bec23cb10bef6901861d8fcdfd0e95f7c22af3246158",
+            "md5": "ffc97eb7fd177e31dfa2be0ffc4d8c83",
+            "size": "96122917"
+        },
+        "linux-aarch64": {
+            "relative_path": "cuda_nvrtc/linux-aarch64/cuda_nvrtc-linux-aarch64-12.2.91-archive.tar.xz",
+            "sha256": "a00c80a98b7582e94601e7b82845d065acef7d9f10805a73a6f8736745a8b71f",
+            "md5": "156feaa39450acb83deb6e1a768a7b47",
+            "size": "29471304"
+        }
+    },
+    "cuda_nvtx": {
+        "name": "CUDA NVTX",
+        "license": "CUDA Toolkit",
+        "license_path": "cuda_nvtx/LICENSE.txt",
+        "version": "12.2.53",
+        "linux-x86_64": {
+            "relative_path": "cuda_nvtx/linux-x86_64/cuda_nvtx-linux-x86_64-12.2.53-archive.tar.xz",
+            "sha256": "3bcbec1b2ed198bf044f8a85f73fdf011719e5567b418376fcdcde28b0b29c3e",
+            "md5": "7eb7e5ca661f27fd2b6bc8b816dfc774",
+            "size": "48372"
+        },
+        "linux-ppc64le": {
+            "relative_path": "cuda_nvtx/linux-ppc64le/cuda_nvtx-linux-ppc64le-12.2.53-archive.tar.xz",
+            "sha256": "446e02152814f41cc3eb725c8adccb3d597a36934fefc4fdfd53c78e012571c6",
+            "md5": "3a1dbd4cbf2e8a93837873d795dc9b07",
+            "size": "48428"
+        },
+        "linux-sbsa": {
+            "relative_path": "cuda_nvtx/linux-sbsa/cuda_nvtx-linux-sbsa-12.2.53-archive.tar.xz",
+            "sha256": "8d8b10154b55212ace5ab9e9be4c24c6579b3ef4940fafb0090274e30aa44a49",
+            "md5": "b24cc3a2b3b4432c80910978595eb541",
+            "size": "49004"
+        },
+        "windows-x86_64": {
+            "relative_path": "cuda_nvtx/windows-x86_64/cuda_nvtx-windows-x86_64-12.2.53-archive.zip",
+            "sha256": "04a54a3bf04ca81750c5495d5c5c69f218338c2f01b8e433dd7858f61760e729",
+            "md5": "1e497aa200c0827f2da7486d6961f6bd",
+            "size": "65690"
+        },
+        "linux-aarch64": {
+            "relative_path": "cuda_nvtx/linux-aarch64/cuda_nvtx-linux-aarch64-12.2.53-archive.tar.xz",
+            "sha256": "5b85fabb3a212832180be0e79b4af225e73a8d2202646a9166995efb3e0ff22e",
+            "md5": "c44c019829a1270f030704014cc01fbf",
+            "size": "51548"
+        }
+    },
+    "cuda_nvvp": {
+        "name": "CUDA NVVP",
+        "license": "CUDA Toolkit",
+        "license_path": "cuda_nvvp/LICENSE.txt",
+        "version": "12.2.60",
+        "linux-x86_64": {
+            "relative_path": "cuda_nvvp/linux-x86_64/cuda_nvvp-linux-x86_64-12.2.60-archive.tar.xz",
+            "sha256": "b213d80a96d6fa22dd48a1e471de817c8c462a52a7cebcffceb37bc942dc00f2",
+            "md5": "726c6d43ef0e28996f2e7e6aa6ee5751",
+            "size": "117694060"
+        },
+        "linux-ppc64le": {
+            "relative_path": "cuda_nvvp/linux-ppc64le/cuda_nvvp-linux-ppc64le-12.2.60-archive.tar.xz",
+            "sha256": "c597d50e6345739f63bcec8b7af2bfc096da348f1be0721ffcd7f4037cc8be26",
+            "md5": "966f4b457038d6cb5e4cc2ce1ddda338",
+            "size": "117147564"
+        },
+        "windows-x86_64": {
+            "relative_path": "cuda_nvvp/windows-x86_64/cuda_nvvp-windows-x86_64-12.2.60-archive.zip",
+            "sha256": "225a86ef18bdb5ec49a53d89fbf2b37eabc623f817dc668e536a02ae6f6052d6",
+            "md5": "0a3ba61f91a92dee25aef180d3f199e2",
+            "size": "120358259"
+        }
+    },
+    "cuda_opencl": {
+        "name": "CUDA OpenCL",
+        "license": "CUDA Toolkit",
+        "license_path": "cuda_opencl/LICENSE.txt",
+        "version": "12.2.53",
+        "linux-x86_64": {
+            "relative_path": "cuda_opencl/linux-x86_64/cuda_opencl-linux-x86_64-12.2.53-archive.tar.xz",
+            "sha256": "139fc9d16f4aaaa68a9161367829a927fe1ae2602e82a1d93adf2a9250b506d3",
+            "md5": "dd671fd1df845bcef67fd854fa66b2a1",
+            "size": "74936"
+        },
+        "windows-x86_64": {
+            "relative_path": "cuda_opencl/windows-x86_64/cuda_opencl-windows-x86_64-12.2.53-archive.zip",
+            "sha256": "5fc4f66532f797c1daaa2539e55ca32d9accb9d41429e0f3ca6112f893c6627c",
+            "md5": "5b54f604183a206896e9d0e81f72991c",
+            "size": "112902"
+        }
+    },
+    "cuda_profiler_api": {
+        "name": "CUDA Profiler API",
+        "license": "CUDA Toolkit",
+        "license_path": "cuda_profiler_api/LICENSE.txt",
+        "version": "12.2.53",
+        "linux-x86_64": {
+            "relative_path": "cuda_profiler_api/linux-x86_64/cuda_profiler_api-linux-x86_64-12.2.53-archive.tar.xz",
+            "sha256": "b534489386c9e1df62a5a8544da86fabaae872ef12b3209d8cf222fbb1678ba4",
+            "md5": "806822db69e151e01992422a5e92fca0",
+            "size": "16060"
+        },
+        "linux-ppc64le": {
+            "relative_path": "cuda_profiler_api/linux-ppc64le/cuda_profiler_api-linux-ppc64le-12.2.53-archive.tar.xz",
+            "sha256": "2b7473f96fac0af92d13fb3a40eaf2c4fa5df60b4ab8afc3a9f2e0f252b8b084",
+            "md5": "b9fe730c03d14430e258c7634407ab5d",
+            "size": "16056"
+        },
+        "linux-sbsa": {
+            "relative_path": "cuda_profiler_api/linux-sbsa/cuda_profiler_api-linux-sbsa-12.2.53-archive.tar.xz",
+            "sha256": "42c7463dcc2f1ee1c06576d103ad9886ba3620e8348ea760f22aaa963100fd99",
+            "md5": "628d561d285e45aa5ec28b20d7f57abb",
+            "size": "16052"
+        },
+        "windows-x86_64": {
+            "relative_path": "cuda_profiler_api/windows-x86_64/cuda_profiler_api-windows-x86_64-12.2.53-archive.zip",
+            "sha256": "4b07eb70491d31ee48c6b181a4923dbcf98c2b5b9d14f7c8e12a1a519320b7c9",
+            "md5": "38d7cc004f8f921271faaaf1e1ee6c0e",
+            "size": "20075"
+        },
+        "linux-aarch64": {
+            "relative_path": "cuda_profiler_api/linux-aarch64/cuda_profiler_api-linux-aarch64-12.2.53-archive.tar.xz",
+            "sha256": "72d6f489b77deb65aa576fef66e4b6015fbe7a1a0a5695d45acf76682c9ab7c8",
+            "md5": "28b71ef7ca59a5fb6546b5dfe701b0cf",
+            "size": "16048"
+        }
+    },
+    "cuda_sanitizer_api": {
+        "name": "CUDA Compute Sanitizer API",
+        "license": "CUDA Toolkit",
+        "license_path": "cuda_sanitizer_api/LICENSE.txt",
+        "version": "12.2.53",
+        "linux-x86_64": {
+            "relative_path": "cuda_sanitizer_api/linux-x86_64/cuda_sanitizer_api-linux-x86_64-12.2.53-archive.tar.xz",
+            "sha256": "ad70fb519239cd7b53178938c73183ee3cb1b3b3639eeacf3e63fcea8ef32a92",
+            "md5": "d7c6c2ad94fc0640009c84286da5274e",
+            "size": "8063936"
+        },
+        "linux-ppc64le": {
+            "relative_path": "cuda_sanitizer_api/linux-ppc64le/cuda_sanitizer_api-linux-ppc64le-12.2.53-archive.tar.xz",
+            "sha256": "1d5f46fc86e34f9279fe9acde1efc688388db72dc08ea3b95cf0f27df68124eb",
+            "md5": "2651d09b3f8acfc1586a449863da3f83",
+            "size": "7638524"
+        },
+        "linux-sbsa": {
+            "relative_path": "cuda_sanitizer_api/linux-sbsa/cuda_sanitizer_api-linux-sbsa-12.2.53-archive.tar.xz",
+            "sha256": "9e1c66bd3d3b81d5b28c3cbabf798a853a63ea31eb86d14d4e259c0d49b27613",
+            "md5": "aaba9569e08361ad47794e54cf3bde39",
+            "size": "6215664"
+        },
+        "windows-x86_64": {
+            "relative_path": "cuda_sanitizer_api/windows-x86_64/cuda_sanitizer_api-windows-x86_64-12.2.53-archive.zip",
+            "sha256": "1d3f7a07a5fe18e0bccf859e58c98f92a6e40080b156fc65ebf89d9967ed4f7e",
+            "md5": "ad145cb1bf0bdd1a08045a33f01809a8",
+            "size": "13897178"
+        },
+        "linux-aarch64": {
+            "relative_path": "cuda_sanitizer_api/linux-aarch64/cuda_sanitizer_api-linux-aarch64-12.2.53-archive.tar.xz",
+            "sha256": "24cbb446c763a49875d15aba1a2878d408c796d6412118884a130e54f585409b",
+            "md5": "9478627e21ed32a1fd2f682da606eb51",
+            "size": "3538240"
+        }
+    },
+    "fabricmanager": {
+        "name": "NVIDIA Fabric Manager",
+        "license": "NVIDIA Driver",
+        "license_path": "fabricmanager/LICENSE.txt",
+        "version": "535.54.03",
+        "linux-x86_64": {
+            "relative_path": "fabricmanager/linux-x86_64/fabricmanager-linux-x86_64-535.54.03-archive.tar.xz",
+            "sha256": "a04f72d5491d102e402d48f91096272276caf38c868852ad5d13a151bcb41a62",
+            "md5": "7fa84b39ceee1f56f075284413c8d0ac",
+            "size": "1819128"
+        },
+        "linux-sbsa": {
+            "relative_path": "fabricmanager/linux-sbsa/fabricmanager-linux-sbsa-535.54.03-archive.tar.xz",
+            "sha256": "d5d9ca3e4aad2fc5382b490b99c3a79e4bffce90b433dabcee99d66bbc8766d6",
+            "md5": "ad6b474572fea29a14044c92d9ad1454",
+            "size": "1679976"
+        }
+    },
+    "libcublas": {
+        "name": "CUDA cuBLAS",
+        "license": "CUDA Toolkit",
+        "license_path": "libcublas/LICENSE.txt",
+        "version": "12.2.1.16",
+        "linux-x86_64": {
+            "relative_path": "libcublas/linux-x86_64/libcublas-linux-x86_64-12.2.1.16-archive.tar.xz",
+            "sha256": "59b7509bc16c438b88469705f7c46cbcfb20848d6738845c1e4f39e2ea3b1d2c",
+            "md5": "d1cbebbf93af112a80a8fd2b71e7d098",
+            "size": "486327288"
+        },
+        "linux-ppc64le": {
+            "relative_path": "libcublas/linux-ppc64le/libcublas-linux-ppc64le-12.2.1.16-archive.tar.xz",
+            "sha256": "0174812ce96bd997d8bb3707140788d7283c054c8f04ea0674f286816ebfe331",
+            "md5": "27f53db7127c73fcdf68a92f0b74dc55",
+            "size": "389457560"
+        },
+        "linux-sbsa": {
+            "relative_path": "libcublas/linux-sbsa/libcublas-linux-sbsa-12.2.1.16-archive.tar.xz",
+            "sha256": "0bde331f46d0251a6416a198697a5ff07b9ff73b30794ee6a3647248d3793973",
+            "md5": "ef9244b625a693e85e093b72832271de",
+            "size": "484681612"
+        },
+        "windows-x86_64": {
+            "relative_path": "libcublas/windows-x86_64/libcublas-windows-x86_64-12.2.1.16-archive.zip",
+            "sha256": "70c8bbc1cb1b58e8987623fef465477398839f14118cf9026868327159b8ec89",
+            "md5": "02630f7d68d31841c521f49c4f0931c3",
+            "size": "433276035"
+        },
+        "linux-aarch64": {
+            "relative_path": "libcublas/linux-aarch64/libcublas-linux-aarch64-12.2.1.16-archive.tar.xz",
+            "sha256": "5d3dd3e92964c48e2ad976410cef944820964649683f15b3d090ea259efcfc91",
+            "md5": "ec74be5b9456476f1735eb1e472a58a2",
+            "size": "442689448"
+        }
+    },
+    "libcudla": {
+        "name": "cuDLA",
+        "license": "CUDA Toolkit",
+        "license_path": "libcudla/LICENSE.txt",
+        "version": "12.2.53",
+        "linux-aarch64": {
+            "relative_path": "libcudla/linux-aarch64/libcudla-linux-aarch64-12.2.53-archive.tar.xz",
+            "sha256": "c0c5ec192110a4eb556a2d042c07281574aa0ffbf27aa354f017152dd26dd8e6",
+            "md5": "7766e66ace29d881556eb3b8f8205869",
+            "size": "37856"
+        }
+    },
+    "libcufft": {
+        "name": "CUDA cuFFT",
+        "license": "CUDA Toolkit",
+        "license_path": "libcufft/LICENSE.txt",
+        "version": "11.0.8.15",
+        "linux-x86_64": {
+            "relative_path": "libcufft/linux-x86_64/libcufft-linux-x86_64-11.0.8.15-archive.tar.xz",
+            "sha256": "ce0991bff7d17caddf38262573ce783afbf4faf68034ae2e0543472f8dd90f40",
+            "md5": "152eaa27cf4c2c23b9bfc68dbcc797bd",
+            "size": "170425736"
+        },
+        "linux-ppc64le": {
+            "relative_path": "libcufft/linux-ppc64le/libcufft-linux-ppc64le-11.0.8.15-archive.tar.xz",
+            "sha256": "9df5e513987601cc4dbfe3ee084da21d0e318e448fa94550e5d4762ecf4d6aae",
+            "md5": "1b9df07f5b2c2803ca46a9b3fa2b5d74",
+            "size": "170536256"
+        },
+        "linux-sbsa": {
+            "relative_path": "libcufft/linux-sbsa/libcufft-linux-sbsa-11.0.8.15-archive.tar.xz",
+            "sha256": "3eeb365441549334ae582318653260c92137943c1ad285bb325eeccfba9e15e7",
+            "md5": "b4adab68ba9ab153f5b0b16c57f40cbb",
+            "size": "170569432"
+        },
+        "windows-x86_64": {
+            "relative_path": "libcufft/windows-x86_64/libcufft-windows-x86_64-11.0.8.15-archive.zip",
+            "sha256": "cbec006d998561eed5d89fc8365247dce597bba5280e3642e0e4ba34db083645",
+            "md5": "e79fcca7c4ffcc1a67bda6f32e85044e",
+            "size": "97456840"
+        },
+        "linux-aarch64": {
+            "relative_path": "libcufft/linux-aarch64/libcufft-linux-aarch64-11.0.8.15-archive.tar.xz",
+            "sha256": "a877d212db7cc4b2320d9579a9e2344609a3ec86b8b0c3f1716b0eec98dd8e11",
+            "md5": "a2a0df7cbd1373e93ede7be8d1015069",
+            "size": "170665012"
+        }
+    },
+    "libcufile": {
+        "name": "CUDA cuFile",
+        "license": "CUDA Toolkit",
+        "license_path": "libcufile/LICENSE.txt",
+        "version": "1.7.0.149",
+        "linux-x86_64": {
+            "relative_path": "libcufile/linux-x86_64/libcufile-linux-x86_64-1.7.0.149-archive.tar.xz",
+            "sha256": "dbcec7913ad9b59162a60aa5818335d3dbb5aee207ed2c3c65c8995a77746a96",
+            "md5": "41b451c16c1657e1126f11cb9bae080e",
+            "size": "41848568"
+        },
+        "linux-sbsa": {
+            "relative_path": "libcufile/linux-sbsa/libcufile-linux-sbsa-1.7.0.149-archive.tar.xz",
+            "sha256": "86f5b0b910e3813ea190a074bb743f319ad9b95bfc31bb402d663ac5c284b2c8",
+            "md5": "a19e71dc765d85a3007493a9b31484a4",
+            "size": "41294576"
+        },
+        "linux-aarch64": {
+            "relative_path": "libcufile/linux-aarch64/libcufile-linux-aarch64-1.7.0.149-archive.tar.xz",
+            "sha256": "39a7dbd1763b6d4c7da2cb5b15db75501e723844a8f8a5914a29fcaa6ad9eca3",
+            "md5": "7855d4c52825274fb5acfb2d27387e7b",
+            "size": "41274348"
+        }
+    },
+    "libcurand": {
+        "name": "CUDA cuRAND",
+        "license": "CUDA Toolkit",
+        "license_path": "libcurand/LICENSE.txt",
+        "version": "10.3.3.53",
+        "linux-x86_64": {
+            "relative_path": "libcurand/linux-x86_64/libcurand-linux-x86_64-10.3.3.53-archive.tar.xz",
+            "sha256": "890181ef02a4752fd4cf4113770c27340f19112d81cd6076d0630dba8f746ed6",
+            "md5": "c11537005ba88971f536effdc0825a5a",
+            "size": "81945064"
+        },
+        "linux-ppc64le": {
+            "relative_path": "libcurand/linux-ppc64le/libcurand-linux-ppc64le-10.3.3.53-archive.tar.xz",
+            "sha256": "d0d819e85139346229aef2000231e42ff8d20e13c9ad6acae780e265d3dc8b8e",
+            "md5": "501debf6ad4405494bfee9a769a976f0",
+            "size": "81983028"
+        },
+        "linux-sbsa": {
+            "relative_path": "libcurand/linux-sbsa/libcurand-linux-sbsa-10.3.3.53-archive.tar.xz",
+            "sha256": "4367394f6d57dd0ff9b597f5f7471b8b346f6c878ad5dca6f2b8f377d0b23d72",
+            "md5": "6a16970981b6c64be5cbeec2245a5f07",
+            "size": "81931700"
+        },
+        "windows-x86_64": {
+            "relative_path": "libcurand/windows-x86_64/libcurand-windows-x86_64-10.3.3.53-archive.zip",
+            "sha256": "39a68f5049825bb52af30cabf2f29b20a1cfe0f127875ae11a3684824efd41d5",
+            "md5": "f8654726922d89040d8679cddc5bd150",
+            "size": "55279087"
+        },
+        "linux-aarch64": {
+            "relative_path": "libcurand/linux-aarch64/libcurand-linux-aarch64-10.3.3.53-archive.tar.xz",
+            "sha256": "759082826aea2bfd4d63f7dafb84518a24a306f3007ffc061554d28faf9b4dc6",
+            "md5": "ae3d27bf5dcb77af666bb89463ce5c88",
+            "size": "84107132"
+        }
+    },
+    "libcusolver": {
+        "name": "CUDA cuSOLVER",
+        "license": "CUDA Toolkit",
+        "license_path": "libcusolver/LICENSE.txt",
+        "version": "11.5.0.53",
+        "linux-x86_64": {
+            "relative_path": "libcusolver/linux-x86_64/libcusolver-linux-x86_64-11.5.0.53-archive.tar.xz",
+            "sha256": "0ce1f6058005117fc1aa2dd731e1c6009aa79993c179cbdb2d01f17959dfdc87",
+            "md5": "2df25f844d081afb79b3cffe6bc53ce6",
+            "size": "123332556"
+        },
+        "linux-ppc64le": {
+            "relative_path": "libcusolver/linux-ppc64le/libcusolver-linux-ppc64le-11.5.0.53-archive.tar.xz",
+            "sha256": "1f690cabb35ae92ef5a1cd3d6f1222a535bafea86a259d88cf8d2410558b6414",
+            "md5": "46670044a53afbf7ebdb2fff57bd2a64",
+            "size": "122967236"
+        },
+        "linux-sbsa": {
+            "relative_path": "libcusolver/linux-sbsa/libcusolver-linux-sbsa-11.5.0.53-archive.tar.xz",
+            "sha256": "5135dff78a3cf7353362b7c6547af61fdca164e8b792fbff4066989c36183925",
+            "md5": "419bad18195a23817c76aba940d8e5ff",
+            "size": "122295788"
+        },
+        "windows-x86_64": {
+            "relative_path": "libcusolver/windows-x86_64/libcusolver-windows-x86_64-11.5.0.53-archive.zip",
+            "sha256": "36bac40d8f8f9a05bf9936a2348cfe71c848fbb52d40750dfb6600c3e84ef9ff",
+            "md5": "edad14e88c2faeae872a53ee1975575b",
+            "size": "120629517"
+        },
+        "linux-aarch64": {
+            "relative_path": "libcusolver/linux-aarch64/libcusolver-linux-aarch64-11.5.0.53-archive.tar.xz",
+            "sha256": "4eaec6e813dded192cef54252902b915de9116149c52aa840b7631bab7e244a3",
+            "md5": "f93615f925e87ad318f1307d303a4c5c",
+            "size": "133342388"
+        }
+    },
+    "libcusparse": {
+        "name": "CUDA cuSPARSE",
+        "license": "CUDA Toolkit",
+        "license_path": "libcusparse/LICENSE.txt",
+        "version": "12.1.1.53",
+        "linux-x86_64": {
+            "relative_path": "libcusparse/linux-x86_64/libcusparse-linux-x86_64-12.1.1.53-archive.tar.xz",
+            "sha256": "3b38e39c27fc9e91ccae949bc06692a76e5d6d88320177d8b1795be3086ea305",
+            "md5": "9333e20cba966d557186fa32ad47008b",
+            "size": "211590820"
+        },
+        "linux-ppc64le": {
+            "relative_path": "libcusparse/linux-ppc64le/libcusparse-linux-ppc64le-12.1.1.53-archive.tar.xz",
+            "sha256": "4c5297adea9229fd820c7891694e851f39ecbe69bd642449007e7eca62c6124f",
+            "md5": "acd166b34c7f6e5dbe60ddea1ad4a76a",
+            "size": "211736192"
+        },
+        "linux-sbsa": {
+            "relative_path": "libcusparse/linux-sbsa/libcusparse-linux-sbsa-12.1.1.53-archive.tar.xz",
+            "sha256": "504b2a6bfd588cda6cb293f030f98b7aa36a6d60a30063c4c4aa9b74ab27dc92",
+            "md5": "e233abe1bd165db5619d1bfa1abbe3a9",
+            "size": "211253852"
+        },
+        "windows-x86_64": {
+            "relative_path": "libcusparse/windows-x86_64/libcusparse-windows-x86_64-12.1.1.53-archive.zip",
+            "sha256": "39b9d0927c5f3ac9a3b92523b60aac7871b41fa7a72a210bc9bb3b5828b8d5f8",
+            "md5": "6d8e6e1c410d3cf50ad95d3df21d0d67",
+            "size": "192210264"
+        },
+        "linux-aarch64": {
+            "relative_path": "libcusparse/linux-aarch64/libcusparse-linux-aarch64-12.1.1.53-archive.tar.xz",
+            "sha256": "b86fcc1f706080bc6cdc5f2f8f99f99ceab62977a40aa13f97eb01e10ad97334",
+            "md5": "88264e9ac0334655f5b80eb8cea03a2e",
+            "size": "226908380"
+        }
+    },
+    "libnpp": {
+        "name": "CUDA NPP",
+        "license": "CUDA Toolkit",
+        "license_path": "libnpp/LICENSE.txt",
+        "version": "12.1.1.14",
+        "linux-x86_64": {
+            "relative_path": "libnpp/linux-x86_64/libnpp-linux-x86_64-12.1.1.14-archive.tar.xz",
+            "sha256": "efc53c1d554dab8cd4f75b21528b68f39a32b20eaabc5d8d2585e0db91f4353d",
+            "md5": "902f1d530b9245d35a61ba56ec8cd516",
+            "size": "182561952"
+        },
+        "linux-ppc64le": {
+            "relative_path": "libnpp/linux-ppc64le/libnpp-linux-ppc64le-12.1.1.14-archive.tar.xz",
+            "sha256": "4d58706c834addf38613eaa76eed01690762ee337faeab085ecbf7528d6fac70",
+            "md5": "ce315e5b89199106aa93a03db65ca39f",
+            "size": "182373984"
+        },
+        "linux-sbsa": {
+            "relative_path": "libnpp/linux-sbsa/libnpp-linux-sbsa-12.1.1.14-archive.tar.xz",
+            "sha256": "e99c853cd9ec8526cc053228d1b90597e6bb89ae1856af72bf85a7095b83106c",
+            "md5": "0a3254d7e4042d88ac522b14a43e278f",
+            "size": "181513452"
+        },
+        "windows-x86_64": {
+            "relative_path": "libnpp/windows-x86_64/libnpp-windows-x86_64-12.1.1.14-archive.zip",
+            "sha256": "846e7ba7d473a10918a97f81ce6b3742a11282ae0126ca99692971a4d30736b1",
+            "md5": "cb84a09751bceb3380a8f9e028e8f1c5",
+            "size": "151773014"
+        },
+        "linux-aarch64": {
+            "relative_path": "libnpp/linux-aarch64/libnpp-linux-aarch64-12.1.1.14-archive.tar.xz",
+            "sha256": "77c0b1cccd53e2dec1928dfc22cbce819f51140ede32edcf567840119f51f89d",
+            "md5": "82a83bf87d10da2f80e443e45deef998",
+            "size": "199197524"
+        }
+    },
+    "libnvidia_nscq": {
+        "name": "NVIDIA NSCQ API",
+        "license": "NVIDIA Driver",
+        "license_path": "libnvidia_nscq/LICENSE.txt",
+        "version": "535.54.03",
+        "linux-x86_64": {
+            "relative_path": "libnvidia_nscq/linux-x86_64/libnvidia_nscq-linux-x86_64-535.54.03-archive.tar.xz",
+            "sha256": "3433f2b46c47efeec54fc1eef990859b070801af9dfdcb5305783380e322e833",
+            "md5": "6e4728a04c1de840190f481b6b9cc0f0",
+            "size": "349948"
+        },
+        "linux-sbsa": {
+            "relative_path": "libnvidia_nscq/linux-sbsa/libnvidia_nscq-linux-sbsa-535.54.03-archive.tar.xz",
+            "sha256": "8ee52b4f763062e68ab41ed0af7b0daf2ce9d4c0bd3d27aeb14059584703e915",
+            "md5": "ead66878ffdf57c8875c0151855828b6",
+            "size": "317244"
+        }
+    },
+    "libnvjitlink": {
+        "name": "NVIDIA compiler library for JIT LTO functionality",
+        "license": "CUDA Toolkit",
+        "license_path": "libnvjitlink/LICENSE.txt",
+        "version": "12.2.91",
+        "linux-x86_64": {
+            "relative_path": "libnvjitlink/linux-x86_64/libnvjitlink-linux-x86_64-12.2.91-archive.tar.xz",
+            "sha256": "5f99b51c7dbb7420ad2559f295d651064259c42780298a1fcb6e647560421a98",
+            "md5": "377b9a77093f05b73e023164ccd58ff1",
+            "size": "26077128"
+        },
+        "linux-ppc64le": {
+            "relative_path": "libnvjitlink/linux-ppc64le/libnvjitlink-linux-ppc64le-12.2.91-archive.tar.xz",
+            "sha256": "18c703ad153525b14d69c0e5ff46b5505b22354e406923887e2d26f3a09f2f9b",
+            "md5": "09721fd552a006237fe8aad0b6e5dc03",
+            "size": "23976600"
+        },
+        "linux-sbsa": {
+            "relative_path": "libnvjitlink/linux-sbsa/libnvjitlink-linux-sbsa-12.2.91-archive.tar.xz",
+            "sha256": "8b2141ffa23e030fdc7d707b6eebda2b3f32c3e33379c0fe75868640c0f5c701",
+            "md5": "0d728f150ca04bae7f8f5f6930d27be6",
+            "size": "23937120"
+        },
+        "windows-x86_64": {
+            "relative_path": "libnvjitlink/windows-x86_64/libnvjitlink-windows-x86_64-12.2.91-archive.zip",
+            "sha256": "bb66172487d485d4aa969600a6128d92f0a6e4c02687c5008d282648b9f087e0",
+            "md5": "fedd2335f22e42106f76966845e031bf",
+            "size": "86994854"
+        },
+        "linux-aarch64": {
+            "relative_path": "libnvjitlink/linux-aarch64/libnvjitlink-linux-aarch64-12.2.91-archive.tar.xz",
+            "sha256": "6676827058de20c4d63819050fb8b53528dc19fd24982fc381ff28456472f6c4",
+            "md5": "6703a7759c62a74b658859913d5a4c63",
+            "size": "25130600"
+        }
+    },
+    "libnvjpeg": {
+        "name": "CUDA nvJPEG",
+        "license": "CUDA Toolkit",
+        "license_path": "libnvjpeg/LICENSE.txt",
+        "version": "12.1.1.14",
+        "linux-x86_64": {
+            "relative_path": "libnvjpeg/linux-x86_64/libnvjpeg-linux-x86_64-12.1.1.14-archive.tar.xz",
+            "sha256": "7ffeea14fc61f6600c29fd7872edbebad57abf360b3db15308d96902cbec34e7",
+            "md5": "36c92e8bd55423399dc64a80b1e4e2d5",
+            "size": "2506196"
+        },
+        "linux-ppc64le": {
+            "relative_path": "libnvjpeg/linux-ppc64le/libnvjpeg-linux-ppc64le-12.1.1.14-archive.tar.xz",
+            "sha256": "c56eea8afd8f500b827041f26bfe127d836ba08b15028a48fd41c122e8f06e5c",
+            "md5": "5d42d6e37898c2f612da15e455fd1ef9",
+            "size": "2490368"
+        },
+        "linux-sbsa": {
+            "relative_path": "libnvjpeg/linux-sbsa/libnvjpeg-linux-sbsa-12.1.1.14-archive.tar.xz",
+            "sha256": "cb17129e4dcbb7338ef7e37149de9ce4023ca9e2efad97de1ae0806bf67bdd10",
+            "md5": "b020197978d730b63a92caa140bb2a2a",
+            "size": "2336180"
+        },
+        "windows-x86_64": {
+            "relative_path": "libnvjpeg/windows-x86_64/libnvjpeg-windows-x86_64-12.1.1.14-archive.zip",
+            "sha256": "bf4107f5993c6595834821da5e2d50b1b1cd1dd687cb6224176656c198cacbbd",
+            "md5": "0da427edeea81414df1466fd5bc9b791",
+            "size": "2766220"
+        },
+        "linux-aarch64": {
+            "relative_path": "libnvjpeg/linux-aarch64/libnvjpeg-linux-aarch64-12.1.1.14-archive.tar.xz",
+            "sha256": "9b39d91814bf077c89e4ad5fbd5608acda0dd2fae4a0ccf0c91da6e45b11eaa6",
+            "md5": "e36afb6fd678c4846d1202f22a97b2fa",
+            "size": "2474640"
+        }
+    },
+    "nsight_compute": {
+        "name": "Nsight Compute",
+        "license": "NVIDIA SLA",
+        "license_path": "nsight_compute/LICENSE.txt",
+        "version": "2023.2.0.16",
+        "linux-x86_64": {
+            "relative_path": "nsight_compute/linux-x86_64/nsight_compute-linux-x86_64-2023.2.0.16-archive.tar.xz",
+            "sha256": "d4232eecbdb709f1482629af916c8fe6c6c6084764fff9fe5d4eec289cc10cb8",
+            "md5": "bad0c0f76173996c9995884bfb6ae3b6",
+            "size": "724640244"
+        },
+        "linux-ppc64le": {
+            "relative_path": "nsight_compute/linux-ppc64le/nsight_compute-linux-ppc64le-2023.2.0.16-archive.tar.xz",
+            "sha256": "ac3e1530830cf70b4d298818d5ed4e33864c1ebd6c44455ecafaaa264b8d3be7",
+            "md5": "7fcdf966becc5b915dcd65700e7f6e38",
+            "size": "185175700"
+        },
+        "linux-sbsa": {
+            "relative_path": "nsight_compute/linux-sbsa/nsight_compute-linux-sbsa-2023.2.0.16-archive.tar.xz",
+            "sha256": "5d9f2daeed1aaf87ac4fd8237699d0c915ef2de52b66a1f4ab4bda0057f47c7f",
+            "md5": "d9639e34e406f705530a25ccfcb55358",
+            "size": "350199152"
+        },
+        "windows-x86_64": {
+            "relative_path": "nsight_compute/windows-x86_64/nsight_compute-windows-x86_64-2023.2.0.16-archive.zip",
+            "sha256": "16579328355102bd1dd27f6969ab6bda426ea9e8a1bdf2f62f2bbf8b9370d5b9",
+            "md5": "c6be0d2ff8d1f1fe7cce5181393b79a8",
+            "size": "664635780"
+        },
+        "linux-aarch64": {
+            "relative_path": "nsight_compute/linux-aarch64/nsight_compute-linux-aarch64-2023.2.0.16-archive.tar.xz",
+            "sha256": "09a815a8e00fde87acc4b32c6409dfb616b8b49b7ae8f931c66de7c795db87e4",
+            "md5": "f3879107229a1a031b5971e77cd18916",
+            "size": "740361468"
+        }
+    },
+    "nsight_systems": {
+        "name": "Nsight Systems",
+        "license": "NVIDIA SLA",
+        "license_path": "nsight_systems/LICENSE.txt",
+        "version": "2023.2.3.1001",
+        "linux-x86_64": {
+            "relative_path": "nsight_systems/linux-x86_64/nsight_systems-linux-x86_64-2023.2.3.1001-archive.tar.xz",
+            "sha256": "3c5ff99cd44d99808e25d72059372cf8d36cd435ff4724e840a227cc674d79d0",
+            "md5": "4addd2a842d5e753e992bb2595babf15",
+            "size": "222188232"
+        },
+        "linux-ppc64le": {
+            "relative_path": "nsight_systems/linux-ppc64le/nsight_systems-linux-ppc64le-2023.2.3.1001-archive.tar.xz",
+            "sha256": "c71f3e39355bb23c6da411450360acb763b4effc5752918d0735517633d38352",
+            "md5": "2ef6e9dc891b39439541b123056b69c7",
+            "size": "64464952"
+        },
+        "linux-sbsa": {
+            "relative_path": "nsight_systems/linux-sbsa/nsight_systems-linux-sbsa-2023.2.3.1001-archive.tar.xz",
+            "sha256": "6e559924fcdcfbc677490131f343ea9a2ab2a9ecb994906b3a23791601428dfc",
+            "md5": "92dfed2062891bc73e4b5f488cf48467",
+            "size": "197068636"
+        },
+        "windows-x86_64": {
+            "relative_path": "nsight_systems/windows-x86_64/nsight_systems-windows-x86_64-2023.2.3.1001-archive.zip",
+            "sha256": "928d40a3edd0434d82fd5a48d70781e41a01071db8095891588d0299ba888962",
+            "md5": "1bb802ca720f4dabdbc5933f426f35ee",
+            "size": "335353534"
+        }
+    },
+    "nsight_vse": {
+        "name": "Nsight Visual Studio Edition (VSE)",
+        "license": "NVIDIA SLA",
+        "license_path": "nsight_vse/LICENSE.txt",
+        "version": "2023.2.0.23143",
+        "windows-x86_64": {
+            "relative_path": "nsight_vse/windows-x86_64/nsight_vse-windows-x86_64-2023.2.0.23143-archive.zip",
+            "sha256": "07a819f72797cae9aa95e4308ae65b712384d1e76ed104842cc2d51ac6196b9f",
+            "md5": "5cd16b1761028a887351148ac8e078f1",
+            "size": "526806378"
+        }
+    },
+    "nvidia_driver": {
+        "name": "NVIDIA Linux Driver",
+        "license": "NVIDIA Driver",
+        "license_path": "nvidia_driver/LICENSE.txt",
+        "version": "535.54.03",
+        "linux-x86_64": {
+            "relative_path": "nvidia_driver/linux-x86_64/nvidia_driver-linux-x86_64-535.54.03-archive.tar.xz",
+            "sha256": "c394729dc4a52d47d88d2573265fd29037709732f20f489a37ac4ab47f6822f1",
+            "md5": "955c14cf3dd6178547257a50f07b8c6f",
+            "size": "399961036"
+        },
+        "linux-ppc64le": {
+            "relative_path": "nvidia_driver/linux-ppc64le/nvidia_driver-linux-ppc64le-535.54.03-archive.tar.xz",
+            "sha256": "72176f44f8317fcaa4e3a14ad28dbff0c4d999a1b72f9cd91171cda3d7f0d66c",
+            "md5": "4a459d6fdd07d8dd9b94d26e96cf9f23",
+            "size": "99839420"
+        },
+        "linux-sbsa": {
+            "relative_path": "nvidia_driver/linux-sbsa/nvidia_driver-linux-sbsa-535.54.03-archive.tar.xz",
+            "sha256": "01bca95203ebac62fc7e87b4142cb0b2ebdaed5290e957fb13999e6c460f78ef",
+            "md5": "3a69e12fd2d28c957156512021a0dc3e",
+            "size": "313982992"
+        }
+    },
+    "nvidia_fs": {
+        "name": "NVIDIA filesystem",
+        "license": "CUDA Toolkit",
+        "license_path": "nvidia_fs/LICENSE.txt",
+        "version": "2.16.1",
+        "linux-x86_64": {
+            "relative_path": "nvidia_fs/linux-x86_64/nvidia_fs-linux-x86_64-2.16.1-archive.tar.xz",
+            "sha256": "c899c58d07dbbe337abead01337a2aec72a7fd4600b95838b044335c85199c6b",
+            "md5": "f6f00d81e1e0dcb0847fea3b3c83d3a1",
+            "size": "57608"
+        },
+        "linux-sbsa": {
+            "relative_path": "nvidia_fs/linux-sbsa/nvidia_fs-linux-sbsa-2.16.1-archive.tar.xz",
+            "sha256": "779d2b669d5021125da6689dfc1c45772996abb63ace42d388cbc03a85dfa4fb",
+            "md5": "c462ac53d3318e5fb73bc04201a78046",
+            "size": "57580"
+        },
+        "linux-aarch64": {
+            "relative_path": "nvidia_fs/linux-aarch64/nvidia_fs-linux-aarch64-2.16.1-archive.tar.xz",
+            "sha256": "a6f56b158246178637a5e87889d81ec3796407a6105ae8b17844842a3d0beafb",
+            "md5": "ee4bdba81554d3548cf778a72e6321a7",
+            "size": "57596"
+        }
+    },
+    "visual_studio_integration": {
+        "name": "CUDA Visual Studio Integration",
+        "license": "CUDA Toolkit",
+        "license_path": "visual_studio_integration/LICENSE.txt",
+        "version": "12.2.53",
+        "windows-x86_64": {
+            "relative_path": "visual_studio_integration/windows-x86_64/visual_studio_integration-windows-x86_64-12.2.53-archive.zip",
+            "sha256": "427c33b33f67f0d412d37e1e34c72c16e9fd34ef25f6d15b90ab91488ed3d0f5",
+            "md5": "ddf0c3651191623c29c63e268c6720f2",
+            "size": "517874"
+        }
+    }
+}

--- a/pkgs/development/compilers/cudatoolkit/versions.toml
+++ b/pkgs/development/compilers/cudatoolkit/versions.toml
@@ -83,3 +83,9 @@ version = "12.1.1"
 url = "https://developer.download.nvidia.com/compute/cuda/12.1.1/local_installers/cuda_12.1.1_530.30.02_linux.run"
 sha256 = "sha256-10Ai1B2AEFMZ36Ib7qObd6W5kZU5wEh6BcqvJEbWpw4="
 gcc = "gcc12"
+
+["12.2"]
+version = "12.2.0"
+url = "https://developer.download.nvidia.com/compute/cuda/12.2.0/local_installers/cuda_12.2.0_535.54.03_linux.run"
+sha256 = "sha256-7PPSr63LrAKfD0UFeFgQ1S0AbkuHunn/P5hDNqK79Rg="
+gcc = "gcc12"

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6857,6 +6857,7 @@ with pkgs;
 
   cudaPackages_12_0 = callPackage ./cuda-packages.nix { cudaVersion = "12.0"; };
   cudaPackages_12_1 = callPackage ./cuda-packages.nix { cudaVersion = "12.1"; };
+  cudaPackages_12_2 = callPackage ./cuda-packages.nix { cudaVersion = "12.2"; };
   cudaPackages_12 = cudaPackages_12_0;
 
   # TODO: try upgrading once there is a cuDNN release supporting CUDA 12. No


### PR DESCRIPTION
###### Description of changes

Update cudaPackages: 12.1.1 -> 12.2.0

https://docs.nvidia.com/cuda/archive/12.1.1/ -> https://docs.nvidia.com/cuda/cuda-toolkit-release-notes/index.html

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).