### PR TITLE
qrscan: init at 0.1.9

### DIFF
--- a/pkgs/tools/misc/qrscan/default.nix
+++ b/pkgs/tools/misc/qrscan/default.nix
@@ -1,0 +1,36 @@
+{ lib, rustPlatform, fetchFromGitHub, stdenv }:
+
+rustPlatform.buildRustPackage rec {
+  pname = "qrscan";
+  version = "0.1.9";
+
+  src = fetchFromGitHub {
+    owner = "sayanarijit";
+    repo = "qrscan";
+    rev = "v${version}";
+    hash = "sha256-nAUZUE7NppsCAV8UyR8+OkikT4nJtnamsSVeyNz21EQ=";
+  };
+
+  nativeBuildInputs = [
+    rustPlatform.bindgenHook
+  ];
+
+  cargoHash = "sha256-P40IwFRtEQp6BGRgmt1x3UXtAKtWaMjR3kqhYq+p7wQ=";
+
+  checkFlags = [
+    # requires filesystem write access
+    "--skip=tests::test_export_files"
+    "--skip=tests::test_scan_from_stdin"
+    "--skip=tests::test_scan_jpeg_file"
+    "--skip=tests::test_scan_no_content"
+    "--skip=tests::test_scan_png_file"
+  ];
+
+  meta = with lib; {
+    description = "Scan a QR code in the terminal using the system camera or a given image";
+    homepage = "https://github.com/sayanarijit/qrscan";
+    license = licenses.mit;
+    broken = stdenv.isDarwin;
+    maintainers = [ maintainers.sayanarijit ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -11917,6 +11917,8 @@ with pkgs;
 
   qrcp = callPackage ../tools/networking/qrcp { };
 
+  qrscan = callPackage ../tools/misc/qrscan { };
+
   qtikz = libsForQt5.callPackage ../applications/graphics/ktikz { };
 
   qtspim = libsForQt5.callPackage ../development/tools/misc/qtspim { };


### PR DESCRIPTION
###### Description of changes

[qrscan](https://github.com/sayanarijit/qrscan) is a command-line utility that scans QR codes from the system camera, or from a given image, and prints the value in the terminal along with other metadata, recreating the QR code in different formats (ascii, jpeg, png, svg etc.) if required.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
